### PR TITLE
ref(metrics): Remove queries against the unavailable generic metrics storage

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -163,9 +163,11 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         result = get_dataset(dataset_label)
         if result is None:
             raise ParseError(detail=f"dataset must be one of: {', '.join(PUBLIC_DATASET_LABELS)}")
-        if result is metrics_performance:
-            # Scoped to the events endpoints: alerts resolve `metrics` through
-            # sentry.snuba.utils to identify the sessions dataset.
+        if result is metrics_performance and request.GET.get("useOnDemandMetrics") != "true":
+            # On-demand extraction still reads generic metrics, and relies on an
+            # incompatible query erroring rather than falling back. Scoped to the events
+            # endpoints: alerts resolve `metrics` through sentry.snuba.utils to identify
+            # the sessions dataset.
             result = metrics_enhanced_performance
         sentry_sdk.set_tag("query.dataset", dataset_label)
         sentry_sdk.set_attribute("query.dataset", dataset_label)

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -164,10 +164,6 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if result is None:
             raise ParseError(detail=f"dataset must be one of: {', '.join(PUBLIC_DATASET_LABELS)}")
         if result is metrics_performance and request.GET.get("useOnDemandMetrics") != "true":
-            # On-demand extraction still reads generic metrics, and relies on an
-            # incompatible query erroring rather than falling back. Scoped to the events
-            # endpoints: alerts resolve `metrics` through sentry.snuba.utils to identify
-            # the sessions dataset.
             result = metrics_enhanced_performance
         sentry_sdk.set_tag("query.dataset", dataset_label)
         sentry_sdk.set_attribute("query.dataset", dataset_label)

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -54,7 +54,7 @@ from sentry.search.eap.types import AdditionalQueries, SupportedTraceItemType
 from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS
 from sentry.search.events.fields import get_function_alias, is_function
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
-from sentry.snuba import discover
+from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.utils import (
@@ -163,6 +163,10 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         result = get_dataset(dataset_label)
         if result is None:
             raise ParseError(detail=f"dataset must be one of: {', '.join(PUBLIC_DATASET_LABELS)}")
+        if result is metrics_performance:
+            # Scoped to the events endpoints: alerts resolve `metrics` through
+            # sentry.snuba.utils to identify the sessions dataset.
+            result = metrics_enhanced_performance
         sentry_sdk.set_tag("query.dataset", dataset_label)
         sentry_sdk.set_attribute("query.dataset", dataset_label)
         return result

--- a/src/sentry/api/endpoints/organization_measurements_meta.py
+++ b/src/sentry/api/endpoints/organization_measurements_meta.py
@@ -4,12 +4,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
-from sentry.search.events.constants import METRIC_FUNCTION_LIST_BY_TYPE
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.snuba.metrics.datasource import get_custom_measurements
-from sentry.utils.tracing import start_span
 
 
 @cell_silo_endpoint
@@ -20,26 +15,8 @@ class OrganizationMeasurementsMeta(OrganizationEventsEndpointBase):
 
     def get(self, request: Request, organization: Organization) -> Response:
         try:
-            snuba_params = self.get_snuba_params(request, organization)
+            self.get_snuba_params(request, organization)
         except NoProjects:
             return Response({})
 
-        with handle_query_errors():
-            metric_meta = get_custom_measurements(
-                project_ids=snuba_params.project_ids,
-                organization_id=organization.id,
-                start=snuba_params.start_date,
-                end=snuba_params.end_date,
-                use_case_id=UseCaseID.TRANSACTIONS,
-            )
-
-        with start_span(op="transform", name="metric meta"):
-            result = {
-                item["name"]: {
-                    "functions": METRIC_FUNCTION_LIST_BY_TYPE[item["type"]],
-                    "unit": item["unit"],
-                }
-                for item in metric_meta
-            }
-
-        return Response(result)
+        return Response({})

--- a/src/sentry/api/endpoints/organization_measurements_meta.py
+++ b/src/sentry/api/endpoints/organization_measurements_meta.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.models.organization import Organization
 
 
@@ -14,9 +14,4 @@ class OrganizationMeasurementsMeta(OrganizationEventsEndpointBase):
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-        try:
-            self.get_snuba_params(request, organization)
-        except NoProjects:
-            return Response({})
-
         return Response({})

--- a/src/sentry/api/endpoints/project_statistical_detectors.py
+++ b/src/sentry/api/endpoints/project_statistical_detectors.py
@@ -8,10 +8,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models.project import Project
 from sentry.search.utils import parse_datetime_string
-from sentry.tasks.statistical_detectors import (
-    _detect_function_change_points,
-    _detect_transaction_change_points,
-)
+from sentry.tasks.statistical_detectors import _detect_function_change_points
 
 
 @cell_silo_endpoint
@@ -35,11 +32,6 @@ class ProjectStatisticalDetectors(ProjectEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"details": "Invalid value for end"},
             )
-
-        transaction = request.GET.get("transaction")
-        if transaction is not None:
-            _detect_transaction_change_points([(project.id, transaction)], timestamp)
-            return Response(status=status.HTTP_202_ACCEPTED)
 
         fingerprint = request.GET.get("function")
         if fingerprint is not None:

--- a/src/sentry/api/endpoints/project_statistical_detectors.py
+++ b/src/sentry/api/endpoints/project_statistical_detectors.py
@@ -47,5 +47,5 @@ class ProjectStatisticalDetectors(ProjectEndpoint):
 
         return Response(
             status=status.HTTP_400_BAD_REQUEST,
-            data={"details": "Missing transaction or fingerprint"},
+            data={"details": "Missing fingerprint"},
         )

--- a/src/sentry/core/endpoints/organization_projects.py
+++ b/src/sentry/core/endpoints/organization_projects.py
@@ -59,7 +59,7 @@ from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.utils import tokenize_query
 from sentry.signals import project_created, team_created
-from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
+from sentry.snuba import discover, metrics_enhanced_performance
 from sentry.users.models.user import User
 from sentry.utils.snowflake import MaxSnowflakeRetryError
 
@@ -89,7 +89,7 @@ DATASETS = {
     "": discover,  # in case they pass an empty query string fall back on default
     "discover": discover,
     "metricsEnhanced": metrics_enhanced_performance,
-    "metrics": metrics_performance,
+    "metrics": metrics_enhanced_performance,
 }
 
 CONFLICTING_TEAM_SLUG_ERROR = "A team with this slug already exists."

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -221,14 +221,13 @@ class ArithmeticVisitor(NodeVisitor):
         "trace_status_rate",
     }
 
-    def __init__(self, max_operators: int | None, custom_measurements: set[str] | None):
+    def __init__(self, max_operators: int | None):
         super().__init__()
         self.operators: int = 0
         self.terms: int = 0
         self.max_operators = max_operators if max_operators else self.DEFAULT_MAX_OPERATORS
         self.fields: set[str] = set()
         self.functions: set[str] = set()
-        self.custom_measurements: set[str] = custom_measurements or set()
 
     def visit_term(self, _, children):
         maybe_factor, remaining_adds = children
@@ -300,7 +299,7 @@ class ArithmeticVisitor(NodeVisitor):
 
     def visit_field_value(self, node, _):
         field = node.text
-        if field not in self.field_allowlist and field not in self.custom_measurements:
+        if field not in self.field_allowlist:
             raise ArithmeticValidationError(f"{field} not allowed in arithmetic")
         self.fields.add(field)
         return field
@@ -322,7 +321,6 @@ class ArithmeticVisitor(NodeVisitor):
 def parse_arithmetic(
     equation: str,
     max_operators: int | None = None,
-    custom_measurements: set[str] | None = None,
     *,
     validate_single_operator: Literal[True],
 ) -> tuple[Operation, list[str], list[str]]: ...
