### PR TITLE
fix(preprod): Try to reduce likelihood of some task race conditions

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -464,18 +464,23 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 },
             )
 
-        # Queue status check and PR comment updates only after size eligibility
-        # has finalized the metrics row they read.
-        if updated_fields:
-            task_kwargs = {
-                "preprod_artifact_id": artifact_id_int,
-                "caller": "artifact_update_endpoint",
-            }
-            create_preprod_status_check_task.apply_async(kwargs=task_kwargs)
-            if not can_run_size:
-                # If size analysis does not run, no completion task will update
-                # the comment, so refresh it now.
-                create_preprod_size_pr_comment_task.apply_async(kwargs=task_kwargs)
+        # Refresh the status check and PR comment only after size eligibility is
+        # resolved, so workers cannot render stale PENDING metrics.
+        should_update_size_status_check = bool(updated_fields) or not can_run_size
+        if should_update_size_status_check:
+            create_preprod_status_check_task.delay(
+                preprod_artifact_id=artifact_id_int,
+                caller="artifact_update_endpoint",
+            )
+
+        should_update_size_pr_comment = not can_run_size
+        if should_update_size_pr_comment:
+            # If size analysis does not run, no completion task will update
+            # the comment, so update it now.
+            create_preprod_size_pr_comment_task.delay(
+                preprod_artifact_id=artifact_id_int,
+                caller="artifact_update_endpoint",
+            )
 
         can_run_distro, distro_skip_reason = should_run_distribution(head_artifact)
         if can_run_distro:

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -28,6 +28,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
 )
 from sentry.preprod.quotas import PreprodFeature, should_run_distribution, should_run_size
+from sentry.preprod.vcs.pr_comments.size_tasks import create_preprod_size_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 
 logger = logging.getLogger(__name__)
@@ -394,13 +395,6 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 },
             )
 
-            create_preprod_status_check_task.apply_async(
-                kwargs={
-                    "preprod_artifact_id": artifact_id_int,
-                    "caller": "artifact_update_endpoint",
-                }
-            )
-
         mobile_app_info = head_artifact.get_mobile_app_info()
         build_version = mobile_app_info.build_version if mobile_app_info else None
         build_number = mobile_app_info.build_number if mobile_app_info else None
@@ -469,6 +463,19 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                     "error_message": error_message,
                 },
             )
+
+        # Queue status check and PR comment updates only after size eligibility
+        # has finalized the metrics row they read.
+        if updated_fields:
+            task_kwargs = {
+                "preprod_artifact_id": artifact_id_int,
+                "caller": "artifact_update_endpoint",
+            }
+            create_preprod_status_check_task.apply_async(kwargs=task_kwargs)
+            if not can_run_size:
+                # If size analysis does not run, no completion task will update
+                # the comment, so refresh it now.
+                create_preprod_size_pr_comment_task.apply_async(kwargs=task_kwargs)
 
         can_run_distro, distro_skip_reason = should_run_distribution(head_artifact)
         if can_run_distro:

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -67,16 +67,6 @@ def create_preprod_size_pr_comment_task(
     rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
     evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
 
-    # Unlike the status check (which posts a neutral "skipped" check regardless),
-    # a comment should only exist when there is size data to report. No evaluated
-    # artifacts means every sibling was skipped or had no size metrics.
-    if not evaluation.evaluated_artifacts:
-        logger.info(
-            "preprod.size_pr_comments.create.no_size_data",
-            extra={"preprod_artifact_id": artifact.id},
-        )
-        return
-
     triggered_rules = evaluation.triggered_rules
     comment_body = format_size_pr_comment(evaluation.title, evaluation.subtitle, evaluation.summary)
 
@@ -91,6 +81,15 @@ def create_preprod_size_pr_comment_task(
                 target_id=commit_comparison.id,
                 comment_type=COMMENT_TYPE,
             )
+
+            # Do not create a comment when there is no size data, but update an
+            # existing comment so stale processing content is not left behind.
+            if not evaluation.evaluated_artifacts and not existing_comment_id:
+                logger.info(
+                    "preprod.size_pr_comments.create.no_size_data",
+                    extra={"preprod_artifact_id": artifact.id},
+                )
+                return
 
             # The trigger check gates first creation only; once a comment exists it is
             # always updated to reflect current state. With no rules configured, post a

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -5,7 +5,11 @@ import orjson
 from django.test import override_settings
 
 from sentry.preprod.api.endpoints.project_preprod_artifact_update import find_or_create_release
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactMobileAppInfo
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodArtifactSizeMetrics,
+)
 from sentry.preprod.quotas import DISTRIBUTION_ENABLED_QUERY_KEY, SIZE_ENABLED_QUERY_KEY
 from sentry.testutils.auth import generate_service_request_signature
 from sentry.testutils.cases import TestCase
