### PR TITLE
fix(seer): Scope markdown issue links to organization

### DIFF
--- a/static/app/components/seer/markdown/index.tsx
+++ b/static/app/components/seer/markdown/index.tsx
@@ -15,14 +15,8 @@ import {SeerEmbedRegistry} from './embeds';
 const ISSUE_SHORT_ID_PATTERN =
   /\b((?:[A-Z][A-Z0-9_]+|[0-9_]+[A-Z][A-Z0-9_]*)(?:-[A-Z0-9]+)+)\b/;
 
-function IssueLink({children, shortId}: {children: ReactNode; shortId: string}) {
-  const organization = useOrganization();
-  return (
-    <Link to={`/organizations/${organization.slug}/issues/${shortId}/`}>{children}</Link>
-  );
-}
-
 function LinkifyIssueShortIds({children}: {children: string}): ReactNode {
+  const organization = useOrganization();
   const parts = children.split(ISSUE_SHORT_ID_PATTERN);
   if (parts.length === 1) {
     return children;
@@ -35,9 +29,9 @@ function LinkifyIssueShortIds({children}: {children: string}): ReactNode {
         }
         if (i % 2 === 1) {
           return (
-            <IssueLink key={i} shortId={part}>
+            <Link key={i} to={`/organizations/${organization.slug}/issues/${part}/`}>
               {part}
-            </IssueLink>
+            </Link>
           );
         }
         return <Fragment key={i}>{part}</Fragment>;
@@ -109,15 +103,16 @@ const SEER_EMBED_COMPONENTS: MarkdownProps['components'] = {
   },
   InlineCode: function SeerInlineCode({children, Default}) {
     const isInsideLink = useContext(IsInsideLinkContext);
+    const organization = useOrganization();
     if (isInsideLink) {
       return <Default>{children}</Default>;
     }
     const parts = children.split(ISSUE_SHORT_ID_PATTERN);
     if (parts.length === 3 && parts[1]) {
       return (
-        <IssueLink shortId={parts[1]}>
+        <Link to={`/organizations/${organization.slug}/issues/${parts[1]}/`}>
           <Default>{children}</Default>
-        </IssueLink>
+        </Link>
       );
     }
     return <Default>{children}</Default>;

--- a/static/app/components/seer/markdown/index.tsx
+++ b/static/app/components/seer/markdown/index.tsx
@@ -7,11 +7,20 @@ import {Link} from '@sentry/scraps/link';
 import {Markdown, type MarkdownProps} from '@sentry/scraps/markdown';
 import {Heading} from '@sentry/scraps/text';
 
+import {useOrganization} from 'sentry/utils/useOrganization';
+
 import {STRUCTURED_SEER_EMBED_SCHEMAS} from './embeds/schemas';
 import {SeerEmbedRegistry} from './embeds';
 
 const ISSUE_SHORT_ID_PATTERN =
   /\b((?:[A-Z][A-Z0-9_]+|[0-9_]+[A-Z][A-Z0-9_]*)(?:-[A-Z0-9]+)+)\b/;
+
+function IssueLink({children, shortId}: {children: ReactNode; shortId: string}) {
+  const organization = useOrganization();
+  return (
+    <Link to={`/organizations/${organization.slug}/issues/${shortId}/`}>{children}</Link>
+  );
+}
 
 function LinkifyIssueShortIds({children}: {children: string}): ReactNode {
   const parts = children.split(ISSUE_SHORT_ID_PATTERN);
@@ -26,9 +35,9 @@ function LinkifyIssueShortIds({children}: {children: string}): ReactNode {
         }
         if (i % 2 === 1) {
           return (
-            <Link key={i} to={`/issues/${part}/`}>
+            <IssueLink key={i} shortId={part}>
               {part}
-            </Link>
+            </IssueLink>
           );
         }
         return <Fragment key={i}>{part}</Fragment>;
@@ -106,9 +115,9 @@ const SEER_EMBED_COMPONENTS: MarkdownProps['components'] = {
     const parts = children.split(ISSUE_SHORT_ID_PATTERN);
     if (parts.length === 3 && parts[1]) {
       return (
-        <Link to={`/issues/${parts[1]}/`}>
+        <IssueLink shortId={parts[1]}>
           <Default>{children}</Default>
-        </Link>
+        </IssueLink>
       );
     }
     return <Default>{children}</Default>;

--- a/static/app/views/seerExplorer/components/chat/assistant.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/assistant.spec.tsx
@@ -174,26 +174,6 @@ describe('AssistantBlock', () => {
     expect(link).toHaveAttribute('href', '/issues/ABC-123/');
   });
 
-  it('renders issue IDs as organization-scoped links', () => {
-    const organization = OrganizationFixture({slug: 'org-slug'});
-    const block = createBlock({
-      message: {
-        role: 'assistant',
-        content: 'Compare FRONTEND-123 with `BACKEND-456`.',
-      },
-    });
-    render(<BlockComponent block={block} blockIndex={0} />, {organization});
-
-    expect(screen.getByRole('link', {name: 'FRONTEND-123'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/issues/FRONTEND-123/'
-    );
-    expect(screen.getByRole('link', {name: 'BACKEND-456'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/issues/BACKEND-456/'
-    );
-  });
-
   it('renders external links with target _blank', () => {
     const block = createBlock({
       message: {

--- a/static/app/views/seerExplorer/components/chat/assistant.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/assistant.spec.tsx
@@ -174,6 +174,26 @@ describe('AssistantBlock', () => {
     expect(link).toHaveAttribute('href', '/issues/ABC-123/');
   });
 
+  it('renders issue IDs as organization-scoped links', () => {
+    const organization = OrganizationFixture({slug: 'org-slug'});
+    const block = createBlock({
+      message: {
+        role: 'assistant',
+        content: 'Compare FRONTEND-123 with `BACKEND-456`.',
+      },
+    });
+    render(<BlockComponent block={block} blockIndex={0} />, {organization});
+
+    expect(screen.getByRole('link', {name: 'FRONTEND-123'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/FRONTEND-123/'
+    );
+    expect(screen.getByRole('link', {name: 'BACKEND-456'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/BACKEND-456/'
+    );
+  });
+
   it('renders external links with target _blank', () => {
     const block = createBlock({
       message: {


### PR DESCRIPTION
Plain-text and inline-code issue IDs in Seer markdown were linking through the legacy unscoped issue route.

Build those links with the active organization slug so they work with both customer-domain and non-customer-domain routing.