### PR TITLE
ref(issue detection): Add helper to extract numerical span data

### DIFF
--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -1,6 +1,8 @@
 import hashlib
 import logging
+import math
 import re
+import sys
 from datetime import timedelta
 from typing import Any, TypedDict
 from urllib.parse import ParseResult, parse_qs, urlparse
@@ -455,3 +457,98 @@ def log_invalid_span_data(
             **(extra_data or {}),
         },
     )
+
+
+def _presumably_safe_ensure_numeric_type[T: (int, float)](
+    value: Any, desired_type: type[T]
+) -> tuple[bool, T | None, str | None]:
+    """
+    Attempt to coerce `value` to be either an int or float. Returns a tuple of the form `(True,
+    new_value, None)` if conversion is successful, and `(False, None, failure_reason)` if it's not,
+    where `failure_reason` is a string describing the kind of invalid value found.
+
+    Rejects bools, `NaN`, and `inf` because they don't represent usable numbers, even if they
+    technically would pass a typecheck. Also rejects non-integral floats and oversize ints, because
+    conversion would be lossy or raise errors, respectively.
+
+    Note: This theoretically covers all of the ways a value can be invalid, and therefore shouldn't
+    ever error out. That said, it purposefully doesn't wrap the final conversion in a try-except, so
+    that if a new way to be wrong ever does show up, it'll be noisier than just a warning log and
+    we'll know to come and fix this helper. Thus "presumably safe" rather than "safe."
+    """
+    # Strings are the one non-number type we might be able to use. If we find one, first try
+    # converting it into a number before doing the other checks/the final conversion. We use `float`
+    # here because it will accept both stringified floats and stringified ints, whereas `int` only
+    # accepts the latter.
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except Exception:
+            return (False, None, "non_number_string")
+
+    # Not a number at all
+    if not isinstance(value, (int, float)):
+        return (False, None, type(value).__name__)
+
+    # Technically a number, typecheck-wise, but not a true numerical value
+    if isinstance(value, bool):
+        return (False, None, "bool")
+    if isinstance(value, float) and not math.isfinite(value):
+        return (False, None, "non_number_float")
+
+    # A real numerical value, but not one we can convert to the type we want
+    if desired_type is int and not value.is_integer():
+        return (False, None, "non_integer_float")
+    if desired_type is float and abs(value) > sys.float_info.max:
+        return (False, None, "oversize_int")
+
+    # If we get here, we've got a value which is both valid and convertible. To save ourselves a
+    # bunch more typechecking, we unconditionally apply the conversion function, even though it'll
+    # end up just being a pass-through for values which are already the right type.
+    return (True, desired_type(value), None)
+
+
+def get_numeric_value_from_span[T: (int, float)](
+    span: Span,
+    keys: list[str],  # A list of keys under which to look for the data
+    detector: str,  # Detector identifier to use in invalid data logs
+    number_type: type[T],  # `int` or `float`, used for converting string values
+    default: T | None = None,  # Optional default value to return instead of None
+) -> T | None:
+    """
+    Pull a numeric value from a span's `data` attribute, attempting to convert it to the desired
+    type if necessary. Tracks invalid values using the `log_invalid_span_data` util. Returns `None`
+    (or the optional default, if given) for missing or invalid values.
+    """
+    if not keys:  # Failsafe - shouldn't happen
+        return default
+
+    data = span.get("data")
+    if not data:
+        return default
+
+    # Some data might exist under multiple potential keys
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            break
+
+    if value is None:
+        return default
+
+    # Check value type and attempt to convert if necessary
+    success, result, bad_value_type = _presumably_safe_ensure_numeric_type(value, number_type)
+
+    if success:
+        return result
+    else:
+        log_invalid_span_data(
+            span,
+            detector=detector,
+            key=key,
+            value=value,
+            error=ValueError(
+                f"Couldn't convert <{bad_value_type}> to <{number_type.__name__}>. Invalid value: {value}"
+            ),
+        )
+        return default

