### PR TITLE
feat(explore): Stop logs requests after validation errors

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageData.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageData.tsx
@@ -8,9 +8,16 @@ import {
   useLogsQueryHighFidelity,
 } from 'sentry/views/explore/logs/useLogsQuery';
 import {useLogsTotalPayload} from 'sentry/views/explore/logs/useLogsTotalPayload';
+import {useValidateLogsTab} from 'sentry/views/explore/logs/useValidateLogsTab';
+import {
+  getQueryValidationState,
+  useLastSettledQueryResult,
+} from 'sentry/views/explore/queryValidation';
 
 interface LogsPageData {
   infiniteLogsQueryResult: UseInfiniteLogsQueryResult;
+  preservePreviousData: boolean;
+  queriesEnabled: boolean;
   totalPayloadBytes: number | undefined;
 }
 
@@ -26,34 +33,107 @@ export function useLogsPageData(): LogsPageData {
   return context;
 }
 
-export function LogsPageDataProvider({
-  children,
-  allowHighFidelity,
-  disabled,
-  staleTime,
-}: {
+interface LogsPageDataProviderProps {
   children: React.ReactNode;
   allowHighFidelity?: boolean;
   disabled?: boolean;
   staleTime?: number;
+  validateQuery?: boolean;
+}
+
+export function LogsPageDataProvider(props: LogsPageDataProviderProps) {
+  if (props.validateQuery) {
+    return <ValidatedLogsPageDataProvider {...props} />;
+  }
+
+  return (
+    <LogsPageDataProviderInner {...props} preservePreviousData={false} queriesEnabled />
+  );
+}
+
+function ValidatedLogsPageDataProvider(props: LogsPageDataProviderProps) {
+  const validationResult = useValidateLogsTab();
+  const {preservePreviousData, queriesEnabled} =
+    getQueryValidationState(validationResult);
+
+  return (
+    <LogsPageDataProviderInner
+      {...props}
+      preservePreviousData={preservePreviousData}
+      queriesEnabled={queriesEnabled}
+      validationResult={validationResult}
+    />
+  );
+}
+
+function LogsPageDataProviderInner({
+  children,
+  allowHighFidelity,
+  disabled,
+  preservePreviousData,
+  queriesEnabled,
+  staleTime,
+  validationResult,
+}: LogsPageDataProviderProps & {
+  preservePreviousData: boolean;
+  queriesEnabled: boolean;
+  validationResult?: Pick<ReturnType<typeof useValidateLogsTab>, 'error'>;
 }) {
   const organization = useOrganization();
   const feature = isLogsEnabled(organization);
   const highFidelity = useLogsQueryHighFidelity();
-  const infiniteLogsQueryResult = useInfiniteLogsQuery({
-    disabled: disabled || !feature,
+  const queriedInfiniteLogsResult = useInfiniteLogsQuery({
+    disabled: disabled || !feature || !queriesEnabled,
     highFidelity: allowHighFidelity && highFidelity,
+    preservePreviousData,
     staleTime,
   });
+  const preservedInfiniteLogsResult = useLastSettledQueryResult(
+    queriedInfiniteLogsResult,
+    queriedInfiniteLogsResult,
+    queriesEnabled
+  );
   const totalPayloadBytes = useLogsTotalPayload({
-    enabled: !!(allowHighFidelity && highFidelity && feature && !disabled),
+    enabled: !!(
+      allowHighFidelity &&
+      highFidelity &&
+      feature &&
+      !disabled &&
+      queriesEnabled
+    ),
   });
   const value = useMemo(() => {
+    const infiniteLogsQueryResult = queriesEnabled
+      ? queriedInfiniteLogsResult
+      : preservePreviousData
+        ? preservedInfiniteLogsResult
+        : {
+            ...queriedInfiniteLogsResult,
+            data: [],
+            error: validationResult?.error ?? null,
+            isEmpty: !validationResult?.error,
+            isError: !!validationResult?.error,
+            isFetching: false,
+            isPending: false,
+            isRefetching: false,
+            meta: {fields: {}, units: {}},
+            refetch: queriedInfiniteLogsResult.refetch,
+          };
+
     return {
       infiniteLogsQueryResult,
+      preservePreviousData,
+      queriesEnabled,
       totalPayloadBytes,
     };
-  }, [infiniteLogsQueryResult, totalPayloadBytes]);
+  }, [
+    preservePreviousData,
+    preservedInfiniteLogsResult,
+    queriedInfiniteLogsResult,
+    queriesEnabled,
+    totalPayloadBytes,
+    validationResult?.error,
+  ]);
   return <LogsPageDataContext value={value}>{children}</LogsPageDataContext>;
 }
 

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -355,11 +355,7 @@ describe('LogsPage', () => {
 
       expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBe('enabled');
 
-      await waitFor(() => {
-        expect(screen.getByTestId('logs-table')).toBeInTheDocument();
-      });
-
-      expect(screen.getAllByTestId('log-table-row')).toHaveLength(5);
+      expect(await screen.findAllByTestId('log-table-row')).toHaveLength(5);
 
       expect(rowDetailsMock).not.toHaveBeenCalled();
 

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -65,7 +65,7 @@ export default function LogsContent() {
                 source="location"
               >
                 <LogsHeader />
-                <LogsPageDataProvider allowHighFidelity>
+                <LogsPageDataProvider allowHighFidelity validateQuery>
                   {defined(onboardingProject) ? (
                     <LogsTabOnboarding
                       organization={organization}

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.tsx
@@ -17,11 +17,13 @@ import {
 type LogsAggregateExportModalButtonProps = {
   isLoading: boolean;
   tableData: OurLogsAggregateResponseItem[];
+  disabled?: boolean;
   error?: Error | null;
   pageLinks?: string | null;
 };
 
 export function LogsAggregateExportModalButton({
+  disabled,
   error,
   isLoading,
   pageLinks,
@@ -46,6 +48,7 @@ export function LogsAggregateExportModalButton({
 
   return (
     <LogsExportModalButton
+      disabled={disabled}
       error={error}
       estimatedRowCount={estimatedRowCount}
       isLoading={isLoading}

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
@@ -14,10 +14,12 @@ import {
 type LogsDirectExportModalButtonProps = {
   isLoading: boolean;
   tableData: OurLogsResponseItem[];
+  disabled?: boolean;
   error?: Error | null;
 };
 
 export function LogsDirectExportModalButton({
+  disabled,
   error,
   isLoading,
   tableData,
@@ -29,10 +31,11 @@ export function LogsDirectExportModalButton({
     field: [...fields],
     sort: sortBys.map(formatExportSort),
   });
-  const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length);
+  const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length, !disabled);
 
   return (
     <LogsExportModalButton
+      disabled={disabled}
       error={error}
       estimatedRowCount={estimatedRowCount}
       isLoading={isLoading}

--- a/static/app/views/explore/logs/exports/logsExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.tsx
@@ -32,6 +32,7 @@ type LogsExportModalButtonProps = {
   supportsAllColumns: boolean;
   tableData: Array<OurLogsResponseItem | OurLogsAggregateResponseItem>;
   title: string;
+  disabled?: boolean;
   error?: Error | null;
 };
 
@@ -65,6 +66,7 @@ export function useLogsQueryInfo({
 }
 
 export function LogsExportModalButton({
+  disabled,
   error,
   estimatedRowCount,
   isLoading,
@@ -105,6 +107,7 @@ export function LogsExportModalButton({
   return (
     <ExploreExportModalButton
       config={config}
+      disabled={disabled}
       isDataEmpty={!tableData?.length}
       isDataError={error !== null}
       isDataLoading={isLoading}

--- a/static/app/views/explore/logs/exports/useLogsExportEstimatedRowCount.tsx
+++ b/static/app/views/explore/logs/exports/useLogsExportEstimatedRowCount.tsx
@@ -44,9 +44,9 @@ function useLogsExportEstimateTimeseries({
  * Intentionally coincidentally the same semantics as the default count(logs) chart.
  * This way, the default view requests are deduplicated.
  */
-export function useLogsExportEstimatedRowCount(tableDataLength: number) {
+export function useLogsExportEstimatedRowCount(tableDataLength: number, enabled = true) {
   const baseRequest = useLogsTimeseriesRequest({
-    enabled: true,
+    enabled,
     timeseriesIngestDelay: getMaxIngestDelayTimestamp(),
     yAxesOverride: [DEFAULT_LOGS_TIMESERIES_Y_AXIS],
   });
@@ -56,7 +56,7 @@ export function useLogsExportEstimatedRowCount(tableDataLength: number) {
     queryHookImplementation: useLogsExportEstimateTimeseries,
     queryHookArgs: {
       baseRequest,
-      enabled: true,
+      enabled,
     },
     queryOptions: {
       canTriggerHighAccuracy: result => {

--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -68,10 +68,11 @@ export function AutorefreshToggle({averageLogsPerSecond = 0}: AutorefreshToggleP
   const {selection} = usePageFilters();
   const selectionString = JSON.stringify(selection);
   const previousSelection = usePrevious(selectionString);
-  const {infiniteLogsQueryResult} = useLogsPageData();
+  const {infiniteLogsQueryResult, queriesEnabled} = useLogsPageData();
   const {isError, fetchPreviousPage} = infiniteLogsQueryResult;
 
   useLogsAutoRefreshInterval({
+    enabled: queriesEnabled,
     fetchPreviousPage: () => fetchPreviousPage() as any,
     isError,
   });

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -1,7 +1,13 @@
 import {initializeLogsTest} from 'sentry-fixture/log';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
@@ -45,6 +51,16 @@ const datePageFilterProps: DatePageFilterProps = {
   }),
 };
 
+const validValidationBody: EventValidationData = {
+  dataset: [],
+  environment: [],
+  field: [],
+  orderby: [],
+  projects: [],
+  query: {error: null, fields: [], valid: true},
+  valid: true,
+};
+
 beforeEach(() => {
   mockElementSize();
 });
@@ -62,6 +78,17 @@ describe('LogsTabContent', () => {
         source="location"
       >
         <LogsPageDataProvider>{children}</LogsPageDataProvider>
+      </LogsQueryParamsProvider>
+    );
+  }
+
+  function ValidatedProviderWrapper({children}: {children: React.ReactNode}) {
+    return (
+      <LogsQueryParamsProvider
+        analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+        source="location"
+      >
+        <LogsPageDataProvider validateQuery>{children}</LogsPageDataProvider>
       </LogsQueryParamsProvider>
     );
   }
@@ -183,15 +210,7 @@ describe('LogsTabContent', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/validate/`,
       method: 'GET',
-      body: {
-        dataset: [],
-        environment: [],
-        field: [],
-        orderby: [],
-        projects: [],
-        query: {error: null, fields: [], valid: true},
-        valid: true,
-      },
+      body: validValidationBody,
     });
 
     MockApiClient.addMockResponse({
@@ -208,41 +227,45 @@ describe('LogsTabContent', () => {
       additionalWrapper: ProviderWrapper,
     });
 
-    expect(eventTableMock).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/events/`,
-      expect.objectContaining({
-        query: expect.objectContaining({
-          environment: [],
-          statsPeriod: '14d',
-          dataset: 'ourlogs',
-          field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
-          sort: 'sentry.message.parameters.0',
-          query: 'severity:error',
-        }),
-      })
-    );
+    await waitFor(() => {
+      expect(eventTableMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: [],
+            statsPeriod: '14d',
+            dataset: 'ourlogs',
+            field: [...AlwaysPresentLogFields, 'message', 'sentry.message.parameters.0'],
+            sort: 'sentry.message.parameters.0',
+            query: 'severity:error',
+          }),
+        })
+      );
+    });
 
-    expect(eventsTimeSeriesMock).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/events-timeseries/`,
-      expect.objectContaining({
-        query: expect.objectContaining({
-          dataset: 'ourlogs',
-          disableAggregateExtrapolation: '0',
-          environment: [],
-          excludeOther: 0,
-          groupBy: [],
-          interval: '1h',
-          partial: 1,
-          project: [2],
-          query: 'severity:error',
-          referrer: 'api.explore.ourlogs-timeseries',
-          sampling: 'NORMAL',
-          sort: '-count_message',
-          statsPeriod: '14d',
-          yAxis: ['count(message)'],
-        }),
-      })
-    );
+    await waitFor(() => {
+      expect(eventsTimeSeriesMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events-timeseries/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'ourlogs',
+            disableAggregateExtrapolation: '0',
+            environment: [],
+            excludeOther: 0,
+            groupBy: [],
+            interval: '1h',
+            partial: 1,
+            project: [2],
+            query: 'severity:error',
+            referrer: 'api.explore.ourlogs-timeseries',
+            sampling: 'NORMAL',
+            sort: '-count_message',
+            statsPeriod: '14d',
+            yAxis: ['count(message)'],
+          }),
+        })
+      );
+    });
 
     const table = screen.getByTestId('logs-table');
     await screen.findByText('some log message1');
@@ -250,13 +273,176 @@ describe('LogsTabContent', () => {
     expect(table).toHaveTextContent(/some log message2/);
   });
 
+  it('does not run logs queries when validation fails', async () => {
+    MockApiClient.clearMockResponses();
+    const validationMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: {
+        ...validValidationBody,
+        query: {
+          error: 'unknown attribute',
+          fields: [
+            {
+              attrType: null,
+              error: 'unknown attribute',
+              name: 'missing.key',
+              valid: false,
+            },
+          ],
+          valid: false,
+        },
+        valid: false,
+      },
+      statusCode: 400,
+    });
+    const blockedEventsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {},
+    });
+    const blockedTimeseriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      method: 'GET',
+      body: {timeSeries: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/stats/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/`,
+      method: 'GET',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/stats_v2/`,
+      method: 'GET',
+      body: {},
+    });
+
+    render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
+      initialRouterConfig,
+      organization,
+      additionalWrapper: ValidatedProviderWrapper,
+    });
+
+    await waitFor(() => expect(validationMock).toHaveBeenCalled());
+    expect(blockedEventsMock).not.toHaveBeenCalled();
+    expect(blockedTimeseriesMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+  });
+
+  it('preserves valid logs while revalidating and clears them when invalid', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'POST',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: validValidationBody,
+      match: [MockApiClient.matchQuery({query: 'severity:error'})],
+    });
+    const delayedValidationMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: validValidationBody,
+      asyncDelay: 100_000,
+      match: [MockApiClient.matchQuery({query: 'severity:warning'})],
+    });
+    const invalidValidationBody: EventValidationData = {
+      ...validValidationBody,
+      query: {
+        error: 'unknown attribute',
+        fields: [
+          {
+            attrType: null,
+            error: 'unknown attribute',
+            name: 'missing.key',
+            valid: false,
+          },
+        ],
+        valid: false,
+      },
+      valid: false,
+    };
+    const invalidValidationMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/validate/`,
+      method: 'GET',
+      body: invalidValidationBody,
+      statusCode: 400,
+      match: [MockApiClient.matchQuery({query: 'missing.key:foo'})],
+    });
+    const unvalidatedTableMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [], meta: {fields: {}}},
+      match: [
+        MockApiClient.matchQuery({
+          query: 'severity:warning',
+          referrer: 'api.explore.logs-table',
+        }),
+      ],
+    });
+
+    const {router} = render(
+      <LogsTabContentHarness datePageFilterProps={datePageFilterProps} />,
+      {
+        initialRouterConfig,
+        organization,
+        additionalWrapper: ValidatedProviderWrapper,
+      }
+    );
+
+    expect(await screen.findByText('some log message1')).toBeInTheDocument();
+
+    router.navigate(
+      `/organizations/${organization.slug}/explore/logs/?${LOGS_QUERY_KEY}=severity%3Awarning`
+    );
+    await waitFor(() => expect(delayedValidationMock).toHaveBeenCalled());
+    expect(screen.getByText('some log message1')).toBeInTheDocument();
+    expect(unvalidatedTableMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+
+    router.navigate(
+      `/organizations/${organization.slug}/explore/logs/?${LOGS_QUERY_KEY}=missing.key%3Afoo`
+    );
+    await waitFor(() => expect(invalidValidationMock).toHaveBeenCalled());
+    await waitForElementToBeRemoved(() => screen.queryByText('some log message1'));
+    expect(screen.getByText('No logs found')).toBeInTheDocument();
+    expect(unvalidatedTableMock).not.toHaveBeenCalled();
+  });
+
   it('removes invalid selected columns after validation', async () => {
     const validationBody: EventValidationData = {
       dataset: [],
       environment: [],
       field: [
-        {attrType: 'number', error: null, name: 'custom.duration', valid: true},
-        {attrType: 'boolean', error: null, name: 'custom.enabled', valid: true},
+        {
+          attrType: 'number',
+          error: null,
+          name: 'custom.duration',
+          valid: true,
+        },
+        {
+          attrType: 'boolean',
+          error: null,
+          name: 'custom.enabled',
+          valid: true,
+        },
         {
           attrType: null,
           error: 'unknown attribute',
@@ -333,7 +519,12 @@ describe('LogsTabContent', () => {
       dataset: [],
       environment: [],
       field: [
-        {attrType: 'number', error: null, name: 'custom.duration', valid: true},
+        {
+          attrType: 'number',
+          error: null,
+          name: 'custom.duration',
+          valid: true,
+        },
         {
           attrType: null,
           error: 'unknown attribute',
@@ -406,7 +597,12 @@ describe('LogsTabContent', () => {
       dataset: [],
       environment: [],
       field: [
-        {attrType: 'number', error: null, name: 'custom.duration', valid: true},
+        {
+          attrType: 'number',
+          error: null,
+          name: 'custom.duration',
+          valid: true,
+        },
         {
           attrType: null,
           error: 'unknown attribute',
@@ -588,7 +784,9 @@ describe('LogsTabContent', () => {
       organization,
       additionalWrapper: ProviderWrapper,
     });
-    const refreshButton = await screen.findByRole('button', {name: 'Refresh'});
+    const refreshButton = await screen.findByRole('button', {
+      name: 'Refresh',
+    });
     expect(refreshButton).toBeDisabled();
   });
 });

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -333,7 +333,16 @@ describe('LogsTabContent', () => {
     });
 
     render(<LogsTabContentHarness datePageFilterProps={datePageFilterProps} />, {
-      initialRouterConfig,
+      initialRouterConfig: {
+        ...initialRouterConfig,
+        location: {
+          ...initialRouterConfig.location,
+          query: {
+            ...initialRouterConfig.location.query,
+            [LOGS_AUTO_REFRESH_KEY]: 'enabled',
+          },
+        },
+      },
       organization,
       additionalWrapper: ValidatedProviderWrapper,
     });

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -89,9 +89,13 @@ import {
   useQueryParamsVisualizes,
   useSetQueryParamsMode,
 } from 'sentry/views/explore/queryParams/context';
+import {
+  getEmptyQueryResult,
+  usePreserveQueryResult,
+} from 'sentry/views/explore/queryValidation';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {useRawCounts} from 'sentry/views/explore/useRawCounts';
+import {type RawCounts, useRawCounts} from 'sentry/views/explore/useRawCounts';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
@@ -100,6 +104,11 @@ import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAl
 
 type LogsTabProps = {
   datePageFilterProps: DatePageFilterProps;
+};
+
+const EMPTY_RAW_COUNTS: RawCounts = {
+  normal: {count: null, isLoading: false},
+  total: {count: null, isLoading: false},
 };
 
 interface LogsSearchBarProps {
@@ -260,6 +269,8 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
   const aggregateSortBys = useQueryParamsAggregateSortBys();
   const setMode = useSetQueryParamsMode();
   const tableData = useLogsPageDataQueryResult();
+  const {infiniteLogsQueryResult, preservePreviousData, queriesEnabled} =
+    useLogsPageData();
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const searchQuery = useQueryParamsSearch().formatString();
   const visualizes = useQueryParamsVisualizes();
@@ -293,22 +304,43 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
     }
   }, [autorefreshEnabled]);
 
-  const rawLogCounts = useRawCounts({dataset: DiscoverDatasets.OURLOGS});
+  const queriedRawLogCounts = useRawCounts({
+    dataset: DiscoverDatasets.OURLOGS,
+    enabled: queriesEnabled,
+    preservePreviousData,
+  });
+  const rawLogCounts = preservePreviousData ? queriedRawLogCounts : EMPTY_RAW_COUNTS;
 
   const yAxes = useMemo(() => {
     const uniqueYAxes = new Set(visualizes.map(visualize => visualize.yAxis));
     return [...uniqueYAxes];
   }, [visualizes]);
 
-  const timeseriesResult = useLogsTimeseries({
-    enabled: true,
+  const queriedTimeseriesResult = useLogsTimeseries({
+    enabled: queriesEnabled,
     tableData,
     timeseriesIngestDelay,
   });
-  const aggregatesTableResult = useLogsAggregatesTable({
-    enabled: mode === Mode.AGGREGATE,
+  const queriedAggregatesTableResult = useLogsAggregatesTable({
+    enabled: queriesEnabled && mode === Mode.AGGREGATE,
     limit: 50,
   });
+  const preservedTimeseriesResult = usePreserveQueryResult(
+    queriedTimeseriesResult,
+    preservePreviousData,
+    queriedTimeseriesResult
+  );
+  const preservedAggregatesTableResult = usePreserveQueryResult(
+    queriedAggregatesTableResult,
+    preservePreviousData,
+    queriedAggregatesTableResult
+  );
+  const timeseriesResult = preservePreviousData
+    ? preservedTimeseriesResult
+    : getEmptyQueryResult({...preservedTimeseriesResult, meta: undefined}, {});
+  const aggregatesTableResult = preservePreviousData
+    ? preservedAggregatesTableResult
+    : getEmptyQueryResult(preservedAggregatesTableResult, undefined);
 
   const {
     attributes: {
@@ -437,8 +469,6 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
     };
   }, [pageFilters.selection.datetime, autorefreshEnabled]);
 
-  const {infiniteLogsQueryResult} = useLogsPageData();
-
   return (
     <LogsSidebarProvider value={setSidebarOpen}>
       <LogsSearchSection datePageFilterProps={datePageFilterProps} />
@@ -472,6 +502,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
               </Container>
               {mode === Mode.AGGREGATE ? (
                 <LogsAggregateExportModalButton
+                  disabled={!queriesEnabled}
                   isLoading={aggregatesTableResult.isPending}
                   tableData={aggregatesTableResult.data?.data ?? []}
                   error={aggregatesTableResult.error}
@@ -479,6 +510,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
                 />
               ) : (
                 <LogsDirectExportModalButton
+                  disabled={!queriesEnabled}
                   isLoading={tableData.isPending}
                   tableData={tableData.data}
                   error={tableData.error}
@@ -514,7 +546,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
                     <Button
                       size="sm"
                       icon={<IconRefresh />}
-                      disabled={!canManuallyRefresh}
+                      disabled={!canManuallyRefresh || !queriesEnabled}
                       onClick={refreshTable}
                       aria-label={t('Refresh')}
                     />

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -552,7 +552,7 @@ export const FloatingBottomContainer = styled('div')<{
   justify-content: center;
 `;
 
-export const HoveringRowLoadingRendererContainer = styled(TableRow)<{
+export const HoveringRowLoadingRendererContainer = styled('tr')<{
   headerHeight: number;
   height: number;
   position: 'top' | 'bottom';

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -49,8 +49,9 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
       p.isClickable &&
       css`
         &:active {
-          background-color: ${p.theme.tokens.interactive.transparent.neutral.background
-            .active};
+          background-color: ${
+            p.theme.tokens.interactive.transparent.neutral.background.active
+          };
         }
       `}
 
@@ -97,8 +98,9 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
         background-color: ${p.theme.tokens.background.transparent.accent.muted};
 
         &:hover {
-          background-color: ${p.theme.tokens.interactive.transparent.accent.selected
-            .background.active};
+          background-color: ${
+            p.theme.tokens.interactive.transparent.accent.selected.background.active
+          };
         }
       }
     `}
@@ -550,7 +552,7 @@ export const FloatingBottomContainer = styled('div')<{
   justify-content: center;
 `;
 
-export const HoveringRowLoadingRendererContainer = styled('div')<{
+export const HoveringRowLoadingRendererContainer = styled(TableRow)<{
   headerHeight: number;
   height: number;
   position: 'top' | 'bottom';
@@ -571,6 +573,13 @@ export const HoveringRowLoadingRendererContainer = styled('div')<{
   justify-content: center;
   height: ${p => p.height}px;
   ${p => (p.position === 'top' ? 'top: 0px;' : 'bottom: 0px;')}
+
+  > td {
+    align-items: center;
+    min-height: 0;
+    padding: 0;
+    width: 100%;
+  }
 `;
 
 export const StyledPageFilterBar = styled(PageFilterBar)`

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -971,11 +971,13 @@ function HoveringRowLoadingRenderer({
       headerHeight={isEmbedded ? 0 : 45}
       height={isEmbedded ? LOGS_GRID_BODY_ROW_HEIGHT * 1 : LOGS_GRID_BODY_ROW_HEIGHT * 3}
     >
-      <LoadingIndicator
-        size={
-          isEmbedded ? LOGS_GRID_BODY_ROW_HEIGHT * 0.8 : LOGS_GRID_BODY_ROW_HEIGHT * 1.5
-        }
-      />
+      <TableBodyCell>
+        <LoadingIndicator
+          size={
+            isEmbedded ? LOGS_GRID_BODY_ROW_HEIGHT * 0.8 : LOGS_GRID_BODY_ROW_HEIGHT * 1.5
+          }
+        />
+      </TableBodyCell>
     </HoveringRowLoadingRendererContainer>
   );
 }

--- a/static/app/views/explore/logs/useLogsAggregatesTable.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.tsx
@@ -75,6 +75,8 @@ export function useLogsAggregatesTable({
 
   return {
     data: result.data?.json,
+    dataUpdatedAt: result.dataUpdatedAt,
+    errorUpdatedAt: result.errorUpdatedAt,
     isLoading: result.isLoading,
     isPending: result.isPending,
     isError: result.isError,

--- a/static/app/views/explore/logs/useLogsAutoRefreshInterval.spec.tsx
+++ b/static/app/views/explore/logs/useLogsAutoRefreshInterval.spec.tsx
@@ -1,0 +1,100 @@
+import {useState} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {
+  ABSOLUTE_MAX_AUTO_REFRESH_TIME_MS,
+  LOGS_AUTO_REFRESH_KEY,
+  LOGS_REFRESH_INTERVAL_KEY,
+} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import {useLogsAutoRefreshInterval} from 'sentry/views/explore/logs/useLogsAutoRefreshInterval';
+
+type TestComponentProps = Parameters<typeof useLogsAutoRefreshInterval>[0];
+
+function TestComponent(props: Omit<TestComponentProps, 'enabled'>) {
+  const [enabled, setEnabled] = useState(true);
+  useLogsAutoRefreshInterval({...props, enabled});
+
+  return (
+    <div>
+      <button onClick={() => setEnabled(false)}>Disable</button>
+      <button onClick={() => setEnabled(true)}>Enable</button>
+    </div>
+  );
+}
+
+describe('useLogsAutoRefreshInterval', () => {
+  const organization = OrganizationFixture();
+  const refreshInterval = 60 * 1000;
+
+  function renderTestComponent(props: Omit<TestComponentProps, 'enabled'>) {
+    const children = (
+      <LogsQueryParamsProvider
+        analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+        source="location"
+      >
+        <TestComponent {...props} />
+      </LogsQueryParamsProvider>
+    );
+
+    const result = render(children, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/explore/logs/',
+          query: {
+            [LOGS_AUTO_REFRESH_KEY]: 'enabled',
+            [LOGS_REFRESH_INTERVAL_KEY]: refreshInterval,
+          },
+        },
+      },
+    });
+
+    return result;
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('preserves the absolute timeout while temporarily disabled', async () => {
+    const fetchPreviousPage = jest.fn(() => false as const);
+    const {router} = renderTestComponent({fetchPreviousPage, isError: false});
+    const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+
+    await act(() => jest.advanceTimersByTimeAsync(ABSOLUTE_MAX_AUTO_REFRESH_TIME_MS / 2));
+
+    await user.click(screen.getByRole('button', {name: 'Disable'}));
+    await user.click(screen.getByRole('button', {name: 'Enable'}));
+
+    await act(() =>
+      jest.advanceTimersByTimeAsync(
+        ABSOLUTE_MAX_AUTO_REFRESH_TIME_MS / 2 + refreshInterval
+      )
+    );
+
+    await waitFor(() => {
+      expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBe('timeout');
+    });
+  });
+
+  it('does not start another request when re-enabled during an active request', async () => {
+    const fetchPreviousPage = jest.fn(() => new Promise<never>(() => {}));
+    renderTestComponent({fetchPreviousPage, isError: false});
+    const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+
+    expect(fetchPreviousPage).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', {name: 'Disable'}));
+    await user.click(screen.getByRole('button', {name: 'Enable'}));
+
+    expect(fetchPreviousPage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/explore/logs/useLogsAutoRefreshInterval.tsx
+++ b/static/app/views/explore/logs/useLogsAutoRefreshInterval.tsx
@@ -20,9 +20,11 @@ import {parseLinkHeaderFromLogsPage} from 'sentry/views/explore/logs/utils';
  * Handles rate limiting, error checking, and timeout conditions.
  */
 export function useLogsAutoRefreshInterval({
+  enabled,
   fetchPreviousPage,
   isError,
 }: {
+  enabled: boolean;
   fetchPreviousPage: () =>
     | false
     | Promise<
@@ -156,7 +158,7 @@ export function useLogsAutoRefreshInterval({
   // Set up the refresh interval
   useEffect(() => {
     resetTrackingState();
-    if (autoRefresh === 'enabled') {
+    if (enabled && autoRefresh === 'enabled') {
       fetchPageWithChecks();
       intervalRef.current = setInterval(fetchPageWithChecks, refreshInterval);
     }
@@ -165,5 +167,5 @@ export function useLogsAutoRefreshInterval({
       resetTrackingState();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoRefresh, refreshInterval]);
+  }, [autoRefresh, enabled, refreshInterval]);
 }

--- a/static/app/views/explore/logs/useLogsAutoRefreshInterval.tsx
+++ b/static/app/views/explore/logs/useLogsAutoRefreshInterval.tsx
@@ -145,26 +145,32 @@ export function useLogsAutoRefreshInterval({
     isError,
   ]);
 
-  const resetTrackingState = () => {
+  const clearRefreshInterval = () => {
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
     }
+  };
+
+  const resetTrackingState = () => {
     startTimeRef.current = Date.now();
     consecutivePagesWithMoreDataRef.current = 0;
-    isRefreshRunningRef.current = false;
   };
+
+  useEffect(() => {
+    resetTrackingState();
+  }, [autoRefresh]);
 
   // Set up the refresh interval
   useEffect(() => {
-    resetTrackingState();
+    clearRefreshInterval();
     if (enabled && autoRefresh === 'enabled') {
       fetchPageWithChecks();
       intervalRef.current = setInterval(fetchPageWithChecks, refreshInterval);
     }
 
     return () => {
-      resetTrackingState();
+      clearRefreshInterval();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoRefresh, enabled, refreshInterval]);

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {logger} from '@sentry/react';
 import type {QueryClient} from '@tanstack/react-query';
-import {useInfiniteQuery, useQueryClient} from '@tanstack/react-query';
+import {keepPreviousData, useInfiniteQuery, useQueryClient} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
@@ -102,7 +102,9 @@ function useLogsApiOptions({
   const frozenTraceIds = useLogsFrozenTraceIds();
   const frozenTraceTimestamp = useLogsFrozenTraceTimestamp();
   const frozenReplayInfo = useLogsFrozenReplayInfo();
-  const {maxPickableDays} = useMaxPickableDays({dataCategories: LOGS_DATA_CATEGORIES});
+  const {maxPickableDays} = useMaxPickableDays({
+    dataCategories: LOGS_DATA_CATEGORIES,
+  });
   const {selection, isReady: pageFiltersReady} = usePageFilters();
   const location = useLocation();
   const projectIds = useLogsFrozenProjectIds();
@@ -349,7 +351,9 @@ export function getIngestDelayFilterValue(timestamp: bigint) {
 }
 
 function getIngestDelayFilter() {
-  return ` ${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:${getIngestDelayFilterValue(getMaxIngestDelayTimestamp())}`;
+  return ` ${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:${getIngestDelayFilterValue(
+    getMaxIngestDelayTimestamp()
+  )}`;
 }
 
 function getParamBasedQuery(
@@ -439,11 +443,13 @@ function maxPagesForLogsInfiniteQuery(client: QueryClient, queryKey: QueryKey): 
 export function useInfiniteLogsQuery({
   disabled,
   highFidelity,
+  preservePreviousData,
   referrer,
   staleTime: staleTimeOverride,
 }: {
   disabled?: boolean;
   highFidelity?: boolean;
+  preservePreviousData?: boolean;
   referrer?: string;
   staleTime?: number;
 } = {}) {
@@ -524,7 +530,10 @@ export function useInfiniteLogsQuery({
       ) {
         const retryOptions: QueryKeyEndpointOptions = {
           ...baseOptions,
-          query: {...baseOptions?.query, sampling: SAMPLING_MODE.HIGH_ACCURACY},
+          query: {
+            ...baseOptions?.query,
+            sampling: SAMPLING_MODE.HIGH_ACCURACY,
+          },
         };
         response = await apiFetch<EventsLogsResult>({
           ...fetchContext,
@@ -552,6 +561,7 @@ export function useInfiniteLogsQuery({
     getNextPageParam,
     initialPageParam,
     enabled: !disabled,
+    placeholderData: preservePreviousData ? keepPreviousData : undefined,
     staleTime:
       staleTimeOverride ??
       (autoRefresh ? Infinity : getStaleTimeForEventView(other.eventView)),
@@ -623,7 +633,10 @@ export function useInfiniteLogsQuery({
     });
   }, [highFidelity, queryClient, queryKeyWithInfinite, sortBys]);
 
-  const {virtualStreamedTimestamp} = useVirtualStreaming({data, highFidelity});
+  const {virtualStreamedTimestamp} = useVirtualStreaming({
+    data,
+    highFidelity,
+  });
 
   // Due to the way we prune empty pages, we cannot simply compute the sum of bytes scanned
   // for all pages as most empty pages would have been evicted already.
@@ -728,7 +741,9 @@ export function useInfiniteLogsQuery({
   });
 
   return {
+    dataUpdatedAt: queryResult.dataUpdatedAt,
     error,
+    errorUpdatedAt: queryResult.errorUpdatedAt,
     isError,
     isFetching,
     isPending:

--- a/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
@@ -79,7 +79,9 @@ describe('useLogsTimeseries', () => {
           enabled: true,
           timeseriesIngestDelay: 0n,
           tableData: {
+            dataUpdatedAt: 0,
             error: null,
+            errorUpdatedAt: 0,
             isError: false,
             isFetching: false,
             isPending: false,

--- a/static/app/views/explore/logs/useValidateLogsTab.tsx
+++ b/static/app/views/explore/logs/useValidateLogsTab.tsx
@@ -27,7 +27,7 @@ export function useValidateLogsTab({enabled = true}: UseValidateLogsTabArgs = {}
   const sortBys = useQueryParamsSortBys();
   const aggregateSortBys = useQueryParamsAggregateSortBys();
 
-  const {data, isFetching, isLoading, isPlaceholderData} = useQuery({
+  const {data, error, isFetching, isLoading, isPlaceholderData} = useQuery({
     ...validateEventParamsOptions({
       organization,
       selection,
@@ -46,6 +46,7 @@ export function useValidateLogsTab({enabled = true}: UseValidateLogsTabArgs = {}
 
   return {
     data,
+    error,
     isFetching,
     isPlaceholderData,
     isLoading,

--- a/static/app/views/explore/queryValidation.tsx
+++ b/static/app/views/explore/queryValidation.tsx
@@ -1,0 +1,79 @@
+import {useEffect, useEffectEvent, useState} from 'react';
+
+interface QueryValidationResult {
+  data: {valid: boolean} | undefined;
+  error: unknown;
+  isFetching: boolean;
+  isLoading: boolean;
+  isPlaceholderData: boolean;
+}
+
+export function getQueryValidationState(validationResult: QueryValidationResult) {
+  const isPending =
+    validationResult.isFetching ||
+    validationResult.isLoading ||
+    validationResult.isPlaceholderData;
+  const queriesEnabled =
+    !isPending && !validationResult.error && validationResult.data?.valid === true;
+  const preservePreviousData =
+    !validationResult.error &&
+    (isPending ? validationResult.data?.valid !== false : queriesEnabled);
+
+  return {preservePreviousData, queriesEnabled};
+}
+
+export function getEmptyQueryResult<
+  TResult extends {
+    data: unknown;
+    error: unknown;
+    isError: boolean;
+    isLoading: boolean;
+    isPending: boolean;
+  },
+>(result: TResult, data: TResult['data']): TResult {
+  return {
+    ...result,
+    data,
+    error: null,
+    isError: false,
+    isLoading: false,
+    isPending: false,
+  };
+}
+
+interface QueryState {
+  dataUpdatedAt: number;
+  errorUpdatedAt: number;
+  isPending: boolean;
+}
+
+export function useLastSettledQueryResult<T>(
+  result: T,
+  queryState: QueryState,
+  enabled = true
+): T {
+  const [lastSettledResult, setLastSettledResult] = useState(result);
+  const updateLastSettledResult = useEffectEvent(() => setLastSettledResult(result));
+
+  useEffect(() => {
+    if (enabled && !queryState.isPending) {
+      updateLastSettledResult();
+    }
+  }, [
+    enabled,
+    queryState.dataUpdatedAt,
+    queryState.errorUpdatedAt,
+    queryState.isPending,
+  ]);
+
+  return lastSettledResult;
+}
+
+export function usePreserveQueryResult<T>(
+  result: T,
+  preservePreviousData: boolean,
+  queryState: QueryState
+): T {
+  const lastSettledResult = useLastSettledQueryResult(result, queryState);
+  return preservePreviousData && queryState.isPending ? lastSettledResult : result;
+}

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useEffectEvent, useState} from 'react';
+import {Fragment, useEffect} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {keepPreviousData, useQuery} from '@tanstack/react-query';
@@ -58,6 +58,11 @@ import {
   useQueryParamsVisualizes,
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
+import {
+  getEmptyQueryResult,
+  getQueryValidationState,
+  usePreserveQueryResult,
+} from 'sentry/views/explore/queryValidation';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
 import {SPANS_TABLE_LIMIT} from 'sentry/views/explore/spans/constants';
 import {useCrossEventDatasetAvailability} from 'sentry/views/explore/spans/crossEvents/useCrossEventDatasetAvailability';
@@ -212,13 +217,13 @@ function SpanTabContentSectionInner({
     isPlaceholderData: isValidationPlaceholderData,
   } = useValidateSpansTab();
 
-  const isValidationPending =
-    isValidationFetching || isValidationLoading || isValidationPlaceholderData;
-  const queriesEnabled =
-    !isValidationPending && !validationError && validationData?.valid === true;
-  const preservePreviousData =
-    !validationError &&
-    (isValidationPending ? validationData?.valid !== false : queriesEnabled);
+  const {preservePreviousData, queriesEnabled} = getQueryValidationState({
+    data: validationData,
+    error: validationError,
+    isFetching: isValidationFetching,
+    isLoading: isValidationLoading,
+    isPlaceholderData: isValidationPlaceholderData,
+  });
 
   // In aggregate mode the table is driven by aggregateSortBys, not the
   // samples sort (which falls back to `-timestamp`), so pick accordingly.
@@ -325,7 +330,11 @@ function SpanTabContentSectionInner({
     : {
         ...displayedAggregatesTableResult,
         result: getEmptyQueryResult(
-          {...displayedAggregatesTableResult.result, pageLinks: undefined},
+          {
+            ...displayedAggregatesTableResult.result,
+            isFetching: false,
+            pageLinks: undefined,
+          },
           []
         ),
       };
@@ -334,7 +343,7 @@ function SpanTabContentSectionInner({
     : {
         ...displayedSpansTableResult,
         result: getEmptyQueryResult(
-          {...displayedSpansTableResult.result, pageLinks: undefined},
+          {...displayedSpansTableResult.result, isFetching: false, pageLinks: undefined},
           []
         ),
       };
@@ -342,11 +351,17 @@ function SpanTabContentSectionInner({
     ? displayedTracesTableResult
     : {
         error: null,
-        result: getEmptyQueryResult(displayedTracesTableResult.result, undefined),
+        result: getEmptyQueryResult(
+          {...displayedTracesTableResult.result, isFetching: false},
+          undefined
+        ),
       };
   const timeseriesResultForDisplay = preservePreviousData
     ? displayedTimeseriesResult
-    : getEmptyQueryResult({...displayedTimeseriesResult, meta: undefined}, {});
+    : getEmptyQueryResult(
+        {...displayedTimeseriesResult, isFetching: false, meta: undefined},
+        {}
+      );
 
   const [interval] = useChartInterval();
 
@@ -458,48 +473,6 @@ function SpanTabContentSectionInner({
       </TourElement>
     </ExploreContentSection>
   );
-}
-
-function getEmptyQueryResult<
-  TResult extends {
-    data: unknown;
-    error: unknown;
-    isError: boolean;
-    isFetching: boolean;
-    isLoading: boolean;
-    isPending: boolean;
-  },
->(result: TResult, data: TResult['data']): TResult {
-  return {
-    ...result,
-    data,
-    error: null,
-    isError: false,
-    isFetching: false,
-    isLoading: false,
-    isPending: false,
-  };
-}
-
-function usePreserveQueryResult<T>(
-  result: T,
-  preservePreviousData: boolean,
-  queryState: {
-    dataUpdatedAt: number;
-    errorUpdatedAt: number;
-    isPending: boolean;
-  }
-): T {
-  const [lastSettledResult, setLastSettledResult] = useState(result);
-  const updateLastSettledResult = useEffectEvent(() => setLastSettledResult(result));
-
-  useEffect(() => {
-    if (!queryState.isPending) {
-      updateLastSettledResult();
-    }
-  }, [queryState.dataUpdatedAt, queryState.errorUpdatedAt, queryState.isPending]);
-
-  return preservePreviousData && queryState.isPending ? lastSettledResult : result;
 }
 
 const SpanTabContentSection = registerLLMContext(


### PR DESCRIPTION
- stop Logs Explore data requests while query validation is pending or invalid
- preserve the last valid results during revalidation and clear them after validation fails
- disable refresh and export actions for invalid queries, including export row-count estimates
- share validation and query-result preservation behavior with the spans implementation from EXP-1070

Closes EXP-1071