### PR TITLE
feat(autofix): Add flagged steering to Autofix to run checks

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -334,6 +334,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-pr-iteration-cap-assign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the pr content verification prior to opening a PR
     manager.add("organizations:autofix-verify-pr-content", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Steer autofix to run the repo's linter and tests over its changes
+    manager.add("organizations:autofix-should-run-repo-checks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Expose one-shot question answers on the Seer runs list (?expand=questions)
     manager.add("organizations:seer-run-questions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable showing seer in a persistent sidebar

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -175,7 +175,7 @@ def build_step_prompt(
     group: Group,
     user_context: str | None = None,
     run_state: SeerRunState | None = None,
-    enable_bash_tools: bool = False,
+    should_run_repo_checks: bool = False,
 ) -> str:
     """
     Build the prompt for a step using issue details.
@@ -184,7 +184,7 @@ def build_step_prompt(
         step: The autofix step to build prompt for
         group: The Sentry group (issue) being analyzed
         run_state: The current run state, used to surface PR links for iteration
-        enable_bash_tools: Whether bash tools are available to the run
+        should_run_repo_checks: Whether to steer the run to verify changes with the repo's own checks
 
     Returns:
         Formatted prompt string
@@ -196,7 +196,7 @@ def build_step_prompt(
         culprit=group.culprit or "unknown",
         artifact_key=step.value,
         run_state=run_state,
-        enable_bash_tools=enable_bash_tools,
+        should_run_repo_checks=should_run_repo_checks,
     )
 
     parts = [prompt]
@@ -611,7 +611,9 @@ def trigger_autofix_agent(
         group,
         user_context,
         run_state=run_state,
-        enable_bash_tools=client.enable_bash_tools,
+        should_run_repo_checks=features.has(
+            "organizations:autofix-should-run-repo-checks", group.organization
+        ),
     )
     prompt_metadata = {
         "step": step.value,

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
     from sentry.seer.agent.client_models import SeerRunState
 
 
+_CHECK_COMMAND_SOURCES = (
+    "Take the commands from the repository itself — its README/contributing docs, Makefile,"
+    " package.json scripts, tox/pyproject config, or CI workflow files — rather than guessing."
+)
+
+
 class PromptBuilder(Protocol):
     """Signature shared by all autofix step prompt builders."""
 
@@ -20,7 +26,7 @@ class PromptBuilder(Protocol):
         culprit: str,
         artifact_key: str | None,
         run_state: "SeerRunState | None" = None,
-        enable_bash_tools: bool = False,
+        should_run_repo_checks: bool = False,
     ) -> str: ...
 
 
@@ -31,7 +37,7 @@ def root_cause_prompt(
     culprit: str,
     artifact_key: str | None,
     run_state: "SeerRunState | None" = None,
-    enable_bash_tools: bool = False,
+    should_run_repo_checks: bool = False,
 ) -> str:
     return dedent(
         f"""\
@@ -65,8 +71,15 @@ def solution_prompt(
     culprit: str,
     artifact_key: str | None,
     run_state: "SeerRunState | None" = None,
-    enable_bash_tools: bool = False,
+    should_run_repo_checks: bool = False,
 ) -> str:
+    testing_guidance = (
+        "End your plan with a verification step that runs the repository's linter over the"
+        " changed files and the tests covering the changed code."
+        f" {_CHECK_COMMAND_SOURCES} Name them in the step."
+        if should_run_repo_checks
+        else "Do NOT include testing as part of your plan."
+    )
     return dedent(
         f"""\
         Plan a solution for issue {short_id}: "{title}" (culprit: {culprit})
@@ -78,7 +91,7 @@ def solution_prompt(
         2. Explore the codebase to understand the affected areas
         3. Consider different possible approaches and pick the single most pragmatic one.
 
-        Do NOT include testing as part of your plan.
+        {testing_guidance}
 
         If you have previously generated this artifact, disregard the prior attempt and produce a completely new one from scratch.
 
@@ -100,7 +113,7 @@ def code_changes_prompt(
     culprit: str,
     artifact_key: str | None,
     run_state: "SeerRunState | None" = None,
-    enable_bash_tools: bool = False,
+    should_run_repo_checks: bool = False,
 ) -> str:
     prompt = dedent(
         f"""\
@@ -119,8 +132,16 @@ def code_changes_prompt(
         """
     )
 
-    if enable_bash_tools:
-        prompt = f"{prompt}Use the bash tool to test and lint the changes you make according to repo standards.\n"
+    if should_run_repo_checks:
+        prompt += dedent(
+            f"""
+            Before you finish, verify your changes with the repository's own tooling:
+            - Run the linter/formatter over the files you changed.
+            - Run the tests covering the code you changed, scoping the run to the affected area when the suite is large.
+            - Fix any failures your changes introduced, then re-run until they pass.
+
+            {_CHECK_COMMAND_SOURCES} If a check cannot be run, report that instead of claiming it passed."""
+        )
 
     return prompt
 
@@ -132,7 +153,7 @@ def pr_iteration_prompt(
     culprit: str,
     artifact_key: str | None,
     run_state: "SeerRunState | None" = None,
-    enable_bash_tools: bool = False,
+    should_run_repo_checks: bool = False,
 ) -> str:
     prompt = dedent(
         f"""\

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -254,6 +254,30 @@ class TestBuildStepPrompt(TestCase):
         assert "app.views.handler" in prompt
         assert "Implement the fix" in prompt
 
+    def test_solution_prompt_without_should_run_repo_checks_skips_testing(self) -> None:
+        prompt = build_step_prompt(AutofixStep.SOLUTION, self.group)
+
+        assert "Do NOT include testing as part of your plan." in prompt
+
+    def test_solution_prompt_with_should_run_repo_checks_plans_verification(self) -> None:
+        prompt = build_step_prompt(AutofixStep.SOLUTION, self.group, should_run_repo_checks=True)
+
+        assert "Do NOT include testing as part of your plan." not in prompt
+        assert "End your plan with a verification step" in prompt
+
+    def test_code_changes_prompt_without_should_run_repo_checks_omits_checks(self) -> None:
+        prompt = build_step_prompt(AutofixStep.CODE_CHANGES, self.group)
+
+        assert "linter" not in prompt
+
+    def test_code_changes_prompt_with_should_run_repo_checks_includes_checks(self) -> None:
+        prompt = build_step_prompt(
+            AutofixStep.CODE_CHANGES, self.group, should_run_repo_checks=True
+        )
+
+        assert "Run the linter/formatter over the files you changed." in prompt
+        assert "Run the tests covering the code you changed" in prompt
+
     def test_prompt_with_missing_culprit_uses_default(self) -> None:
         self.group.culprit = None
         self.group.save()


### PR DESCRIPTION
This adds content to the prompt of the planning and coding steps of Autofix. The new text is behind a new flag:
`organizations:autofix-should-run-repo-checks`. When this flag is enabled:
- The planning prompt instructs the agent to detail the tests / lints to run as part of the plan.
- The coding prompt instructs the agent to verify the change using the tools detailed in the repo.
