### PR TITLE
fix(preprod): Accept CFBundleVersion groups beyond the third

### DIFF
--- a/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
@@ -78,10 +78,10 @@ class ProjectPreprodBuildDistributionLatestEndpoint(ProjectEndpoint):
                 name="buildNumber",
                 description=(
                     "Current build number. Accepts a plain integer (e.g. 42) or a "
-                    "version string of two to three period-separated integers (e.g. "
-                    "1.2.3), each up to 6 digits — the format used by build "
-                    "identifiers such as Apple's CFBundleVersion. Either this or "
-                    "mainBinaryIdentifier must be provided when buildVersion is set."
+                    "version string of two or more period-separated integers (e.g. "
+                    "1.2.3), each up to 6 digits. Groups beyond the third are "
+                    "dropped. Either this or mainBinaryIdentifier must be provided "
+                    "when buildVersion is set."
                 ),
                 required=False,
                 type={"oneOf": [{"type": "integer"}, {"type": "string"}]},

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
@@ -78,10 +78,12 @@ class ProjectPreprodBuildDistributionLatestEndpoint(ProjectEndpoint):
                 name="buildNumber",
                 description=(
                     "Current build number. Accepts a plain integer (e.g. 42) or a "
-                    "version string of two to three period-separated integers (e.g. "
+                    "version string of two or more period-separated integers (e.g. "
                     "1.2.3), each up to 6 digits — the format used by build "
-                    "identifiers such as Apple's CFBundleVersion. Either this or "
-                    "mainBinaryIdentifier must be provided when buildVersion is set."
+                    "identifiers such as Apple's CFBundleVersion. Groups beyond "
+                    "the third are dropped, per the CFBundleVersion spec. Either "
+                    "this or mainBinaryIdentifier must be provided when "
+                    "buildVersion is set."
                 ),
                 required=False,
                 type={"oneOf": [{"type": "integer"}, {"type": "string"}]},

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_build_distribution_latest.py
@@ -78,12 +78,10 @@ class ProjectPreprodBuildDistributionLatestEndpoint(ProjectEndpoint):
                 name="buildNumber",
                 description=(
                     "Current build number. Accepts a plain integer (e.g. 42) or a "
-                    "version string of two or more period-separated integers (e.g. "
+                    "version string of two to three period-separated integers (e.g. "
                     "1.2.3), each up to 6 digits — the format used by build "
-                    "identifiers such as Apple's CFBundleVersion. Groups beyond "
-                    "the third are dropped, per the CFBundleVersion spec. Either "
-                    "this or mainBinaryIdentifier must be provided when "
-                    "buildVersion is set."
+                    "identifiers such as Apple's CFBundleVersion. Either this or "
+                    "mainBinaryIdentifier must be provided when buildVersion is set."
                 ),
                 required=False,
                 type={"oneOf": [{"type": "integer"}, {"type": "string"}]},

