### PR TITLE
fix(GAL): Enroll projects using write feature

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Sequence
 from datetime import datetime
 
 from django.utils import timezone
@@ -35,7 +34,7 @@ _ENROLLMENT_TASK_KEY = "enroll_projects_for_group_action_log_backfill"
 _ORGANIZATION_ENROLLMENT_TASK_KEY = "enroll_organization_projects_for_group_action_log_backfill"
 GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION = "sentry:group_action_log_backfill_completed"
 
-_GROUP_ACTION_LOG_ROLLOUT_FEATURE = "organizations:issue-action-log-seer-rollout"
+_GROUP_ACTION_LOG_WRITE_FEATURE = "projects:issue-action-log-write-to-db"
 
 
 @instrumented_task(
@@ -372,18 +371,6 @@ def _complete_project_backfill(project: Project, chain_pr_lifecycle: bool) -> No
         generate_project_derived_data.delay(project_id=project.id)
 
 
-def _get_eligible_organization_ids(organizations: Sequence[Organization]) -> set[int]:
-    rollout = features.batch_has_for_organizations(_GROUP_ACTION_LOG_ROLLOUT_FEATURE, organizations)
-    if rollout is None:
-        raise RuntimeError("Unable to evaluate group action log rollout feature")
-
-    return {
-        organization.id
-        for organization in organizations
-        if rollout.get(f"organization:{organization.id}", False)
-    }
-
-
 @instrumented_task(
     name=(
         "sentry.tasks.backfill_group_action_log."
@@ -426,32 +413,56 @@ def enroll_organization_projects_for_group_action_log_backfill(
         )
         return
 
-    project_ids = list(
+    try:
+        organization = Organization.objects.get(id=organization_id, status=ObjectStatus.ACTIVE)
+    except Organization.DoesNotExist:
+        logger.info(
+            "backfill_group_action_log.organization_enrollment.organization_not_found",
+            extra={"organization_id": organization_id},
+        )
+        return
+
+    projects = list(
         Project.objects.filter(
             organization_id=organization_id,
-            organization__status=ObjectStatus.ACTIVE,
             status=ObjectStatus.ACTIVE,
             id__gt=last_project_id,
-        )
-        .order_by("id")
-        .values_list("id", flat=True)[:batch_size]
+        ).order_by("id")[:batch_size]
     )
-    if not project_ids:
+    if not projects:
         logger.info(
             "backfill_group_action_log.organization_enrollment.completed",
             extra={"organization_id": organization_id, "last_project_id": last_project_id},
         )
         return
 
+    feature_results = features.batch_has(
+        [_GROUP_ACTION_LOG_WRITE_FEATURE],
+        projects=projects,
+        organization=organization,
+    )
+    if feature_results is None:
+        raise RuntimeError("Unable to evaluate group action log write feature")
+
+    eligible_project_ids = [
+        project.id
+        for project in projects
+        if feature_results.get(f"project:{project.id}", {}).get(
+            _GROUP_ACTION_LOG_WRITE_FEATURE, False
+        )
+    ]
+
     # Track missing rows so we only invalidate caches for newly enrolled projects.
     project_ids_with_option = set(
         ProjectOption.objects.filter(
-            project_id__in=project_ids,
+            project_id__in=eligible_project_ids,
             key=GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION,
         ).values_list("project_id", flat=True)
     )
     project_ids_to_enroll = [
-        project_id for project_id in project_ids if project_id not in project_ids_with_option
+        project_id
+        for project_id in eligible_project_ids
+        if project_id not in project_ids_with_option
     ]
     ProjectOption.objects.bulk_create(
         [
@@ -475,17 +486,18 @@ def enroll_organization_projects_for_group_action_log_backfill(
         "backfill_group_action_log.organization_enrollment.batch_completed",
         extra={
             "organization_id": organization_id,
-            "batch_size": len(project_ids),
-            "first_project_id": project_ids[0],
-            "last_project_id": project_ids[-1],
+            "batch_size": len(projects),
+            "eligible_projects": len(eligible_project_ids),
+            "first_project_id": projects[0].id,
+            "last_project_id": projects[-1].id,
         },
     )
 
-    if len(project_ids) == batch_size:
+    if len(projects) == batch_size:
         enroll_organization_projects_for_group_action_log_backfill.apply_async(
             kwargs={
                 "organization_id": organization_id,
-                "last_project_id": project_ids[-1],
+                "last_project_id": projects[-1].id,
             },
             countdown=inter_batch_delay_s,
             headers={"sentry-propagate-traces": False},
@@ -504,7 +516,7 @@ def enroll_projects_for_group_action_log_backfill(
     last_organization_id: int = 0,
     **kwargs: object,
 ) -> None:
-    """Dispatch project enrollment for active organizations in the rollout."""
+    """Dispatch project enrollment for active organizations."""
     task_state = current_task()
     activation_id = task_state.id if task_state else None
     if activation_id and already_spawned(_ENROLLMENT_TASK_KEY, activation_id):
@@ -545,10 +557,9 @@ def enroll_projects_for_group_action_log_backfill(
         )
         return
 
-    eligible_organization_ids = _get_eligible_organization_ids(organizations)
-    for organization_id in eligible_organization_ids:
+    for organization in organizations:
         enroll_organization_projects_for_group_action_log_backfill.apply_async(
-            kwargs={"organization_id": organization_id},
+            kwargs={"organization_id": organization.id},
             headers={"sentry-propagate-traces": False},
         )
 
@@ -556,7 +567,6 @@ def enroll_projects_for_group_action_log_backfill(
         "backfill_group_action_log.enrollment.batch_completed",
         extra={
             "batch_size": len(organizations),
-            "eligible_organizations": len(eligible_organization_ids),
             "first_organization_id": organizations[0].id,
             "last_organization_id": organizations[-1].id,
         },

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -604,53 +604,63 @@ class EnrollProjectsForGroupActionLogBackfillTest(TestCase):
             )
         )
 
-    def _feature_results(self, enabled: dict[str, set[int]]) -> Any:
-        def side_effect(feature_name: str, organizations: list[Any]) -> dict[str, bool]:
-            enabled_organizations = enabled.get(feature_name, set())
+    def _project_feature_results(self, enabled_project_ids: set[int]) -> Any:
+        def build_batch_results(
+            feature_names: list[str], *, projects: list[Any], organization: Any
+        ) -> dict[str, dict[str, bool]]:
+            feature_name = feature_names[0]
             return {
-                f"organization:{organization.id}": organization.id in enabled_organizations
-                for organization in organizations
+                f"project:{project.id}": {feature_name: project.id in enabled_project_ids}
+                for project in projects
             }
 
         return patch(
-            "sentry.tasks.backfill_group_action_log.features.batch_has_for_organizations",
-            side_effect=side_effect,
+            "sentry.tasks.backfill_group_action_log.features.batch_has",
+            side_effect=build_batch_results,
         )
 
-    def test_dispatches_enrollment_for_organizations_in_rollout(self) -> None:
-        rollout_org = self.create_organization()
-        excluded_org = self.create_organization()
-        enabled = {
-            "organizations:issue-action-log-seer-rollout": {rollout_org.id},
-        }
+    def test_dispatches_enrollment_for_active_organizations(self) -> None:
+        first_organization = self.create_organization()
+        second_organization = self.create_organization()
+        inactive_organization = self.create_organization(status=1)
 
-        with (
-            self._feature_results(enabled),
-            patch.object(
-                enroll_organization_projects_for_group_action_log_backfill, "apply_async"
-            ) as mock_apply,
-        ):
+        with patch.object(
+            enroll_organization_projects_for_group_action_log_backfill, "apply_async"
+        ) as mock_apply:
             enroll_projects_for_group_action_log_backfill()
 
         dispatched_organization_ids = {
             call.kwargs["kwargs"]["organization_id"] for call in mock_apply.call_args_list
         }
-        assert dispatched_organization_ids == {rollout_org.id}
-        assert excluded_org.id not in dispatched_organization_ids
+        assert dispatched_organization_ids == {first_organization.id, second_organization.id}
+        assert inactive_organization.id not in dispatched_organization_ids
 
     def test_enrolls_active_projects_without_overwriting_existing_option(self) -> None:
         organization = self.create_organization()
         pending_project = self.create_project(organization=organization)
+        ineligible_project = self.create_project(organization=organization)
         completed_project = self.create_project(organization=organization)
         inactive_project = self.create_project(organization=organization)
         completed_project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
         inactive_project.update(status=1)
         assert pending_project.get_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION) is None
 
-        enroll_organization_projects_for_group_action_log_backfill(organization.id)
+        with self._project_feature_results(
+            {pending_project.id, completed_project.id}
+        ) as mock_batch_has:
+            enroll_organization_projects_for_group_action_log_backfill(organization.id)
 
+        mock_batch_has.assert_called_once_with(
+            ["projects:issue-action-log-write-to-db"],
+            projects=[pending_project, ineligible_project, completed_project],
+            organization=organization,
+        )
         assert pending_project.get_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION) is False
         assert completed_project.get_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION) is True
+        assert not ProjectOption.objects.filter(
+            project=ineligible_project,
+            key=GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION,
+        ).exists()
         assert not ProjectOption.objects.filter(
             project=inactive_project,
             key=GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION,
@@ -664,7 +674,6 @@ class EnrollProjectsForGroupActionLogBackfillTest(TestCase):
             override_options(
                 {"issues.backfill_group_action_log.enrollment_organization_batch_size": 2}
             ),
-            self._feature_results({}),
             patch.object(
                 enroll_projects_for_group_action_log_backfill, "apply_async"
             ) as mock_apply,
@@ -684,6 +693,7 @@ class EnrollProjectsForGroupActionLogBackfillTest(TestCase):
             patch.object(
                 enroll_organization_projects_for_group_action_log_backfill, "apply_async"
             ) as mock_apply,
+            self._project_feature_results(set()),
         ):
             enroll_organization_projects_for_group_action_log_backfill(organization.id)
 


### PR DESCRIPTION
GAL backfill enrollment now uses `projects:issue-action-log-write-to-db` as the source of project eligibility instead of treating the organization-level Seer rollout flag as sufficient. This prevents projects that cannot write action logs from receiving pending backfill markers.

The organization coordinator still fans out per active organization for parallelism. Each organization task batch-evaluates the project feature, enrolls only enabled active projects, and advances its cursor across the full project batch.
