### PR TITLE
Return Conduit credentials in response headers

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -169,7 +169,9 @@ def apply_cors_headers(
         "sentry-trace, baggage, X-CSRFToken"
     )
     response["Access-Control-Expose-Headers"] = (
-        "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+        "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+        "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+        "Endpoint, Retry-After, Link"
     )
 
     if request.META.get("HTTP_ORIGIN") == "null":

--- a/src/sentry/conduit/api.py
+++ b/src/sentry/conduit/api.py
@@ -1,0 +1,25 @@
+from django.http.response import HttpResponseBase
+
+from sentry.conduit.auth import ConduitCredentials, get_conduit_credentials
+
+CONDUIT_TOKEN_HEADER = "X-Conduit-Token"
+CONDUIT_CHANNEL_ID_HEADER = "X-Conduit-Channel-Id"
+CONDUIT_URL_HEADER = "X-Conduit-Url"
+
+
+def add_conduit_response_headers(
+    response: HttpResponseBase,
+    organization_id: int,
+    *,
+    channel_id: str | None = None,
+) -> ConduitCredentials | None:
+    """Attach the credentials needed by conduit-client to an API response."""
+    try:
+        credentials = get_conduit_credentials(organization_id, channel_id=channel_id)
+    except ValueError:
+        return None
+
+    response.headers[CONDUIT_TOKEN_HEADER] = credentials.token
+    response.headers[CONDUIT_CHANNEL_ID_HEADER] = credentials.channel_id
+    response.headers[CONDUIT_URL_HEADER] = credentials.url
+    return credentials

