### PR TITLE
fix(alerts): Don't use legacy Rule name in issue alert notifs

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -253,10 +253,10 @@ class BaseIssueAlertHandler(ABC):
             ).first()
             if alert_rule_workflow:
                 try:
-                    label = Rule.objects.get(
+                    Rule.objects.get(
                         id=alert_rule_workflow.rule_id,
                         project__organization_id=detector.linked_project.organization_id,
-                    ).label
+                    )
                     rule_id = alert_rule_workflow.rule_id
                 except Rule.DoesNotExist:
                     logger.exception(

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -141,7 +141,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.environment_id is not None
         assert self.workflow.environment is not None
         assert rule.environment_id == self.workflow.environment.id
-        assert rule.label == rule.label
+        assert rule.label == self.workflow.name
         assert rule.data == {
             "actions": [
                 {
@@ -209,6 +209,24 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
             ]
         }
 
+    def test_create_rule_instance_from_action_uses_workflow_name_not_stale_rule_label(
+        self,
+    ) -> None:
+        """Regression test: label should come from Workflow.name, not the legacy Rule.label.
+
+        When a user renames the alert (updating Workflow.name), the legacy
+        Rule.label may be stale. Slack/PD read the synthetic Rule's label, so
+        it must reflect the Workflow name, not the stale Rule label.
+        """
+        self.workflow.update(name="Renamed Alert Name")
+        rule = self.handler.create_rule_instance_from_action(
+            self.action, self.detector, self.event_data, workflow_id=self.workflow.id
+        )
+
+        assert isinstance(rule, Rule)
+        assert rule.label == "Renamed Alert Name"
+        assert rule.label != self.rule.label  # legacy rule label is still "Test Alert"
+
     def test_create_rule_instance_from_action_with_test_notification_id(self) -> None:
         """Test that Workflow lookup is skipped for test notifications, falling back to detector name"""
         rule = self.handler.create_rule_instance_from_action(
@@ -241,7 +259,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.id == self.action.id
         assert rule.project == self.detector.project
         assert rule.environment_id is None
-        assert rule.label == rule.label
+        assert rule.label == self.workflow.name
         assert rule.data == {
             "actions": [
                 {

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -209,20 +209,13 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
             ]
         }
 
-    def test_create_rule_instance_from_action_uses_workflow_name_not_stale_rule_label(
+    def test_rule_instance_from_action_uses_workflow_name_not_stale_rule_label(
         self,
     ) -> None:
-        """Regression test: label should come from Workflow.name, not the legacy Rule.label.
-
-        When a user renames the alert (updating Workflow.name), the legacy
-        Rule.label may be stale. Slack/PD read the synthetic Rule's label, so
-        it must reflect the Workflow name, not the stale Rule label.
-        """
         self.workflow.update(name="Renamed Alert Name")
         rule = self.handler.create_rule_instance_from_action(
             self.action, self.detector, self.event_data, workflow_id=self.workflow.id
         )
-
         assert isinstance(rule, Rule)
         assert rule.label == "Renamed Alert Name"
         assert rule.label != self.rule.label  # legacy rule label is still "Test Alert"


### PR DESCRIPTION
We don't need the notification content derived from legacy models if they exist, using the workflow and falling back to the detector is fine.