### PR TITLE
ref(seer): Remove dead use_agent_sandbox option

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -349,8 +349,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-disable-coding-setting", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GitLab as a supported SCM provider for Seer
     manager.add("organizations:seer-gitlab-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Run Seer agents inside the sandbox execution environment
-    manager.add("organizations:seer-use-agent-sandbox", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Append a "text" summary to SentryApp webhooks sent to Claude Code routine fire URLs
     manager.add("organizations:sentry-apps-claude-routine-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable prefill templates on the internal integration creation page

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -634,13 +634,6 @@ class SeerAgentClient:
             opts["enable_frontend_code_search"] = True
 
         if features.has(
-            "organizations:seer-use-agent-sandbox",
-            self.organization,
-            actor=self.user,
-        ):
-            opts["use_agent_sandbox"] = True
-
-        if features.has(
             "organizations:seer-explorer-thinking-summary",
             self.organization,
             actor=self.user,
@@ -775,13 +768,6 @@ class SeerAgentClient:
             actor=self.user,
         ):
             agent_run_options["enable_frontend_code_search"] = True
-
-        if features.has(
-            "organizations:seer-use-agent-sandbox",
-            self.organization,
-            actor=self.user,
-        ):
-            agent_run_options["use_agent_sandbox"] = True
 
         if features.has(
             "organizations:seer-explorer-thinking-summary",


### PR DESCRIPTION
Sandbox state is now controlled by a Seer side flag.