### PR TITLE
feat(workflow_engine): Add Evaluation Logs to Delayed Processor in Workflow Engine

### DIFF
--- a/src/sentry/workflow_engine/buffer/batch_client.py
+++ b/src/sentry/workflow_engine/buffer/batch_client.py
@@ -36,6 +36,9 @@ class DelayedWorkflowItem:
     # Should be close to when fast conditions were evaluated to try to be consistent.
     timestamp: datetime
 
+    detector_id: int | None = None
+    detector_type: str | None = None
+
     def buffer_key(self) -> str:
         when_condition_group_str = (
             str(self.delayed_when_group_id) if self.delayed_when_group_id else ""
@@ -50,6 +53,8 @@ class DelayedWorkflowItem:
                 "event_id": self.event.event_id,
                 "occurrence_id": self.event.occurrence_id,
                 "timestamp": self.timestamp,
+                **({"detector_id": self.detector_id} if self.detector_id is not None else {}),
+                **({"detector_type": self.detector_type} if self.detector_type else {}),
             }
         )
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
-from dataclasses import dataclass, field
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from functools import cached_property
-from typing import Any
+from typing import Any, cast
 
 import sentry_sdk
 from django.utils import timezone
@@ -48,7 +48,13 @@ from sentry.workflow_engine.processors.data_condition_group import (
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
 )
-from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.evaluation_logging import (
+    emit_delayed_workflow_evaluation_logs,
+)
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    DelayedWorkflowEvaluation,
+)
 from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
@@ -70,6 +76,8 @@ class EventInstance(BaseModel):
     event_id: str
     occurrence_id: str | None = None
     timestamp: datetime | None = None
+    detector_id: int | None = None
+    detector_type: str | None = None
 
     class Config:
         # Ignore unknown fields; we'd like to be able to add new fields easily.
@@ -446,10 +454,13 @@ def get_condition_group_results(
     for time_and_groups in queries_to_groups.values():
         all_group_ids.update(time_and_groups.group_ids)
 
-    all_groups: list[GroupValues] = list(
-        Group.objects.filter(id__in=all_group_ids).values(
-            "id", "type", "project_id", "project__organization_id"
-        )
+    all_groups = cast(
+        list[GroupValues],
+        list(
+            Group.objects.filter(id__in=all_group_ids).values(
+                "id", "type", "project_id", "project__organization_id"
+            )
+        ),
     )
 
     last_try = False
@@ -574,40 +585,7 @@ class _ConditionEvaluationStats:
 class DelayedWorkflowEvaluationResult:
     groups_to_fire: dict[GroupId, set[DataConditionGroup]]
     stats: _ConditionEvaluationStats
-
-    # All workflow IDs evaluated (for log filtering)
-    workflow_ids: set[WorkflowId]
-
-    # Per-evaluation outcomes
-    when_dcg_missing: dict[WorkflowId, list[GroupId]]
-    when_failed_untainted: dict[WorkflowId, list[GroupId]]
-    when_failed_tainted: dict[WorkflowId, list[GroupId]]
-    # workflow_id -> group_id -> {dcg_id: [condition_ids that passed]}
-    # Includes both re-evaluated DCGs and pre-passing DCGs.
-    if_dcg_passed: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]]
-    # workflow_id -> group_id -> [dcg_ids that failed]
-    # Condition-level detail is omitted; all conditions not in if_dcg_passed are assumed failed.
-    if_dcg_failed: dict[WorkflowId, dict[GroupId, list[DataConditionGroupId]]]
-
-    def iter_per_workflow_log_dicts(self) -> Iterator[dict[str, Any]]:
-        """Yield one log-ready dict per workflow, keeping each entry bounded in size."""
-        for workflow_id in sorted(self.workflow_ids):
-            yield {
-                "workflow_id": workflow_id,
-                "if_dcg_passed": self.if_dcg_passed.get(workflow_id, {}),
-                "if_dcg_failed": self.if_dcg_failed.get(workflow_id, {}),
-                "when_failed_untainted": self.when_failed_untainted.get(workflow_id, []),
-                "when_failed_tainted": self.when_failed_tainted.get(workflow_id, []),
-                "when_dcg_missing": self.when_dcg_missing.get(workflow_id, []),
-            }
-
-    def summary_log_dict(self) -> dict[str, Any]:
-        """Return bounded aggregate stats for a single summary log entry."""
-        return {
-            "workflows": sorted(self.workflow_ids),
-            "tainted_conditions": self.stats.tainted,
-            "untainted_conditions": self.stats.untainted,
-        }
+    evaluations: list[DelayedWorkflowEvaluation]
 
 
 @trace
@@ -617,32 +595,26 @@ def get_groups_to_fire(
     event_data: EventRedisData,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
+    *,
+    project_id: int | None = None,
 ) -> DelayedWorkflowEvaluationResult:
     data_condition_group_mapping = {dcg.id: dcg for dcg in data_condition_groups}
     groups_to_fire: dict[GroupId, set[DataConditionGroup]] = defaultdict(set)
 
-    # Mutable outcome tracking
-    evaluated_workflow_ids: set[WorkflowId] = set()
-    when_dcg_missing: dict[WorkflowId, list[GroupId]] = defaultdict(list)
-    when_failed_untainted: dict[WorkflowId, list[GroupId]] = defaultdict(list)
-    when_failed_tainted: dict[WorkflowId, list[GroupId]] = defaultdict(list)
-    if_dcg_passed: dict[WorkflowId, dict[GroupId, dict[DataConditionGroupId, list[int]]]] = (
-        defaultdict(lambda: defaultdict(dict))
-    )
-    if_dcg_failed: dict[WorkflowId, dict[GroupId, list[DataConditionGroupId]]] = defaultdict(
-        lambda: defaultdict(list)
-    )
-
+    evaluations: list[DelayedWorkflowEvaluation] = []
     tainted, untainted = 0, 0
-    for event_key in event_data.events:
+    for event_key, event_instance in event_data.events.items():
         group_id = event_key.group_id
         workflow_id = event_key.workflow_id
         if workflow_id not in workflows_to_envs:
             # The workflow is deleted, so we can skip it
             continue
 
-        evaluated_workflow_ids.add(workflow_id)
         workflow_env = workflows_to_envs[workflow_id]