--- a/src/sentry/conduit/auth.py
+++ b/src/sentry/conduit/auth.py
@@ -67,6 +67,7 @@ def generate_conduit_token(
 def get_conduit_credentials(
     org_id: int,
     gateway_url: str | None = None,
+    channel_id: str | None = None,
 ) -> ConduitCredentials:
     """
     Generate all credentials needed to connect to Conduit.
@@ -76,7 +77,10 @@ def get_conduit_credentials(
     """
     if gateway_url is None:
         gateway_url = settings.CONDUIT_GATEWAY_URL
-    channel_id = generate_channel_id()
+    if not gateway_url:
+        raise ValueError("CONDUIT_GATEWAY_URL not configured")
+    if channel_id is None:
+        channel_id = generate_channel_id()
     token = generate_conduit_token(org_id, channel_id)
 
     metrics.incr(

--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -1,5 +1,4 @@
-import sentry_sdk
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -9,19 +8,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.conduit.auth import get_conduit_credentials
+from sentry.conduit.api import add_conduit_response_headers
 from sentry.conduit.tasks import stream_demo_data
 from sentry.models.organization import Organization
-
-
-class ConduitCredentialsSerializer(serializers.Serializer):
-    token = serializers.CharField()
-    channel_id = serializers.UUIDField()
-    url = serializers.URLField()
-
-
-class ConduitCredentialsResponseSerializer(serializers.Serializer):
-    conduit = ConduitCredentialsSerializer()
 
 
 class OrganizationConduitDemoPermission(OrganizationPermission):
@@ -47,22 +36,13 @@ class OrganizationConduitDemoEndpoint(OrganizationEndpoint):
     def post(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:conduit-demo", organization, actor=request.user):
             return Response(status=404)
-        try:
-            conduit_credentials = get_conduit_credentials(
-                organization.id,
-            )
-        except ValueError as e:
-            sentry_sdk.capture_exception(e, level="warning")
+        response = Response(status=status.HTTP_201_CREATED)
+        conduit_credentials = add_conduit_response_headers(response, organization.id)
+        if conduit_credentials is None:
             return Response(
                 {"error": "Conduit is not configured properly"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         # Kick off a task to stream data to Conduit
         stream_demo_data.delay(organization.id, conduit_credentials.channel_id)
-        serializer = ConduitCredentialsResponseSerializer(
-            {
-                "conduit": conduit_credentials._asdict(),
-            }
-        )
-        # Respond back to the user with the credentials needed to connect to Conduit
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return response

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -134,7 +134,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert "Access-Control-Allow-Credentials" not in response
@@ -161,7 +163,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
@@ -188,7 +192,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
@@ -216,7 +222,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
         assert response["Access-Control-Allow-Credentials"] == "true"
@@ -288,7 +296,9 @@ class EndpointTest(APITestCase):
             "sentry-trace, baggage, X-CSRFToken"
         )
         assert response["Access-Control-Expose-Headers"] == (
-            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, Endpoint, Retry-After, Link"
+            "X-Sentry-Error, X-Sentry-Direct-Hit, X-Hits, X-Max-Hits, "
+            "X-Conduit-Token, X-Conduit-Channel-Id, X-Conduit-Url, "
+            "Endpoint, Retry-After, Link"
         )
         assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
 

--- a/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
+++ b/tests/sentry/conduit/endpoints/test_organization_conduit_demo.py
@@ -35,11 +35,9 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
             status_code=201,
         )
 
-        assert "conduit" in response.data
-        assert "token" in response.data["conduit"]
-        assert "channel_id" in response.data["conduit"]
-        assert "url" in response.data["conduit"]
-        assert str(self.organization.id) in response.data["conduit"]["url"]
+        assert response["X-Conduit-Token"]
+        assert response["X-Conduit-Channel-Id"]
+        assert str(self.organization.id) in response["X-Conduit-Url"]
 
     @override_settings(
         CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,
@@ -65,9 +63,8 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
             status_code=201,
         )
 
-        assert "conduit" in response.data
-        assert "token" in response.data["conduit"]
-        assert "channel_id" in response.data["conduit"]
+        assert response["X-Conduit-Token"]
+        assert response["X-Conduit-Channel-Id"]
 
     @with_feature("organizations:conduit-demo")
     def test_post_without_org_access(self) -> None:
@@ -112,8 +109,8 @@ class OrganizationConduitDemoEndpointTest(APITestCase):
             status_code=201,
         )
 
-        assert response1.data["conduit"]["token"] != response2.data["conduit"]["token"]
-        assert response1.data["conduit"]["channel_id"] != response2.data["conduit"]["channel_id"]
+        assert response1["X-Conduit-Token"] != response2["X-Conduit-Token"]
+        assert response1["X-Conduit-Channel-Id"] != response2["X-Conduit-Channel-Id"]
 
     @override_settings(
         CONDUIT_GATEWAY_PRIVATE_KEY=RS256_KEY_B64,

--- a/tests/sentry/conduit/test_auth.py
+++ b/tests/sentry/conduit/test_auth.py
@@ -1,6 +1,7 @@
 import base64
 import time
 from unittest.mock import patch
+from uuid import uuid4
 
 import jwt as pyjwt
 import pytest
@@ -166,6 +167,14 @@ def test_get_conduit_credentials_returns_all_credentials() -> None:
         assert result.url == f"{gateway_url}/events/{org_id}"
 
 
+def test_get_conduit_credentials_requires_gateway_url() -> None:
+    with patch("sentry.conduit.auth.settings") as mock_settings:
+        mock_settings.CONDUIT_GATEWAY_URL = None
+
+        with pytest.raises(ValueError, match="CONDUIT_GATEWAY_URL not configured"):
+            get_conduit_credentials(123)
+
+
 def test_get_conduit_credentials_uses_custom_url() -> None:
     """Should use provided gateway_url instead of settings."""
     gateway_url = "https://custom.conduit.io"
@@ -183,6 +192,20 @@ def test_get_conduit_credentials_uses_custom_url() -> None:
 
         assert str(org_id) in result.url
         assert result.url == f"{gateway_url}/events/{org_id}"
+
+
+def test_get_conduit_credentials_uses_existing_channel() -> None:
+    gateway_url = "https://conduit.example.com"
+    channel_id = str(uuid4())
+    with patch("sentry.conduit.auth.settings") as mock_settings:
+        mock_settings.CONDUIT_GATEWAY_PRIVATE_KEY = RS256_KEY_B64
+        mock_settings.CONDUIT_GATEWAY_JWT_ISSUER = "sentry"
+        mock_settings.CONDUIT_GATEWAY_JWT_AUDIENCE = "conduit"
+        mock_settings.CONDUIT_GATEWAY_URL = gateway_url
+
+        result = get_conduit_credentials(123, channel_id=channel_id)
+
+        assert result.channel_id == channel_id
 
 
 def test_get_conduit_credentials_token_is_valid() -> None:


### PR DESCRIPTION
Conduit initialization responses now expose the token, channel ID, and gateway URL through `X-Conduit-*` headers instead of adding a Conduit-specific object to each endpoint's response schema. The headers are included in CORS exposure, and the shared response helper keeps credential generation and graceful configuration failure handling consistent across endpoints.

The Conduit demo endpoint adopts the header contract in this PR. Agentic onboarding integration remains in the dependent follow-up PR.