### PR TITLE
fix(deletions): drop the stale-comment immortality pin from PullRequest retention

### DIFF
--- a/src/sentry/deletions/defaults/pullrequest.py
+++ b/src/sentry/deletions/defaults/pullrequest.py
@@ -16,6 +16,12 @@ from sentry.seer.models.run import SeerRunPullRequest
 
 
 class PullRequestDeletionTask(ModelDeletionTask[PullRequest]):
+    # Each PR deletion fans out to seven child relations, so a backlog of newly
+    # eligible rows costs far more than its own row count. The ceiling is well above
+    # steady-state throughput; it exists to bound bursts (e.g. a retention filter
+    # that just released rows it had been pinning).
+    rate_limit_option_default = "deletions.pull-request.rate-limit"
+
     def get_query_filter(self) -> Q:
         """
         Returns a Q object that filters for unused PRs.

--- a/src/sentry/deletions/defaults/pullrequest.py
+++ b/src/sentry/deletions/defaults/pullrequest.py
@@ -16,10 +16,8 @@ from sentry.seer.models.run import SeerRunPullRequest
 
 
 class PullRequestDeletionTask(ModelDeletionTask[PullRequest]):
-    # Each PR deletion fans out to seven child relations, so a backlog of newly
-    # eligible rows costs far more than its own row count. The ceiling is well above
-    # steady-state throughput; it exists to bound bursts (e.g. a retention filter
-    # that just released rows it had been pinning).
+    # Each PR deletion fans out to seven child relations, so a burst costs far more
+    # than its row count suggests.
     rate_limit_option_default = "deletions.pull-request.rate-limit"
 
     def get_query_filter(self) -> Q:

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -376,35 +376,24 @@ class PullRequest(Model):
         """
         Returns a Q object that filters for unused PRs.
         This is the inverse of what makes a PR "in use".
+
+        Every keep condition is bounded, either by ``cutoff_date`` or by the lifetime
+        of the object that references the PR. A condition that can be true forever
+        makes the PR immortal: retention scans it in every run and can never remove it.
         """
         from sentry.models.grouplink import GroupLink
         from sentry.models.releasecommit import ReleaseCommit
         from sentry.models.releaseheadcommit import ReleaseHeadCommit
 
-        # Subquery for checking if there's a valid GroupLink
+        # Bounded by the *group's* lifetime, not the PR's: an issue that is still
+        # alive shows this PR (issue detail, weekly report, resolution activity), and
+        # the join through ``group__project`` drops the link once either is gone.
+        # GroupLink is deleted with its Group, which retention ages out on last_seen.
         grouplink_exists = Exists(
             GroupLink.objects.filter(
                 linked_type=GroupLink.LinkedType.pull_request,
                 linked_id=OuterRef("id"),
                 group__project__isnull=False,
-            )
-        )
-
-        # Subquery for checking if comment has valid group_ids
-        # Note: Django aliases the table as U0 in the EXISTS subquery
-        comment_has_valid_group = Exists(
-            PullRequestComment.objects.filter(
-                pull_request_id=OuterRef("id"),
-                group_ids__isnull=False,
-            )
-            .exclude(group_ids__len=0)
-            .extra(
-                where=[
-                    """EXISTS (
-                        SELECT 1 FROM sentry_groupedmessage g
-                        WHERE g.id = ANY(U0.group_ids)
-                    )"""
-                ]
             )
         )
 
@@ -414,8 +403,21 @@ class PullRequest(Model):
             ).filter(Q(created_at__gte=cutoff_date) | Q(updated_at__gte=cutoff_date))
         )
 
-        commit_in_release = Exists(ReleaseCommit.objects.filter(commit_id=OuterRef("commit_id")))
-        commit_in_head = Exists(ReleaseHeadCommit.objects.filter(commit_id=OuterRef("commit_id")))
+        # Bounded by the *release's* recency: what a release surfaces is the
+        # commit -> PR link on its commit list, so a release past the retention
+        # window has no claim on the PR. Commits in a release are themselves kept
+        # forever (see CommitDeletionTask), so keying on the commit would not bound
+        # this at all.
+        commit_in_release = Exists(
+            ReleaseCommit.objects.filter(
+                commit_id=OuterRef("commit_id"), release__date_added__gte=cutoff_date
+            )
+        )
+        commit_in_head = Exists(
+            ReleaseHeadCommit.objects.filter(
+                commit_id=OuterRef("commit_id"), release__date_added__gte=cutoff_date
+            )
+        )
         commit_exists = Exists(
             PullRequestCommit.objects.filter(
                 pull_request_id=OuterRef("id"),
@@ -425,10 +427,9 @@ class PullRequest(Model):
         # Define what makes a PR "in use" (should be kept)
         keep_conditions = (
             Q(date_added__gte=cutoff_date)
-            | recent_comment_exists
-            | commit_exists
-            | grouplink_exists
-            | comment_has_valid_group
+            | Q(recent_comment_exists)
+            | Q(commit_exists)
+            | Q(grouplink_exists)
         )
 
         # Return the inverse - we want PRs that DON'T meet any keep conditions

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -378,7 +378,8 @@ class PullRequest(Model):
         This is the inverse of what makes a PR "in use".
 
         Every keep condition must be bounded, either by ``cutoff_date`` or by the
-        lifetime of the object referencing the PR. An unbounded one makes the PR immortal.
+        lifetime of the object referencing the PR. A condition bounded by neither
+        makes the PR immortal and must say why that is intended.
         """
         from sentry.models.grouplink import GroupLink
         from sentry.models.releasecommit import ReleaseCommit
