### PR TITLE
chore(scm-messaging-integration-ui): Serializing MS teams installation type

### DIFF
--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -96,6 +96,9 @@ class MsTeamsIntegration(IntegrationInstallation, IntegrationNotificationClient)
     def get_client(self) -> MsTeamsClient:
         return MsTeamsClient(self.model)
 
+    def get_config_data(self) -> Mapping[str, str]:
+        return {"installationType": self.model.metadata.get("installation_type", "")}
+
     def send_notification(
         self, target: IntegrationNotificationTarget, payload: AdaptiveCard
     ) -> None:

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -226,3 +226,23 @@ class MsTeamsIntegrationSendNotificationTest(TestCase):
             self.installation.send_notification(target=self.target, payload=payload)
 
         assert str(e.value) == error_payload
+
+
+@control_silo_test
+class MsTeamsIntegrationConfigTest(TestCase):
+    def setUp(self) -> None:
+        self.integration = self.create_provider_integration(
+            provider="msteams", name="Microsoft Teams", metadata={}
+        )
+        self.installation = MsTeamsIntegration(self.integration, self.organization.id)
+
+    def test_config_data_team(self) -> None:
+        self.integration.metadata["installation_type"] = "team"
+        assert self.installation.get_config_data()["installationType"] == "team"
+
+    def test_config_data_tenant(self) -> None:
+        self.integration.metadata["installation_type"] = "tenant"
+        assert self.installation.get_config_data()["installationType"] == "tenant"
+
+    def test_config_data_missing(self) -> None:
+        assert self.installation.get_config_data()["installationType"] == ""


### PR DESCRIPTION
Needed by: https://github.com/getsentry/sentry/pull/121631

## Background

MS Teams installations come in two flavours: `"team"` (a single team) and `"tenant"` (an org-wide tenant install). Only team installs support Issue Alerts, so the frontend's `isEligibleForIssueAlerts` check gates tenant installs out of the inline destination picker. The problem is that `installation_type` lives in `Integration.metadata` but never reaches the API — `MsTeamsIntegration` inherits the default `get_config_data()`, which returns `OrganizationIntegration.config` and nothing else. The frontend always receives `configData: undefined`, making the eligibility check permanently dead code.

## Change

Override `get_config_data()` on `MsTeamsIntegration` to pluck `installation_type` from `self.model.metadata` and expose it as `installationType` in `configData`, defaulting to `""` for legacy installs that predate the field (`"" !== "tenant"` so they remain eligible). This mirrors the pattern Slack already uses for its own `installationType`. No schema or DB changes — the value already exists in metadata, we are only serializing it. Three unit tests cover the `team`, `tenant`, and missing cases.