### PR TITLE
fix(pagefilters): keep absolute date ranges inside the max window

### DIFF
--- a/static/app/components/pageFilters/actions.tsx
+++ b/static/app/components/pageFilters/actions.tsx
@@ -19,13 +19,14 @@ import {
   setPageFiltersStorage,
 } from 'sentry/components/pageFilters/persistence';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import type {DateString, PageFilters, PinnedPageFilter} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import {DAY as DAY_IN_MS, HOUR as HOUR_IN_MS} from 'sentry/utils/formatters';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
@@ -82,6 +83,10 @@ export function resetPageFilters() {
 
 function getProjectIdFromProject(project: MinimalProject) {
   return parseInt(project.id, 10);
+}
+
+export function getOldestPickableStart(maxPickableDays: number, now = Date.now()) {
+  return new Date(now - maxPickableDays * DAY_IN_MS);
 }
 
 /**
@@ -316,20 +321,20 @@ export function initializeUrlState({
   let shouldUseMaxDateRange = false;
 
   if (maxPickableDays && pageFilters.datetime) {
+    const now = Date.now();
     let {start, end} = pageFilters.datetime;
 
     if (pageFilters.datetime.period) {
-      const parsedPeriod = parseStatsPeriod(pageFilters.datetime.period);
-      start = parsedPeriod.start;
-      end = parsedPeriod.end;
+      const periodInHours = parsePeriodToHours(pageFilters.datetime.period);
+      start = new Date(now - periodInHours * HOUR_IN_MS);
+      end = new Date(now);
     }
 
     if (start && end) {
       const periodStart = new Date(start);
       const periodEnd = new Date(end);
-      const maxPeriod = parseStatsPeriod(`${maxPickableDays}d`);
-      const maxTimeRange = (maxDateRange ?? maxPickableDays) * 24 * 60 * 60 * 1000;
-      const maxStart = new Date(maxPeriod.start);
+      const maxTimeRange = (maxDateRange ?? maxPickableDays) * DAY_IN_MS;
+      const maxStart = getOldestPickableStart(maxPickableDays, now);
       if (maxDateRange) {
         if (
           periodEnd.getTime() - periodStart.getTime() > maxTimeRange ||

--- a/static/app/components/pageFilters/container.spec.tsx
+++ b/static/app/components/pageFilters/container.spec.tsx
@@ -561,6 +561,70 @@ describe('PageFiltersContainer', () => {
       );
     });
 
+    describe('when the account timezone differs from the browser timezone', () => {
+      const accountTimezone = moment().tz();
+
+      beforeEach(() => {
+        moment.tz.setDefault('Pacific/Auckland');
+      });
+
+      afterEach(() => {
+        moment.tz.setDefault(accountTimezone);
+      });
+
+      it('keeps an absolute range that starts inside the window', async () => {
+        const start = moment()
+          .utc()
+          .subtract(30, 'days')
+          .add(6, 'hours')
+          .format('YYYY-MM-DDTHH:mm:ss');
+        const end = moment().utc().subtract(29, 'days').format('YYYY-MM-DDTHH:mm:ss');
+
+        const {router} = render(<PageFiltersContainer maxPickableDays={30} />, {
+          organization,
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/test/',
+              query: {start, end},
+            },
+            route: '/organizations/:orgId/test/',
+          },
+        });
+
+        await waitFor(() =>
+          expect(PageFiltersStore.getState().selection.datetime).toEqual({
+            period: null,
+            utc: null,
+            start: getUtcToLocalDateObject(start),
+            end: getUtcToLocalDateObject(end),
+          })
+        );
+        expect(router.location.query).toEqual({start, end});
+      });
+
+      it('keeps a relative period equal to maxPickableDays', async () => {
+        render(<PageFiltersContainer maxPickableDays={30} />, {
+          organization,
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/test/',
+              query: {statsPeriod: '30d'},
+            },
+            route: '/organizations/:orgId/test/',
+          },
+        });
+
+        await waitFor(() =>
+          expect(PageFiltersStore.getState().selection.datetime).toEqual({
+            period: '30d',
+            utc: null,
+            start: null,
+            end: null,
+          })
+        );
+      });
+    });
+
     it('applies maxPickableDays when mounted route changes to absolute params in the past', async () => {
       const {router} = render(<PageFiltersContainer maxPickableDays={30} />, {
         organization,

--- a/static/app/components/pageFilters/container.tsx
+++ b/static/app/components/pageFilters/container.tsx
@@ -6,6 +6,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {InitializeUrlStateParams} from 'sentry/components/pageFilters/actions';
 import {
+  getOldestPickableStart,
   initializeUrlState,
   updateDateTime,
   updateEnvironments,
@@ -13,7 +14,6 @@ import {
   updateProjects,
 } from 'sentry/components/pageFilters/actions';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {DAY as DAY_IN_MS} from 'sentry/utils/formatters';
@@ -152,12 +152,10 @@ export function PageFiltersContainer({
     }
 
     // For absolute date ranges, check if the start date is before the allowed window.
-    // Uses same calculation as initialization in pageFilters.tsx
     if (start && end) {
       const periodStart = new Date(start);
       const periodEnd = new Date(end);
-      const maxPeriod = parseStatsPeriod(`${maxPickableDays}d`);
-      const maxStart = new Date(maxPeriod.start);
+      const maxStart = getOldestPickableStart(maxPickableDays);
 
       if (maxDateRange) {
         const maxTimeRange = maxDateRange * DAY_IN_MS;


### PR DESCRIPTION
`PageFiltersContainer` and `initializeUrlState` both decide whether an absolute date selection still fits inside `maxPickableDays`, and both derive the window edge by:

1. `moment`-y: Formatting a `moment()`, which is in the _account_ timezone
2. `Date`-y: Re-parsing it with `new Date()`, which is in the _browser_ timezone

That's a discrepancy! Which will cause, depending on what cardinal direction difference your _account_ is...

- _East_ of the browser: the window is too narrow -> ranges starting inside get discarded and the page gets snapped back to the Replay max relative period of 90D. Hence REPLAY-992. 💫 
- _West_ of the browser: the window is too wide -> ranges starting outside it slip through. Which is also a weird little bug.

Both call sites now compare instants via a shared `getOldestPickableStart`, and the relative-period branch in `initializeUrlState` derives its start on the same basis. So even though we're still using both `moment`-y and `Date`-y logic, the timezone discrepancy should be ironed out.

Closes REPLAY-992.