@@ -399,19 +400,13 @@ class PullRequest(Model):
             ).filter(Q(created_at__gte=cutoff_date) | Q(updated_at__gte=cutoff_date))
         )
 
-        # Bounded by the release's recency rather than the commit's: CommitDeletionTask
-        # keeps any commit that is in a release forever, so keying on the commit
-        # bounds nothing.
-        commit_in_release = Exists(
-            ReleaseCommit.objects.filter(
-                commit_id=OuterRef("commit_id"), release__date_added__gte=cutoff_date
-            )
-        )
-        commit_in_head = Exists(
-            ReleaseHeadCommit.objects.filter(
-                commit_id=OuterRef("commit_id"), release__date_added__gte=cutoff_date
-            )
-        )
+        # Bounded by the release's lifetime, deliberately: a PR whose commit shipped
+        # in a release is part of that release's provenance (CommitSerializer attaches
+        # it to the release's commits), so it lives as long as the release — the same
+        # condition under which CommitDeletionTask keeps the commit itself. Releases
+        # at the tail are effectively immortal, and these PRs are too, by choice.
+        commit_in_release = Exists(ReleaseCommit.objects.filter(commit_id=OuterRef("commit_id")))
+        commit_in_head = Exists(ReleaseHeadCommit.objects.filter(commit_id=OuterRef("commit_id")))
         commit_exists = Exists(
             PullRequestCommit.objects.filter(
                 pull_request_id=OuterRef("id"),

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -377,18 +377,14 @@ class PullRequest(Model):
         Returns a Q object that filters for unused PRs.
         This is the inverse of what makes a PR "in use".
 
-        Every keep condition is bounded, either by ``cutoff_date`` or by the lifetime
-        of the object that references the PR. A condition that can be true forever
-        makes the PR immortal: retention scans it in every run and can never remove it.
+        Every keep condition must be bounded, either by ``cutoff_date`` or by the
+        lifetime of the object referencing the PR. An unbounded one makes the PR immortal.
         """
         from sentry.models.grouplink import GroupLink
         from sentry.models.releasecommit import ReleaseCommit
         from sentry.models.releaseheadcommit import ReleaseHeadCommit
 
-        # Bounded by the *group's* lifetime, not the PR's: an issue that is still
-        # alive shows this PR (issue detail, weekly report, resolution activity), and
-        # the join through ``group__project`` drops the link once either is gone.
-        # GroupLink is deleted with its Group, which retention ages out on last_seen.
+        # Bounded by the group's lifetime: GroupLink is deleted along with its Group.
         grouplink_exists = Exists(
             GroupLink.objects.filter(
                 linked_type=GroupLink.LinkedType.pull_request,
@@ -403,11 +399,9 @@ class PullRequest(Model):
             ).filter(Q(created_at__gte=cutoff_date) | Q(updated_at__gte=cutoff_date))
         )
 
-        # Bounded by the *release's* recency: what a release surfaces is the
-        # commit -> PR link on its commit list, so a release past the retention
-        # window has no claim on the PR. Commits in a release are themselves kept
-        # forever (see CommitDeletionTask), so keying on the commit would not bound
-        # this at all.
+        # Bounded by the release's recency rather than the commit's: CommitDeletionTask
+        # keeps any commit that is in a release forever, so keying on the commit
+        # bounds nothing.
         commit_in_release = Exists(
             ReleaseCommit.objects.filter(
                 commit_id=OuterRef("commit_id"), release__date_added__gte=cutoff_date

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -332,6 +332,14 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Aggregate rows/sec ceiling for PullRequest deletions across all concurrent
+# deletion tasks. 0 disables rate limiting.
+register(
+    "deletions.pull-request.rate-limit",
+    default=500,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "unmerge.killswitch-projects",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -333,10 +333,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Aggregate rows/sec ceiling for PullRequest deletions across all concurrent
-# deletion tasks. 0 disables rate limiting.
+# deletion tasks. 0 disables rate limiting. Sized to sit well above the
+# steady-state deletion rate while keeping any backlog drain gentle, so it
+# needs no tuning around deploys.
 register(
     "deletions.pull-request.rate-limit",
-    default=500,
+    default=100,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/tests/sentry/deletions/test_pullrequest.py
+++ b/tests/sentry/deletions/test_pullrequest.py
@@ -227,8 +227,8 @@ class PullRequestDeletionTaskTest(TestCase):
 
         assert not PullRequest.objects.filter(id__in=[pr.id for pr in prs]).exists()
         mock_limiter_cls.assert_called_with(
-            burst_limit=500,
-            drip_rate=500,
+            burst_limit=100,
+            drip_rate=100,
             key="deletions.rate_limit:deletions.pull-request.rate-limit",
         )
 

--- a/tests/sentry/deletions/test_pullrequest.py
+++ b/tests/sentry/deletions/test_pullrequest.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.utils import timezone
 
@@ -87,16 +88,28 @@ class PullRequestDeletionTaskTest(TestCase):
         assert len(filtered) == 1
         assert filtered[0].id == pr_old_unused.id
 
-    def test_query_filter_keeps_pr_with_release_commit(self) -> None:
+    def test_query_filter_keeps_pr_with_recent_release_commit(self) -> None:
         pr = self.create_pr("pr_release", self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
 
-        release = self.create_release(project=self.project)
+        release = self.create_release(project=self.project, date_added=self.recent_date)
         self.create_release_commit(release, commit)
 
         filtered = list(PullRequest.objects.filter(self.task.get_query_filter()))
         assert len(filtered) == 0
+
+    def test_query_filter_deletes_pr_whose_release_is_past_the_window(self) -> None:
+        pr = self.create_pr("pr_old_release", self.old_date)
+        commit = self.create_old_commit()
+        self.create_pull_request_commit(pr, commit)
+
+        release = self.create_release(project=self.project, date_added=self.old_date)
+        self.create_release_commit(release, commit)
+
+        filtered = list(PullRequest.objects.filter(self.task.get_query_filter()))
+        assert len(filtered) == 1
+        assert filtered[0].id == pr.id
 
     def test_query_filter_keeps_pr_with_valid_group_link(self) -> None:
         pr = self.create_pr("pr_group", self.old_date)
@@ -126,23 +139,25 @@ class PullRequestDeletionTaskTest(TestCase):
         assert len(filtered) == 1
         assert filtered[0].id == pr.id
 
-    def test_query_filter_with_comment_group_ids(self) -> None:
-        pr_valid_group = self.create_pr("pr_valid", self.old_date)
+    def test_query_filter_ignores_comment_group_ids(self) -> None:
+        """Comment recency decides, not what the comment happens to reference."""
+        pr_stale_comment = self.create_pr("pr_stale", self.old_date)
         group = self.create_group(project=self.project)
         self.create_pull_request_comment(
-            pull_request=pr_valid_group,
+            pull_request=pr_stale_comment,
             group_ids=[group.id],
         )
 
-        pr_invalid_group = self.create_pr("pr_invalid", self.old_date)
+        pr_recent_comment = self.create_pr("pr_recent", self.old_date)
         self.create_pull_request_comment(
-            pull_request=pr_invalid_group,
-            group_ids=[999999],  # Non-existent
+            pull_request=pr_recent_comment,
+            updated_at=self.recent_date,
+            group_ids=[group.id],
         )
 
         filtered = list(PullRequest.objects.filter(self.task.get_query_filter()))
         assert len(filtered) == 1
-        assert filtered[0].id == pr_invalid_group.id
+        assert filtered[0].id == pr_stale_comment.id
 
     def test_get_child_relations_includes_all_child_models(self) -> None:
         pr = self.create_pr("pr_children", self.old_date)
@@ -202,6 +217,20 @@ class PullRequestDeletionTaskTest(TestCase):
         assert not PullRequestMetrics.objects.filter(id=metrics.id).exists()
         assert not SeerRunPullRequest.objects.filter(id=link.id).exists()
         assert not PullRequest.objects.filter(id=pr.id).exists()
+
+    def test_deletion_is_rate_limited(self) -> None:
+        prs = [self.create_pr(f"pr_throttled_{i}", self.old_date) for i in range(3)]
+
+        with mock.patch("sentry.deletions.base.LeakyBucketRateLimiter") as mock_limiter_cls:
+            mock_limiter_cls.return_value.use_and_get_info.return_value = mock.Mock(wait_time=0)
+            self.task.chunk(apply_filter=True)
+
+        assert not PullRequest.objects.filter(id__in=[pr.id for pr in prs]).exists()
+        mock_limiter_cls.assert_called_with(
+            burst_limit=500,
+            drip_rate=500,
+            key="deletions.rate_limit:deletions.pull-request.rate-limit",
+        )
 
     def test_query_filter_with_no_prs(self) -> None:
         filtered = list(PullRequest.objects.filter(self.task.get_query_filter()))

--- a/tests/sentry/deletions/test_pullrequest.py
+++ b/tests/sentry/deletions/test_pullrequest.py
@@ -88,18 +88,19 @@ class PullRequestDeletionTaskTest(TestCase):
         assert len(filtered) == 1
         assert filtered[0].id == pr_old_unused.id
 
-    def test_query_filter_keeps_pr_with_recent_release_commit(self) -> None:
+    def test_query_filter_keeps_pr_with_release_commit(self) -> None:
         pr = self.create_pr("pr_release", self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
 
-        release = self.create_release(project=self.project, date_added=self.recent_date)
+        release = self.create_release(project=self.project)
         self.create_release_commit(release, commit)
 
         filtered = list(PullRequest.objects.filter(self.task.get_query_filter()))
         assert len(filtered) == 0
 
-    def test_query_filter_deletes_pr_whose_release_is_past_the_window(self) -> None:
+    def test_query_filter_keeps_pr_whose_release_is_past_the_window(self) -> None:
+        """The release pin lasts for the release's lifetime, however old the release."""
         pr = self.create_pr("pr_old_release", self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
@@ -108,8 +109,7 @@ class PullRequestDeletionTaskTest(TestCase):
         self.create_release_commit(release, commit)
 
         filtered = list(PullRequest.objects.filter(self.task.get_query_filter()))
-        assert len(filtered) == 1
-        assert filtered[0].id == pr.id
+        assert len(filtered) == 0
 
     def test_query_filter_keeps_pr_with_valid_group_link(self) -> None:
         pr = self.create_pr("pr_group", self.old_date)

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -332,12 +332,12 @@ class PullRequestRetentionTest(TestCase):
         self.create_pull_request_commit(pr, commit)
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_in_recent_release_is_not_unused(self) -> None:
-        """PR with a commit in a release from within the window should not be unused"""
+    def test_pr_with_commit_in_release_is_not_unused(self) -> None:
+        """PR with a commit that's part of a release should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
-        release = self.create_release(project=self.project, date_added=self.recent_date)
+        release = self.create_release(project=self.project)
         ReleaseCommit.objects.create(
             organization_id=self.organization.id,
             release=release,
@@ -346,8 +346,9 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_in_old_release_is_unused(self) -> None:
-        """A release older than the window no longer pins the PR that shipped in it"""
+    def test_pr_with_commit_in_old_release_is_not_unused(self) -> None:
+        """The release pin is for the release's lifetime, not its recency: the PR is
+        part of the release's provenance for as long as the release exists"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
@@ -358,14 +359,14 @@ class PullRequestRetentionTest(TestCase):
             commit=commit,
             order=1,
         )
-        assert pr.is_unused(self.cutoff_date)
+        assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_as_recent_release_head_is_not_unused(self) -> None:
-        """PR with a commit heading a release from within the window should not be unused"""
+    def test_pr_with_commit_as_release_head_is_not_unused(self) -> None:
+        """PR with a commit that's a release head should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
-        release = self.create_release(project=self.project, date_added=self.recent_date)
+        release = self.create_release(project=self.project)
         ReleaseHeadCommit.objects.create(
             organization_id=self.organization.id,
             repository_id=self.repo.id,
@@ -374,8 +375,8 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_as_old_release_head_is_unused(self) -> None:
-        """An old release doesn't pin the PR through its head commit either"""
+    def test_pr_with_commit_as_old_release_head_is_not_unused(self) -> None:
+        """An old release pins the PR through its head commit for its lifetime too"""
         pr = self.create_pr(date_added=self.old_date)
         commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
@@ -386,7 +387,7 @@ class PullRequestRetentionTest(TestCase):
             release=release,
             commit=commit,
         )
-        assert pr.is_unused(self.cutoff_date)
+        assert not pr.is_unused(self.cutoff_date)
 
     def test_pr_linked_to_existing_group_is_not_unused(self) -> None:
         """PR linked to an existing group via GroupLink should not be unused"""

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -261,6 +261,17 @@ class PullRequestRetentionTest(TestCase):
         pr.refresh_from_db()
         return pr
 
+    def create_old_commit(self):
+        """Helper to create a commit that is itself past the cutoff"""
+        commit = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.author,
+        )
+        Commit.objects.filter(id=commit.id).update(date_added=self.old_date)
+        commit.refresh_from_db()
+        return commit
+
     def test_old_pr_with_no_references_is_unused(self) -> None:
         """An old PR with no references should be marked as unused"""
         pr = self.create_pr(date_added=self.old_date)
