### PR TITLE
feat(hybridcloud): Report mailbox depth quantiles alongside max_depth

### DIFF
--- a/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
+++ b/src/sentry/hybridcloud/tasks/webhook_backlog_metrics.py
@@ -1,7 +1,8 @@
 import datetime
 import logging
+import math
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 
 from django.db import OperationalError, connections, transaction
@@ -28,6 +29,12 @@ size. Measured at ~830 buffers against a 2.6M row table, but nothing in the desi
 bounds it, so it gets an explicit bound.
 """
 
+DEPTH_QUANTILES = (50, 90, 99)
+"""
+`max_depth` reads the same whether one mailbox is stuck or a provider's whole backlog
+has shifted deeper. One is a mailbox to go look at, the other a capacity problem.
+"""
+
 MAILBOX_DEPTH_QUERY_TIMEOUT = datetime.timedelta(seconds=30)
 """
 Ceiling on the per-mailbox aggregate below.
@@ -37,6 +44,17 @@ the one that could turn this monitor into a second incident. Bounding it means a
 pathological table loses the per-provider breakdown rather than pinning a control
 replica; the far cheaper `backlog.*` signals still report.
 """
+
+
+def _nearest_rank(sorted_depths: Sequence[int], percentile: int) -> int:
+    """
+    Depth of the mailbox at `percentile` of an ascending `sorted_depths`.
+
+    Nearest-rank, so every value returned is a depth some mailbox actually has. The
+    clamp stops a low percentile from indexing -1 and returning the deepest instead.
+    """
+    index = math.ceil(percentile / 100 * len(sorted_depths)) - 1
+    return sorted_depths[max(index, 0)]
 
 
 @contextmanager
@@ -146,6 +164,9 @@ def record_mailbox_depth_metrics() -> None:
     is made of and joins to `github.webhook.forwarded_event`; summing over the tag
     reproduces the provider-only value. Only that metric — the rest read fine per
     provider, and every tag value costs a series per worker that runs the task.
+
+    `depth_quantile` gives the shape behind `max_depth`. The depths are already in
+    memory for the aggregates above, so it costs one sort per provider.
     """
     replica = WebhookPayload.objects.using_replica()
     mailboxes = replica.values("provider", "mailbox_name").annotate(
@@ -162,18 +183,16 @@ def record_mailbox_depth_metrics() -> None:
 
     now = timezone.now()
     pending: dict[tuple[str, str], int] = defaultdict(int)
-    mailbox_count: dict[str, int] = defaultdict(int)
-    max_depth: dict[str, int] = defaultdict(int)
     oldest: dict[str, datetime.datetime] = {}
+    depths: dict[str, list[int]] = defaultdict(list)
     for row in rows:
         # The column is nullable, and rows predating it still drain through here.
         provider = row["provider"] or "unknown"
         depth, row_oldest = row["depth"], row["oldest"]
         event_type = event_type_from_mailbox(provider, row["mailbox_name"])
         pending[(provider, event_type)] += depth
-        mailbox_count[provider] += 1
-        max_depth[provider] = max(max_depth[provider], depth)
         oldest[provider] = min(oldest.get(provider, row_oldest), row_oldest)
+        depths[provider].append(depth)
 
     for (provider, event_type), pending_count in pending.items():
         metrics.gauge(
@@ -183,17 +202,25 @@ def record_mailbox_depth_metrics() -> None:
             sample_rate=1.0,
         )
 
-    for provider, active_count in mailbox_count.items():
+    for provider, mailbox_depths in depths.items():
+        mailbox_depths.sort()
         tags = {"provider": provider}
+        for percentile in DEPTH_QUANTILES:
+            metrics.gauge(
+                "hybridcloud.webhookpayload.mailbox.depth_quantile",
+                _nearest_rank(mailbox_depths, percentile),
+                tags={**tags, "quantile": f"p{percentile}"},
+                sample_rate=1.0,
+            )
         metrics.gauge(
             "hybridcloud.webhookpayload.mailbox.active_count",
-            active_count,
+            len(mailbox_depths),
             tags=tags,
             sample_rate=1.0,
         )
         metrics.gauge(
             "hybridcloud.webhookpayload.mailbox.max_depth",
-            max_depth[provider],
+            mailbox_depths[-1],
             tags=tags,
             sample_rate=1.0,
         )

--- a/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
+++ b/tests/sentry/hybridcloud/tasks/test_webhook_backlog_metrics.py
@@ -23,6 +23,7 @@ MAILBOX_PENDING_METRIC = "hybridcloud.webhookpayload.mailbox.pending_count"
 MAILBOX_ACTIVE_METRIC = "hybridcloud.webhookpayload.mailbox.active_count"
 MAILBOX_MAX_DEPTH_METRIC = "hybridcloud.webhookpayload.mailbox.max_depth"
 MAILBOX_AGE_METRIC = "hybridcloud.webhookpayload.mailbox.oldest_pending_age_seconds"
+MAILBOX_DEPTH_QUANTILE_METRIC = "hybridcloud.webhookpayload.mailbox.depth_quantile"
 
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> None:
@@ -37,6 +38,15 @@ def gauge_calls(mock_metrics: MagicMock, key: str) -> list[tuple[float, dict[str
         for call in mock_metrics.gauge.call_args_list
         if call[0][0] == key
     ]
+
+
+def depth_quantiles(mock_metrics: MagicMock, provider: str) -> dict[str, float]:
+    """{quantile: depth} reported for `provider`."""
+    return {
+        tags["quantile"]: value
+        for value, tags in gauge_calls(mock_metrics, MAILBOX_DEPTH_QUANTILE_METRIC)
+        if tags["provider"] == provider
+    }
 
 
 @control_silo_test
@@ -312,6 +322,40 @@ class MailboxDepthMetricsTest(TestCase):
             assert [tags for _, tags in gauge_calls(mock_metrics, metric)] == [
                 {"provider": "github"}
             ], metric
+        assert all(
+            "event_type" not in tags
+            for _, tags in gauge_calls(mock_metrics, MAILBOX_DEPTH_QUANTILE_METRIC)
+        )
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_depth_quantiles_describe_the_distribution(self, mock_metrics: MagicMock) -> None:
+        for depth, mailbox in enumerate(("a", "b", "c", "d"), start=1):
+            create_payloads(depth, f"github:{mailbox}:push", provider="github")
+
+        # Nearest-rank over [1, 2, 3, 4].
+        record_mailbox_depth_metrics()
+
+        assert depth_quantiles(mock_metrics, "github") == {"p50": 2, "p90": 4, "p99": 4}
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_depth_quantiles_hold_for_a_single_mailbox(self, mock_metrics: MagicMock) -> None:
+        create_payloads(5, "github:123:push", provider="github")
+
+        record_mailbox_depth_metrics()
+
+        # Covers the index clamp; a wrap to -1 is only visible in the test above.
+        assert depth_quantiles(mock_metrics, "github") == {"p50": 5, "p90": 5, "p99": 5}
+
+    @patch("sentry.hybridcloud.tasks.webhook_backlog_metrics.metrics")
+    def test_depth_quantiles_are_per_provider(self, mock_metrics: MagicMock) -> None:
+        create_payloads(1, "github:1:push", provider="github")
+        create_payloads(9, "github:2:push", provider="github")
+        create_payloads(4, "gitlab:3", provider="gitlab")
+
+        record_mailbox_depth_metrics()
+
+        assert depth_quantiles(mock_metrics, "github") == {"p50": 1, "p90": 9, "p99": 9}
+        assert depth_quantiles(mock_metrics, "gitlab") == {"p50": 4, "p90": 4, "p99": 4}
 
     def test_aggregate_runs_under_a_statement_timeout(self) -> None:
         create_payloads(1, "github:123", provider="github")


### PR DESCRIPTION
Reports p50/p90/p99 of the per-mailbox backlog depths, alongside the existing `max_depth`.

### Why

Delivery is ordered within a mailbox, so a deep one stalls everything behind it. `max_depth` makes that visible, but it reads the same whether a single mailbox is stuck at 300 or a provider's whole backlog has shifted deeper — one is a mailbox to go look at, the other a capacity problem.

Telling them apart today means comparing `max_depth` against the region-wide backlog total: two gauges with different aggregation semantics, easy to combine wrongly. Reading the recent webhook backlog needed exactly that comparison to conclude one mailbox held the bulk of it.

It is also the signal that would let `MAX_MAILBOX_DRAIN` (300) and `PARALLEL_DRAIN_THRESHOLD` (60) be argued from data instead of assumed.

### What

`hybridcloud.webhookpayload.mailbox.depth_quantile`, tagged `provider` and `quantile:p50|p90|p99`. Nearest-rank, so every value returned is a depth some mailbox actually has.

`active_count` and `max_depth` now derive from the same sorted list rather than from separate accumulators that tracked it by construction.

### Cost

The aggregate already runs every 5 minutes and already walks these depths in memory, so this adds one sort per provider and 3 series per provider. Reporting quantiles rather than a distribution is what keeps that bounded — a `metrics.distribution` per mailbox would scale series with the backlog it exists to measure.

### Before merging

`depth_quantile` is a new metric, so it lands in Datadog's exclude-tags mode and gets billed across the ~40 GKE node tags the agent attaches. It needs a tag configuration narrowing it to `provider`/`quantile`/`sentry_region`, applied **before** this deploys — tag config is not retroactive.

### Scope

No behaviour change: no query, delivery decision, or claim bound is altered.

Part of [CW-1830](https://linear.app/getsentry/issue/CW-1830).
