### PR TITLE
ref(workflow_engine): Remove the `TRIGGER_CONDITIONS` list

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -4,13 +4,16 @@ from django.db import router, transaction
 from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.utils import registry
 from sentry.workflow_engine.endpoints.validators.base.data_condition import (
     BaseDataConditionValidator,
     DataConditionInput,
 )
 from sentry.workflow_engine.endpoints.validators.utils import remove_items_by_api_input
 from sentry.workflow_engine.models import DataConditionGroup
-from sentry.workflow_engine.models.data_condition import TRIGGER_CONDITIONS, DataCondition
+from sentry.workflow_engine.models.data_condition import Condition, DataCondition
+from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.types import DataConditionHandler
 
 
 class DataConditionGroupInput(TypedDict):
@@ -40,7 +43,15 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
         break upon updating.
         """
         for condition in condition_data:
-            if (condition.get("type") in TRIGGER_CONDITIONS) and (
+            try:
+                condition_type = Condition(condition.get("type"))
+                condition_handler = condition_handler_registry.get(condition_type)
+            except (registry.NoRegistrationExistsError, ValueError):
+                raise serializers.ValidationError(
+                    f"Invalid condition type, '{condition.get('type')}'"
+                )
+
+            if (condition_handler.group == DataConditionHandler.Group.WORKFLOW_TRIGGER) and (
                 logic_type != DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
             ):
                 raise serializers.ValidationError("Triggers' logic type must be 'any-short'")

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -53,9 +53,11 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
                 )
 
             condition_handler = get_condition_handler(condition_type)
-            if (condition_handler.group == DataConditionHandler.Group.WORKFLOW_TRIGGER) and (
-                logic_type != DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
-            ):
+
+            if (
+                condition_handler is not None
+                and condition_handler.group == DataConditionHandler.Group.WORKFLOW_TRIGGER
+            ) and (logic_type != DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value):
                 raise serializers.ValidationError("Triggers' logic type must be 'any-short'")
 
     def update_or_create_condition(

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -46,7 +46,7 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
         """
         for condition in condition_data:
             try:
-                condition_type = Condition(condition.get("type"))
+                condition_type = Condition(str(condition.get("type")))
             except ValueError:
                 raise serializers.ValidationError(
                     f"Invalid condition type, '{condition.get('type')}'"

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -4,15 +4,17 @@ from django.db import router, transaction
 from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
-from sentry.utils import registry
 from sentry.workflow_engine.endpoints.validators.base.data_condition import (
     BaseDataConditionValidator,
     DataConditionInput,
 )
 from sentry.workflow_engine.endpoints.validators.utils import remove_items_by_api_input
 from sentry.workflow_engine.models import DataConditionGroup
-from sentry.workflow_engine.models.data_condition import Condition, DataCondition
-from sentry.workflow_engine.registry import condition_handler_registry
+from sentry.workflow_engine.models.data_condition import (
+    Condition,
+    DataCondition,
+    get_condition_handler,
+)
 from sentry.workflow_engine.types import DataConditionHandler
 
 
@@ -45,12 +47,12 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
         for condition in condition_data:
             try:
                 condition_type = Condition(condition.get("type"))
-                condition_handler = condition_handler_registry.get(condition_type)
-            except (registry.NoRegistrationExistsError, ValueError):
+            except ValueError:
                 raise serializers.ValidationError(
                     f"Invalid condition type, '{condition.get('type')}'"
                 )
 
+            condition_handler = get_condition_handler(condition_type)
             if (condition_handler.group == DataConditionHandler.Group.WORKFLOW_TRIGGER) and (
                 logic_type != DataConditionGroup.Type.ANY_SHORT_CIRCUIT.value
             ):

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -258,7 +258,9 @@ class DataCondition(DefaultFieldsModel):
         )
 
 
-def get_condition_handler(condition_type: Condition) -> DataConditionHandler:
+def get_condition_handler(
+    condition_type: Condition,
+) -> type[DataConditionHandler[Any]] | None:
     if condition_type not in CONDITION_OPS:
         try:
             return condition_handler_registry.get(condition_type)

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -14,7 +14,12 @@ from sentry.workflow_engine.processors.evaluations import (
     DataConditionEvaluationException,
 )
 from sentry.workflow_engine.registry import condition_handler_registry
-from sentry.workflow_engine.types import ConditionError, DataConditionResult, DetectorPriorityLevel
+from sentry.workflow_engine.types import (
+    ConditionError,
+    DataConditionHandler,
+    DataConditionResult,
+    DetectorPriorityLevel,
+)
 from sentry.workflow_engine.utils import scopedstats
 
 logger = logging.getLogger(__name__)
@@ -251,6 +256,16 @@ class DataCondition(DefaultFieldsModel):
             result=result,
             data=value,
         )
+
+
+def get_condition_handler(condition_type: Condition) -> DataConditionHandler:
+    if condition_type not in CONDITION_OPS:
+        try:
+            return condition_handler_registry.get(condition_type)
+        except registry.NoRegistrationExistsError:
+            pass
+
+    return None
 
 
 def is_slow_condition(condition: DataCondition) -> bool:

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -70,13 +70,6 @@ class Condition(StrEnum):
     SEER_ACTIVITY_TRIGGER = "seer_activity_trigger"
 
 