@@ -321,17 +332,12 @@ class PullRequestRetentionTest(TestCase):
         self.create_pull_request_commit(pr, commit)
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_in_release_is_not_unused(self) -> None:
-        """PR with a commit that's part of a release should not be unused"""
+    def test_pr_with_commit_in_recent_release_is_not_unused(self) -> None:
+        """PR with a commit in a release from within the window should not be unused"""
         pr = self.create_pr(date_added=self.old_date)
-        commit = self.create_commit(
-            project=self.project,
-            repo=self.repo,
-            author=self.author,
-        )
-        Commit.objects.filter(id=commit.id).update(date_added=self.old_date)
+        commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
-        release = self.create_release(project=self.project)
+        release = self.create_release(project=self.project, date_added=self.recent_date)
         ReleaseCommit.objects.create(
             organization_id=self.organization.id,
             release=release,
@@ -340,17 +346,26 @@ class PullRequestRetentionTest(TestCase):
         )
         assert not pr.is_unused(self.cutoff_date)
 
-    def test_pr_with_commit_as_release_head_is_not_unused(self) -> None:
-        """PR with a commit that's a release head should not be unused"""
+    def test_pr_with_commit_in_old_release_is_unused(self) -> None:
+        """A release older than the window no longer pins the PR that shipped in it"""
         pr = self.create_pr(date_added=self.old_date)
