### PR TITLE
feat(smart-assignment): Simple solution to GA Smart Assignment for all Seer customers

### DIFF
--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -55,7 +55,13 @@ def _apply_prediction(
     """If the feature flag is enabled and we predicted an acutal org user,
     create a (suggested) GroupOwner for them. Then promote the suggestion to an
     assignment iff the project auto-assigns to owners."""
-    if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
+    if not (
+        features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization)
+        and (
+            features.has("organizations:seer-added", group.organization)
+            or features.has("organizations:seat-based-seer-enabled", group.organization)
+        )
+    ):
         return
 
     if top_user_id is None:

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -56,7 +56,13 @@ def trigger_smart_assignment(
     """
     organization = group.organization
 
-    if not features.has(FEATURE_FLAG, organization):
+    if not (
+        features.has(FEATURE_FLAG, organization)
+        and (
+            features.has("organizations:seer-added", organization)
+            or features.has("organizations:seat-based-seer-enabled", organization)
+        )
+    ):
         return
 
     if activity_type in RESOLUTION_ACTIVITIES and resolver_user_id(activity) is None:

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -14,6 +14,9 @@ from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 
 AUTO_ASSIGN_FLAG = "organizations:seer-smart-assignment-assign"
+SEER_ADDED = "organizations:seer-added"
+SEAT_BASED_SEER = "organizations:seat-based-seer-enabled"
+ASSIGN_FEATURES = [AUTO_ASSIGN_FLAG, SEER_ADDED]
 
 
 class ProcessSmartAssignmentCompletionTest(TestCase):
@@ -87,16 +90,36 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
 
     def test_no_writes_without_flag(self) -> None:
         alice = self._member()
-        process_smart_assignment_completion(self.group, self._activity([alice.id]))
+        with self.feature(SEER_ADDED):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
 
         # Everything user-facing is behind the flag: no suggested owner, no assignment.
         assert self._suggested_owners() == []
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
-    def test_suggests_without_assigning_when_project_auto_assign_off(self) -> None:
+    def test_no_writes_without_seer_customer_flag(self) -> None:
         alice = self._member()
         self._set_project_auto_assignment(False)
         with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_suggests_with_seat_based_seer(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature([AUTO_ASSIGN_FLAG, SEAT_BASED_SEER]):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        owners = self._suggested_owners()
+        assert len(owners) == 1
+        assert owners[0].user_id == alice.id
+
+    def test_suggests_without_assigning_when_project_auto_assign_off(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([alice.id, None]))
 
         owners = self._suggested_owners()
@@ -109,7 +132,7 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
     def test_promotes_suggestion_to_assignment_when_project_auto_assigns(self) -> None:
         alice = self._member()
         self._set_project_auto_assignment(True)
-        with self.feature(AUTO_ASSIGN_FLAG):
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([alice.id]))
 
         # Suggested owner is always written...
@@ -128,7 +151,7 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
         alice = self._member()
         GroupAssignee.objects.assign(self.group, existing)
         self._set_project_auto_assignment(True)
-        with self.feature(AUTO_ASSIGN_FLAG):
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([alice.id]))
 
         # We record the suggestion but never override a manual assignment.
@@ -140,7 +163,7 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
         # alternate behind them is the one that can actually own the issue.
         alice = self._member()
         self._set_project_auto_assignment(False)
-        with self.feature(AUTO_ASSIGN_FLAG):
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([None, alice.id]))
 
         owners = self._suggested_owners()
@@ -150,14 +173,14 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
         assert self._extras()["predicted_assignee_user_ids"] == [None, alice.id]
 
     def test_no_writes_when_top_pick_unlinked(self) -> None:
-        with self.feature(AUTO_ASSIGN_FLAG):
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([None]))
 
         assert self._suggested_owners() == []
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
     def test_no_writes_on_abstain(self) -> None:
-        with self.feature(AUTO_ASSIGN_FLAG):
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([]))
 
         assert self._suggested_owners() == []
@@ -166,7 +189,7 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
     def test_suggested_owner_is_idempotent(self) -> None:
         alice = self._member()
         self._set_project_auto_assignment(False)
-        with self.feature(AUTO_ASSIGN_FLAG):
+        with self.feature(ASSIGN_FEATURES):
             process_smart_assignment_completion(self.group, self._activity([alice.id]))
             process_smart_assignment_completion(self.group, self._activity([alice.id]))
 

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -15,6 +15,11 @@ from sentry.types.activity import ActivityType
 CLIENT_PATH = "sentry.seer.smart_assignment.trigger.SeerAgentClient"
 SCORING_METRICS_PATH = "sentry.seer.smart_assignment.scoring.metrics"
 
+RUN_FLAG = "organizations:seer-smart-assignment-run"
+SEER_ADDED = "organizations:seer-added"
+SEAT_BASED_SEER = "organizations:seat-based-seer-enabled"
+RUN_FEATURES = [RUN_FLAG, SEER_ADDED]
+
 SEER_START_ACTIVITY_TYPES = (
     ActivityType.SEER_RCA_STARTED,
     ActivityType.SEER_SOLUTION_STARTED,
@@ -91,7 +96,7 @@ class TriggerSmartAssignmentTest(TestCase):
     @patch(CLIENT_PATH)
     def test_dispatch_creates_run_mirror(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
@@ -105,14 +110,36 @@ class TriggerSmartAssignmentTest(TestCase):
 
     @patch(CLIENT_PATH)
     def test_flag_disabled_is_noop(self, mock_client_cls: MagicMock) -> None:
-        trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED, self._seer_started())
+        with self.feature(SEER_ADDED):
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
         assert self._mirrors() == []
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)
+    def test_no_seer_customer_flag_is_noop(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        with self.feature(RUN_FLAG):
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
+        assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_dispatches_with_seat_based_seer(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        with self.feature([RUN_FLAG, SEAT_BASED_SEER]):
+            trigger_smart_assignment(
+                self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
+            )
+        assert len(self._mirrors()) == 1
+
+    @patch(CLIENT_PATH)
     def test_dedup_skips_second_dispatch(self, mock_client_cls: MagicMock) -> None:
         self._mirror(trigger=ActivityType.SEER_RCA_STARTED.name)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
@@ -126,7 +153,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
         ):
             trigger_smart_assignment(
@@ -147,7 +174,7 @@ class TriggerSmartAssignmentTest(TestCase):
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
         ):
             trigger_smart_assignment(
@@ -163,7 +190,7 @@ class TriggerSmartAssignmentTest(TestCase):
         self._wire_client(mock_client_cls)
         resolver = self.create_user()
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
         ):
             trigger_smart_assignment(
@@ -181,7 +208,7 @@ class TriggerSmartAssignmentTest(TestCase):
     def test_dispatch_stamps_triggering_activity(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         activity = self._seer_started()
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED, activity)
 
         mirror = self._mirrors()[0]
@@ -196,7 +223,7 @@ class TriggerSmartAssignmentTest(TestCase):
     def test_org_rate_limit_skips_dispatch(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.max_dispatches_per_org_per_day": 0}),
         ):
             trigger_smart_assignment(
@@ -211,7 +238,7 @@ class TriggerSmartAssignmentTest(TestCase):
         self._wire_client(mock_client_cls)
         # Org cap is generous; the global cap is what trips here.
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.max_dispatches_per_day": 0}),
         ):
             trigger_smart_assignment(
@@ -231,7 +258,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 0.0}),
         ):
             trigger_smart_assignment(
@@ -245,7 +272,7 @@ class TriggerSmartAssignmentTest(TestCase):
     def test_eval_sample_rate_does_not_gate_seer_starts(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 0.0}),
         ):
             trigger_smart_assignment(
@@ -265,7 +292,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 0.10}),
         ):
             trigger_smart_assignment(
@@ -285,7 +312,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 0.10}),
         ):
             trigger_smart_assignment(
@@ -305,7 +332,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options(
                 {
                     "seer.smart_assignment.max_dispatches_per_org_per_day": 0,
@@ -329,7 +356,7 @@ class TriggerSmartAssignmentTest(TestCase):
         GroupAssignee.objects.create(
             group=self.group, project=self.group.project, user_id=assignee.id
         )
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.ASSIGNED,
@@ -346,7 +373,7 @@ class TriggerSmartAssignmentTest(TestCase):
         self._wire_client(mock_client_cls)
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.ASSIGNED,
@@ -365,7 +392,7 @@ class TriggerSmartAssignmentTest(TestCase):
         self._mirror(trigger=ActivityType.SEER_RCA_STARTED.name)
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.ASSIGNED,
@@ -388,7 +415,7 @@ class TriggerSmartAssignmentTest(TestCase):
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
         self._assigned_activity(team.id, "team", integration=ActivityIntegration.CODEOWNERS.value)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
@@ -410,7 +437,7 @@ class TriggerSmartAssignmentTest(TestCase):
         )
         human = self.create_user()
         with (
-            self.feature("organizations:seer-smart-assignment-run"),
+            self.feature(RUN_FEATURES),
             self.options({"seer.smart_assignment.eval_sample_rate": 1.0}),
         ):
             trigger_smart_assignment(
@@ -443,7 +470,7 @@ class TriggerSmartAssignmentTest(TestCase):
             assignee = self.create_user()
             GroupAssignee.objects.create(group=group, project=group.project, user_id=assignee.id)
             self._assigned_activity(assignee.id, group=group)
-            with self.feature("organizations:seer-smart-assignment-run"):
+            with self.feature(RUN_FEATURES):
                 trigger_smart_assignment(
                     group,
                     activity_type,
@@ -463,7 +490,7 @@ class TriggerSmartAssignmentTest(TestCase):
         team = self.create_team(organization=self.organization)
         GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
         self._assigned_activity(team.id, "team")
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
@@ -483,7 +510,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         self._assigned_activity(assignee.id)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             for activity_type in (
                 ActivityType.SEER_RCA_STARTED,
                 ActivityType.SEER_SOLUTION_STARTED,
@@ -516,7 +543,7 @@ class TriggerSmartAssignmentTest(TestCase):
             group=self.group, project=self.group.project, user_id=assignee.id
         )
         self._assigned_activity(assignee.id)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
@@ -536,7 +563,7 @@ class TriggerSmartAssignmentTest(TestCase):
     @patch(CLIENT_PATH)
     def test_automatic_resolution_is_skipped(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group, ActivityType.SET_RESOLVED, self._activity(ActivityType.SET_RESOLVED)
             )
@@ -549,7 +576,7 @@ class TriggerSmartAssignmentTest(TestCase):
     def test_integration_resolution_is_skipped(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         proxy_user = self.create_user(is_sentry_app=True)
-        with self.feature("organizations:seer-smart-assignment-run"):
+        with self.feature(RUN_FEATURES):
             trigger_smart_assignment(
                 self.group,
                 ActivityType.SET_RESOLVED_IN_RELEASE,


### PR DESCRIPTION
After lots of back-and-forth and an incident, this solution is very simple and should get us the functionality we want. We can just enable the `smart-assignment-run` and `smart-assignment-assign` flags for all customers, and require one of the Seer-enabled flags as well.