### PR TITLE
fix(workflows): validate Sentry App action targets

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -17,7 +17,7 @@ class SentryAppActionHandler(ActionHandler):
         "description": "The configuration schema for a Sentry App Action",
         "type": "object",
         "properties": {
-            "target_identifier": {"type": ["string"]},
+            "target_identifier": {"type": ["string"], "pattern": "^[0-9]+$"},
             "target_display": {"type": ["string", "null"]},
             "target_type": {
                 "type": ["integer"],

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -314,6 +314,31 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         }
         assert action.data["settings"] == self.sentry_app_settings
 
+    def test_update_rejects_non_numeric_sentry_app_target_identifier(self) -> None:
+        self.valid_workflow["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [],
+                "actions": [
+                    {
+                        "config": {
+                            "targetIdentifier": str(self.sentry_app_installation.uuid),
+                            "targetType": ActionType.SENTRY_APP,
+                        },
+                        "data": {"settings": self.sentry_app_settings},
+                        "type": Action.Type.SENTRY_APP,
+                    },
+                ],
+            }
+        ]
+
+        self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=self.valid_workflow,
+            status_code=400,
+        )
+
     def test_update_triggers_with_empty_conditions(self) -> None:
         """Test that passing an empty list to triggers.conditions clears all conditions"""
         # Create a workflow with a trigger condition


### PR DESCRIPTION
We want to return a 400 instead of a 500 from the workflow endpoint when users pass invalid ids.

Fixes SENTRY-5QBF