### PR TITLE
fix(sentry-apps): validate empty app creation requests

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -215,7 +215,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
         objects from URI params, we're applying the same logic for a param in
         the request body.
         """
-        if not request.data:
+        if request.method != "POST":
             return (args, kwargs)
 
         context = self._get_org_context(request)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -571,11 +571,8 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.data["slug"] != sentry_app.slug
 
     def test_cannot_create_app_without_organization(self) -> None:
-        self.create_project(organization=self.organization)
-        sentry_app = self.create_internal_integration(name="Foo Bar")
+        response = self.get_error_response(status_code=404)
 
-        data = self.get_data(name=sentry_app.name, organization=None)
-        response = self.get_error_response(**data, status_code=404)
         assert response.data == {
             "detail": "Please provide a valid value for the 'organization' field.",
         }


### PR DESCRIPTION
Seems like sometimes we see POSTs with empty data, which we treat as a GET request and fail to populate organization context. We can just check for POSt requests in general.

Fixes SENTRY-5JK7
