### PR TITLE
perf(dynamic-sampling): use chunking in batch pre-validate for CursoredScheduler & check the feature flag before spawning per-org tasks in DS

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
 import sentry_sdk
@@ -54,6 +55,7 @@ from sentry.dynamic_sampling.per_org.telemetry import (
 )
 from sentry.dynamic_sampling.rules.utils import OrganizationId
 from sentry.dynamic_sampling.tasks.common import get_organization_volume
+from sentry.dynamic_sampling.utils import org_ids_with_dynamic_sampling
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
@@ -271,6 +273,18 @@ def schedule_per_org_calculations() -> None:
         dispatched += 1
         return True
 
+    def keep_orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
+        # Checked once per cycle instead of on every dispatch, because a per-org feature
+        # check on every tick is too expensive. An org that gains or loses the feature
+        # mid-cycle keeps its previous state until the next snapshot.
+        kept = org_ids_with_dynamic_sampling(organizations)
+        emit_status(
+            SCHEDULER_BUCKET_ORG_STATUS_METRIC,
+            DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING,
+            amount=len(organizations) - len(kept),
+        )
+        return kept
+
     scheduler = CursoredScheduler(
         name="ds_per_org",
         schedule_key="dynamic-sampling-schedule-per-org-calculations",
@@ -288,6 +302,7 @@ def schedule_per_org_calculations() -> None:
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
+        prevalidate_batch=keep_orgs_with_dynamic_sampling,
         preserve_queryset_order=True,
     )
     scheduler.tick()

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -275,9 +275,9 @@ def schedule_per_org_calculations() -> None:
         return True
 
     def keep_orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
-        # An empty result means the check failed, which would otherwise read as "none of them".
+        # A None result means the check failed, which would otherwise read as "none of them".
         results = features.batch_has_for_organizations(DYNAMIC_SAMPLING_FEATURE, organizations)