-TRIGGER_CONDITIONS = [
-    Condition.FIRST_SEEN_EVENT,
-    Condition.ISSUE_RESOLVED_TRIGGER,
-    Condition.REAPPEARED_EVENT,
-    Condition.REGRESSION_EVENT,
-]
-
 CONDITION_OPS = {
     Condition.EQUAL: operator.eq,
     Condition.GREATER_OR_EQUAL: operator.ge,

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_data_condition_group.py
@@ -149,6 +149,44 @@ class TestBaseDataConditionGroupValidatorCreate(TestBaseDataConditionGroupValida
         assert condition.comparison == 1
         assert condition.condition_group == result
 
+    def test_create_operator_condition__non_short_circuit_logic_type(self) -> None:
+        self.valid_data["logicType"] = DataConditionGroup.Type.ALL
+        self.valid_data["conditions"] = [
+            {
+                "type": Condition.EQUAL,
+                "comparison": 1,
+                "conditionResult": True,
+            }
+        ]
+
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        result = validator.create(validator.validated_data)
+
+        assert result.logic_type == DataConditionGroup.Type.ALL
+        assert result.conditions.count() == 1
+
+    def test_create_action_filter__non_short_circuit_logic_type(self) -> None:
+        self.valid_data["logicType"] = DataConditionGroup.Type.ALL
+        self.valid_data["conditions"] = [
+            {
+                "type": Condition.AGE_COMPARISON,
+                "comparison": {
+                    "comparison_type": "older",
+                    "value": 1,
+                    "time": "day",
+                },
+                "conditionResult": True,
+            }
+        ]
+
+        validator = BaseDataConditionGroupValidator(data=self.valid_data, context=self.context)
+        validator.is_valid(raise_exception=True)
+        result = validator.create(validator.validated_data)
+
+        assert result.logic_type == DataConditionGroup.Type.ALL
+        assert result.conditions.count() == 1
+
     def test_create_trigger__valid_logic_type(self) -> None:
         valid_data = {
             "organizationId": self.organization.id,
@@ -194,7 +232,9 @@ class TestBaseDataConditionGroupValidatorCreate(TestBaseDataConditionGroupValida
             "logicType": DataConditionGroup.Type.ALL,
             "conditions": [
                 {
-                    "type": Condition.FIRST_SEEN_EVENT,
+                    # This trigger was never included in the former TRIGGER_CONDITIONS list.
+                    # Its handler metadata must be the source of truth for validation.
+                    "type": Condition.EVERY_EVENT,
                     "comparison": True,
                     "conditionResult": True,
                 }

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -1,10 +1,12 @@
 from enum import IntEnum
+from typing import Any, cast
 from unittest import mock
 
 import pytest
 
 from sentry.testutils.cases import TestCase
-from sentry.workflow_engine.models.data_condition import Condition
+from sentry.utils.registry import NoRegistrationExistsError
+from sentry.workflow_engine.models.data_condition import Condition, get_condition_handler
 from sentry.workflow_engine.processors.evaluations import DataConditionEvaluationException
 from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest, DataConditionHandlerMixin
@@ -45,10 +47,26 @@ class GetConditionResultTest(TestCase):
         assert dc.get_condition_result() is True
 
 
+class GetConditionHandlerTest(TestCase):
+    def test_operator_condition(self) -> None:
+        assert get_condition_handler(Condition.EQUAL) is None
+
+    def test_registered_condition(self) -> None:
+        assert get_condition_handler(Condition.EVERY_EVENT) is not None
+
+    @mock.patch("sentry.workflow_engine.models.data_condition.condition_handler_registry.get")
+    def test_unregistered_condition(self, mock_get: mock.Mock) -> None:
+        mock_get.side_effect = NoRegistrationExistsError
+
+        assert get_condition_handler(Condition.AGE_COMPARISON) is None
+
+
 class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
     def test(self) -> None:
         dc = self.create_data_condition(
-            type=Condition.GREATER, comparison=1.0, condition_result=DetectorPriorityLevel.HIGH
+            type=Condition.GREATER,
+            comparison=cast(Any, 1.0),
+            condition_result=DetectorPriorityLevel.HIGH,
         )
         evaluation = dc.evaluate_value(2)
         assert evaluation.triggered is True
@@ -84,7 +102,9 @@ class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
         with pytest.raises(ValueError):
             # Raises ValueError because the condition is invalid
             self.create_data_condition(
-                type="invalid", comparison=1.0, condition_result=DetectorPriorityLevel.HIGH
+                type=cast(Any, "invalid"),
+                comparison=cast(Any, 1.0),
+                condition_result=DetectorPriorityLevel.HIGH,
             )
 
     def test_bad_comparison(self) -> None:
@@ -100,7 +120,7 @@ class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
     def test_condition_result_comparison_fails(self) -> None:
         dc = self.create_data_condition(
             type=Condition.GREATER,
-            comparison=1.0,
+            comparison=cast(Any, 1.0),
             condition_result="wrong",
         )
         evaluation = dc.evaluate_value(2)


### PR DESCRIPTION
# Description
Remove the `TRIGGER_CONDITIONS` list, as it's easy to forget to update. We also already have an attribute on a condition, `group` that says if this is a detector trigger, workflow trigger, or action filter -- so this PR refactors the 1 use of `TRIGGER_CONDITIONS` to use the `DetectorHandler.group` abstraction instead.