--- a/tests/sentry/issue_detection/test_utils.py
+++ b/tests/sentry/issue_detection/test_utils.py
@@ -8,103 +8,102 @@ from sentry.issue_detection.detectors.utils import (
 from sentry.testutils.issue_detection.event_generators import create_span
 
 
-@pytest.mark.parametrize(
-    ("url", "expected_result"),
-    [
-        ("https://[Filtered]/dogs/1121", True),
-        ("https://[Redacted IP]/dogs/1231", True),
-        ("https://[dogs].are.great/dogs/908", True),
-        ("https://[Filtered]:8080/dogs/415", True),
-        ("https://user:[Filtered]@dogs.are.great/x", True),
-        ("//[Filtered]/dogs/2012", True),  # protocol-relative
-        ("https://[4.15.9.8]/dogs/2013", False),  # a real IP address
-        ("https://dogs.are.great/dogs/[number]", False),
-        ("https://dogs.are.great/dogs/[filtered id]", False),
-        ("https://dogs.are.great/dogs/1121", False),
-        ("https://dogs.are.great/dogs/1231?year=2012", False),
-    ],
-)
-def test_span_has_obfuscated_hostname(url: str, expected_result: bool) -> None:
-    span = create_span("http.client", 320415204, f"GET {url}")
-    assert span_has_obfuscated_hostname(span) == expected_result
+class TestDetectorUtils:
+    @pytest.mark.parametrize(
+        ("url", "expected_result"),
+        [
+            ("https://[Filtered]/dogs/1121", True),
+            ("https://[Redacted IP]/dogs/1231", True),
+            ("https://[dogs].are.great/dogs/908", True),
+            ("https://[Filtered]:8080/dogs/415", True),
+            ("https://user:[Filtered]@dogs.are.great/x", True),
+            ("//[Filtered]/dogs/2012", True),  # protocol-relative
+            ("https://[4.15.9.8]/dogs/2013", False),  # a real IP address
+            ("https://dogs.are.great/dogs/[number]", False),
+            ("https://dogs.are.great/dogs/[filtered id]", False),
+            ("https://dogs.are.great/dogs/1121", False),
+            ("https://dogs.are.great/dogs/1231?year=2012", False),
+        ],
+    )
+    def test_span_has_obfuscated_hostname(self, url: str, expected_result: bool) -> None:
+        span = create_span("http.client", 320415204, f"GET {url}")
+        assert span_has_obfuscated_hostname(span) == expected_result
 
+    @pytest.mark.parametrize(
+        ("url", "expected_netloc"),
+        [
+            ("https://[Filtered]/dogs/1121", "[Filtered]"),
+            ("https://[Redacted IP]/dogs/1231", "[Redacted IP]"),
+            ("https://[dogs].are.great/dogs/908", "[dogs].are.great"),
+            ("https://[Filtered]:8080/dogs/415", "[Filtered]:8080"),
+            ("https://user:[Filtered]@dogs.are.great/x", "user:[Filtered]@dogs.are.great"),
+            ("//[Filtered]/dogs/2012", "[Filtered]"),  # protocol-relative
+            ("https://[4.15.9.8]/dogs/2013", "[4.15.9.8]"),  # a real IP address
+            ("https://dogs.are.great/dogs/[number]", "dogs.are.great"),
+            ("https://dogs.are.great/dogs/[filtered id]", "dogs.are.great"),
+            ("https://dogs.are.great/dogs/1121", "dogs.are.great"),
+            ("https://dogs.are.great/dogs/1231?year=2012", "dogs.are.great"),
+        ],
+    )
+    def test_safe_urlparse(self, url: str, expected_netloc: str) -> None:
+        assert safer_urlparse(url).netloc == expected_netloc
 
-@pytest.mark.parametrize(
-    ("url", "expected_netloc"),
-    [
-        ("https://[Filtered]/dogs/1121", "[Filtered]"),
-        ("https://[Redacted IP]/dogs/1231", "[Redacted IP]"),
-        ("https://[dogs].are.great/dogs/908", "[dogs].are.great"),
-        ("https://[Filtered]:8080/dogs/415", "[Filtered]:8080"),
-        ("https://user:[Filtered]@dogs.are.great/x", "user:[Filtered]@dogs.are.great"),
-        ("//[Filtered]/dogs/2012", "[Filtered]"),  # protocol-relative
-        ("https://[4.15.9.8]/dogs/2013", "[4.15.9.8]"),  # a real IP address
-        ("https://dogs.are.great/dogs/[number]", "dogs.are.great"),
-        ("https://dogs.are.great/dogs/[filtered id]", "dogs.are.great"),
-        ("https://dogs.are.great/dogs/1121", "dogs.are.great"),
-        ("https://dogs.are.great/dogs/1231?year=2012", "dogs.are.great"),
-    ],
-)
-def test_safe_urlparse(url: str, expected_netloc: str) -> None:
-    assert safer_urlparse(url).netloc == expected_netloc
+    @pytest.mark.parametrize(
+        ("url", "expected_result_data"),  # Expected result is (url, path_params, query_params)
+        [
+            (
+                "https://[Filtered]/dogs/1121",
+                ("https://[Filtered]/dogs/*", ["1121"], {}),
+            ),
+            (
+                "https://[Redacted IP]/dogs/1231",
+                ("https://[Redacted IP]/dogs/*", ["1231"], {}),
+            ),
+            (
+                "https://[dogs].are.great/dogs/908",
+                ("https://[dogs].are.great/dogs/*", ["908"], {}),
+            ),
+            (
+                "https://[Filtered]:8080/dogs/415",
+                ("https://[Filtered]:8080/dogs/*", ["415"], {}),
+            ),
+            (
+                "https://user:[Filtered]@dogs.are.great/x",
+                ("https://user:[Filtered]@dogs.are.great/x", [], {}),
+            ),
+            (
+                "//[Filtered]/dogs/2012",  # protocol-relative
+                ("[Filtered]/dogs/*", ["2012"], {}),
+            ),
+            (
+                "https://[4.15.9.8]/dogs/2013",  # a real IP address
+                ("https://[4.15.9.8]/dogs/*", ["2013"], {}),
+            ),
+            (
+                "https://dogs.are.great/dogs/[number]",
+                ("https://dogs.are.great/dogs/*", ["[number]"], {}),
+            ),
+            (
+                "https://dogs.are.great/dogs/[filtered id]",
+                ("https://dogs.are.great/dogs/*", ["[filtered id]"], {}),
+            ),
+            (
+                "https://dogs.are.great/dogs/1121",
+                ("https://dogs.are.great/dogs/*", ["1121"], {}),
+            ),
+            (
+                "https://dogs.are.great/dogs/1231?year=2012",
+                ("https://dogs.are.great/dogs/*?year=*", ["1231"], {"year": ["2012"]}),
+            ),
+        ],
+    )
+    def test_parameterize_url_with_result(
+        self, url: str, expected_result_data: tuple[str, list[str], dict[str, list[str]]]
+    ) -> None:
+        parameterized_url, path_params, query_params = expected_result_data
 
-
-@pytest.mark.parametrize(
-    ("url", "expected_result_data"),  # Expected result is (url, path_params, query_params)
-    [
-        (
-            "https://[Filtered]/dogs/1121",
-            ("https://[Filtered]/dogs/*", ["1121"], {}),
-        ),
-        (
-            "https://[Redacted IP]/dogs/1231",
-            ("https://[Redacted IP]/dogs/*", ["1231"], {}),
-        ),
-        (
-            "https://[dogs].are.great/dogs/908",
-            ("https://[dogs].are.great/dogs/*", ["908"], {}),
-        ),
-        (
-            "https://[Filtered]:8080/dogs/415",
-            ("https://[Filtered]:8080/dogs/*", ["415"], {}),
-        ),
-        (
-            "https://user:[Filtered]@dogs.are.great/x",
-            ("https://user:[Filtered]@dogs.are.great/x", [], {}),
-        ),
-        (
-            "//[Filtered]/dogs/2012",  # protocol-relative
-            ("[Filtered]/dogs/*", ["2012"], {}),
-        ),
-        (
-            "https://[4.15.9.8]/dogs/2013",  # a real IP address
-            ("https://[4.15.9.8]/dogs/*", ["2013"], {}),
-        ),
-        (
-            "https://dogs.are.great/dogs/[number]",
-            ("https://dogs.are.great/dogs/*", ["[number]"], {}),
-        ),
-        (
-            "https://dogs.are.great/dogs/[filtered id]",
-            ("https://dogs.are.great/dogs/*", ["[filtered id]"], {}),
-        ),
-        (
-            "https://dogs.are.great/dogs/1121",
-            ("https://dogs.are.great/dogs/*", ["1121"], {}),
-        ),
-        (
-            "https://dogs.are.great/dogs/1231?year=2012",
-            ("https://dogs.are.great/dogs/*?year=*", ["1231"], {"year": ["2012"]}),
-        ),
-    ],
-)
-def test_parameterize_url_with_result(
-    url: str, expected_result_data: tuple[str, list[str], dict[str, list[str]]]
-) -> None:
-    expected_parameterized_url, expected_path_params, expected_query_params = expected_result_data
-
-    assert parameterize_url_with_result(url) == {
-        "url": expected_parameterized_url,
-        "path_params": expected_path_params,
-        "query_params": expected_query_params,
-    }
+        assert parameterize_url_with_result(url) == {
+            "url": parameterized_url,
+            "path_params": path_params,
+            "query_params": query_params,
+        }

--- a/tests/sentry/issue_detection/test_utils.py
+++ b/tests/sentry/issue_detection/test_utils.py
@@ -1,11 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from sentry.issue_detection.detectors.utils import (
+    get_numeric_value_from_span,
     parameterize_url_with_result,
     safer_urlparse,
     span_has_obfuscated_hostname,
 )
 from sentry.testutils.issue_detection.event_generators import create_span
+
+
+@pytest.fixture
+def mock_log_invalid_data() -> Generator[MagicMock]:
+    with patch(
+        "sentry.issue_detection.detectors.utils.log_invalid_span_data"
+    ) as mock_log_invalid_data:
+        yield mock_log_invalid_data
 
 
 class TestDetectorUtils:
@@ -107,3 +122,108 @@ class TestDetectorUtils:
             "path_params": path_params,
             "query_params": query_params,
         }
