### PR TITLE
fix(ratelimits): expire concurrent rate limit keys

### DIFF
--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -43,9 +43,9 @@ class ConcurrentRateLimiter:
 
     def start_request(self, key: str, limit: int, request_uid: str) -> ConcurrentLimitInfo:
         redis_key = self.namespaced_key(key)
-        current_executions, request_allowed, cleaned_up_requests = (-1, True, 0)
+        current_executions, request_allowed = (-1, True)
         try:
-            current_executions, request_allowed, cleaned_up_requests = rate_limit_info(
+            current_executions, request_allowed = rate_limit_info(
                 [redis_key], [limit, request_uid, time(), self.max_ttl_seconds], self.client
             )
         except Exception:
@@ -53,17 +53,6 @@ class ConcurrentRateLimiter:
                 "Could not start request", dict(key=redis_key, limit=limit, request_uid=request_uid)
             )
             return ConcurrentLimitInfo(limit, -1, False)
-        if cleaned_up_requests != 0:
-            logger.info(
-                "Cleaned up concurrent executions: %s",
-                cleaned_up_requests,
-                extra={
-                    "cleaned_up_requests": cleaned_up_requests,
-                    "key": key,
-                    "limit": limit,
-                    "request_uid": request_uid,
-                },
-            )
         return ConcurrentLimitInfo(limit, int(current_executions), not bool(request_allowed))
 
     def get_concurrent_requests(self, key: str) -> int:

--- a/src/sentry/scripts/ratelimits/api_limiter.lua
+++ b/src/sentry/scripts/ratelimits/api_limiter.lua
@@ -53,6 +53,13 @@ if allowed then
   current_executions = current_executions + 1
 end
 
+-- Handles the case where an unfinished request (timeout, etc) results in a member
+-- being leaked and not cleaned up. The TTL keeps leakage scoped to 1 day.
+local key_ttl_seconds = 86400
+if current_executions > 0 then
+  redis.call("expire", key, key_ttl_seconds)
+end
+
 -- NOTE: the cleaned up execution number should be removed once we know the rate limiter
 -- is working correctly
 return { current_executions, allowed, cleaned_up_requests}

--- a/src/sentry/scripts/ratelimits/api_limiter.lua
+++ b/src/sentry/scripts/ratelimits/api_limiter.lua
@@ -44,20 +44,18 @@ local current_executions = redis.call("zcard", key)
 local allowed = current_executions < concurrent_limit
 local cleaned_up_requests = current_executions_pre_cleanup - current_executions
 
+-- Handles the case where an unfinished request (timeout, etc) results in a member
+-- being leaked and not cleaned up. The TTL keeps leakage scoped to 1 day.
+local key_ttl_seconds = 86400
+
 if allowed then
   -- if below the limit, add to the set
   redis.call("zadd", key, cur_time, request_uid)
+  redis.call("expire", key, key_ttl_seconds)
   -- a lua script executes atomically and only one element was added to the set
   -- hence we can safely say that the amount of current executions is one higher
   -- than it was before
   current_executions = current_executions + 1
-end
-
--- Handles the case where an unfinished request (timeout, etc) results in a member
--- being leaked and not cleaned up. The TTL keeps leakage scoped to 1 day.
-local key_ttl_seconds = 86400
-if current_executions > 0 then
-  redis.call("expire", key, key_ttl_seconds)
 end
 
 -- NOTE: the cleaned up execution number should be removed once we know the rate limiter

--- a/src/sentry/scripts/ratelimits/api_limiter.lua
+++ b/src/sentry/scripts/ratelimits/api_limiter.lua
@@ -14,7 +14,7 @@
 --  concurrent_limit, request_uid, current_time, max_tll_seconds
 --
 -- Output:
--- current_executions (including the one that was just added), request_allowed?, cleaned_up_requests
+-- current_executions (including the one that was just added), request_allowed?
 local key = KEYS[1]
 
 -- The maximum amount of concurrent requests for the given key
@@ -31,18 +31,12 @@ local cur_time = tonumber(ARGV[3])
 -- or the server timed it out
 local max_tll_seconds = tonumber(ARGV[4])
 
--- NOTE (Volo): this is only for debug purposes and should be taken out by 2022-04-01
--- this is trying to figure out how many stale requests were cleaned up to make sure
--- that the rate limiter is working correctly
-local current_executions_pre_cleanup = redis.call("zcard", key)
-
 -- first we remove all the requests whose scores (i.e. their timestamps) are older than the now - max ttl
 -- this prevents us from overcounting concurrent requests
 redis.call("zremrangebyscore", key, "-inf", cur_time - max_tll_seconds)
 -- get the size of the set, which tells us how many requests are currently executing
 local current_executions = redis.call("zcard", key)
 local allowed = current_executions < concurrent_limit
