### PR TITLE
ref(pr-metrics): Register permanent organizations:pr-metrics flag

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -142,6 +142,11 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:integrations-issue-sync": FlagpoleFeature(default=True, api_expose=True),
         # Signals that the organization supports the on demand metrics prefill.
         "organizations:on-demand-metrics-prefill": FlagpoleFeature(default=False, api_expose=True),
+        # Track PR lifecycle activity and emit PR Merge Live Metrics. Permanent
+        # rather than a rollout flag: customer single-tenants run a noop analytics
+        # backend, so emission has nowhere to land and the pipeline stays excluded
+        # there indefinitely. Default off keeps self-hosted on today's behavior.
+        "organizations:pr-metrics": FlagpoleFeature(default=False),
     }
 
     # Permanent project features that are controlled via flagpole. These are


### PR DESCRIPTION
### Problem

The PR Merge Live Metrics pipeline is gated by four `organizations:pr-metrics-*` stage flags
(`-activity`, `-attribution`, `-emit`, `-judge`). All four are at 100% GA in flagpole and differ
only in that each carries the same `not_in sentry_cell: *_customer_single_tenants` condition.
They are staged-rollout flags with no rollout left to do.

(A fifth, `-activity-document`, is not a rollout flag — it routes activity writes between the
legacy row store and the per-PR document, so it stays. See #121939 for why.)

The single-tenant exclusion is not a rollout step that will finish. Customer STs are legacy
monoliths with their own GitHub Apps, and gen-ai/Seer is enabled there, so the pipeline really
would run — but their analytics backend is a noop, so the BigQuery emission the pipeline exists
to produce has nowhere to land, and the judge would burn Seer compute on verdicts nothing
consumes. That exclusion needs a permanent home.

### Approach

Register a single permanent `organizations:pr-metrics` flag to carry the exclusion, so the four
temporary stage flags can be deleted rather than left registered forever.

This PR is registration only — nothing checks the flag yet. The order matters: an unconfigured
flagpole flag evaluates false, so swapping the existing checks before the flagpole config exists
would dark-window the whole pipeline while the deploy rolls.

1. **this PR** — register `organizations:pr-metrics` in `permanent.py`
2. [sentry-options-automator#9217](https://github.com/getsentry/sentry-options-automator/pull/9217)
   — its flagpole config (GA 100%, ST exclusion, comment recording why the exclusion is permanent)
3. [#121939](https://github.com/getsentry/sentry/pull/121939) — point the `pr-metrics-*` checks at
   the new flag
4. cleanup — drop the stage flags from flagpole, then from `temporary.py`

`api_expose=False` matches the stage flags it replaces (nothing in the frontend reads them).
`default=False` keeps self-hosted exactly where it is today — the flags are all flagpole-only, so
self-hosted has never had this behavior. The separate self-hosted enablement ticket can flip the
default when it lands.

### Notes

- The judge is only reachable through the emit path (single caller chain), so one flag covers it;
  it keeps its independent `has_seer_access` gate regardless.
- `s4s2` is an ST *cell*, not a customer ST — already at 100%, unaffected.
- Future multi-region STs inherit the feature automatically.

Refs CORE-298

