### PR TITLE
fix(issues): Preserve Seer setup analytics keys

### DIFF
--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -115,10 +115,7 @@ export const AutofixQuotaContent = registerLLMContext(
 export function AutofixContent({aiConfig, group, project}: AutofixContentProps) {
   const organization = useOrganization();
   const analyticsArea = useAnalyticsArea() || 'seer';
-  const setupAnalyticsEventKey =
-    analyticsArea === 'issue_inbox'
-      ? 'issue_inbox.seer_setup_clicked'
-      : 'issue_details.seer_setup_clicked';
+  const setupAnalyticsEventKey = `${analyticsArea}.seer_setup_clicked`;
   const autofix = useExplorerAutofix(group);
   const {data: setupCheck, isPending} = useQuery(
     getSeerOnboardingCheckQueryOptions({organization})

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -115,6 +115,10 @@ export const AutofixQuotaContent = registerLLMContext(
 export function AutofixContent({aiConfig, group, project}: AutofixContentProps) {
   const organization = useOrganization();
   const analyticsArea = useAnalyticsArea() || 'seer';
+  const setupAnalyticsEventKey =
+    analyticsArea === 'issue_inbox'
+      ? 'issue_inbox.seer_setup_clicked'
+      : 'issue_details.seer_setup_clicked';
   const autofix = useExplorerAutofix(group);
   const {data: setupCheck, isPending} = useQuery(
     getSeerOnboardingCheckQueryOptions({organization})
@@ -221,7 +225,7 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
               <LinkButton
                 to={`/settings/${organization.slug}/seer/onboarding/`}
                 icon={<IconSeer />}
-                analyticsEventKey={`${analyticsArea}.setup_clicked`}
+                analyticsEventKey={setupAnalyticsEventKey}
                 analyticsEventName={
                   analyticsArea === 'issue_inbox'
                     ? 'Issue Inbox: Seer Setup Clicked'
@@ -235,7 +239,7 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
               <LinkButton
                 to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
                 icon={<IconSeer />}
-                analyticsEventKey={`${analyticsArea}.setup_clicked`}
+                analyticsEventKey={setupAnalyticsEventKey}
                 analyticsEventName={
                   analyticsArea === 'issue_inbox'
                     ? 'Issue Inbox: Seer Setup Clicked'


### PR DESCRIPTION
forgot to push this last commit in #121903 to revert a change to the analytics key