### PR TITLE
Remove unreachable onboarding Redis check

### DIFF
--- a/src/sentry/onboarding/agentic_progress/service.py
+++ b/src/sentry/onboarding/agentic_progress/service.py
@@ -108,10 +108,7 @@ class OnboardingProgressService:
                 sequence=0,
                 stages=initial_stages(),
             )
-            if not self.redis.set(
-                self._state_key(claim.claimed_run_id), self._serialize(run), ex=ttl
-            ):
-                raise RuntimeError("Unable to store onboarding run")
+            self.redis.set(self._state_key(claim.claimed_run_id), self._serialize(run), ex=ttl)
         except Exception:
             self._release_index(token_key, claim.claimed_run_id)
             self._release_index(index_key, claim.claimed_run_id)


### PR DESCRIPTION
Redis `SET` without `NX` or `XX` returns success or raises an exception. Remove the unreachable false-result branch so the service reflects the actual Redis client contract and relies on the underlying exception for write failures.