### PR TITLE
fix(alerts): Serialize targetless workflow actions

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -57,7 +57,7 @@ class WorkflowEngineActionSerializer(Serializer[dict[str, Any]]):
         type_value: int | None = ActionService.get_value(obj.type)
         target = attrs.get("target")
 
-        target_type: int = obj.config.get("target_type")
+        target_type: int | None = obj.config.get("target_type")
         target_identifier: str | None = obj.config.get("target_identifier")
         target_display: str | None = obj.config.get("target_display")
 
@@ -75,7 +75,11 @@ class WorkflowEngineActionSerializer(Serializer[dict[str, Any]]):
             ),
             "alertRuleTriggerId": str(alert_rule_trigger_id),
             "type": obj.type,
-            "targetType": ACTION_TARGET_TYPE_TO_STRING[ActionTarget(target_type)],
+            "targetType": (
+                ACTION_TARGET_TYPE_TO_STRING[ActionTarget(target_type)]
+                if target_type is not None
+                else None
+            ),
             "targetIdentifier": get_identifier_from_action(
                 type_value, str(target_identifier), target_display
             ),

--- a/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
@@ -19,6 +19,7 @@ from sentry.workflow_engine.models import (
     Action,
     DataCondition,
     DataConditionGroup,
+    DataConditionGroupAction,
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.data_condition import Condition
@@ -104,6 +105,36 @@ class TestDataConditionSerializer(TestWorkflowEngineSerializer):
         expected_trigger = self.expected_triggers[0].copy()
         expected_trigger["actions"] = expected_actions
         assert serialized_data_condition == expected_trigger
+
+    def test_targetless_webhook_action(self) -> None:
+        webhook_action = self.create_action(
+            type=Action.Type.WEBHOOK,
+            config={
+                "target_identifier": "webhooks",
+                "target_display": None,
+                "target_type": None,
+            },
+        )
+        action_filter = DataConditionGroupAction.objects.get(
+            action=self.critical_action
+        ).condition_group
+        self.create_data_condition_group_action(
+            action=webhook_action,
+            condition_group=action_filter,
+        )
+
+        serialized_data_condition = serialize(
+            self.critical_detector_trigger,
+            self.user,
+            WorkflowEngineDataConditionSerializer(),
+        )
+
+        serialized_webhook_action = next(
+            action
+            for action in serialized_data_condition["actions"]
+            if action["type"] == Action.Type.WEBHOOK
+        )
+        assert serialized_webhook_action["targetType"] is None
 
     def test_action_filter_without_priority_condition(self) -> None:
         """


### PR DESCRIPTION
Seems webhook workflows can pass `target_type` as None, leading to some serialization errors. We can be a bit more graceful in the serializer.

Fixes SENTRY-5NQG