### PR TITLE
ref(control): Baseline the GitHub own-repo-PR check drop to on

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2515,12 +2515,12 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Drops GitHub check webhooks that reference no pull request based in their own
-# repo (see ActionFilter.own_repo_pr_actions). Ships off: unlike the other parser
-# drops this one keys off payload shape rather than a header, so it needs a switch
-# that stops the loss immediately if the predicate turns out to be wrong.
+# repo (see ActionFilter.own_repo_pr_actions). The predicate reads payload shape
+# rather than a header, so it keeps a switch: setting this false stops the drop
+# without a deploy.
 register(
     "hybridcloud.webhookpayload.github_drop_checks_without_own_repo_pr",
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Break glass controls

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -553,8 +553,12 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_cells(cell_config)
     @responses.activate
     def test_forwards_check_run_completed(self) -> None:
+        # An own-repo PR is the only shape of completed check that reaches a mailbox.
         integration = self.get_integration()
-        request = self._post_check_event(action="completed")
+        request = self._post_check_event(
+            action="completed",
+            container={"pull_requests": [{"number": 7, "base": {"repo": {"id": 123}}}]},
+        )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
         response = parser.get_response()
 
@@ -730,9 +734,12 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_cells(cell_config)
     @responses.activate
     def test_forwards_check_suite_completed(self) -> None:
+        # Needs an own-repo PR to survive the drop, as for check_run.
         integration = self.get_integration()
         request = self._post_check_event(
-            action="completed", event_type=GithubWebhookType.CHECK_SUITE
+            action="completed",
+            event_type=GithubWebhookType.CHECK_SUITE,
+            container={"pull_requests": [{"number": 7, "base": {"repo": {"id": 123}}}]},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
         response = parser.get_response()
@@ -815,10 +822,12 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
     @responses.activate
+    @override_options({DROP_NO_OWN_REPO_PR_OPTION: False})
     @patch("sentry.middleware.integrations.parsers.github.metrics")
     def test_forwarded_event_metric_foreign_repo_pull_request(self, mock_metrics: Mock) -> None:
         """GitHub also lists PRs that merely share a head sha but live in another repo;
-        the cell skips those, so they count as no work."""
+        the cell skips those, so they count as no work. Reachable only with the drop
+        disabled -- with it on, these are dropped before the forward."""
         self.get_integration()
         request = self._post_check_event(
             action="completed",
@@ -837,9 +846,11 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
     @responses.activate
+    @override_options({DROP_NO_OWN_REPO_PR_OPTION: False})
     @patch("sentry.middleware.integrations.parsers.github.metrics")
     def test_forwarded_event_metric_no_pull_requests(self, mock_metrics: Mock) -> None:
-        """The common case for CI on a non-PR commit: an empty pull_requests array."""
+        """The common case for CI on a non-PR commit: an empty pull_requests array.
+        Reachable only with the drop disabled."""
         self.get_integration()
         request = self._post_check_event(action="completed", container={"pull_requests": []})
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
@@ -897,10 +908,12 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
     @responses.activate
+    @override_options({DROP_NO_OWN_REPO_PR_OPTION: False})
     @patch("sentry.middleware.integrations.parsers.github.metrics")
     def test_forwarded_event_metric_malformed_pull_requests(self, mock_metrics: Mock) -> None:
         """The body is unverified here, so junk in place of any nested member must not
-        raise — it just means no pull request was matched."""
+        raise — it just means no pull request was matched. Pinned off to assert the
+        forward; the drop path has its own test."""
         self.get_integration()
         request = self._post_check_event(
             action="completed",
@@ -1126,8 +1139,27 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
     @responses.activate
-    def test_check_suite_completed_without_own_repo_pr_is_forwarded_by_default(self) -> None:
-        """Ships off for check_suite too."""
+    def test_check_suite_completed_without_own_repo_pr_is_dropped_by_default(self) -> None:
+        """Same for check_suite."""
+        self.get_integration()
+        request = self._post_check_event(
+            action="completed",
+            event_type=GithubWebhookType.CHECK_SUITE,
+            container={"pull_requests": []},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @override_options({DROP_NO_OWN_REPO_PR_OPTION: False})
+    def test_check_suite_completed_without_own_repo_pr_is_forwarded_when_disabled(self) -> None:
+        """The kill switch, for check_suite."""
         self.get_integration()
         request = self._post_check_event(
             action="completed",
@@ -1179,8 +1211,23 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
     @responses.activate
-    def test_check_run_completed_without_own_repo_pr_is_forwarded_by_default(self) -> None:
-        """Ships off. Until the option is enabled this is a pure no-op."""
+    def test_check_run_completed_without_own_repo_pr_is_dropped_by_default(self) -> None:
+        """An unset option drops: the registered default carries the drop."""
+        self.get_integration()
+        request = self._post_check_event(action="completed", container={"pull_requests": []})
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @override_options({DROP_NO_OWN_REPO_PR_OPTION: False})
+    def test_check_run_completed_without_own_repo_pr_is_forwarded_when_disabled(self) -> None:
+        """The kill switch: setting the option false forwards instead of dropping."""
         self.get_integration()
         request = self._post_check_event(action="completed", container={"pull_requests": []})
         parser = GithubRequestParser(request=request, response_handler=self.get_response)


### PR DESCRIPTION
Moves the rolled-out value of `hybridcloud.webhookpayload.github_drop_checks_without_own_repo_pr` into the registered default, so the automator can drop its temporary control-silo override ([options#9218](https://github.com/getsentry/sentry-options-automator/pull/9218)).

Baseline, not removal: the option stays registered and the parser keeps reading it, so setting it `false` is still the revert and needs no deploy.

### Why

The drop ([#121719](https://github.com/getsentry/sentry/pull/121719)) shipped off behind an option because its predicate reads payload shape rather than a header — if it were wrong, real check activity would silently stop being recorded. Two days on the control silo say it is right. Same-clock 11:58–12:55Z windows, which avoids attributing the European CI ramp to the change:

| Signal | 08-13 vs 08-12 | 08-13 vs 08-11 (pre-toggle) |
| --- | --- | --- |
| `check.activity_recorded` check_run | +2.2% | metric did not exist |
| `check.activity_recorded` check_suite | +1.8% | metric did not exist |
| `forwarded_event` check_run `has_own_repo_pr:true` | +3.3% | +5.4% |
| `forwarded_event` check_suite `has_own_repo_pr:true` | +2.3% | +0.8% |
| `deliver_webhooks.saved` `provider:github` | +0.7% | **−18.3%** |

The self-normalizing test — recorded activity over forwarded events, which cancels out traffic volume — never stepped at the cutover: check_run held 0.72–0.88 and check_suite 0.73–0.92 across 30 hours spanning the toggle. `has_own_repo_pr:false` has emitted nothing since 11:57Z on 08-12, one minute before these windows open. Net effect: roughly 18% fewer GitHub webhookpayload rows/day — about 14% of all rows, since GitHub is not the only provider writing them.

### Blast radius

Control silo only. `IntegrationControlMiddleware._should_operate` returns early unless `SiloMode` is `CONTROL`, so region, single-tenant, and self-hosted deployments never reach this parser whatever the default says. The control silo already runs `true` via the automator, so no live behavior changes here — only where the value comes from.

### Tests

Six tests depended on the old default:

- The two `..._is_forwarded_by_default` tests become `..._is_dropped_by_default`, each gaining an explicit `option: False` counterpart covering the kill switch.
- Three `forwarded_event` metric tests asserting `has_own_repo_pr:"false"` now pin the option off — with the drop on, that tag is unreachable.
- `test_forwards_check_run_completed` / `test_forwards_check_suite_completed` now carry an own-repo PR, so they exercise the mailbox routing that production actually takes.

`tests/sentry/middleware/integrations/` passes, 174 tests.

### Merge order

Deploy this to all regions **before** merging [options#9218](https://github.com/getsentry/sentry-options-automator/pull/9218). The other order drops the control-silo value while the deployed default is still `false`, reverting the drop for the length of the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

