### PR TITLE
feat(dynamic-sampling): add metric for cache hits/misses & make TTL configurable for recalibration

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.dynamic_sampling.tasks.constants import ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL
+from sentry.dynamic_sampling.tasks.constants import FactorReadSource, adjusted_factor_ttl_ms
 from sentry.utils import metrics
 
 PER_ORG_RECALIBRATION_FACTOR_CACHE_KEY = "ds::per_org:o:{org_id}:recalibration_factor"
@@ -16,7 +16,7 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
         redis_client = get_redis_client_for_ds()
         cache_key = generate_recalibrate_orgs_cache_key(org_id)
         redis_client.set(cache_key, adjusted_factor)
-        redis_client.pexpire(cache_key, ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL)
+        redis_client.pexpire(cache_key, adjusted_factor_ttl_ms())
         metrics.distribution(
             "dynamic_sampling.per_org.recalibration.set_guarded_adjusted_factor",
             adjusted_factor,
@@ -25,17 +25,23 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
         delete_adjusted_factor(org_id)
 
 
-def get_adjusted_factor(org_id: int) -> float:
+def get_adjusted_factor(org_id: int, source: FactorReadSource) -> float:
     redis_client = get_redis_client_for_ds()
     cache_key = generate_recalibrate_orgs_cache_key(org_id)
 
+    factor = None
     try:
         value = redis_client.get(cache_key)
         if value is not None:
-            return float(value)
+            factor = float(value)
     except (TypeError, ValueError):
         pass
-    return 1.0
+
+    metrics.incr(
+        "dynamic_sampling.per_org.recalibration.get_adjusted_factor",
+        tags={"source": source, "result": "hit" if factor is not None else "miss"},
+    )
+    return 1.0 if factor is None else factor
 
 
 def delete_adjusted_factor(org_id: int) -> None:

--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.dynamic_sampling.tasks.constants import FactorReadSource, adjusted_factor_ttl_ms
+from sentry.dynamic_sampling.tasks.constants import adjusted_factor_ttl_ms
 from sentry.utils import metrics
 
 PER_ORG_RECALIBRATION_FACTOR_CACHE_KEY = "ds::per_org:o:{org_id}:recalibration_factor"
@@ -25,7 +25,7 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
         delete_adjusted_factor(org_id)
 
 
-def get_adjusted_factor(org_id: int, source: FactorReadSource) -> float:
+def get_adjusted_factor(org_id: int, source: str) -> float:
     redis_client = get_redis_client_for_ds()
     cache_key = generate_recalibrate_orgs_cache_key(org_id)
 

--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -92,11 +92,11 @@ def calculate_recalibration_factor(
 def get_cached_recalibration_factor(org_id: int) -> float:
     # A missing key is the stored form of 1.0: set_guarded_adjusted_factor deletes the key
     # instead of writing the identity factor, and the serving path resolves a miss back to 1.0.
-    return legacy_recalibration_cache.get_adjusted_factor(org_id)
+    return legacy_recalibration_cache.get_adjusted_factor(org_id, source="task")
 
 
 def get_cached_per_org_recalibration_factor(org_id: int) -> float:
-    return per_org_recalibration_cache.get_adjusted_factor(org_id)
+    return per_org_recalibration_cache.get_adjusted_factor(org_id, source="task")
 
 
 def get_effective_sample_rate(volume: OrganizationDataVolume | None) -> float | None:

--- a/src/sentry/dynamic_sampling/per_org/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/configuration.py
@@ -131,7 +131,7 @@ class BaseDynamicSamplingConfiguration(ABC):
 
         adjusted_factor = calculate_recalibration_factor(
             org_volume,
-            per_org_recalibration_cache.get_adjusted_factor(self.organization.id),
+            per_org_recalibration_cache.get_adjusted_factor(self.organization.id, source="task"),
             self.get_sample_rate(),
         )
         if adjusted_factor is None:

--- a/src/sentry/dynamic_sampling/rules/biases/recalibration_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/recalibration_bias.py
@@ -22,9 +22,9 @@ class RecalibrationBias(Bias):
 
     def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
         if is_project_mode_sampling(project.organization):
-            adjusted_factor = get_adjusted_project_factor(project.id)
+            adjusted_factor = get_adjusted_project_factor(project.id, source="serving")
         else:
-            adjusted_factor = get_adjusted_factor(project.organization.id)
+            adjusted_factor = get_adjusted_factor(project.organization.id, source="serving")
 
         # We don't want to generate any rule in case the factor is 1.0 since we should multiply the factor and 1.0
         # is the identity of the multiplication.

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -1,9 +1,28 @@
 from datetime import timedelta
+from typing import Literal
+
+from sentry import options
 
 # TTL in milliseconds for values persisted by the dynamic sampling tasks.
 DEFAULT_REDIS_CACHE_KEY_TTL = 24 * 60 * 60 * 1000  # 24 hours
-# TTL in milliseconds for the adjusted factor value persisted by the recalibrate org task.
-ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL = 10 * 60 * 1000  # 10 minutes
+
+ADJUSTED_FACTOR_TTL_MINUTES_OPTION = "dynamic-sampling.recalibration.factor-ttl-minutes"
+
+# Where a read of the adjusted factor comes from. Serving reads happen per project config
+# build and decide whether the recalibration rule is emitted at all; task reads happen once
+# per recalibration pass and decide which factor the next one builds on.
+FactorReadSource = Literal["serving", "task"]
+
+
+def adjusted_factor_ttl_ms() -> int:
+    """TTL in milliseconds for the adjusted factor persisted by the recalibration tasks.
+
+    The TTL bounds how far the effective sample rate can drift on a factor that no task
+    refreshes anymore. It has to outlive the interval between two recalibration passes,
+    otherwise the factor expires before it is rewritten and the correction is lost.
+    """
+    return int(options.get(ADJUSTED_FACTOR_TTL_MINUTES_OPTION)) * 60 * 1000
+
 
 # Parameters to bound the queries run in Snuba.
 MAX_ORGS_PER_QUERY = 80

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Literal
 
 from sentry import options
 
@@ -7,11 +6,6 @@ from sentry import options
 DEFAULT_REDIS_CACHE_KEY_TTL = 24 * 60 * 60 * 1000  # 24 hours
 
 ADJUSTED_FACTOR_TTL_MINUTES_OPTION = "dynamic-sampling.recalibration.factor-ttl-minutes"
-
-# Where a read of the adjusted factor comes from. Serving reads happen per project config
-# build and decide whether the recalibration rule is emitted at all; task reads happen once
-# per recalibration pass and decide which factor the next one builds on.
-FactorReadSource = Literal["serving", "task"]
 
 
 def adjusted_factor_ttl_ms() -> int:

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -9,12 +9,6 @@ ADJUSTED_FACTOR_TTL_MINUTES_OPTION = "dynamic-sampling.recalibration.factor-ttl-
 
 
 def adjusted_factor_ttl_ms() -> int:
-    """TTL in milliseconds for the adjusted factor persisted by the recalibration tasks.
-
-    The TTL bounds how far the effective sample rate can drift on a factor that no task
-    refreshes anymore. It has to outlive the interval between two recalibration passes,
-    otherwise the factor expires before it is rewritten and the correction is lost.
-    """
     return int(options.get(ADJUSTED_FACTOR_TTL_MINUTES_OPTION)) * 60 * 1000
 
 

--- a/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
@@ -1,6 +1,18 @@
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.dynamic_sampling.tasks.constants import ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL
+from sentry.dynamic_sampling.tasks.constants import FactorReadSource, adjusted_factor_ttl_ms
 from sentry.utils import metrics
+
+
+def _read_cached_factor(cache_key: str) -> float | None:
+    redis_client = get_redis_client_for_ds()
+
+    try:
+        value = redis_client.get(cache_key)
+        if value is not None:
+            return float(value)
+    except (TypeError, ValueError):
+        pass
+    return None
 
 
 def generate_recalibrate_orgs_cache_key(org_id: int) -> str:
@@ -17,7 +29,7 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
         redis_client.set(cache_key, adjusted_factor)
         # Since we don't want any error to cause the system to drift significantly from the target sample rate, we want
         # to set a small TTL for the adjusted factor.
-        redis_client.pexpire(cache_key, ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL)
+        redis_client.pexpire(cache_key, adjusted_factor_ttl_ms())
         metrics.distribution(
             "dynamic_sampling.tasks.recalibrate_orgs.set_guarded_adjusted_factor", adjusted_factor
         )
@@ -25,20 +37,15 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
         delete_adjusted_factor(org_id)
 
 
-def get_adjusted_factor(org_id: int) -> float:
-    redis_client = get_redis_client_for_ds()
-    cache_key = generate_recalibrate_orgs_cache_key(org_id)
-
-    try:
-        value = redis_client.get(cache_key)
-        if value is not None:
-            return float(value)
-    except (TypeError, ValueError):
-        # By default, the previous factor is equal to the identity of the multiplication and this is done because
-        # the recalibration rule will be a factor rule and thus multiplied with the first sample rate rule that will
-        # match after this.
-        pass
-    return 1.0
+def get_adjusted_factor(org_id: int, source: FactorReadSource) -> float:
+    factor = _read_cached_factor(generate_recalibrate_orgs_cache_key(org_id))
+    metrics.incr(
+        "dynamic_sampling.tasks.recalibrate_orgs.get_adjusted_factor",
+        tags={"source": source, "result": "hit" if factor is not None else "miss"},
+    )
+    # On a miss the factor is the identity of the multiplication, because the recalibration rule
+    # is a factor rule and thus multiplied with the first sample rate rule that matches after it.
+    return 1.0 if factor is None else factor
 
 
 def delete_adjusted_factor(org_id: int) -> None:
@@ -63,7 +70,7 @@ def set_guarded_adjusted_project_factor(project_id: int, adjusted_factor: float)
         redis_client.set(cache_key, adjusted_factor)
         # Since we don't want any error to cause the system to drift significantly from the target sample rate, we want
         # to set a small TTL for the adjusted factor.
-        redis_client.pexpire(cache_key, ADJUSTED_FACTOR_REDIS_CACHE_KEY_TTL)
+        redis_client.pexpire(cache_key, adjusted_factor_ttl_ms())
         metrics.distribution(
             "dynamic_sampling.tasks.recalibrate_projects.set_guarded_adjusted_project_factor",
             adjusted_factor,
@@ -72,20 +79,13 @@ def set_guarded_adjusted_project_factor(project_id: int, adjusted_factor: float)
         delete_adjusted_project_factor(project_id)
 
 
-def get_adjusted_project_factor(project_id: int) -> float:
-    redis_client = get_redis_client_for_ds()
-    cache_key = generate_recalibrate_projects_cache_key(project_id)
-
-    try:
-        value = redis_client.get(cache_key)
-        if value is not None:
-            return float(value)
-    except (TypeError, ValueError):
-        # By default, the previous factor is equal to the identity of the multiplication and this is done because
-        # the recalibration rule will be a factor rule and thus multiplied with the first sample rate rule that will
-        # match after this.
-        pass
-    return 1.0
+def get_adjusted_project_factor(project_id: int, source: FactorReadSource) -> float:
+    factor = _read_cached_factor(generate_recalibrate_projects_cache_key(project_id))
+    metrics.incr(
+        "dynamic_sampling.tasks.recalibrate_projects.get_adjusted_project_factor",
+        tags={"source": source, "result": "hit" if factor is not None else "miss"},
+    )
+    return 1.0 if factor is None else factor
 
 
 def delete_adjusted_project_factor(project_id: int) -> None:

--- a/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
@@ -41,8 +41,6 @@ def get_adjusted_factor(org_id: int, source: str) -> float:
         "dynamic_sampling.tasks.recalibrate_orgs.get_adjusted_factor",
         tags={"source": source, "result": "hit" if factor is not None else "miss"},
     )
-    # On a miss the factor is the identity of the multiplication, because the recalibration rule
-    # is a factor rule and thus multiplied with the first sample rate rule that matches after it.
     return 1.0 if factor is None else factor
 
 

--- a/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
@@ -3,18 +3,6 @@ from sentry.dynamic_sampling.tasks.constants import adjusted_factor_ttl_ms
 from sentry.utils import metrics
 
 
-def _read_cached_factor(cache_key: str) -> float | None:
-    redis_client = get_redis_client_for_ds()
-
-    try:
-        value = redis_client.get(cache_key)
-        if value is not None:
-            return float(value)
-    except (TypeError, ValueError):
-        pass
-    return None
-
-
 def generate_recalibrate_orgs_cache_key(org_id: int) -> str:
     return f"ds::o:{org_id}:rate_rebalance_factor2"
 
@@ -38,7 +26,17 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
 
 
 def get_adjusted_factor(org_id: int, source: str) -> float:
-    factor = _read_cached_factor(generate_recalibrate_orgs_cache_key(org_id))
+    redis_client = get_redis_client_for_ds()
+    cache_key = generate_recalibrate_orgs_cache_key(org_id)
+
+    factor = None
+    try:
+        value = redis_client.get(cache_key)
+        if value is not None:
+            factor = float(value)
+    except (TypeError, ValueError):
+        pass
+
     metrics.incr(
         "dynamic_sampling.tasks.recalibrate_orgs.get_adjusted_factor",
         tags={"source": source, "result": "hit" if factor is not None else "miss"},
@@ -80,7 +78,17 @@ def set_guarded_adjusted_project_factor(project_id: int, adjusted_factor: float)
 
 
 def get_adjusted_project_factor(project_id: int, source: str) -> float:
-    factor = _read_cached_factor(generate_recalibrate_projects_cache_key(project_id))
+    redis_client = get_redis_client_for_ds()
+    cache_key = generate_recalibrate_projects_cache_key(project_id)
+
+    factor = None
+    try:
+        value = redis_client.get(cache_key)
+        if value is not None:
+            factor = float(value)
+    except (TypeError, ValueError):
+        pass
+
     metrics.incr(
         "dynamic_sampling.tasks.recalibrate_projects.get_adjusted_project_factor",
         tags={"source": source, "result": "hit" if factor is not None else "miss"},

--- a/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
@@ -1,5 +1,5 @@
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
-from sentry.dynamic_sampling.tasks.constants import FactorReadSource, adjusted_factor_ttl_ms
+from sentry.dynamic_sampling.tasks.constants import adjusted_factor_ttl_ms
 from sentry.utils import metrics
 
 
@@ -37,7 +37,7 @@ def set_guarded_adjusted_factor(org_id: int, adjusted_factor: float) -> None:
         delete_adjusted_factor(org_id)
 
 
-def get_adjusted_factor(org_id: int, source: FactorReadSource) -> float:
+def get_adjusted_factor(org_id: int, source: str) -> float:
     factor = _read_cached_factor(generate_recalibrate_orgs_cache_key(org_id))
     metrics.incr(
         "dynamic_sampling.tasks.recalibrate_orgs.get_adjusted_factor",
@@ -79,7 +79,7 @@ def set_guarded_adjusted_project_factor(project_id: int, adjusted_factor: float)
         delete_adjusted_project_factor(project_id)
 
 
-def get_adjusted_project_factor(project_id: int, source: FactorReadSource) -> float:
+def get_adjusted_project_factor(project_id: int, source: str) -> float:
     factor = _read_cached_factor(generate_recalibrate_projects_cache_key(project_id))
     metrics.incr(
         "dynamic_sampling.tasks.recalibrate_projects.get_adjusted_project_factor",

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -121,7 +121,7 @@ def recalibrate_org(org_id: OrganizationId, total: int, indexed: int) -> None:
     # We compute the effective sample rate that we had in the last considered time window.
     effective_sample_rate = indexed / total
     # We get the previous factor that was used for the recalibration.
-    previous_factor = get_adjusted_factor(org_id)
+    previous_factor = get_adjusted_factor(org_id, source="task")
 
     # We want to compute the new adjusted factor.
     adjusted_factor = compute_adjusted_factor(
@@ -179,7 +179,7 @@ def recalibrate_project(
     # We compute the effective sample rate that we had in the last considered time window.
     effective_sample_rate = indexed / total
     # We get the previous factor that was used for the recalibration.
-    previous_factor = get_adjusted_project_factor(project_id)
+    previous_factor = get_adjusted_project_factor(project_id, source="task")
 
     # We want to compute the new adjusted factor.
     adjusted_factor = compute_adjusted_factor(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2334,6 +2334,18 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# TTL in minutes of the recalibration factor stored in Redis. The recalibration tasks run every
+# 10 minutes, so at the default of 10 the factor expires at about the same time as the next pass
+# rewrites it, and serving loses the correction whenever a pass is late or fails. Raise this to
+# give the factor more headroom, at the cost of applying a staler factor when a task stops
+# refreshing it.
+register(
+    "dynamic-sampling.recalibration.factor-ttl-minutes",
+    type=Int,
+    default=10,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Stops dynamic sampling rules from being emitted in relay config.
 # This is required for ST instances that have flakey flags as we want to be able kill DS ruining customer data if necessary.
 # It is only a killswitch for behaviour, it may actually increase infra load if flipped for a user currently being sampled.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2334,11 +2334,7 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# TTL in minutes of the recalibration factor stored in Redis. The recalibration tasks run every
-# 10 minutes, so at the default of 10 the factor expires at about the same time as the next pass
-# rewrites it, and serving loses the correction whenever a pass is late or fails. Raise this to
-# give the factor more headroom, at the cost of applying a staler factor when a task stops
-# refreshing it.
+# TTL in minutes of the recalibration factor stored in Redis.
 register(
     "dynamic-sampling.recalibration.factor-ttl-minutes",
     type=Int,

--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -182,7 +182,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.organization_recalibration_factor == 0.7
-        mocks[GET_FACTOR].assert_called_once_with(org.id)
+        mocks[GET_FACTOR].assert_called_once_with(org.id, source="task")
         mocks[CALCULATE_FACTOR].assert_called_once_with(org_volume, 1.4, 0.5)
         mocks[SET_FACTOR].assert_called_once_with(org.id, 0.7)
 

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -68,13 +68,13 @@ class PerOrgRecalibrationCacheTest(TestCase):
         assert legacy_key != per_org_key
 
         redis.set(legacy_key, 2.5)
-        assert legacy_recalibration_cache.get_adjusted_factor(org.id) == 2.5
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 1.0
+        assert legacy_recalibration_cache.get_adjusted_factor(org.id, source="task") == 2.5
+        assert per_org_recalibration_cache.get_adjusted_factor(org.id, source="task") == 1.0
 
         redis.delete(legacy_key)
         redis.set(per_org_key, 3.5)
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 3.5
-        assert legacy_recalibration_cache.get_adjusted_factor(org.id) == 1.0
+        assert per_org_recalibration_cache.get_adjusted_factor(org.id, source="task") == 3.5
+        assert legacy_recalibration_cache.get_adjusted_factor(org.id, source="task") == 1.0
 
     def test_per_org_cache_sets_and_deletes_adjusted_factor(self) -> None:
         org = self.create_organization()
@@ -84,10 +84,10 @@ class PerOrgRecalibrationCacheTest(TestCase):
         redis.delete(cache_key)
 
         per_org_recalibration_cache.set_guarded_adjusted_factor(org.id, 2.5)
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 2.5
+        assert per_org_recalibration_cache.get_adjusted_factor(org.id, source="task") == 2.5
 
         per_org_recalibration_cache.set_guarded_adjusted_factor(org.id, 1.0)
-        assert per_org_recalibration_cache.get_adjusted_factor(org.id) == 1.0
+        assert per_org_recalibration_cache.get_adjusted_factor(org.id, source="task") == 1.0
 
 
 class SchedulePerOrgCalculationsTest(TestCase):

--- a/tests/sentry/dynamic_sampling/tasks/helpers/test_recalibrate_orgs.py
+++ b/tests/sentry/dynamic_sampling/tasks/helpers/test_recalibrate_orgs.py
@@ -1,6 +1,16 @@
+from unittest.mock import patch
+
 import pytest
 
-from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import compute_adjusted_factor
+from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
+from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
+    compute_adjusted_factor,
+    generate_recalibrate_orgs_cache_key,
+    get_adjusted_factor,
+    set_guarded_adjusted_factor,
+)
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 @pytest.mark.parametrize(
@@ -21,3 +31,40 @@ def test_adjusted_factor(
         compute_adjusted_factor(prev_factor, actual_rate, desired_sample_rate)
         == expected_adj_factor
     )
+
+
+@django_db_all
+@override_options({"dynamic-sampling.recalibration.factor-ttl-minutes": 25})
+def test_set_guarded_adjusted_factor_uses_ttl_option() -> None:
+    org_id = 1234
+    cache_key = generate_recalibrate_orgs_cache_key(org_id)
+    redis_client = get_redis_client_for_ds()
+    redis_client.delete(cache_key)
+
+    set_guarded_adjusted_factor(org_id, 2.0)
+
+    assert 24 * 60 * 1000 < redis_client.pttl(cache_key) <= 25 * 60 * 1000
+
+
+@django_db_all
+def test_get_adjusted_factor_records_hit_and_miss() -> None:
+    org_id = 1235
+    cache_key = generate_recalibrate_orgs_cache_key(org_id)
+    redis_client = get_redis_client_for_ds()
+    redis_client.delete(cache_key)
+
+    with patch("sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs.metrics.incr") as incr:
+        assert get_adjusted_factor(org_id, source="serving") == 1.0
+        incr.assert_called_once_with(
+            "dynamic_sampling.tasks.recalibrate_orgs.get_adjusted_factor",
+            tags={"source": "serving", "result": "miss"},
+        )
+
+    set_guarded_adjusted_factor(org_id, 2.0)
+
+    with patch("sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs.metrics.incr") as incr:
+        assert get_adjusted_factor(org_id, source="task") == 2.0
+        incr.assert_called_once_with(
+            "dynamic_sampling.tasks.recalibrate_orgs.get_adjusted_factor",
+            tags={"source": "task", "result": "hit"},
+        )


### PR DESCRIPTION
- The recalibration factor has a hard-coded 10 minute TTL, and the recalibration tasks run every 10 minutes. If a pass is late or fails, the factor expires before it gets rewritten and serving drops the recalibration rule.
- Add a metric to record when we have cache hits/misses so we understand what is  happening

Contributes to TET-2815
