### PR TITLE
fix(issues): stop leaking a grouphash key per group type without a noise_config

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -794,12 +794,16 @@ def should_create_group(
     grouphash: str,
     project: Project,
 ) -> bool:
-    key = f"grouphash:{grouphash}:{project.id}"
-    times_seen = client.incr(key)
     noise_config = grouptype.noise_config
 
     if not noise_config:
         return True
+
+    key = f"grouphash:{grouphash}:{project.id}"
+    pipe = client.pipeline()
+    pipe.incr(key)
+    pipe.expire(key, noise_config.expiry_seconds)
+    times_seen = pipe.execute()[0]
 
     over_threshold = times_seen >= noise_config.ignore_limit
 
@@ -816,7 +820,6 @@ def should_create_group(
         client.delete(key)
         return True
     else:
-        client.expire(key, noise_config.expiry_seconds)
         return False
 
 

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 from unittest.mock import patch
+from uuid import uuid4
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import (
@@ -14,8 +15,10 @@ from sentry.issues.grouptype import (
     PerformanceSlowDBQueryGroupType,
     get_group_type_by_slug,
     get_group_types_by_category,
+    should_create_group,
 )
 from sentry.testutils.cases import TestCase
+from sentry.utils.redis import redis_clusters
 
 
 class BaseGroupTypeTest(TestCase):
@@ -124,6 +127,46 @@ class GroupTypeTest(BaseGroupTypeTest):
 
         assert TestGroupType.noise_config.ignore_limit == 100
         assert TestGroupType.noise_config.expiry_time == timedelta(hours=12)
+
+
+class ShouldCreateGroupTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.redis_client = redis_clusters.get("default")
+        self.grouphash = uuid4().hex
+        self.key = f"grouphash:{self.grouphash}:{self.project.id}"
+        self.addCleanup(self.redis_client.delete, self.key)
+
+    def test_no_noise_config_leaves_no_key(self) -> None:
+        with patch.object(PerformanceSlowDBQueryGroupType, "noise_config", None):
+            assert should_create_group(
+                PerformanceSlowDBQueryGroupType, self.redis_client, self.grouphash, self.project
+            )
+
+        assert not self.redis_client.exists(self.key)
+
+    def test_below_ignore_limit_key_expires(self) -> None:
+        with patch.object(
+            PerformanceSlowDBQueryGroupType, "noise_config", NoiseConfig(ignore_limit=2)
+        ):
+            assert not should_create_group(
+                PerformanceSlowDBQueryGroupType, self.redis_client, self.grouphash, self.project
+            )
+
+        assert self.redis_client.ttl(self.key) > 0
+
+    def test_at_ignore_limit_key_is_deleted(self) -> None:
+        with patch.object(
+            PerformanceSlowDBQueryGroupType, "noise_config", NoiseConfig(ignore_limit=2)
+        ):
+            assert not should_create_group(
+                PerformanceSlowDBQueryGroupType, self.redis_client, self.grouphash, self.project
+            )
+            assert should_create_group(
+                PerformanceSlowDBQueryGroupType, self.redis_client, self.grouphash, self.project
+            )
+
+        assert not self.redis_client.exists(self.key)
 
 
 class GroupTypeReleasedTest(BaseGroupTypeTest):


### PR DESCRIPTION
Part 1 of cleaning up grouphash keys that should have expiries. Part 2 is the cleanup

Problem: `should_create_group` writes one permanent Redis key per distinct grouphash per project, for every group type that does not set a `noise_config`.

```python
key = f"grouphash:{grouphash}:{project.id}"
times_seen = client.incr(key)     # creates the key, no expiry
noise_config = grouptype.noise_config

if not noise_config:
    return True                   # returns before the expire and the delete below
```

`noise_config` defaults to `None` on `GroupType`. 18 of the 46 `GroupType` subclasses set one, and all 18 are performance or query-injection detectors. Everything else on the issue platform leaks.

Measured on `performance-issues-ratelimiter`, the US cluster this function writes to

| Metric | Value |
| --- | --- |
| Total keys | 29.7M |
| Keys with a TTL | ~460k |
| Evicted keys, last 30 days | 0 |
| Memory used | 1.30 GB |
| Key count, May 2025 to Aug 2026 | 19.5M to 29.7M, monotonic |

About 29.2M keys carry no expiry, and the population grows roughly 680k keys and 20 MB per month with no ceiling.

Fix: read `noise_config` first and return before touching Redis. A group type with no threshold has nothing to count, and nothing in `sentry` or `getsentry` ever read that counter back.

Also folds the `incr` and the `expire` into one pipeline, the same shape as `src/sentry/ratelimits/redis.py:110`.

Refs INFRENG-473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