+        filter_group_evaluations: dict[DataConditionGroupId, DataConditionGroupEvaluation] = {}
+        missing_condition_group_ids: set[DataConditionGroupId] = set()
+        evaluate_filter_groups = True
+
         # When there is no WHEN group, treat the workflow as triggered with no taint.
         # This is the identity element for the taint-aware AND (`.all`) below.
         when_evaluation = DataConditionGroupEvaluation(
@@ -655,79 +627,95 @@ def get_groups_to_fire(
         )
         if when_dcg_id := event_key.when_dcg_id:
             when_dcg = data_condition_group_mapping.get(when_dcg_id)
-            if not when_dcg:
-                when_dcg_missing[workflow_id].append(group_id)
-                continue
-            when_evaluation = _evaluate_group_result_for_dcg(
-                when_dcg,
-                dcg_to_slow_conditions,
-                group_id,
-                workflow_env,
-                condition_group_results,
-            )
-            if not when_evaluation.triggered:
-                # If we're not triggering, all action-y if conditions need to be treated
-                # as tainted or not based on the when condition result.
-                if_conds = event_key.if_dcg_ids | event_key.passing_dcg_ids
-                # Limit to those we can access to be consistent with the if conditions evaluation.
-                if_cond_count = len(if_conds & data_condition_group_mapping.keys())
-                if when_evaluation.is_tainted():
-                    tainted += if_cond_count
-                    when_failed_tainted[workflow_id].append(group_id)
-                else:
-                    untainted += if_cond_count
-                    when_failed_untainted[workflow_id].append(group_id)
-                continue
-
-        # the WHEN condition passed / was not evaluated, so we can now check the IF conditions
-        for if_dcg_id in event_key.if_dcg_ids:
-            if dcg := data_condition_group_mapping.get(if_dcg_id):
-                if_group = _evaluate_group_result_for_dcg(
-                    dcg,
+            if when_dcg is None:
+                missing_condition_group_ids.add(when_dcg_id)
+                when_evaluation = DataConditionGroupEvaluation(
+                    result=False,
+                    triggered=False,
+                    data={
+                        "condition_evaluations": [],
+                        "logic_type": DataConditionGroup.Type.ANY,
+                    },
+                )
+                evaluate_filter_groups = False
+            else:
+                when_evaluation = _evaluate_group_result_for_dcg(
+                    when_dcg,
                     dcg_to_slow_conditions,
                     group_id,
                     workflow_env,
                     condition_group_results,
                 )
-                if_triggered, if_error = DataConditionGroupEvaluation.all(
-                    [when_evaluation, if_group]
-                )
+                if not when_evaluation.triggered:
+                    # If we're not triggering, all action-y if conditions need to be treated
+                    # as tainted or not based on the when condition result.
+                    if_conds = event_key.if_dcg_ids | event_key.passing_dcg_ids
+                    # Limit to those we can access to be consistent with the if conditions evaluation.
+                    if_cond_count = len(if_conds & data_condition_group_mapping.keys())
+                    if when_evaluation.is_tainted():
+                        tainted += if_cond_count
+                    else:
+                        untainted += if_cond_count
+                    evaluate_filter_groups = False
 
-                if if_error is not None:
-                    tainted += 1
+        if evaluate_filter_groups:
+            # The WHEN condition passed or was not evaluated, so check the IF conditions.
+            for if_dcg_id in event_key.if_dcg_ids:
+                if dcg := data_condition_group_mapping.get(if_dcg_id):
+                    if_group = _evaluate_group_result_for_dcg(
+                        dcg,
+                        dcg_to_slow_conditions,
+                        group_id,
+                        workflow_env,
+                        condition_group_results,
+                    )
+                    if_triggered, if_error = DataConditionGroupEvaluation.all(
+                        [when_evaluation, if_group]
+                    )
+
+                    if if_error is not None:
+                        tainted += 1
+                    else:
+                        untainted += 1
+
+                    filter_group_evaluations[dcg.id] = if_group
+                    if if_triggered:
+                        groups_to_fire[group_id].add(dcg)
                 else:
-                    untainted += 1
+                    missing_condition_group_ids.add(if_dcg_id)
 
-                if if_triggered:
+            for if_dcg_id in event_key.passing_dcg_ids:
+                if dcg := data_condition_group_mapping.get(if_dcg_id):
+                    # TODO: Propagate taint with passing conditions.
+                    if when_evaluation.is_tainted():
+                        tainted += 1
+                    else:
+                        untainted += 1
+
                     groups_to_fire[group_id].add(dcg)
-                    if_dcg_passed[workflow_id][group_id][dcg.id] = [
-                        pc.condition.id for pc in if_group.data["condition_evaluations"]
-                    ]
                 else:
-                    if_dcg_failed[workflow_id][group_id].append(dcg.id)
+                    missing_condition_group_ids.add(if_dcg_id)
 
-        for if_dcg_id in event_key.passing_dcg_ids:
-            if dcg := data_condition_group_mapping.get(if_dcg_id):
-                # TODO: Propagate taint with passing conditions.
-                if when_evaluation.is_tainted():
-                    tainted += 1
-                else:
-                    untainted += 1
-
-                groups_to_fire[group_id].add(dcg)
-                if_dcg_passed[workflow_id][group_id][dcg.id] = [
-                    c.id for c in dcg_to_slow_conditions.get(dcg.id, [])
-                ]
+        evaluations.append(
+            DelayedWorkflowEvaluation(
+                workflow_id=workflow_id,
+                detector_id=event_instance.detector_id,
+                detector_type=event_instance.detector_type,
+                project_id=project_id,
+                group_id=group_id,
+                event_id=event_instance.event_id,
+                trigger_group_id=event_key.when_dcg_id,
+                trigger_group_evaluation=when_evaluation,
+                filter_group_evaluations=filter_group_evaluations,
+                passing_filter_group_ids=event_key.passing_dcg_ids,
+                missing_condition_group_ids=frozenset(missing_condition_group_ids),
+            )
+        )
 
     return DelayedWorkflowEvaluationResult(
         groups_to_fire=groups_to_fire,
         stats=_ConditionEvaluationStats(tainted=tainted, untainted=untainted),
-        workflow_ids=evaluated_workflow_ids,
-        when_dcg_missing=when_dcg_missing,
-        when_failed_untainted=when_failed_untainted,
-        when_failed_tainted=when_failed_tainted,
-        if_dcg_passed=if_dcg_passed,
-        if_dcg_failed=if_dcg_failed,
+        evaluations=evaluations,
     )
 
 
@@ -808,7 +796,7 @@ def fire_actions_for_groups(
     organization: Organization,
     groups_to_fire: dict[GroupId, set[DataConditionGroup]],
     group_to_groupevent: dict[Group, tuple[GroupEvent, datetime | None]],
-) -> None:
+) -> dict[tuple[WorkflowId, GroupId], set[int]]:
     from sentry.workflow_engine.processors.action import (
         filter_recently_fired_workflow_actions,
         fire_actions,
@@ -826,6 +814,7 @@ def fire_actions_for_groups(
     )
 
     total_actions = 0
+    action_ids_by_workflow_and_group: dict[tuple[WorkflowId, GroupId], set[int]] = defaultdict(set)
     with track_batch_performance(
         "workflow_engine.delayed_workflow.fire_actions_for_groups.loop",
         logger,
@@ -858,7 +847,7 @@ def fire_actions_for_groups(
                 workflow_uuid_map: dict[WorkflowId, str] = {}
                 if workflow_fire_histories:
                     workflow_uuid_map = {
-                        history.workflow_id: str(history.notification_uuid)
+                        history.workflow_id: str(history.notification_uuid)  # pyright: ignore[reportAttributeAccessIssue]
                         for history in workflow_fire_histories
                     }
 
@@ -871,7 +860,10 @@ def fire_actions_for_groups(
                     "workflow_engine.delayed_workflow.triggered_actions",
                     extra={
                         "workflow_ids": sorted(
-                            {wfh.workflow_id for wfh in workflow_fire_histories}
+                            {
+                                wfh.workflow_id  # pyright: ignore[reportAttributeAccessIssue]
+                                for wfh in workflow_fire_histories
+                            }
                         ),
                         "actions": [action.id for action in filtered_actions],
                         "event_data": workflow_event_data,
@@ -879,6 +871,9 @@ def fire_actions_for_groups(
                     },
                 )
                 total_actions += len(filtered_actions)
+                for action in filtered_actions:
+                    if (workflow_id := action_to_workflow_id.get(action.id)) is not None:
+                        action_ids_by_workflow_and_group[workflow_id, group.id].add(action.id)
 
                 fire_actions(
                     filtered_actions,
@@ -891,6 +886,7 @@ def fire_actions_for_groups(
         "workflow_engine.delayed_workflow.triggered_actions_summary",
         extra={"total_actions": total_actions},
     )
+    return action_ids_by_workflow_and_group
 
 
 @trace
@@ -913,7 +909,7 @@ def _summarize_by_first[T1, T2: int | str](it: Iterable[tuple[T1, T2]]) -> dict[
 
 
 def _process_workflows_for_project(project: Project, event_data: EventRedisData) -> None:
-    """Process workflows for a project - evaluate conditions and fire actions."""
+    """Process workflows for a project by evaluating conditions and firing actions."""
     with start_span(op="delayed_workflow.prepare_data", name="delayed_workflow.prepare_data"):
         if features.has(
             "organizations:workflow-engine-process-workflows-logs", project.organization
@@ -962,8 +958,6 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
     condition_groups = get_condition_query_groups(
         data_condition_groups, event_data, workflows_to_envs, dcg_to_slow_conditions
     )
-    if not condition_groups:
-        return
     logger.debug(
         "delayed_workflow.condition_query_groups",
         extra={
@@ -972,12 +966,16 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         },
     )
 
+    if not condition_groups:
+        return
+
     try:
         condition_group_results = get_condition_group_results(condition_groups)
     except SnubaError:
         # We expect occasional errors, so we report as info and retry.
         sentry_sdk.capture_exception(level="info")
         retry_task()
+        return
 
     logger.debug(
         "delayed_workflow.condition_group_results",
@@ -993,6 +991,7 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         event_data,
         condition_group_results,
         dcg_to_slow_conditions,
+        project_id=project.id,
     )
     metrics.incr(
         "workflow_engine.delayed_workflow.workflow_if_conditions_evaluated",
@@ -1022,16 +1021,30 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
         project,
     )
 
+    action_ids_by_workflow_and_group: dict[tuple[WorkflowId, GroupId], set[int]] = defaultdict(set)
     if evaluation.groups_to_fire and group_to_groupevent:
-        fire_actions_for_groups(
+        action_ids_by_workflow_and_group = fire_actions_for_groups(
             project.organization, evaluation.groups_to_fire, group_to_groupevent
         )
 
-    for workflow_log in evaluation.iter_per_workflow_log_dicts():
-        logger.debug(
-            "workflow_engine.delayed_workflow.evaluation_result",
-            extra=workflow_log,
+    evaluations = [
+        replace(
+            delayed_evaluation,
+            triggered_action_ids=tuple(
+                sorted(
+                    action_ids_by_workflow_and_group[
+                        delayed_evaluation.workflow_id, delayed_evaluation.group_id
+                    ]
+                )
+            ),
         )
+        for delayed_evaluation in evaluation.evaluations
+    ]
+    emit_delayed_workflow_evaluation_logs(
+        logger,
+        organization=project.organization,
+        evaluations=evaluations,
+    )
 
 
 @trace

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -6,8 +6,11 @@ from typing import TYPE_CHECKING, cast
 
 from sentry import features, options
 from sentry.utils.sdk import sdk_logger
-from sentry.workflow_engine.processors.evaluations.detector import ProcessDetectorsResult
-from sentry.workflow_engine.processors.evaluations.workflow import ProcessWorkflowsResult
+from sentry.workflow_engine.processors.evaluations import (
+    DelayedWorkflowEvaluation,
+    ProcessDetectorsResult,
+    ProcessWorkflowsResult,
+)
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -15,6 +18,7 @@ if TYPE_CHECKING:
 
 DETECTOR_EVALUATION_LOG_PREFIX = "workflow_engine.process_detectors.evaluation"
 WORKFLOW_EVALUATION_LOG_PREFIX = "workflow_engine.process_workflows.evaluation"
+DELAYED_WORKFLOW_EVALUATION_LOG_PREFIX = "workflow_engine.process_delayed_workflows.evaluation"
 
 
 def _is_sampled() -> bool:
@@ -22,16 +26,20 @@ def _is_sampled() -> bool:
     return random.random() < sample_rate
 
 
-def should_log(organization: Organization, result: ProcessWorkflowsResult) -> bool:
+def should_log_workflow_ids(organization: Organization, workflow_ids: set[int]) -> bool:
     if features.has("organizations:workflow-engine-log-evaluations", organization):
         return True
 
     target_workflow_ids = cast(
         list[int], options.get("workflow_engine.evaluation_log_target_workflow_ids")
     )
-    if any(workflow_id in result.evaluations for workflow_id in target_workflow_ids):
+    if workflow_ids.intersection(target_workflow_ids):
         return True
     return _is_sampled()
+
+
+def should_log(organization: Organization, result: ProcessWorkflowsResult) -> bool:
+    return should_log_workflow_ids(organization, set(result.evaluations))
 
 
 def _emit_evaluation_artifacts(
@@ -66,6 +74,28 @@ def emit_detector_evaluation_logs(
         logger,
         organization_id=organization_id,
         artifacts=result.evaluation_artifacts(),
+        log_prefix=log_prefix,
+    )
+    return True
+
+
+def emit_delayed_workflow_evaluation_logs(
+    logger: Logger,
+    *,
+    organization: Organization,
+    evaluations: list[DelayedWorkflowEvaluation],
+    log_prefix: str = DELAYED_WORKFLOW_EVALUATION_LOG_PREFIX,
+) -> bool:
+    """Sample a delayed batch and emit one self-contained artifact per event evaluation."""
+    if not evaluations or not should_log_workflow_ids(
+        organization, {evaluation.workflow_id for evaluation in evaluations}
+    ):
+        return False
+
+    _emit_evaluation_artifacts(
+        logger,
+        organization_id=organization.id,
+        artifacts=[evaluation.to_artifact() for evaluation in evaluations],
         log_prefix=log_prefix,
     )
     return True

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     "DataConditionEvaluation",
     "DataConditionEvaluationException",
     "DataConditionGroupEvaluation",
+    "DelayedWorkflowEvaluation",
     "DetectorEvaluation",
     "DetectorEvaluationData",
     "DetectorEvaluationOutcome",
@@ -26,8 +27,13 @@ from .detector import (
 )
 from .workflow import (
     DeferredWorkflowEvaluationResult,
-    ProcessWorkflowsResult,
-    WorkflowEvaluation,
+    DelayedWorkflowEvaluation,
     WorkflowEvaluationData,
     WorkflowEvaluationOutcome,
+)
+from .workflow import (
+    ProcessWorkflowsResult as ProcessWorkflowsResult,
+)
+from .workflow import (
+    WorkflowEvaluation as WorkflowEvaluation,
 )

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -75,41 +75,19 @@ def _condition_group_artifact(
     }
 
 
-def build_workflow_evaluation_artifact_fields(
-    *,
-    phase: EvaluationPhase,
-    workflow_id: WorkflowId,
-    detector_id: DetectorId | None,
-    detector_type: str | None,
-    project_id: int | None,
-    event_id: str | None,
-    group_id: GroupId,
-    outcome: WorkflowEvaluationOutcome,
-    triggered_action_ids: Sequence[ActionId],
-    trigger_group_id: DataConditionGroupId | None,
-    trigger_group_evaluation: DataConditionGroupEvaluation,
-    filter_group_evaluations: Mapping[DataConditionGroupId, DataConditionGroupEvaluation],
-) -> dict[str, object]:
-    """Build the fields shared by initial and delayed workflow evaluation artifacts."""
-    return {
-        "evaluation_type": EvaluationType.WORKFLOW,
-        "evaluation_phase": phase,
-        "workflow_id": workflow_id,
-        "detector_id": detector_id,
-        "detector_type": detector_type,
-        "project_id": project_id,
-        "event_id": event_id,
-        "group_id": group_id,
-        "outcome": outcome,
-        "triggered_action_ids": list(triggered_action_ids),
-        "trigger_group_evaluation": _condition_group_artifact(
-            trigger_group_id, trigger_group_evaluation
-        ),
-        "filter_group_evaluations": [
-            _condition_group_artifact(condition_group_id, evaluation)
-            for condition_group_id, evaluation in sorted(filter_group_evaluations.items())
-        ],
-    }
+@dataclass(frozen=True, kw_only=True)
+class WorkflowEvaluationArtifact:
+    evaluation_type: EvaluationType
+    evaluation_phase: EvaluationPhase
+    workflow_id: WorkflowId
+    detector_id: DetectorId | None
+    detector_type: str | None
+    event_iid: str | None
+    group_id: GroupId
+    outcome: WorkflowEvaluationOutcome
+    triggered_action_ids: Sequence[ActionId]
+    trigger_group_evaluation: Mapping[DataConditionGroupId, DataConditionGroupEvaluation]
+    filter_group_evaluations: Mapping[DataConditionGroupId, DataConditionGroupEvaluation]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -168,7 +146,12 @@ class WorkflowEvaluation(
             if isinstance(event_data.event, GroupEvent)
             else event_data.event.id
         )
-        artifact = build_workflow_evaluation_artifact_fields(
+
+        trigger_group_id = self.data.get("trigger_group_id")
+        trigger_evaluations = self.data.get("trigger_group_eval", {})
+        filter_evaluations = self.data.get("filter_group_evals", {})
+
+        artifact = WorkflowEvaluationArtifact(
             phase=EvaluationPhase.INITIAL,
             workflow_id=self.workflow_id,
             detector_id=self.detector_id,
@@ -177,13 +160,17 @@ class WorkflowEvaluation(
             event_id=str(event_id) if event_id else None,
             group_id=event_data.group.id,
             outcome=self.outcome,
-            triggered_action_ids=triggered_action_ids,
-            trigger_group_id=self.data["trigger_group_id"],
-            trigger_group_evaluation=self.data["trigger_group_eval"],
-            filter_group_evaluations=self.data["filter_group_evals"],
+            triggered_action_ids=list(triggered_action_ids),
+            trigger_group_evaluation={trigger_group_id: trigger_evaluations.to_artifact()},
+            filter_group_evaluations=[
+                _condition_group_artifact(condition_group_id, evaluation)
+                for condition_group_id, evaluation in sorted(filter_evaluations.items())
+            ],
         )
+
         if deferred is not None:
             artifact["deferred"] = deferred
+
         return artifact
 
 

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -47,6 +47,75 @@ class WorkflowEvaluationOutcome(StrEnum):
     NOT_TRIGGERED = "not_triggered"
 
 
+@dataclass(frozen=True, kw_only=True)
+class DelayedWorkflowEvaluation:
+    """The second half of a deferred workflow evaluation for one event and group."""
+
+    workflow_id: WorkflowId
+    detector_id: DetectorId | None
+    detector_type: str | None
+    project_id: int | None
+    group_id: GroupId
+    event_id: str
+    trigger_group_id: DataConditionGroupId | None
+    trigger_group_evaluation: DataConditionGroupEvaluation
+    filter_group_evaluations: Mapping[DataConditionGroupId, DataConditionGroupEvaluation]
+    passing_filter_group_ids: frozenset[DataConditionGroupId]
+    missing_condition_group_ids: frozenset[DataConditionGroupId]
+    triggered_action_ids: tuple[ActionId, ...] = ()
+
+    def _condition_group_evaluations(self) -> tuple[DataConditionGroupEvaluation, ...]:
+        return (
+            self.trigger_group_evaluation,
+            *self.filter_group_evaluations.values(),
+        )
+
+    @property
+    def outcome(self) -> WorkflowEvaluationOutcome:
+        if self.missing_condition_group_ids or any(
+            evaluation.is_tainted() for evaluation in self._condition_group_evaluations()
+        ):
+            return WorkflowEvaluationOutcome.ERROR
+        if not self.trigger_group_evaluation.triggered:
+            return WorkflowEvaluationOutcome.NOT_TRIGGERED
+        if self.triggered_action_ids:
+            return WorkflowEvaluationOutcome.ACTIONS_TRIGGERED
+        return WorkflowEvaluationOutcome.NO_ACTIONS
+
+    def to_artifact(self) -> dict[str, object]:
+        error = next(
+            (
+                evaluation.error.msg
+                for evaluation in self._condition_group_evaluations()
+                if evaluation.error is not None
+            ),
+            None,
+        )
+        if error is None and self.missing_condition_group_ids:
+            error = "DataConditionGroup does not exist"
+
+        return {
+            **build_workflow_evaluation_artifact_fields(
+                phase=EvaluationPhase.DELAYED,
+                workflow_id=self.workflow_id,
+                detector_id=self.detector_id,
+                detector_type=self.detector_type,
+                project_id=self.project_id,
+                event_id=self.event_id,
+                group_id=self.group_id,
+                outcome=self.outcome,
+                triggered_action_ids=self.triggered_action_ids,
+                trigger_group_id=self.trigger_group_id,
+                trigger_group_evaluation=self.trigger_group_evaluation,
+                filter_group_evaluations=self.filter_group_evaluations,
+            ),
+            "passing_filter_group_ids": sorted(self.passing_filter_group_ids),
+            "missing_condition_group_ids": sorted(self.missing_condition_group_ids),
+            "triggered": self.trigger_group_evaluation.triggered,
+            "error": error,
+        }
+
+
 class WorkflowEvaluationData(TypedDict):
     """
     Track all of the data that went into evaluating a single workflow.
@@ -156,7 +225,7 @@ class WorkflowEvaluation(
             workflow_id=self.workflow_id,
             detector_id=self.detector_id,
             detector_type=self.detector_type,
-            project_id=event_data.event.project_id,
+            project_id=event_data.event.project_id,  # pyright: ignore[reportAttributeAccessIssue]
             event_id=str(event_id) if event_id else None,
             group_id=event_data.group.id,
             outcome=self.outcome,

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, TypedDict
 
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.types import (
+    ActionId,
     DataConditionGroupId,
+    DetectorId,
+    GroupId,
     WorkflowEventData,
     WorkflowId,
 )
@@ -50,14 +53,63 @@ class WorkflowEvaluationData(TypedDict):
 
     # TODO - Should this also include the DetectorWorkflow information?
 
+    `trigger_group_id`: The condition group used to trigger the workflow, if present.
     `trigger_group_eval`: The evaluation of the conditions for triggering a workflow.
-    `filter_group_evals`: All of the condition groups that determine if an action should be triggered.
+    `filter_group_evals`: Action-filter evaluations keyed by condition group ID.
     `event`: The data that started the workflow's evaluation.
     """
 
+    trigger_group_id: DataConditionGroupId | None
     trigger_group_eval: DataConditionGroupEvaluation
-    filter_group_evals: Sequence[DataConditionGroupEvaluation]
+    filter_group_evals: Mapping[DataConditionGroupId, DataConditionGroupEvaluation]
     event: WorkflowEventData
+
+
+def _condition_group_artifact(
+    condition_group_id: DataConditionGroupId | None,
+    evaluation: DataConditionGroupEvaluation,
+) -> dict[str, object]:
+    return {
+        "condition_group_id": condition_group_id,
+        **evaluation.to_artifact(),
+    }
+
+
+def build_workflow_evaluation_artifact_fields(
+    *,
+    phase: EvaluationPhase,
+    workflow_id: WorkflowId,
+    detector_id: DetectorId | None,
+    detector_type: str | None,
+    project_id: int | None,
+    event_id: str | None,
+    group_id: GroupId,
+    outcome: WorkflowEvaluationOutcome,
+    triggered_action_ids: Sequence[ActionId],
+    trigger_group_id: DataConditionGroupId | None,
+    trigger_group_evaluation: DataConditionGroupEvaluation,
+    filter_group_evaluations: Mapping[DataConditionGroupId, DataConditionGroupEvaluation],
+) -> dict[str, object]:
+    """Build the fields shared by initial and delayed workflow evaluation artifacts."""
+    return {
+        "evaluation_type": EvaluationType.WORKFLOW,
+        "evaluation_phase": phase,
+        "workflow_id": workflow_id,
+        "detector_id": detector_id,
+        "detector_type": detector_type,
+        "project_id": project_id,
+        "event_id": event_id,
+        "group_id": group_id,
+        "outcome": outcome,
+        "triggered_action_ids": list(triggered_action_ids),
+        "trigger_group_evaluation": _condition_group_artifact(
+            trigger_group_id, trigger_group_evaluation
+        ),
+        "filter_group_evaluations": [
+            _condition_group_artifact(condition_group_id, evaluation)
+            for condition_group_id, evaluation in sorted(filter_group_evaluations.items())
+        ],
+    }
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -86,7 +138,9 @@ class WorkflowEvaluation(
     def outcome(self) -> WorkflowEvaluationOutcome:
         if isinstance(self.result, DeferredWorkflowEvaluationResult):
             return WorkflowEvaluationOutcome.DEFERRED
-        if self.error or any(evaluation.error for evaluation in self.data["filter_group_evals"]):
+        if self.error or any(
+            evaluation.error for evaluation in self.data["filter_group_evals"].values()
+        ):
             return WorkflowEvaluationOutcome.ERROR
         if not self.triggered:
             return WorkflowEvaluationOutcome.NOT_TRIGGERED
@@ -114,23 +168,23 @@ class WorkflowEvaluation(
             if isinstance(event_data.event, GroupEvent)
             else event_data.event.id
         )
-        return {
-            "evaluation_type": EvaluationType.WORKFLOW,
-            "evaluation_phase": EvaluationPhase.INITIAL,
-            "workflow_id": self.workflow_id,
-            "detector_id": self.detector_id,
-            "detector_type": self.detector_type,
-            "project_id": event_data.event.project_id,
-            "event_id": str(event_id) if event_id else None,
-            "group_id": event_data.group.id,
-            "outcome": self.outcome,
-            "triggered_action_ids": triggered_action_ids,
-            **({"deferred": deferred} if deferred else {}),
-            "trigger_group_evaluation": self.data.get("trigger_group_eval").to_artifact(),
-            "filter_group_evaluations": [
-                evaluation.to_artifact() for evaluation in self.data.get("filter_group_evals")
-            ],
-        }
+        artifact = build_workflow_evaluation_artifact_fields(
+            phase=EvaluationPhase.INITIAL,
+            workflow_id=self.workflow_id,
+            detector_id=self.detector_id,
+            detector_type=self.detector_type,
+            project_id=event_data.event.project_id,
+            event_id=str(event_id) if event_id else None,
+            group_id=event_data.group.id,
+            outcome=self.outcome,
+            triggered_action_ids=triggered_action_ids,
+            trigger_group_id=self.data["trigger_group_id"],
+            trigger_group_evaluation=self.data["trigger_group_eval"],
+            filter_group_evaluations=self.data["filter_group_evals"],
+        )
+        if deferred is not None:
+            artifact["deferred"] = deferred
+        return artifact
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -259,7 +259,7 @@ def evaluate_workflows_action_filters(
     set[DataConditionGroup],
     dict[Workflow, DelayedWorkflowItem],
     EvaluationStats,
-    dict[Workflow, list[DataConditionGroupEvaluation]],
+    dict[Workflow, dict[int, DataConditionGroupEvaluation]],
 ]:
     """
     Evaluate the action filters for the given workflows.
@@ -304,7 +304,9 @@ def evaluate_workflows_action_filters(
     workflow_to_result: dict[int, DataConditionGroupEvaluation] = {
         wf.id: result for wf, result in triggered_workflows.items()
     }
-    filter_evals_by_workflow: dict[Workflow, list[DataConditionGroupEvaluation]] = defaultdict(list)
+    filter_evals_by_workflow: dict[Workflow, dict[int, DataConditionGroupEvaluation]] = defaultdict(
+        dict
+    )
     for action_condition_group, workflow in action_conditions_to_workflow.items():
         with log_context.new_context(
             workflow_id=workflow.id,
@@ -317,7 +319,7 @@ def evaluate_workflows_action_filters(
                 workflow_event_data,
                 data_conditions_by_dcg_id.get(action_condition_group.id),
             )
-            filter_evals_by_workflow[workflow].append(group_evaluation)
+            filter_evals_by_workflow[workflow][action_condition_group.id] = group_evaluation
 
             if slow_conditions:
                 # If there are remaining conditions for the action filter to evaluate,
@@ -443,7 +445,7 @@ def _build_workflow_evaluations(
     detector: Detector,
     event_data: WorkflowEventData,
     trigger_evals: dict[Workflow, DataConditionGroupEvaluation],
-    filter_evals: dict[Workflow, list[DataConditionGroupEvaluation]],
+    filter_evals: dict[Workflow, dict[int, DataConditionGroupEvaluation]],
     delayed_items: dict[Workflow, DelayedWorkflowItem],
     actions: Iterable[Action],
     action_to_workflow_id: dict[int, WorkflowId],
@@ -484,14 +486,15 @@ def _build_workflow_evaluations(
             or next(
                 (
                     evaluation.error
-                    for evaluation in filter_evals.get(workflow, [])
+                    for evaluation in filter_evals.get(workflow, {}).values()
                     if evaluation.error
                 ),
                 None,
             ),
             data={
+                "trigger_group_id": workflow.when_condition_group_id,
                 "trigger_group_eval": trigger_eval,
-                "filter_group_evals": filter_evals.get(workflow, []),
+                "filter_group_evals": filter_evals.get(workflow, {}),
                 "event": event_data,
             },
         )

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -666,6 +666,10 @@ def process_workflows(
     )
     (trigger_stats + action_stats).report_metrics("process_workflows.workflows_evaluated")
 
+    for delayed_item in delayed_items_by_workflow.values():
+        delayed_item.detector_id = associated_detector.id
+        delayed_item.detector_type = associated_detector.type
+
     enqueue_workflows(batch_client, delayed_items_by_workflow)
 
     actions, action_to_workflow_id = filter_recently_fired_workflow_actions(

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -5,6 +5,7 @@ from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.processors.evaluation_logging import (
+    emit_delayed_workflow_evaluation_logs,
     emit_workflow_evaluation_logs,
     should_log,
 )
@@ -12,6 +13,7 @@ from sentry.workflow_engine.processors.evaluations import (
     DataConditionEvaluation,
     DataConditionGroupEvaluation,
     DeferredWorkflowEvaluationResult,
+    DelayedWorkflowEvaluation,
     EvaluationPhase,
     EvaluationType,
     ProcessWorkflowsResult,
@@ -171,6 +173,91 @@ class TestWorkflowEvaluationArtifact(TestCase):
             }
         ]
 
+    def test_delayed_evaluation_artifact_matches_workflow_fields(self) -> None:
+        condition = self.create_data_condition()
+        trigger_evaluation = DataConditionGroupEvaluation(
+            result=True,
+            triggered=True,
+            data={
+                "condition_evaluations": [],
+                "logic_type": DataConditionGroup.Type.ANY,
+            },
+        )
+        filter_evaluation = DataConditionGroupEvaluation(
+            result=True,
+            triggered=True,
+            data={
+                "condition_evaluations": [
+                    DataConditionEvaluation(
+                        condition=condition,
+                        result=True,
+                        triggered=True,
+                        data=[101],
+                    )
+                ],
+                "logic_type": DataConditionGroup.Type.ALL,
+            },
+        )
+        evaluation = DelayedWorkflowEvaluation(
+            workflow_id=10,
+            detector_id=self.detector.id,
+            detector_type=self.detector.type,
+            project_id=self.project.id,
+            group_id=self.group.id,
+            event_id=self.event.event_id,
+            trigger_group_id=20,
+            trigger_group_evaluation=trigger_evaluation,
+            filter_group_evaluations={30: filter_evaluation},
+            passing_filter_group_ids=frozenset({40}),
+            missing_condition_group_ids=frozenset(),
+            triggered_action_ids=(50,),
+        )
+
+        assert evaluation.to_artifact() == {
+            "evaluation_type": EvaluationType.WORKFLOW,
+            "evaluation_phase": EvaluationPhase.DELAYED,
+            "workflow_id": 10,
+            "detector_id": self.detector.id,
+            "detector_type": self.detector.type,
+            "project_id": self.project.id,
+            "group_id": self.group.id,
+            "event_id": self.event.event_id,
+            "outcome": WorkflowEvaluationOutcome.ACTIONS_TRIGGERED,
+            "triggered": True,
+            "error": None,
+            "triggered_action_ids": [50],
+            "trigger_group_evaluation": {
+                "condition_group_id": 20,
+                "logic_type": DataConditionGroup.Type.ANY,
+                "result": True,
+                "condition_evaluations": [],
+                "triggered": True,
+                "error": None,
+            },
+            "filter_group_evaluations": [
+                {
+                    "condition_group_id": 30,
+                    "logic_type": DataConditionGroup.Type.ALL,
+                    "result": True,
+                    "condition_evaluations": [
+                        {
+                            "condition_id": condition.id,
+                            "condition_type": condition.type,
+                            "input_type": "list",
+                            "input": None,
+                            "result": True,
+                            "triggered": True,
+                            "error": None,
+                        }
+                    ],
+                    "triggered": True,
+                    "error": None,
+                }
+            ],
+            "passing_filter_group_ids": [40],
+            "missing_condition_group_ids": [],
+        }
+
     def test_condition_artifact_excludes_raw_input_data(self) -> None:
         condition = self.create_data_condition()
         evaluation = DataConditionEvaluation(
@@ -203,6 +290,50 @@ class TestWorkflowEvaluationArtifact(TestCase):
         )
 
         assert evaluation.to_artifact()["input"] == "production"
+
+    def test_delayed_emitter_uses_targeted_workflow_id(self) -> None:
+        evaluation = DelayedWorkflowEvaluation(
+            workflow_id=10,
+            detector_id=self.detector.id,
+            detector_type=self.detector.type,
+            project_id=self.project.id,
+            group_id=self.group.id,
+            event_id=self.event.event_id,
+            trigger_group_id=None,
+            trigger_group_evaluation=DataConditionGroupEvaluation(
+                result=True,
+                triggered=True,
+                data={
+                    "condition_evaluations": [],
+                    "logic_type": DataConditionGroup.Type.ANY,
+                },
+            ),
+            filter_group_evaluations={},
+            passing_filter_group_ids=frozenset(),
+            missing_condition_group_ids=frozenset(),
+        )
+        mock_logger = mock.MagicMock()
+
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": False}),
+            override_options(
+                {
+                    "workflow_engine.evaluation_log_target_workflow_ids": [10],
+                    "workflow_engine.evaluation_log_sample_rate": 0.0,
+                    "workflow_engine.evaluation_logs_direct_to_sentry": False,
+                }
+            ),
+        ):
+            assert emit_delayed_workflow_evaluation_logs(
+                mock_logger,
+                organization=self.organization,
+                evaluations=[evaluation],
+            )
+
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_delayed_workflows.evaluation",
+            extra={**evaluation.to_artifact(), "organization_id": self.organization.id},
+        )
 
     def test_emitter_always_logs_with_feature_enabled(self) -> None:
         evaluation = self._build_evaluation()

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -45,7 +45,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
         error: ConditionError | None = None,
         deferred: bool = False,
         workflow_id: int = 10,
-        filter_group_evaluations: list[DataConditionGroupEvaluation] | None = None,
+        filter_group_evaluations: dict[int, DataConditionGroupEvaluation] | None = None,
     ) -> WorkflowEvaluation:
         trigger_evaluation = DataConditionGroupEvaluation(
             result=triggered,
@@ -72,8 +72,9 @@ class TestWorkflowEvaluationArtifact(TestCase):
             triggered=triggered,
             error=error,
             data={
+                "trigger_group_id": 20,
                 "trigger_group_eval": trigger_evaluation,
-                "filter_group_evals": filter_group_evaluations or [],
+                "filter_group_evals": filter_group_evaluations or {},
                 "event": self.event_data,
             },
         )
@@ -113,6 +114,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             "outcome": WorkflowEvaluationOutcome.ERROR,
             "triggered_action_ids": [],
             "trigger_group_evaluation": {
+                "condition_group_id": 20,
                 "triggered": True,
                 "error": "evaluation failed",
                 "logic_type": DataConditionGroup.Type.ANY,
@@ -154,10 +156,20 @@ class TestWorkflowEvaluationArtifact(TestCase):
         )
         evaluation = self._build_evaluation(
             triggered=True,
-            filter_group_evaluations=[filter_evaluation],
+            filter_group_evaluations={30: filter_evaluation},
         )
 
         assert evaluation.outcome == WorkflowEvaluationOutcome.ERROR
+        assert evaluation.to_artifact()["filter_group_evaluations"] == [
+            {
+                "condition_group_id": 30,
+                "logic_type": DataConditionGroup.Type.ANY,
+                "result": False,
+                "condition_evaluations": [],
+                "triggered": False,
+                "error": "action filter failed",
+            }
+        ]
 
     def test_condition_artifact_excludes_raw_input_data(self) -> None:
         condition = self.create_data_condition()

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -45,6 +45,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     EventRedisData,
     GroupQueryParams,
     UniqueConditionQuery,
+    _process_workflows_for_project,
     bulk_fetch_events,
     cleanup_redis_buffer,
     fetch_project,
@@ -56,6 +57,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     get_group_to_groupevent,
     get_groups_to_fire,
 )
+from sentry.workflow_engine.processors.evaluations import DelayedWorkflowEvaluation
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
@@ -708,7 +710,9 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             events={
                 EventKey.from_redis_key(
                     f"{self.workflow1.id}:{self.group1.id}:{self.workflow1.when_condition_group_id}:{self.workflow1_if_dcgs[0].id}:{self.workflow1_if_dcgs[1].id}"
-                ): EventInstance(event_id="test-event-1"),
+                ): EventInstance(
+                    event_id="test-event-1", detector_id=123, detector_type="test-detector"
+                ),
                 EventKey.from_redis_key(
                     f"{self.workflow2.id}:{self.group2.id}:{self.workflow2.when_condition_group_id}:{self.workflow2_if_dcgs[0].id}:{self.workflow2_if_dcgs[1].id}"
                 ): EventInstance(event_id="test-event-2"),
@@ -725,6 +729,25 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             self.condition_group_results,
             self.dcg_to_slow_conditions,
         )
+
+        assert len(eval_result.evaluations) == 2
+        first_evaluation = eval_result.evaluations[0]
+        assert isinstance(first_evaluation, DelayedWorkflowEvaluation)
+        assert first_evaluation.workflow_id == self.workflow1.id
+        assert first_evaluation.detector_id == 123
+        assert first_evaluation.detector_type == "test-detector"
+        assert first_evaluation.project_id is None
+        assert first_evaluation.group_id == self.group1.id
+        assert first_evaluation.event_id == "test-event-1"
+        assert (
+            first_evaluation.trigger_group_id == self.workflow1.when_condition_group_id  # pyright: ignore[reportAttributeAccessIssue]
+        )
+        assert first_evaluation.trigger_group_evaluation.triggered
+        assert set(first_evaluation.filter_group_evaluations) == {self.workflow1_if_dcgs[0].id}
+        assert first_evaluation.passing_filter_group_ids == frozenset(
+            {self.workflow1_if_dcgs[1].id}
+        )
+        assert first_evaluation.missing_condition_group_ids == frozenset()
 
         # NOTE: no WHEN DCGs. We only collect IF DCGs here to fire their actions in the fire_actions_for_groups function
         assert (
@@ -918,21 +941,55 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         assert eval_result.stats.untainted == 3
 
 
+class TestProcessWorkflowsForProject(TestDelayedWorkflowBase):
+    def test_no_condition_queries_skips_evaluation_and_actions(self) -> None:
+        event_data = EventRedisData(
+            events={
+                EventKey.from_redis_key(
+                    f"{self.workflow1.id}:{self.group1.id}:"
+                    f"{self.workflow1.when_condition_group_id}:"  # pyright: ignore[reportAttributeAccessIssue]
+                    f":{self.workflow1_if_dcgs[1].id}"
+                ): EventInstance(event_id=self.event1.event_id)
+            }
+        )
+
+        with (
+            patch(
+                "sentry.workflow_engine.processors.delayed_workflow.get_condition_query_groups",
+                return_value={},
+            ),
+            patch(
+                "sentry.workflow_engine.processors.delayed_workflow.get_groups_to_fire"
+            ) as mock_get_groups_to_fire,
+            patch(
+                "sentry.workflow_engine.processors.delayed_workflow.fire_actions_for_groups"
+            ) as mock_fire_actions_for_groups,
+            patch(
+                "sentry.workflow_engine.processors.delayed_workflow.emit_delayed_workflow_evaluation_logs"
+            ) as mock_emit_evaluation_logs,
+        ):
+            _process_workflows_for_project(self.project, event_data)
+
+        mock_get_groups_to_fire.assert_not_called()
+        mock_fire_actions_for_groups.assert_not_called()
+        mock_emit_evaluation_logs.assert_not_called()
+
+
 class TestFireActionsForGroups(TestDelayedWorkflowBase):
     def setUp(self) -> None:
         super().setUp()
 
-        action1 = self.create_action(
+        self.action1 = self.create_action(
             type=Action.Type.DISCORD,
             integration_id="1234567890",
             config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )
         self.create_data_condition_group_action(
-            condition_group=self.workflow1_if_dcgs[0], action=action1
+            condition_group=self.workflow1_if_dcgs[0], action=self.action1
         )
 
-        action2 = self.create_action(
+        self.action2 = self.create_action(
             type=Action.Type.SLACK,
             integration_id="1234567890",
             data={"tags": "environment,user", "notes": "Important alert"},
@@ -943,7 +1000,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             },
         )
         self.create_data_condition_group_action(
-            condition_group=self.workflow2_if_dcgs[0], action=action2
+            condition_group=self.workflow2_if_dcgs[0], action=self.action2
         )
 
         self.groups_to_dcgs = {
@@ -983,12 +1040,16 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
     @patch("sentry.workflow_engine.tasks.actions.trigger_action.apply_async")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger: MagicMock) -> None:
-        fire_actions_for_groups(
+        action_ids_by_workflow_and_group = fire_actions_for_groups(
             self.project.organization,
             self.groups_to_dcgs,
             self.group_to_groupevent,
         )
 
+        assert action_ids_by_workflow_and_group == {
+            (self.workflow1.id, self.group1.id): {self.action1.id},
+            (self.workflow2.id, self.group2.id): {self.action2.id},
+        }
         assert mock_trigger.call_count == 2
 
         # First call should be for workflow1/group1
@@ -1146,6 +1207,12 @@ class TestEventKeyAndInstance:
         instance = EventInstance(event_id="test-event")
         assert instance.event_id == "test-event"
         assert instance.occurrence_id is None
+        assert instance.detector_id is None
+        assert instance.detector_type is None
+
+        instance = EventInstance(event_id="test-event", detector_id=123, detector_type="test")
+        assert instance.detector_id == 123
+        assert instance.detector_type == "test"
 
         # Test with occurrence ID
         instance = EventInstance(event_id="test-event", occurrence_id="test-occurrence")


### PR DESCRIPTION
## Description
Add Evaluation logs to the slow condition evaluations.

This will allow us to filter on a `workflow_id` in the sentry logs, seeing each workflows evaluation and understand if there's a problem where and how to fix it. This also will help us quickly identify and troubleshoot user configuration issues.