-        if not results:
+        if results is None:
             raise RuntimeError(f"Unable to evaluate {DYNAMIC_SAMPLING_FEATURE} for a batch of orgs")
 
         kept = [org.id for org in organizations if results.get(f"organization:{org.id}", False)]

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -9,6 +9,7 @@ from django.db.models import Exists, F, OuterRef
 from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.calculations import (
@@ -55,7 +56,7 @@ from sentry.dynamic_sampling.per_org.telemetry import (
 )
 from sentry.dynamic_sampling.rules.utils import OrganizationId
 from sentry.dynamic_sampling.tasks.common import get_organization_volume
-from sentry.dynamic_sampling.utils import org_ids_with_dynamic_sampling
+from sentry.dynamic_sampling.utils import DYNAMIC_SAMPLING_FEATURE
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
@@ -274,7 +275,12 @@ def schedule_per_org_calculations() -> None:
         return True
 
     def keep_orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
-        kept = org_ids_with_dynamic_sampling(organizations)
+        # An empty result means the check failed, which would otherwise read as "none of them".
+        results = features.batch_has_for_organizations(DYNAMIC_SAMPLING_FEATURE, organizations)
+        if not results:
+            raise RuntimeError(f"Unable to evaluate {DYNAMIC_SAMPLING_FEATURE} for a batch of orgs")
+
+        kept = [org.id for org in organizations if results.get(f"organization:{org.id}", False)]
         emit_status(
             SCHEDULER_BUCKET_ORG_STATUS_METRIC,
             DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING,

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -274,9 +274,6 @@ def schedule_per_org_calculations() -> None:
         return True
 
     def keep_orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
-        # Checked once per cycle instead of on every dispatch, because a per-org feature
-        # check on every tick is too expensive. An org that gains or loses the feature
-        # mid-cycle keeps its previous state until the next snapshot.
         kept = org_ids_with_dynamic_sampling(organizations)
         emit_status(
             SCHEDULER_BUCKET_ORG_STATUS_METRIC,

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from django.contrib.auth.models import AnonymousUser
 
 from sentry import features
@@ -7,14 +9,37 @@ from sentry.models.organization import Organization
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 
+DYNAMIC_SAMPLING_FEATURE = "organizations:dynamic-sampling"
+
 
 def has_dynamic_sampling(
     organization: Organization | None, actor: User | RpcUser | AnonymousUser | None = None
 ) -> bool:
     # If an organization can't be fetched, we will assume it has no dynamic sampling.
     return organization is not None and features.has(
-        "organizations:dynamic-sampling", organization, actor=actor
+        DYNAMIC_SAMPLING_FEATURE, organization, actor=actor
     )
+
+
+def org_ids_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
+    """The batched form of has_dynamic_sampling, for callers that check many organizations
+    at once. Returns the ids of those that have it, in the order they were given.
+
+    Raises on an empty result, because the alternative is to silently treat every
+    organization as if it had no dynamic sampling.
+    """
+    if not organizations:
+        return []
+
+    results = features.batch_has_for_organizations(DYNAMIC_SAMPLING_FEATURE, organizations)
+    if not results:
+        raise RuntimeError(f"Unable to evaluate {DYNAMIC_SAMPLING_FEATURE} for a batch of orgs")
+
+    return [
+        organization.id
+        for organization in organizations
+        if results.get(f"organization:{organization.id}", False)
+    ]
 
 
 def has_custom_dynamic_sampling(

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,5 +1,3 @@
-from collections.abc import Sequence
-
 from django.contrib.auth.models import AnonymousUser
 
 from sentry import features
@@ -19,25 +17,6 @@ def has_dynamic_sampling(
     return organization is not None and features.has(
         DYNAMIC_SAMPLING_FEATURE, organization, actor=actor
     )
-
-
-def org_ids_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
-    """The batched form of has_dynamic_sampling. Returns the ids that have it, in the
-    order they were given, and raises on an empty result: the batch check returns an
-    empty mapping on error, which would otherwise read as "none of them".
-    """
-    if not organizations:
-        return []
-
-    results = features.batch_has_for_organizations(DYNAMIC_SAMPLING_FEATURE, organizations)
-    if not results:
-        raise RuntimeError(f"Unable to evaluate {DYNAMIC_SAMPLING_FEATURE} for a batch of orgs")
-
-    return [
-        organization.id
-        for organization in organizations
-        if results.get(f"organization:{organization.id}", False)
-    ]
 
 
 def has_custom_dynamic_sampling(

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -22,11 +22,9 @@ def has_dynamic_sampling(
 
 
 def org_ids_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
-    """The batched form of has_dynamic_sampling, for callers that check many organizations
-    at once. Returns the ids of those that have it, in the order they were given.
-
-    Raises on an empty result, because the alternative is to silently treat every
-    organization as if it had no dynamic sampling.
+    """The batched form of has_dynamic_sampling. Returns the ids that have it, in the
+    order they were given, and raises on an empty result: the batch check returns an
+    empty mapping on error, which would otherwise read as "none of them".
     """
     if not organizations:
         return []

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -54,9 +54,10 @@ It runs on every item of every tick, and an item it rejects is not dispatched.
 Use it for a check that must see the state at dispatch time.
 
 Optional prevalidate_batch callback, for a batched check at cycle start. It
-receives the queryset's rows and returns the PKs to keep:
+receives the queryset's rows and returns the PKs to keep, in the order it got
+them:
 
-    def has_my_feature(orgs: Sequence[Organization]) -> Collection[int]:
+    def has_my_feature(orgs: Sequence[Organization]) -> Sequence[int]:
         results = features.batch_has_for_organizations("organizations:my-feature", orgs)
         return [org.id for org in orgs if results[f"organization:{org.id}"]]
 
@@ -65,10 +66,11 @@ receives the queryset's rows and returns the PKs to keep:
         prevalidate_batch=has_my_feature,
     )
 
-It runs once per cycle, when the PK list is snapshotted. Only the PKs it keeps
-reach Redis, so the rest never occupy a batch and the check costs one
-cycle-start rather than time on every tick. The tradeoff is staleness: an item
-that stops qualifying mid-cycle is still dispatched until the next snapshot.
+It runs at cycle start, when the PK list is snapshotted, over chunks of at most
+PREVALIDATE_CHUNK_SIZE rows. Only the PKs it keeps reach Redis, so the rest
+never occupy a batch and the check costs one cycle-start rather than time on
+every tick. The tradeoff is staleness: an item that stops qualifying mid-cycle
+is still dispatched until the next snapshot.
 
 Getting the rows rather than their PKs means a check that needs more than the PK —
 a feature flag, an option — does not have to fetch them back. Setting it makes the
@@ -85,7 +87,7 @@ import logging
 import math
 import random
 import time
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Sequence
 from datetime import timedelta
 
 from django.conf import settings
@@ -109,6 +111,10 @@ LOCK_PREFIX = "cursored_scheduler_lock"
 DEFAULT_LOCK_DURATION_SECONDS = 120
 MIN_BATCH_SIZE = 1
 RPUSH_CHUNK_SIZE = 10_000
+# How many rows a single prevalidate_batch call gets. It bounds both the rows held in
+# memory at cycle start and the size of whatever query the check runs per call, which
+# matters for a queryset of millions of rows.
+PREVALIDATE_CHUNK_SIZE = 10_000
 
 
 def _get_tick_interval(schedule_key: str) -> timedelta:
@@ -164,7 +170,7 @@ class CursoredScheduler[M: Model]:
         cycle_duration: timedelta,
         lock_duration: int = DEFAULT_LOCK_DURATION_SECONDS,
         validate_item: Callable[[int], bool] | None = None,
-        prevalidate_batch: Callable[[Sequence[M]], Collection[int]] | None = None,
+        prevalidate_batch: Callable[[Sequence[M]], Sequence[int]] | None = None,
         shuffle: bool = False,
         preserve_queryset_order: bool = False,
     ):
@@ -264,15 +270,18 @@ class CursoredScheduler[M: Model]:
 
     def _prevalidated_pks(self, queryset: QuerySet[M]) -> list[int]:
         """
-        Apply the batch prevalidation function to the queryset.
+        Apply the batch prevalidation function to the queryset, one chunk at a time.
         If no prevalidation function is provided, return the PKs in queryset order.
         """
         if self.prevalidate_batch is None:
             return list(queryset.values_list("pk", flat=True))
 
-        rows = list(queryset)
-        kept = set(self.prevalidate_batch(rows))
-        return [row.pk for row in rows if row.pk in kept]
+        prevalidated_pks: list[int] = []
+        for rows in chunked(
+            queryset.iterator(chunk_size=PREVALIDATE_CHUNK_SIZE), PREVALIDATE_CHUNK_SIZE
+        ):
+            prevalidated_pks.extend(self.prevalidate_batch(rows))
+        return prevalidated_pks
 
     def _initialize_cycle(self) -> int:
         init_start = time.time()

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -15,6 +15,7 @@ persists across invocations. A distributed lock prevents overlapping ticks.
 Usage:
 
     from datetime import timedelta
+from typing import Any
     from sentry.utils.cursored_scheduler import CursoredScheduler
 
     # my_module/tasks.py
@@ -89,6 +90,7 @@ import random
 import time
 from collections.abc import Callable, Sequence
 from datetime import timedelta
+from typing import Any
 
 from django.conf import settings
 from django.core.cache import cache
@@ -99,6 +101,7 @@ from sentry.locks import locks
 from sentry.utils import metrics, redis
 from sentry.utils.iterators import chunked
 from sentry.utils.locking import UnableToAcquireLock
+from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -269,17 +272,24 @@ class CursoredScheduler[M: Model]:
     def _prevalidated_pks(self, queryset: QuerySet[M]) -> list[int]:
         """
         Apply the batch prevalidation function to the queryset, one chunk at a time.
-        If no prevalidation function is provided, return the PKs in queryset order.
+        Chunks are fetched by PK range (RangeQuerySetWrapper) because server-side
+        cursors from QuerySet.iterator() do not work through pgbouncer.
+        The returned PKs follow the queryset order.
         """
         if self.prevalidate_batch is None:
             return list(queryset.values_list("pk", flat=True))
 
-        prevalidated_pks: list[int] = []
-        for rows in chunked(
-            queryset.iterator(chunk_size=PREVALIDATE_CHUNK_SIZE), PREVALIDATE_CHUNK_SIZE
-        ):
-            prevalidated_pks.extend(self.prevalidate_batch(rows))
-        return prevalidated_pks
+        unordered: QuerySet[Any] = queryset.order_by()
+        rows_by_pk = RangeQuerySetWrapper[M](unordered, step=PREVALIDATE_CHUNK_SIZE)
+        kept_pks: list[int] = []
+        for rows in chunked(rows_by_pk, PREVALIDATE_CHUNK_SIZE):
+            kept_pks.extend(self.prevalidate_batch(rows))
+
+        if not self.preserve_queryset_order:
+            return kept_pks
+
+        kept = set(kept_pks)
+        return [pk for pk in queryset.values_list("pk", flat=True) if pk in kept]
 
     def _initialize_cycle(self) -> int:
         init_start = time.time()

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -111,9 +111,7 @@ LOCK_PREFIX = "cursored_scheduler_lock"
 DEFAULT_LOCK_DURATION_SECONDS = 120
 MIN_BATCH_SIZE = 1
 RPUSH_CHUNK_SIZE = 10_000
-# How many rows a single prevalidate_batch call gets. It bounds both the rows held in
-# memory at cycle start and the size of whatever query the check runs per call, which
-# matters for a queryset of millions of rows.
+# How many rows a single prevalidate_batch call gets.
 PREVALIDATE_CHUNK_SIZE = 10_000
 
 

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -15,7 +15,6 @@ persists across invocations. A distributed lock prevents overlapping ticks.
 Usage:
 
     from datetime import timedelta
-from typing import Any
     from sentry.utils.cursored_scheduler import CursoredScheduler
 
     # my_module/tasks.py

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import DEFAULT, Mock, patch
 
+import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
 from sentry.constants import ObjectStatus
@@ -134,6 +135,39 @@ class SchedulePerOrgCalculationsTest(TestCase):
         assert org_with_project.id in org_ids
         assert org_without_projects.id not in org_ids
         assert org_with_inactive_project.id not in org_ids
+
+    def _prevalidated_org_ids(self) -> set[int]:
+        """Run the real prevalidate_batch callback over every org in the queryset."""
+        with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:
+            MockScheduler.return_value.tick.return_value = False
+            schedule_per_org_calculations()
+
+            kwargs = MockScheduler.call_args.kwargs
+            return set(kwargs["prevalidate_batch"](list(kwargs["queryset"])))
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_skips_orgs_without_dynamic_sampling(self) -> None:
+        with_dynamic_sampling = self.create_organization()
+        self.create_project(organization=with_dynamic_sampling)
+        without_dynamic_sampling = self.create_organization()
+        self.create_project(organization=without_dynamic_sampling)
+
+        with self.feature({"organizations:dynamic-sampling": [with_dynamic_sampling.slug]}):
+            org_ids = self._prevalidated_org_ids()
+
+        assert with_dynamic_sampling.id in org_ids
+        assert without_dynamic_sampling.id not in org_ids
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_raises_when_the_feature_cannot_be_evaluated(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with (
+            patch("sentry.features.batch_has_for_organizations", return_value=None),
+            pytest.raises(RuntimeError),
+        ):
+            self._prevalidated_org_ids()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_org_in_rollout_is_dispatched(self) -> None:

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.cache import cache
@@ -18,6 +18,8 @@ from sentry.utils.cursored_scheduler import (
     _get_tick_interval,
 )
 from sentry.utils.redis import redis_clusters
+
+CURSORED_SCHEDULER = "sentry.utils.cursored_scheduler"
 
 TEST_SCHEDULES = {
     "test-scheduler-beat": {
@@ -400,6 +402,34 @@ class CursoredSchedulerTest(TestCase):
         assert dispatched_pks
         for pk in dispatched_pks:
             assert pk in even_pks
+
+    def test_prevalidate_batch_is_called_in_chunks(self):
+        """The rows are prevalidated a chunk at a time, so a huge queryset stays bounded."""
+        ois = self._create_org_integrations(5)
+        chunk_sizes = []
+
+        def record(rows):
+            chunk_sizes.append(len(rows))
+            return [oi.pk for oi in rows]
+
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=OrganizationIntegration.objects.filter(
+                integration__provider="github",
+                status=ObjectStatus.ACTIVE,
+            ),
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            prevalidate_batch=record,
+        )
+
+        with patch(f"{CURSORED_SCHEDULER}.PREVALIDATE_CHUNK_SIZE", 2):
+            scheduler.tick()
+
+        assert chunk_sizes == [2, 2, 1]
+        snapshot = [int(pk) for pk in self.redis_client.lrange(self.pk_list_key, 0, -1)]
+        assert snapshot == sorted(oi.pk for oi in ois)
 
     def test_validate_item_only_sees_prevalidated_items(self):
         """

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -650,6 +650,30 @@ class CursoredSchedulerTest(TestCase):
 
         assert all_dispatched == [oi.pk for oi in reversed(ois)]
 
+    def test_preserve_queryset_order_with_prevalidate_batch(self):
+        """Prevalidation runs by PK range, but the snapshot still follows the queryset order."""
+        ois = self._create_org_integrations(5)
+        even_pks = {oi.pk for oi in ois if oi.pk % 2 == 0}
+        queryset = OrganizationIntegration.objects.filter(
+            integration__provider="github",
+            status=ObjectStatus.ACTIVE,
+        ).order_by("-pk")
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=queryset,
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            prevalidate_batch=lambda rows: [oi.pk for oi in rows if oi.pk in even_pks],
+            preserve_queryset_order=True,
+        )
+
+        with patch(f"{CURSORED_SCHEDULER}.PREVALIDATE_CHUNK_SIZE", 2):
+            scheduler.tick()
+
+        snapshot = [int(pk) for pk in self.redis_client.lrange(self.pk_list_key, 0, -1)]
+        assert snapshot == sorted(even_pks, reverse=True)
+
     def test_interval_decrease_halves_batch_size(self):
         """When tick interval is halved, batch size is halved for remaining items."""
         self._create_org_integrations(30)


### PR DESCRIPTION
- Follow-up to https://github.com/getsentry/sentry/pull/121515
- Run batch pre-validation in batches of 10.000 to prevent holding too much in-memory
- Use the batch pre-validation for the dynamic sampling tasks

Contributes to TET-2820