@@ -332,14 +330,12 @@ def parse_arithmetic(
 def parse_arithmetic(
     equation: str,
     max_operators: int | None = None,
-    custom_measurements: set[str] | None = None,
 ) -> tuple[Operation | float | str, list[str], list[str]]: ...
 
 
 def parse_arithmetic(
     equation: str,
     max_operators: int | None = None,
-    custom_measurements: set[str] | None = None,
     validate_single_operator: bool = False,
 ) -> tuple[Operation | float | str, list[str], list[str]]:
     """Given a string equation try to parse it into a set of Operations"""
@@ -349,7 +345,7 @@ def parse_arithmetic(
         raise ArithmeticParseError(
             "Unable to parse your equation, make sure it is well formed arithmetic"
         )
-    visitor = ArithmeticVisitor(max_operators, custom_measurements)
+    visitor = ArithmeticVisitor(max_operators)
     result = visitor.visit(tree)
     # total count is the exception to the no mixing rule
     if (
@@ -370,7 +366,6 @@ def resolve_equation_list(
     aggregates_only: bool = False,
     auto_add: bool = False,
     plain_math: bool = False,
-    custom_measurements: set[str] | None = None,
 ) -> tuple[list[str], list[ParsedEquation]]:
     """Given a list of equation strings, resolve them to their equivalent snuba json query formats
     :param equations: list of equations strings that haven't been parsed yet
@@ -385,7 +380,7 @@ def resolve_equation_list(
     resolved_columns: list[str] = selected_columns[:]
     for index, equation in enumerate(equations):
         parsed_equation, fields, functions = parse_arithmetic(
-            equation, None, custom_measurements, validate_single_operator=True
+            equation, None, validate_single_operator=True
         )
 
         if (len(fields) == 0 and len(functions) == 0) and not plain_math:

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import datetime
 from re import Match
 from typing import Any, Union, cast
 
 import sentry_sdk
-from django.utils.functional import cached_property
 from parsimonious.exceptions import ParseError
 from snuba_sdk import (
     AliasedExpression,
@@ -29,7 +28,6 @@ from snuba_sdk import (
     Request,
 )
 
-from sentry import features
 from sentry.api import event_search
 from sentry.discover.arithmetic import (
     OperandType,
@@ -57,7 +55,6 @@ from sentry.search.events.types import (
     WhereType,
 )
 from sentry.snuba.dataset import Dataset, EntityKey
-from sentry.snuba.metrics.utils import MetricMeta
 from sentry.snuba.query_sources import QuerySource
 from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start
@@ -650,7 +647,6 @@ class BaseQueryBuilder:
                     if self.builder_config.equation_config
                     else {}
                 ),
-                custom_measurements=self.get_custom_measurement_names_set(),
             )
             for index, parsed_equation in enumerate(parsed_equations):
                 resolved_equation = self.resolve_equation(
@@ -989,53 +985,6 @@ class BaseQueryBuilder:
 
         return flattened
 
-    @cached_property
-    def custom_measurement_map(self) -> Sequence[MetricMeta]:
-        # Both projects & org are required, but might be missing for the search parser
-        if self.organization_id is None or not self.builder_config.has_metrics:
-            return []
-
-        from sentry.snuba.metrics.datasource import get_custom_measurements
-
-        should_use_user_time_range = self.params.organization is not None and features.has(
-            "organizations:performance-discover-get-custom-measurements-reduced-range",
-            self.params.organization,
-            actor=None,
-        )
-
-        start = (
-            self.params.start
-            if should_use_user_time_range
-            else datetime.today() - timedelta(days=90)
-        )
-        end = self.params.end if should_use_user_time_range else datetime.today()
-
-        try:
-            result = get_custom_measurements(
-                project_ids=self.params.project_ids,
-                organization_id=self.organization_id,
-                start=start,
-                end=end,
-            )
-        # Don't fully fail if we can't get the CM, but still capture the exception
-        except Exception as error:
-            sentry_sdk.capture_exception(error)
-            return []
-        return result
-
-    def get_custom_measurement_names_set(self) -> set[str]:
-        return {measurement["name"] for measurement in self.custom_measurement_map}
-
-    def get_measurement_by_name(self, name: str) -> MetricMeta | None:
-        # Skip the iteration if its not a measurement, which can save a custom measurement query entirely
-        if not is_measurement(name):
-            return None
-
-        for measurement in self.custom_measurement_map:
-            if measurement["name"] == name:
-                return measurement
-        return None
-
     def get_field_type(self, field: str) -> str | None:
         if field in self.meta_resolver_map:
             return self.meta_resolver_map[field]
@@ -1054,20 +1003,8 @@ class BaseQueryBuilder:
         if unit := self.size_fields.get(field):
             return unit
 
-        measurement = self.get_measurement_by_name(field)
         # let the caller decide what to do
-        if measurement is None:
-            return None
-
-        unit = measurement["unit"]
-        if unit in constants.SIZE_UNITS or unit in constants.DURATION_UNITS:
-            return unit
-        elif unit == "none":
-            return "integer"
-        elif unit in constants.PERCENT_UNITS:
-            return "percentage"
-        else:
-            return "number"
+        return None
 
     def validate_having_clause(self) -> None:
         """Validate that the functions in having are selected columns

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -484,29 +484,6 @@ METRIC_PERCENTILES = {
 }
 
 CUSTOM_MEASUREMENT_PATTERN = re.compile(r"^measurements\..+$")
-METRIC_FUNCTION_LIST_BY_TYPE = {
-    "generic_distribution": [
-        "apdex",
-        "avg",
-        "p50",
-        "p75",
-        "p90",
-        "p95",
-        "p99",
-        "p100",
-        "max",
-        "min",
-        "sum",
-        "percentile",
-        "http_error_count",
-        "http_error_rate",
-    ],
-    "generic_set": [
-        "count_miserable",
-        "user_misery",
-        "count_unique",
-    ],
-}
 
 # The limit in snuba currently for a single query is 131,535bytes, including room for other parameters picking 120,000
 # for now

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -70,12 +70,6 @@ class MetricsDatasetConfig(DatasetConfig):
         mri_map = constants.SPAN_METRICS_MAP | constants.METRICS_MAP
         metric_id = self.builder.resolve_metric_index(mri_map.get(value, value))
         if metric_id is None:
-            # Maybe this is a custom measurment?
-            for measurement in self.builder.custom_measurement_map:
-                if measurement["name"] == value and measurement["metric_id"] is not None:
-                    metric_id = measurement["metric_id"]
-        # If its still None its not a custom measurement
-        if metric_id is None:
             raise IncompatibleMetricsQuery(f"Metric: {value} could not be resolved")
         self.builder.metric_ids.add(metric_id)
         return metric_id
@@ -91,8 +85,6 @@ class MetricsDatasetConfig(DatasetConfig):
         """While the final functions in clickhouse must have their -Merge combinators in order to function, we don't
         need to add them here since snuba has a FunctionMapper that will add it for us. Basically it turns expressions
         like quantiles(0.9)(value) into quantilesMerge(0.9)(percentiles)
-        Make sure to update METRIC_FUNCTION_LIST_BY_TYPE when adding functions here, can't be a dynamic list since the
-        Metric Layer will actually handle which dataset each function goes to
         """
         resolve_metric_id = {
             "name": "metric_id",

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -87,8 +87,6 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         """While the final functions in clickhouse must have their -Merge combinators in order to function, we don't
         need to add them here since snuba has a FunctionMapper that will add it for us. Basically it turns expressions
         like quantiles(0.9)(value) into quantilesMerge(0.9)(percentiles)
-        Make sure to update METRIC_FUNCTION_LIST_BY_TYPE when adding functions here, can't be a dynamic list since the
-        Metric Layer will actually handle which dataset each function goes to
         """
         resolve_metric_id = {
             "name": "metric_id",

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -32,16 +32,15 @@ from sentry.sentry_metrics.utils import (
     bulk_reverse_resolve_tag_value,
     resolve_tag_key,
 )
-from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.fields import run_metrics_query
 from sentry.snuba.metrics.fields.base import (
     CompositeEntityDerivedMetric,
-    SnubaDataType,
     get_derived_metrics,
     org_id_from_projects,
 )
 from sentry.snuba.metrics.naming_layer.mapping import get_mri
-from sentry.snuba.metrics.naming_layer.mri import is_custom_measurement, is_mri, parse_mri
+from sentry.snuba.metrics.naming_layer.mri import is_mri
 from sentry.snuba.metrics.query import DeprecatingMetricsQuery, Groupable, MetricField
 from sentry.snuba.metrics.query_builder import (
     SnubaQueryBuilder,
@@ -49,14 +48,9 @@ from sentry.snuba.metrics.query_builder import (
     translate_meta_results,
 )
 from sentry.snuba.metrics.utils import (
-    AVAILABLE_GENERIC_OPERATIONS,
-    CUSTOM_MEASUREMENT_DATASETS,
-    METRIC_TYPE_TO_ENTITY,
-    METRIC_TYPE_TO_METRIC_ENTITY,
     UNALLOWED_TAGS,
     DerivedMetricParseException,
     MetricDoesNotExistInIndexer,
-    MetricMeta,
     MetricType,
     NotSupportedOverCompositeEntityException,
     Tag,
@@ -76,28 +70,6 @@ __all__ = (
 
 
 logger = logging.getLogger(__name__)
-
-
-def _get_metrics_for_entity(
-    entity_key: EntityKey,
-    project_ids: Sequence[int],
-    org_id: int,
-    use_case_id: UseCaseID,
-    start: datetime | None = None,
-    end: datetime | None = None,
-) -> list[SnubaDataType]:
-    return run_metrics_query(
-        entity_key=entity_key,
-        select=[Column("metric_id")],
-        groupby=[Column("metric_id")],
-        where=[Condition(Column("use_case_id"), Op.EQ, use_case_id.value)],
-        referrer="snuba.metrics.get_metrics_names_for_entity",
-        project_ids=project_ids,
-        org_id=org_id,
-        use_case_id=use_case_id,
-        start=start,
-        end=end,
-    )
 
 
 def get_available_derived_metrics(
@@ -151,49 +123,6 @@ def get_available_derived_metrics(
             found_derived_metrics.add(composite_derived_metric_obj.metric_mri)
 
     return found_derived_metrics.intersection(get_derived_metrics())
-
-
-def get_custom_measurements(
-    project_ids: Sequence[int],
-    organization_id: int,
-    start: datetime | None = None,
-    end: datetime | None = None,
-    use_case_id: UseCaseID = UseCaseID.TRANSACTIONS,
-) -> Sequence[MetricMeta]:
-    assert project_ids
-
-    metrics_meta = []
-    for metric_type in CUSTOM_MEASUREMENT_DATASETS:
-        rows = _get_metrics_for_entity(
-            entity_key=METRIC_TYPE_TO_ENTITY[metric_type],
-            project_ids=project_ids,
-            org_id=organization_id,
-            use_case_id=use_case_id,
-            start=start,
-            end=end,
-        )
-
-        mri_indexes = {row["metric_id"] for row in rows}
-        mris = bulk_reverse_resolve(use_case_id, organization_id, mri_indexes)
-
-        for row in rows:
-            mri_index = row["metric_id"]
-            parsed_mri = parse_mri(mris.get(mri_index))
-            if parsed_mri is not None and is_custom_measurement(parsed_mri):
-                metrics_meta.append(
-                    MetricMeta(
-                        name=parsed_mri.name,
-                        type=metric_type,
-                        operations=AVAILABLE_GENERIC_OPERATIONS[
-                            METRIC_TYPE_TO_METRIC_ENTITY[metric_type]
-                        ],
-                        unit=parsed_mri.unit,
-                        metric_id=row["metric_id"],
-                        mri=parsed_mri.mri_string,
-                    )
-                )
-
-    return metrics_meta
 
 
 def _get_metrics_filter_ids(

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -43,7 +43,6 @@ __all__ = (
     "get_num_intervals",
     "to_intervals",
     "OP_REGEX",
-    "CUSTOM_MEASUREMENT_DATASETS",
     "DATASET_COLUMNS",
     "NON_RESOLVABLE_TAG_VALUES",
 )
@@ -380,7 +379,6 @@ UNALLOWED_TAGS = {"session.status"}
 DATASET_COLUMNS = {"project_id", "metric_id"}
 
 # Custom measurements are always extracted as a distribution
-CUSTOM_MEASUREMENT_DATASETS: frozenset[MetricType] = frozenset(("generic_distribution",))
 
 
 def combine_dictionary_of_list_values[K, V](

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -9,19 +9,11 @@ from django.utils import timezone as django_timezone
 from snuba_sdk import (
     And,
     BooleanCondition,
-    BooleanOp,
     Column,
     Condition,
-    CurriedFunction,
-    Direction,
-    Entity,
-    Function,
-    Granularity,
     Limit,
-    LimitBy,
     Op,
     Or,
-    OrderBy,
     Query,
     Request,
     Storage,
@@ -38,12 +30,8 @@ from sentry.search.events.fields import resolve_datetime64
 from sentry.search.events.types import SnubaParams
 from sentry.seer.breakpoints import BreakpointData
 from sentry.seer.signed_seer_api import SeerViewerContext
-from sentry.sentry_metrics import indexer
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba import functions
-from sentry.snuba.dataset import Dataset, EntityKey, StorageKey
-from sentry.snuba.discover import zerofill
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.snuba.dataset import Dataset, StorageKey
 from sentry.snuba.referrer import Referrer
 from sentry.statistical_detectors.algorithm import (
     DetectorAlgorithm,
@@ -51,10 +39,6 @@ from sentry.statistical_detectors.algorithm import (
 )
 from sentry.statistical_detectors.base import DetectorPayload
 from sentry.statistical_detectors.detector import RegressionDetector
-from sentry.statistical_detectors.issue_platform_adapter import (
-    fingerprint_regression,
-    send_regression_to_platform,
-)
 from sentry.statistical_detectors.redis import RedisDetectorStore
 from sentry.statistical_detectors.store import DetectorStore
 from sentry.tasks.base import instrumented_task
@@ -71,8 +55,6 @@ logger = logging.getLogger("sentry.tasks.statistical_detectors")
 
 FUNCTIONS_PER_PROJECT = 50
 FUNCTIONS_PER_BATCH = 1_000
-TRANSACTIONS_PER_PROJECT = 50
-TRANSACTIONS_PER_BATCH = 1_000
 PROJECTS_PER_BATCH = 1_000
 TIMESERIES_PER_BATCH = 10
 
@@ -117,56 +99,11 @@ def run_detection() -> None:
     now = django_timezone.now()
 
     projects = all_projects_with_flags()
-    projects = dispatch_performance_projects(projects, now)
     projects = dispatch_profiling_projects(projects, now)
 
     # make sure to consume the generator
     for _ in projects:
         pass
-
-
-def dispatch_performance_projects(
-    all_projects: Generator[tuple[int, int]],
-    timestamp: datetime,
-) -> Generator[tuple[int, int]]:
-    projects = []
-    count = 0
-
-    for project_id, flags in all_projects:
-        if flags & Project.flags.has_transactions:
-            projects.append(project_id)
-            count += 1
-
-        if len(projects) >= PROJECTS_PER_BATCH:
-            detect_transaction_trends.apply_async(
-                args=[
-                    [],
-                    projects,
-                    timestamp.isoformat(),
-                ],
-                countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
-            )
-            projects = []
-
-        yield project_id, flags
-
-    # make sure to dispatch a task to handle the remaining projects
-    if projects:
-        detect_transaction_trends.apply_async(
-            args=[
-                [],
-                projects,
-                timestamp.isoformat(),
-            ],
-            countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
-        )
-
-    metrics.incr(
-        "statistical_detectors.projects.total",
-        amount=count,
-        tags={"source": "transaction"},
-        sample_rate=1.0,
-    )
 
 
 def dispatch_profiling_projects(
@@ -203,52 +140,6 @@ def dispatch_profiling_projects(
         tags={"source": "profile"},
         sample_rate=1.0,
     )
-
-
-class EndpointRegressionDetector(RegressionDetector):
-    source = "transaction"
-    kind = "endpoint"
-    regression_type = RegressionType.ENDPOINT
-    min_change = 200  # 200ms in ms
-    buffer_period = timedelta(days=1)
-    resolution_rel_threshold = 0.1
-    escalation_rel_threshold = 0.75
-
-    @classmethod
-    def min_throughput_threshold(cls) -> int:
-        return options.get("statistical_detectors.throughput.threshold.transactions")
-
-    @classmethod
-    def detector_algorithm_factory(cls) -> DetectorAlgorithm:
-        return MovingAverageRelativeChangeDetector(
-            source=cls.source,
-            kind=cls.kind,
-            min_data_points=18,
-            moving_avg_short_factory=lambda: ExponentialMovingAverage(2 / 21),
-            moving_avg_long_factory=lambda: ExponentialMovingAverage(2 / 41),
-            threshold=0.15,
-        )
-
-    @classmethod
-    def detector_store_factory(cls) -> DetectorStore:
-        return RedisDetectorStore(regression_type=RegressionType.ENDPOINT)
-
-    @classmethod
-    def query_payloads(
-        cls,
-        projects: list[Project],
-        start: datetime,
-    ) -> Iterable[DetectorPayload]:
-        return query_transactions(projects, start)
-
-    @classmethod
-    def query_timeseries(
-        cls,
-        objects: list[tuple[Project, int | str]],
-        start: datetime,
-        function: str,
-    ) -> Iterable[tuple[int, int | str, SnubaTSResult]]:
-        return query_transactions_timeseries(objects, start, function)
 
 
 class FunctionRegressionDetector(RegressionDetector):
@@ -295,107 +186,6 @@ class FunctionRegressionDetector(RegressionDetector):
         function: str,
     ) -> Iterable[tuple[int, int | str, SnubaTSResult]]:
         return query_functions_timeseries(objects, start, function)
-
-
-@instrumented_task(
-    name="sentry.tasks.statistical_detectors.detect_transaction_trends",
-    namespace=performance_tasks,
-    processing_deadline_duration=30,
-)
-def detect_transaction_trends(
-    _org_ids: list[int], project_ids: list[int], start: str, *args, **kwargs
-) -> None:
-    if not options.get("statistical_detectors.enable"):
-        return
-
-    start_time = datetime.fromisoformat(start)
-
-    EndpointRegressionDetector.configure_tags()
-
-    projects = get_detector_enabled_projects(
-        project_ids,
-        project_option=InternalProjectOptions.TRANSACTION_DURATION_REGRESSION,
-    )
-
-    trends = EndpointRegressionDetector.detect_trends(projects, start_time)
-    trends = EndpointRegressionDetector.get_regression_groups(trends)
-    trends = EndpointRegressionDetector.redirect_resolutions(trends, start_time)
-    trends = EndpointRegressionDetector.redirect_escalations(trends, start_time)
-    trends = EndpointRegressionDetector.limit_regressions_by_project(trends)
-
-    delay = 12  # hours
-    delayed_start = start_time + timedelta(hours=delay)
-
-    for regression_chunk in chunked(trends, TRANSACTIONS_PER_BATCH):
-        detect_transaction_change_points.apply_async(
-            args=[
-                [(bundle.payload.project_id, bundle.payload.group) for bundle in regression_chunk],
-                delayed_start.isoformat(),
-            ],
-            # delay the check by delay hours because we want to make sure there
-            # will be enough data after the potential change point to be confident
-            # that a change has occurred
-            countdown=delay * 60 * 60,
-        )
-
-
-@instrumented_task(
-    name="sentry.tasks.statistical_detectors.detect_transaction_change_points",
-    namespace=performance_tasks,
-)
-def detect_transaction_change_points(
-    transactions: list[tuple[int, str | int]], start: str, *args, **kwargs
-) -> None:
-    start_time = datetime.fromisoformat(start)
-
-    _detect_transaction_change_points(transactions, start_time, *args, **kwargs)
-
-
-def _detect_transaction_change_points(
-    transactions: list[tuple[int, str | int]], start: datetime, *args, **kwargs
-) -> None:
-    if not options.get("statistical_detectors.enable"):
-        return
-
-    EndpointRegressionDetector.configure_tags()
-
-    projects_by_id = {
-        project.id: project
-        for project in get_detector_enabled_projects(
-            [project_id for project_id, _ in transactions],
-        )
-    }
-
-    transaction_pairs: list[tuple[Project, int | str]] = [
-        (projects_by_id[item[0]], item[1]) for item in transactions if item[0] in projects_by_id
-    ]
-
-    viewer_context = None
-    if transaction_pairs:
-        project = transaction_pairs[0][0]
-        viewer_context = SeerViewerContext(organization_id=project.organization_id)
-
-    regressions = EndpointRegressionDetector.detect_regressions(
-        transaction_pairs,
-        start,
-        "p95(transaction.duration)",
-        TIMESERIES_PER_BATCH,
-        viewer_context=viewer_context,
-    )
-    regressions = EndpointRegressionDetector.save_regressions_with_versions(regressions)
-
-    breakpoint_count = 0
-
-    for regression in regressions:
-        breakpoint_count += 1
-        send_regression_to_platform(regression)
-
-    metrics.incr(
-        "statistical_detectors.breakpoint.emitted",
-        amount=breakpoint_count,
-        tags={"source": "transaction", "kind": "endpoint"},
-        sample_rate=1.0,
-    )
 
 
 @instrumented_task(
@@ -692,300 +482,6 @@ def fetch_continuous_examples(raw_examples):
             }
 
     return examples
-
-
-BACKEND_TRANSACTION_OPS = [
-    # Common
-    "function.aws",
-    "function.aws.lambda",
-    "http.server",
-    "serverless.function",
-    # Python
-    "asgi.server",
-    # Ruby
-    "rails.request",
-]
-
-
-def query_transactions(
-    projects: list[Project],
-    start: datetime,
-    transactions_per_project: int = TRANSACTIONS_PER_PROJECT,
-) -> list[DetectorPayload]:
-    start = start - timedelta(hours=1)
-    start = start.replace(minute=0, second=0, microsecond=0)
-    end = start + timedelta(hours=1)
-
-    org_ids = list({p.organization_id for p in projects})
-    project_ids = list({p.id for p in projects})
-
-    use_case_id = UseCaseID.TRANSACTIONS
-
-    # both the metric and tag that we are using are hardcoded values in sentry_metrics.indexer.strings
-    # so the org_id that we are using does not actually matter here, we only need to pass in an org_id
-    #
-    # Because we filter on more than just `transaction`, we have to use DURATION here instead of
-    # DURATION_LIGHT.
-    duration_metric_id = indexer.resolve(
-        use_case_id, org_ids[0], str(TransactionMRI.DURATION.value)
-    )
-    transaction_name_metric_id = indexer.resolve(
-        use_case_id,
-        org_ids[0],
-        "transaction",
-    )
-    transaction_op_metric_id = indexer.resolve(
-        use_case_id,
-        org_ids[0],
-        "transaction.op",
-    )
-
-    # if our time range is more than an hour, use the hourly granularity
-    granularity = 3600 if int(end.timestamp()) - int(start.timestamp()) >= 3600 else 60
-
-    # This query returns the top `transactions_per_project` transaction names by count in the specified
-    # [start, end) time period along with the p95 of each transaction in that time period
-    # this is written in raw SnQL because the metrics layer does not support the limitby clause which is necessary for this operation to work
-
-    query = Query(
-        match=Entity(EntityKey.GenericMetricsDistributions.value),
-        select=[
-            Column("project_id"),
-            Function(
-                "arrayElement",
-                (
-                    CurriedFunction(
-                        "quantilesIf",
-                        [0.95],
-                        (
-                            Column("value"),
-                            Function("equals", (Column("metric_id"), duration_metric_id)),
-                        ),
-                    ),
-                    1,
-                ),
-                "p95",
-            ),
-            Function(
-                "countIf",
-                (Column("value"), Function("equals", (Column("metric_id"), duration_metric_id))),
-                "count",
-            ),
-            Function(
-                "transform",
-                (
-                    Column(f"tags_raw[{transaction_name_metric_id}]"),
-                    Function("array", ("",)),
-                    Function("array", ("<< unparameterized >>",)),
-                ),
-                "transaction_name",
-            ),
-        ],
-        groupby=[
-            Column("project_id"),
-            Column("transaction_name"),
-        ],
-        where=[
-            Condition(Column("org_id"), Op.IN, list(org_ids)),
-            Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("timestamp"), Op.GTE, start),
-            Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column("metric_id"), Op.EQ, duration_metric_id),
-            Condition(
-                Column(f"tags_raw[{transaction_op_metric_id}]"),
-                Op.IN,
-                list(BACKEND_TRANSACTION_OPS),
-            ),
-        ],
-        limitby=LimitBy([Column("project_id")], transactions_per_project),
-        orderby=[
-            OrderBy(Column("project_id"), Direction.DESC),
-            OrderBy(Column("count"), Direction.DESC),
-        ],
-        granularity=Granularity(granularity),
-        limit=Limit(len(project_ids) * transactions_per_project),
-    )
-    request = Request(
-        dataset=Dataset.PerformanceMetrics.value,
-        app_id="statistical_detectors",
-        query=query,
-        tenant_ids={
-            "referrer": Referrer.STATISTICAL_DETECTORS_FETCH_TOP_TRANSACTION_NAMES.value,
-            "cross_org_query": 1,
-            "use_case_id": use_case_id.value,
-        },
-    )
-    data = raw_snql_query(
-        request, referrer=Referrer.STATISTICAL_DETECTORS_FETCH_TOP_TRANSACTION_NAMES.value
-    )["data"]
-    return [
-        DetectorPayload(
-            project_id=row["project_id"],
-            group=row["transaction_name"],
-            fingerprint=fingerprint_regression(row["transaction_name"]),
-            count=row["count"],
-            value=row["p95"],
-            timestamp=start,
-        )
-        for row in data
-    ]
-
-
-def query_transactions_timeseries(
-    transactions: list[tuple[Project, int | str]],
-    start: datetime,
-    agg_function: str,
-) -> Generator[tuple[int, int | str, SnubaTSResult]]:
-    end = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
-    days_to_query = options.get("statistical_detectors.query.transactions.timeseries_days")
-    start = end - timedelta(days=days_to_query)
-    use_case_id = UseCaseID.TRANSACTIONS
-    interval = 3600  # 1 hour
-
-    project_objects = {p for p, _ in transactions}
-    project_ids = [project.id for project in project_objects]
-    org_ids = list({project.organization_id for project in project_objects})
-    # The only tag available on DURATION_LIGHT is `transaction`: as long as
-    # we don't filter on any other tags, DURATION_LIGHT's lower cardinality
-    # will be faster to query.
-    duration_metric_id = indexer.resolve(
-        use_case_id, org_ids[0], str(TransactionMRI.DURATION_LIGHT.value)
-    )
-    transaction_name_metric_id = indexer.resolve(
-        use_case_id,
-        org_ids[0],
-        "transaction",
-    )
-
-    transactions_condition = None
-    if len(transactions) == 1:
-        project, transaction_name = transactions[0]
-        transactions_condition = BooleanCondition(
-            BooleanOp.AND,
-            [
-                Condition(Column("project_id"), Op.EQ, project.id),
-                Condition(Column("transaction"), Op.EQ, transaction_name),
-            ],
-        )
-    else:
-        transactions_condition = BooleanCondition(
-            BooleanOp.OR,
-            [
-                BooleanCondition(
-                    BooleanOp.AND,
-                    [
-                        Condition(Column("project_id"), Op.EQ, project.id),
-                        Condition(Column("transaction"), Op.EQ, transaction_name),
-                    ],
-                )
-                for project, transaction_name in transactions
-            ],
-        )
-
-    query = Query(
-        match=Entity(EntityKey.GenericMetricsDistributions.value),
-        select=[
-            Column("project_id"),
-            Function(
-                "arrayElement",
-                (
-                    CurriedFunction(
-                        "quantilesIf",
-                        [0.95],
-                        (
-                            Column("value"),
-                            Function("equals", (Column("metric_id"), duration_metric_id)),
-                        ),
-                    ),
-                    1,
-                ),
-                "p95_transaction_duration",
-            ),
-            Function(
-                "transform",
-                (
-                    Column(f"tags_raw[{transaction_name_metric_id}]"),
-                    Function("array", ("",)),
-                    Function("array", ("<< unparameterized >>",)),
-                ),
-                "transaction",
-            ),
-        ],
-        groupby=[
-            Column("transaction"),
-            Column("project_id"),
-            Function(
-                "toStartOfInterval",
-                (Column("timestamp"), Function("toIntervalSecond", (3600,)), "Universal"),
-                "time",
-            ),
-        ],
-        where=[
-            Condition(Column("org_id"), Op.IN, list(org_ids)),
-            Condition(Column("project_id"), Op.IN, list(project_ids)),
-            Condition(Column("timestamp"), Op.GTE, start),
-            Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column("metric_id"), Op.EQ, duration_metric_id),
-            transactions_condition,
-        ],
-        orderby=[
-            OrderBy(Column("project_id"), Direction.ASC),
-            OrderBy(Column("transaction"), Direction.ASC),
-            OrderBy(
-                Function(
-                    "toStartOfInterval",
-                    (Column("timestamp"), Function("toIntervalSecond", (3600,)), "Universal"),
-                    "time",
-                ),
-                Direction.ASC,
-            ),
-        ],
-        granularity=Granularity(interval),
-        limit=Limit(10000),
-    )
-    request = Request(
-        dataset=Dataset.PerformanceMetrics.value,
-        app_id="statistical_detectors",
-        query=query,
-        tenant_ids={
-            "referrer": Referrer.STATISTICAL_DETECTORS_FETCH_TRANSACTION_TIMESERIES.value,
-            "cross_org_query": 1,
-            "use_case_id": use_case_id.value,
-        },
-    )
-    data = raw_snql_query(
-        request, referrer=Referrer.STATISTICAL_DETECTORS_FETCH_TRANSACTION_TIMESERIES.value
-    )["data"]
-
-    results = {}
-    for index, datapoint in enumerate(data or []):
-        key = (datapoint["project_id"], datapoint["transaction"])
-        if key not in results:
-            results[key] = {
-                "data": [datapoint],
-            }
-        else:
-            data = results[key]["data"]
-            data.append(datapoint)
-
-    for key, item in results.items():
-        project_id, transaction_name = key
-        formatted_result = SnubaTSResult(
-            {
-                "data": zerofill(
-                    item["data"],
-                    start,
-                    end,
-                    interval,
-                    ["time"],
-                ),
-                "project": project_id,
-            },
-            start,
-            end,
-            interval,
-        )
-        yield project_id, transaction_name, formatted_result
 
 
 def query_functions(projects: list[Project], start: datetime) -> list[DetectorPayload]:

--- a/tests/sentry/api/bases/test_organization_events.py
+++ b/tests/sentry/api/bases/test_organization_events.py
@@ -8,12 +8,19 @@ from sentry.testutils.requests import drf_request_from_request
 
 
 class OrganizationEventsEndpointBaseGetDatasetTest(TestCase):
-    def resolve(self, dataset_label: str):
-        request = drf_request_from_request(RequestFactory().get("/", {"dataset": dataset_label}))
+    def resolve(self, dataset_label: str, **params: str):
+        request = drf_request_from_request(
+            RequestFactory().get("/", {"dataset": dataset_label, **params})
+        )
         return OrganizationEventsEndpointBase().get_dataset(request, self.organization)
 
     def test_metrics_resolves_to_metrics_enhanced_performance(self) -> None:
         assert self.resolve("metrics") is metrics_enhanced_performance
+
+    def test_metrics_stays_on_metrics_performance_for_on_demand(self) -> None:
+        # On-demand extraction still reads generic metrics, and relies on an
+        # incompatible query erroring rather than falling back.
+        assert self.resolve("metrics", useOnDemandMetrics="true") is metrics_performance
 
     def test_metrics_enhanced_is_unchanged(self) -> None:
         assert self.resolve("metricsEnhanced") is metrics_enhanced_performance

--- a/tests/sentry/api/bases/test_organization_events.py
+++ b/tests/sentry/api/bases/test_organization_events.py
@@ -1,0 +1,29 @@
+from django.test import RequestFactory
+
+from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
+from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance, transactions
+from sentry.snuba.utils import get_dataset
+from sentry.testutils.cases import TestCase
+from sentry.testutils.requests import drf_request_from_request
+
+
+class OrganizationEventsEndpointBaseGetDatasetTest(TestCase):
+    def resolve(self, dataset_label: str):
+        request = drf_request_from_request(RequestFactory().get("/", {"dataset": dataset_label}))
+        return OrganizationEventsEndpointBase().get_dataset(request, self.organization)
+
+    def test_metrics_resolves_to_metrics_enhanced_performance(self) -> None:
+        assert self.resolve("metrics") is metrics_enhanced_performance
+
+    def test_metrics_enhanced_is_unchanged(self) -> None:
+        assert self.resolve("metricsEnhanced") is metrics_enhanced_performance
+
+    def test_discover_is_unchanged(self) -> None:
+        assert self.resolve("discover") is discover
+
+    def test_transactions_is_unchanged(self) -> None:
+        assert self.resolve("transactions") is transactions
+
+    def test_registry_still_maps_metrics_for_alerts(self) -> None:
+        # Alerts compare against metrics_performance to identify the sessions dataset.
+        assert get_dataset("metrics") is metrics_performance

--- a/tests/sentry/api/bases/test_organization_events.py
+++ b/tests/sentry/api/bases/test_organization_events.py
@@ -2,7 +2,6 @@ from django.test import RequestFactory
 
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance, transactions
-from sentry.snuba.utils import get_dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.requests import drf_request_from_request
 
@@ -18,8 +17,6 @@ class OrganizationEventsEndpointBaseGetDatasetTest(TestCase):
         assert self.resolve("metrics") is metrics_enhanced_performance
 
     def test_metrics_stays_on_metrics_performance_for_on_demand(self) -> None:
-        # On-demand extraction still reads generic metrics, and relies on an
-        # incompatible query erroring rather than falling back.
         assert self.resolve("metrics", useOnDemandMetrics="true") is metrics_performance
 
     def test_metrics_enhanced_is_unchanged(self) -> None:
@@ -30,7 +27,3 @@ class OrganizationEventsEndpointBaseGetDatasetTest(TestCase):
 
     def test_transactions_is_unchanged(self) -> None:
         assert self.resolve("transactions") is transactions
-
-    def test_registry_still_maps_metrics_for_alerts(self) -> None:
-        # Alerts compare against metrics_performance to identify the sessions dataset.
-        assert get_dataset("metrics") is metrics_performance

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3065,58 +3065,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 200, response.data
         assert sorted(response.data["projects"]) == [project1.id, project2.id]
 
-    def test_save_widget_with_custom_measurement_in_equation_tables(self) -> None:
-        BaseMetricsTestCase.store_metric(
-            self.organization.id,
-            self.project.id,
-            "d:transactions/measurements.custom_duration@millisecond",
-            {},
-            int(before_now(days=1).timestamp()),
-            1,
-        )
-
-        data: dict[str, Any] = {
-            "title": "First dashboard",
-            "widgets": [
-                {
-                    "title": "EPM table",
-                    "widgetType": "transaction-like",
-                    "displayType": "table",
-                    "queries": [
-                        {
-                            "name": "",
-                            "fields": [
-                                "transaction.duration",
-                                "measurements.custom_duration",
-                                "equation|measurements.custom_duration / transaction.duration",
-                            ],
-                            "columns": [
-                                "transaction.duration",
-                                "measurements.custom_duration",
-                            ],
-                            "aggregates": [
-                                "equation|measurements.custom_duration / transaction.duration"
-                            ],
-                            "conditions": "",
-                            "orderby": "",
-                            "selectedAggregate": 1,
-                        }
-                    ],
-                },
-            ],
-        }
-        response = self.do_request("put", self.url(self.dashboard.id), data=data)
-        assert response.status_code == 200, response.data
-
-        widgets = self.get_widgets(self.dashboard.id)
-        assert len(widgets) == 1
-
-        self.assert_serialized_widget(data["widgets"][0], widgets[0])
-
-        queries = widgets[0].dashboardwidgetquery_set.all()
-        assert len(queries) == 1
-        self.assert_serialized_widget_query(data["widgets"][0]["queries"][0], queries[0])
-
     def test_save_widget_with_custom_measurement_in_equation_line_chart(self) -> None:
         BaseMetricsTestCase.store_metric(
             self.organization.id,

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -5,7 +5,6 @@ Metrics Service Layer Tests for Performance
 import re
 from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
-from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -18,7 +17,6 @@ from sentry.models.transaction_threshold import (
     ProjectTransactionThresholdOverride,
     TransactionMetric,
 )
-from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.aggregation_option_registry import AggregationOption
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics import (
@@ -29,7 +27,7 @@ from sentry.snuba.metrics import (
     MetricGroupByField,
     MetricOrderByField,
 )
-from sentry.snuba.metrics.datasource import get_custom_measurements, get_series
+from sentry.snuba.metrics.datasource import get_series
 from sentry.snuba.metrics.naming_layer import (
     TransactionMetricKey,
     TransactionMRI,
@@ -39,7 +37,6 @@ from sentry.snuba.metrics.naming_layer import (
 from sentry.snuba.metrics.query_builder import QueryDefinition
 from sentry.testutils.cases import (
     BaseMetricsLayerTestCase,
-    MetricsEnhancedPerformanceTestCase,
     TestCase,
 )
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -2002,132 +1999,3 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
         mq = DeprecatingMetricsQuery(**metrics_query_dict, interval=3600)
         assert mq.limit is not None
         assert mq.limit.limit == 50
-
-
-class GetCustomMeasurementsTestCase(MetricsEnhancedPerformanceTestCase):
-    METRIC_STRINGS = [
-        "d:transactions/measurements.something_custom@millisecond",
-        "d:transactions/measurements.something_else@byte",
-    ]
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
-
-    def test_simple(self) -> None:
-        something_custom_metric = "d:transactions/measurements.something_custom@millisecond"
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_custom",
-            internal_metric=something_custom_metric,
-            entity="metrics_distributions",
-            timestamp=self.day_ago + timedelta(hours=1, minutes=0),
-        )
-        result = get_custom_measurements(
-            project_ids=[self.project.id],
-            organization_id=self.organization.id,
-            start=self.day_ago,
-            use_case_id=UseCaseID.TRANSACTIONS,
-        )
-        assert result == [
-            {
-                "name": "measurements.something_custom",
-                "type": "generic_distribution",
-                "operations": [
-                    "avg",
-                    "count",
-                    "histogram",
-                    "max",
-                    "max_timestamp",
-                    "min",
-                    "min_timestamp",
-                    "p50",
-                    "p75",
-                    "p90",
-                    "p95",
-                    "p99",
-                    "sum",
-                ],
-                "unit": "millisecond",
-                "metric_id": indexer.resolve(
-                    UseCaseID.TRANSACTIONS,
-                    self.organization.id,
-                    something_custom_metric,
-                ),
-                "mri": something_custom_metric,
-            }
-        ]
-
-    def test_metric_outside_query_daterange(self) -> None:
-        something_custom_metric = "d:transactions/measurements.something_custom@millisecond"
-        something_else_metric = "d:transactions/measurements.something_else@byte"
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_custom",
-            internal_metric=something_custom_metric,
-            entity="metrics_distributions",
-            timestamp=self.day_ago + timedelta(hours=1, minutes=0),
-        )
-        # Shouldn't show up
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_else",
-            internal_metric=something_else_metric,
-            entity="metrics_distributions",
-            timestamp=self.day_ago - timedelta(days=1, minutes=0),
-        )
-        result = get_custom_measurements(
-            project_ids=[self.project.id],
-            organization_id=self.organization.id,
-            start=self.day_ago,
-            use_case_id=UseCaseID.TRANSACTIONS,
-        )
-
-        assert result == [
-            {
-                "name": "measurements.something_custom",
-                "type": "generic_distribution",
-                "operations": [
-                    "avg",
-                    "count",
-                    "histogram",
-                    "max",
-                    "max_timestamp",
-                    "min",
-                    "min_timestamp",
-                    "p50",
-                    "p75",
-                    "p90",
-                    "p95",
-                    "p99",
-                    "sum",
-                ],
-                "unit": "millisecond",
-                "metric_id": indexer.resolve(
-                    UseCaseID.TRANSACTIONS,
-                    self.organization.id,
-                    something_custom_metric,
-                ),
-                "mri": something_custom_metric,
-            }
-        ]
-
-    @mock.patch("sentry.snuba.metrics.datasource.parse_mri")
-    def test_broken_custom_metric(self, mocked_parse_mri: mock.MagicMock) -> None:
-        # Store valid metric
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_custom",
-            internal_metric="d:transactions/measurements.something_custom@millisecond",
-            entity="metrics_distributions",
-            timestamp=self.day_ago + timedelta(hours=1, minutes=0),
-        )
-
-        # mock mri failing to parse the metric
-        mocked_parse_mri.return_value = None
-        result = get_custom_measurements(
-            project_ids=[self.project.id],
-            organization_id=self.organization.id,
-            start=self.day_ago,
-        )
-        assert result == []

--- a/tests/sentry/snuba/test_utils.py
+++ b/tests/sentry/snuba/test_utils.py
@@ -1,0 +1,6 @@
+from sentry.snuba import metrics_performance
+from sentry.snuba.utils import get_dataset
+
+
+def test_metrics_resolves_to_metrics_performance() -> None:
+    assert get_dataset("metrics") is metrics_performance

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -8,7 +8,6 @@ from django.db.models import F
 
 from sentry.issues.endpoints.project_performance_issue_settings import InternalProjectOptions
 from sentry.issues.grouptype import (
-    PerformanceP95EndpointRegressionGroupType,
     ProfileFunctionRegressionType,
 )
 from sentry.issues.occurrence_consumer import _process_message
@@ -23,31 +22,23 @@ from sentry.models.statistical_detectors import (
     get_regression_groups,
 )
 from sentry.seer.breakpoints import BreakpointData
-from sentry.snuba.discover import zerofill
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.statistical_detectors.algorithm import MovingAverageDetectorState
 from sentry.statistical_detectors.base import DetectorPayload, TrendType
 from sentry.statistical_detectors.detector import TrendBundle, generate_fingerprint
 from sentry.tasks.statistical_detectors import (
-    EndpointRegressionDetector,
     FunctionRegressionDetector,
     detect_function_change_points,
     detect_function_trends,
-    detect_transaction_change_points,
-    detect_transaction_trends,
     emit_function_regression_issue,
     query_functions,
-    query_transactions,
-    query_transactions_timeseries,
     run_detection,
 )
-from sentry.testutils.cases import MetricsAPIBaseTestCase, ProfilesSnubaTestCase
+from sentry.testutils.cases import ProfilesSnubaTestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.types.group import GroupSubStatus
-from sentry.utils.snuba import SnubaTSResult
 
 
 @pytest.fixture
@@ -70,88 +61,17 @@ def project(organization):
     return Factories.create_project(organization=organization)
 
 
-@pytest.mark.parametrize(
-    [
-        "project_flags",
-        "enable",
-        "expected_performance_project",
-        "expected_profiling_project",
-    ],
-    [
-        pytest.param(None, False, False, False, id="disabled"),
-        pytest.param(None, True, False, False, id="no projects"),
-        pytest.param(None, True, False, False, id="no transactions"),
-        pytest.param(None, True, False, False, id="no profiles"),
-        pytest.param(
-            Project.flags.has_transactions,
-            True,
-            True,
-            False,
-            id="performance only",
-        ),
-        pytest.param(Project.flags.has_profiles, True, False, True, id="profiling only"),
-        pytest.param(
-            Project.flags.has_transactions | Project.flags.has_profiles,
-            True,
-            True,
-            True,
-            id="performance + profiling",
-        ),
-    ],
-)
-@mock.patch("sentry.tasks.statistical_detectors.detect_transaction_trends")
-@mock.patch("sentry.tasks.statistical_detectors.detect_function_trends")
-@django_db_all
-def test_run_detection_options(
-    detect_function_trends,
-    detect_transaction_trends,
-    project_flags,
-    enable,
-    expected_performance_project,
-    expected_profiling_project,
-    project,
-    timestamp,
-):
-    if project_flags is not None:
-        project.update(flags=F("flags").bitor(project_flags))
-
-    options = {
-        "statistical_detectors.enable": enable,
-    }
-
-    with freeze_time(timestamp), override_options(options):
-        run_detection()
-
-    if expected_performance_project:
-        assert detect_transaction_trends.apply_async.called
-        detect_transaction_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[], [project.id], timestamp.isoformat()], countdown=0)]
-        )
-    else:
-        assert not detect_transaction_trends.apply_async.called
-
-    if expected_profiling_project:
-        assert detect_function_trends.apply_async.called
-        detect_function_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[project.id], timestamp.isoformat()], countdown=0)]
-        )
-    else:
-        assert not detect_function_trends.apply_async.called
-
-
-@mock.patch("sentry.tasks.statistical_detectors.detect_transaction_trends")
 @mock.patch("sentry.tasks.statistical_detectors.detect_function_trends")
 @mock.patch("sentry.tasks.statistical_detectors.PROJECTS_PER_BATCH", 5)
 @django_db_all
 def test_run_detection_options_multiple_batches(
     detect_function_trends,
-    detect_transaction_trends,
     organization,
     timestamp,
 ):
     projects = []
 
-    flags = Project.flags.has_transactions | Project.flags.has_profiles
+    flags = Project.flags.has_profiles
     for _ in range(9):
         project = Factories.create_project(organization=organization)
         project.update(flags=F("flags").bitor(flags))
@@ -166,20 +86,6 @@ def test_run_detection_options_multiple_batches(
 
     # total of 9 projects, broken into batches of 5 means batch sizes of 5 + 4
 
-    assert detect_transaction_trends.apply_async.called
-    detect_transaction_trends.apply_async.assert_has_calls(
-        [
-            mock.call(
-                args=[
-                    [],
-                    [project.id for project in projects[i : i + 5]],
-                    timestamp.isoformat(),
-                ],
-                countdown=countdown,
-            )
-            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=0, step=17))
-        ]
-    )
     assert detect_function_trends.apply_async.called
     detect_function_trends.apply_async.assert_has_calls(
         [
@@ -190,39 +96,6 @@ def test_run_detection_options_multiple_batches(
             for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=0, step=17))
         ]
     )
-
-
-@pytest.mark.parametrize(
-    ["task_enabled", "option_enabled"],
-    [
-        pytest.param(True, True, id="both enabled"),
-        pytest.param(False, False, id="both disabled"),
-        pytest.param(True, False, id="option disabled"),
-        pytest.param(False, True, id="task disabled"),
-    ],
-)
-@mock.patch("sentry.tasks.statistical_detectors.query_transactions")
-@django_db_all
-def test_detect_transaction_trends_options(
-    query_transactions,
-    task_enabled,
-    option_enabled,
-    timestamp,
-    project,
-):
-    ProjectOption.objects.set_value(
-        project=project,
-        key="sentry:performance_issue_settings",
-        value={InternalProjectOptions.TRANSACTION_DURATION_REGRESSION.value: option_enabled},
-    )
-
-    options = {
-        "statistical_detectors.enable": task_enabled,
-    }
-
-    with override_options(options):
-        detect_transaction_trends([project.organization_id], [project.id], timestamp.isoformat())
-    assert query_transactions.called == (task_enabled and option_enabled)
 
 
 @pytest.mark.parametrize(
@@ -297,198 +170,8 @@ def test_detect_function_trends_query_timerange(functions_query, timestamp, proj
 
 
 @pytest.mark.parametrize(
-    ["count", "should_emit"],
-    [(100, True), (10, False)],
-)
-@mock.patch("sentry.tasks.statistical_detectors.query_transactions")
-@mock.patch("sentry.tasks.statistical_detectors.detect_transaction_change_points")
-@django_db_all
-def test_detect_transaction_trends(
-    detect_transaction_change_points,
-    query_transactions,
-    timestamp,
-    project,
-    count,
-    should_emit,
-):
-    n = 50
-    timestamps = [timestamp - timedelta(hours=n - i) for i in range(n)]
-
-    query_transactions.side_effect = [
-        [
-            DetectorPayload(
-                project_id=project.id,
-                group="/123",
-                fingerprint="/123",
-                count=count,
-                value=100 if i < n / 2 else 300,
-                timestamp=ts,
-            ),
-        ]
-        for i, ts in enumerate(timestamps)
-    ]
-
-    options = {
-        "statistical_detectors.enable": True,
-    }
-
-    with override_options(options):
-        for ts in timestamps:
-            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
-
-    if should_emit:
-        assert detect_transaction_change_points.apply_async.called
-    else:
-        assert not detect_transaction_change_points.apply_async.called
-
-
-@mock.patch("sentry.issues.status_change_message.uuid4", return_value=uuid.UUID(int=0))
-@mock.patch("sentry.tasks.statistical_detectors.raw_snql_query")
-@mock.patch("sentry.tasks.statistical_detectors.detect_transaction_change_points")
-@mock.patch("sentry.statistical_detectors.detector.produce_occurrence_to_kafka")
-@django_db_all
-@pytest.mark.sentry_metrics
-def test_detect_transaction_trends_auto_resolution(
-    produce_occurrence_to_kafka,
-    detect_transaction_change_points,
-    raw_snql_query,
-    mock_uuid4,
-    timestamp,
-    project,
-):
-    n = 150
-    timestamps = [timestamp - timedelta(hours=n - i) for i in range(n)]
-
-    raw_snql_query.side_effect = [
-        {
-            "data": [
-                {
-                    "project_id": project.id,
-                    "transaction_name": "/123",
-                    "count": 100,
-                    "p95": 100 if i < 25 or i >= 50 else 300,
-                },
-            ],
-        }
-        for i, ts in enumerate(timestamps)
-    ]
-
-    options = {
-        "statistical_detectors.enable": True,
-    }
-
-    with override_options(options):
-        for ts in timestamps[:50]:
-            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
-
-    assert detect_transaction_change_points.apply_async.called
-
-    with override_options(options):
-        RegressionGroup.objects.create(
-            type=RegressionType.ENDPOINT.value,
-            date_regressed=timestamps[10],
-            version=1,
-            active=True,
-            project_id=project.id,
-            fingerprint=generate_fingerprint(RegressionType.ENDPOINT, "/123"),
-            baseline=100,
-            regressed=300,
-        )
-        for ts in timestamps[50:]:
-            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
-
-    status_change = StatusChangeMessage(
-        fingerprint=[generate_fingerprint(RegressionType.ENDPOINT, "/123")],
-        project_id=project.id,
-        new_status=GroupStatus.RESOLVED,
-        new_substatus=None,
-    )
-    produce_occurrence_to_kafka.assert_has_calls(
-        [mock.call(payload_type=PayloadType.STATUS_CHANGE, status_change=status_change)]
-    )
-
-
-@pytest.mark.parametrize(
-    ["ratelimit", "expected_calls"],
-    [(-1, 3), (0, 0), (1, 1), (2, 2), (3, 3)],
-)
-@mock.patch("sentry.tasks.statistical_detectors.query_transactions")
-@mock.patch("sentry.tasks.statistical_detectors.detect_transaction_change_points")
-@django_db_all
-def test_detect_transaction_trends_ratelimit(
-    detect_transaction_change_points,
-    query_transactions,
-    ratelimit,
-    expected_calls,
-    timestamp,
-    organization,
-    project,
-):
-    n = 50
-    timestamps = [timestamp - timedelta(hours=n - i) for i in range(n)]
-
-    query_transactions.side_effect = [
-        [
-            DetectorPayload(
-                project_id=project.id,
-                group="/1",
-                fingerprint="/1",
-                count=100,
-                value=100 if i < n / 2 else 301,
-                timestamp=ts,
-            ),
-            DetectorPayload(
-                project_id=project.id,
-                group="/2",
-                fingerprint="/2",
-                count=100,
-                value=100 if i < n / 2 else 302,
-                timestamp=ts,
-            ),
-            DetectorPayload(
-                project_id=project.id,
-                group="/3",
-                fingerprint="/3",
-                count=100,
-                value=100 if i < n / 2 else 303,
-                timestamp=ts,
-            ),
-        ]
-        for i, ts in enumerate(timestamps)
-    ]
-
-    options = {
-        "statistical_detectors.enable": True,
-        "statistical_detectors.ratelimit.ema": ratelimit,
-    }
-
-    with override_options(options):
-        for ts in timestamps:
-            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
-
-    if expected_calls > 0:
-        assert detect_transaction_change_points.apply_async.call_count == 1
-        detect_transaction_change_points.apply_async.assert_has_calls(
-            [
-                mock.call(
-                    args=[
-                        [(project.id, "/1"), (project.id, "/2"), (project.id, "/3")][
-                            -expected_calls:
-                        ],
-                        mock.ANY,
-                    ],
-                    countdown=12 * 60 * 60,
-                ),
-            ],
-        )
-    else:
-        assert detect_transaction_change_points.apply_async.call_count == 0
-
-
-@pytest.mark.parametrize(
     ["detector_cls"],
     [
-        pytest.param(EndpointRegressionDetector, id="endpoint"),
         pytest.param(FunctionRegressionDetector, id="function"),
     ],
 )
@@ -537,7 +220,6 @@ def test_limit_regressions_by_project(detector_cls, ratelimit, timestamp, expect
 @pytest.mark.parametrize(
     ["detector_cls"],
     [
-        pytest.param(EndpointRegressionDetector, id="endpoint"),
         pytest.param(FunctionRegressionDetector, id="function"),
     ],
 )
@@ -639,12 +321,6 @@ def test_get_regression_versions(
 @pytest.mark.parametrize(
     ["detector_cls", "object_name", "issue_type"],
     [
-        pytest.param(
-            EndpointRegressionDetector,
-            "transaction_1",
-            PerformanceP95EndpointRegressionGroupType,
-            id="endpoint",
-        ),
         pytest.param(
             FunctionRegressionDetector,
             123,
@@ -999,11 +675,6 @@ def test_detect_function_change_points(
     ["detector_cls", "object_name"],
     [
         pytest.param(
-            EndpointRegressionDetector,
-            "transaction_1",
-            id="endpoint",
-        ),
-        pytest.param(
             FunctionRegressionDetector,
             "123",
             id="function",
@@ -1088,11 +759,6 @@ def test_new_regression_group(
     ["detector_cls", "object_name"],
     [
         pytest.param(
-            EndpointRegressionDetector,
-            "transaction_1",
-            id="endpoint",
-        ),
-        pytest.param(
             FunctionRegressionDetector,
             "123",
             id="function",
@@ -1147,15 +813,6 @@ def test_save_regressions_with_versions(
 @pytest.mark.parametrize(
     ["detector_cls", "object_name", "baseline", "regressed", "escalated", "issue_type"],
     [
-        pytest.param(
-            EndpointRegressionDetector,
-            "transaction_1",
-            100,
-            300,
-            500,
-            PerformanceP95EndpointRegressionGroupType,
-            id="endpoint",
-        ),
         pytest.param(
             FunctionRegressionDetector,
             123,
@@ -1650,276 +1307,3 @@ class FunctionsTasksTest(ProfilesSnubaTestCase):
                 )
             ],
         )
-
-
-@pytest.mark.sentry_metrics
-class TestTransactionsQuery(MetricsAPIBaseTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.num_projects = 2
-        self.num_transactions = 4
-
-        self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
-        self.hour_ago_seconds = int(self.hour_ago.timestamp())
-        self.projects = [
-            self.create_project(organization=self.organization) for _ in range(self.num_projects)
-        ]
-
-        for project in self.projects:
-            for i in range(self.num_transactions):
-                # Store metrics for a backend transaction
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"transaction_{i}", "transaction.op": "http.server"},
-                    self.hour_ago_seconds,
-                    1.0,
-                )
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"transaction_{i}", "transaction.op": "http.server"},
-                    self.hour_ago_seconds,
-                    9.5,
-                )
-
-                # Store metrics for a frontend transaction, which should be
-                # ignored by the query
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"fe_transaction_{i}", "transaction.op": "navigation"},
-                    self.hour_ago_seconds,
-                    1.0,
-                )
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"fe_transaction_{i}", "transaction.op": "navigation"},
-                    self.hour_ago_seconds,
-                    9.5,
-                )
-
-    @property
-    def now(self):
-        return MetricsAPIBaseTestCase.MOCK_DATETIME
-
-    def test_transactions_query(self) -> None:
-        res = query_transactions(
-            self.projects,
-            self.now,
-            self.num_transactions + 1,  # detect if any extra transactions are returned
-        )
-
-        assert len(res) == len(self.projects) * self.num_transactions
-        for trend_payload in res:
-            assert trend_payload.count == 2
-            # p95 is  calculated by a probabilistic data structure, as such the value won't actually be 9.5 since we only have
-            # one sample at 9.5, but it should be close
-            assert trend_payload.value > 9
-            assert trend_payload.timestamp == self.hour_ago
-
-
-@pytest.mark.sentry_metrics
-class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.num_projects = 2
-        self.num_transactions = 4
-
-        self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
-        self.hour_ago_seconds = int(self.hour_ago.timestamp())
-        self.projects = [
-            self.create_project(organization=self.organization) for _ in range(self.num_projects)
-        ]
-
-        def store_metric(project_id, transaction, minutes_ago, value):
-            self.store_metric(
-                self.organization.id,
-                project_id,
-                TransactionMRI.DURATION_LIGHT.value,
-                {"transaction": transaction},
-                int((self.now - timedelta(minutes=minutes_ago)).timestamp()),
-                value,
-            )
-
-        for project in self.projects:
-            for i in range(self.num_transactions):
-                store_metric(project.id, f"transaction_{i}", 20, 9.5)
-                store_metric(project.id, f"transaction_{i}", 40, 9.5)
-                store_metric(project.id, f"transaction_{i}", 60, 9.5)
-                store_metric(project.id, f"transaction_{i}", 80, 1.0)
-                store_metric(project.id, f"transaction_{i}", 100, 1.0)
-                store_metric(project.id, f"transaction_{i}", 120, 1.0)
-
-    @property
-    def now(self):
-        return MetricsAPIBaseTestCase.MOCK_DATETIME
-
-    def test_query_transactions_timeseries(self) -> None:
-        results = [
-            timeseries
-            for timeseries in query_transactions_timeseries(
-                [
-                    (self.projects[0], "transaction_1"),
-                    (self.projects[0], "transaction_2"),
-                    (self.projects[1], "transaction_1"),
-                ],
-                self.now,
-                "p95(transaction.duration)",
-            )
-        ]
-
-        end = self.now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
-        start = end - timedelta(days=14)
-        first_timeseries_time = self.now - timedelta(hours=2)
-        second_timeseries_time = self.now - timedelta(hours=1)
-        assert results == [
-            (
-                self.projects[0].id,
-                "transaction_1",
-                SnubaTSResult(
-                    {
-                        "data": zerofill(
-                            [
-                                {
-                                    "transaction": "transaction_1",
-                                    "time": first_timeseries_time.isoformat(),
-                                    "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 1.0,
-                                },
-                                {
-                                    "transaction": "transaction_1",
-                                    "time": second_timeseries_time.isoformat(),
-                                    "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 9.5,
-                                },
-                            ],
-                            start,
-                            end,
-                            3600,
-                            ["time"],
-                        ),
-                        "project": self.projects[0].id,
-                    },
-                    start,
-                    end,
-                    3600,
-                ),
-            ),
-            (
-                self.projects[0].id,
-                "transaction_2",
-                SnubaTSResult(
-                    {
-                        "data": zerofill(
-                            [
-                                {
-                                    "transaction": "transaction_2",
-                                    "time": first_timeseries_time.isoformat(),
-                                    "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 1.0,
-                                },
-                                {
-                                    "transaction": "transaction_2",
-                                    "time": second_timeseries_time.isoformat(),
-                                    "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 9.5,
-                                },
-                            ],
-                            start,
-                            end,
-                            3600,
-                            ["time"],
-                        ),
-                        "project": self.projects[0].id,
-                    },
-                    start,
-                    end,
-                    3600,
-                ),
-            ),
-            (
-                self.projects[1].id,
-                "transaction_1",
-                SnubaTSResult(
-                    {
-                        "data": zerofill(
-                            [
-                                {
-                                    "transaction": "transaction_1",
-                                    "time": first_timeseries_time.isoformat(),
-                                    "project_id": self.projects[1].id,
-                                    "p95_transaction_duration": 1.0,
-                                },
-                                {
-                                    "transaction": "transaction_1",
-                                    "time": second_timeseries_time.isoformat(),
-                                    "project_id": self.projects[1].id,
-                                    "p95_transaction_duration": 9.5,
-                                },
-                            ],
-                            start,
-                            end,
-                            3600,
-                            ["time"],
-                        ),
-                        "project": self.projects[1].id,
-                    },
-                    start,
-                    end,
-                    3600,
-                ),
-            ),
-        ]
-
-    def test_query_transactions_single_timeseries(self) -> None:
-        results = [
-            timeseries
-            for timeseries in query_transactions_timeseries(
-                [(self.projects[0], "transaction_1")],
-                self.now,
-                "p95(transaction.duration)",
-            )
-        ]
-        assert len(results) == 1
-
-    @mock.patch("sentry.tasks.statistical_detectors.send_regression_to_platform")
-    @mock.patch("sentry.statistical_detectors.detector.detect_breakpoints")
-    def test_transaction_change_point_detection(
-        self, mock_detect_breakpoints, mock_send_regression_to_platform
-    ) -> None:
-        mock_detect_breakpoints.return_value = {
-            "data": [
-                {
-                    "absolute_percentage_change": 5.0,
-                    "aggregate_range_1": 100000000.0,
-                    "aggregate_range_2": 500000000.0,
-                    "breakpoint": 1687323600,
-                    "change": "regression",
-                    "project": str(self.projects[0].id),
-                    "transaction": "transaction_1",
-                    "trend_difference": 400000000.0,
-                    "trend_percentage": 5.0,
-                    "unweighted_p_value": 0.0,
-                    "unweighted_t_value": -float("inf"),
-                },
-            ]
-        }
-
-        options = {"statistical_detectors.enable": True}
-
-        with override_options(options):
-            detect_transaction_change_points(
-                [
-                    (self.projects[0].id, "transaction_1"),
-                    (self.projects[0].id, "transaction_2"),
-                    (self.projects[1].id, "transaction_1"),
-                ],
-                self.now.isoformat(),
-            )
-        assert mock_send_regression_to_platform.called

--- a/tests/snuba/api/endpoints/test_discover_homepage_query.py
+++ b/tests/snuba/api/endpoints/test_discover_homepage_query.py
@@ -3,8 +3,6 @@ from django.urls import reverse
 
 from sentry.api.serializers import serialize
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
-from sentry.testutils.cases import BaseMetricsTestCase
-from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_discover_saved_queries import DiscoverSavedQueryBase
 
 FEATURES = ("organizations:discover-query",)
@@ -170,46 +168,6 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
         assert not DiscoverSavedQuery.objects.filter(
             created_by_id=self.user.id, organization=self.org, is_homepage=True
         ).exists()
-
-    def test_put_allows_custom_measurements_in_equations_with_query(self) -> None:
-        # Having a custom measurement stored implies that a transaction with this measurement has been stored
-        BaseMetricsTestCase.store_metric(
-            self.org.id,
-            self.project_ids[0],
-            "d:transactions/measurements.custom_duration@millisecond",
-            {},
-            int(before_now(days=1).timestamp()),
-            1,
-        )
-
-        homepage_query_payload = {
-            "version": 2,
-            "name": "New Homepage Query",
-            "projects": [self.project_ids[0]],
-            "environment": ["alpha"],
-            "fields": [
-                "transaction.duration",
-                "measurements.custom_duration",
-                "equation|measurements.custom_duration / transaction.duration",
-            ],
-            "orderby": "-transaction.duration",
-            "query": "test",
-            "range": None,
-            "queryDataset": DiscoverSavedQueryTypes.get_type_name(
-                DiscoverSavedQueryTypes.TRANSACTION_LIKE
-            ),
-        }
-
-        with self.feature(FEATURES):
-            response = self.client.put(self.url, data=homepage_query_payload)
-
-        assert response.status_code == 201, response.content
-
-        new_query = DiscoverSavedQuery.objects.get(
-            created_by_id=self.user.id, organization=self.org, is_homepage=True
-        )
-        assert response.data == serialize(new_query)
-        assert list(new_query.projects.values_list("id", flat=True)) == [self.project_ids[0]]
 
     def test_put_success_is_filter(self) -> None:
         with self.feature(FEATURES):

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -14,7 +14,6 @@ from sentry.testutils.cases import (
 )
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
-from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
@@ -95,43 +94,6 @@ class OrganizationEventsMetaEndpoint(
 
         assert response.status_code == 200, response.content
         assert response.data["count"] == 1
-
-    def test_custom_measurements_query_uses_units(self) -> None:
-        self.store_transaction_metric(
-            33,
-            metric="measurements.custom",
-            internal_metric="d:transactions/measurements.custom@second",
-            entity="metrics_distributions",
-            tags={"transaction": "foo_transaction"},
-            timestamp=self.min_ago,
-        )
-        data = load_data("transaction", timestamp=self.min_ago)
-        data["measurements"] = {
-            "custom": {"value": 0.199, "unit": "second"},
-        }
-        self.store_event(data, self.project.id)
-        data = load_data("transaction", timestamp=self.min_ago)
-        data["measurements"] = {
-            "custom": {"value": 0.201, "unit": "second"},
-        }
-        self.store_event(data, self.project.id)
-        url = reverse(
-            "sentry-api-0-organization-events-meta",
-            kwargs={"organization_id_or_slug": self.project.organization.slug},
-        )
-        features = {
-            "organizations:discover-basic": True,
-        }
-        for dataset in ["discover", "transactions"]:
-            query = {
-                "field": ["measurements.custom"],
-                "query": "measurements.custom:>200",
-                "dataset": dataset,
-            }
-            with self.feature(features):
-                response = self.client.get(url, query, format="json")
-            assert response.status_code == 200, response.content
-            assert response.data["count"] == 1
 
     def test_invalid_query(self) -> None:
         with self.feature(self.features):

--- a/tests/snuba/api/endpoints/test_organization_measurements_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_measurements_meta.py
@@ -9,12 +9,11 @@ from sentry.testutils.helpers.datetime import before_now
 pytestmark = pytest.mark.sentry_metrics
 
 
-class OrganizationMeasurementsMetaEndpoint(MetricsEnhancedPerformanceTestCase):
+class OrganizationMeasurementsMetaEmptyEndpoint(MetricsEnhancedPerformanceTestCase):
     endpoint = "sentry-api-0-organization-measurements-meta"
     METRIC_STRINGS = [
         "d:transactions/measurements.something_custom@millisecond",
     ]
-    features = {"organizations:discover-basic": True}
 
     def setUp(self) -> None:
         super().setUp()
@@ -26,124 +25,13 @@ class OrganizationMeasurementsMetaEndpoint(MetricsEnhancedPerformanceTestCase):
         )
         self.features = {}
 
-    def test_simple(self) -> None:
+    def test_returns_no_measurements(self) -> None:
         self.store_transaction_metric(
             1,
             metric="measurements.something_custom",
             internal_metric="d:transactions/measurements.something_custom@millisecond",
             entity="metrics_distributions",
             timestamp=self.day_ago + timedelta(hours=1, minutes=0),
-        )
-        response = self.do_request(
-            {
-                "project": self.project.id,
-                "statsPeriod": "14d",
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data == {
-            "measurements.something_custom": {
-                "functions": [
-                    "apdex",
-                    "avg",
-                    "p50",
-                    "p75",
-                    "p90",
-                    "p95",
-                    "p99",
-                    "p100",
-                    "max",
-                    "min",
-                    "sum",
-                    "percentile",
-                    "http_error_count",
-                    "http_error_rate",
-                ],
-                "unit": "millisecond",
-            }
-        }
-
-    def test_measurements_with_numbers_in_name(self) -> None:
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_custom",
-            internal_metric="d:transactions/measurements.1234567890.abcdef@millisecond",
-            entity="metrics_distributions",
-            timestamp=self.day_ago + timedelta(hours=1, minutes=0),
-        )
-        response = self.do_request(
-            {
-                "project": self.project.id,
-                "statsPeriod": "14d",
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data == {
-            "measurements.1234567890.abcdef": {
-                "functions": [
-                    "apdex",
-                    "avg",
-                    "p50",
-                    "p75",
-                    "p90",
-                    "p95",
-                    "p99",
-                    "p100",
-                    "max",
-                    "min",
-                    "sum",
-                    "percentile",
-                    "http_error_count",
-                    "http_error_rate",
-                ],
-                "unit": "millisecond",
-            }
-        }
-
-    def test_measurements_with_lots_of_periods(self) -> None:
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_custom",
-            internal_metric="d:transactions/measurements.a.b.c.d.e.f.g@millisecond",
-            entity="metrics_distributions",
-            timestamp=self.day_ago + timedelta(hours=1, minutes=0),
-        )
-        response = self.do_request(
-            {
-                "project": self.project.id,
-                "statsPeriod": "14d",
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data == {
-            "measurements.a.b.c.d.e.f.g": {
-                "functions": [
-                    "apdex",
-                    "avg",
-                    "p50",
-                    "p75",
-                    "p90",
-                    "p95",
-                    "p99",
-                    "p100",
-                    "max",
-                    "min",
-                    "sum",
-                    "percentile",
-                    "http_error_count",
-                    "http_error_rate",
-                ],
-                "unit": "millisecond",
-            }
-        }
-
-    def test_metric_outside_query_daterange(self) -> None:
-        self.store_transaction_metric(
-            1,
-            metric="measurements.something_custom",
-            internal_metric="d:transactions/measurements.something_custom@millisecond",
-            entity="metrics_distributions",
-            timestamp=self.day_ago - timedelta(days=15, minutes=0),
         )
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_measurements_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_measurements_meta.py
@@ -23,7 +23,7 @@ class OrganizationMeasurementsMetaEmptyEndpoint(MetricsEnhancedPerformanceTestCa
         self.url = reverse(
             self.endpoint, kwargs={"organization_id_or_slug": self.project.organization.slug}
         )
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def test_returns_no_measurements(self) -> None:
         self.store_transaction_metric(


### PR DESCRIPTION
Snuba no longer serves the `generic_metrics_distributions` storage, so every query against it fails with `SnubaError: The selected storage=generic_metrics_distributions is not available in this environment yet`. Custom metrics are dead, so these paths are removed rather than gated.

- **Statistical detectors:** the endpoint (transaction) regression detector read its payloads and timeseries from generic metrics. Removes `EndpointRegressionDetector`, its two tasks, the transaction queries, and the performance dispatcher. The profiling function detector is untouched.
- **Custom measurements:** `get_custom_measurements` and the builder's `custom_measurement_map` only ever read generic metrics distributions. The builder already swallowed the error and resolved nothing, so this drops a failing round-trip from every discover query. The measurements-meta endpoint keeps its route and reports no measurements, since frontend and backend don't deploy atomically.
- **`?dataset=metrics`** on the events endpoints resolved straight to `metrics_performance`. It now resolves to `metrics_enhanced_performance`, which falls back to transactions, so these requests return data instead of a 500. Scoped to `OrganizationEventsEndpointBase` — alerts resolve datasets through `sentry.snuba.utils` and compare against `metrics_performance` to identify the sessions dataset, so the registry itself is left alone.

Tests covering the removed behaviour are deleted rather than skipped.

Two pre-existing options are now orphaned and left registered for a follow-up once sentry-options-automator is updated: `statistical_detectors.query.transactions.timeseries_days` and `statistical_detectors.throughput.threshold.transactions`.

Fixes SENTRY-5T6A
Fixes SENTRY-5T6B
Fixes SENTRY-5T6F

https://claude.ai/code/session_01SKD5ZuX5DQuEtbef1aBmyB