### PR TITLE
fix(seer): Return seerReposLinked=True for free cohort orgs

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -96,17 +96,13 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
                 organization=org, project=group.project
             )
 
-        # Free cohort orgs have no Seer subscription, so check_seer_quota
-        # always returns False. We want them to see autofix results when
-        # night shift has already processed the issue, but NOT show the
-        # "Start Analysis" button for issues night shift skipped — manual
-        # triggers would fail with a quota error. So we return True only
-        # when an autofix run already exists for this group, which renders
-        # the results UI. Otherwise False, which renders the paywall.
-        if is_free_cohort_org(org):
-            # Night shift can go through either the regular autofix path
-            # (source="autofix") or the RCA feature path (source="autofix_rca")
-            # depending on the organizations:autofix-rca-in-seer flag.
+        # Free cohort orgs have no subscription — quota check always fails. Return hasAutofixQuota
+        # True only when a run exists (so they see results), False otherwise (shows paywall).
+        # Also set seerReposLinked=True since night shift resolves repos at runtime.
+        is_free_cohort = is_free_cohort_org(org)
+        if is_free_cohort:
+            # Night shift can go through either the regular autofix path (source="autofix") or
+            # the RCA feature path (source="autofix_rca") depending on the organizations:autofix-rca-in-seer.
             has_autofix_quota = (
                 runs_for_group(group.id, "autofix").exists()
                 or runs_for_group(group.id, "autofix_rca").exists()
@@ -117,8 +113,9 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
             )
 
         seer_repos_linked = False
-        # Check if org has github integration and is on seat-based tier.
-        if integration_check is None:
+        if is_free_cohort:
+            seer_repos_linked = True
+        elif integration_check is None:
             try:
                 seer_repos_linked = has_project_connected_repos(org, group.project)
             except Exception as e:

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.models.projectrepository import ProjectRepository
 from sentry.models.repository import Repository
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.endpoints.group_autofix_setup_check import (
@@ -332,26 +331,10 @@ class GroupAIAutofixSetupFreeCohortTest(APITestCase, SnubaTestCase):
         "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",
         return_value=True,
     )
-    @patch(
-        "sentry.seer.autofix.utils.is_free_cohort_org",
-        return_value=True,
-    )
-    @patch(
-        "sentry.seer.endpoints.group_autofix_setup_check.get_autofix_integration_setup_problems",
-        return_value=None,
-    )
-    def test_free_cohort_org_with_project_repos_has_seer_repos_linked(
-        self,
-        mock_integration_check: MagicMock,
-        mock_utils_free_cohort: MagicMock,
-        mock_endpoint_free_cohort: MagicMock,
-    ) -> None:
-        """Free cohort orgs with ProjectRepository rows get seerReposLinked: True."""
-        ProjectRepository.objects.create(
-            project=self.project,
-            repository=self.repo,
-        )
-
+    def test_free_cohort_org_has_seer_repos_linked(self, mock_is_free_cohort: MagicMock) -> None:
+        """Free cohort orgs always get seerReposLinked: True — night shift
+        handles repo resolution at runtime via the ProjectRepository fallback,
+        so the setup prompt is not relevant."""
         group = self.create_group()
         self.login_as(user=self.user)
         url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"


### PR DESCRIPTION
## Summary
Free cohort orgs were seeing a "Set Up Seer for This Project" prompt because `seerReposLinked` returned `False` from `/autofix/setup/`. Night shift resolves repos at runtime via the `ProjectRepository` fallback, so this setup prompt is irrelevant. Now returns `seerReposLinked: True` directly for free cohort orgs.

Also simplifies the repos-linked test to match — no longer needs extra mocks for `has_project_connected_repos` internals.

## Test plan
- [x] `test_free_cohort_org_has_seer_repos_linked` — free cohort org gets `seerReposLinked: True`
- [x] All 17 tests pass