### PR TITLE
Support multiple onboarding projects and issues

### DIFF
--- a/src/sentry/api/endpoints/organization_agentic_onboarding.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding.py
@@ -62,8 +62,8 @@ class AgenticOnboardingStatusRequest(TypedDict):
     status: StageStatusValue
     run_status: NotRequired[Literal["completed", "failed"]]
     event_note: NotRequired[str]
-    project_slug: NotRequired[str]
-    issue_id: NotRequired[str]
+    project_slugs: NotRequired[list[str]]
+    issue_ids: NotRequired[list[str]]
 
 
 class AgenticOnboardingStatusData(TypedDict):
@@ -100,16 +100,20 @@ class AgenticOnboardingStatusRequestSerializer(CamelSnakeSerializer[AgenticOnboa
     event_note = serializers.CharField(
         required=False, allow_blank=False, max_length=MAX_EVENT_NOTE_LENGTH
     )
-    project_slug = serializers.SlugField(required=False)
-    issue_id = serializers.CharField(required=False)
+    project_slugs = serializers.ListField(
+        child=serializers.SlugField(), required=False, allow_empty=False, max_length=100
+    )
+    issue_ids = serializers.ListField(
+        child=serializers.CharField(), required=False, allow_empty=False, max_length=100
+    )
 
     def validate(self, attrs: AgenticOnboardingStatusRequest) -> AgenticOnboardingStatusData:
         update = ProgressUpdate(
             stage=Stage(attrs["stage"]),
             status=StageStatus(attrs["status"]),
             event_note=attrs.get("event_note"),
-            project_slug=attrs.get("project_slug"),
-            issue_id=attrs.get("issue_id"),
+            project_slugs=tuple(attrs.get("project_slugs", [])),
+            issue_ids=tuple(attrs.get("issue_ids", [])),
             run_status=(RunStatus(attrs["run_status"]) if "run_status" in attrs else None),
         )
         try:

--- a/src/sentry/api/serializers/models/agentic_onboarding.py
+++ b/src/sentry/api/serializers/models/agentic_onboarding.py
@@ -23,8 +23,8 @@ class AgenticOnboardingRunResponse(TypedDict):
     expiresAt: str
     continueUpdates: bool
     runStatus: RunStatus
-    projectSlug: str | None
-    issueId: str | None
+    projectSlugs: list[str]
+    issueIds: list[str]
     stages: list[AgenticOnboardingStageResponse]
 
 
@@ -47,8 +47,8 @@ class AgenticOnboardingRunSerializer(Serializer[AgenticOnboardingRunResponse]):
             expiresAt=obj.expires_at.isoformat(),
             continueUpdates=obj.run_status is RunStatus.ACTIVE,
             runStatus=obj.run_status,
-            projectSlug=obj.project_slug,
-            issueId=obj.issue_id,
+            projectSlugs=list(obj.project_slugs),
+            issueIds=list(obj.issue_ids),
             stages=[
                 AgenticOnboardingStageResponse(
                     stage=state.stage,

--- a/src/sentry/onboarding/agentic_progress/model.py
+++ b/src/sentry/onboarding/agentic_progress/model.py
@@ -108,8 +108,8 @@ class ProgressUpdateField(StrEnum):
 
     EVENT_NOTE = "event_note"
     STATUS = "status"
-    PROJECT_SLUG = "project_slug"
-    ISSUE_ID = "issue_id"
+    PROJECT_SLUGS = "project_slugs"
+    ISSUE_IDS = "issue_ids"
     RUN_STATUS = "run_status"
 
 
@@ -156,11 +156,11 @@ class ProgressUpdate:
     event_note: str | None = None
     """Optional user-visible context for the update."""
 
-    project_slug: str | None = None
-    """Validated project selected during the create-project stage."""
+    project_slugs: tuple[str, ...] = ()
+    """Validated projects selected during the create-project stage."""
 
-    issue_id: str | None = None
-    """Validated issue received during the receive-verification-error stage."""
+    issue_ids: tuple[str, ...] = ()
+    """Validated issues received during the receive-verification-error stage."""
 
     run_status: RunStatus | None = None
     """Optional terminal transition for the complete run."""
@@ -206,11 +206,11 @@ class OnboardingRun:
     run_status: RunStatus = RunStatus.ACTIVE
     """Lifecycle state of the complete onboarding run."""
 
-    project_slug: str | None = None
-    """Validated Sentry project selected for instrumentation."""
+    project_slugs: tuple[str, ...] = ()
+    """Validated Sentry projects selected for instrumentation."""
 
-    issue_id: str | None = None
-    """Validated Sentry issue proving end-to-end event delivery."""
+    issue_ids: tuple[str, ...] = ()
+    """Validated Sentry issues proving end-to-end event delivery."""
 
     schema_version: int = SCHEMA_VERSION
     """Version of the Redis and public snapshot representation."""
@@ -283,8 +283,8 @@ class OnboardingRun:
                 sequence=value["sequence"],
                 stages=stages,
                 run_status=run_status,
-                project_slug=value.get("project_slug"),
-                issue_id=value.get("issue_id"),
+                project_slugs=tuple(value.get("project_slugs", [])),
+                issue_ids=tuple(value.get("issue_ids", [])),
                 schema_version=value["schema_version"],
             )
         except InvalidOnboardingRun:
@@ -346,15 +346,15 @@ def validate_update(update: ProgressUpdate) -> None:
         raise InvalidProgressUpdate(
             ProgressUpdateField.STATUS, "Bypassed stages are inferred by the backend"
         )
-    if update.project_slug is not None and update.stage is not Stage.CREATE_PROJECT:
+    if update.project_slugs and update.stage is not Stage.CREATE_PROJECT:
         raise InvalidProgressUpdate(
-            ProgressUpdateField.PROJECT_SLUG,
-            "Project slug is only valid for the create-project stage",
+            ProgressUpdateField.PROJECT_SLUGS,
+            "Project slugs are only valid for the create-project stage",
         )
-    if update.issue_id is not None and update.stage is not Stage.RECEIVE_VERIFICATION_ERROR:
+    if update.issue_ids and update.stage is not Stage.RECEIVE_VERIFICATION_ERROR:
         raise InvalidProgressUpdate(
-            ProgressUpdateField.ISSUE_ID,
-            "Issue ID is only valid for the receive-verification-error stage",
+            ProgressUpdateField.ISSUE_IDS,
+            "Issue IDs are only valid for the receive-verification-error stage",
         )
     if update.run_status not in {None, RunStatus.COMPLETED, RunStatus.FAILED}:
         raise InvalidProgressUpdate(
@@ -405,15 +405,15 @@ def apply_update(run: OnboardingRun, update: ProgressUpdate, now: datetime) -> O
         StageStatus.BYPASSED,
     }
     if current.status in frozen_statuses and update.status is not current.status:
-        project_slug = update.project_slug or run.project_slug
-        issue_id = update.issue_id or run.issue_id
-        if project_slug == run.project_slug and issue_id == run.issue_id:
+        project_slugs = tuple(dict.fromkeys((*run.project_slugs, *update.project_slugs)))
+        issue_ids = tuple(dict.fromkeys((*run.issue_ids, *update.issue_ids)))
+        if project_slugs == run.project_slugs and issue_ids == run.issue_ids:
             return run
 
         return replace(
             run,
-            project_slug=project_slug,
-            issue_id=issue_id,
+            project_slugs=project_slugs,
+            issue_ids=issue_ids,
             updated_at=now.astimezone(timezone.utc),
             sequence=run.sequence + 1,
         )
@@ -431,8 +431,8 @@ def apply_update(run: OnboardingRun, update: ProgressUpdate, now: datetime) -> O
         run,
         stages=tuple(stages[definition.stage] for definition in STAGE_DEFINITIONS),
         run_status=update.run_status or run.run_status,
-        project_slug=update.project_slug or run.project_slug,
-        issue_id=update.issue_id or run.issue_id,
+        project_slugs=tuple(dict.fromkeys((*run.project_slugs, *update.project_slugs))),
+        issue_ids=tuple(dict.fromkeys((*run.issue_ids, *update.issue_ids))),
     )
     if candidate == run:
         return run

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
@@ -50,6 +50,7 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
                     "stage": "create_project",
                     "status": "completed",
                     "eventNote": "Project already existed.",
+                    "projectSlugs": ["frontend", "backend"],
                 },
             )
 
