### PR TITLE
fix(api): return X-Max-Hits header from OffsetPaginator

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -308,7 +308,13 @@ class OffsetPaginator(PaginatorLike):
         else:
             hits = None
 
-        return CursorResult(results=results, next=next_cursor, prev=prev_cursor, hits=hits)
+        return CursorResult(
+            results=results,
+            next=next_cursor,
+            prev=prev_cursor,
+            hits=hits,
+            max_hits=max_hits if count_hits else None,
+        )
 
     def count_hits(self, max_hits: int) -> int:
         return count_hits(self.queryset, max_hits)

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -156,6 +156,26 @@ class OffsetPaginatorTest(TestCase):
         with pytest.raises(BadPaginationError):
             paginator.get_result(cursor=cursor)
 
+    def test_count_hits(self) -> None:
+        self.create_user("foo@example.com")
+        self.create_user("bar@example.com")
+        queryset = User.objects.all()
+        paginator = OffsetPaginator(queryset)
+
+        result = paginator.get_result(count_hits=True, max_hits=1)
+
+        assert result.hits == 1
+        assert result.max_hits == 1
+
+    def test_does_not_set_max_hits_without_counting_hits(self) -> None:
+        queryset = User.objects.all()
+        paginator = OffsetPaginator(queryset)
+
+        result = paginator.get_result()
+
+        assert result.hits is None
+        assert result.max_hits is None
+
     def test_order_by_multiple(self) -> None:
         res1 = self.create_user("foo@example.com")
         self.create_user("bar@example.com")


### PR DESCRIPTION
`OffsetPaginator`, with `count_hits=True`, was not returning `X-Max-Hits` which we use in the UI to show text like `1-10 of 1000+`.

Very simple fix, we just weren't passing that value along to the result.