### PR TITLE
feat(action-log): Route recovery through dedicated outbox

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -916,6 +916,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.integrations.tasks.update_comment",
     "sentry.integrations.vsts.tasks.kickoff_subscription_check",
     "sentry.integrations.vsts.tasks.subscription_check",
+    "sentry.issues.action_log.tasks",
     "sentry.issues.derived.tasks",
     "sentry.issues.escalating.forecasts",
     "sentry.middleware.integrations.tasks",
@@ -1075,6 +1076,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "deliver-from-outbox": {
         "task": "hybridcloud:sentry.tasks.enqueue_outbox_jobs",
+        "schedule": crontab("*/1", "*", "*", "*", "*"),
+    },
+    "deliver-group-action-log-outbox": {
+        "task": "issues.action_log:sentry.issues.action_log.tasks.enqueue_group_action_log_outbox_jobs",
         "schedule": crontab("*/1", "*", "*", "*", "*"),
     },
     "update-user-reports": {

--- a/src/sentry/issues/action_log/tasks.py
+++ b/src/sentry/issues/action_log/tasks.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sentry_sdk
+
+from sentry.hybridcloud.tasks.deliver_from_outbox import (
+    process_outbox_batch,
+    schedule_outbox_model,
+)
+from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import issues_action_log_tasks
+
+
+@instrumented_task(
+    name="sentry.issues.action_log.tasks.enqueue_group_action_log_outbox_jobs",
+    namespace=issues_action_log_tasks,
+    silo_mode=SiloMode.CELL,
+    processing_deadline_duration=30,
+)
+def enqueue_group_action_log_outbox_jobs(concurrency: int | None = None, **kwargs: Any) -> None:
+    try:
+        schedule_outbox_model(
+            silo_mode=SiloMode.CELL,
+            outbox_model=GroupActionLogOutbox,
+            drain_task=drain_group_action_log_outbox_shards,
+            concurrency=concurrency,
+        )
+    except Exception:
+        sentry_sdk.capture_exception()
+        raise
+
+
+@instrumented_task(
+    name="sentry.issues.action_log.tasks.drain_group_action_log_outbox_shards",
+    namespace=issues_action_log_tasks,
+    silo_mode=SiloMode.CELL,
+    processing_deadline_duration=90,
+)
+def drain_group_action_log_outbox_shards(
+    outbox_identifier_low: int = 0,
+    outbox_identifier_hi: int = 0,
+) -> None:
+    try:
+        process_outbox_batch(
+            outbox_identifier_hi=outbox_identifier_hi,
+            outbox_identifier_low=outbox_identifier_low,
+            outbox_model=GroupActionLogOutbox,
+        )
+    except Exception:
+        sentry_sdk.capture_exception()
+        raise

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -715,12 +715,15 @@ See: https://github.com/getsentry/snuba#sentry--snuba"""
 
 def validate_outbox_config() -> None:
     from sentry.hybridcloud.models.outbox import CellOutboxBase, ControlOutboxBase
+    from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
 
     for outbox_name in settings.SENTRY_OUTBOX_MODELS["CONTROL"]:
         ControlOutboxBase.from_outbox_name(outbox_name)
 
     for outbox_name in settings.SENTRY_OUTBOX_MODELS["CELL"]:
         CellOutboxBase.from_outbox_name(outbox_name)
+
+    CellOutboxBase.from_outbox_name(GroupActionLogOutbox._meta.label)
 
 
 def import_grouptype() -> None:

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -166,6 +166,11 @@ issues_tasks = app.taskregistry.create_namespace(
     app_feature="issueplatform",
 )
 
+issues_action_log_tasks = app.taskregistry.create_namespace(
+    "issues.action_log",
+    app_feature="issueplatform",
+)
+
 issues_merge_tasks = app.taskregistry.create_namespace(
     "issues.merge",
     app_feature="issueplatform",

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -13,6 +13,8 @@ from sentry.hybridcloud.tasks.deliver_from_outbox import (
     enqueue_outbox_jobs,
     enqueue_outbox_jobs_control,
 )
+from sentry.issues.action_log.tasks import enqueue_group_action_log_outbox_jobs
+from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
 from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
@@ -41,16 +43,20 @@ def outbox_runner(wrapped: Any | None = None) -> Any:
     yield
     from sentry.testutils.helpers.task_runner import TaskRunner
 
+    outbox_models = [
+        OutboxBase.from_outbox_name(outbox_name)
+        for outbox_names in settings.SENTRY_OUTBOX_MODELS.values()
+        for outbox_name in outbox_names
+    ]
+    outbox_models.append(GroupActionLogOutbox)
+
     with TaskRunner(), assume_test_silo_mode(SiloMode.MONOLITH):
-        for i in range(10):
+        for _ in range(10):
             enqueue_outbox_jobs(concurrency=1, process_outbox_backfills=False)
             enqueue_outbox_jobs_control(concurrency=1, process_outbox_backfills=False)
+            enqueue_group_action_log_outbox_jobs(concurrency=1)
 
-            if not any(
-                OutboxBase.from_outbox_name(outbox_name).find_scheduled_shards()
-                for outbox_names in settings.SENTRY_OUTBOX_MODELS.values()
-                for outbox_name in outbox_names
-            ):
+            if not any(outbox_model.find_scheduled_shards() for outbox_model in outbox_models):
                 break
         else:
             raise OutboxRecursionLimitError

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -6,8 +6,9 @@ from django.contrib.auth.models import AnonymousUser
 from django.db import router, transaction
 
 from sentry.auth.services.auth import AuthenticatedToken
-from sentry.hybridcloud.models.outbox import CellOutbox, outbox_context
+from sentry.hybridcloud.models.outbox import CellOutbox, OutboxFlushError, outbox_context
 from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.hybridcloud.tasks.deliver_from_outbox import enqueue_outbox_jobs
 from sentry.issues.action_log import (
     SYSTEM_ACTOR,
     ActionContext,
@@ -18,6 +19,7 @@ from sentry.issues.action_log import (
     resolve_action_actor,
     resolve_action_source,
 )
+from sentry.issues.action_log.tasks import enqueue_group_action_log_outbox_jobs
 from sentry.issues.action_log.types import (
     ActionSource,
     ArchiveAction,
@@ -39,6 +41,7 @@ from sentry.issues.action_log.types import (
     ViewAction,
 )
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
@@ -516,6 +519,118 @@ class TestExternalIssueLinkingActionLog(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 204
         log.assert_not_logged()
+
+
+class TestGroupActionLogOutboxRecovery(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+
+    def _publish_shared_outbox(self, action: GroupAction, group: Group) -> None:
+        with self.feature("projects:issue-action-log-write-to-db"), outbox_context(flush=False):
+            publish_action(
+                action,
+                source=ActionSource.API,
+                group_id=group.id,
+                project=group.project,
+            )
+
+    def _seed_dedicated_outbox(self, action: GroupAction, group: Group) -> None:
+        # Recovery ships before the producer cutover, so seed the dedicated table
+        # from the payload produced by the existing shared route.
+        self._publish_shared_outbox(action, group)
+        shared_outbox = CellOutbox.objects.get(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT,
+            shard_identifier=group.id,
+        )
+        with outbox_context(flush=False):
+            GroupActionLogOutbox(
+                shard_scope=shared_outbox.shard_scope,
+                shard_identifier=shared_outbox.shard_identifier,
+                category=shared_outbox.category,
+                object_identifier=GroupActionLogOutbox.next_object_identifier(),
+                payload=shared_outbox.payload,
+            ).save()
+        shared_outbox.delete()
+
+    def test_shared_scheduler_does_not_drain_dedicated_outbox(self) -> None:
+        other_group = self.create_group(project=self.group.project)
+        self._publish_shared_outbox(ViewAction(), self.group)
+        self._seed_dedicated_outbox(ResolveAction(), other_group)
+
+        with self.tasks():
+            enqueue_outbox_jobs(concurrency=1, process_outbox_backfills=False)
+
+        assert not CellOutbox.objects.filter(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+        ).exists()
+        assert GroupActionLogOutbox.objects.count() == 1
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+        assert GroupActionLogEntry.objects.filter(group_id=other_group.id).count() == 0
+
+        with self.tasks():
+            enqueue_group_action_log_outbox_jobs(concurrency=1)
+
+        assert not GroupActionLogOutbox.objects.exists()
+        assert GroupActionLogEntry.objects.filter(group_id=other_group.id).count() == 1
+
+    def test_dedicated_scheduler_does_not_drain_shared_outbox(self) -> None:
+        self._publish_shared_outbox(ViewAction(), self.group)
+
+        with self.tasks():
+            enqueue_group_action_log_outbox_jobs(concurrency=1)
+
+        assert (
+            CellOutbox.objects.filter(category=OutboxCategory.GROUP_ACTION_LOG_EVENT).count() == 1
+        )
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
+
+    def test_receiver_failure_retains_dedicated_row(self) -> None:
+        other_group = self.create_group(project=self.group.project)
+        self._publish_shared_outbox(ResolveAction(), other_group)
+        self._seed_dedicated_outbox(ViewAction(), self.group)
+
+        with (
+            patch(
+                "sentry.hybridcloud.models.outbox.process_cell_outbox.send",
+                side_effect=ValueError("receiver failed"),
+            ),
+            self.tasks(),
+            pytest.raises(OutboxFlushError),
+        ):
+            enqueue_group_action_log_outbox_jobs(concurrency=1)
+
+        outbox = GroupActionLogOutbox.objects.get()
+        assert outbox.scheduled_for > outbox.scheduled_from
+        assert (
+            CellOutbox.objects.filter(category=OutboxCategory.GROUP_ACTION_LOG_EVENT).count() == 1
+        )
+
+        with self.tasks():
+            enqueue_outbox_jobs(concurrency=1, process_outbox_backfills=False)
+
+        assert not CellOutbox.objects.filter(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+        ).exists()
+        assert GroupActionLogOutbox.objects.count() == 1
+        assert GroupActionLogEntry.objects.filter(group_id=other_group.id).count() == 1
+
+    def test_outbox_runner_drains_shared_and_dedicated_outboxes(self) -> None:
+        other_group = self.create_group(project=self.group.project)
+        self._publish_shared_outbox(ViewAction(), self.group)
+        self._seed_dedicated_outbox(ResolveAction(), other_group)
+
+        with outbox_runner():
+            pass
+
+        assert not CellOutbox.objects.filter(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+        ).exists()
+        assert not GroupActionLogOutbox.objects.exists()
+        assert (
+            GroupActionLogEntry.objects.filter(group_id__in=(self.group.id, other_group.id)).count()
+            == 2
+        )
 
 
 class TestPublishActionWrite(TestCase):

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -1,9 +1,12 @@
 import types
+from unittest.mock import patch
 
 import pytest
 from django.core.cache import caches
 from django.test import override_settings
 
+from sentry.hybridcloud.models.outbox import CellOutboxBase
+from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
 from sentry.options import default_store
 from sentry.runner.initializer import (
     ConfigurationError,
@@ -11,6 +14,7 @@ from sentry.runner.initializer import (
     bind_cache_to_option_store,
     bootstrap_options,
     validate_options,
+    validate_outbox_config,
 )
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -254,6 +258,13 @@ def test_initialize_app(settings) -> None:
     settings.SENTRY_OPTIONS = {"system.secret-key": "secret-key"}
     bootstrap_options(settings)
     apply_legacy_settings(settings)
+
+
+def test_validate_outbox_config_includes_group_action_log_outbox() -> None:
+    with patch.object(CellOutboxBase, "from_outbox_name") as validate_cell_outbox:
+        validate_outbox_config()
+
+    validate_cell_outbox.assert_any_call(GroupActionLogOutbox._meta.label)
 
 
 def test_require_secret_key(settings) -> None:


### PR DESCRIPTION
We introduced a new `CellOutbox` for the GAL. We also want to separate out the recovery task + cron so that in the cases where GAL may backlog / cause issues, we don't bottleneck other critical outbox tasks. Add new tasks to specifically look at the new GAL outbox model.