-local cleaned_up_requests = current_executions_pre_cleanup - current_executions
 
 -- Handles the case where an unfinished request (timeout, etc) results in a member
 -- being leaked and not cleaned up. The TTL keeps leakage scoped to 1 day.
@@ -58,6 +52,4 @@ if allowed then
   current_executions = current_executions + 1
 end
 
--- NOTE: the cleaned up execution number should be removed once we know the rate limiter
--- is working correctly
-return { current_executions, allowed, cleaned_up_requests}
+return { current_executions, allowed }

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -142,7 +142,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
             patch.object(RatelimitMiddlewareTest.TestEndpoint, "enforce_rate_limit", True),
             patch("sentry.ratelimits.concurrent.rate_limit_info") as rate_limit_info,
         ):
-            rate_limit_info.return_value = (1, False, 0)
+            rate_limit_info.return_value = (1, False)
 
             default_rate_limit_mock.return_value = RateLimit(
                 limit=0, window=100, concurrent_limit=1

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -84,18 +84,6 @@ class ConcurrentLimiterTest(TestCase):
         self.backend.start_request("ttl_key", 1, "abandoned_request")
         assert 0 < self.backend.client.ttl(key) <= KEY_TTL_SECONDS
 
-    def test_key_is_expired_when_over_the_limit(self) -> None:
-        """A request that is rejected does not write a member, but the members already in the
-        key are still live and the key must keep its expiry"""
-        key = self.backend.namespaced_key("ttl_key_over_the_limit")
-        self.backend.start_request("ttl_key_over_the_limit", 1, "abandoned_request")
-        self.backend.client.persist(key)
-
-        assert self.backend.start_request(
-            "ttl_key_over_the_limit", 1, "over_the_limit"
-        ).limit_exceeded
-        assert 0 < self.backend.client.ttl(key) <= KEY_TTL_SECONDS
-
     def test_finish_non_existent(self) -> None:
         # this shouldn't crash
         self.backend.finish_request("fasdlfkdsalfkjlasdkjlasdkjflsakj", "fsdlkajflsdakjsda")

--- a/tests/sentry/ratelimits/test_redis_concurrent.py
+++ b/tests/sentry/ratelimits/test_redis_concurrent.py
@@ -12,6 +12,9 @@ from sentry.ratelimits.concurrent import (
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
+# must match the expiry the api_limiter.lua script sets on the key
+KEY_TTL_SECONDS = 86400
+
 
 class ConcurrentLimiterTest(TestCase):
     def setUp(self) -> None:
@@ -74,6 +77,24 @@ class ConcurrentLimiterTest(TestCase):
             assert (
                 self.backend.start_request("foo", limit, "updated_request").current_executions == 1
             )
+
+    def test_key_is_expired(self) -> None:
+        """A request that never finishes leaves a member behind, so the key must expire on its own"""
+        key = self.backend.namespaced_key("ttl_key")
+        self.backend.start_request("ttl_key", 1, "abandoned_request")
+        assert 0 < self.backend.client.ttl(key) <= KEY_TTL_SECONDS
+
+    def test_key_is_expired_when_over_the_limit(self) -> None:
+        """A request that is rejected does not write a member, but the members already in the
+        key are still live and the key must keep its expiry"""
+        key = self.backend.namespaced_key("ttl_key_over_the_limit")
+        self.backend.start_request("ttl_key_over_the_limit", 1, "abandoned_request")
+        self.backend.client.persist(key)
+
+        assert self.backend.start_request(
+            "ttl_key_over_the_limit", 1, "over_the_limit"
+        ).limit_exceeded
+        assert 0 < self.backend.client.ttl(key) <= KEY_TTL_SECONDS
 
     def test_finish_non_existent(self) -> None:
         # this shouldn't crash


### PR DESCRIPTION
Problem: Rate limiter sets no expiry on `concurrent_limit:{key}`, which is fine since it's a rate limiter (and will naturally drain). But if a request fails to complete, we'll leak the associated key since it never has its last member removed.

Fix: `EXPIRE` the key at the end of the script, refreshed on every call, so a key stays alive while requests keep arriving and is reaped once traffic stops.

Notes:
- Prod points at the ratelimiter cluster. The US instance is a 30 GB Memorystore Redis 6 instance with no redis_configs block, so it runs the Memorystore default maxmemory-policy of volatile-lru. That policy evicts only keys that have a TTL.
- Before this change, concurrent_limit:* keys were not evictable, so growth pushed eviction pressure onto the other rate-limit keys, which do carry TTLs. After this change, a live concurrent-limit key can be evicted under memory pressure, and the limit for that key silently resets. 
- The net effect is favorable, and the reset fails open in the same way the limiter already does on Redis errors, but this is a behavior change on a shared 30 GB instance so worth calling out.

Refs INFRENG-487