### PR TITLE
fix(issues): Keep mention navigation inside dropdown

### DIFF
--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -143,11 +143,16 @@ export function ListBox<T extends ListItemBase>({
   ...props
 }: ListBoxProps<T>) {
   const listElementRef = useRef<HTMLUListElement>(null);
+  const scrollElementRef = useRef<HTMLDivElement>(null);
   const [hasEverOverflowed, setHasEverOverflowed] = useState(false);
 
   const {listBoxProps, labelProps} = useListBox(
     {
       ...props,
+      // useListBox forwards this to useSelectableCollection, but omits it from its
+      // public options type. This identifies the element that actually owns overflow.
+      // @ts-expect-error React Aria supports scrollRef at runtime but does not expose it here.
+      scrollRef: scrollElementRef,
       autoFocus,
       label,
       shouldFocusWrap,
@@ -218,7 +223,12 @@ export function ListBox<T extends ListItemBase>({
 
       setHasEverOverflowed(scrollContainer.scrollHeight > scrollContainer.clientHeight);
     };
-    return mergeRefs(overflowTracker, virtualizer.scrollElementRef, scrollContainerRef);
+    return mergeRefs(
+      scrollElementRef,
+      overflowTracker,
+      virtualizer.scrollElementRef,
+      scrollContainerRef
+    );
   }, [hasEverOverflowed, virtualizer.scrollElementRef, listItems, scrollContainerRef]);
 
   return (

--- a/static/app/components/mentionInput/mentionInput.tsx
+++ b/static/app/components/mentionInput/mentionInput.tsx
@@ -5,7 +5,6 @@ import {mergeProps} from '@react-aria/utils';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 import type {QueryStatus} from '@tanstack/react-query';
 
-import {ListBox} from '@sentry/scraps/compactSelect';
 import {Container} from '@sentry/scraps/layout';
 
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
@@ -23,7 +22,7 @@ import {
 } from './dom';
 import {findActiveMention, getRequestKey, type ActiveMention} from './matching';
 import {type Mention, type MentionInputValue, reconcileMentions} from './model';
-import {CaretAnchor, MentionEditor, SuggestionStatus} from './styles';
+import {CaretAnchor, MentionEditor, SuggestionListBox, SuggestionStatus} from './styles';
 import type {MentionInputProps} from './types';
 import {useMentionSuggestions} from './useMentionSuggestions';
 
@@ -164,6 +163,7 @@ export function MentionInput<TSuggestion>({
     getSuggestion,
     listBoxId,
     listBoxRef,
+    listBoxScrollRef,
     listState,
     queryStatus,
   } = useMentionSuggestions({
@@ -389,31 +389,27 @@ export function MentionInput<TSuggestion>({
           zIndex={theme.zIndex.dropdown}
         >
           <Overlay>
-            <Container
-              minWidth="220px"
-              maxWidth="360px"
-              maxHeight="200px"
-              overflowY="auto"
-            >
-              {hasSuggestions ? (
-                <ListBox
-                  id={listBoxId}
-                  aria-label={t('%s suggestions', activeSource.label)}
-                  autoFocus="first"
-                  ref={listBoxRef}
-                  listState={listState}
-                  overlayIsOpen
-                  onAction={selectSuggestion}
-                  selectionMode="none"
-                  shouldUseVirtualFocus
-                  size="sm"
-                />
-              ) : (
+            {hasSuggestions ? (
+              <SuggestionListBox
+                id={listBoxId}
+                aria-label={t('%s suggestions', activeSource.label)}
+                autoFocus="first"
+                ref={listBoxRef}
+                scrollContainerRef={listBoxScrollRef}
+                listState={listState}
+                overlayIsOpen
+                onAction={selectSuggestion}
+                selectionMode="none"
+                shouldUseVirtualFocus
+                size="sm"
+              />
+            ) : (
+              <Container minWidth="220px" maxWidth="360px">
                 <SuggestionStatus>
                   {getSuggestionStatusMessage(queryStatus)}
                 </SuggestionStatus>
-              )}
-            </Container>
+              </Container>
+            )}
           </Overlay>
         </PositionWrapper>
       ) : null}

--- a/static/app/components/mentionInput/styles.tsx
+++ b/static/app/components/mentionInput/styles.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {ListBox} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -40,6 +41,12 @@ export const CaretAnchor = styled('span')`
   height: 1px;
   visibility: hidden;
   pointer-events: none;
+`;
+
+export const SuggestionListBox = styled(ListBox)`
+  min-width: 220px;
+  max-width: 360px;
+  max-height: 200px;
 `;
 
 export function SuggestionStatus({children}: {children: React.ReactNode}) {

--- a/static/app/components/mentionInput/useMentionSuggestions.tsx
+++ b/static/app/components/mentionInput/useMentionSuggestions.tsx
@@ -100,6 +100,7 @@ export function useMentionSuggestions<T>({
 
   const listBoxId = useId();
   const listBoxRef = useRef<HTMLUListElement>(null);
+  const listBoxScrollRef = useRef<HTMLDivElement>(null);
   const focusedKey = listState.selectionManager.focusedKey;
   const activeDescendant =
     queryStatus === 'success' && items.length > 0 && focusedKey !== null
@@ -115,14 +116,17 @@ export function useMentionSuggestions<T>({
       }),
     [listBoxRef, listState.collection, listState.selectionManager.disabledKeys]
   );
+
+  // The rendered ListBox owns the popup's listbox behavior. This collection hook only
+  // forwards keyboard navigation from the editor, where DOM focus remains.
   const {collectionProps} = useSelectableCollection({
     selectionManager: listState.selectionManager,
     keyboardDelegate,
     shouldFocusWrap: true,
     shouldUseVirtualFocus: true,
     disallowTypeAhead: true,
-    isVirtualized: true,
     ref: inputRef,
+    scrollRef: listBoxScrollRef,
   });
 
   return {
@@ -133,6 +137,7 @@ export function useMentionSuggestions<T>({
     count: items.length,
     listBoxId,
     listBoxRef,
+    listBoxScrollRef,
     listState,
     queryStatus,
   };

--- a/static/app/components/mentionInput/useMentionSuggestions.tsx
+++ b/static/app/components/mentionInput/useMentionSuggestions.tsx
@@ -117,8 +117,6 @@ export function useMentionSuggestions<T>({
     [listBoxRef, listState.collection, listState.selectionManager.disabledKeys]
   );
 
-  // The rendered ListBox owns the popup's listbox behavior. This collection hook only
-  // forwards keyboard navigation from the editor, where DOM focus remains.
   const {collectionProps} = useSelectableCollection({
     selectionManager: listState.selectionManager,
     keyboardDelegate,


### PR DESCRIPTION
Using the arrow keys in mention suggestions scrolled and recentered the entire page instead of only scrolling the dropdown.

This is slightly funky because we want the editor to retain focus and capture arrow keys while React Aria virtually focuses dropdown options. We were giving React Aria the editor/list element but not the div that actually owns the scrollbar. This passes a ref to that overflow div, which is basically telling React Aria "scroll this box when the highlighted option moves."

Drops `isVirtualized` from the mention navigation hook because this list is not virtualized, and current React Aria does not use that option to disable this scrolling behavior.