### PR TITLE
feat(onboarding): Add agentic progress hooks

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -31,6 +31,9 @@ const productionEntryPoints = [
   'static/app/components/connectRepository/**/*.{ts,tsx}',
   // TODO: Remove when wired into the React authentication flow
   'static/app/components/brandPageLayout/**/*.{ts,tsx}',
+  // TODO: Remove when wired into the agentic onboarding flow
+  'static/app/views/onboarding/agenticProgress/useAgenticProgress.ts',
+  'static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts',
   // https://github.com/getsentry/sentry/pull/121178
   'static/app/components/core/table/*.tsx',
   'static/app/components/core/dragHandle/*.tsx',

--- a/static/app/views/onboarding/agenticProgress/api.ts
+++ b/static/app/views/onboarding/agenticProgress/api.ts
@@ -1,0 +1,20 @@
+import {skipToken} from '@tanstack/react-query';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+import type {AgenticProgressRun} from './types';
+
+export const agenticProgressRunOptions = ({
+  organizationSlug,
+  runId,
+}: {
+  organizationSlug: string;
+  runId: string | null;
+}) =>
+  apiOptions.as<AgenticProgressRun>()(
+    '/organizations/$organizationIdOrSlug/onboarding/agent/runs/$runId/',
+    {
+      path: runId ? {organizationIdOrSlug: organizationSlug, runId} : skipToken,
+      staleTime: 0,
+    }
+  );

--- a/static/app/views/onboarding/agenticProgress/types.ts
+++ b/static/app/views/onboarding/agenticProgress/types.ts
@@ -1,0 +1,54 @@
+type AgenticProgressStage =
+  | 'connect_mcp'
+  | 'analyze_project'
+  | 'create_project'
+  | 'instrument_app'
+  | 'plan_test_error'
+  | 'send_verification_error'
+  | 'receive_verification_error'
+  | 'prepare_production'
+  | 'check_stack_trace_quality';
+
+type AgenticProgressStageStatus =
+  | 'active'
+  | 'waiting'
+  | 'completed'
+  | 'skipped'
+  | 'bypassed'
+  | 'failed';
+
+type AgenticProgressRunStatus = 'active' | 'completed' | 'failed' | 'cancelled';
+
+type Stage<
+  Key extends AgenticProgressStage,
+  Extra extends Record<string, unknown> | null = null,
+> = {
+  eventNote: string | null;
+  extra: Extra;
+  stage: Key;
+  status: AgenticProgressStageStatus | null;
+};
+
+type AgenticProgressStageState =
+  | Stage<'create_project', {projectSlugs: string[]} | null>
+  | Stage<'receive_verification_error', {issueIds: string[]} | null>
+  | Stage<Exclude<AgenticProgressStage, 'create_project' | 'receive_verification_error'>>;
+
+export type AgenticProgressRun = {
+  channelId: string;
+  clientRunId: string;
+  continueUpdates: boolean;
+  createdAt: string;
+  expiresAt: string;
+  runId: string;
+  runStatus: AgenticProgressRunStatus;
+  schemaVersion: number;
+  sequence: number;
+  stages: AgenticProgressStageState[];
+  updatedAt: string;
+  onboardingCode?: string;
+};
+
+export type InitializedAgenticProgressRun = AgenticProgressRun & {
+  onboardingCode: string;
+};

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgress.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgress.spec.tsx
@@ -1,0 +1,33 @@
+import {AgenticProgressRunFixture} from 'sentry-fixture/agenticProgressRun';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useAgenticProgress} from './useAgenticProgress';
+
+describe('useAgenticProgress', () => {
+  const run = AgenticProgressRunFixture();
+  const endpoint = `/organizations/org-slug/onboarding/agent/runs/${run.runId}/`;
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('loads the current run state', async () => {
+    MockApiClient.addMockResponse({url: endpoint, body: run});
+
+    const {result} = renderHookWithProviders(
+      () => useAgenticProgress({runId: run.runId}),
+      {organization: {slug: 'org-slug'}}
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(run));
+  });
+
+  it('does not load a run without an identifier', () => {
+    const {result} = renderHookWithProviders(() => useAgenticProgress({runId: null}), {
+      organization: {slug: 'org-slug'},
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgress.ts
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgress.ts
@@ -1,0 +1,27 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {agenticProgressRunOptions} from './api';
+
+const POLL_INTERVAL_MS = 5000;
+
+type UseAgenticProgressOptions = {
+  runId: string | null;
+  enabled?: boolean;
+};
+
+export function useAgenticProgress({runId, enabled = true}: UseAgenticProgressOptions) {
+  const organization = useOrganization();
+  const queryEnabled = enabled && runId !== null;
+
+  return useQuery({
+    ...agenticProgressRunOptions({
+      organizationSlug: organization.slug,
+      runId: queryEnabled ? runId : null,
+    }),
+    enabled: queryEnabled,
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.spec.tsx
@@ -1,0 +1,51 @@
+import {AgenticProgressRunFixture} from 'sentry-fixture/agenticProgressRun';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useAgenticProgressInit} from './useAgenticProgressInit';
+
+describe('useAgenticProgressInit', () => {
+  const organization = OrganizationFixture();
+  const endpoint = `/organizations/${organization.slug}/onboarding/agent/runs/`;
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    window.sessionStorage.clear();
+  });
+
+  it('does not initialize a run while disabled', () => {
+    const request = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: AgenticProgressRunFixture(),
+    });
+
+    renderHookWithProviders(() => useAgenticProgressInit({enabled: false}), {
+      organization,
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('initializes once and returns the onboarding code', async () => {
+    const run = AgenticProgressRunFixture();
+    const request = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: run,
+    });
+
+    const {result, rerender} = renderHookWithProviders(
+      () => useAgenticProgressInit({enabled: true}),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(run));
+    expect(result.current.data?.onboardingCode).toBe('Lg1iSt2qeQ');
+    expect(request).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts
@@ -1,0 +1,52 @@
+import {useEffect, useRef, useState} from 'react';
+import {uuid4} from '@sentry/core';
+import {useMutation} from '@tanstack/react-query';
+
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+
+import type {InitializedAgenticProgressRun} from './types';
+
+type UseAgenticProgressInitOptions = {
+  enabled: boolean;
+};
+
+export function useAgenticProgressInit({enabled}: UseAgenticProgressInitOptions) {
+  const organization = useOrganization();
+  const [initialClientRunId] = useState(uuid4);
+  const [clientRunId] = useSessionStorage(
+    `agentic-progress-client-run-id:${organization.id}`,
+    initialClientRunId
+  );
+  const startedForClientRunId = useRef<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      fetchMutation<InitializedAgenticProgressRun>({
+        method: 'POST',
+        url: getApiUrl('/organizations/$organizationIdOrSlug/onboarding/agent/runs/', {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+        data: {clientRunId},
+      }),
+  });
+  const {mutate} = mutation;
+
+  useEffect(() => {
+    if (!enabled) {
+      startedForClientRunId.current = null;
+      return;
+    }
+
+    if (startedForClientRunId.current === clientRunId) {
+      return;
+    }
+
+    startedForClientRunId.current = clientRunId;
+    mutate();
+  }, [clientRunId, enabled, mutate]);
+
+  return mutation;
+}

--- a/tests/js/fixtures/agenticProgressRun.ts
+++ b/tests/js/fixtures/agenticProgressRun.ts
@@ -1,0 +1,28 @@
+import type {AgenticProgressRun} from 'sentry/views/onboarding/agenticProgress/types';
+
+export function AgenticProgressRunFixture(
+  params: Partial<AgenticProgressRun> = {}
+): AgenticProgressRun {
+  return {
+    channelId: '54c300212517432d91c915960bfc5c09',
+    clientRunId: '021902d5-2333-4823-81a9-5596b331e8af',
+    continueUpdates: true,
+    createdAt: '2026-08-13T14:01:28.298407Z',
+    expiresAt: '2026-08-14T14:01:28.298407Z',
+    runId: '16ff4fe7966f495ab788069fb35d8e7b',
+    runStatus: 'active',
+    schemaVersion: 1,
+    sequence: 0,
+    stages: [
+      {
+        eventNote: null,
+        extra: null,
+        stage: 'connect_mcp',
+        status: null,
+      },
+    ],
+    updatedAt: '2026-08-13T14:01:28.298407Z',
+    onboardingCode: 'Lg1iSt2qeQ',
+    ...params,
+  };
+}


### PR DESCRIPTION
Adds frontend hooks for the agentic onboarding run lifecycle. `useAgenticProgressInit` creates or resumes a client-scoped run, persists its client identifier for the session, and exposes the onboarding code; `useAgenticProgress` loads the current run snapshot, polls every five seconds, and refreshes when the window regains focus.

The response types match the stage-owned `extra` contract through a generic stage helper: project slugs belong to `create_project`, and issue IDs belong to `receive_verification_error`. Conduit delivery is intentionally deferred, keeping the query result as the single source of truth.

Refs [VDY-169](https://linear.app/getsentry/issue/VDY-169/update-agentic-onboarding-progress-hooks-for-conduit).