-        commit = self.create_commit(
-            project=self.project,
-            repo=self.repo,
-            author=self.author,
-        )
-        Commit.objects.filter(id=commit.id).update(date_added=self.old_date)
+        commit = self.create_old_commit()
         self.create_pull_request_commit(pr, commit)
-        release = self.create_release(project=self.project)
+        release = self.create_release(project=self.project, date_added=self.old_date)
+        ReleaseCommit.objects.create(
+            organization_id=self.organization.id,
+            release=release,
+            commit=commit,
+            order=1,
+        )
+        assert pr.is_unused(self.cutoff_date)
+
+    def test_pr_with_commit_as_recent_release_head_is_not_unused(self) -> None:
+        """PR with a commit heading a release from within the window should not be unused"""
+        pr = self.create_pr(date_added=self.old_date)
+        commit = self.create_old_commit()
+        self.create_pull_request_commit(pr, commit)
+        release = self.create_release(project=self.project, date_added=self.recent_date)
         ReleaseHeadCommit.objects.create(
             organization_id=self.organization.id,
             repository_id=self.repo.id,
@@ -358,6 +373,20 @@ class PullRequestRetentionTest(TestCase):
             commit=commit,
         )
         assert not pr.is_unused(self.cutoff_date)
+
+    def test_pr_with_commit_as_old_release_head_is_unused(self) -> None:
+        """An old release doesn't pin the PR through its head commit either"""
+        pr = self.create_pr(date_added=self.old_date)
+        commit = self.create_old_commit()
+        self.create_pull_request_commit(pr, commit)
+        release = self.create_release(project=self.project, date_added=self.old_date)
+        ReleaseHeadCommit.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            release=release,
+            commit=commit,
+        )
+        assert pr.is_unused(self.cutoff_date)
 
     def test_pr_linked_to_existing_group_is_not_unused(self) -> None:
         """PR linked to an existing group via GroupLink should not be unused"""
