### PR TITLE
feat(investigations): add Explore list entrypoint

### DIFF
--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -122,6 +122,17 @@ describe('buildRoutes()', () => {
   });
 
   describe('explore route catch-all', () => {
+    it('matches Investigations before the catch-all', () => {
+      const matchedPaths = getMatchedPaths(
+        buildRoutes(),
+        '/organizations/test-org/explore/investigations/'
+      );
+
+      expect(matchedPaths).toContain('investigations/');
+      expect(matchedPaths).not.toContain(':catchAll/');
+      expect(matchedPaths).not.toContain('*');
+    });
+
     it('catches unknown subpaths under /explore/', () => {
       const spy = jest.spyOn(constants, 'USING_CUSTOMER_DOMAIN', 'get');
 

--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -122,17 +122,6 @@ describe('buildRoutes()', () => {
   });
 
   describe('explore route catch-all', () => {
-    it('matches Investigations before the catch-all', () => {
-      const matchedPaths = getMatchedPaths(
-        buildRoutes(),
-        '/organizations/test-org/explore/investigations/'
-      );
-
-      expect(matchedPaths).toContain('investigations/');
-      expect(matchedPaths).not.toContain(':catchAll/');
-      expect(matchedPaths).not.toContain('*');
-    });
-
     it('catches unknown subpaths under /explore/', () => {
       const spy = jest.spyOn(constants, 'USING_CUSTOMER_DOMAIN', 'get');
 

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2306,6 +2306,10 @@ function buildRoutes(): RouteObject[] {
       path: 'saved-queries/',
       component: make(() => import('sentry/views/explore/savedQueries')),
     },
+    {
+      path: 'investigations/',
+      component: make(() => import('sentry/views/investigations')),
+    },
     // Unknown /explore/ subpaths redirect to the default explore view, rather
     // than falling through to the `/:orgId/:projectId/` legacy redirect and
     // rendering "The project you were looking for was not found".

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -1,3 +1,9 @@
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query';
+
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {InvestigationListItem} from 'sentry/views/investigations/types';
@@ -23,43 +29,94 @@ export function investigationListQueryOptions({
   );
 }
 
-export function createInvestigation(organizationSlug: string) {
-  return fetchMutation<InvestigationListItem>({
-    url: `/organizations/${organizationSlug}/investigations/`,
-    method: 'POST',
-    data: {title: 'Untitled investigation'},
+type FavoriteVariables = {
+  investigation: InvestigationListItem;
+  shouldFavorite: boolean;
+};
+
+type MutationOptions<TData, TVariables> = Omit<
+  UseMutationOptions<TData, Error, TVariables>,
+  'mutationFn'
+>;
+
+function useInvestigationMutation<TData, TVariables>(
+  organizationSlug: string,
+  mutationFn: (variables: TVariables) => Promise<TData>,
+  options?: MutationOptions<TData, TVariables>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...options,
+    mutationFn,
+    onSuccess: async (data, variables, onMutateResult, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
+      });
+      await options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
   });
 }
 
-export function setInvestigationFavorite(
+export function useCreateInvestigationMutation(
   organizationSlug: string,
-  investigationId: string,
-  shouldFavorite: boolean
+  options?: MutationOptions<InvestigationListItem, void>
 ) {
-  return fetchMutation({
-    url: `/organizations/${organizationSlug}/investigations/${investigationId}/favorite/`,
-    method: 'PUT',
-    data: {shouldFavorite},
-  });
+  return useInvestigationMutation(
+    organizationSlug,
+    () =>
+      fetchMutation<InvestigationListItem>({
+        url: `/organizations/${organizationSlug}/investigations/`,
+        method: 'POST',
+        data: {title: 'Untitled investigation'},
+      }),
+    options
+  );
 }
 
-export function duplicateInvestigation(
+export function useSetInvestigationFavoriteMutation(
   organizationSlug: string,
-  investigationId: string
+  options?: MutationOptions<void, FavoriteVariables>
 ) {
-  return fetchMutation<InvestigationListItem>({
-    url: `/organizations/${organizationSlug}/investigations/${investigationId}/duplicate/`,
-    method: 'POST',
-  });
+  return useInvestigationMutation(
+    organizationSlug,
+    ({investigation, shouldFavorite}: FavoriteVariables) =>
+      fetchMutation<void>({
+        url: `/organizations/${organizationSlug}/investigations/${investigation.id}/favorite/`,
+        method: 'PUT',
+        data: {shouldFavorite},
+      }),
+    options
+  );
 }
 
-export function deleteInvestigation(
+export function useDuplicateInvestigationMutation(
   organizationSlug: string,
-  investigation: InvestigationListItem
+  options?: MutationOptions<InvestigationListItem, InvestigationListItem>
 ) {
-  return fetchMutation({
-    url: `/organizations/${organizationSlug}/investigations/${investigation.id}/`,
-    method: 'DELETE',
-    data: {investigationVersion: investigation.version},
-  });
+  return useInvestigationMutation(
+    organizationSlug,
+    investigation =>
+      fetchMutation<InvestigationListItem>({
+        url: `/organizations/${organizationSlug}/investigations/${investigation.id}/duplicate/`,
+        method: 'POST',
+      }),
+    options
+  );
+}
+
+export function useDeleteInvestigationMutation(
+  organizationSlug: string,
+  options?: MutationOptions<void, InvestigationListItem>
+) {
+  return useInvestigationMutation(
+    organizationSlug,
+    investigation =>
+      fetchMutation<void>({
+        url: `/organizations/${organizationSlug}/investigations/${investigation.id}/`,
+        method: 'DELETE',
+        data: {investigationVersion: investigation.version},
+      }),
+    options
+  );
 }

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -1,0 +1,65 @@
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import type {InvestigationListItem} from 'sentry/views/investigations/types';
+
+type ListOptions = {
+  organizationSlug: string;
+  cursor?: string;
+  query?: string;
+};
+
+export function investigationListQueryOptions({
+  organizationSlug,
+  cursor,
+  query,
+}: ListOptions) {
+  return apiOptions.as<InvestigationListItem[]>()(
+    '/organizations/$organizationIdOrSlug/investigations/',
+    {
+      path: {organizationIdOrSlug: organizationSlug},
+      query: {status: 'active', cursor, query},
+      staleTime: 0,
+    }
+  );
+}
+
+export function createInvestigation(organizationSlug: string) {
+  return fetchMutation<InvestigationListItem>({
+    url: `/organizations/${organizationSlug}/investigations/`,
+    method: 'POST',
+    data: {title: 'Untitled investigation'},
+  });
+}
+
+export function setInvestigationFavorite(
+  organizationSlug: string,
+  investigationId: string,
+  shouldFavorite: boolean
+) {
+  return fetchMutation({
+    url: `/organizations/${organizationSlug}/investigations/${investigationId}/favorite/`,
+    method: 'PUT',
+    data: {shouldFavorite},
+  });
+}
+
+export function duplicateInvestigation(
+  organizationSlug: string,
+  investigationId: string
+) {
+  return fetchMutation<InvestigationListItem>({
+    url: `/organizations/${organizationSlug}/investigations/${investigationId}/duplicate/`,
+    method: 'POST',
+  });
+}
+
+export function archiveInvestigation(
+  organizationSlug: string,
+  investigation: InvestigationListItem
+) {
+  return fetchMutation({
+    url: `/organizations/${organizationSlug}/investigations/${investigation.id}/`,
+    method: 'DELETE',
+    data: {investigationVersion: investigation.version},
+  });
+}

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -53,7 +53,7 @@ export function duplicateInvestigation(
   });
 }
 
-export function archiveInvestigation(
+export function deleteInvestigation(
   organizationSlug: string,
   investigation: InvestigationListItem
 ) {

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -99,10 +99,9 @@ describe('Explore Investigations', () => {
     renderView();
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    expect(await screen.findByText('Database latency investigation')).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', {name: 'Database latency investigation'})
-    ).not.toBeInTheDocument();
+      await screen.findByRole('link', {name: 'Database latency investigation'})
+    ).toHaveAttribute('href', '/organizations/org-slug/seer/1/');
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -1,0 +1,386 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import * as indicators from 'sentry/actionCreators/indicator';
+import type {Organization} from 'sentry/types/organization';
+import InvestigationsView from 'sentry/views/investigations';
+import type {InvestigationListItem} from 'sentry/views/investigations/types';
+import {getPaginationPageLink} from 'sentry/views/organizationStats/utils';
+
+const organization = OrganizationFixture({
+  features: ['investigations'],
+  openMembership: true,
+});
+const listUrl = '/organizations/org-slug/investigations/';
+
+function renderView({
+  renderOrganization = organization,
+  query = {},
+}: {query?: Record<string, string>; renderOrganization?: Organization} = {}) {
+  return render(<InvestigationsView />, {
+    organization: renderOrganization,
+    initialRouterConfig: {
+      location: {
+        pathname: '/organizations/org-slug/explore/investigations/',
+        query,
+      },
+    },
+  });
+}
+
+function InvestigationFixture(
+  overrides: Partial<InvestigationListItem> = {}
+): InvestigationListItem {
+  return {
+    id: '1',
+    title: 'Database latency investigation',
+    status: 'active',
+    sourceType: 'manual',
+    createdBy: '1',
+    dateCreated: '2026-08-13T20:00:00Z',
+    dateUpdated: '2026-08-13T21:00:00Z',
+    version: 3,
+    blockCount: 4,
+    isFavorited: false,
+    ...overrides,
+  };
+}
+
+describe('Explore Investigations', () => {
+  beforeEach(() => {
+    jest.spyOn(indicators, 'addSuccessMessage').mockImplementation();
+    jest.spyOn(indicators, 'addErrorMessage').mockImplementation();
+  });
+
+  it('shows the standard feature-disabled state without the feature', () => {
+    renderView({
+      renderOrganization: OrganizationFixture({features: []}),
+    });
+
+    expect(
+      screen.getByText('This feature is not enabled on your Sentry installation.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText('Search Investigations')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the feature-disabled state for a closed-membership organization', () => {
+    const listRequest = MockApiClient.addMockResponse({url: listUrl, body: []});
+
+    renderView({
+      renderOrganization: OrganizationFixture({
+        features: ['investigations'],
+        openMembership: false,
+      }),
+    });
+
+    expect(
+      screen.getByText(
+        'Investigations are only available to organizations with open membership.'
+      )
+    ).toBeInTheDocument();
+    expect(listRequest).not.toHaveBeenCalled();
+  });
+
+  it('renders loading and populated table states without unsupported controls', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+
+    renderView();
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(await screen.findByText('Database latency investigation')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: 'Database latency investigation'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.queryByText('All Projects')).not.toBeInTheDocument();
+    expect(screen.queryByText('All Environments')).not.toBeInTheDocument();
+    expect(screen.queryByText('Status')).not.toBeInTheDocument();
+  });
+
+  it('renders the dashboard-style empty state', async () => {
+    MockApiClient.addMockResponse({url: listUrl, body: []});
+
+    renderView();
+
+    expect(
+      await screen.findByText('Sorry, no investigations match your filters.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the route error state', async () => {
+    MockApiClient.addMockResponse({url: listUrl, statusCode: 500});
+
+    renderView();
+
+    expect(await screen.findByText('Oops! Something went wrong')).toBeInTheDocument();
+  });
+
+  it('syncs search to the URL and clears the cursor', async () => {
+    MockApiClient.addMockResponse({url: listUrl, body: []});
+
+    const {router} = renderView({query: {cursor: '123:0:0'}});
+    await userEvent.type(screen.getByPlaceholderText('Search Investigations'), 'latency');
+    await userEvent.keyboard('{Enter}');
+
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/explore/investigations/'
+    );
+    expect(router.location.query).toEqual({query: 'latency'});
+  });
+
+  it('fetches the active list using URL search and cursor values', async () => {
+    const listRequest = MockApiClient.addMockResponse({url: listUrl, body: []});
+
+    renderView({query: {query: 'latency', cursor: '123:0:0'}});
+    await screen.findByText('Sorry, no investigations match your filters.');
+
+    expect(listRequest).toHaveBeenCalledWith(
+      listUrl,
+      expect.objectContaining({
+        query: {status: 'active', query: 'latency', cursor: '123:0:0'},
+      })
+    );
+  });
+
+  it('uses the collection Link header for pagination', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+      headers: {
+        Link: getPaginationPageLink({numRows: 20, pageSize: 10, offset: 0}),
+      },
+    });
+
+    const {router} = renderView();
+    await userEvent.click(await screen.findByLabelText('Next'));
+
+    expect(router.location.query).toEqual({cursor: '0:10:0'});
+  });
+
+  it('creates an untitled investigation and refreshes the list', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [],
+    });
+    const createRequest = MockApiClient.addMockResponse({
+      url: listUrl,
+      method: 'POST',
+      body: InvestigationFixture({title: 'Untitled investigation'}),
+    });
+
+    const {router} = renderView();
+    await screen.findByText('Sorry, no investigations match your filters.');
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture({title: 'Untitled investigation'})],
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'New Investigation'}));
+
+    await waitFor(() =>
+      expect(createRequest).toHaveBeenCalledWith(
+        listUrl,
+        expect.objectContaining({data: {title: 'Untitled investigation'}})
+      )
+    );
+    expect(await screen.findByText('Untitled investigation')).toBeInTheDocument();
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/explore/investigations/'
+    );
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Investigation created.');
+  });
+
+  it('toggles an investigation favorite and refreshes the list', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    const favoriteRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/favorite/',
+      method: 'PUT',
+    });
+
+    renderView();
+    await screen.findByLabelText('Favorite Database latency investigation');
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture({isFavorited: true})],
+    });
+    await userEvent.click(
+      screen.getByLabelText('Favorite Database latency investigation')
+    );
+
+    await waitFor(() =>
+      expect(favoriteRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/investigations/1/favorite/',
+        expect.objectContaining({data: {shouldFavorite: true}})
+      )
+    );
+    expect(
+      await screen.findByLabelText('Unfavorite Database latency investigation')
+    ).toBeInTheDocument();
+
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture({isFavorited: false})],
+    });
+    await userEvent.click(
+      screen.getByLabelText('Unfavorite Database latency investigation')
+    );
+    await waitFor(() =>
+      expect(favoriteRequest).toHaveBeenLastCalledWith(
+        '/organizations/org-slug/investigations/1/favorite/',
+        expect.objectContaining({data: {shouldFavorite: false}})
+      )
+    );
+    expect(
+      await screen.findByLabelText('Favorite Database latency investigation')
+    ).toBeInTheDocument();
+  });
+
+  it('duplicates from the overflow menu', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    const duplicateRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/duplicate/',
+      method: 'POST',
+      body: InvestigationFixture({id: '2'}),
+    });
+
+    renderView();
+    await screen.findByText('Database latency investigation');
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [
+        InvestigationFixture(),
+        InvestigationFixture({id: '2', title: 'Database latency investigation copy'}),
+      ],
+    });
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Duplicate'}));
+
+    await waitFor(() => expect(duplicateRequest).toHaveBeenCalled());
+    expect(
+      await screen.findByText('Database latency investigation copy')
+    ).toBeInTheDocument();
+  });
+
+  it('archives only after confirmation and sends the current version', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    const archiveRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/',
+      method: 'DELETE',
+    });
+
+    renderView();
+    await screen.findByText('Database latency investigation');
+    MockApiClient.addMockResponse({url: listUrl, body: []});
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Archive'}));
+    expect(archiveRequest).not.toHaveBeenCalled();
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(archiveRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/investigations/1/',
+        expect.objectContaining({data: {investigationVersion: 3}})
+      )
+    );
+    await waitFor(() =>
+      expect(screen.queryByText('Database latency investigation')).not.toBeInTheDocument()
+    );
+  });
+
+  it.each([
+    ['create', 'New Investigation', listUrl, 'POST', 'Unable to create investigation.'],
+    [
+      'favorite',
+      'Favorite Database latency investigation',
+      '/organizations/org-slug/investigations/1/favorite/',
+      'PUT',
+      'Unable to update investigation favorite.',
+    ],
+  ])('reports a %s failure', async (_name, buttonName, url, method, message) => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    MockApiClient.addMockResponse({url, method, statusCode: 500});
+
+    renderView();
+    await userEvent.click(await screen.findByRole('button', {name: buttonName}));
+
+    await waitFor(() => expect(indicators.addErrorMessage).toHaveBeenCalledWith(message));
+  });
+
+  it('reports a duplicate failure', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/duplicate/',
+      method: 'POST',
+      statusCode: 500,
+    });
+
+    renderView();
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Duplicate'}));
+
+    await waitFor(() =>
+      expect(indicators.addErrorMessage).toHaveBeenCalledWith(
+        'Unable to duplicate investigation.'
+      )
+    );
+  });
+
+  it('reports an archive failure', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/',
+      method: 'DELETE',
+      statusCode: 500,
+    });
+
+    renderView();
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Archive'}));
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(indicators.addErrorMessage).toHaveBeenCalledWith(
+        'Unable to archive investigation.'
+      )
+    );
+  });
+});

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -104,9 +104,10 @@ describe('Explore Investigations', () => {
       screen.queryByRole('link', {name: 'Database latency investigation'})
     ).not.toBeInTheDocument();
     expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.queryByText('All Projects')).not.toBeInTheDocument();
     expect(screen.queryByText('All Environments')).not.toBeInTheDocument();
