### PR TITLE
feat(explore): Gate metrics requests on validation

### DIFF
--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -10,6 +10,7 @@ import {
   useProgressiveQuery,
   type RPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {usePreserveMetricQueryResult} from 'sentry/views/explore/metrics/hooks/usePreserveMetricQueryResult';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricVisualize,
@@ -29,6 +30,7 @@ interface UseMetricAggregatesTableOptions {
   enabled: boolean;
   limit: number;
   traceMetric: TraceMetric;
+  preservePreviousData?: boolean;
   queryExtras?: RPCQueryExtras;
   staleTime?: number;
 }
@@ -53,6 +55,7 @@ export function useMetricAggregatesTable({
   traceMetric,
   queryExtras,
   staleTime,
+  preservePreviousData,
 }: UseMetricAggregatesTableOptions) {
   const visualize = useMetricVisualize();
   const canTriggerHighAccuracy = useCallback(
@@ -70,7 +73,7 @@ export function useMetricAggregatesTable({
     },
     [traceMetric, visualize]
   );
-  return useProgressiveQuery<typeof useMetricAggregatesTableImp>({
+  const result = useProgressiveQuery<typeof useMetricAggregatesTableImp>({
     queryHookImplementation: useMetricAggregatesTableImp,
     queryHookArgs: {
       enabled,
@@ -83,6 +86,12 @@ export function useMetricAggregatesTable({
       canTriggerHighAccuracy,
     },
   });
+
+  return usePreserveMetricQueryResult(
+    result,
+    Boolean(preservePreviousData),
+    result.result
+  );
 }
 
 function useMetricAggregatesTableImp({

--- a/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricSamplesTable.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react';
+import {keepPreviousData} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
@@ -20,6 +21,7 @@ import {
   AlwaysPresentTraceMetricFields,
   NONE_UNIT,
 } from 'sentry/views/explore/metrics/constants';
+import {usePreserveMetricQueryResult} from 'sentry/views/explore/metrics/hooks/usePreserveMetricQueryResult';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricsFrozenSearch,
@@ -44,12 +46,15 @@ interface UseMetricSamplesTableOptions {
   limit: number;
   disabled?: boolean;
   ingestionDelaySeconds?: number;
+  preservePreviousData?: boolean;
   queryExtras?: RPCQueryExtras;
   staleTime?: number;
   traceMetric?: TraceMetric;
 }
 
 interface MetricSamplesTableResult {
+  dataUpdatedAt: number;
+  errorUpdatedAt: number;
   result: {
     data: TraceMetricEventsResponseItem[] | undefined;
     isFetched: boolean;
@@ -219,6 +224,7 @@ export function useMetricSamplesTable({
   ingestionDelaySeconds,
   queryExtras,
   staleTime,
+  preservePreviousData,
 }: UseMetricSamplesTableOptions) {
   const canTriggerHighAccuracy = useCallback(
     (result: MetricSamplesTableResult['result']) => {
@@ -229,7 +235,7 @@ export function useMetricSamplesTable({
     []
   );
 
-  return useProgressiveQuery<typeof useMetricSamplesTableImpl>({
+  const result = useProgressiveQuery<typeof useMetricSamplesTableImpl>({
     queryHookImplementation: useMetricSamplesTableImpl,
     queryHookArgs: {
       enabled: !disabled,
@@ -239,10 +245,17 @@ export function useMetricSamplesTable({
       ingestionDelaySeconds,
       queryExtras,
       staleTime,
+      preservePreviousData,
     },
     queryOptions: {
       canTriggerHighAccuracy,
     },
+  });
+
+  return usePreserveMetricQueryResult(result, Boolean(preservePreviousData), {
+    dataUpdatedAt: result.dataUpdatedAt,
+    errorUpdatedAt: result.errorUpdatedAt,
+    isPending: Boolean(result.isPending),
   });
 }
 
@@ -254,6 +267,7 @@ function useMetricSamplesTableImpl({
   ingestionDelaySeconds = INGESTION_DELAY,
   queryExtras,
   staleTime,
+  preservePreviousData,
 }: UseMetricSamplesTableOptions & {enabled: boolean}): MetricSamplesTableResult {
   const {queryKey, other} = useMetricsQueryKey({
     limit,
@@ -266,11 +280,14 @@ function useMetricSamplesTableImpl({
 
   const result = useApiQuery<{data: any[]; meta?: EventsMetaType}>(queryKey, {
     enabled,
+    placeholderData: preservePreviousData ? keepPreviousData : undefined,
     staleTime: staleTime ?? getStaleTimeForEventView(other.eventView),
   });
 
   return {
+    dataUpdatedAt: result.dataUpdatedAt,
     error: result.error ?? undefined,
+    errorUpdatedAt: result.errorUpdatedAt,
     isError: result.isError,
     isFetching: result.isFetching,
     isPending: result.isPending,

--- a/static/app/views/explore/metrics/hooks/usePreserveMetricQueryResult.tsx
+++ b/static/app/views/explore/metrics/hooks/usePreserveMetricQueryResult.tsx
@@ -1,0 +1,28 @@
+import {useEffect, useEffectEvent, useState} from 'react';
+
+export function usePreserveMetricQueryResult<T>(
+  result: T,
+  preservePreviousData: boolean,
+  queryState: {
+    isPending: boolean;
+    dataUpdatedAt?: number;
+    errorUpdatedAt?: number;
+    resultVersion?: unknown;
+  }
+): T {
+  const [lastSettledResult, setLastSettledResult] = useState(result);
+  const updateLastSettledResult = useEffectEvent(() => setLastSettledResult(result));
+
+  useEffect(() => {
+    if (!queryState.isPending) {
+      updateLastSettledResult();
+    }
+  }, [
+    queryState.dataUpdatedAt,
+    queryState.errorUpdatedAt,
+    queryState.isPending,
+    queryState.resultVersion,
+  ]);
+
+  return preservePreviousData && queryState.isPending ? lastSettledResult : result;
+}

--- a/static/app/views/explore/metrics/hooks/useValidateMetricsTab.tsx
+++ b/static/app/views/explore/metrics/hooks/useValidateMetricsTab.tsx
@@ -30,7 +30,7 @@ export function useValidateMetricsTab({
   const groupBys = useQueryParamsGroupBys();
   const visualizes = useQueryParamsVisualizes({validate: true});
 
-  const {data, isFetching, isLoading, isPlaceholderData} = useQuery({
+  const {data, error, isFetching, isLoading, isPlaceholderData} = useQuery({
     ...validateEventParamsOptions({
       organization,
       selection,
@@ -54,6 +54,7 @@ export function useValidateMetricsTab({
 
   return {
     data,
+    error,
     isFetching,
     isPlaceholderData,
     isLoading,

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -1,16 +1,19 @@
 import {useMemo} from 'react';
 
-import {ExternalLink} from '@sentry/scraps/link';
-
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {plottablesCanBeVisualized} from 'sentry/views/dashboards/widgets/plottablesCanBeVisualized';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {ChartVisualization} from 'sentry/views/explore/components/chart/chartVisualization';
+import {
+  ChartVisualization,
+  useChartVisualizationPlottables,
+} from 'sentry/views/explore/components/chart/chartVisualization';
 import {ConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import {doesMetricSupportHeatMapVisualization} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -48,7 +51,6 @@ import {
   useSynchronizeCharts,
 } from 'sentry/views/insights/common/components/chart';
 import type {SortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
-import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 import {WidgetWrapper} from './styles';
 
@@ -224,8 +226,14 @@ function Graph({
     return title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
   }, [aggregate, metricLabel, metricName, visualizes.length, title]);
 
+  const plottables = useChartVisualizationPlottables(chartInfo);
   const showEmptyState = isMetricOptionsEmpty && visualize.visible;
   const showChart = visualize.visible && !isMetricOptionsEmpty;
+  const showFooter =
+    showChart &&
+    (timeseriesResult.isPending ||
+      timeseriesResult.isFetching ||
+      plottablesCanBeVisualized(plottables));
 
   const height = visualize.visible ? STACKED_GRAPH_HEIGHT : MINIMIZED_GRAPH_HEIGHT;
 
@@ -236,24 +244,13 @@ function Graph({
         Actions={actions}
         Visualization={
           showEmptyState ? (
-            <GenericWidgetEmptyStateWarning
-              message={tct(
-                'No application metrics found for this time period. If this is unexpected, try updating your filters or [link:learn more] about how to use application metrics.',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/explore/metrics/">
-                      {t('learn more')}
-                    </ExternalLink>
-                  ),
-                }
-              )}
-            />
+            <TimeSeriesWidgetVisualization.NoData />
           ) : showChart ? (
             <ChartVisualization chartInfo={chartInfo} />
           ) : undefined
         }
         Footer={
-          showChart ? (
+          showFooter ? (
             <ConfidenceFooter
               chartInfo={chartInfo}
               isLoading={timeseriesResult.isPending || timeseriesResult.isFetching}

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -92,6 +92,7 @@ interface MetricsGraphProps {
   actions: React.ReactNode;
   timeseriesResult: SortedTimeSeries;
   isMetricOptionsEmpty?: boolean;
+  queriesEnabled?: boolean;
   title?: string;
 }
 
@@ -99,6 +100,7 @@ export function MetricsGraph({
   timeseriesResult,
   actions,
   isMetricOptionsEmpty,
+  queriesEnabled,
   title,
 }: MetricsGraphProps) {
   const metricQueries = useMultiMetricsQueryParams();
@@ -118,6 +120,7 @@ export function MetricsGraph({
       timeseriesResult={timeseriesResult}
       actions={actions}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
+      queriesEnabled={queriesEnabled}
       title={title}
     />
   );
@@ -129,6 +132,7 @@ interface GraphProps {
   visualize: ReturnType<typeof useMetricVisualize>;
   visualizes: ReturnType<typeof useMetricVisualizes>;
   isMetricOptionsEmpty?: boolean;
+  queriesEnabled?: boolean;
   title?: string;
 }
 
@@ -138,6 +142,7 @@ function Graph({
   visualizes,
   actions,
   isMetricOptionsEmpty,
+  queriesEnabled,
   title,
 }: GraphProps) {
   const aggregate = visualize.yAxis;
@@ -149,8 +154,9 @@ function Graph({
   const rawMetricCounts = useRawCounts({
     dataset: DiscoverDatasets.TRACEMETRICS,
     enabled:
-      Boolean(traceMetric.name) ||
-      (isVisualizeEquation(visualize) && Boolean(visualize.expression.text)),
+      queriesEnabled !== false &&
+      (Boolean(traceMetric.name) ||
+        (isVisualizeEquation(visualize) && Boolean(visualize.expression.text))),
     query: isVisualizeEquation(visualize)
       ? getEquationMetricsTotalFilter(visualize.expression.text)
       : createTraceMetricEventsFilter([traceMetric]),

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -92,6 +92,7 @@ interface MetricsGraphProps {
   actions: React.ReactNode;
   timeseriesResult: SortedTimeSeries;
   isMetricOptionsEmpty?: boolean;
+  preservePreviousData?: boolean;
   queriesEnabled?: boolean;
   title?: string;
 }
@@ -100,6 +101,7 @@ export function MetricsGraph({
   timeseriesResult,
   actions,
   isMetricOptionsEmpty,
+  preservePreviousData,
   queriesEnabled,
   title,
 }: MetricsGraphProps) {
@@ -120,6 +122,7 @@ export function MetricsGraph({
       timeseriesResult={timeseriesResult}
       actions={actions}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
+      preservePreviousData={preservePreviousData}
       queriesEnabled={queriesEnabled}
       title={title}
     />
@@ -132,6 +135,7 @@ interface GraphProps {
   visualize: ReturnType<typeof useMetricVisualize>;
   visualizes: ReturnType<typeof useMetricVisualizes>;
   isMetricOptionsEmpty?: boolean;
+  preservePreviousData?: boolean;
   queriesEnabled?: boolean;
   title?: string;
 }
@@ -142,6 +146,7 @@ function Graph({
   visualizes,
   actions,
   isMetricOptionsEmpty,
+  preservePreviousData,
   queriesEnabled,
   title,
 }: GraphProps) {
@@ -161,6 +166,7 @@ function Graph({
       ? getEquationMetricsTotalFilter(visualize.expression.text)
       : createTraceMetricEventsFilter([traceMetric]),
     normalModeExtrapolated: true,
+    preservePreviousData,
   });
 
   const chartInfo = useMemo(() => {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -78,6 +78,7 @@ const METRIC_NAME_COLUMN: TableColumn<string> = {
 interface AggregatesTabProps {
   traceMetric: TraceMetric;
   isMetricOptionsEmpty?: boolean;
+  preservePreviousData?: boolean;
   queriesEnabled?: boolean;
   showEmptyResults?: boolean;
 }
@@ -85,6 +86,7 @@ interface AggregatesTabProps {
 export function AggregatesTab({
   traceMetric,
   isMetricOptionsEmpty,
+  preservePreviousData,
   queriesEnabled,
   showEmptyResults,
 }: AggregatesTabProps) {
@@ -103,6 +105,7 @@ export function AggregatesTab({
     limit: RESULT_LIMIT,
     traceMetric,
     staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+    preservePreviousData,
   });
   const resultForDisplay = showEmptyResults
     ? {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -78,9 +78,16 @@ const METRIC_NAME_COLUMN: TableColumn<string> = {
 interface AggregatesTabProps {
   traceMetric: TraceMetric;
   isMetricOptionsEmpty?: boolean;
+  queriesEnabled?: boolean;
+  showEmptyResults?: boolean;
 }
 
-export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTabProps) {
+export function AggregatesTab({
+  traceMetric,
+  isMetricOptionsEmpty,
+  queriesEnabled,
+  showEmptyResults,
+}: AggregatesTabProps) {
   const theme = useTheme();
   const {selection} = usePageFilters();
   const organization = useOrganization();
@@ -88,17 +95,30 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
   const visualize = useMetricVisualize();
 
   const {result, eventView, fields} = useMetricAggregatesTable({
-    enabled: isVisualizeFunction(visualize)
-      ? Boolean(traceMetric.name) && !isMetricOptionsEmpty
-      : isVisualizeEquation(visualize) && Boolean(visualize.expression.text),
+    enabled:
+      queriesEnabled !== false &&
+      (isVisualizeFunction(visualize)
+        ? Boolean(traceMetric.name) && !isMetricOptionsEmpty
+        : isVisualizeEquation(visualize) && Boolean(visualize.expression.text)),
     limit: RESULT_LIMIT,
     traceMetric,
     staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
   });
+  const resultForDisplay = showEmptyResults
+    ? {
+        ...result,
+        data: [],
+        error: null,
+        isError: false,
+        isFetching: false,
+        isLoading: false,
+        isPending: false,
+      }
+    : result;
 
   const columns = useMemo(
-    () => decodeColumnOrder(eventView.fields, result.meta),
-    [eventView, result.meta]
+    () => decodeColumnOrder(eventView.fields, resultForDisplay.meta),
+    [eventView, resultForDisplay.meta]
   );
   const sorts = useQueryParamsAggregateSortBys();
   const setSorts = useSetQueryParamsAggregateSortBys();
@@ -118,7 +138,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
     select: selectTraceItemTagCollection(),
   });
 
-  const meta = result.meta ?? {};
+  const meta = resultForDisplay.meta ?? {};
 
   // When no group bys are selected, prepend the metric name as a virtual group-by column
   const displayFields = useMemo(() => {
@@ -177,9 +197,11 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
     return false;
   };
 
-  const topResultsCount = topEvents ? Math.min(result.data?.length ?? 0, topEvents) : 0;
+  const topResultsCount = topEvents
+    ? Math.min(resultForDisplay.data?.length ?? 0, topEvents)
+    : 0;
 
-  const isPending = result.isPending && !isMetricOptionsEmpty;
+  const isPending = resultForDisplay.isPending && !isMetricOptionsEmpty;
 
   return (
     <AggregatesSimpleTable style={tableStyle}>
@@ -235,12 +257,12 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
       </AggregatesStyledHeader>
 
       <AggregatesTableBody>
-        {result.isError ? (
+        {resultForDisplay.isError ? (
           <SimpleTable.Empty>
             <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
           </SimpleTable.Empty>
-        ) : result.data?.length ? (
-          result.data.map((row, i) => {
+        ) : resultForDisplay.data?.length ? (
+          resultForDisplay.data.map((row, i) => {
             const displayRow =
               groupBys.length === 0
                 ? {...row, [TraceMetricKnownFieldKey.METRIC_NAME]: traceMetric.name}

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -22,6 +22,7 @@ interface MetricInfoTabsProps {
   additionalActions?: React.ReactNode;
   contentsHidden?: boolean;
   isMetricOptionsEmpty?: boolean;
+  preservePreviousData?: boolean;
   queriesEnabled?: boolean;
   showEmptyResults?: boolean;
 }
@@ -31,6 +32,7 @@ export function MetricInfoTabs({
   additionalActions,
   contentsHidden,
   isMetricOptionsEmpty,
+  preservePreviousData,
   queriesEnabled,
   showEmptyResults,
 }: MetricInfoTabsProps) {
@@ -77,6 +79,7 @@ export function MetricInfoTabs({
                 <AggregatesTab
                   traceMetric={traceMetric}
                   queriesEnabled={queriesEnabled}
+                  preservePreviousData={preservePreviousData}
                   showEmptyResults={showEmptyResults}
                   isMetricOptionsEmpty={isMetricOptionsEmpty}
                 />
@@ -85,6 +88,7 @@ export function MetricInfoTabs({
                 <SamplesTab
                   traceMetric={traceMetric}
                   queriesEnabled={queriesEnabled}
+                  preservePreviousData={preservePreviousData}
                   showEmptyResults={showEmptyResults}
                   isMetricOptionsEmpty={isMetricOptionsEmpty}
                 />

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -22,6 +22,8 @@ interface MetricInfoTabsProps {
   additionalActions?: React.ReactNode;
   contentsHidden?: boolean;
   isMetricOptionsEmpty?: boolean;
+  queriesEnabled?: boolean;
+  showEmptyResults?: boolean;
 }
 
 export function MetricInfoTabs({
@@ -29,6 +31,8 @@ export function MetricInfoTabs({
   additionalActions,
   contentsHidden,
   isMetricOptionsEmpty,
+  queriesEnabled,
+  showEmptyResults,
 }: MetricInfoTabsProps) {
   const visualize = useMetricVisualize();
   const queryParamsMode = useQueryParamsMode();
@@ -72,12 +76,16 @@ export function MetricInfoTabs({
               <TabPanels.Item key={Mode.AGGREGATE}>
                 <AggregatesTab
                   traceMetric={traceMetric}
+                  queriesEnabled={queriesEnabled}
+                  showEmptyResults={showEmptyResults}
                   isMetricOptionsEmpty={isMetricOptionsEmpty}
                 />
               </TabPanels.Item>
               <TabPanels.Item key={Mode.SAMPLES}>
                 <SamplesTab
                   traceMetric={traceMetric}
+                  queriesEnabled={queriesEnabled}
+                  showEmptyResults={showEmptyResults}
                   isMetricOptionsEmpty={isMetricOptionsEmpty}
                 />
               </TabPanels.Item>

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
@@ -38,6 +38,8 @@ const TWO_MINUTE_DELAY = 120;
 interface MetricsSamplesTableProps {
   isMetricOptionsEmpty?: boolean;
   overrideTableData?: TraceMetricEventsResponseItem[];
+  queriesEnabled?: boolean;
+  showEmptyResults?: boolean;
   source?: MetricsSamplesTableSource;
   traceMetric?: TraceMetric;
 }
@@ -47,6 +49,8 @@ export function MetricsSamplesTable({
   source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
   isMetricOptionsEmpty,
   overrideTableData,
+  queriesEnabled,
+  showEmptyResults,
 }: MetricsSamplesTableProps) {
   const isEmbedded = isEmbeddedMetricsSamplesTableSource(source);
   const columns = isEmbedded
@@ -62,13 +66,16 @@ export function MetricsSamplesTable({
   } = useMetricSamplesTable({
     disabled: isEmbedded
       ? !!overrideTableData
-      : !traceMetric?.name || isMetricOptionsEmpty,
+      : queriesEnabled === false || !traceMetric?.name || isMetricOptionsEmpty,
     limit: isEmbedded ? EMBEDDED_RESULT_LIMIT : RESULT_LIMIT,
     traceMetric,
     fields,
     ingestionDelaySeconds: TWO_MINUTE_DELAY,
     staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
   });
+  const dataForDisplay = showEmptyResults ? [] : data;
+  const errorForDisplay = showEmptyResults ? undefined : error;
+  const isFetchingForDisplay = !showEmptyResults && isFetching;
 
   const metaWithValueUnit = useMemo<EventsMetaType>(() => {
     const {fieldType, unit} = mapMetricUnitToFieldType(traceMetric?.unit);
@@ -87,15 +94,15 @@ export function MetricsSamplesTable({
 
   return (
     <SimpleTableGrid source={source}>
-      {isFetching && <TransparentLoadingMask />}
+      {isFetchingForDisplay && <TransparentLoadingMask />}
       <MetricsSamplesTableHeader columns={columns} source={source} />
       <StyledSimpleTableBody>
-        {!overrideTableData?.length && error ? (
+        {!overrideTableData?.length && errorForDisplay ? (
           <SimpleTable.Empty style={{minHeight: '140px'}}>
             <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
           </SimpleTable.Empty>
-        ) : overrideTableData?.length || data?.length ? (
-          (overrideTableData ?? data ?? []).map((row, i) => (
+        ) : overrideTableData?.length || dataForDisplay?.length ? (
+          (overrideTableData ?? dataForDisplay ?? []).map((row, i) => (
             <SampleTableRow
               key={i}
               row={row}
@@ -104,7 +111,7 @@ export function MetricsSamplesTable({
               source={source}
             />
           ))
-        ) : isFetching ? (
+        ) : isFetchingForDisplay ? (
           <SimpleTable.Empty style={{minHeight: '140px'}}>
             <LoadingIndicator size={40} style={{margin: '1em 1em'}} />
           </SimpleTable.Empty>

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
@@ -38,6 +38,7 @@ const TWO_MINUTE_DELAY = 120;
 interface MetricsSamplesTableProps {
   isMetricOptionsEmpty?: boolean;
   overrideTableData?: TraceMetricEventsResponseItem[];
+  preservePreviousData?: boolean;
   queriesEnabled?: boolean;
   showEmptyResults?: boolean;
   source?: MetricsSamplesTableSource;
@@ -49,6 +50,7 @@ export function MetricsSamplesTable({
   source = DEFAULT_METRICS_SAMPLES_TABLE_SOURCE,
   isMetricOptionsEmpty,
   overrideTableData,
+  preservePreviousData,
   queriesEnabled,
   showEmptyResults,
 }: MetricsSamplesTableProps) {
@@ -72,6 +74,7 @@ export function MetricsSamplesTable({
     fields,
     ingestionDelaySeconds: TWO_MINUTE_DELAY,
     staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+    preservePreviousData,
   });
   const dataForDisplay = showEmptyResults ? [] : data;
   const errorForDisplay = showEmptyResults ? undefined : error;

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
@@ -4,12 +4,21 @@ import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 interface SamplesTabProps {
   traceMetric: TraceMetric;
   isMetricOptionsEmpty?: boolean;
+  queriesEnabled?: boolean;
+  showEmptyResults?: boolean;
 }
 
-export function SamplesTab({traceMetric, isMetricOptionsEmpty}: SamplesTabProps) {
+export function SamplesTab({
+  traceMetric,
+  isMetricOptionsEmpty,
+  queriesEnabled,
+  showEmptyResults,
+}: SamplesTabProps) {
   return (
     <MetricsSamplesTable
       traceMetric={traceMetric}
+      queriesEnabled={queriesEnabled}
+      showEmptyResults={showEmptyResults}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
     />
   );

--- a/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/samplesTab.tsx
@@ -4,6 +4,7 @@ import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 interface SamplesTabProps {
   traceMetric: TraceMetric;
   isMetricOptionsEmpty?: boolean;
+  preservePreviousData?: boolean;
   queriesEnabled?: boolean;
   showEmptyResults?: boolean;
 }
@@ -11,6 +12,7 @@ interface SamplesTabProps {
 export function SamplesTab({
   traceMetric,
   isMetricOptionsEmpty,
+  preservePreviousData,
   queriesEnabled,
   showEmptyResults,
 }: SamplesTabProps) {
@@ -18,6 +20,7 @@ export function SamplesTab({
     <MetricsSamplesTable
       traceMetric={traceMetric}
       queriesEnabled={queriesEnabled}
+      preservePreviousData={preservePreviousData}
       showEmptyResults={showEmptyResults}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
     />

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -169,6 +169,78 @@ describe('MetricPanel', () => {
     setupMocks(organization.slug);
   });
 
+  it('does not run metric queries when validation fails', async () => {
+    const validationMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: {
+        dataset: [],
+        environment: [],
+        field: [],
+        orderby: [],
+        projects: [],
+        query: {error: 'unknown attribute', fields: [], valid: false},
+        valid: false,
+      },
+      statusCode: 400,
+    });
+    const samplesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+      match: [MockApiClient.matchQuery({referrer: 'api.explore.metric-samples-table'})],
+    });
+    const aggregatesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+      match: [
+        MockApiClient.matchQuery({referrer: 'api.explore.metric-aggregates-table'}),
+      ],
+    });
+    const normalRawCountMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.tracemetrics.raw-count.normal',
+        }),
+      ],
+    });
+    const totalRawCountMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.tracemetrics.raw-count.normal-extrapolated-total',
+        }),
+      ],
+    });
+    const timeseriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {timeSeries: []},
+    });
+
+    render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
+      organization,
+      additionalWrapper: createWrapper({
+        queryParams: queryParams.replace({mode: Mode.AGGREGATE}),
+        traceMetric,
+      }),
+    });
+
+    await waitFor(() => expect(validationMock).toHaveBeenCalled());
+    expect(await screen.findByText('No aggregates found')).toBeInTheDocument();
+    expect(samplesMock).not.toHaveBeenCalled();
+    expect(aggregatesMock).not.toHaveBeenCalled();
+    expect(normalRawCountMock).not.toHaveBeenCalled();
+    expect(totalRawCountMock).not.toHaveBeenCalled();
+    expect(timeseriesMock).not.toHaveBeenCalled();
+  });
+
   it('renders the metric panel', async () => {
     render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
       organization,

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -59,6 +59,28 @@ function createWrapper({
   };
 }
 
+function MetricPanelWithQueryParams({
+  queryParams,
+  traceMetric,
+}: {
+  queryParams: ReadableQueryParams;
+  traceMetric: TraceMetric;
+}) {
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <MetricsQueryParamsProvider
+        traceMetric={traceMetric}
+        queryParams={queryParams}
+        setQueryParams={() => {}}
+        setTraceMetric={() => {}}
+        removeMetric={() => {}}
+      >
+        <MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />
+      </MetricsQueryParamsProvider>
+    </MultiMetricsQueryParamsProvider>
+  );
+}
+
 function setupMocks(orgSlug: string) {
   MockApiClient.addMockResponse({
     url: `/organizations/${orgSlug}/events-timeseries/`,
@@ -169,7 +191,12 @@ describe('MetricPanel', () => {
     setupMocks(organization.slug);
   });
 
-  it('does not run metric queries when validation fails', async () => {
+  it('keeps empty results while revalidating after validation fails', async () => {
+    const invalidQueryParams = queryParams.replace({
+      mode: Mode.AGGREGATE,
+      query: 'missing.key:foo',
+    });
+    const revalidatingQueryParams = invalidQueryParams.replace({query: 'span.op:http'});
     const validationMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/validate/`,
       method: 'GET',
@@ -183,6 +210,22 @@ describe('MetricPanel', () => {
         valid: false,
       },
       statusCode: 400,
+      match: [MockApiClient.matchQuery({query: 'missing.key:foo'})],
+    });
+    const revalidationMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: {
+        dataset: [],
+        environment: [],
+        field: [],
+        orderby: [],
+        projects: [],
+        query: {error: null, fields: [], valid: true},
+        valid: true,
+      },
+      asyncDelay: 100_000,
+      match: [MockApiClient.matchQuery({query: 'span.op:http'})],
     });
     const samplesMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -224,16 +267,28 @@ describe('MetricPanel', () => {
       body: {timeSeries: []},
     });
 
-    render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
-      organization,
-      additionalWrapper: createWrapper({
-        queryParams: queryParams.replace({mode: Mode.AGGREGATE}),
-        traceMetric,
-      }),
-    });
+    const {rerender} = render(
+      <MetricPanelWithQueryParams
+        queryParams={invalidQueryParams}
+        traceMetric={traceMetric}
+      />,
+      {
+        organization,
+      }
+    );
 
     await waitFor(() => expect(validationMock).toHaveBeenCalled());
     expect(await screen.findByText('No aggregates found')).toBeInTheDocument();
+
+    rerender(
+      <MetricPanelWithQueryParams
+        queryParams={revalidatingQueryParams}
+        traceMetric={traceMetric}
+      />
+    );
+
+    await waitFor(() => expect(revalidationMock).toHaveBeenCalled());
+    expect(screen.getByText('No aggregates found')).toBeInTheDocument();
     expect(samplesMock).not.toHaveBeenCalled();
     expect(aggregatesMock).not.toHaveBeenCalled();
     expect(normalRawCountMock).not.toHaveBeenCalled();

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -81,11 +81,23 @@ function MetricPanelWithQueryParams({
   );
 }
 
-function setupMocks(orgSlug: string) {
+type TimeseriesResponse = {timeSeries: Array<ReturnType<typeof TimeSeriesFixture>>};
+
+function setupMocks(
+  orgSlug: string,
+  timeseriesResponse:
+    | TimeseriesResponse
+    | ((
+        url: string,
+        options: {query: Record<string, string | string[] | undefined>}
+      ) => TimeseriesResponse) = {
+    timeSeries: [TimeSeriesFixture()],
+  }
+) {
   MockApiClient.addMockResponse({
     url: `/organizations/${orgSlug}/events-timeseries/`,
     method: 'GET',
-    body: {timeSeries: [TimeSeriesFixture()]},
+    body: timeseriesResponse,
   });
 
   // Catch-all for /events/ requests not matched by specific referrer mocks
@@ -365,6 +377,109 @@ describe('MetricPanel', () => {
     });
 
     expect(await screen.findByTestId('metric-panel')).toBeInTheDocument();
+  });
+
+  it('shows the standard chart empty state when no metrics are available', async () => {
+    setupEventsMock(
+      [],
+      [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          referrer: 'api.explore.metric-options',
+        }),
+      ]
+    );
+
+    render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
+      organization,
+      additionalWrapper: createWrapper({queryParams, traceMetric}),
+    });
+
+    expect(
+      await screen.findByRole('heading', {name: 'No data to plot.'})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Try adjusting the filters.')).toBeInTheDocument();
+  });
+
+  it('does not show raw counts when there is no data to plot', async () => {
+    const populatedSeries = TimeSeriesFixture({
+      yAxis: 'sum(value,bar,distribution,none)',
+      meta: {
+        ...TimeSeriesFixture().meta,
+        dataScanned: 'full',
+      },
+      values: [
+        {
+          timestamp: 1729796400000,
+          value: 1,
+          sampleCount: 1,
+          sampleRate: 1,
+        },
+      ],
+    });
+    MockApiClient.clearMockResponses();
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupMocks(organization.slug, (_url, options) => {
+      const requestedYAxis = options.query.yAxis;
+      return {
+        timeSeries:
+          options.query.query === 'span.op:db'
+            ? []
+            : [
+                {
+                  ...populatedSeries,
+                  yAxis: Array.isArray(requestedYAxis)
+                    ? requestedYAxis[0]!
+                    : requestedYAxis!,
+                },
+              ],
+      };
+    });
+    setupEventsMock(metricFixtures.detailedFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-options',
+      }),
+    ]);
+    const totalRawCountMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [{'count(value)': 1}],
+        meta: {fields: {'count(value)': 'integer'}, units: {}},
+      },
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.explore.tracemetrics.raw-count.normal-extrapolated-total',
+        }),
+      ],
+    });
+    const initialQueryParams = queryParams.replace({query: ''});
+    const filteredQueryParams = initialQueryParams.replace({query: 'span.op:db'});
+
+    const {rerender} = render(
+      <MetricPanelWithQueryParams
+        queryParams={initialQueryParams}
+        traceMetric={traceMetric}
+      />,
+      {organization}
+    );
+
+    const metricPanel = await screen.findByTestId('metric-panel');
+    await waitFor(() => expect(metricPanel).toHaveTextContent('1 data point'));
+
+    rerender(
+      <MetricPanelWithQueryParams
+        queryParams={filteredQueryParams}
+        traceMetric={traceMetric}
+      />
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'No data to plot.'})
+    ).toBeInTheDocument();
+    await waitFor(() => expect(totalRawCountMock).toHaveBeenCalled());
+    expect(metricPanel).not.toHaveTextContent('Estimated from 0 matches of 1 data point');
   });
 
   it('renders the visualize label badge', async () => {

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -296,6 +296,68 @@ describe('MetricPanel', () => {
     expect(timeseriesMock).not.toHaveBeenCalled();
   });
 
+  it('preserves previous results while validation is pending', async () => {
+    const initialQueryParams = queryParams.replace({mode: Mode.AGGREGATE});
+    const revalidatingQueryParams = initialQueryParams.replace({query: 'span.op:db'});
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupEventsMock(metricFixtures.detailedFixtures, [
+      MockApiClient.matchQuery({
+        dataset: 'tracemetrics',
+        referrer: 'api.explore.metric-options',
+      }),
+    ]);
+    const revalidationMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: {
+        dataset: [],
+        environment: [],
+        field: [],
+        orderby: [],
+        projects: [],
+        query: {error: null, fields: [], valid: true},
+        valid: true,
+      },
+      asyncDelay: 100_000,
+      match: [MockApiClient.matchQuery({query: 'span.op:db'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [{'sum(value,bar,distribution,none)': 12345}],
+        meta: {
+          fields: {'sum(value,bar,distribution,none)': 'number'},
+          units: {},
+          dataScanned: 'full',
+        },
+      },
+      match: [
+        MockApiClient.matchQuery({referrer: 'api.explore.metric-aggregates-table'}),
+      ],
+    });
+    const {rerender} = render(
+      <MetricPanelWithQueryParams
+        queryParams={initialQueryParams}
+        traceMetric={traceMetric}
+      />,
+      {organization}
+    );
+
+    const aggregatesTable = await screen.findByRole('table');
+    expect(await within(aggregatesTable).findByText('bar')).toBeInTheDocument();
+
+    rerender(
+      <MetricPanelWithQueryParams
+        queryParams={revalidatingQueryParams}
+        traceMetric={traceMetric}
+      />
+    );
+
+    await waitFor(() => expect(revalidationMock).toHaveBeenCalled());
+    expect(within(aggregatesTable).getByText('bar')).toBeInTheDocument();
+  });
+
   it('renders the metric panel', async () => {
     render(<MetricPanel traceMetric={traceMetric} queryIndex={0} queryLabel="A" />, {
       organization,

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -130,7 +130,10 @@ export function MetricPanel({
     isValidationFetching || isValidationLoading || isValidationPlaceholderData;
   const isValidationValid =
     !isValidationPending && !validationError && validationData?.valid === true;
-  const showEmptyResults = !isValidationPending && !isValidationValid;
+  const preservePreviousData =
+    !validationError &&
+    (isValidationPending ? validationData?.valid !== false : isValidationValid);
+  const showEmptyResults = !preservePreviousData;
 
   const isHeatmap = visualize.chartType === ChartType.HEATMAP;
 

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -34,6 +34,7 @@ import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMe
 import {useMetricHeatMapData} from 'sentry/views/explore/metrics/hooks/useMetricHeatMapData';
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
+import {useValidateMetricsTab} from 'sentry/views/explore/metrics/hooks/useValidateMetricsTab';
 import {
   MetricsGraph,
   getMetricsChartTypeOptions,
@@ -117,6 +118,19 @@ export function MetricPanel({
   const visualizes = useMetricVisualizes();
   const setVisualizes = useSetMetricVisualizes();
   const setAggregateFields = useSetMetricAggregateFields();
+  const {
+    data: validationData,
+    error: validationError,
+    isFetching: isValidationFetching,
+    isLoading: isValidationLoading,
+    isPlaceholderData: isValidationPlaceholderData,
+  } = useValidateMetricsTab();
+
+  const isValidationPending =
+    isValidationFetching || isValidationLoading || isValidationPlaceholderData;
+  const isValidationValid =
+    !isValidationPending && !validationError && validationData?.valid === true;
+  const showEmptyResults = !isValidationPending && !isValidationValid;
 
   const isHeatmap = visualize.chartType === ChartType.HEATMAP;
 
@@ -143,9 +157,11 @@ export function MetricPanel({
     }
   }, [visualize, referenceMap]);
 
-  const areQueriesEnabled = isVisualizeFunction(visualize)
-    ? Boolean(traceMetric.name) && !isMetricOptionsEmpty
-    : isVisualizeEquation(visualize) && Boolean(visualize.expression.text);
+  const areQueriesEnabled =
+    isValidationValid &&
+    (isVisualizeFunction(visualize)
+      ? Boolean(traceMetric.name) && !isMetricOptionsEmpty
+      : isVisualizeEquation(visualize) && Boolean(visualize.expression.text));
 
   const metricSamplesTableResult = useMetricSamplesTable({
     disabled: !areQueriesEnabled,
@@ -170,6 +186,7 @@ export function MetricPanel({
   const {result: timeseriesResult} = useMetricTimeseries({
     traceMetric,
     enabled:
+      isValidationValid &&
       !(areHeatMapsEnabled && isHeatmap) &&
       (!isMetricOptionsEmpty ||
         (isVisualizeEquation(visualize) && Boolean(visualize.expression.text))),
@@ -195,8 +212,21 @@ export function MetricPanel({
     query: userQuery,
     interval: heatMapBucketDimensions?.interval,
     yBuckets: heatMapBucketDimensions?.yBuckets,
-    enabled: areHeatMapsEnabled && isHeatmap && !isMetricOptionsEmpty,
+    enabled:
+      isValidationValid && areHeatMapsEnabled && isHeatmap && !isMetricOptionsEmpty,
   });
+  const timeseriesResultForDisplay = showEmptyResults
+    ? getEmptyQueryResult({...timeseriesResult, meta: undefined}, {})
+    : timeseriesResult;
+  const heatMapDataForDisplay = showEmptyResults
+    ? {
+        error: null,
+        isFetching: false,
+        isPartial: false,
+        isPending: false,
+        series: undefined,
+      }
+    : heatMapData;
 
   useMetricsPanelAnalytics({
     interval,
@@ -323,15 +353,16 @@ export function MetricPanel({
                     <Container minWidth="0" ref={chartContainerRef}>
                       {areHeatMapsEnabled && isHeatmap ? (
                         <MetricsHeatMap
-                          heatMapData={heatMapData}
+                          heatMapData={heatMapDataForDisplay}
                           actions={actions}
                           title={title}
                           queryLabel={queryLabel}
                         />
                       ) : (
                         <MetricsGraph
-                          timeseriesResult={timeseriesResult}
+                          timeseriesResult={timeseriesResultForDisplay}
                           actions={actions}
+                          queriesEnabled={isValidationValid}
                           isMetricOptionsEmpty={isMetricOptionsEmpty}
                           title={title}
                         />
@@ -340,6 +371,8 @@ export function MetricPanel({
                     <Container minWidth="0">
                       <MetricInfoTabs
                         traceMetric={traceMetric}
+                        queriesEnabled={isValidationValid}
+                        showEmptyResults={showEmptyResults}
                         isMetricOptionsEmpty={isMetricOptionsEmpty}
                       />
                     </Container>
@@ -352,6 +385,27 @@ export function MetricPanel({
       </PanelBody>
     </Panel>
   );
+}
+
+function getEmptyQueryResult<
+  TResult extends {
+    data: unknown;
+    error: unknown;
+    isError: boolean;
+    isFetching: boolean;
+    isLoading: boolean;
+    isPending: boolean;
+  },
+>(result: TResult, data: TResult['data']): TResult {
+  return {
+    ...result,
+    data,
+    error: null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    isPending: false,
+  };
 }
 
 function DnDPlaceholder({

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -34,6 +34,7 @@ import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMe
 import {useMetricHeatMapData} from 'sentry/views/explore/metrics/hooks/useMetricHeatMapData';
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
+import {usePreserveMetricQueryResult} from 'sentry/views/explore/metrics/hooks/usePreserveMetricQueryResult';
 import {useValidateMetricsTab} from 'sentry/views/explore/metrics/hooks/useValidateMetricsTab';
 import {
   MetricsGraph,
@@ -133,6 +134,8 @@ export function MetricPanel({
   const preservePreviousData =
     !validationError &&
     (isValidationPending ? validationData?.valid !== false : isValidationValid);
+  const shouldPreservePreviousResults =
+    isValidationPending && validationData?.valid === true;
   const showEmptyResults = !preservePreviousData;
 
   const isHeatmap = visualize.chartType === ChartType.HEATMAP;
@@ -173,6 +176,7 @@ export function MetricPanel({
     fields,
     ingestionDelaySeconds: TWO_MINUTE_DELAY,
     staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+    preservePreviousData: shouldPreservePreviousResults,
   });
 
   const metricAggregatesTableResult = useMetricAggregatesTable({
@@ -182,6 +186,7 @@ export function MetricPanel({
     // We can use Infinity here because the data will remain the same, and if the args to
     // change the data changes, the cache will be invalidated.
     staleTime: Infinity,
+    preservePreviousData: shouldPreservePreviousResults,
   });
 
   const areHeatMapsEnabled = canUseMetricsHeatMap(organization);
@@ -218,9 +223,19 @@ export function MetricPanel({
     enabled:
       isValidationValid && areHeatMapsEnabled && isHeatmap && !isMetricOptionsEmpty,
   });
+  const preservedTimeseriesResult = usePreserveMetricQueryResult(
+    timeseriesResult,
+    shouldPreservePreviousResults,
+    timeseriesResult
+  );
+  const preservedHeatMapData = usePreserveMetricQueryResult(
+    heatMapData,
+    shouldPreservePreviousResults,
+    {...heatMapData, resultVersion: heatMapData.series}
+  );
   const timeseriesResultForDisplay = showEmptyResults
     ? getEmptyQueryResult({...timeseriesResult, meta: undefined}, {})
-    : timeseriesResult;
+    : preservedTimeseriesResult;
   const heatMapDataForDisplay = showEmptyResults
     ? {
         error: null,
@@ -229,7 +244,7 @@ export function MetricPanel({
         isPending: false,
         series: undefined,
       }
-    : heatMapData;
+    : preservedHeatMapData;
 
   useMetricsPanelAnalytics({
     interval,
@@ -366,6 +381,7 @@ export function MetricPanel({
                           timeseriesResult={timeseriesResultForDisplay}
                           actions={actions}
                           queriesEnabled={isValidationValid}
+                          preservePreviousData={shouldPreservePreviousResults}
                           isMetricOptionsEmpty={isMetricOptionsEmpty}
                           title={title}
                         />
@@ -375,6 +391,7 @@ export function MetricPanel({
                       <MetricInfoTabs
                         traceMetric={traceMetric}
                         queriesEnabled={isValidationValid}
+                        preservePreviousData={shouldPreservePreviousResults}
                         showEmptyResults={showEmptyResults}
                         isMetricOptionsEmpty={isMetricOptionsEmpty}
                       />

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -404,8 +404,7 @@ describe('MetricsTabContent', () => {
     expect(toolbars).toHaveLength(1);
 
     await waitFor(() => {
-      expect(trackAnalyticsMock).toHaveBeenNthCalledWith(
-        1,
+      expect(trackAnalyticsMock).toHaveBeenCalledWith(
         'metrics.explorer.panel.metadata',
         expect.objectContaining({
           panel_index: 0,
@@ -417,8 +416,7 @@ describe('MetricsTabContent', () => {
       );
     });
 
-    expect(trackAnalyticsMock).toHaveBeenNthCalledWith(
-      2,
+    expect(trackAnalyticsMock).toHaveBeenCalledWith(
       'metrics.explorer.metadata',
       expect.objectContaining({
         metric_panels_with_filters_count: 0,


### PR DESCRIPTION
Stops metrics result requests until query validation succeeds. When validation fails, charts, heatmaps, samples, and aggregate tables render settled empty states instead of remaining in loading states.

This PR is stacked on the EXP-1070 spans validation work.

Closes EXP-1072