@@ -58,6 +59,8 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
         assert response.data["stages"][0]["status"] == "bypassed"
         assert response.data["stages"][1]["status"] == "bypassed"
         assert response.data["stages"][2]["status"] == "completed"
+        assert response.data["projectSlugs"] == ["frontend", "backend"]
+        assert response.data["issueIds"] == []
 
     def test_status_rejects_unknown_run(self) -> None:
         path = reverse(

--- a/tests/sentry/onboarding/agentic_progress/test_model.py
+++ b/tests/sentry/onboarding/agentic_progress/test_model.py
@@ -380,22 +380,22 @@ def test_inferred_bypass_clears_stale_event_note() -> None:
 
 
 @pytest.mark.parametrize(
-    ("later_stage", "owning_stage", "project_slug", "issue_id"),
+    ("later_stage", "owning_stage", "project_slugs", "issue_ids"),
     [
-        (Stage.INSTRUMENT_APP, Stage.CREATE_PROJECT, "example-project", None),
+        (Stage.INSTRUMENT_APP, Stage.CREATE_PROJECT, ("example-project",), ()),
         (
             Stage.PREPARE_PRODUCTION,
             Stage.RECEIVE_VERIFICATION_ERROR,
-            None,
-            "12345",
+            (),
+            ("12345",),
         ),
     ],
 )
 def test_bypassed_stage_accepts_late_metadata(
     later_stage: Stage,
     owning_stage: Stage,
-    project_slug: str | None,
-    issue_id: str | None,
+    project_slugs: tuple[str, ...],
+    issue_ids: tuple[str, ...],
 ) -> None:
     now = datetime(2020, 1, 1, tzinfo=timezone.utc)
     advanced = apply_update(
@@ -409,16 +409,16 @@ def test_bypassed_stage_accepts_late_metadata(
         ProgressUpdate(
             stage=owning_stage,
             status=StageStatus.COMPLETED,
-            project_slug=project_slug,
-            issue_id=issue_id,
+            project_slugs=project_slugs,
+            issue_ids=issue_ids,
         ),
         now + timedelta(seconds=1),
     )
 
     assert enriched.stages[list(Stage).index(owning_stage)].status is StageStatus.BYPASSED
     assert enriched.sequence == advanced.sequence + 1
-    assert enriched.project_slug == project_slug
-    assert enriched.issue_id == issue_id
+    assert enriched.project_slugs == project_slugs
+    assert enriched.issue_ids == issue_ids
 
 
 @pytest.mark.parametrize(
@@ -467,13 +467,13 @@ def test_expired_run_rejects_update() -> None:
         )
 
 
-def test_issue_id_is_scoped_to_verification_receipt() -> None:
-    with pytest.raises(ValueError, match="Issue ID"):
+def test_issue_ids_are_scoped_to_verification_receipt() -> None:
+    with pytest.raises(ValueError, match="Issue IDs"):
         validate_update(
             ProgressUpdate(
                 stage=Stage.CREATE_PROJECT,
                 status=StageStatus.COMPLETED,
-                issue_id="123",
+                issue_ids=("123",),
             )
         )
 
@@ -481,18 +481,18 @@ def test_issue_id_is_scoped_to_verification_receipt() -> None:
         ProgressUpdate(
             stage=Stage.RECEIVE_VERIFICATION_ERROR,
             status=StageStatus.COMPLETED,
-            issue_id="123",
+            issue_ids=("123",),
         )
     )
 
 
-def test_project_slug_is_scoped_to_project_creation() -> None:
-    with pytest.raises(ValueError, match="Project slug"):
+def test_project_slugs_are_scoped_to_project_creation() -> None:
+    with pytest.raises(ValueError, match="Project slugs"):
         validate_update(
             ProgressUpdate(
                 stage=Stage.INSTRUMENT_APP,
                 status=StageStatus.COMPLETED,
-                project_slug="project-slug",
+                project_slugs=("project-one", "project-two"),
             )
         )
 
@@ -500,9 +500,34 @@ def test_project_slug_is_scoped_to_project_creation() -> None:
         ProgressUpdate(
             stage=Stage.CREATE_PROJECT,
             status=StageStatus.COMPLETED,
-            project_slug="project-slug",
+            project_slugs=("project-one", "project-two"),
         )
     )
+
+
+def test_metadata_accumulates_unique_values() -> None:
+    now = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    first = apply_update(
+        make_run(now),
+        ProgressUpdate(
+            stage=Stage.CREATE_PROJECT,
+            status=StageStatus.ACTIVE,
+            project_slugs=("frontend", "backend"),
+        ),
+        now,
+    )
+
+    updated = apply_update(
+        first,
+        ProgressUpdate(
+            stage=Stage.CREATE_PROJECT,
+            status=StageStatus.COMPLETED,
+            project_slugs=("backend", "worker"),
+        ),
+        now + timedelta(seconds=1),
+    )
+
+    assert updated.project_slugs == ("frontend", "backend", "worker")
 
 
 @pytest.mark.parametrize("field", ["created_at", "updated_at", "expires_at"])


### PR DESCRIPTION
Agentic onboarding runs now accumulate multiple validated project slugs and issue IDs across status updates and expose both collections as arrays in every API snapshot. This aligns the backend response with the deployed MCP contract and prevents successful progress updates from failing response validation before any references exist.

The Conduit transport remains isolated in #121916, and frontend adoption remains separate because frontend and backend deploy independently.

Fixes https://sentry.sentry.io/issues/MCP-SERVER-G77