### PR TITLE
feat(action_log): Configure GroupActionLogOutbox for use

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -440,7 +440,7 @@ TEMPLATES = [
 
 SENTRY_OUTBOX_MODELS: Mapping[str, list[str]] = {
     "CONTROL": ["sentry.ControlOutbox"],
-    "CELL": ["sentry.CellOutbox"],
+    "CELL": ["sentry.CellOutbox", "sentry.GroupActionLogOutbox"],
 }
 
 # Do not modify reordering

--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -102,10 +102,11 @@ def publish_action(
     # load time so it can be imported from models without creating cycles.
     from django.db import router, transaction
 
-    from sentry import features, options
+    from sentry import features
     from sentry.hybridcloud.models.outbox import CellOutbox, CellOutboxBase, outbox_context
     from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
     from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
+    from sentry.options.rollout import in_rollout_group
     from sentry.utils import metrics
 
     for callback in _publish_callbacks.get():
@@ -158,7 +159,7 @@ def publish_action(
 
     outbox_model: type[CellOutboxBase] = (
         GroupActionLogOutbox
-        if options.get("issues.group_action_log.use_dedicated_outbox")
+        if in_rollout_group("issues.group_action_log.dedicated_outbox_rollout", group_id)
         else CellOutbox
     )
     outbox = outbox_model(

--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -34,9 +34,9 @@ _publish_callbacks: ContextVar[tuple[_PublishCallback, ...]] = ContextVar(
 
 # Group Action Log — tracks who did what to an issue and how.
 #
-# publish_action() writes a CellOutbox entry; the outbox receiver creates the
-# GroupActionLogEntry on the (eventually separate) grouplog database and kicks
-# off derived-data processing.
+# publish_action() writes an outbox entry; the outbox receiver
+# creates the GroupActionLogEntry on the (eventually separate) grouplog database
+# and kicks off derived-data processing.
 #
 # Most mutation sites should use publish_action_from_context(), which reads attribution
 # from a ContextVar set at the request boundary via action_context_scope().
@@ -102,9 +102,10 @@ def publish_action(
     # load time so it can be imported from models without creating cycles.
     from django.db import router, transaction
 
-    from sentry import features
-    from sentry.hybridcloud.models.outbox import CellOutbox, outbox_context
+    from sentry import features, options
+    from sentry.hybridcloud.models.outbox import CellOutbox, CellOutboxBase, outbox_context
     from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
+    from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
     from sentry.utils import metrics
 
     for callback in _publish_callbacks.get():
@@ -155,15 +156,20 @@ def publish_action(
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
 
-    outbox = CellOutbox(
+    outbox_model: type[CellOutboxBase] = (
+        GroupActionLogOutbox
+        if options.get("issues.group_action_log.use_dedicated_outbox")
+        else CellOutbox
+    )
+    outbox = outbox_model(
         shard_scope=OutboxScope.GROUP_SCOPE,
         shard_identifier=group_id,
         category=OutboxCategory.GROUP_ACTION_LOG_EVENT,
-        object_identifier=CellOutbox.next_object_identifier(),
+        object_identifier=outbox_model.next_object_identifier(),
         payload=payload,
     )
     # Flush on commit by default; callers can wrap in outbox_context(flush=False) to defer.
-    with outbox_context(transaction.atomic(router.db_for_write(CellOutbox))):
+    with outbox_context(transaction.atomic(router.db_for_write(outbox_model))):
         outbox.save()
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1389,10 +1389,10 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "issues.group_action_log.use_dedicated_outbox",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+    "issues.group_action_log.dedicated_outbox_rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "issues.backfill_pr_lifecycle_action_log.killswitch",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1389,6 +1389,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "issues.group_action_log.use_dedicated_outbox",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "issues.backfill_pr_lifecycle_action_log.killswitch",
     type=Bool,
     default=False,

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -39,12 +39,14 @@ from sentry.issues.action_log.types import (
     ViewAction,
 )
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.seer.endpoints.seer_rpc import SeerRpcSignatureAuthentication
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.action_log import CapturedAction, capture_action_log
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
@@ -649,6 +651,30 @@ class TestPublishActionWrite(TestCase):
                 category=OutboxCategory.GROUP_ACTION_LOG_EVENT
             ).exists()
             assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
+
+            with outbox_runner():
+                pass
+
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    @override_options({"issues.group_action_log.use_dedicated_outbox": True})
+    def test_dedicated_outbox_table(self) -> None:
+        with self.feature("projects:issue-action-log-write-to-db"):
+            with outbox_context(flush=False):
+                publish_action(
+                    ViewAction(),
+                    source=ActionSource.API,
+                    group_id=self.group.id,
+                    project=self.group.project,
+                    actor=GroupActionActor.user(self.user.id),
+                )
+
+            assert GroupActionLogOutbox.objects.filter(
+                category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+            ).exists()
+            assert not CellOutbox.objects.filter(
+                category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+            ).exists()
 
             with outbox_runner():
                 pass

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -657,7 +657,7 @@ class TestPublishActionWrite(TestCase):
 
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
 
-    @override_options({"issues.group_action_log.use_dedicated_outbox": True})
+    @override_options({"issues.group_action_log.dedicated_outbox_rollout": 1.0})
     def test_dedicated_outbox_table(self) -> None:
         with self.feature("projects:issue-action-log-write-to-db"):
             with outbox_context(flush=False):


### PR DESCRIPTION
Adds a config (disabled by default) to switch us to the new model, and registers it for processing.

Rollout plan is to wait for it to push and confirm backlog processing, then enable for s4s, and finally roll out to larger regions starting with a very small fraction and going up.

Rollout is group ID based, because that's our unit of sequencing. 
