### PR TITLE
feat(api): Audit undeclared runtime permission scopes

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.api")
 api_access_logger = logging.getLogger("sentry.access.api")
 
-from sentry import analytics, options, tsdb
+from sentry import analytics, tsdb
 from sentry.analytics.events.release_set_commits import ReleaseSetCommitsLocalEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -120,9 +120,6 @@ def _with_endpoint_scope_declaration(
 ) -> Callable[..., Response]:
     @functools.wraps(func)
     def wrapper(self: Endpoint, request: Request, *args: Any, **kwargs: Any) -> Response:
-        if not options.get("api.permission-scope-audit.enabled"):
-            return func(self, request, *args, **kwargs)
-
         endpoint = f"{type(self).__module__}.{type(self).__qualname__}"
         with bind_endpoint_scope_declaration(
             endpoint=endpoint,

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.api")
 api_access_logger = logging.getLogger("sentry.access.api")
 
-from sentry import analytics, tsdb
+from sentry import analytics, options, tsdb
 from sentry.analytics.events.release_set_commits import ReleaseSetCommitsLocalEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -41,6 +41,7 @@ from sentry.api.exceptions import (
 )
 from sentry.apidocs.hooks import HTTP_METHOD_NAME
 from sentry.auth import access
+from sentry.auth.scope_declaration import bind_endpoint_scope_declaration
 from sentry.auth.staff import has_staff_option
 from sentry.hybridcloud.apigateway.cell_request_resolvers import CellRequestResolver
 from sentry.middleware import is_frontend_request
@@ -112,6 +113,25 @@ DEFAULT_AUTHENTICATION = (
     ViewerContextAuthentication,
     SessionAuthentication,
 )
+
+
+def _with_endpoint_scope_declaration(
+    func: Callable[..., Response],
+) -> Callable[..., Response]:
+    @functools.wraps(func)
+    def wrapper(self: Endpoint, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if not options.get("api.permission-scope-audit.enabled"):
+            return func(self, request, *args, **kwargs)
+
+        endpoint = f"{type(self).__module__}.{type(self).__qualname__}"
+        with bind_endpoint_scope_declaration(
+            endpoint=endpoint,
+            method=request.method or "",
+            permission_classes=self.permission_classes,
+        ):
+            return func(self, request, *args, **kwargs)
+
+    return wrapper
 
 
 def allow_cors_options(func):
@@ -413,6 +433,7 @@ class Endpoint(APIView):
 
     @csrf_exempt
     @allow_cors_options
+    @_with_endpoint_scope_declaration
     def dispatch(self, request: Request, *args, **kwargs) -> Response:
         """
         Identical to rest framework's dispatch except we add the ability

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -120,10 +120,11 @@ def _with_endpoint_scope_declaration(
 ) -> Callable[..., Response]:
     @functools.wraps(func)
     def wrapper(self: Endpoint, request: Request, *args: Any, **kwargs: Any) -> Response:
+        assert request.method is not None
         endpoint = f"{type(self).__module__}.{type(self).__qualname__}"
         with bind_endpoint_scope_declaration(
             endpoint=endpoint,
-            method=request.method or "",
+            method=request.method,
             permission_classes=self.permission_classes,
         ):
             return func(self, request, *args, **kwargs)

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -13,6 +13,7 @@ from rest_framework.request import Request
 
 from sentry import features, roles
 from sentry.api.exceptions import DataSecrecyError
+from sentry.auth.scope_declaration import check_scope_declaration, check_scope_declarations
 from sentry.auth.services.access.service import access_service
 from sentry.auth.services.auth import AuthenticatedToken, RpcAuthState, RpcMemberSsoState
 from sentry.auth.staff import is_active_staff
@@ -128,6 +129,7 @@ class Access(abc.ABC):
         Return bool representing if the user has the given scope.
         >>> access.has_project('org:read')
         """
+        check_scope_declaration(scope)
         return scope in self.scopes
 
     def get_organization_role(self) -> OrganizationRole | None:
@@ -322,6 +324,7 @@ class DbAccess(Access):
 
         >>> access.has_team_scope(team, 'team:read')
         """
+        check_scope_declaration(scope)
         if not self.has_team_access(team):
             return False
         if self.has_scope(scope):
@@ -357,6 +360,7 @@ class DbAccess(Access):
 
         For performance's sake, prefer this over multiple calls to `has_project_scope`.
         """
+        check_scope_declarations(scopes)
         if not self.has_project_access(project):
             return False
         if any(self.has_scope(scope) for scope in scopes):
@@ -522,6 +526,7 @@ class RpcBackedAccess(Access):
         return None
 
     def has_team_scope(self, team: Team, scope: str) -> bool:
+        check_scope_declaration(scope)
         if not self.has_team_access(team):
             return False
         if self.has_scope(scope):
@@ -570,6 +575,7 @@ class RpcBackedAccess(Access):
 
         For performance's sake, prefer this over multiple calls to `has_project_scope`.
         """
+        check_scope_declarations(scopes)
         if not self.has_project_access(project):
             return False
         if any(self.has_scope(scope) for scope in scopes):
@@ -859,12 +865,14 @@ class OrganizationlessAccess(Access):
         return frozenset()
 
     def has_team_scope(self, team: Team, scope: str) -> bool:
+        check_scope_declaration(scope)
         return False
 
     def get_team_role(self, team: Team) -> TeamRole | None:
         return None
 
     def has_any_project_scope(self, project: Project, scopes: Collection[str]) -> bool:
+        check_scope_declarations(scopes)
         if not self.has_project_access(project):
             return False
 
@@ -888,6 +896,7 @@ class SystemAccess(OrganizationlessAccess):
         return True
 
     def has_scope(self, scope: str) -> bool:
+        check_scope_declaration(scope)
         return True
 
     def has_team_access(self, team: Team) -> bool:

--- a/src/sentry/auth/scope_declaration.py
+++ b/src/sentry/auth/scope_declaration.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any
+
+from sentry_sdk import capture_message, new_scope
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EndpointScopeDeclaration:
+    endpoint: str
+    method: str
+    permission_classes: tuple[str, ...]
+    declared_scopes: frozenset[str]
+    reported_scopes: set[str] = field(default_factory=set)
+
+
+_endpoint_scope_declaration: ContextVar[EndpointScopeDeclaration | None] = ContextVar(
+    "endpoint_scope_declaration", default=None
+)
+
+
+def _qualified_name(value: object) -> str:
+    value_type = value if isinstance(value, type) else type(value)
+    return f"{value_type.__module__}.{value_type.__qualname__}"
+
+
+@contextmanager
+def bind_endpoint_scope_declaration(
+    *, endpoint: str, method: str, permission_classes: Iterable[object]
+) -> Iterator[None]:
+    """Bind the permission declarations used for observational scope auditing.
+
+    The audit unions declarations from every permission class, but each ``scope_map``
+    remains an any-of token admission list. Adding a scope to resolve a warning can
+    therefore broaden endpoint access and requires a separate authorization review.
+    """
+    method = method.upper()
+    declared_scopes: set[str] = set()
+    permission_class_names: list[str] = []
+
+    for permission_class in permission_classes:
+        permission_class_names.append(_qualified_name(permission_class))
+        scope_map: Any = getattr(permission_class, "scope_map", None)
+        if isinstance(scope_map, Mapping):
+            declared_scopes.update(scope_map.get(method, ()))
+
+    token = _endpoint_scope_declaration.set(
+        EndpointScopeDeclaration(
+            endpoint=endpoint,
+            method=method,
+            permission_classes=tuple(permission_class_names),
+            declared_scopes=frozenset(declared_scopes),
+        )
+    )
+    try:
+        yield
+    finally:
+        _endpoint_scope_declaration.reset(token)
+
+
+def check_scope_declaration(scope: str) -> None:
+    declaration = _endpoint_scope_declaration.get()
+    if declaration is None or scope in declaration.declared_scopes:
+        return
+    if scope in declaration.reported_scopes:
+        return
+
+    declaration.reported_scopes.add(scope)
+    event_context = {
+        "endpoint": declaration.endpoint,
+        "method": declaration.method,
+        "scope": scope,
+        "declared_scopes": sorted(declaration.declared_scopes),
+        "permission_classes": declaration.permission_classes,
+    }
+    logger.warning(
+        "api.permission_scope.undeclared",
+        extra=event_context,
+    )
+    with new_scope() as event_scope:
+        event_scope.fingerprint = [
+            "api.permission_scope.undeclared",
+            declaration.endpoint,
+            declaration.method,
+            scope,
+        ]
+        event_scope.set_context("permission_scope", event_context)
+        capture_message("api.permission_scope.undeclared", level="warning")
+
+
+def check_scope_declarations(scopes: Collection[str]) -> None:
+    if isinstance(scopes, str):
+        check_scope_declaration(scopes)
+        return
+    for scope in scopes:
+        check_scope_declaration(scope)

--- a/src/sentry/auth/scope_declaration.py
+++ b/src/sentry/auth/scope_declaration.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from sentry_sdk import capture_message, new_scope
 
+from sentry import options
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,6 +21,7 @@ class EndpointScopeDeclaration:
     permission_classes: tuple[str, ...]
     declared_scopes: frozenset[str]
     reported_scopes: set[str] = field(default_factory=set)
+    audit_enabled: bool | None = None
 
 
 _endpoint_scope_declaration: ContextVar[EndpointScopeDeclaration | None] = ContextVar(
@@ -70,6 +73,10 @@ def check_scope_declaration(scope: str) -> None:
     if declaration is None or scope in declaration.declared_scopes:
         return
     if scope in declaration.reported_scopes:
+        return
+    if declaration.audit_enabled is None:
+        declaration.audit_enabled = options.get("api.permission-scope-audit.enabled")
+    if not declaration.audit_enabled:
         return
 
     declaration.reported_scopes.add(scope)

--- a/src/sentry/auth/scope_declaration.py
+++ b/src/sentry/auth/scope_declaration.py
@@ -19,6 +19,7 @@ class EndpointScopeDeclaration:
     endpoint: str
     method: str
     permission_classes: tuple[str, ...]
+    permission_scopes: dict[str, frozenset[str]]
     declared_scopes: frozenset[str]
     reported_scopes: set[str] = field(default_factory=set)
     audit_enabled: bool | None = None
@@ -47,18 +48,25 @@ def bind_endpoint_scope_declaration(
     method = method.upper()
     declared_scopes: set[str] = set()
     permission_class_names: list[str] = []
+    permission_scopes: dict[str, frozenset[str]] = {}
 
     for permission_class in permission_classes:
-        permission_class_names.append(_qualified_name(permission_class))
+        permission_class_name = _qualified_name(permission_class)
+        permission_class_names.append(permission_class_name)
         scope_map: Any = getattr(permission_class, "scope_map", None)
         if isinstance(scope_map, Mapping):
-            declared_scopes.update(scope_map.get(method, ()))
+            scopes = frozenset(scope_map.get(method, ()))
+            permission_scopes[permission_class_name] = scopes
+            declared_scopes.update(scopes)
+        else:
+            permission_scopes[permission_class_name] = frozenset()
 
     token = _endpoint_scope_declaration.set(
         EndpointScopeDeclaration(
             endpoint=endpoint,
             method=method,
             permission_classes=tuple(permission_class_names),
+            permission_scopes=permission_scopes,
             declared_scopes=frozenset(declared_scopes),
         )
     )
@@ -66,6 +74,27 @@ def bind_endpoint_scope_declaration(
         yield
     finally:
         _endpoint_scope_declaration.reset(token)
+
+
+def update_permission_scope_declaration(
+    permission_class: object, scope_map: Mapping[str, Collection[str]]
+) -> None:
+    declaration = _endpoint_scope_declaration.get()
+    if declaration is None:
+        return
+
+    permission_class_name = _qualified_name(permission_class)
+    if permission_class_name not in declaration.permission_scopes:
+        return
+
+    declaration.permission_scopes[permission_class_name] = frozenset(
+        scope_map.get(declaration.method, ())
+    )
+    declaration.declared_scopes = frozenset(
+        scope
+        for permission_scopes in declaration.permission_scopes.values()
+        for scope in permission_scopes
+    )
 
 
 def check_scope_declaration(scope: str) -> None:

--- a/src/sentry/auth/services/auth/model.py
+++ b/src/sentry/auth/services/auth/model.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from django.http.request import HttpRequest
 from pydantic.fields import Field
 
+from sentry.auth.scope_declaration import check_scope_declaration
 from sentry.hybridcloud.rpc import RpcModel
 from sentry.users.services.user import RpcUser
 
@@ -127,6 +128,7 @@ class AuthenticatedToken(RpcModel):
         return self.scopes
 
     def has_scope(self, scope: str) -> bool:
+        check_scope_declaration(scope)
         if self.kind == "system":
             return True
         return scope in self.get_scopes()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -300,6 +300,13 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "api.permission-scope-audit.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # POST rate limit for ProjectTransferEndpoint, overridable via automator.
 register(
     "api.project-transfer.rate-limit-overrides",

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -242,6 +242,8 @@ class SentryAppPermission(SentryPermission):
     }
 
     def has_object_permission(self, request: Request, view, sentry_app: RpcSentryApp | SentryApp):
+        scope_map = self._scopes_for_sentry_app(sentry_app)
+
         if not hasattr(request, "user") or not request.user:
             return False
 
@@ -276,9 +278,7 @@ class SentryAppPermission(SentryPermission):
         if sentry_app.is_published and request.method == "GET":
             return True
 
-        return ensure_scoped_permission(
-            request, self._scopes_for_sentry_app(sentry_app).get(request.method)
-        )
+        return ensure_scoped_permission(request, scope_map.get(request.method))
 
     def _scopes_for_sentry_app(self, sentry_app):
         scope_map: Mapping[str, Collection[str]]

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Collection, Mapping, Sequence
 from typing import Any
 
 import sentry_sdk
@@ -13,6 +13,7 @@ from sentry import options
 from sentry.api.authentication import ClientIdSecretAuthentication, JWTClientSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
+from sentry.auth.scope_declaration import update_permission_scope_declaration
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser, superuser_has_permission
 from sentry.integrations.api.bases.integration import PARANOID_GET
@@ -280,10 +281,13 @@ class SentryAppPermission(SentryPermission):
         )
 
     def _scopes_for_sentry_app(self, sentry_app):
+        scope_map: Mapping[str, Collection[str]]
         if sentry_app.is_published:
-            return self.published_scope_map
+            scope_map = self.published_scope_map
         else:
-            return self.unpublished_scope_map
+            scope_map = self.unpublished_scope_map
+        update_permission_scope_declaration(self, scope_map)
+        return scope_map
 
 
 class SentryAppAndStaffPermission(StaffPermissionMixin, SentryAppPermission):

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -16,6 +16,7 @@ from sentry.api.base import Endpoint, EndpointSiloLimit, StatsMixin
 from sentry.api.exceptions import SuperuserRequired
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.permissions import SuperuserPermission
+from sentry.auth import access
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.models.apikey import ApiKey
 from sentry.silo.base import FunctionSiloLimit, SiloMode
@@ -39,6 +40,25 @@ class DummyEndpoint(Endpoint):
     permission_classes: tuple[type[BasePermission], ...] = ()
 
     def get(self, request):
+        return Response({"ok": True})
+
+
+class DummyDeclaredScopePermission(AllowAny):
+    scope_map = {"GET": ("org:read",), "POST": ("project:write",)}
+
+
+class DummySecondDeclaredScopePermission(AllowAny):
+    scope_map = {"GET": ("team:read",)}
+
+
+class DummyScopeCheckingEndpoint(Endpoint):
+    permission_classes = (DummyDeclaredScopePermission, DummySecondDeclaredScopePermission)
+
+    def get(self, request):
+        request.access.has_scope("org:read")
+        request.access.has_scope("team:read")
+        request.access.has_scope("project:write")
+        request.access.has_scope("project:write")
         return Response({"ok": True})
 
 
@@ -108,11 +128,84 @@ class DummyPaginationStreamingEndpoint(Endpoint):
 
 
 _dummy_endpoint = DummyEndpoint.as_view()
+_dummy_scope_checking_endpoint = DummyScopeCheckingEndpoint.as_view()
 _dummy_streaming_endpoint = DummyPaginationStreamingEndpoint.as_view()
 
 
 @all_silo_test
 class EndpointTest(APITestCase):
+    @mock.patch("sentry.auth.scope_declaration.new_scope")
+    @mock.patch("sentry.auth.scope_declaration.capture_message")
+    @mock.patch("sentry.auth.scope_declaration.logger.warning")
+    def test_warns_once_for_undeclared_scope(
+        self, warning: MagicMock, capture_message: MagicMock, new_scope: MagicMock
+    ) -> None:
+        request = self.make_request(method="GET")
+
+        with override_options({"api.permission-scope-audit.enabled": True}):
+            response = _dummy_scope_checking_endpoint(request)
+
+        assert response.status_code == 200
+        warning.assert_called_once_with(
+            "api.permission_scope.undeclared",
+            extra={
+                "endpoint": "tests.sentry.api.test_base.DummyScopeCheckingEndpoint",
+                "method": "GET",
+                "scope": "project:write",
+                "declared_scopes": ["org:read", "team:read"],
+                "permission_classes": (
+                    "tests.sentry.api.test_base.DummyDeclaredScopePermission",
+                    "tests.sentry.api.test_base.DummySecondDeclaredScopePermission",
+                ),
+            },
+        )
+        capture_message.assert_called_once_with("api.permission_scope.undeclared", level="warning")
+        event_scope = new_scope.return_value.__enter__.return_value
+        assert event_scope.fingerprint == [
+            "api.permission_scope.undeclared",
+            "tests.sentry.api.test_base.DummyScopeCheckingEndpoint",
+            "GET",
+            "project:write",
+        ]
+        event_scope.set_context.assert_called_once_with(
+            "permission_scope",
+            {
+                "endpoint": "tests.sentry.api.test_base.DummyScopeCheckingEndpoint",
+                "method": "GET",
+                "scope": "project:write",
+                "declared_scopes": ["org:read", "team:read"],
+                "permission_classes": (
+                    "tests.sentry.api.test_base.DummyDeclaredScopePermission",
+                    "tests.sentry.api.test_base.DummySecondDeclaredScopePermission",
+                ),
+            },
+        )
+
+        warning.reset_mock()
+        capture_message.reset_mock()
+        access.DEFAULT.has_scope("project:write")
+        warning.assert_not_called()
+        capture_message.assert_not_called()
+
+        with override_options({"api.permission-scope-audit.enabled": True}):
+            second_response = _dummy_scope_checking_endpoint(self.make_request(method="GET"))
+
+        assert second_response.status_code == 200
+        warning.assert_called_once()
+        capture_message.assert_called_once()
+        assert new_scope.call_count == 2
+
+    @mock.patch("sentry.auth.scope_declaration.capture_message")
+    @mock.patch("sentry.auth.scope_declaration.logger.warning")
+    def test_scope_declaration_audit_is_disabled_by_default(
+        self, warning: MagicMock, capture_message: MagicMock
+    ) -> None:
+        response = _dummy_scope_checking_endpoint(self.make_request(method="GET"))
+
+        assert response.status_code == 200
+        warning.assert_not_called()
+        capture_message.assert_not_called()
+
     def test_basic_cors(self) -> None:
         org = self.create_organization()
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -183,7 +183,7 @@ class EndpointTest(APITestCase):
 
         warning.reset_mock()
         capture_message.reset_mock()
-        access.DEFAULT.has_scope("project:write")
+        access.DEFAULT.has_scope("org:admin")
         warning.assert_not_called()
         capture_message.assert_not_called()
 

--- a/tests/sentry/auth/services/test_model.py
+++ b/tests/sentry/auth/services/test_model.py
@@ -5,6 +5,7 @@ from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.services.auth.serial import serialize_api_key, serialize_api_token
 from sentry.models.apikey import ApiKey
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -14,6 +15,7 @@ class DeclaredScopePermission:
 
 @patch("sentry.auth.scope_declaration.capture_message")
 @patch("sentry.auth.scope_declaration.logger.warning")
+@override_options({"api.permission-scope-audit.enabled": True})
 def test_authenticated_token_reports_undeclared_scope(warning: Mock, capture_message: Mock) -> None:
     token = AuthenticatedToken(kind="api_token", scopes=["org:read"])
 

--- a/tests/sentry/auth/services/test_model.py
+++ b/tests/sentry/auth/services/test_model.py
@@ -1,7 +1,31 @@
+from unittest.mock import Mock, patch
+
+from sentry.auth.scope_declaration import bind_endpoint_scope_declaration
+from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.services.auth.serial import serialize_api_key, serialize_api_token
 from sentry.models.apikey import ApiKey
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
+
+
+class DeclaredScopePermission:
+    scope_map = {"GET": ("org:read",)}
+
+
+@patch("sentry.auth.scope_declaration.capture_message")
+@patch("sentry.auth.scope_declaration.logger.warning")
+def test_authenticated_token_reports_undeclared_scope(warning: Mock, capture_message: Mock) -> None:
+    token = AuthenticatedToken(kind="api_token", scopes=["org:read"])
+
+    with bind_endpoint_scope_declaration(
+        endpoint="test.Endpoint", method="GET", permission_classes=(DeclaredScopePermission,)
+    ):
+        assert token.has_scope("org:read")
+        assert not token.has_scope("project:write")
+
+    assert warning.call_count == 1
+    assert warning.call_args.kwargs["extra"]["scope"] == "project:write"
+    assert capture_message.call_count == 1
 
 
 @control_silo_test

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from sentry.auth import access
 from sentry.auth.access import Access, NoAccess
 from sentry.auth.providers.dummy import DummyProvider
+from sentry.auth.scope_declaration import bind_endpoint_scope_declaration
 from sentry.auth.services.access.service import access_service
 from sentry.auth.superuser import SUPERUSER_READONLY_SCOPES, SUPERUSER_SCOPES
 from sentry.constants import ObjectStatus
@@ -925,6 +926,48 @@ class FromSentryAppTest(AccessFactoryTestCase):
 
 @no_silo_test
 class DefaultAccessTest(TestCase):
+    @patch("sentry.auth.scope_declaration.capture_message")
+    @patch("sentry.auth.scope_declaration.logger.warning")
+    def test_reports_project_and_team_scope_checks_without_access(
+        self, warning: Mock, capture_message: Mock
+    ) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:read",)}
+
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+        ):
+            assert not access.DEFAULT.has_scope("org:read")
+            assert not access.DEFAULT.has_team_scope(Mock(), "team:write")
+            assert not access.DEFAULT.has_project_scope(Mock(), "project:write")
+
+        assert [call.kwargs["extra"]["scope"] for call in warning.call_args_list] == [
+            "team:write",
+            "project:write",
+        ]
+        assert capture_message.call_count == 2
+
+    @patch("sentry.auth.scope_declaration.capture_message")
+    @patch("sentry.auth.scope_declaration.logger.warning")
+    def test_reports_every_scope_in_direct_project_scope_check(
+        self, warning: Mock, capture_message: Mock
+    ) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:read",)}
+
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+        ):
+            assert not access.DEFAULT.has_any_project_scope(
+                Mock(), ["project:read", "project:write"]
+            )
+
+        assert [call.kwargs["extra"]["scope"] for call in warning.call_args_list] == [
+            "project:read",
+            "project:write",
+        ]
+        assert capture_message.call_count == 2
+
     def test_no_access(self) -> None:
         result = access.DEFAULT
         assert result.sso_is_valid

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -926,8 +926,38 @@ class FromSentryAppTest(AccessFactoryTestCase):
 
 @no_silo_test
 class DefaultAccessTest(TestCase):
+    @patch("sentry.auth.scope_declaration.options.get")
+    def test_declared_scope_check_does_not_read_audit_option(self, options_get: Mock) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:read",)}
+
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+        ):
+            assert not access.DEFAULT.has_scope("org:read")
+
+        options_get.assert_not_called()
+
+    def test_disabled_scope_audit_reads_option_once_per_endpoint(self) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:read",)}
+
+        with (
+            patch("sentry.auth.scope_declaration.options.get", return_value=False) as options_get,
+            patch("sentry.auth.scope_declaration.logger.warning") as warning,
+            bind_endpoint_scope_declaration(
+                endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+            ),
+        ):
+            assert not access.DEFAULT.has_scope("project:read")
+            assert not access.DEFAULT.has_scope("project:write")
+
+        options_get.assert_called_once_with("api.permission-scope-audit.enabled")
+        warning.assert_not_called()
+
     @patch("sentry.auth.scope_declaration.capture_message")
     @patch("sentry.auth.scope_declaration.logger.warning")
+    @override_options({"api.permission-scope-audit.enabled": True})
     def test_reports_project_and_team_scope_checks_without_access(
         self, warning: Mock, capture_message: Mock
     ) -> None:
@@ -949,6 +979,7 @@ class DefaultAccessTest(TestCase):
 
     @patch("sentry.auth.scope_declaration.capture_message")
     @patch("sentry.auth.scope_declaration.logger.warning")
+    @override_options({"api.permission-scope-audit.enabled": True})
     def test_reports_every_scope_in_direct_project_scope_check(
         self, warning: Mock, capture_message: Mock
     ) -> None:

--- a/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
+++ b/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
@@ -60,6 +60,31 @@ class SentryAppPermissionTest(TestCase):
         assert warning.call_args.kwargs["extra"]["scope"] == "event:read"
         assert capture_message.call_count == 1
 
+    @patch("sentry.auth.scope_declaration.capture_message")
+    @patch("sentry.auth.scope_declaration.logger.warning")
+    @override_options({"api.permission-scope-audit.enabled": True})
+    def test_unpublished_app_uses_runtime_scope_declaration_for_superuser(
+        self, warning: Mock, capture_message: Mock
+    ) -> None:
+        request = drf_request_from_request(
+            self.make_request(user=self.superuser, method="GET", is_superuser=True)
+        )
+
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint",
+            method="GET",
+            permission_classes=(SentryAppPermission,),
+        ):
+            assert self.permission.has_object_permission(request, APIView(), self.sentry_app)
+            assert not access.DEFAULT.has_scope("org:admin")
+            warning.assert_not_called()
+            capture_message.assert_not_called()
+            assert not access.DEFAULT.has_scope("event:read")
+
+        assert warning.call_count == 1
+        assert warning.call_args.kwargs["extra"]["scope"] == "event:read"
+        assert capture_message.call_count == 1
+
     def test_request_user_is_not_app_owner_fails(self) -> None:
         non_owner = self.create_user()
         self.request = drf_request_from_request(self.make_request(user=non_owner, method="GET"))

--- a/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
+++ b/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
@@ -1,8 +1,12 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test.utils import override_settings
 from rest_framework.views import APIView
 
+from sentry.auth import access
+from sentry.auth.scope_declaration import bind_endpoint_scope_declaration
 from sentry.sentry_apps.api.bases.sentryapps import (
     IntegrationPlatformEndpoint,
     SentryAppAndStaffPermission,
@@ -34,6 +38,27 @@ class SentryAppPermissionTest(TestCase):
 
     def test_request_user_is_app_owner_succeeds(self) -> None:
         assert self.permission.has_object_permission(self.request, APIView(), self.sentry_app)
+
+    @patch("sentry.auth.scope_declaration.capture_message")
+    @patch("sentry.auth.scope_declaration.logger.warning")
+    @override_options({"api.permission-scope-audit.enabled": True})
+    def test_unpublished_app_uses_runtime_scope_declaration(
+        self, warning: Mock, capture_message: Mock
+    ) -> None:
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint",
+            method="GET",
+            permission_classes=(SentryAppPermission,),
+        ):
+            assert self.permission.has_object_permission(self.request, APIView(), self.sentry_app)
+            assert not access.DEFAULT.has_scope("org:admin")
+            warning.assert_not_called()
+            capture_message.assert_not_called()
+            assert not access.DEFAULT.has_scope("event:read")
+
+        assert warning.call_count == 1
+        assert warning.call_args.kwargs["extra"]["scope"] == "event:read"
+        assert capture_message.call_count == 1
 
     def test_request_user_is_not_app_owner_fails(self) -> None:
         non_owner = self.create_user()

--- a/tools/pytest_scope_audit.py
+++ b/tools/pytest_scope_audit.py
@@ -11,19 +11,19 @@ from __future__ import annotations
 
 import json
 from collections import Counter
-from contextlib import AbstractContextManager
+from contextlib import ExitStack
 from typing import Any
+from unittest.mock import patch
 
 Finding = tuple[str, str, str, tuple[str, ...], tuple[str, ...]]
 
 _findings: Counter[Finding] = Counter()
-_options_override: AbstractContextManager[None] | None = None
+_scope_audit_stack: ExitStack | None = None
 
 
 def pytest_configure() -> None:
-    global _options_override
+    global _scope_audit_stack
 
-    from sentry.auth import scope_declaration
     from sentry.testutils.helpers.options import override_options
 
     def record_warning(message: str, *, extra: dict[str, Any]) -> None:
@@ -43,15 +43,19 @@ def pytest_configure() -> None:
         # endpoint test run deliberately exercises known declaration gaps.
         pass
 
-    scope_declaration.logger.warning = record_warning
-    scope_declaration.capture_message = discard_capture_message
-    _options_override = override_options({"api.permission-scope-audit.enabled": True})
-    _options_override.__enter__()
+    _scope_audit_stack = ExitStack()
+    _scope_audit_stack.enter_context(
+        patch("sentry.auth.scope_declaration.logger.warning", record_warning)
+    )
+    _scope_audit_stack.enter_context(
+        patch("sentry.auth.scope_declaration.capture_message", discard_capture_message)
+    )
+    _scope_audit_stack.enter_context(override_options({"api.permission-scope-audit.enabled": True}))
 
 
 def pytest_unconfigure() -> None:
-    if _options_override is not None:
-        _options_override.__exit__(None, None, None)
+    if _scope_audit_stack is not None:
+        _scope_audit_stack.close()
 
 
 def pytest_sessionfinish() -> None:

--- a/tools/pytest_scope_audit.py
+++ b/tools/pytest_scope_audit.py
@@ -1,0 +1,73 @@
+"""Collect undeclared permission-scope checks while running existing endpoint tests.
+
+Example:
+    .venv/bin/python -m pytest -q --reuse-db -p tools.pytest_scope_audit \
+        tests/sentry/core/endpoints/test_team_projects.py
+
+Run without pytest-xdist so findings can be aggregated in one process.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from contextlib import AbstractContextManager
+from typing import Any
+
+Finding = tuple[str, str, str, tuple[str, ...], tuple[str, ...]]
+
+_findings: Counter[Finding] = Counter()
+_options_override: AbstractContextManager[None] | None = None
+
+
+def pytest_configure() -> None:
+    global _options_override
+
+    from sentry.auth import scope_declaration
+    from sentry.testutils.helpers.options import override_options
+
+    def record_warning(message: str, *, extra: dict[str, Any]) -> None:
+        assert message == "api.permission_scope.undeclared"
+        _findings[
+            (
+                extra["endpoint"],
+                extra["method"],
+                extra["scope"],
+                tuple(extra["declared_scopes"]),
+                tuple(extra["permission_classes"]),
+            )
+        ] += 1
+
+    def discard_capture_message(*args: Any, **kwargs: Any) -> None:
+        # The warning is the audit signal. Avoid creating SDK events while a broad
+        # endpoint test run deliberately exercises known declaration gaps.
+        pass
+
+    scope_declaration.logger.warning = record_warning
+    scope_declaration.capture_message = discard_capture_message
+    _options_override = override_options({"api.permission-scope-audit.enabled": True})
+    _options_override.__enter__()
+
+
+def pytest_unconfigure() -> None:
+    if _options_override is not None:
+        _options_override.__exit__(None, None, None)
+
+
+def pytest_sessionfinish() -> None:
+    for finding, count in sorted(_findings.items()):
+        endpoint, method, scope, declared_scopes, permission_classes = finding
+        print(
+            "SCOPE_AUDIT_SUMMARY "
+            + json.dumps(
+                {
+                    "count": count,
+                    "declared_scopes": declared_scopes,
+                    "endpoint": endpoint,
+                    "method": method,
+                    "permission_classes": permission_classes,
+                    "scope": scope,
+                },
+                sort_keys=True,
+            )
+        )


### PR DESCRIPTION
API endpoints can now report when their implementation checks a permission
scope that is absent from the current method's permission-class declarations.
When the default-off `api.permission-scope-audit.enabled` option is enabled,
dispatch binds the endpoint declaration for the request and centralized access
checks emit one structured warning and warning-level Sentry event per scope,
with stable endpoint, method, and scope grouping.

Permission `scope_map` entries remain any-of token admission lists, so findings
are diagnostic and should receive an authorization review rather than being
resolved by automatically adding scopes. A pytest plugin enables the audit for
existing endpoint suites, aggregates findings, and suppresses only the
detector's event capture during audit runs.
