### PR TITLE
ref(autofix): Dispatch RCA runs under the autofix feature id

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -281,7 +281,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display the Seer Night Shift UI
     manager.add("organizations:seer-night-shift-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Route autofix RCA through the Seer autofix_rca feature
+    # Route autofix RCA through the Seer autofix feature
     manager.add("organizations:autofix-rca-in-seer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Roll out structured LLM page context on STRUCTURED_CONTEXT_ROUTES to all orgs
     manager.add("organizations:seer-explorer-structured-context-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/seer/agent/feature_delivery.py
+++ b/src/sentry/seer/agent/feature_delivery.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.autofix_rca.delivery import deliver_autofix_rca_result
+from sentry.seer.autofix_rca.models import FEATURE_ID as AUTOFIX_FEATURE_ID
+from sentry.seer.autofix_rca.models import LEGACY_FEATURE_ID as LEGACY_AUTOFIX_FEATURE_ID
 from sentry.seer.night_shift.delivery import deliver_night_shift_result
 from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
 
@@ -25,5 +27,7 @@ class FeatureDeliveryFn(Protocol):
 DELIVERY_HANDLERS: dict[str, FeatureDeliveryFn] = {
     "night_shift": deliver_night_shift_result,
     "smart_assignment": deliver_smart_assignment_result,
-    "autofix_rca": deliver_autofix_rca_result,
+    AUTOFIX_FEATURE_ID: deliver_autofix_rca_result,
+    # Runs started before the autofix_rca -> autofix rename deliver the old id.
+    LEGACY_AUTOFIX_FEATURE_ID: deliver_autofix_rca_result,
 }

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -52,7 +52,8 @@ from sentry.seer.autofix.utils import (
     clear_preference_automation_handoff,
     get_automation_handoff,
 )
-from sentry.seer.autofix_rca.models import FEATURE_ID as AUTOFIX_RCA_FEATURE_ID
+from sentry.seer.autofix_rca.models import FEATURE_ID as AUTOFIX_FEATURE_ID
+from sentry.seer.autofix_rca.models import LEGACY_FEATURE_ID as LEGACY_AUTOFIX_FEATURE_ID
 from sentry.seer.entrypoints.operator import (
     SeerAutofixOperator,
     process_autofix_updates,
@@ -111,7 +112,7 @@ def _stopping_point_from_run(organization: Organization, run_id: int) -> str | N
         SeerAgentRun.objects.filter(
             run__organization_id=organization.id,
             run__seer_run_state_id=run_id,
-            source=AUTOFIX_RCA_FEATURE_ID,
+            source__in=(AUTOFIX_FEATURE_ID, LEGACY_AUTOFIX_FEATURE_ID),
         )
         .values_list("extras__stopping_point", flat=True)
         .first()
@@ -125,7 +126,7 @@ def _group_and_referrer_from_run(
         SeerAgentRun.objects.filter(
             run__organization_id=organization.id,
             run__seer_run_state_id=run_id,
-            source=AUTOFIX_RCA_FEATURE_ID,
+            source__in=(AUTOFIX_FEATURE_ID, LEGACY_AUTOFIX_FEATURE_ID),
         )
         .values("group_id", "extras")
         .first()
@@ -762,7 +763,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             return
 
         # Get pipeline metadata from state, falling back to the Sentry-side run
-        # mirror for runs Seer started without it (the autofix_rca feature).
+        # mirror for runs Seer started without it (the autofix feature).
         raw_stopping_point = (state.metadata or {}).get(
             "stopping_point"
         ) or _stopping_point_from_run(organization, run_id)

--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -9,7 +9,7 @@ from django.db import router, transaction
 
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
-from sentry.seer.autofix_rca.models import FEATURE_ID
+from sentry.seer.autofix_rca.models import FEATURE_ID, LEGACY_FEATURE_ID
 from sentry.seer.models.run import SeerAgentRun
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ def deliver_autofix_rca_result(
             .filter(
                 run__uuid=run_uuid,
                 run__organization_id=organization_id,
-                source=FEATURE_ID,
+                source__in=(FEATURE_ID, LEGACY_FEATURE_ID),
             )
             .select_related("run", "run__organization")
             .first()

--- a/src/sentry/seer/autofix_rca/models.py
+++ b/src/sentry/seer/autofix_rca/models.py
@@ -4,9 +4,11 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-# Keep models in sync with src/seer/automation/features/autofix_rca/models.py in Seer
+# Keep models in sync with src/seer/automation/features/autofix/models.py in Seer
 
-FEATURE_ID = "autofix_rca"
+FEATURE_ID = "autofix"
+# In-flight runs started before the rename still deliver and persist this id.
+LEGACY_FEATURE_ID = "autofix_rca"
 
 
 class AutofixRCATweaks(BaseModel):

--- a/tests/sentry/seer/agent/test_feature_delivery.py
+++ b/tests/sentry/seer/agent/test_feature_delivery.py
@@ -1,0 +1,9 @@
+from sentry.seer.agent.feature_delivery import DELIVERY_HANDLERS
+from sentry.seer.autofix_rca.delivery import deliver_autofix_rca_result
+
+
+def test_autofix_delivery_routes_under_current_and_legacy_feature_ids() -> None:
+    # Runs started before the autofix_rca -> autofix rename still deliver the old
+    # id from persisted state until they drain.
+    assert DELIVERY_HANDLERS["autofix"] is deliver_autofix_rca_result
+    assert DELIVERY_HANDLERS["autofix_rca"] is deliver_autofix_rca_result

--- a/tests/sentry/seer/agent/test_feature_delivery.py
+++ b/tests/sentry/seer/agent/test_feature_delivery.py
@@ -1,9 +1,0 @@
-from sentry.seer.agent.feature_delivery import DELIVERY_HANDLERS
-from sentry.seer.autofix_rca.delivery import deliver_autofix_rca_result
-
-
-def test_autofix_delivery_routes_under_current_and_legacy_feature_ids() -> None:
-    # Runs started before the autofix_rca -> autofix rename still deliver the old
-    # id from persisted state until they drain.
-    assert DELIVERY_HANDLERS["autofix"] is deliver_autofix_rca_result
-    assert DELIVERY_HANDLERS["autofix_rca"] is deliver_autofix_rca_result

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -293,6 +293,17 @@ class TestStoppingPointFromRun(TestCase):
             == AutofixStoppingPoint.CODE_CHANGES.value
         )
 
+    def test_matches_runs_created_with_the_autofix_source(self) -> None:
+        self._create_run(
+            123,
+            extras={"stopping_point": AutofixStoppingPoint.CODE_CHANGES.value},
+            source="autofix",
+        )
+        assert (
+            _stopping_point_from_run(self.organization, 123)
+            == AutofixStoppingPoint.CODE_CHANGES.value
+        )
+
     def test_is_scoped_to_the_organization(self) -> None:
         self._create_run(123, extras={"stopping_point": AutofixStoppingPoint.CODE_CHANGES.value})
         assert _stopping_point_from_run(self.create_organization(), 123) is None
@@ -307,6 +318,13 @@ class TestStoppingPointFromRun(TestCase):
 
     def test_group_and_referrer_returns_autofix_rca_context(self) -> None:
         self._create_run(123, extras={"referrer": AutofixReferrer.WEB.value})
+        assert _group_and_referrer_from_run(self.organization, 123) == (
+            self.group.id,
+            AutofixReferrer.WEB,
+        )
+
+    def test_group_and_referrer_matches_the_autofix_source(self) -> None:
+        self._create_run(123, extras={"referrer": AutofixReferrer.WEB.value}, source="autofix")
         assert _group_and_referrer_from_run(self.organization, 123) == (
             self.group.id,
             AutofixReferrer.WEB,

--- a/tests/sentry/seer/autofix_rca/test_delivery.py
+++ b/tests/sentry/seer/autofix_rca/test_delivery.py
@@ -124,6 +124,27 @@ class TestDeliverAutofixRCAResult(TestCase):
         assert kwargs["payload"]["run_id"] == 123
         assert kwargs["payload"]["root_cause"]["one_line_description"] == "null deref in handler"
 
+    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
+    def test_completed_result_matches_run_with_autofix_source(
+        self, mock_fetch: MagicMock, mock_broadcast: MagicMock
+    ) -> None:
+        # Runs dispatched after the feature rename persist source="autofix".
+        self.agent_run.source = "autofix"
+        self.agent_run.save()
+        mock_fetch.return_value = self._run_state()
+
+        deliver_autofix_rca_result(
+            organization_id=self.organization.id,
+            run_uuid=self.agent_run.run.uuid,
+            status="completed",
+            result=VALID_RESULT,
+            error=None,
+        )
+
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "completed"
+
     def test_error_status_recorded(self) -> None:
         agent_run = self.agent_run
 

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -42,7 +42,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
 
         # Feature run dispatched with the RCA payload.
         run_kwargs = client.start_feature_run.call_args.kwargs
-        assert run_kwargs["feature_id"] == "autofix_rca"
+        assert run_kwargs["feature_id"] == "autofix"
         assert run_kwargs["flush"] is True
         payload = run_kwargs["payload"]
         assert payload["group_id"] == self.group.id


### PR DESCRIPTION
Seer renamed its `autofix_rca` feature to `autofix` (getsentry/seer#7750), keeping `autofix_rca` registered as an alias. This switches the Sentry-side dispatch to send `feature_id="autofix"` when triggering RCA feature runs, so new runs — and their `SeerAgentRun` mirrors (`source=feature_id`) — carry the canonical name.

Compatibility: runs started before the rename persist `feature_id="autofix_rca"` in `state.metadata` and deliver results under that id, and their mirrors are stored with `source="autofix_rca"`. Until those runs drain, the delivery registry routes both ids to the same handler, and the mirror lookups in `deliver_autofix_rca_result` and the on-completion-hook fallbacks match both sources.

Deploy order is safe in either direction: Seer already accepts both ids.

Follow-ups once old runs have drained: remove `LEGACY_FEATURE_ID` handling here, then drop the `autofix_rca` alias in Seer's registry.