@@ -384,8 +413,21 @@ class PullRequestRetentionTest(TestCase):
         )
         assert pr.is_unused(self.cutoff_date)
 
-    def test_pr_comment_with_existing_group_is_not_unused(self) -> None:
-        """PR with a comment referencing an existing group should not be unused"""
+    def test_pr_with_recent_comment_referencing_live_group_is_not_unused(self) -> None:
+        """A comment Sentry can still update keeps its PR, issues referenced or not"""
+        pr = self.create_pr(date_added=self.old_date)
+        group = self.create_group(project=self.project)
+        self.create_pull_request_comment(
+            pull_request=pr,
+            created_at=self.recent_date,
+            updated_at=self.recent_date,
+            group_ids=[group.id],
+        )
+        assert not pr.is_unused(self.cutoff_date)
+
+    def test_pr_with_old_comment_referencing_live_group_is_unused(self) -> None:
+        """A live issue in a stale comment no longer pins the PR -- the comment is
+        past the window in which Sentry would ever rewrite it"""
         pr = self.create_pr(date_added=self.old_date)
         group = self.create_group(project=self.project)
         self.create_pull_request_comment(
@@ -393,40 +435,6 @@ class PullRequestRetentionTest(TestCase):
             created_at=self.old_date,
             updated_at=self.old_date,
             group_ids=[group.id],
-        )
-        assert not pr.is_unused(self.cutoff_date)
-
-    def test_pr_comment_with_deleted_group_is_unused(self) -> None:
-        """PR with a comment referencing only non-existent groups should be unused"""
-        pr = self.create_pr(date_added=self.old_date)
-        self.create_pull_request_comment(
-            pull_request=pr,
-            created_at=self.old_date,
-            updated_at=self.old_date,
-            group_ids=[999999],  # Non-existent group
-        )
-        assert pr.is_unused(self.cutoff_date)
-
-    def test_pr_comment_with_mixed_groups_is_not_unused(self) -> None:
-        """PR with comment referencing both existing and non-existent groups should not be unused"""
-        pr = self.create_pr(date_added=self.old_date)
-        group = self.create_group(project=self.project)
-        self.create_pull_request_comment(
-            pull_request=pr,
-            created_at=self.old_date,
-            updated_at=self.old_date,
-            group_ids=[group.id, 999999],  # One exists, one doesn't
-        )
-        assert not pr.is_unused(self.cutoff_date)
-
-    def test_pr_comment_with_empty_groups_is_unused(self) -> None:
-        """PR with comment that has empty group_ids should be unused"""
-        pr = self.create_pr(date_added=self.old_date)
-        self.create_pull_request_comment(
-            pull_request=pr,
-            created_at=self.old_date,
-            updated_at=self.old_date,
-            group_ids=[],
         )
         assert pr.is_unused(self.cutoff_date)
 


