### PR TITLE
feat(audit): Mark delegated agent actions

### DIFF
--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -1,10 +1,12 @@
 import re
+from copy import copy
 
 from django.db.models import prefetch_related_objects
 from sentry_sdk import capture_exception
 
 from sentry import audit_log
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.audit_log.metadata import AGENT_DELEGATION_DATA_KEY, SEER_AGENT_DELEGATION
 from sentry.models.auditlogentry import AuditLogEntry
 
 
@@ -64,12 +66,22 @@ class AuditLogEntrySerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
         audit_log_event = audit_log.get(obj.event)
+        agent_delegation = obj.data.get(AGENT_DELEGATION_DATA_KEY)
+        render_obj = obj
+        if agent_delegation is not None:
+            render_obj = copy(obj)
+            render_obj.data = {
+                key: value for key, value in obj.data.items() if key != AGENT_DELEGATION_DATA_KEY
+            }
 
         try:
-            note = audit_log_event.render(obj)
+            note = audit_log_event.render(render_obj)
         except KeyError as exc:
             note = ""
             capture_exception(exc)
+
+        if agent_delegation == SEER_AGENT_DELEGATION:
+            note = f"{note} (via Seer agent)" if note else "Performed via Seer agent"
 
         return {
             "id": str(obj.id),
@@ -80,5 +92,6 @@ class AuditLogEntrySerializer(Serializer):
             "targetObject": obj.target_object,
             "targetUser": attrs["targetUser"],
             "data": fix(obj.data),
+            "agentDelegation": agent_delegation,
             "dateCreated": obj.datetime,
         }

--- a/src/sentry/audit_log/metadata.py
+++ b/src/sentry/audit_log/metadata.py
@@ -1,0 +1,2 @@
+AGENT_DELEGATION_DATA_KEY = "agent_delegation"
+SEER_AGENT_DELEGATION = "seer"

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -6,6 +6,7 @@ from typing import Any
 from django.http.request import HttpRequest
 
 from sentry import audit_log
+from sentry.audit_log.metadata import AGENT_DELEGATION_DATA_KEY, SEER_AGENT_DELEGATION
 from sentry.audit_log.services.log import log_service
 from sentry.models.apikey import ApiKey
 from sentry.models.auditlogentry import AuditLogEntry