--- a/src/sentry/preprod/api/validators.py
+++ b/src/sentry/preprod/api/validators.py
@@ -24,10 +24,9 @@ class PreprodLatestInstallableBuildValidator(serializers.Serializer[Any]):
         required=False,
         help_text=(
             "Current build number. Accepts a plain integer (e.g. 42) or a version "
-            "string of two to three period-separated integers (e.g. 1.2.3), each up "
-            "to 6 digits — the format used by build identifiers such as Apple's "
-            "CFBundleVersion. Either this or mainBinaryIdentifier must be provided "
-            "when buildVersion is set."
+            "string of two or more period-separated integers (e.g. 1.2.3), each up "
+            "to 6 digits. Groups beyond the third are dropped. Either this or "
+            "mainBinaryIdentifier must be provided when buildVersion is set."
         ),
     )
     mainBinaryIdentifier = serializers.CharField(
@@ -50,8 +49,9 @@ class PreprodLatestInstallableBuildValidator(serializers.Serializer[Any]):
         parsed = parse_build_number(value)
         if parsed is None:
             raise serializers.ValidationError(
-                "buildNumber must be an integer or two to three period-separated "
-                "integers of up to 6 digits each (e.g. 42 or 1.2.3)."
+                "buildNumber must be an integer or two or more period-separated "
+                "integers of up to 6 digits each (e.g. 42 or 1.2.3); groups beyond "
+                "the third are dropped."
             )
         return parsed
 

--- a/src/sentry/preprod/api/validators.py
+++ b/src/sentry/preprod/api/validators.py
@@ -24,11 +24,10 @@ class PreprodLatestInstallableBuildValidator(serializers.Serializer[Any]):
         required=False,
         help_text=(
             "Current build number. Accepts a plain integer (e.g. 42) or a version "
-            "string of two or more period-separated integers (e.g. 1.2.3), each up "
+            "string of two to three period-separated integers (e.g. 1.2.3), each up "
             "to 6 digits — the format used by build identifiers such as Apple's "
-            "CFBundleVersion. Groups beyond the third are dropped, per the "
-            "CFBundleVersion spec. Either this or mainBinaryIdentifier must be "
-            "provided when buildVersion is set."
+            "CFBundleVersion. Either this or mainBinaryIdentifier must be provided "
+            "when buildVersion is set."
         ),
     )
     mainBinaryIdentifier = serializers.CharField(
@@ -51,9 +50,8 @@ class PreprodLatestInstallableBuildValidator(serializers.Serializer[Any]):
         parsed = parse_build_number(value)
         if parsed is None:
             raise serializers.ValidationError(
-                "buildNumber must be an integer or two or more period-separated "
-                "integers of up to 6 digits each (e.g. 42 or 1.2.3); groups beyond "
-                "the third are dropped."
+                "buildNumber must be an integer or two to three period-separated "
+                "integers of up to 6 digits each (e.g. 42 or 1.2.3)."
             )
         return parsed
 

--- a/src/sentry/preprod/api/validators.py
+++ b/src/sentry/preprod/api/validators.py
@@ -24,10 +24,11 @@ class PreprodLatestInstallableBuildValidator(serializers.Serializer[Any]):
         required=False,
         help_text=(
             "Current build number. Accepts a plain integer (e.g. 42) or a version "
-            "string of two to three period-separated integers (e.g. 1.2.3), each up "
+            "string of two or more period-separated integers (e.g. 1.2.3), each up "
             "to 6 digits — the format used by build identifiers such as Apple's "
-            "CFBundleVersion. Either this or mainBinaryIdentifier must be provided "
-            "when buildVersion is set."
+            "CFBundleVersion. Groups beyond the third are dropped, per the "
+            "CFBundleVersion spec. Either this or mainBinaryIdentifier must be "
+            "provided when buildVersion is set."
         ),
     )
     mainBinaryIdentifier = serializers.CharField(
@@ -50,8 +51,9 @@ class PreprodLatestInstallableBuildValidator(serializers.Serializer[Any]):
         parsed = parse_build_number(value)
         if parsed is None:
             raise serializers.ValidationError(
-                "buildNumber must be an integer or two to three period-separated "
-                "integers of up to 6 digits each (e.g. 42 or 1.2.3)."
+                "buildNumber must be an integer or two or more period-separated "
+                "integers of up to 6 digits each (e.g. 42 or 1.2.3); groups beyond "
+                "the third are dropped."
             )
         return parsed
 

--- a/src/sentry/preprod/build_distribution_utils.py
+++ b/src/sentry/preprod/build_distribution_utils.py
@@ -26,10 +26,12 @@ _BUILD_NUMBER_COMPONENT_WIDTH = 6
 def parse_build_number(build: str) -> int | None:
     """Parse a build number into the sortable int launchpad stores on the artifact.
 
-    Mirrors launchpad's ``_parse_build_number``: plain integers pass through, two
-    or three period-separated integers (e.g. "1.2.3") are packed by zero-padding
-    each component, and anything else (or a value too large for the build_number
-    column) returns None.
+    Mirrors launchpad's ``_parse_build_number``: plain integers pass through,
+    period-separated integers (e.g. "1.2.3") are packed by zero-padding each
+    component, and anything else (or a value too large for the build_number
+    column) returns None. Per the CFBundleVersion spec, more than three
+    period-separated integer groups are accepted and groups beyond the third
+    are dropped.
     """
     build = build.strip()
 
@@ -38,10 +40,12 @@ def parse_build_number(build: str) -> int | None:
         value = int(build)
     else:
         parts = build.split(".")
-        if not (
-            2 <= len(parts) <= 3
-            and all(p.isdecimal() and len(p) <= _BUILD_NUMBER_COMPONENT_WIDTH for p in parts)
-        ):
+        if not all(p.isdecimal() for p in parts):
+            return None
+        # CFBundleVersion allows more than three groups; groups beyond the
+        # third are dropped.
+        parts = parts[:3]
+        if not (2 <= len(parts) and all(len(p) <= _BUILD_NUMBER_COMPONENT_WIDTH for p in parts)):
             return None
         parts += ["0"] * (3 - len(parts))
         value = sum(

--- a/tests/sentry/preprod/test_parse_build_number.py
+++ b/tests/sentry/preprod/test_parse_build_number.py
@@ -14,13 +14,21 @@ from sentry.utils.numbers import validate_bigint
         ("9999", 9999),
         ("0", 0),
         ("1", 1),
-        # Apple CFBundleVersion: up to three dot-separated non-negative integers
+        # Apple CFBundleVersion: two or three dot-separated non-negative integers
         ("1.2.3", 1_000_002_000_003),
         ("1.2", 1_000_002_000_000),
+        # CFBundleVersion allows more than three groups; groups beyond the
+        # third are dropped
+        ("1.2.3.4", 1_000_002_000_003),
+        ("1.2.3.4.5", 1_000_002_000_003),
+        ("1.2.3.0", 1_000_002_000_003),
+        # Dropped groups are not width-checked, but must still be numeric
+        ("1.2.3.1234567", 1_000_002_000_003),
+        ("1.2.3.beta", None),
+        ("1.2.3.", None),
         # Malformed or unsupported shapes fall back to None
         ("1.2.a", None),
         ("abc", None),
-        ("1.2.3.4", None),
         ("", None),
         # A component too wide for the padding width is refused rather than
         # silently corrupting the ordering of adjacent components


### PR DESCRIPTION
`parse_build_number` rejected period-separated build numbers with more than three integer groups (e.g. `1.2.3.4`). The CFBundleVersion spec allows extra groups and requires parsers to drop groups beyond the third, so such build numbers now parse to the same packed integer as their first three groups (`1.2.3.4` -> `1.2.3`). All groups must still be numeric (`1.2.3.beta` stays rejected), and only the first three groups are width-checked. The public endpoint documentation now describes the accepted format directly: two or more period-separated integers, with groups beyond the third dropped.

This must deploy before the matching launchpad change to `artifact_processor._parse_build_number`, so query-side parsing accepts the extra groups before launchpad starts producing them.
