### PR TITLE
ref(types): extract PageFilterDatetime from PageFilters

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -5,7 +5,7 @@ import orderBy from 'lodash/orderBy';
 import moment from 'moment-timezone';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {ECharts, ReactEchartsRef} from 'sentry/types/echarts';
 import type {
   EventsStats,
@@ -43,7 +43,7 @@ export const FIVE_MINUTES = 5;
  */
 export const RELEASE_LINES_THRESHOLD = 50;
 
-export type DateTimeObject = Partial<PageFilters['datetime']>;
+export type DateTimeObject = Partial<PageFilterDatetime>;
 
 export function truncationFormatter(
   value: string,

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -8,12 +8,12 @@ import {
   type BreakpointEvidenceData,
   type EventBreakpointChartData,
 } from 'sentry/components/events/eventStatisticalDetector/breakpointChartOptions';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 
 interface ChartProps {
   chartType: ChartType;
-  datetime: PageFilters['datetime'];
+  datetime: PageFilterDatetime;
   evidenceData: BreakpointEvidenceData;
   percentileData: EventBreakpointChartData['percentileData'];
 }

--- a/static/app/components/pageFilters/actions.tsx
+++ b/static/app/components/pageFilters/actions.tsx
@@ -21,7 +21,12 @@ import {
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
-import type {DateString, PageFilters, PinnedPageFilter} from 'sentry/types/core';
+import type {
+  DateString,
+  PageFilters,
+  PageFilterDatetime,
+  PinnedPageFilter,
+} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -88,11 +93,8 @@ function getProjectIdFromProject(project: MinimalProject) {
  * Merges two date time objects, where the `base` object takes precedence, and
  * the `fallback` values are used when the base values are null or undefined.
  */
-function mergeDatetime(
-  base: PageFilters['datetime'],
-  fallback?: Partial<PageFilters['datetime']>
-) {
-  const datetime: PageFilters['datetime'] = {
+function mergeDatetime(base: PageFilterDatetime, fallback?: Partial<PageFilterDatetime>) {
+  const datetime: PageFilterDatetime = {
     start: base.start ?? fallback?.start ?? null,
     end: base.end ?? fallback?.end ?? null,
     period: base.period ?? fallback?.period ?? null,

--- a/static/app/components/pageFilters/parse.tsx
+++ b/static/app/components/pageFilters/parse.tsx
@@ -6,7 +6,7 @@ import moment from 'moment-timezone';
 
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {toArray} from 'sentry/utils/array/toArray';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
@@ -339,7 +339,7 @@ export function extractSelectionParameters(query: Location['query']) {
 export function getDatetimeFromState(state: PageFiltersState) {
   return Object.fromEntries(
     Object.entries(state).filter(([key]) => DATE_TIME_KEYS.includes(key))
-  ) as PageFilters['datetime'];
+  ) as PageFilterDatetime;
 }
 
 /**

--- a/static/app/components/pageFilters/store.tsx
+++ b/static/app/components/pageFilters/store.tsx
@@ -2,13 +2,10 @@ import {createStore} from 'reflux';
 
 import {getDefaultPageFilterSelection} from 'sentry/components/pageFilters/constants';
 import type {StrictStoreDefinition} from 'sentry/stores/types';
-import type {PageFilters, PinnedPageFilter} from 'sentry/types/core';
+import type {PageFilters, PinnedPageFilter, PageFilterDatetime} from 'sentry/types/core';
 import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 
-function datetimeHasSameValue(
-  a: PageFilters['datetime'],
-  b: PageFilters['datetime']
-): boolean {
+function datetimeHasSameValue(a: PageFilterDatetime, b: PageFilterDatetime): boolean {
   if (Object.keys(a).length !== Object.keys(b).length) {
     return false;
   }
@@ -65,7 +62,7 @@ interface PageFiltersStoreDefinition extends StrictStoreDefinition<PageFiltersSt
   onReset(): void;
   pin(filter: PinnedPageFilter, pin: boolean): void;
   reset(selection?: PageFilters): void;
-  updateDateTime(datetime: PageFilters['datetime']): void;
+  updateDateTime(datetime: PageFilterDatetime): void;
   updateEnvironments(environments: string[] | null): void;
   updatePersistence(shouldPersist: boolean): void;
   updateProjects(projects: PageFilters['projects'], environments: null | string[]): void;

--- a/static/app/components/pageFilters/types.tsx
+++ b/static/app/components/pageFilters/types.tsx
@@ -1,3 +1,8 @@
+export type StatsPeriodRange = {
+  statsPeriodEnd: string;
+  statsPeriodStart: string;
+};
+
 /**
  * This is a flat normalized variant of the PageFilters type.
  */

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -4,7 +4,7 @@ import {STATIC_SEMVER_TAGS} from 'sentry/components/events/searchBarFieldConstan
 import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind, type AggregationKey} from 'sentry/utils/fields';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
@@ -22,7 +22,7 @@ export interface UseSpanSearchQueryBuilderProps {
   searchSource: string;
   autoFocus?: boolean;
   caseInsensitive?: CaseInsensitive;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   defaultToAskSeerOnFreeTextSearch?: SearchQueryBuilderProps['defaultToAskSeerOnFreeTextSearch'];
   disableLoadingTags?: boolean;
   disallowNegation?: boolean;

--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -12,7 +12,7 @@ import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils/defined';
 import {
@@ -31,7 +31,7 @@ import {useGlobalAlerts} from 'sentry/views/app/globalAlerts';
 interface TransactionSearchQueryBuilderProps {
   initialQuery: string;
   searchSource: string;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   disableLoadingTags?: boolean;
   disallowFreeText?: boolean;
   filterKeyMenuWidth?: number;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup.ts
@@ -9,7 +9,7 @@ import {
 import {Token} from 'sentry/components/searchSyntax/parser';
 import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import type {DateString} from 'sentry/types/core';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useProjects} from 'sentry/utils/useProjects';
 import {parseTraceMetricFromQuery} from 'sentry/views/explore/metrics/utils';
@@ -235,7 +235,7 @@ export function buildSeerDateTimeSelection(
   resultStart: string | null,
   resultEnd: string | null,
   statsPeriod: string,
-  pageFiltersDatetime: PageFilters['datetime']
+  pageFiltersDatetime: PageFilterDatetime
 ): SeerDateTimeSelection {
   const normalized = normalizeSeerDateTimeParams({
     start: resultStart,

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -66,16 +66,18 @@ export type IntervalPeriod = string;
  */
 export type PinnedPageFilter = 'projects' | 'environments' | 'datetime';
 
+export type PageFilterDatetime = {
+  end: DateString | null;
+  period: string | null;
+  start: DateString | null;
+  utc: boolean | null;
+};
+
 export type PageFilters = {
   /**
    * Currently selected time filter
    */
-  datetime: {
-    end: DateString | null;
-    period: string | null;
-    start: DateString | null;
-    utc: boolean | null;
-  };
+  datetime: PageFilterDatetime;
   /**
    * Currently selected environment names
    */

--- a/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
+++ b/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -10,7 +10,7 @@ import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface BaseAggregateFlamegraphQueryParameters {
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   environments?: PageFilters['environments'];
   metrics?: true;

--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -2,7 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -13,7 +13,7 @@ interface UseProfileEventsOptions<F extends string = ProfilingFieldType> {
   referrer: string;
   sort: Sort<F>;
   cursor?: string;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   limit?: number;
   projects?: Array<number | string>;

--- a/static/app/utils/profiling/hooks/useProfileEventsStats.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEventsStats.tsx
@@ -3,7 +3,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {transformStatsResponse} from 'sentry/utils/profiling/hooks/utils';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -12,7 +12,7 @@ interface UseProfileEventsStatsOptions<F> {
   dataset: 'discover' | 'profiles' | 'profileFunctions';
   referrer: string;
   yAxes: readonly F[];
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   interval?: string;
   query?: string;

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.tsx
@@ -2,7 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -12,7 +12,7 @@ interface UseProfileFunctionTrendsOptions {
   trendFunction: 'p50()' | 'p75()' | 'p95()' | 'p99()';
   trendType: TrendType;
   cursor?: string;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   limit?: number;
   projects?: Array<number | string>;

--- a/static/app/utils/profiling/hooks/useProfileFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.tsx
@@ -2,7 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -13,7 +13,7 @@ interface UseProfileFunctionsOptions<F extends string> {
   referrer: string;
   sort: Sort<F>;
   cursor?: string;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   limit?: number;
   projects?: Array<number | string>;

--- a/static/app/utils/profiling/hooks/useProfileTopEventsStats.tsx
+++ b/static/app/utils/profiling/hooks/useProfileTopEventsStats.tsx
@@ -3,7 +3,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import type {EventsStatsSeries} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {defined} from 'sentry/utils/defined';
@@ -17,7 +17,7 @@ interface UseProfileTopEventsStatsOptions<F> {
   referrer: string;
   topEvents: number;
   yAxes: readonly F[];
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   interval?: string;
   projects?: PageFilters['projects'];

--- a/static/app/utils/profiling/hooks/useRelativeDateTime.tsx
+++ b/static/app/utils/profiling/hooks/useRelativeDateTime.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 
 import {useTimezone} from 'sentry/components/timezoneProvider';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -38,5 +38,5 @@ export function useRelativeDateTime({
     end: afterDateTime,
     utc: timezone.includes('UTC'),
     period: null,
-  } satisfies PageFilters['datetime'];
+  } satisfies PageFilterDatetime;
 }

--- a/static/app/utils/useChartInterval.tsx
+++ b/static/app/utils/useChartInterval.tsx
@@ -16,7 +16,7 @@ import {
 import {parseStatsPeriod} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t, tn} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -235,7 +235,7 @@ function getIntervalLabel(interval: string): string {
   }
 }
 
-export function getIntervalOptionsForPageFilter(datetime: PageFilters['datetime']) {
+export function getIntervalOptionsForPageFilter(datetime: PageFilterDatetime) {
   const diffInMinutes = getDiffInMinutes(datetime);
 
   const minimumOption = MINIMUM_INTERVAL.getInterval(diffInMinutes);

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -16,7 +16,7 @@ import {
 } from 'sentry/components/charts/utils';
 import {normalizeDateTimeString} from 'sentry/components/pageFilters/parse';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
@@ -120,7 +120,7 @@ export function getThresholdUnitSelectOptions(
 
 export function getWidgetInterval(
   widget: Widget,
-  datetimeObj: Partial<PageFilters['datetime']>,
+  datetimeObj: Partial<PageFilterDatetime>,
   widgetIntervalOverride?: string,
   fidelity?: Fidelity
 ): string {

--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -4,7 +4,7 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {GroupList} from 'sentry/components/issues/groupList';
 import {DetailSection} from 'sentry/components/workflowEngine/ui/detailSection';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -12,7 +12,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 type DetectorDetailsOngoingIssuesProps = {
   // The time range used for the issues query.
   // When null, the query uses 90d as the stats period.
-  dateTimeSelection: PageFilters['datetime'] | null;
+  dateTimeSelection: PageFilterDatetime | null;
   detector: Detector;
 };
 

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -2,7 +2,7 @@ import {useCallback} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
@@ -16,7 +16,7 @@ interface UseGetTraceItemAttributeKeysProps extends Omit<
   UseTraceItemAttributeBaseProps,
   'type'
 > {
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   projectIds?: Array<string | number>;
   query?: string;
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -1,7 +1,7 @@
 import {useCallback} from 'react';
 
 import type {GetTagKeys} from 'sentry/components/searchQueryBuilder';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {useGetTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useGetTraceItemAttributeKeys';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
@@ -16,7 +16,7 @@ export function useGetTraceItemAttributeTagKeys({
   datetime,
 }: {
   itemType: TraceItemDataset;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   extraTags?: TagCollection;
   hiddenKeys?: string[];
   projects?: PageFilters['projects'];

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -11,7 +11,7 @@ import type {
   GetTagValuesParams,
   TagValueWithCount,
 } from 'sentry/components/searchQueryBuilder';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {defined} from 'sentry/utils/defined';
@@ -31,7 +31,7 @@ interface TraceItemAttributeValue {
 }
 
 interface UseGetTraceItemAttributeValuesProps extends UseTraceItemAttributeBaseProps {
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   projectIds?: PageFilters['projects'];
   query?: string;
 }

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -3,7 +3,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {defined} from 'sentry/utils/defined';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -16,7 +16,7 @@ import {
 } from 'sentry/views/explore/metrics/types';
 
 interface UseMetricOptionsProps {
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   enabled?: boolean;
   environments?: PageFilters['environments'];
   orgSlug?: string;

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -3,7 +3,7 @@ import {queryOptions} from '@tanstack/react-query';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -57,7 +57,7 @@ export interface TraceResults {
 interface UseTracesOptions {
   caseInsensitive?: CaseInsensitive;
   cursor?: string;
-  datetime?: PageFilters['datetime'];
+  datetime?: PageFilterDatetime;
   limit?: number;
   logQuery?: string[];
   metricQuery?: string[];

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -17,7 +17,7 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {Version} from 'sentry/components/version';
 import {IconPlay} from 'sentry/icons';
 import {tct} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {stripAnsi} from 'sentry/utils/ansiEscapeCodes';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -78,7 +78,7 @@ export interface RendererExtra extends RenderFunctionBaggage {
   >;
   attributes: Record<string, string | number | boolean>;
   caseSensitiveHighlighting: boolean;
-  datetime: PageFilters['datetime'];
+  datetime: PageFilterDatetime;
   highlightTerms: string[];
   logColors: ReturnType<typeof getLogColors>;
   align?: 'left' | 'center' | 'right';

--- a/static/app/views/explore/logs/logsTabSeerComboBox.tsx
+++ b/static/app/views/explore/logs/logsTabSeerComboBox.tsx
@@ -23,7 +23,7 @@ import {
 import {resolveSeerProjectSelection} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -67,7 +67,7 @@ export function getLogsSeerLocationQuery({
 }: {
   currentAggregateFields: readonly AggregateField[];
   currentLocation: Location;
-  pageDatetime: PageFilters['datetime'];
+  pageDatetime: PageFilterDatetime;
   result: AskSeerSearchQuery;
   projects?: Project[];
 }): LogsSeerLocationQueryResult {

--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.spec.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {partitionDateTimeIntoHeatMapWindows} from 'sentry/views/explore/metrics/hooks/partitionHeatMapWindows';
 
 const HOUR = 60 * 60 * 1000;
@@ -8,7 +8,7 @@ const HOUR = 60 * 60 * 1000;
 // A fixed, recent, hour-aligned anchor so window strings read as real dates.
 const BASE_MS = Date.UTC(2024, 0, 1); // 2024-01-01T00:00:00Z
 
-type DateTimeFilter = PageFilters['datetime'];
+type DateTimeFilter = PageFilterDatetime;
 
 describe('partitionDateTimeIntoHeatMapWindows', () => {
   it('Returns an empty plan when the interval is unusable', () => {

--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
@@ -2,12 +2,13 @@ import moment from 'moment-timezone';
 
 import {getDiffInMinutes} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
-import type {PageFilters} from 'sentry/types/core';
+import type {StatsPeriodRange} from 'sentry/components/pageFilters/types';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
 
-type DateTimeFilter = PageFilters['datetime'];
+type DateTimeFilter = PageFilterDatetime;
 
 /**
  * A loading window for a Heat Map visualization. Heat Maps load data in
@@ -16,8 +17,8 @@ type DateTimeFilter = PageFilters['datetime'];
  */
 export type HeatMapWindow =
   | {end: string; start: string}
-  | {statsPeriodEnd: string; statsPeriodStart: string}
-  | {statsPeriod: string};
+  | {statsPeriod: string}
+  | StatsPeriodRange;
 
 /** An epoch-ms time span (the heat map's X-axis domain) */
 export interface TimeDomain {

--- a/static/app/views/explore/seerQuery.ts
+++ b/static/app/views/explore/seerQuery.ts
@@ -3,7 +3,7 @@ import {
   buildSeerDateTimeSelection,
   type SeerDateTimeSelection,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/useSeerComboBoxSetup';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {Sort} from 'sentry/utils/discover/fields';
 import type {
   AggregateField,
@@ -62,7 +62,7 @@ export function getSeerExploreQuery({
   pageDatetime,
   result,
 }: {
-  pageDatetime: PageFilters['datetime'];
+  pageDatetime: PageFilterDatetime;
   result: AskSeerSearchQuery;
 }): SeerExploreQuery {
   const datetime = buildSeerDateTimeSelection(

--- a/static/app/views/issueList/issueViews/utils.tsx
+++ b/static/app/views/issueList/issueViews/utils.tsx
@@ -1,12 +1,12 @@
 import {openConfirmModal} from 'sentry/components/confirm';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 import type {IssueSortOptions} from 'sentry/views/issueList/utils';
 
-export const DEFAULT_TIME_FILTERS: PageFilters['datetime'] = {
+export const DEFAULT_TIME_FILTERS: PageFilterDatetime = {
   start: null,
   end: null,
   period: '14d',
@@ -24,7 +24,7 @@ export interface IssueViewParams {
   projects: number[];
   query: string;
   querySort: IssueSortOptions;
-  timeFilters: PageFilters['datetime'];
+  timeFilters: PageFilterDatetime;
 }
 
 export function canEditIssueView({

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -25,7 +25,7 @@ import {t, tct} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import {IssueListCacheStore} from 'sentry/stores/IssueListCacheStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {BaseGroup, Group, PriorityLevel} from 'sentry/types/group';
 import {GroupStatus} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -92,7 +92,7 @@ interface Props {
   withColumns?: GroupListColumn[];
 }
 
-interface EndpointParams extends Partial<PageFilters['datetime']> {
+interface EndpointParams extends Partial<PageFilterDatetime> {
   environment: string[];
   project: number[];
   cursor?: string;

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -1,4 +1,4 @@
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {
   GroupStatusResolution,
   MarkReviewed,
@@ -39,7 +39,7 @@ export type StarredGroupSearchView = {
   query: string;
   querySort: IssueSortOptions;
   stars: number;
-  timeFilters: PageFilters['datetime'];
+  timeFilters: PageFilterDatetime;
 };
 
 export type GroupSearchView = StarredGroupSearchView & {

--- a/static/app/views/navigation/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
@@ -1,4 +1,4 @@
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -8,7 +8,7 @@ import {IssueCount} from 'sentry/views/navigation/secondary/sections/issues/issu
 import type {IssueView} from 'sentry/views/navigation/secondary/sections/issues/issueViews/issueViews';
 
 const constructCountTimeFrame = (
-  timeFilters: PageFilters['datetime']
+  timeFilters: PageFilterDatetime
 ): {
   end?: string;
   start?: string;

--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -9,7 +9,7 @@ import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -18,7 +18,7 @@ import {withPageFilters} from 'sentry/utils/withPageFilters';
 
 type Props = Omit<
   EventsChartProps,
-  keyof Omit<PageFilters, 'datetime'> | keyof PageFilters['datetime']
+  keyof Omit<PageFilters, 'datetime'> | keyof PageFilterDatetime
 > & {
   onTotalValuesChange: (value: number | null) => void;
   selection: PageFilters;

--- a/static/gsApp/components/performance/quotaExceededAlert.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.tsx
@@ -6,7 +6,7 @@ import {Link} from '@sentry/scraps/link';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {tct} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
@@ -19,7 +19,7 @@ import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 // Returns the beggining of statsPeriod formatted like "Jan 1, 2022"
 // or absolute date range formatted like "Jan 1, 2022 - Jan 2, 2022"
-function getFormattedDateTime(dateTime: PageFilters['datetime']): string | null {
+function getFormattedDateTime(dateTime: PageFilterDatetime): string | null {
   const {start, end, period} = dateTime;
   const format = getFormat({dateOnly: true, year: true});
 

--- a/static/gsApp/overrides/performance/usePerformanceUsageStats.tsx
+++ b/static/gsApp/overrides/performance/usePerformanceUsageStats.tsx
@@ -1,5 +1,5 @@
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -22,7 +22,7 @@ export function usePerformanceUsageStats({
   dateRange,
   projectIds,
 }: {
-  dateRange: PageFilters['datetime'];
+  dateRange: PageFilterDatetime;
   organization: Organization;
   projectIds: PageFilters['projects'];
 }) {


### PR DESCRIPTION
`PageFilters['datetime']` was indexed inline at ~35 call sites, and `DateTimeObject` in `charts/utils` re-derived the same shape. This extracts it to a `PageFilterDatetime` type as a type-only change.

Split out of #121567 to make the exports work not so grossly large.