@@ -574,13 +578,39 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert "build_distribution" in resp_data["requestedFeatures"]
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
-    def test_update_preprod_artifact_filters_size_by_query(self) -> None:
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_status_check_task"
+    )
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_artifact_update"
+        ".create_preprod_size_pr_comment_task"
+    )
+    def test_update_preprod_artifact_filters_size_by_query(
+        self, mock_pr_comment_task, mock_status_check_task
+    ) -> None:
         """Test that SIZE_ANALYSIS is filtered out when project query doesn't match."""
         self.preprod_artifact.app_id = "com.my.app"
         self.preprod_artifact.save()
+        self.create_preprod_artifact_size_metrics(
+            self.preprod_artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
 
         # Set a query filter that doesn't match
         self.project.update_option(SIZE_ENABLED_QUERY_KEY, "app_id:com.other.app")
+
+        observed_states = []
+
+        def record_metrics_state(**kwargs: Any) -> None:
+            metrics = PreprodArtifactSizeMetrics.objects.get(
+                preprod_artifact=self.preprod_artifact,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            )
+            observed_states.append((metrics.state, metrics.error_code))
+
+        mock_status_check_task.apply_async.side_effect = record_metrics_state
+        mock_pr_comment_task.apply_async.side_effect = record_metrics_state
 
         data = {"artifact_type": 1}
         response = self._make_request(data)
@@ -590,6 +620,18 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert "requestedFeatures" in resp_data
         assert "size_analysis" not in resp_data["requestedFeatures"]
         assert "build_distribution" in resp_data["requestedFeatures"]
+        mock_status_check_task.apply_async.assert_called_once()
+        mock_pr_comment_task.apply_async.assert_called_once()
+        assert observed_states == [
+            (
+                PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+                PreprodArtifactSizeMetrics.ErrorCode.SKIPPED,
+            ),
+            (
+                PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+                PreprodArtifactSizeMetrics.ErrorCode.SKIPPED,
+            ),
+        ]
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_includes_size_when_query_matches(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -612,7 +612,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         mock_status_check_task.delay.side_effect = record_metrics_state
         mock_pr_comment_task.delay.side_effect = record_metrics_state
 
-        data = {}
+        data: dict[str, Any] = {}
         response = self._make_request(data)
 
         assert response.status_code == 200

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -609,10 +609,10 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             )
             observed_states.append((metrics.state, metrics.error_code))
 
-        mock_status_check_task.apply_async.side_effect = record_metrics_state
-        mock_pr_comment_task.apply_async.side_effect = record_metrics_state
+        mock_status_check_task.delay.side_effect = record_metrics_state
+        mock_pr_comment_task.delay.side_effect = record_metrics_state
 
-        data = {"artifact_type": 1}
+        data = {}
         response = self._make_request(data)
 
         assert response.status_code == 200
@@ -620,8 +620,13 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert "requestedFeatures" in resp_data
         assert "size_analysis" not in resp_data["requestedFeatures"]
         assert "build_distribution" in resp_data["requestedFeatures"]
-        mock_status_check_task.apply_async.assert_called_once()
-        mock_pr_comment_task.apply_async.assert_called_once()
+        assert resp_data["updatedFields"] == []
+        task_kwargs = {
+            "preprod_artifact_id": self.preprod_artifact.id,
+            "caller": "artifact_update_endpoint",
+        }
+        mock_status_check_task.delay.assert_called_once_with(**task_kwargs)
+        mock_pr_comment_task.delay.assert_called_once_with(**task_kwargs)
         assert observed_states == [
             (
                 PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,

--- a/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
@@ -225,6 +225,43 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         artifact.commit_comparison.refresh_from_db()
         assert (artifact.commit_comparison.extras or {}).get("pr_comments") is None
 
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_updates_existing_comment_when_all_artifacts_are_skipped(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(
+            triggered=False,
+            status=StatusCheckStatus.NEUTRAL,
+            subtitle="Size analysis skipped",
+            summary="Configure size analysis",
+            evaluated_artifacts=[],
+        )
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="existing_777",
+            data={"body": "## Size Analysis\n\nSize analysis skipped\n\nConfigure size analysis"},
+        )
+        mock_client.create_comment.assert_not_called()
+
     # --- early-return skips ---------------------------------------------
 
     @patch(_CLIENT_PATH)


### PR DESCRIPTION
Previously we would enqueue status check updates before evaluating whether a size analysis filter applied to an artifact. Those status check tasks could race with the logic that marks an artifact as not processed. This could lead to incorrect status check and PR comments making it seem as though builds were stuck processing when really they were finished but skipped.

This is a minimal patch that attempts to address this primarily by reordering the status check updates so they occur after the filtering has happened. All this logic could probably stand to be made more robust and easier to follow though.

Refs EME-1294