### PR TITLE
fix(replays): pause without seeking when the tab is hidden

### DIFF
--- a/static/app/components/replays/replayContext.spec.tsx
+++ b/static/app/components/replays/replayContext.spec.tsx
@@ -1,0 +1,164 @@
+import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  Provider as ReplayContextProvider,
+  useReplayContext,
+} from 'sentry/components/replays/replayContext';
+import {ReplayReader} from 'sentry/utils/replays/replayReader';
+import {EventType} from 'sentry/utils/replays/types';
+
+const mockPause = jest.fn();
+const mockPlay = jest.fn();
+const mockVideoPause = jest.fn();
+const mockVideoPlay = jest.fn();
+
+jest.mock('@sentry-internal/rrweb', () => {
+  const actual = jest.requireActual('@sentry-internal/rrweb');
+  return {
+    ...actual,
+    Replayer: jest.fn().mockImplementation(() => ({
+      config: {skipInactive: false, speed: 1},
+      destroy: jest.fn(),
+      getCurrentTime: () => 0,
+      getMirror: () => null,
+      iframe: document.createElement('iframe'),
+      on: jest.fn(),
+      pause: mockPause,
+      play: mockPlay,
+      setConfig: jest.fn(),
+      wrapper: document.createElement('div'),
+    })),
+  };
+});
+
+jest.mock('sentry/components/replays/videoReplayerWithInteractions', () => ({
+  VideoReplayerWithInteractions: jest.fn().mockImplementation(() => ({
+    config: {skipInactive: false, speed: 1},
+    destroy: jest.fn(),
+    getCurrentTime: () => 0,
+    pause: mockVideoPause,
+    play: mockVideoPlay,
+    setConfig: jest.fn(),
+  })),
+}));
+
+const startedAt = new Date('2023-12-25T00:00:00');
+
+function TestPlayer() {
+  const {setRoot, togglePlayPause} = useReplayContext();
+
+  return (
+    <div ref={setRoot}>
+      <button onClick={() => togglePlayPause(true)}>Play</button>
+      <button onClick={() => togglePlayPause(false)}>Pause</button>
+    </div>
+  );
+}
+
+function VideoFrameEventFixture() {
+  return {
+    type: EventType.Custom,
+    timestamp: startedAt.getTime(),
+    data: {
+      tag: 'video',
+      payload: {duration: 5_000, segmentId: 0},
+    },
+  };
+}
+
+function renderPlayer({video}: {video?: boolean} = {}) {
+  const replay = ReplayReader.factory({
+    attachments: video
+      ? [VideoFrameEventFixture()]
+      : RRWebInitFrameEventsFixture({timestamp: startedAt}),
+    errors: [],
+    fetching: false,
+    replayRecord: ReplayRecordFixture({started_at: startedAt}),
+  });
+
+  return render(
+    <ReplayContextProvider analyticsContext="" isFetching={false} replay={replay}>
+      <TestPlayer />
+    </ReplayContextProvider>
+  );
+}
+
+async function startPlaying() {
+  await userEvent.click(screen.getByRole('button', {name: 'Play'}));
+  // Starting playback also seeks, which is not what these tests are about
+  jest.clearAllMocks();
+}
+
+function setVisibility(visibilityState: 'hidden' | 'visible') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: visibilityState,
+  });
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+describe('replayContext', () => {
+  afterEach(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+  });
+
+  it('pauses without seeking when the tab is hidden while playing', async () => {
+    renderPlayer();
+    await startPlaying();
+
+    setVisibility('hidden');
+
+    expect(mockPause).toHaveBeenCalledWith();
+  });
+
+  it('pauses with the current time when the tab is hidden during a video replay', async () => {
+    renderPlayer({video: true});
+    await startPlaying();
+
+    setVisibility('hidden');
+
+    expect(mockVideoPause).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it('does not pause when the tab becomes visible while playing', async () => {
+    renderPlayer();
+    await startPlaying();
+
+    setVisibility('visible');
+
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it('does not pause when the tab is hidden while already paused', () => {
+    renderPlayer();
+
+    setVisibility('hidden');
+
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it('seeks to the current time when the user pauses', async () => {
+    renderPlayer();
+    await startPlaying();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Pause'}));
+
+    expect(mockPause).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it('seeks to the current time when the user plays', async () => {
+    renderPlayer();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Play'}));
+
+    expect(mockPlay).toHaveBeenCalledWith(expect.any(Number));
+  });
+});

--- a/static/app/components/replays/replayContext.spec.tsx
+++ b/static/app/components/replays/replayContext.spec.tsx
@@ -1,3 +1,4 @@
+import {ReplayerEvents} from '@sentry-internal/rrweb';
 import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
@@ -14,6 +15,7 @@ const mockPause = jest.fn();
 const mockPlay = jest.fn();
 const mockVideoPause = jest.fn();
 const mockVideoPlay = jest.fn();
+const mockReplayerHandlers = new Map<string, (arg: any) => void>();
 
 jest.mock('@sentry-internal/rrweb', () => {
   const actual = jest.requireActual('@sentry-internal/rrweb');
@@ -25,7 +27,9 @@ jest.mock('@sentry-internal/rrweb', () => {
       getCurrentTime: () => 0,
       getMirror: () => null,
       iframe: document.createElement('iframe'),
-      on: jest.fn(),
+      on: jest.fn((event: string, handler: (arg: any) => void) => {
+        mockReplayerHandlers.set(event, handler);
+      }),
       pause: mockPause,
       play: mockPlay,
       setConfig: jest.fn(),
@@ -48,12 +52,13 @@ jest.mock('sentry/components/replays/videoReplayerWithInteractions', () => ({
 const startedAt = new Date('2023-12-25T00:00:00');
 
 function TestPlayer() {
-  const {setRoot, togglePlayPause} = useReplayContext();
+  const {fastForwardSpeed, setRoot, togglePlayPause} = useReplayContext();
 
   return (
     <div ref={setRoot}>
       <button onClick={() => togglePlayPause(true)}>Play</button>
       <button onClick={() => togglePlayPause(false)}>Pause</button>
+      <span>Fast forward: {fastForwardSpeed}</span>
     </div>
   );
 }
@@ -90,6 +95,12 @@ async function startPlaying() {
   await userEvent.click(screen.getByRole('button', {name: 'Play'}));
   // Starting playback also seeks, which is not what these tests are about
   jest.clearAllMocks();
+}
+
+function startFastForwarding() {
+  act(() => {
+    mockReplayerHandlers.get(ReplayerEvents.SkipStart)?.({speed: 8});
+  });
 }
 
 function setVisibility(visibilityState: 'hidden' | 'visible') {
@@ -160,5 +171,25 @@ describe('replayContext', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Play'}));
 
     expect(mockPlay).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it('clears the fast forward speed when the tab is hidden while skipping', async () => {
+    renderPlayer();
+    await startPlaying();
+    startFastForwarding();
+
+    setVisibility('hidden');
+
+    expect(screen.getByText('Fast forward: 0')).toBeInTheDocument();
+  });
+
+  it('keeps the fast forward speed when the tab stays visible while skipping', async () => {
+    renderPlayer();
+    await startPlaying();
+    startFastForwarding();
+
+    setVisibility('visible');
+
+    expect(screen.getByText('Fast forward: 8')).toBeInTheDocument();
   });
 });

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -513,7 +513,7 @@ export function Provider({
   }, [replayId, isFetching]);
 
   const togglePlayPause = useCallback(
-    (play: boolean) => {
+    (play: boolean, {seek = true} = {}) => {
       const replayer = replayerRef.current;
       if (!replayer) {
         return;
@@ -521,8 +521,10 @@ export function Provider({
 
       if (play) {
         replayer.play(getCurrentPlayerTime());
-      } else {
+      } else if (seek) {
         replayer.pause(getCurrentPlayerTime());
+      } else {
+        replayer.pause();
       }
       setIsPlaying(play);
 
@@ -545,7 +547,11 @@ export function Provider({
 
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible' && replayerRef.current) {
-        togglePlayPause(false);
+        // Seeking makes rrweb rebuild the snapshot inside the player iframe.
+        // This event also fires while the tab is unloading, when the browser
+        // has already torn that document down and the rebuild throws. Video
+        // replays still need the offset, to seek the <video> element itself.
+        togglePlayPause(false, {seek: isVideoReplay});
       }
     };
 
@@ -554,7 +560,7 @@ export function Provider({
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [togglePlayPause, isPlaying]);
+  }, [togglePlayPause, isPlaying, isVideoReplay]);
 
   // Initialize replayer for Video Replays
   useEffect(() => {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -547,10 +547,6 @@ export function Provider({
 
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible' && replayerRef.current) {
-        // Seeking makes rrweb rebuild the snapshot inside the player iframe.
-        // This event also fires while the tab is unloading, when the browser
-        // has already torn that document down and the rebuild throws. Video
-        // replays still need the offset, to seek the <video> element itself.
         togglePlayPause(false, {seek: isVideoReplay});
       }
     };

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -548,6 +548,9 @@ export function Provider({
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible' && replayerRef.current) {
         togglePlayPause(false, {seek: isVideoReplay});
+        // Pausing without a seek skips rrweb's `backToNormal()`, so `SkipEnd`
+        // never fires to clear this
+        setFFSpeed(0);
       }
     };
 


### PR DESCRIPTION
Replay playback throws `HierarchyRequestError: Failed to execute 'appendChild' on 'Node': Can't insert a doctype after the root element.` from inside rrweb's `buildNodeWithSN`. 

### The Problem

`ReplayContext` pauses the replay when the tab loses focus, via `replayer.pause(getCurrentPlayerTime())`. rrweb's `pause(timeOffset)` calls `play(timeOffset)` internally, which re-plays synchronously and rebuilds the full snapshot into the player iframe.

`rebuild()` starts with `doc.close(); doc.open()` to empty that iframe document. But `visibilitychange` also fires while the tab is being closed or navigated away from, and the browser has aborted the iframe's document by then. The document keeps the `<html>` root it got from `about:blank`, so appending the snapshot's `<!DOCTYPE>` throws.

### The Fix

Pause in place on `visibilitychange` instead of seeking. Seeking to the time the player is already at only costs a redundant rebuild for the rrweb player. Video replays keep passing the offset, which the `<video>` element needs in order to seek.

The seek is intentionally left in place for user-initiated pauses: rrweb's `play()` also calls `backToNormal()`, so dropping the offset there would leave the "fast forwarding ×N" indicator stuck when pausing mid-skip.

`replayContext.tsx` had no tests, so this adds a spec covering the pause/play paths and the visibility handler. I like testing. 🧪 

Closes JAVASCRIPT-3371. Closes REPLAY-993.