+
+
+class TestGetNumericValueFromSpan:
+    @pytest.mark.parametrize(
+        ("value", "number_type", "expected_result"),
+        [
+            # Values which are already the type we want
+            (1121, int, 1121),
+            (12.31, float, 12.31),
+            # Strings we can convert directly
+            ("1121", int, 1121),
+            ("12.31", float, 12.31),
+            # Ints are fine when we want floats - they're just missing decimals. The reverse
+            # generally isn't okay, since converting would lose data. The one exception is
+            # whole-number floats, which convert just fine.
+            (1121, float, 1121.0),
+            (1231.0, int, 1231),
+            (11.21, int, Exception),
+            # All of the above still holds if the values start out as strings
+            ("1121", float, 1121.0),
+            ("1231.0", int, 1231),
+            ("11.21", int, Exception),
+            # Bools are technically ints, but they're not what we're after
+            (True, int, Exception),
+            (True, float, Exception),
+            (False, int, Exception),
+            (False, float, Exception),
+            # Similarly, `NaN`-strings can be converted to floats, but also aren't what we want
+            ("NaN", int, Exception),
+            ("NaN", float, Exception),
+            # Values which aren't numbers at all
+            ("dogs", int, Exception),
+            ("dogs", float, Exception),
+            ("", int, Exception),
+            ("", float, Exception),
+            ({"maisey": 1231}, int, Exception),
+            ({"maisey": 1231}, float, Exception),
+            ([1231], int, Exception),
+            ([1231], float, Exception),
+        ],
+    )
+    def test_value_found(
+        self,
+        value: Any,
+        number_type: type[int] | type[float],
+        expected_result: int | float | type[Exception],
+        mock_log_invalid_data: MagicMock,
+    ) -> None:
+        span = create_span("do.dog.stuff", data={"dogs_are_great": value})
+        keys = ["dogs_are_great"]
+        default = 0 if number_type is int else 0.0
+
+        result_without_default = get_numeric_value_from_span(
+            span, keys, "dog_detector", number_type
+        )
+        result_with_default = get_numeric_value_from_span(
+            span, keys, "dog_detector", number_type, default=default
+        )
+
+        if expected_result is Exception:
+            assert result_without_default is None
+            assert result_with_default == default
+            # Invalid data logging happens even when we have a default value to return
+            assert mock_log_invalid_data.call_count == 2
+        else:
+            assert result_without_default == expected_result
+            assert isinstance(result_without_default, number_type)
+            assert result_with_default == expected_result
+            assert isinstance(result_with_default, number_type)
+            assert mock_log_invalid_data.call_count == 0
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            None,  # No span data
+            {},  # Empty span data
+            {"adopt_dont_shop": 1121},  # Span data exists but desired key doesn't
+            {"dogs_are_great": None},  # Desired key exists but has no value
+        ],
+    )
+    def test_value_not_found(
+        self, data: dict[str, Any] | None, mock_log_invalid_data: MagicMock
+    ) -> None:
+        span = create_span("do.dog.stuff", data=data)
+        keys = ["dogs_are_great"]
+
+        # Returns the default value (if given) or `None` (if not)
+        assert get_numeric_value_from_span(span, keys, "dog_detector", int) is None
+        assert get_numeric_value_from_span(span, keys, "dog_detector", int, default=1231) == 1231
+        # Either way, missing data isn't invalid data, so there's nothing to log
+        assert mock_log_invalid_data.call_count == 0
+
+    def test_uses_first_key_with_a_value(self, mock_log_invalid_data: MagicMock) -> None:
+        span = create_span("do.dog.stuff", data={"adopt_dont_shop": 1121, "dogs_are_great": 1231})
+        keys = ["dogs_are_great", "adopt_dont_shop"]
+
+        assert get_numeric_value_from_span(span, keys, "dog_detector", int) == 1231
+        assert mock_log_invalid_data.call_count == 0
+
+    def test_falls_back_to_later_keys(self, mock_log_invalid_data: MagicMock) -> None:
+        span = create_span("do.dog.stuff", data={"adopt_dont_shop": 1121})
+        keys = ["dogs_are_great", "adopt_dont_shop"]
+
+        assert get_numeric_value_from_span(span, keys, "dog_detector", int) == 1121
+        assert mock_log_invalid_data.call_count == 0


### PR DESCRIPTION
There are a number of places in our issue detectors where we extract (what should be) numerical data out of the spans we're examining, to be able to compare it to whatever the relevant thresholds are. In some of those places, we have fallback logic to handle the case in which we find a string rather than a number, but in other places we don't, leading the detector to error out.

To standardize our handling of such cases, this PR adds a new helper, `get_numeric_value_from_span`, to pull the data, try converting it if necessary, and log if it finds anything weird. To keep things easy to review, actual use of this helper in our detectors has been split into [a follow-up PR](https://github.com/getsentry/sentry/pull/122495).

Note: The test changes look bigger than they are. For organization purposes, I pulled the existing collection of utils tests into a generic utils tests class, so that I could then put the tests for this helper in a separate class.