### PR TITLE
feat(onboarding): Add agentic progress components

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -32,6 +32,7 @@ const productionEntryPoints = [
   // TODO: Remove when wired into the React authentication flow
   'static/app/components/brandPageLayout/**/*.{ts,tsx}',
   // TODO: Remove when wired into the agentic onboarding flow
+  'static/app/views/onboarding/agenticProgress/agenticProgressList.tsx',
   'static/app/views/onboarding/agenticProgress/useAgenticProgress.ts',
   'static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts',
   // https://github.com/getsentry/sentry/pull/121178

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
@@ -1,0 +1,133 @@
+import {AgenticProgressRunFixture} from 'sentry-fixture/agenticProgressRun';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {AgenticProgress, AgenticProgressList} from './agenticProgressList';
+
+describe('AgenticProgressList', () => {
+  it('renders every visible stage status and its notes', () => {
+    render(
+      <AgenticProgressList
+        stages={[
+          {stage: 'connect_mcp', status: 'completed', eventNote: null, extra: null},
+          {
+            stage: 'analyze_project',
+            status: 'completed',
+            eventNote: 'Detected a Next.js application.',
+            extra: null,
+          },
+          {stage: 'create_project', status: 'bypassed', eventNote: null, extra: null},
+          {stage: 'instrument_app', status: 'skipped', eventNote: null, extra: null},
+          {
+            stage: 'plan_test_error',
+            status: 'failed',
+            eventNote: 'Could not determine a safe test path.',
+            extra: null,
+          },
+          {
+            stage: 'send_verification_error',
+            status: 'waiting',
+            eventNote: 'Open the app to trigger the error.',
+            extra: null,
+          },
+          {
+            stage: 'receive_verification_error',
+            status: null,
+            eventNote: null,
+            extra: null,
+          },
+          {stage: 'prepare_production', status: 'active', eventNote: null, extra: null},
+          {
+            stage: 'check_stack_trace_quality',
+            status: null,
+            eventNote: null,
+            extra: null,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Connect agent')).toBeInTheDocument();
+    expect(screen.getByText('Confirm test error')).toBeInTheDocument();
+    expect(screen.getByText('Analyzing your application')).toBeInTheDocument();
+    expect(screen.getByText('Detected a Next.js application.')).toBeInTheDocument();
+    expect(screen.getAllByText('Done')).toHaveLength(2);
+    expect(screen.getByText('Skipped')).toBeInTheDocument();
+    expect(screen.getByText('Bypassed')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting Input')).toBeInTheDocument();
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(screen.getByText('Check stack traces')).toBeInTheDocument();
+  });
+
+  it('renders send and confirmation progress as separate rows', () => {
+    render(
+      <AgenticProgressList
+        stages={[
+          {
+            stage: 'send_verification_error',
+            status: 'completed',
+            eventNote: 'Sent the test error.',
+            extra: null,
+          },
+          {
+            stage: 'receive_verification_error',
+            status: 'active',
+            eventNote: 'Waiting for Sentry to process the event.',
+            extra: null,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Send test error')).toBeInTheDocument();
+    expect(screen.getByText('Confirm test error')).toBeInTheDocument();
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(
+      screen.getByText('Waiting for Sentry to process the event.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Sent the test error.')).toBeInTheDocument();
+  });
+
+  it('renders additional stage content', () => {
+    render(
+      <AgenticProgressList
+        stages={[
+          {stage: 'create_project', status: 'completed', eventNote: null, extra: null},
+        ]}
+        extraContentByStage={{create_project: 'Created 2 projects'}}
+      />
+    );
+
+    expect(screen.getByText('Created 2 projects')).toBeInTheDocument();
+  });
+
+  it('composes created projects from the run', async () => {
+    const projectsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [
+        ProjectFixture({slug: 'react-frontend'}),
+        ProjectFixture({slug: 'python-backend'}),
+      ],
+    });
+
+    render(
+      <AgenticProgress
+        run={AgenticProgressRunFixture({
+          stages: [
+            {
+              stage: 'create_project',
+              status: 'completed',
+              eventNote: null,
+              extra: {projectSlugs: ['react-frontend', 'python-backend']},
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Created 2 projects')).toBeInTheDocument();
+    await waitFor(() => expect(projectsRequest).toHaveBeenCalled());
+  });
+});

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
@@ -1,0 +1,251 @@
+import {useState} from 'react';
+
+import {Button, ButtonBar} from '@sentry/scraps/button';
+import {Container, Stack} from '@sentry/scraps/layout';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconChevron} from 'sentry/icons';
+import * as Storybook from 'sentry/stories';
+
+import {AgenticProgress} from './agenticProgressList';
+import type {AgenticProgressRun} from './types';
+
+type AgenticProgressStageState = AgenticProgressRun['stages'][number];
+
+function makeAgenticProgressRun(
+  params: Partial<AgenticProgressRun> = {}
+): AgenticProgressRun {
+  return {
+    channelId: '54c300212517432d91c915960bfc5c09',
+    clientRunId: '021902d5-2333-4823-81a9-5596b331e8af',
+    continueUpdates: true,
+    createdAt: '2026-08-13T14:01:28.298407Z',
+    expiresAt: '2026-08-14T14:01:28.298407Z',
+    runId: '16ff4fe7966f495ab788069fb35d8e7b',
+    runStatus: 'active',
+    schemaVersion: 1,
+    sequence: 0,
+    stages: [],
+    updatedAt: '2026-08-13T14:01:28.298407Z',
+    ...params,
+  };
+}
+
+const pendingStages: AgenticProgressStageState[] = [
+  {stage: 'connect_mcp', status: 'completed', eventNote: null, extra: null},
+  {stage: 'analyze_project', status: null, eventNote: null, extra: null},
+  {stage: 'create_project', status: null, eventNote: null, extra: null},
+  {stage: 'instrument_app', status: null, eventNote: null, extra: null},
+  {stage: 'plan_test_error', status: null, eventNote: null, extra: null},
+  {stage: 'send_verification_error', status: null, eventNote: null, extra: null},
+  {stage: 'receive_verification_error', status: null, eventNote: null, extra: null},
+  {stage: 'prepare_production', status: null, eventNote: null, extra: null},
+  {stage: 'check_stack_trace_quality', status: null, eventNote: null, extra: null},
+];
+
+const createdProjectSlugs = ['react-frontend', 'python-backend'];
+
+export default Storybook.story('Agentic Onboarding Progress', story => {
+  story('All states', () => (
+    <StoryFrame>
+      <AgenticProgress
+        run={makeAgenticProgressRun({
+          sequence: 9,
+          stages: [
+            {stage: 'connect_mcp', status: 'completed', eventNote: null, extra: null},
+            {
+              stage: 'analyze_project',
+              status: 'completed',
+              eventNote: 'Detected a React application using Vite.',
+              extra: null,
+            },
+            {
+              stage: 'create_project',
+              status: 'skipped',
+              eventNote: 'The project already exists in this organization.',
+              extra: null,
+            },
+            {
+              stage: 'instrument_app',
+              status: 'bypassed',
+              eventNote: 'Instrumentation is managed by another package.',
+              extra: null,
+            },
+            {
+              stage: 'plan_test_error',
+              status: 'failed',
+              eventNote: 'Could not determine a safe path for a test error.',
+              extra: null,
+            },
+            {
+              stage: 'send_verification_error',
+              status: 'waiting',
+              eventNote:
+                'Open the application and click “Trigger test error” to continue.',
+              extra: null,
+            },
+            {
+              stage: 'receive_verification_error',
+              status: null,
+              eventNote: null,
+              extra: null,
+            },
+            {
+              stage: 'prepare_production',
+              status: 'active',
+              eventNote: 'Reviewing source maps and release configuration.',
+              extra: null,
+            },
+            {
+              stage: 'check_stack_trace_quality',
+              status: null,
+              eventNote: null,
+              extra: null,
+            },
+          ],
+        })}
+      />
+    </StoryFrame>
+  ));
+
+  story('Interactive progress', () => <InteractiveProgressStory />);
+});
+
+const terminalStatuses = new Set(['completed', 'skipped', 'bypassed', 'failed']);
+
+function InteractiveProgressStory() {
+  const [sequence, setSequence] = useState(1);
+  const [stages, setStages] = useState<AgenticProgressStageState[]>(() =>
+    pendingStages.map(stage =>
+      stage.stage === 'analyze_project'
+        ? {...stage, status: 'active', eventNote: 'Inspecting the application.'}
+        : stage
+    )
+  );
+  const activeStageIndex = stages.findIndex(
+    stage => stage.stage !== 'connect_mcp' && !terminalStatuses.has(stage.status ?? '')
+  );
+  const isComplete = activeStageIndex === -1;
+
+  function resetProgress() {
+    setStages(
+      pendingStages.map(stage =>
+        stage.stage === 'analyze_project'
+          ? {...stage, status: 'active', eventNote: 'Inspecting the application.'}
+          : stage
+      )
+    );
+    setSequence(currentSequence => currentSequence + 1);
+  }
+
+  function updateCurrentStage(status: AgenticProgressStageState['status']) {
+    if (isComplete) {
+      return;
+    }
+
+    setStages(currentStages =>
+      currentStages.map((stage, index) => {
+        if (index === activeStageIndex) {
+          if (stage.stage === 'create_project' && status === 'completed') {
+            return {
+              ...stage,
+              status,
+              eventNote: noteForStatus(status),
+              extra: {projectSlugs: createdProjectSlugs},
+            };
+          }
+
+          return {...stage, status, eventNote: noteForStatus(status)};
+        }
+
+        return stage;
+      })
+    );
+    setSequence(currentSequence => currentSequence + 1);
+  }
+
+  function makeProgress() {
+    if (isComplete) {
+      resetProgress();
+      return;
+    }
+
+    const currentStatus = stages[activeStageIndex]?.status;
+    if (currentStatus === null) {
+      updateCurrentStage('active');
+      return;
+    }
+
+    updateCurrentStage(currentStatus === 'active' ? 'waiting' : 'completed');
+  }
+
+  return (
+    <StoryFrame>
+      <Stack gap="lg" align="start">
+        <ButtonBar>
+          <Button onClick={makeProgress}>{isComplete ? 'Reset' : 'Make Progress'}</Button>
+          <DropdownMenu
+            items={[
+              {
+                key: 'skip',
+                label: 'Skip Step',
+                onAction: () => updateCurrentStage('skipped'),
+              },
+              {
+                key: 'fail',
+                label: 'Fail Step',
+                onAction: () => updateCurrentStage('failed'),
+              },
+              {
+                key: 'bypass',
+                label: 'Bypass Step',
+                onAction: () => updateCurrentStage('bypassed'),
+              },
+            ]}
+            trigger={props => (
+              <Button
+                {...props}
+                aria-label="More progress options"
+                disabled={isComplete}
+                icon={<IconChevron direction="down" />}
+              />
+            )}
+            position="bottom-end"
+          />
+        </ButtonBar>
+        <AgenticProgress
+          run={makeAgenticProgressRun({
+            sequence,
+            stages,
+            runStatus: isComplete ? 'completed' : 'active',
+          })}
+        />
+      </Stack>
+    </StoryFrame>
+  );
+}
+
+function noteForStatus(status: AgenticProgressStageState['status']) {
+  switch (status) {
+    case 'waiting':
+      return 'Waiting for input before continuing.';
+    case 'completed':
+      return 'Finished this step successfully.';
+    case 'skipped':
+      return 'Skipped this step because it was not needed.';
+    case 'failed':
+      return 'Could not complete this step.';
+    case 'bypassed':
+      return 'Completed this step outside the normal workflow.';
+    default:
+      return 'Working on this step.';
+  }
+}
+
+function StoryFrame({children}: {children: React.ReactNode}) {
+  return (
+    <Container width="100%" padding="3xl">
+      {children}
+    </Container>
+  );
+}

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -1,0 +1,298 @@
+import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ProjectList} from 'sentry/components/projectList';
+import {
+  IconCircle,
+  IconCircleCheckmark,
+  IconFatal,
+  IconNot,
+  IconPieHalf,
+} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+
+import type {AgenticProgressRun} from './types';
+
+type AgenticProgressStageState = AgenticProgressRun['stages'][number];
+type AgenticProgressStage = AgenticProgressStageState['stage'];
+type AgenticProgressStageStatus = NonNullable<AgenticProgressStageState['status']>;
+
+const STAGE_LABELS: Record<AgenticProgressStage, string> = {
+  connect_mcp: t('Connect agent'),
+  analyze_project: t('Analyzing your application'),
+  create_project: t('Creating project(s)'),
+  instrument_app: t('Instrumenting app'),
+  plan_test_error: t('Plan test error'),
+  send_verification_error: t('Send test error'),
+  receive_verification_error: t('Confirm test error'),
+  prepare_production: t('Prepare production'),
+  check_stack_trace_quality: t('Check stack traces'),
+};
+
+const STATUS_LABELS: Record<AgenticProgressStageStatus, string> = {
+  active: t('In progress'),
+  waiting: t('Awaiting Input'),
+  completed: t('Done'),
+  skipped: t('Skipped'),
+  bypassed: t('Bypassed'),
+  failed: t('Failed'),
+};
+
+const STATUS_VARIANTS: Record<
+  AgenticProgressStageStatus,
+  'promotion' | 'warning' | 'success' | 'muted' | 'danger'
+> = {
+  active: 'promotion',
+  waiting: 'warning',
+  completed: 'success',
+  skipped: 'muted',
+  bypassed: 'muted',
+  failed: 'danger',
+};
+
+function StageSymbol({status}: {status: AgenticProgressStageStatus | null}) {
+  if (status === 'completed') {
+    return <IconCircleCheckmark size="md" variant="success" />;
+  }
+
+  if (status === 'skipped') {
+    return <IconNot size="md" variant="muted" />;
+  }
+
+  if (status === 'bypassed') {
+    return <IconCircle size="md" variant="muted" />;
+  }
+
+  if (status === 'failed') {
+    return <IconFatal size="md" variant="danger" />;
+  }
+
+  if (status === 'waiting') {
+    return <IconPieHalf size="md" variant="warning" />;
+  }
+
+  if (status === 'active') {
+    return <ActiveLoadingIndicator mini />;
+  }
+
+  return <IconCircle size="md" variant="muted" />;
+}
+
+const ActiveLoadingIndicator = styled(LoadingIndicator)`
+  && {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+  }
+
+  && .loading-indicator {
+    width: 16px;
+    height: 16px;
+    border-width: 2px;
+  }
+`;
+
+const MotionGrid = motion.create(Grid);
+const MotionContainer = motion.create(Container);
+const MotionTag = motion.create(Tag);
+const MotionText = motion.create(Text);
+
+// The negative margins counter ProgressItem's padding so the animated surface is
+// full-bleed. Grid's tokenized margin props do not support negative spacing.
+const MotionExtraContent = styled(MotionGrid)`
+  min-height: 0;
+  margin: 0 -${p => p.theme.space.lg} -${p => p.theme.space.lg};
+`;
+
+function ExtraContent({children}: {children: React.ReactNode}) {
+  return (
+    <MotionExtraContent
+      initial={{height: 0}}
+      animate={{height: 'auto'}}
+      exit={{height: 0}}
+      row="3"
+      column="1 / -1"
+      columns="subgrid"
+      overflow="hidden"
+    >
+      <Grid
+        column="1 / -1"
+        columns="subgrid"
+        marginTop="md"
+        padding="md 0"
+        background="secondary"
+      >
+        <Grid column="2 / 4" align="center">
+          {children}
+        </Grid>
+      </Grid>
+    </MotionExtraContent>
+  );
+}
+
+function ProgressItem({
+  extraContent,
+  isLast,
+  stage,
+}: {
+  isLast: boolean;
+  stage: AgenticProgressStageState;
+  extraContent?: React.ReactNode;
+}) {
+  const label = STAGE_LABELS[stage.stage];
+  const variant =
+    stage.status === 'active'
+      ? 'primary'
+      : stage.status
+        ? STATUS_VARIANTS[stage.status]
+        : 'muted';
+
+  return (
+    <Grid
+      columns="max-content minmax(0, 1fr) max-content"
+      rows="auto auto auto"
+      align="center"
+      gap="0 md"
+      padding="lg"
+      borderBottom={isLast ? undefined : 'muted'}
+    >
+      <Grid row="1" column="1" align="center" justify="center" alignSelf="center">
+        <AnimatePresence initial={false}>
+          <MotionGrid
+            key={stage.status ?? 'pending'}
+            initial={{scale: 1.1, opacity: 0}}
+            animate={{scale: 1, opacity: 1}}
+            exit={{scale: 0.9, opacity: 0}}
+            align="center"
+            justify="center"
+            alignSelf="center"
+            justifySelf="center"
+            style={{gridArea: '1 / 1'}}
+          >
+            <StageSymbol status={stage.status} />
+          </MotionGrid>
+        </AnimatePresence>
+      </Grid>
+      <Grid row="1" column="2" align="center">
+        <Text bold variant={variant}>
+          {label}
+        </Text>
+      </Grid>
+      <Grid row="1" column="3" align="center" justifyItems="end">
+        {stage.status ? null : (
+          <Tag
+            aria-hidden="true"
+            variant="muted"
+            style={{gridArea: '1 / 1', visibility: 'hidden'}}
+          >
+            placeholder
+          </Tag>
+        )}
+        <AnimatePresence initial={false}>
+          {stage.status ? (
+            <MotionTag
+              key={stage.status}
+              initial={{opacity: 0, y: -10}}
+              animate={{opacity: 1, y: 0}}
+              exit={{opacity: 0, y: 10}}
+              style={{gridArea: '1 / 1', justifySelf: 'end'}}
+              variant={STATUS_VARIANTS[stage.status]}
+            >
+              {STATUS_LABELS[stage.status]}
+            </MotionTag>
+          ) : null}
+        </AnimatePresence>
+      </Grid>
+      <AnimatePresence initial={false}>
+        {stage.eventNote ? (
+          <MotionContainer
+            key="note-container"
+            initial={{height: 0}}
+            animate={{height: 'auto'}}
+            exit={{height: 0}}
+            transition={{duration: 0.15}}
+            row="2"
+            column="2 / 4"
+            overflow="hidden"
+          >
+            <Grid paddingTop="xs">
+              <AnimatePresence initial={false}>
+                <MotionText
+                  key={stage.eventNote}
+                  initial={{opacity: 0, y: -10}}
+                  animate={{opacity: 1, y: 0}}
+                  exit={{opacity: 0, y: 10}}
+                  style={{gridArea: '1 / 1'}}
+                  align="left"
+                  size="sm"
+                  variant="muted"
+                  density="comfortable"
+                >
+                  {stage.eventNote}
+                </MotionText>
+              </AnimatePresence>
+            </Grid>
+          </MotionContainer>
+        ) : null}
+      </AnimatePresence>
+      <AnimatePresence initial={false}>
+        {extraContent ? (
+          <ExtraContent key="extra-content">{extraContent}</ExtraContent>
+        ) : null}
+      </AnimatePresence>
+    </Grid>
+  );
+}
+
+export function AgenticProgressList({
+  extraContentByStage,
+  stages,
+}: {
+  stages: AgenticProgressStageState[];
+  extraContentByStage?: Partial<Record<AgenticProgressStage, React.ReactNode>>;
+}) {
+  return (
+    <Stack width="100%" border="muted" radius="lg" overflow="hidden" gap="0">
+      {stages.map((stage, index) => (
+        <ProgressItem
+          key={stage.stage}
+          stage={stage}
+          isLast={index === stages.length - 1}
+          extraContent={extraContentByStage?.[stage.stage]}
+        />
+      ))}
+    </Stack>
+  );
+}
+
+function CreatedProjects({projectSlugs}: {projectSlugs: string[]}) {
+  return (
+    <Grid columns="max-content max-content" align="center" gap="md">
+      <Text size="sm" variant="muted">
+        {tn('Created %s project', 'Created %s projects', projectSlugs.length)}
+      </Text>
+      <ProjectList projectSlugs={projectSlugs} maxVisibleProjects={3} />
+    </Grid>
+  );
+}
+
+export function AgenticProgress({run}: {run: AgenticProgressRun}) {
+  const createProjectStage = run.stages.find(stage => stage.stage === 'create_project');
+  const projectSlugs = createProjectStage?.extra?.projectSlugs ?? [];
+
+  return (
+    <AgenticProgressList
+      stages={run.stages}
+      extraContentByStage={
+        projectSlugs.length
+          ? {create_project: <CreatedProjects projectSlugs={projectSlugs} />}
+          : undefined
+      }
+    />
+  );
+}


### PR DESCRIPTION
Adds the reusable agentic onboarding progress list, individual stage items, animated status and note transitions, and created-project context. Storybook covers every supported state and provides an interactive progression control for iterating on the experience.

Each backend stage remains visible as its own list item, including separate send and confirmation steps, so progress history is preserved as the run advances.