### PR TITLE
fix(releases): delay wide comparison table layout

### DIFF
--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -1170,7 +1170,7 @@ const ChartTable = styled(PanelTable)<{withExpanders: boolean}>`
         p.withExpanders ? '75px' : ''};
   }
 
-  @container (min-width: ${p => p.theme.container['4xl']}) {
+  @container (min-width: ${p => p.theme.container['5xl']}) {
     && {
       grid-template-columns: minmax(400px, auto) repeat(
           3,


### PR DESCRIPTION
The releases comparison table and the page sidebar both switched to their wide layouts at the `4xl` container breakpoint. That leaves less room for the comparison values at the same moment the metric-name column begins reserving at least 400px.
