### PR TITLE
fix(monitors): render the timeline cursor label above list rows

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -474,6 +474,7 @@ const DetectorListSimpleTable = styled(SimpleTable)<{
   isVisualizationExpanded: boolean;
 }>`
   grid-template-columns: 1fr;
+  overflow: clip;
 
   [data-column-name='type'],
   [data-column-name='last-issue'],
@@ -513,7 +514,6 @@ const PositionedGridLineOverlay = styled(GridLineOverlay)`
   grid-column: -3 / -1;
   grid-row: 1 / auto;
   pointer-events: none;
-  z-index: 3;
 
   display: none;
 

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -66,7 +66,7 @@ function VisualizationCell({detector}: {detector: CronDetector}) {
   });
 
   return (
-    <Cell
+    <SimpleTable.RowCell
       data-column-name="visualization"
       padding="lg 0"
       borderLeft="muted"
@@ -93,7 +93,7 @@ function VisualizationCell({detector}: {detector: CronDetector}) {
           );
         })}
       </Stack>
-    </Cell>
+    </SimpleTable.RowCell>
   );
 }
 
@@ -228,14 +228,14 @@ export default function CronDetectorsList() {
       renderVisualization: ({detector}) => {
         if (!detector) {
           return (
-            <Cell
+            <SimpleTable.RowCell
               data-column-name="visualization"
               padding="lg 0"
               borderLeft="muted"
               height="100%"
             >
               <CheckInPlaceholder />
-            </Cell>
+            </SimpleTable.RowCell>
           );
         }
         if (detector.type === 'monitor_check_in_failure') {
@@ -277,10 +277,6 @@ export default function CronDetectorsList() {
     </MonitorViewContext.Provider>
   );
 }
-
-const Cell = styled(SimpleTable.RowCell)`
-  z-index: 4;
-`;
 
 const TimelineFadeIn = styled('div')`
   width: 100%;

--- a/static/app/views/detectors/list/uptime.tsx
+++ b/static/app/views/detectors/list/uptime.tsx
@@ -1,5 +1,4 @@
 import {useMemo, useRef} from 'react';
-import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
 
@@ -43,7 +42,7 @@ function VisualizationCell({detector}: {detector: UptimeDetector}) {
   });
 
   return (
-    <Cell
+    <SimpleTable.RowCell
       data-column-name="visualization"
       padding="lg 0"
       borderLeft="muted"
@@ -62,7 +61,7 @@ function VisualizationCell({detector}: {detector: UptimeDetector}) {
           />
         )}
       </Flex>
-    </Cell>
+    </SimpleTable.RowCell>
   );
 }
 
@@ -82,14 +81,14 @@ export default function UptimeDetectorsList() {
       renderVisualization: ({detector}) => {
         if (!detector) {
           return (
-            <Cell
+            <SimpleTable.RowCell
               data-column-name="visualization"
               padding="lg 0"
               borderLeft="muted"
               height="100%"
             >
               <CheckInPlaceholder />
-            </Cell>
+            </SimpleTable.RowCell>
           );
         }
         if (detector.type === 'uptime_domain_failure') {
@@ -129,7 +128,3 @@ export default function UptimeDetectorsList() {
     </MonitorViewContext.Provider>
   );
 }
-
-const Cell = styled(SimpleTable.RowCell)`
-  z-index: 4;
-`;


### PR DESCRIPTION
On the crons and uptime monitor lists, the timeline cursor label landed a top-bar's height too low and painted *behind* the check-in ticks, instead of sitting in the header row like it does on the details pages.

Two causes, both local to the detector list table:

- `SimpleTable`'s panel uses `overflow: hidden`, which makes it a scroll container. That re-anchored the label's `position: sticky` wrapper to the panel, shoving it down by the top bar height and killing stick-to-viewport on scroll. `overflow: clip` clips identically without becoming a scroll container.
- The grid line overlay's `z-index: 3` trapped the label in a stacking context below the `z-index: 4` visualization cells. Both are gone; rows still paint over the grid lines by DOM order.

<table>
<thead>
<tr>
<th>Area</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>Crons</td>
<td>
<img width="1920" height="907" alt="de-1534-crons-before" src="https://github.com/user-attachments/assets/2dac7816-b88e-4ad9-a22a-cbd3b07fb4fc" />
</td>
<td>
<img width="1920" height="907" alt="de-1534-crons-after" src="https://github.com/user-attachments/assets/8dfb6c62-2c19-44c0-9c60-d68432877320" />
</td>
</tr>
<tr>
<td>Uptime</td>
<td>
<img width="1920" height="907" alt="de-1534-uptime-before" src="https://github.com/user-attachments/assets/5d3257dd-9744-43ab-a074-1d8373a47fe9" />
</td>
<td>
<img width="1920" height="907" alt="de-1534-uptime-after" src="https://github.com/user-attachments/assets/ff9b2d2d-a888-4029-9537-4a7761d9d3e9" />
</td>
</tr>
</tbody>
</table>

Closes DE-1534.