### PR DESCRIPTION
`PullRequest.get_unused_filter` had two keep conditions with no time bound, so any PR that ever matched one could never be deleted — the oldest surviving rows date back to 2019.

- **Removes the comment `group_ids` pin.** The only reader of `group_ids` is the bot-comment rewrite, which is gated to PRs younger than 14 days, and `recent_comment_exists` already keeps any PR whose comment changed inside the 90-day cleanup window. The clause only made PRs immortal. Removing it also drops the `.extra(where=[...])` raw SQL that relied on Django's `U0` table alias.
- **Keeps the release pin, now documented as intentional.** A PR whose commit is in a release stays for the release's lifetime — release pages attach `pullRequest` to their commits — the same rule `CommitDeletionTask` uses for the commit itself. No behavior change; regression tests assert an old release still pins its PRs.
- **Adds a rate limit for PR deletions.** The task declared no `rate_limit_option`, so throttling was a no-op. The new `deletions.pull-request.rate-limit` option (100 rows/sec) sits well above the steady-state deletion rate but keeps the one-time drain of newly eligible rows gentle even with the sevenfold child-relation fanout — no tuning needed around the deploy.

Follow-up (not in this PR): retention that assumes PR rows age out at 90 days — the PR activity document — needs aligning with the lifetime release pin.