-    expect(screen.queryByText('Status')).not.toBeInTheDocument();
   });
 
   it('renders the dashboard-style empty state', async () => {
@@ -186,7 +187,7 @@ describe('Explore Investigations', () => {
       url: listUrl,
       body: [InvestigationFixture({title: 'Untitled investigation'})],
     });
-    await userEvent.click(screen.getByRole('button', {name: 'New Investigation'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Launch investigation'}));
 
     await waitFor(() =>
       expect(createRequest).toHaveBeenCalledWith(
@@ -280,12 +281,39 @@ describe('Explore Investigations', () => {
     ).toBeInTheDocument();
   });
 
-  it('archives only after confirmation and sends the current version', async () => {
+  it('copies the investigation link from the overflow menu', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {writeText},
+      writable: true,
+    });
     MockApiClient.addMockResponse({
       url: listUrl,
       body: [InvestigationFixture()],
     });
-    const archiveRequest = MockApiClient.addMockResponse({
+
+    renderView();
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Copy link'}));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/organizations/org-slug/seer/1/`
+      )
+    );
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
+      'Investigation link copied.'
+    );
+  });
+
+  it('deletes only after confirmation and sends the current version', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    const deleteRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/investigations/1/',
       method: 'DELETE',
     });
@@ -296,13 +324,13 @@ describe('Explore Investigations', () => {
     await userEvent.click(
       await screen.findByLabelText('More options for Database latency investigation')
     );
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Archive'}));
-    expect(archiveRequest).not.toHaveBeenCalled();
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+    expect(deleteRequest).not.toHaveBeenCalled();
     renderGlobalModal();
     await userEvent.click(await screen.findByTestId('confirm-button'));
 
     await waitFor(() =>
-      expect(archiveRequest).toHaveBeenCalledWith(
+      expect(deleteRequest).toHaveBeenCalledWith(
         '/organizations/org-slug/investigations/1/',
         expect.objectContaining({data: {investigationVersion: 3}})
       )
@@ -313,7 +341,13 @@ describe('Explore Investigations', () => {
   });
 
   it.each([
-    ['create', 'New Investigation', listUrl, 'POST', 'Unable to create investigation.'],
+    [
+      'create',
+      'Launch investigation',
+      listUrl,
+      'POST',
+      'Unable to create investigation.',
+    ],
     [
       'favorite',
       'Favorite Database latency investigation',
@@ -358,7 +392,7 @@ describe('Explore Investigations', () => {
     );
   });
 
-  it('reports an archive failure', async () => {
+  it('reports a delete failure', async () => {
     MockApiClient.addMockResponse({
       url: listUrl,
       body: [InvestigationFixture()],
@@ -373,13 +407,13 @@ describe('Explore Investigations', () => {
     await userEvent.click(
       await screen.findByLabelText('More options for Database latency investigation')
     );
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Archive'}));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
     renderGlobalModal();
     await userEvent.click(await screen.findByTestId('confirm-button'));
 
     await waitFor(() =>
       expect(indicators.addErrorMessage).toHaveBeenCalledWith(
-        'Unable to archive investigation.'
+        'Unable to delete investigation.'
       )
     );
   });

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -1,7 +1,6 @@
-import {useCallback} from 'react';
 import styled from '@emotion/styled';
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import type {Query} from 'history';
+import {useQuery} from '@tanstack/react-query';
+import {parseAsString, useQueryStates} from 'nuqs';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -32,18 +31,15 @@ import {IconAdd, IconStar} from 'sentry/icons';
 import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t} from 'sentry/locale';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
-  createInvestigation,
-  deleteInvestigation,
-  duplicateInvestigation,
   investigationListQueryOptions,
-  setInvestigationFavorite,
+  useCreateInvestigationMutation,
+  useDeleteInvestigationMutation,
+  useDuplicateInvestigationMutation,
+  useSetInvestigationFavoriteMutation,
 } from 'sentry/views/investigations/api';
 import type {InvestigationListItem} from 'sentry/views/investigations/types';
 import {RouteError} from 'sentry/views/routeError';
@@ -99,75 +95,46 @@ function ClosedMembershipPage() {
 
 function InvestigationsPage() {
   const organization = useOrganization();
-  const location = useLocation();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const {copy} = useCopyToClipboard();
-  const query = decodeScalar(location.query.query);
-  const cursor = decodeScalar(location.query.cursor);
+  const [{query, cursor}, setQueryParams] = useQueryStates({
+    query: parseAsString,
+    cursor: parseAsString,
+  });
 
   const listOptions = investigationListQueryOptions({
     organizationSlug: organization.slug,
-    query,
-    cursor,
+    query: query ?? undefined,
+    cursor: cursor ?? undefined,
   });
   const {data, isPending, isError, error} = useQuery({
     ...listOptions,
     select: selectJsonWithHeaders,
   });
 
-  const invalidateList = useCallback(
-    () => queryClient.invalidateQueries({queryKey: listOptions.queryKey}),
-    [listOptions.queryKey, queryClient]
-  );
-
-  const createMutation = useMutation({
-    mutationFn: () => createInvestigation(organization.slug),
-    onSuccess: () => {
-      addSuccessMessage(t('Investigation created.'));
-      invalidateList();
-    },
+  const createMutation = useCreateInvestigationMutation(organization.slug, {
+    onSuccess: () => addSuccessMessage(t('Investigation created.')),
     onError: () => addErrorMessage(t('Unable to create investigation.')),
   });
 
-  const favoriteMutation = useMutation({
-    mutationFn: ({investigation, shouldFavorite}: FavoriteVariables) =>
-      setInvestigationFavorite(organization.slug, investigation.id, shouldFavorite),
-    onSuccess: () => {
-      addSuccessMessage(t('Investigation favorite updated.'));
-      invalidateList();
-    },
+  const favoriteMutation = useSetInvestigationFavoriteMutation(organization.slug, {
+    onSuccess: () => addSuccessMessage(t('Investigation favorite updated.')),
     onError: () => addErrorMessage(t('Unable to update investigation favorite.')),
   });
 
-  const duplicateMutation = useMutation({
-    mutationFn: (investigation: InvestigationListItem) =>
-      duplicateInvestigation(organization.slug, investigation.id),
-    onSuccess: () => {
-      addSuccessMessage(t('Investigation duplicated.'));
-      invalidateList();
-    },
+  const duplicateMutation = useDuplicateInvestigationMutation(organization.slug, {
+    onSuccess: () => addSuccessMessage(t('Investigation duplicated.')),
     onError: () => addErrorMessage(t('Unable to duplicate investigation.')),
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (investigation: InvestigationListItem) =>
-      deleteInvestigation(organization.slug, investigation),
-    onSuccess: () => {
-      addSuccessMessage(t('Investigation deleted.'));
-      invalidateList();
-    },
+  const deleteMutation = useDeleteInvestigationMutation(organization.slug, {
+    onSuccess: () => addSuccessMessage(t('Investigation deleted.')),
     onError: () => addErrorMessage(t('Unable to delete investigation.')),
   });
 
   function handleSearch(nextQuery: string) {
-    navigate({
-      pathname: location.pathname,
-      query: {
-        ...location.query,
-        query: nextQuery || undefined,
-        cursor: undefined,
-      },
+    setQueryParams({
+      query: nextQuery || null,
+      cursor: null,
     });
   }
 
@@ -265,7 +232,7 @@ function InvestigationsPage() {
                 >
                   <SearchBar
                     defaultQuery=""
-                    query={query}
+                    query={query ?? ''}
                     placeholder={t('Search Investigations')}
                     onSearch={handleSearch}
                   />
@@ -310,28 +277,27 @@ function InvestigationsPage() {
                         if (!investigation) {
                           return [];
                         }
-                        const item = investigation;
                         return [
                           <Button
-                            key={item.id}
+                            key={investigation.id}
                             size="zero"
                             variant="transparent"
                             aria-label={
-                              item.isFavorited
-                                ? t('Unfavorite %s', item.title)
-                                : t('Favorite %s', item.title)
+                              investigation.isFavorited
+                                ? t('Unfavorite %s', investigation.title)
+                                : t('Favorite %s', investigation.title)
                             }
                             icon={
                               <IconStar
                                 size="sm"
-                                variant={item.isFavorited ? 'warning' : 'muted'}
-                                isSolid={item.isFavorited}
+                                variant={investigation.isFavorited ? 'warning' : 'muted'}
+                                isSolid={investigation.isFavorited}
                               />
                             }
                             onClick={() =>
                               favoriteMutation.mutate({
-                                investigation: item,
-                                shouldFavorite: !item.isFavorited,
+                                investigation,
+                                shouldFavorite: !investigation.isFavorited,
                               })
                             }
                           />,
@@ -353,16 +319,12 @@ function InvestigationsPage() {
                 <Container marginBottom="2xl">
                   <Pagination
                     pageLinks={data?.headers.Link}
-                    onCursor={(nextCursor, path, nextQuery, direction) => {
+                    onCursor={(nextCursor, _path, _nextQuery, direction) => {
                       const offset = Number(nextCursor?.split?.(':')?.[1] ?? 0);
-                      const paginationQuery: Query & {cursor?: string} = {
-                        ...nextQuery,
-                        cursor: nextCursor,
-                      };
-                      if (direction === -1 && offset <= 0) {
-                        delete paginationQuery.cursor;
-                      }
-                      navigate({pathname: path, query: paginationQuery});
+                      setQueryParams({
+                        cursor:
+                          direction === -1 && offset <= 0 ? null : (nextCursor ?? null),
+                      });
                     }}
                   />
                 </Container>
@@ -374,11 +336,6 @@ function InvestigationsPage() {
     </SentryDocumentTitle>
   );
 }
-
-type FavoriteVariables = {
-  investigation: InvestigationListItem;
-  shouldFavorite: boolean;
-};
 
 export default function InvestigationsView() {
   const organization = useOrganization();

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -31,12 +31,14 @@ import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t} from 'sentry/locale';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
-  archiveInvestigation,
   createInvestigation,
+  deleteInvestigation,
   duplicateInvestigation,
   investigationListQueryOptions,
   setInvestigationFavorite,
@@ -48,14 +50,16 @@ enum ColumnKey {
   NAME = 'title',
   BLOCKS = 'blockCount',
   CREATED = 'dateCreated',
+  STATUS = 'status',
   ACTIONS = 'actions',
 }
 
 const COLUMNS: Array<GridColumnOrder<ColumnKey>> = [
   {key: ColumnKey.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
-  {key: ColumnKey.BLOCKS, name: t('Blocks'), width: 100},
-  {key: ColumnKey.CREATED, name: t('Created'), width: 160},
-  {key: ColumnKey.ACTIONS, name: '', width: 56},
+  {key: ColumnKey.BLOCKS, name: t('Blocks'), width: 96},
+  {key: ColumnKey.CREATED, name: t('Created'), width: 140},
+  {key: ColumnKey.STATUS, name: t('Status'), width: 160},
+  {key: ColumnKey.ACTIONS, name: '', width: 40},
 ];
 
 function FeatureDisabledPage() {
@@ -86,6 +90,7 @@ function InvestigationsPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const {copy} = useCopyToClipboard();
   const query = decodeScalar(location.query.query);
   const cursor = decodeScalar(location.query.cursor);
 
@@ -133,14 +138,14 @@ function InvestigationsPage() {
     onError: () => addErrorMessage(t('Unable to duplicate investigation.')),
   });
 
-  const archiveMutation = useMutation({
+  const deleteMutation = useMutation({
     mutationFn: (investigation: InvestigationListItem) =>
-      archiveInvestigation(organization.slug, investigation),
+      deleteInvestigation(organization.slug, investigation),
     onSuccess: () => {
-      addSuccessMessage(t('Investigation archived.'));
+      addSuccessMessage(t('Investigation deleted.'));
       invalidateList();
     },
-    onError: () => addErrorMessage(t('Unable to archive investigation.')),
+    onError: () => addErrorMessage(t('Unable to delete investigation.')),
   });
 
   function handleSearch(nextQuery: string) {
@@ -159,27 +164,38 @@ function InvestigationsPage() {
       <DropdownMenu
         items={[
           {
+            key: 'copy-link',
+            label: t('Copy link'),
+            onAction: () =>
+              copy(
+                `${window.location.origin}${normalizeUrl(
+                  `/organizations/${organization.slug}/seer/${investigation.id}/`
+                )}`,
+                {successMessage: t('Investigation link copied.')}
+              ),
+          },
+          {
             key: 'duplicate',
             label: t('Duplicate'),
             onAction: () => duplicateMutation.mutate(investigation),
           },
           {
-            key: 'archive',
-            label: t('Archive'),
+            key: 'delete',
+            label: t('Delete'),
             priority: 'danger',
             onAction: () =>
               openConfirmModal({
-                message: t('Are you sure you want to archive this investigation?'),
+                message: t('Are you sure you want to delete this investigation?'),
                 priority: 'danger',
-                confirmText: t('Archive'),
-                onConfirm: () => archiveMutation.mutate(investigation),
+                confirmText: t('Delete'),
+                onConfirm: () => deleteMutation.mutate(investigation),
               }),
           },
         ]}
         trigger={triggerProps => (
           <Button
             {...triggerProps}
-            size="sm"
+            size="zero"
             variant="transparent"
             icon={<IconEllipsis />}
             aria-label={t('More options for %s', investigation.title)}
@@ -201,6 +217,8 @@ function InvestigationsPage() {
         return investigation.blockCount;
       case ColumnKey.CREATED:
         return <TimeSince date={investigation.dateCreated} />;
+      case ColumnKey.STATUS:
+        return investigation.status === 'active' ? t('Active') : null;
       case ColumnKey.ACTIONS:
         return renderActions(investigation);
       default:
@@ -249,7 +267,7 @@ function InvestigationsPage() {
                     onClick={() => createMutation.mutate()}
                     busy={createMutation.isPending}
                   >
-                    {t('New Investigation')}
+                    {t('Launch investigation')}
                   </Button>
                 </Grid>
                 <GridEditable

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -1,0 +1,356 @@
+import {useCallback} from 'react';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import type {Query} from 'history';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Pagination} from '@sentry/scraps/pagination';
+import {Text} from '@sentry/scraps/text';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import Feature from 'sentry/components/acl/feature';
+import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {SearchBar} from 'sentry/components/searchBar';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {
+  COL_WIDTH_UNDEFINED,
+  GridEditable,
+  type GridColumnOrder,
+} from 'sentry/components/tables/gridEditable';
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconAdd, IconStar} from 'sentry/icons';
+import {IconEllipsis} from 'sentry/icons/iconEllipsis';
+import {t} from 'sentry/locale';
+import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  archiveInvestigation,
+  createInvestigation,
+  duplicateInvestigation,
+  investigationListQueryOptions,
+  setInvestigationFavorite,
+} from 'sentry/views/investigations/api';
+import type {InvestigationListItem} from 'sentry/views/investigations/types';
+import {RouteError} from 'sentry/views/routeError';
+
+enum ColumnKey {
+  NAME = 'title',
+  BLOCKS = 'blockCount',
+  CREATED = 'dateCreated',
+  ACTIONS = 'actions',
+}
+
+const COLUMNS: Array<GridColumnOrder<ColumnKey>> = [
+  {key: ColumnKey.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
+  {key: ColumnKey.BLOCKS, name: t('Blocks'), width: 100},
+  {key: ColumnKey.CREATED, name: t('Created'), width: 160},
+  {key: ColumnKey.ACTIONS, name: '', width: 56},
+];
+
+function FeatureDisabledPage() {
+  return (
+    <Stack flex={1} padding="2xl 3xl">
+      <FeatureDisabled
+        features="organizations:investigations"
+        featureName={t('Investigations')}
+      />
+    </Stack>
+  );
+}
+
+function ClosedMembershipPage() {
+  return (
+    <Stack flex={1} padding="2xl 3xl">
+      <Alert.Container>
+        <Alert variant="warning">
+          {t('Investigations are only available to organizations with open membership.')}
+        </Alert>
+      </Alert.Container>
+    </Stack>
+  );
+}
+
+function InvestigationsPage() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const query = decodeScalar(location.query.query);
+  const cursor = decodeScalar(location.query.cursor);
+
+  const listOptions = investigationListQueryOptions({
+    organizationSlug: organization.slug,
+    query,
+    cursor,
+  });
+  const {data, isPending, isError, error} = useQuery({
+    ...listOptions,
+    select: selectJsonWithHeaders,
+  });
+
+  const invalidateList = useCallback(
+    () => queryClient.invalidateQueries({queryKey: listOptions.queryKey}),
+    [listOptions.queryKey, queryClient]
+  );
+
+  const createMutation = useMutation({
+    mutationFn: () => createInvestigation(organization.slug),
+    onSuccess: () => {
+      addSuccessMessage(t('Investigation created.'));
+      invalidateList();
+    },
+    onError: () => addErrorMessage(t('Unable to create investigation.')),
+  });
+
+  const favoriteMutation = useMutation({
+    mutationFn: ({investigation, shouldFavorite}: FavoriteVariables) =>
+      setInvestigationFavorite(organization.slug, investigation.id, shouldFavorite),
+    onSuccess: () => {
+      addSuccessMessage(t('Investigation favorite updated.'));
+      invalidateList();
+    },
+    onError: () => addErrorMessage(t('Unable to update investigation favorite.')),
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (investigation: InvestigationListItem) =>
+      duplicateInvestigation(organization.slug, investigation.id),
+    onSuccess: () => {
+      addSuccessMessage(t('Investigation duplicated.'));
+      invalidateList();
+    },
+    onError: () => addErrorMessage(t('Unable to duplicate investigation.')),
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: (investigation: InvestigationListItem) =>
+      archiveInvestigation(organization.slug, investigation),
+    onSuccess: () => {
+      addSuccessMessage(t('Investigation archived.'));
+      invalidateList();
+    },
+    onError: () => addErrorMessage(t('Unable to archive investigation.')),
+  });
+
+  function handleSearch(nextQuery: string) {
+    navigate({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        query: nextQuery || undefined,
+        cursor: undefined,
+      },
+    });
+  }
+
+  function renderActions(investigation: InvestigationListItem) {
+    return (
+      <DropdownMenu
+        items={[
+          {
+            key: 'duplicate',
+            label: t('Duplicate'),
+            onAction: () => duplicateMutation.mutate(investigation),
+          },
+          {
+            key: 'archive',
+            label: t('Archive'),
+            priority: 'danger',
+            onAction: () =>
+              openConfirmModal({
+                message: t('Are you sure you want to archive this investigation?'),
+                priority: 'danger',
+                confirmText: t('Archive'),
+                onConfirm: () => archiveMutation.mutate(investigation),
+              }),
+          },
+        ]}
+        trigger={triggerProps => (
+          <Button
+            {...triggerProps}
+            size="sm"
+            variant="transparent"
+            icon={<IconEllipsis />}
+            aria-label={t('More options for %s', investigation.title)}
+          />
+        )}
+        position="bottom-end"
+      />
+    );
+  }
+
+  const renderBodyCell = (
+    column: GridColumnOrder<ColumnKey>,
+    investigation: InvestigationListItem
+  ) => {
+    switch (column.key) {
+      case ColumnKey.NAME:
+        return <Text ellipsis>{investigation.title}</Text>;
+      case ColumnKey.BLOCKS:
+        return investigation.blockCount;
+      case ColumnKey.CREATED:
+        return <TimeSince date={investigation.dateCreated} />;
+      case ColumnKey.ACTIONS:
+        return renderActions(investigation);
+      default:
+        return null;
+    }
+  };
+
+  const investigations = data?.json ?? [];
+
+  return (
+    <SentryDocumentTitle title={t('Investigations')} orgSlug={organization.slug}>
+      <ErrorBoundary>
+        {isError ? (
+          <Stack flex={1} padding="2xl 3xl">
+            <RouteError error={error} />
+          </Stack>
+        ) : (
+          <Stack flex={1}>
+            <Layout.Title>{t('Investigations')}</Layout.Title>
+            <Layout.Body>
+              <Layout.Main width="full">
+                <Grid
+                  columns={{zero: 'auto', xl: 'auto max-content max-content'}}
+                  gap="md"
+                  marginBottom="xl"
+                >
+                  <SearchBar
+                    defaultQuery=""
+                    query={query}
+                    placeholder={t('Search Investigations')}
+                    onSearch={handleSearch}
+                  />
+                  <CompactSelect
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button {...triggerProps} prefix={t('Sort By')} />
+                    )}
+                    value="recentActivity"
+                    options={[{label: t('Recent Activity'), value: 'recentActivity'}]}
+                    onChange={() => null}
+                    position="bottom-end"
+                    data-test-id="investigations-sort"
+                  />
+                  <Button
+                    variant="primary"
+                    icon={<IconAdd />}
+                    onClick={() => createMutation.mutate()}
+                    busy={createMutation.isPending}
+                  >
+                    {t('New Investigation')}
+                  </Button>
+                </Grid>
+                <GridEditable
+                  data={investigations}
+                  columnOrder={COLUMNS}
+                  columnSortBy={[]}
+                  grid={{
+                    renderHeadCell: column => column.name,
+                    renderBodyCell,
+                    renderPrependColumns: (isHeader, investigation) => {
+                      if (isHeader) {
+                        return [
+                          <IconStar
+                            key="favorite-header"
+                            variant="warning"
+                            isSolid
+                            aria-label={t('Favorite')}
+                          />,
+                        ];
+                      }
+                      if (!investigation) {
+                        return [];
+                      }
+                      const item = investigation;
+                      return [
+                        <Button
+                          key={item.id}
+                          size="zero"
+                          variant="transparent"
+                          aria-label={
+                            item.isFavorited
+                              ? t('Unfavorite %s', item.title)
+                              : t('Favorite %s', item.title)
+                          }
+                          icon={
+                            <IconStar
+                              size="sm"
+                              variant={item.isFavorited ? 'warning' : 'muted'}
+                              isSolid={item.isFavorited}
+                            />
+                          }
+                          onClick={() =>
+                            favoriteMutation.mutate({
+                              investigation: item,
+                              shouldFavorite: !item.isFavorited,
+                            })
+                          }
+                        />,
+                      ];
+                    },
+                    prependColumnWidths: ['max-content'],
+                  }}
+                  isLoading={isPending}
+                  emptyMessage={
+                    <EmptyStateWarning>
+                      <Text as="p">
+                        {t('Sorry, no investigations match your filters.')}
+                      </Text>
+                    </EmptyStateWarning>
+                  }
+                />
+                <Container marginBottom="2xl">
+                  <Pagination
+                    pageLinks={data?.headers.Link}
+                    onCursor={(nextCursor, path, nextQuery, direction) => {
+                      const offset = Number(nextCursor?.split?.(':')?.[1] ?? 0);
+                      const paginationQuery: Query & {cursor?: string} = {
+                        ...nextQuery,
+                        cursor: nextCursor,
+                      };
+                      if (direction === -1 && offset <= 0) {
+                        delete paginationQuery.cursor;
+                      }
+                      navigate({pathname: path, query: paginationQuery});
+                    }}
+                  />
+                </Container>
+              </Layout.Main>
+            </Layout.Body>
+          </Stack>
+        )}
+      </ErrorBoundary>
+    </SentryDocumentTitle>
+  );
+}
+
+type FavoriteVariables = {
+  investigation: InvestigationListItem;
+  shouldFavorite: boolean;
+};
+
+export default function InvestigationsView() {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      organization={organization}
+      features="organizations:investigations"
+      renderDisabled={() => <FeatureDisabledPage />}
+    >
+      {organization.openMembership ? <InvestigationsPage /> : <ClosedMembershipPage />}
+    </Feature>
+  );
+}

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -1,4 +1,5 @@
 import {useCallback} from 'react';
+import styled from '@emotion/styled';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import type {Query} from 'history';
 
@@ -6,6 +7,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
@@ -56,11 +58,21 @@ enum ColumnKey {
 
 const COLUMNS: Array<GridColumnOrder<ColumnKey>> = [
   {key: ColumnKey.NAME, name: t('Name'), width: COL_WIDTH_UNDEFINED},
-  {key: ColumnKey.BLOCKS, name: t('Blocks'), width: 96},
-  {key: ColumnKey.CREATED, name: t('Created'), width: 140},
+  {key: ColumnKey.BLOCKS, name: t('Blocks'), width: 116},
+  {key: ColumnKey.CREATED, name: t('Created'), width: 160},
   {key: ColumnKey.STATUS, name: t('Status'), width: 160},
   {key: ColumnKey.ACTIONS, name: '', width: 40},
 ];
+
+const TableWrapper = styled('div')`
+  table {
+    grid-template-columns: max-content minmax(240px, 1fr) 116px 160px 160px max-content !important;
+  }
+`;
+
+function getInvestigationPath(organizationSlug: string, investigationId: string) {
+  return normalizeUrl(`/organizations/${organizationSlug}/seer/${investigationId}/`);
+}
 
 function FeatureDisabledPage() {
   return (
@@ -168,8 +180,9 @@ function InvestigationsPage() {
             label: t('Copy link'),
             onAction: () =>
               copy(
-                `${window.location.origin}${normalizeUrl(
-                  `/organizations/${organization.slug}/seer/${investigation.id}/`
+                `${window.location.origin}${getInvestigationPath(
+                  organization.slug,
+                  investigation.id
                 )}`,
                 {successMessage: t('Investigation link copied.')}
               ),
@@ -192,16 +205,15 @@ function InvestigationsPage() {
               }),
           },
         ]}
-        trigger={triggerProps => (
-          <Button
-            {...triggerProps}
-            size="zero"
-            variant="transparent"
-            icon={<IconEllipsis />}
-            aria-label={t('More options for %s', investigation.title)}
-          />
-        )}
+        triggerProps={{
+          size: 'sm',
+          showChevron: false,
+          variant: 'transparent',
+          icon: <IconEllipsis />,
+          'aria-label': t('More options for %s', investigation.title),
+        }}
         position="bottom-end"
+        usePortal
       />
     );
   }
@@ -212,7 +224,13 @@ function InvestigationsPage() {
   ) => {
     switch (column.key) {
       case ColumnKey.NAME:
-        return <Text ellipsis>{investigation.title}</Text>;
+        return (
+          <Text ellipsis>
+            <Link to={getInvestigationPath(organization.slug, investigation.id)}>
+              {investigation.title}
+            </Link>
+          </Text>
+        );
       case ColumnKey.BLOCKS:
         return investigation.blockCount;
       case ColumnKey.CREATED:
@@ -270,65 +288,68 @@ function InvestigationsPage() {
                     {t('Launch investigation')}
                   </Button>
                 </Grid>
-                <GridEditable
-                  data={investigations}
-                  columnOrder={COLUMNS}
-                  columnSortBy={[]}
-                  grid={{
-                    renderHeadCell: column => column.name,
-                    renderBodyCell,
-                    renderPrependColumns: (isHeader, investigation) => {
-                      if (isHeader) {
+                <TableWrapper>
+                  <GridEditable
+                    data={investigations}
+                    columnOrder={COLUMNS}
+                    columnSortBy={[]}
+                    grid={{
+                      renderHeadCell: column => column.name,
+                      renderBodyCell,
+                      renderPrependColumns: (isHeader, investigation) => {
+                        if (isHeader) {
+                          return [
+                            <IconStar
+                              key="favorite-header"
+                              variant="warning"
+                              isSolid
+                              aria-label={t('Favorite')}
+                            />,
+                          ];
+                        }
+                        if (!investigation) {
+                          return [];
+                        }
+                        const item = investigation;
                         return [
-                          <IconStar
-                            key="favorite-header"
-                            variant="warning"
-                            isSolid
-                            aria-label={t('Favorite')}
+                          <Button
+                            key={item.id}
+                            size="zero"
+                            variant="transparent"
+                            aria-label={
+                              item.isFavorited
+                                ? t('Unfavorite %s', item.title)
+                                : t('Favorite %s', item.title)
+                            }
+                            icon={
+                              <IconStar
+                                size="sm"
+                                variant={item.isFavorited ? 'warning' : 'muted'}
+                                isSolid={item.isFavorited}
+                              />
+                            }
+                            onClick={() =>
+                              favoriteMutation.mutate({
+                                investigation: item,
+                                shouldFavorite: !item.isFavorited,
+                              })
+                            }
                           />,
                         ];
-                      }
-                      if (!investigation) {
-                        return [];
-                      }
-                      const item = investigation;
-                      return [
-                        <Button
-                          key={item.id}
-                          size="zero"
-                          variant="transparent"
-                          aria-label={
-                            item.isFavorited
-                              ? t('Unfavorite %s', item.title)
-                              : t('Favorite %s', item.title)
-                          }
-                          icon={
-                            <IconStar
-                              size="sm"
-                              variant={item.isFavorited ? 'warning' : 'muted'}
-                              isSolid={item.isFavorited}
-                            />
-                          }
-                          onClick={() =>
-                            favoriteMutation.mutate({
-                              investigation: item,
-                              shouldFavorite: !item.isFavorited,
-                            })
-                          }
-                        />,
-                      ];
-                    },
-                    prependColumnWidths: ['max-content'],
-                  }}
-                  isLoading={isPending}
-                  emptyMessage={
-                    <EmptyStateWarning>
-                      <Text as="p">
-                        {t('Sorry, no investigations match your filters.')}
-                      </Text>
-                    </EmptyStateWarning>
-                  }
-                />
+                      },
+                      prependColumnWidths: ['max-content'],
+                    }}
+                    isLoading={isPending}
+                    resizable={false}
+                    emptyMessage={
+                      <EmptyStateWarning>
+                        <Text as="p">
+                          {t('Sorry, no investigations match your filters.')}
+                        </Text>
+                      </EmptyStateWarning>
+                    }
+                  />
+                </TableWrapper>
                 <Container marginBottom="2xl">
                   <Pagination
                     pageLinks={data?.headers.Link}

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -1,0 +1,12 @@
+export type InvestigationListItem = {
+  blockCount: number;
+  createdBy: string | null;
+  dateCreated: string;
+  dateUpdated: string;
+  id: string;
+  isFavorited: boolean;
+  sourceType: string;
+  status: string;
+  title: string;
+  version: number;
+};

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -56,6 +56,67 @@ describe('ExploreSecondaryNavigation', () => {
     );
 
     expect(screen.getByText('Traces')).toBeInTheDocument();
+    expect(screen.queryByText('Investigations')).not.toBeInTheDocument();
+  });
+
+  it('shows Investigations when the feature is enabled', () => {
+    const {organization: investigationsOrganization} = initializeOrg({
+      organization: {
+        features: ['performance-view', 'visibility-explore-view', 'investigations'],
+        openMembership: true,
+      },
+    });
+
+    render(
+      <PrimaryNavigationContextProvider>
+        <SecondaryNavigationContextProvider>
+          <Navigation />
+          <div id="main" />
+        </SecondaryNavigationContextProvider>
+      </PrimaryNavigationContextProvider>,
+      {
+        organization: investigationsOrganization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/investigations/',
+          },
+        },
+      }
+    );
+
+    expect(screen.getByRole('link', {name: /Investigations/})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/investigations/'
+    );
+    expect(screen.getByLabelText('beta')).toBeInTheDocument();
+  });
+
+  it('hides Investigations for a closed-membership organization', () => {
+    const {organization: closedMembershipOrganization} = initializeOrg({
+      organization: {
+        features: ['performance-view', 'visibility-explore-view', 'investigations'],
+        openMembership: false,
+      },
+    });
+
+    render(
+      <PrimaryNavigationContextProvider>
+        <SecondaryNavigationContextProvider>
+          <Navigation />
+          <div id="main" />
+        </SecondaryNavigationContextProvider>
+      </PrimaryNavigationContextProvider>,
+      {
+        organization: closedMembershipOrganization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+          },
+        },
+      }
+    );
+
+    expect(screen.queryByText('Investigations')).not.toBeInTheDocument();
   });
 
   it('marks Releases as active on preprod pages', () => {

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -152,6 +152,20 @@ export function ExploreSecondaryNavigation() {
                 </SecondaryNavigation.Link>
               </SecondaryNavigation.ListItem>
             </Feature>
+            {organization.openMembership && (
+              <Feature features="organizations:investigations">
+                <SecondaryNavigation.ListItem>
+                  <SecondaryNavigation.Link
+                    to={`${baseUrl}/investigations/`}
+                    activeTo={`${baseUrl}/investigations/`}
+                    analyticsItemName="explore_investigations"
+                    trailingItems={<FeatureBadge type="beta" />}
+                  >
+                    {t('Investigations')}
+                  </SecondaryNavigation.Link>
+                </SecondaryNavigation.ListItem>
+              </Feature>
+            )}
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
         <Feature features={['visibility-explore-view', 'performance-view']}>


### PR DESCRIPTION
## Summary

Adds the first Investigations frontend entrypoints behind the `organizations:investigations` feature flag and the backend-compatible open-membership requirement.

- adds Investigations to Explore navigation with the lab beta badge
- adds `/organizations/:orgId/explore/investigations/`
- builds a Dashboard-style searchable, cursor-paginated list with TanStack Query
- supports create, favorite, duplicate, and confirmed archive actions
- uses the landed Investigations endpoints and does not require Seer
- includes loading, error, filtered-empty, feature-disabled, and closed-membership states

Investigation titles intentionally remain non-navigable until the detail view lands. Unsupported project, environment, time, and execution-status controls are intentionally omitted.

## Validation

- `pnpm run lint:format -- <touched files>`
- `pnpm run lint:js <touched files>`
- `pnpm run typecheck`
- `pnpm test-ci static/app/views/investigations/index.spec.tsx static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx static/app/router/routes.spec.tsx` — 25 tests passed
- `git diff --check`
- pre-push `knip`