@@ -24,6 +25,7 @@ from sentry.silo.base import cell_silo_function
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
+from sentry.viewer_context import ActorType, get_viewer_context
 
 
 def create_audit_entry(
@@ -34,11 +36,11 @@ def create_audit_entry(
     data: dict[str, Any],
     **kwargs: Any,
 ) -> AuditLogEntry:
+    auth = getattr(request, "auth", None)
     user = kwargs.pop("actor", request.user if request.user.is_authenticated else None)
     if user is None:
         # An agent token acts on behalf of a member but authenticates as a non-user actor,
         # so attribute the audit entry to the delegating user.
-        auth = getattr(request, "auth", None)
         if auth is not None and is_agent_auth(auth) and auth.user_id is not None:
             user = user_service.get_user(user_id=auth.user_id)
     api_key = get_api_key_for_audit_log(request)
@@ -50,7 +52,14 @@ def create_audit_entry(
         kwargs["actor_label"] = org_auth_token.name
 
     return create_audit_entry_from_user(
-        user, api_key, request.META["REMOTE_ADDR"], transaction_id, logger, data=data, **kwargs
+        user,
+        api_key,
+        request.META["REMOTE_ADDR"],
+        transaction_id,
+        logger,
+        data=data,
+        agent_delegation=SEER_AGENT_DELEGATION if is_agent_auth(auth) else None,
+        **kwargs,
     )
 
 
@@ -84,10 +93,22 @@ def create_audit_entry_from_user(
     organization_id: int | None = None,
     *,
     data: dict[str, Any],
+    agent_delegation: str | None = None,
     **kwargs: Any,
 ) -> AuditLogEntry:
     organization_id = _org_id(organization, organization_id)
     assert user is not None or api_key is not None or ip_address is not None
+
+    if agent_delegation is None:
+        viewer_context = get_viewer_context()
+        if viewer_context is not None and viewer_context.actor_type == ActorType.AGENT:
+            agent_delegation = SEER_AGENT_DELEGATION
+
+    data = dict(data)
+    if agent_delegation is None:
+        data.pop(AGENT_DELEGATION_DATA_KEY, None)
+    else:
+        data[AGENT_DELEGATION_DATA_KEY] = agent_delegation
 
     entry = AuditLogEntry(
         actor_id=user.id if user else None,

--- a/tests/sentry/api/serializers/test_auditlogentry.py
+++ b/tests/sentry/api/serializers/test_auditlogentry.py
@@ -2,6 +2,7 @@ from django.utils import timezone
 
 from sentry import audit_log
 from sentry.api.serializers import AuditLogEntrySerializer, serialize
+from sentry.audit_log.metadata import AGENT_DELEGATION_DATA_KEY, SEER_AGENT_DELEGATION
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -26,6 +27,28 @@ class AuditLogEntrySerializerTest(TestCase):
         assert result["actor"]["username"] == self.user.username
         assert result["dateCreated"] == datetime
         assert result["data"] == {"slug": "New Team"}
+        assert result["agentDelegation"] is None
+
+    def test_agent_delegation_is_visible_without_polluting_note_data(self) -> None:
+        log = AuditLogEntry.objects.create(
+            organization_id=self.organization.id,
+            event=audit_log.get_event_id("ORG_EDIT"),
+            actor=self.user,
+            datetime=timezone.now(),
+            data={
+                "name": "Example Organization",
+                AGENT_DELEGATION_DATA_KEY: SEER_AGENT_DELEGATION,
+            },
+        )
+
+        result = serialize(log, serializer=AuditLogEntrySerializer())
+
+        assert result["actor"]["username"] == self.user.username
+        assert result["agentDelegation"] == SEER_AGENT_DELEGATION
+        assert result["note"] == (
+            "edited the organization setting: name Example Organization (via Seer agent)"
+        )
+        assert result["data"] == {"name": "Example Organization"}
 
     def test_data_field_filtering(self) -> None:
         """Test that only allowed fields are present in the data field"""

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -2,6 +2,8 @@ from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 
 from sentry import audit_log
+from sentry.audit_log.metadata import AGENT_DELEGATION_DATA_KEY, SEER_AGENT_DELEGATION
+from sentry.auth.services.auth import AuthenticatedToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.deletedorganization import DeletedOrganization
 from sentry.models.deletedproject import DeletedProject
@@ -16,6 +18,7 @@ from sentry.utils.audit import (
     create_audit_entry_from_user,
     create_system_audit_entry,
 )
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 username = "hello" * 20
 
@@ -57,8 +60,6 @@ class CreateAuditEntryTest(TestCase):
         self.assert_no_delete_log_created()
 
     def test_audit_entry_agent_token_attributes_to_delegating_user(self) -> None:
-        from sentry.auth.services.auth import AuthenticatedToken
-
         req = fake_http_request(AnonymousUser())
         # An agent token authenticates as a non-user actor; the audit entry should still be
         # attributed to the member it acts on behalf of.
@@ -66,10 +67,44 @@ class CreateAuditEntryTest(TestCase):
             kind="agent_token", user_id=self.user.id, organization_id=self.org.id
         )
 
-        entry = create_audit_entry(req, organization_id=self.org.id, data={"thing": "to True"})
+        with outbox_runner():
+            entry = create_audit_entry(
+                req,
+                organization_id=self.org.id,
+                target_object=self.org.id,
+                event=audit_log.get_event_id("ORG_EDIT"),
+                data={"name": self.org.name},
+            )
+
         assert entry.actor_id == self.user.id
+        assert entry.data[AGENT_DELEGATION_DATA_KEY] == SEER_AGENT_DELEGATION
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            persisted_entry = AuditLogEntry.objects.get(
+                organization_id=self.org.id,
+                target_object=self.org.id,
+                event=audit_log.get_event_id("ORG_EDIT"),
+            )
+            assert persisted_entry.actor_id == self.user.id
+            assert persisted_entry.data[AGENT_DELEGATION_DATA_KEY] == SEER_AGENT_DELEGATION
 
         self.assert_no_delete_log_created()
+
+    def test_audit_entry_uses_agent_viewer_context_for_delegation(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(
+                user_id=self.user.id,
+                organization_id=self.org.id,
+                actor_type=ActorType.AGENT,
+            )
+        ):
+            entry = create_audit_entry_from_user(
+                self.user,
+                organization_id=self.org.id,
+                data={"thing": "to True"},
+            )
+
+        assert entry.actor_id == self.user.id
+        assert entry.data[AGENT_DELEGATION_DATA_KEY] == SEER_AGENT_DELEGATION
 
     def test_audit_entry_frontend(self) -> None:
         org = self.create_organization()
@@ -80,6 +115,7 @@ class CreateAuditEntryTest(TestCase):
         assert entry.actor == req.user
         assert entry.actor_key is None
         assert entry.ip_address == req.META["REMOTE_ADDR"]
+        assert AGENT_DELEGATION_DATA_KEY not in entry.data
 
         self.assert_no_delete_log_created()
 


### PR DESCRIPTION
Agent-authenticated organization audit entries continue to name the delegating user as the actor and now also record `agent_delegation: "seer"`. The audit API exposes that marker and appends `(via Seer agent)` to the existing note, so the current audit-log UI distinguishes delegated actions without a frontend change or database migration.

Request authentication supplies the marker for API actions, while direct audit helpers read the agent actor type from `ViewerContext`. Non-agent audit entries and actor filtering remain unchanged.

This is a focused follow-up to #121839. The permission matrix in #121840 remains validation-only and will be based on this PR.
