### PR TITLE
tests(workflows): Fix test to use a valid action identifier

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_action_deduplication.py
+++ b/tests/sentry/workflow_engine/processors/test_action_deduplication.py
@@ -394,7 +394,7 @@ class TestActionDeduplication(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_type": ActionTarget.SENTRY_APP,
-                "target_identifier": "action-123",
+                "target_identifier": "123",
             },
         )
 
@@ -402,7 +402,7 @@ class TestActionDeduplication(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_type": ActionTarget.SENTRY_APP,
-                "target_identifier": "action-123",
+                "target_identifier": "123",
             },
         )
 


### PR DESCRIPTION
Test was broken by 10679bdea5d18234963f84170abb55bd7ee244fd, but the test was using an invalid actoin id.
