### PR TITLE
feat: Remove organizations:incidents flag on frontend

### DIFF
--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -1,16 +1,11 @@
 import round from 'lodash/round';
 
-import type {Organization} from 'sentry/types/organization';
 import {SessionFieldWithOperation} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {formatMetricUsingUnit} from 'sentry/utils/number/formatMetricUsingUnit';
 import {SessionsAggregate} from 'sentry/views/alerts/rules/metric/types';
-
-export function hasMetricAlerts(organization: Organization): boolean {
-  return organization.features.includes('incidents');
-}
 
 // Maps a datasource to the relevant dataset and event_types for the backend to use
 

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -50,7 +50,6 @@ export function ChartContextMenu({
       const yAxis = visualizeYAxes[0]!.yAxis;
       menuItems.push(
         getSaveAsAlertMenuItem({
-          organization,
           disabled: isVisualizeEquation(visualizeYAxes[0]!),
           to: getAlertsUrl({
             project,
@@ -97,7 +96,6 @@ export function ChartContextMenu({
 
       menuItems.push(
         getSaveAsAlertMenuItem({
-          organization,
           alertsUrls,
           submenu: true,
           label: getCreateAlertForLabel(),

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -315,7 +315,6 @@ function ContextMenu({interval, visualize}: {interval: string; visualize: Visual
 
     return [
       getSaveAsAlertMenuItem({
-        organization,
         to: getAlertsUrl({
           project,
           query: search.formatString(),

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -211,7 +211,7 @@ describe('useSaveAsItems', () => {
     expect(saveAsItems.some(item => item.key === 'save-query')).toBe(true);
   });
 
-  it('disables the alert option with an upsell tooltip when metric alerts are unavailable', () => {
+  it('enables the alert option when there are aggregates', () => {
     const {result} = renderHookWithProviders(useSaveAsItems, {
       additionalWrapper: createWrapper(),
       initialProps: {
@@ -225,37 +225,10 @@ describe('useSaveAsItems', () => {
     });
 
     const alertItem = result.current.find(item => item.key === 'create-alert') as
-      | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
-      | undefined;
-
-    expect(alertItem?.disabled).toBe(true);
-    expect(alertItem?.tooltip).toBe('Monitors are not available on your current plan.');
-    expect(alertItem?.children).toEqual([]);
-  });
-
-  it('enables the alert option when the org has metric alerts', () => {
-    const orgWithAlerts = OrganizationFixture({
-      features: ['ourlogs-enabled', 'incidents'],
-    });
-
-    const {result} = renderHookWithProviders(useSaveAsItems, {
-      additionalWrapper: createWrapper(orgWithAlerts),
-      initialProps: {
-        visualizes: [new VisualizeFunction('count()')],
-        groupBys: ['message.template'],
-        interval: '5m',
-        mode: Mode.AGGREGATE,
-        search: new MutableSearch('message:"test error"'),
-        sortBys: [{field: 'timestamp', kind: 'desc'}],
-      },
-    });
-
-    const alertItem = result.current.find(item => item.key === 'create-alert') as
-      | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
+      | {children: unknown[]; disabled: boolean}
       | undefined;
 
     expect(alertItem?.disabled).toBe(false);
-    expect(alertItem?.tooltip).toBeUndefined();
     expect(alertItem?.children).toHaveLength(1);
   });
 

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -153,7 +153,7 @@ export function useSaveAsItems({
       };
     });
 
-    return getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
+    return getSaveAsAlertMenuItem({alertsUrls, submenu: true});
   }, [aggregates, interval, organization, pageFilters, project, search]);
 
   const saveAsDashboard = useMemo(() => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -39,7 +39,7 @@ const mockHandleAddMultipleQueriesToDashboard = jest.mocked(
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled', 'incidents'],
+    features: ['tracemetrics-enabled'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();
@@ -296,9 +296,7 @@ describe('useSaveAsMetricItems', () => {
     );
   });
 
-  it('disables the alert option with an upsell tooltip when metric alerts are unavailable', () => {
-    const orgWithoutAlerts = OrganizationFixture({features: ['tracemetrics-enabled']});
-
+  it('enables the alert option when there are aggregates', () => {
     const encodedMetricQuery = encodeMetricQueryParams({
       metric: {name: 'metric.a', type: 'counter'},
       queryParams: new ReadableQueryParams({
@@ -324,17 +322,16 @@ describe('useSaveAsMetricItems', () => {
     );
 
     const {result} = renderHook(useSaveAsMetricItems, {
-      wrapper: createWrapper(orgWithoutAlerts),
+      wrapper: createWrapper(),
       initialProps: {interval: '5m'},
     });
 
     const alertItem = result.current.find(item => item.key === 'create-alert') as
-      | {children: unknown[]; disabled: boolean; tooltip: string | undefined}
+      | {children: unknown[]; disabled: boolean}
       | undefined;
 
-    expect(alertItem?.disabled).toBe(true);
-    expect(alertItem?.tooltip).toBe('Monitors are not available on your current plan.');
-    expect(alertItem?.children).toEqual([]);
+    expect(alertItem?.disabled).toBe(false);
+    expect(alertItem?.children).toHaveLength(1);
   });
 
   it('formats alerts submenu labels for equations', () => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -159,7 +159,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
         };
       });
 
-    return [getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true})];
+    return [getSaveAsAlertMenuItem({alertsUrls, submenu: true})];
   }, [metricQueries, organization, project, pageFilters, options.interval]);
 
   const addToDashboardItems = useMemo(() => {

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -107,7 +107,6 @@ export function MultiQueryModeChart({
   if (defined(yAxes[0])) {
     items.push(
       getSaveAsAlertMenuItem({
-        organization,
         to: getAlertsUrl({
           project,
           query: queryParts.query,

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -36,7 +36,7 @@ jest.mock('sentry/actionCreators/modal');
 
 describe('ExploreToolbar', () => {
   const organization = OrganizationFixture({
-    features: ['dashboards-edit', 'incidents'],
+    features: ['dashboards-edit'],
   });
 
   beforeEach(() => {
@@ -975,35 +975,6 @@ describe('ExploreToolbar', () => {
       project: '1',
       query: '',
     });
-  });
-
-  it('disables the alert option when the org lacks metric alerts', async () => {
-    const orgWithoutAlerts = OrganizationFixture({features: ['dashboards-edit']});
-    function Component() {
-      return <ExploreToolbar />;
-    }
-    render(<Component />, {
-      additionalWrapper: Wrapper,
-      organization: orgWithoutAlerts,
-      initialRouterConfig: {
-        location: {
-          pathname: '/traces/',
-          query: {
-            visualize: encodeURIComponent(
-              '{"chartType":1,"yAxes":["avg(span.duration)"]}'
-            ),
-          },
-        },
-      },
-    });
-
-    const section = screen.getByTestId('section-save-as');
-
-    await userEvent.click(within(section).getByRole('button', {name: /save as/i}));
-
-    expect(
-      within(section).getByRole('menuitemradio', {name: 'Monitor for'})
-    ).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('add to dashboard options correctly', async () => {

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -160,7 +160,7 @@ export function ToolbarSaveAs() {
     },
   });
 
-  items.push(getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true}));
+  items.push(getSaveAsAlertMenuItem({alertsUrls, submenu: true}));
 
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
 

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
@@ -1,26 +1,8 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {
+  getCreateAlertForLabel,
   getCreateAlertLabel,
-  getMetricAlertsUpsellTooltip,
   getSaveAsAlertMenuItem,
 } from 'sentry/views/explore/utils/saveAsAlertMenuItem';
-
-describe('getMetricAlertsUpsellTooltip', () => {
-  it('returns undefined when the organization has metric alerts', () => {
-    const organization = OrganizationFixture({features: ['incidents']});
-
-    expect(getMetricAlertsUpsellTooltip(organization)).toBeUndefined();
-  });
-
-  it('returns a monitor upsell message when metric alerts are unavailable', () => {
-    const organization = OrganizationFixture({features: []});
-
-    expect(getMetricAlertsUpsellTooltip(organization)).toBe(
-      'Monitors are not available on your current plan.'
-    );
-  });
-});
 
 describe('getCreateAlertLabel', () => {
   it('returns the monitor label', () => {
@@ -28,102 +10,76 @@ describe('getCreateAlertLabel', () => {
   });
 });
 
+describe('getCreateAlertForLabel', () => {
+  it('returns the monitor for label', () => {
+    expect(getCreateAlertForLabel()).toBe('Create a Monitor for');
+  });
+});
+
 describe('getSaveAsAlertMenuItem', () => {
   const alertsUrls = [{key: 'count()-0', label: 'count()', to: '/alert/'}];
 
-  it('is enabled with children when the organization has metric alerts', () => {
-    const organization = OrganizationFixture({features: ['incidents']});
-
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
+  it('is enabled with children when there are aggregates', () => {
+    const item = getSaveAsAlertMenuItem({alertsUrls, submenu: true});
 
     expect(item).toEqual(
       expect.objectContaining({
         label: 'Monitor for',
+        textValue: 'Monitor for',
         disabled: false,
-        tooltip: undefined,
         children: alertsUrls,
+        submenu: true,
       })
     );
   });
 
-  it('is disabled with an upsell tooltip when metric alerts are unavailable', () => {
-    const organization = OrganizationFixture({features: []});
-
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls, submenu: true});
-
-    expect(item).toEqual(
-      expect.objectContaining({
-        disabled: true,
-        tooltip: 'Monitors are not available on your current plan.',
-        children: [],
-      })
-    );
-  });
-
-  it('is disabled when the organization has metric alerts but no aggregates', () => {
-    const organization = OrganizationFixture({features: ['incidents']});
-
-    const item = getSaveAsAlertMenuItem({organization, alertsUrls: [], submenu: true});
+  it('is disabled when there are no aggregates', () => {
+    const item = getSaveAsAlertMenuItem({alertsUrls: [], submenu: true});
 
     expect(item.disabled).toBe(true);
-    expect(item.tooltip).toBeUndefined();
   });
 
   it('uses the given label when one is provided', () => {
-    const organization = OrganizationFixture({features: ['incidents']});
-
     const item = getSaveAsAlertMenuItem({
-      organization,
       alertsUrls,
       submenu: true,
       label: 'Create a Monitor for',
     });
 
     expect(item.label).toBe('Create a Monitor for');
+    expect(item.textValue).toBe('Create a Monitor for');
+  });
+
+  it('is disabled when the caller disables the submenu', () => {
+    const item = getSaveAsAlertMenuItem({alertsUrls, disabled: true, submenu: true});
+
+    expect(item.disabled).toBe(true);
   });
 
   it('returns an actionable item with no children when not a submenu', () => {
-    const organization = OrganizationFixture({features: ['incidents']});
     const onAction = jest.fn();
 
-    const item = getSaveAsAlertMenuItem({organization, to: '/alert/', onAction});
+    const item = getSaveAsAlertMenuItem({to: '/alert/', onAction});
 
     expect(item).toEqual(
       expect.objectContaining({
         label: 'Create a Monitor',
-        disabled: false,
-        tooltip: undefined,
+        textValue: 'Create a Monitor',
         to: '/alert/',
         onAction,
       })
     );
+    expect(item.disabled).toBeFalsy();
     expect(item.children).toBeUndefined();
   });
 
-  it('is disabled with an upsell tooltip when not a submenu and metric alerts are unavailable', () => {
-    const organization = OrganizationFixture({features: []});
-
+  it('is disabled when the caller disables the action item', () => {
     const item = getSaveAsAlertMenuItem({
-      organization,
-      to: '/alert/',
-      onAction: jest.fn(),
-    });
-
-    expect(item.disabled).toBe(true);
-    expect(item.tooltip).toBe('Monitors are not available on your current plan.');
-  });
-
-  it('is disabled when the caller disables it for an unrelated reason', () => {
-    const organization = OrganizationFixture({features: ['incidents']});
-
-    const item = getSaveAsAlertMenuItem({
-      organization,
       disabled: true,
       to: '/alert/',
       onAction: jest.fn(),
     });
 
     expect(item.disabled).toBe(true);
-    expect(item.tooltip).toBeUndefined();
   });
 });

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.spec.tsx
@@ -65,11 +65,11 @@ describe('getSaveAsAlertMenuItem', () => {
       expect.objectContaining({
         label: 'Create a Monitor',
         textValue: 'Create a Monitor',
+        disabled: false,
         to: '/alert/',
         onAction,
       })
     );
-    expect(item.disabled).toBeFalsy();
     expect(item.children).toBeUndefined();
   });
 

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -2,11 +2,8 @@ import type {LocationDescriptor} from 'history';
 
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import {hasMetricAlerts} from 'sentry/views/alerts/utils';
 
 interface SaveAsAlertMenuItemBaseOptions {
-  organization: Organization;
   disabled?: boolean;
 }
 
@@ -24,15 +21,6 @@ interface SaveAsAlertActionOptions extends SaveAsAlertMenuItemBaseOptions {
 
 type SaveAsAlertMenuItemOptions = SaveAsAlertSubmenuOptions | SaveAsAlertActionOptions;
 
-export function getMetricAlertsUpsellTooltip(
-  organization: Organization
-): string | undefined {
-  if (hasMetricAlerts(organization)) {
-    return undefined;
-  }
-  return t('Monitors are not available on your current plan.');
-}
-
 export function getCreateAlertLabel(): string {
   return t('Create a Monitor');
 }
@@ -44,9 +32,7 @@ export function getCreateAlertForLabel(): string {
 export function getSaveAsAlertMenuItem(
   options: SaveAsAlertMenuItemOptions
 ): MenuItemProps {
-  const {organization, disabled} = options;
-  const tooltip = getMetricAlertsUpsellTooltip(organization);
-  const hasAccess = !tooltip;
+  const {disabled} = options;
 
   if (options.submenu) {
     const {alertsUrls} = options;
@@ -56,9 +42,8 @@ export function getSaveAsAlertMenuItem(
       key: 'create-alert',
       label,
       textValue: label,
-      children: hasAccess ? alertsUrls : [],
-      disabled: disabled || !hasAccess || alertsUrls.length === 0,
-      tooltip,
+      children: alertsUrls,
+      disabled: disabled || alertsUrls.length === 0,
       submenu: true,
     };
   }
@@ -69,8 +54,7 @@ export function getSaveAsAlertMenuItem(
     key: 'create-alert',
     label,
     textValue: label,
-    disabled: disabled || !hasAccess,
-    tooltip,
+    disabled,
     to: options.to,
     onAction: options.onAction,
   };

--- a/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
+++ b/static/app/views/explore/utils/saveAsAlertMenuItem.tsx
@@ -54,7 +54,7 @@ export function getSaveAsAlertMenuItem(
     key: 'create-alert',
     label,
     textValue: label,
-    disabled,
+    disabled: disabled ?? false,
     to: options.to,
     onAction: options.onAction,
   };


### PR DESCRIPTION
Part 1 of many in removing the organizations:incidents flag, which is now available on all free tiers (AM1/2/3) and is thus no longer needed...

Fixes ISWF-3270