### PR TITLE
ref(conduit): Move stream client into Sentry

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,6 +27,8 @@ const productionEntryPoints = [
   'static/app/chartcuterie/**/*.{js,ts,tsx}',
   // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
+  // TODO: Remove when the Conduit onboarding migration lands
+  'static/app/utils/useConduitStream.tsx',
   // TODO: Remove when wired into the connect repository modal
   'static/app/components/connectRepository/**/*.{ts,tsx}',
   // https://github.com/getsentry/sentry/pull/121178

--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "classnames": "2.3.1",
     "color": "5.0.2",
     "compression-webpack-plugin": "12.0.0",
-    "conduit-client": "^1.0.0",
     "core-js": "3.45.0",
     "cronstrue": "^2.50.0",
     "css-loader": "^7.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,9 +331,6 @@ importers:
       compression-webpack-plugin:
         specifier: 12.0.0
         version: 12.0.0
-      conduit-client:
-        specifier: ^1.0.0
-        version: 1.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       core-js:
         specifier: 3.45.0
         version: 3.45.0
@@ -4802,13 +4799,6 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
-
-  conduit-client@1.0.0:
-    resolution: {integrity: sha512-81EyHn0I78+Lz++v3fI5774RtyEzE4wT3rdotvqa7M99ll24eknDYEXB4nHs93DEeyKnhZNgJt+9GN/+bsBWcg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -13315,11 +13305,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
-
-  conduit-client@1.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
 
   config-chain@1.1.13:
     dependencies:

--- a/static/app/utils/api/apiFetch.tsx
+++ b/static/app/utils/api/apiFetch.tsx
@@ -8,6 +8,9 @@ import {QUERY_API_CLIENT} from 'sentry/utils/queryClient';
 export type ApiResponse<TResponseData = unknown> = {
   headers: {
     Link?: string;
+    'X-Conduit-Channel-Id'?: string;
+    'X-Conduit-Token'?: string;
+    'X-Conduit-Url'?: string;
     'X-Hits'?: number;
     'X-Max-Hits'?: number;
     'X-Sentry-Direct-Hit'?: string;
@@ -35,6 +38,10 @@ export async function apiFetch<TQueryFnData = unknown>(
   return {
     headers: {
       Link: response?.getResponseHeader('Link') ?? undefined,
+      'X-Conduit-Channel-Id':
+        response?.getResponseHeader('X-Conduit-Channel-Id') ?? undefined,
+      'X-Conduit-Token': response?.getResponseHeader('X-Conduit-Token') ?? undefined,
+      'X-Conduit-Url': response?.getResponseHeader('X-Conduit-Url') ?? undefined,
       'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
       'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
       'X-Sentry-Direct-Hit':
@@ -67,6 +74,10 @@ export async function apiFetchInfinite<TQueryFnData = unknown>(
   return {
     headers: {
       Link: response?.getResponseHeader('Link') ?? undefined,
+      'X-Conduit-Channel-Id':
+        response?.getResponseHeader('X-Conduit-Channel-Id') ?? undefined,
+      'X-Conduit-Token': response?.getResponseHeader('X-Conduit-Token') ?? undefined,
+      'X-Conduit-Url': response?.getResponseHeader('X-Conduit-Url') ?? undefined,
       'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
       'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
       'X-Sentry-Direct-Hit':

--- a/static/app/utils/api/apiOptions.spec.tsx
+++ b/static/app/utils/api/apiOptions.spec.tsx
@@ -157,11 +157,22 @@ describe('apiOptions', () => {
 
     expect(result.current.data).toEqual({
       json: ['Project 1', 'Project 2'],
-      headers: {Link: 'my-link', 'X-Hits': 14, 'X-Max-Hits': undefined},
+      headers: {
+        Link: 'my-link',
+        'X-Conduit-Channel-Id': undefined,
+        'X-Conduit-Token': undefined,
+        'X-Conduit-Url': undefined,
+        'X-Hits': 14,
+        'X-Max-Hits': undefined,
+        'X-Sentry-Direct-Hit': undefined,
+      },
     });
 
     expectTypeOf(result.current.data!.headers).toEqualTypeOf<{
       Link?: string;
+      'X-Conduit-Channel-Id'?: string;
+      'X-Conduit-Token'?: string;
+      'X-Conduit-Url'?: string;
       'X-Hits'?: number;
       'X-Max-Hits'?: number;
       'X-Sentry-Direct-Hit'?: string;

--- a/static/app/utils/useConduitStream.spec.tsx
+++ b/static/app/utils/useConduitStream.spec.tsx
@@ -1,0 +1,192 @@
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useConduitStream} from 'sentry/utils/useConduitStream';
+
+type Message = {
+  value: string;
+};
+
+const endpoint = '/organizations/org-slug/conduit-demo/';
+const conduitHeaders = {
+  'X-Conduit-Channel-Id': 'channel-id',
+  'X-Conduit-Token': 'token',
+  'X-Conduit-Url': 'https://conduit.example.com/events',
+};
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  close = jest.fn();
+  listeners = new Map<string, Set<EventListener>>();
+
+  constructor(public url: string | URL) {
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, data = '', lastEventId = '') {
+    const event = new MessageEvent(type, {data, lastEventId});
+    this.listeners.get(type)?.forEach(listener => listener(event));
+  }
+}
+
+function conduitQueryOptions() {
+  return apiOptions.as<{initialized: boolean}>()(
+    '/organizations/$organizationIdOrSlug/conduit-demo/',
+    {
+      path: {organizationIdOrSlug: 'org-slug'},
+      method: 'POST',
+      staleTime: 0,
+    }
+  );
+}
+
+describe('useConduitStream', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    global.EventSource = MockEventSource as unknown as typeof EventSource;
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('starts a stream from API response headers and returns the response body', async () => {
+    MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: {initialized: true},
+      headers: conduitHeaders,
+    });
+
+    const onConnect = jest.fn();
+    const {result} = renderHookWithProviders(() =>
+      useConduitStream({
+        enabled: true,
+        queryOptions: conduitQueryOptions(),
+        onConnect,
+        onMessage: (_message: Message) => {},
+      })
+    );
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    expect(result.current.data).toEqual({initialized: true});
+    expect(MockEventSource.instances[0]!.url.toString()).toBe(
+      'https://conduit.example.com/events?token=token&channel_id=channel-id'
+    );
+
+    act(() => MockEventSource.instances[0]!.emit('open'));
+
+    expect(result.current.isConnected).toBe(true);
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers current messages once and ignores stale sequences', async () => {
+    MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: {},
+      headers: conduitHeaders,
+    });
+
+    const onMessage = jest.fn((_message: Message) => {});
+    renderHookWithProviders(() =>
+      useConduitStream({
+        enabled: true,
+        queryOptions: conduitQueryOptions(),
+        onMessage,
+      })
+    );
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    const eventSource = MockEventSource.instances[0]!;
+    act(() => {
+      eventSource.emit(
+        'stream',
+        JSON.stringify({
+          event_type: 'stream',
+          message_id: 'message-2',
+          payload: {value: 'new'},
+          phase: 'PHASE_DELTA',
+          sequence: 2,
+        })
+      );
+      eventSource.emit(
+        'stream',
+        JSON.stringify({
+          event_type: 'stream',
+          message_id: 'message-1',
+          payload: {value: 'stale'},
+          phase: 'PHASE_DELTA',
+          sequence: 1,
+        })
+      );
+      eventSource.emit(
+        'stream',
+        JSON.stringify({
+          event_type: 'stream',
+          message_id: 'message-2',
+          payload: {value: 'duplicate'},
+          phase: 'PHASE_DELTA',
+          sequence: 3,
+        })
+      );
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith({value: 'new'});
+  });
+
+  it('reports missing response headers without opening a stream', async () => {
+    MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useConduitStream({
+        enabled: true,
+        queryOptions: conduitQueryOptions(),
+        onMessage: (_message: Message) => {},
+      })
+    );
+
+    await waitFor(() =>
+      expect(result.current.error).toEqual(new Error('Missing Conduit response headers'))
+    );
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('does not request credentials when disabled', () => {
+    const request = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: {},
+      headers: conduitHeaders,
+    });
+
+    renderHookWithProviders(() =>
+      useConduitStream({
+        enabled: false,
+        queryOptions: conduitQueryOptions(),
+        onMessage: (_message: Message) => {},
+      })
+    );
+
+    expect(request).not.toHaveBeenCalled();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+});

--- a/static/app/utils/useConduitStream.tsx
+++ b/static/app/utils/useConduitStream.tsx
@@ -1,0 +1,245 @@
+import {useEffect, useEffectEvent, useRef, useState} from 'react';
+import type {QueryKey, UseQueryOptions} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
+
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+
+const MAX_SEEN_MESSAGE_IDS = 2048;
+
+type StreamEnvelope<TMessage> = {
+  event_type: 'stream';
+  message_id: string;
+  phase: 'PHASE_START' | 'PHASE_DELTA' | 'PHASE_END' | 'PHASE_ERROR';
+  sequence: number;
+  payload?: TMessage;
+};
+
+type ControlEnvelope = {
+  control_type: 'server_draining';
+  event_type: 'control';
+  message_id: string;
+};
+
+type StreamQueryOptions<TQueryData, TQueryKey extends QueryKey> = UseQueryOptions<
+  ApiResponse<TQueryData>,
+  Error,
+  TQueryData,
+  TQueryKey
+>;
+
+type UseConduitStreamOptions<TMessage, TQueryData, TQueryKey extends QueryKey> = {
+  enabled: boolean;
+  queryOptions: StreamQueryOptions<TQueryData, TQueryKey>;
+  fallbackRefetchInterval?: UseQueryOptions<
+    ApiResponse<TQueryData>,
+    Error,
+    ApiResponse<TQueryData>,
+    TQueryKey
+  >['refetchInterval'];
+  onClose?: () => void;
+  onConnect?: () => void;
+  onMessage?: (message: TMessage) => void;
+};
+
+function parseEnvelope(event: MessageEvent): unknown | null {
+  try {
+    return JSON.parse(event.data) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function buildConduitUrl({
+  channelId,
+  lastEventId,
+  token,
+  url,
+}: {
+  channelId: string;
+  token: string;
+  url: string;
+  lastEventId?: string;
+}) {
+  const conduitUrl = new URL(url);
+  conduitUrl.searchParams.set('token', token);
+  conduitUrl.searchParams.set('channel_id', channelId);
+
+  if (lastEventId !== undefined) {
+    conduitUrl.searchParams.set('last_event_id', lastEventId);
+  }
+
+  return conduitUrl.toString();
+}
+
+export function useConduitStream<TMessage, TQueryData, TQueryKey extends QueryKey>({
+  enabled,
+  fallbackRefetchInterval,
+  onClose,
+  onConnect,
+  onMessage,
+  queryOptions,
+}: UseConduitStreamOptions<TMessage, TQueryData, TQueryKey>) {
+  const [isConnected, setIsConnected] = useState(false);
+  const [streamError, setStreamError] = useState<Error | null>(null);
+  const [connectionAttempt, setConnectionAttempt] = useState(0);
+  const channelIdRef = useRef<string | undefined>(undefined);
+  const hasConnectedRef = useRef(false);
+  const lastEventIdRef = useRef<string | undefined>(undefined);
+  const lastSequenceRef = useRef<number | undefined>(undefined);
+  const seenMessageIdsRef = useRef(new Set<string>());
+
+  const query = useQuery<
+    ApiResponse<TQueryData>,
+    Error,
+    ApiResponse<TQueryData>,
+    TQueryKey
+  >({
+    ...queryOptions,
+    enabled: enabled && queryOptions.enabled !== false,
+    refetchInterval: isConnected ? false : fallbackRefetchInterval,
+    select: selectJsonWithHeaders,
+  });
+  const {
+    data: queryResponse,
+    error: queryError,
+    fetchStatus,
+    isError,
+    isPending,
+    refetch,
+  } = query;
+
+  const reportClose = useEffectEvent(() => onClose?.());
+  const reportConnect = useEffectEvent(() => onConnect?.());
+  const reportMessage = useEffectEvent((message: TMessage) => onMessage?.(message));
+
+  const token = queryResponse?.headers['X-Conduit-Token'];
+  const channelId = queryResponse?.headers['X-Conduit-Channel-Id'];
+  const url = queryResponse?.headers['X-Conduit-Url'];
+
+  useEffect(() => {
+    if (!enabled || isPending || isError) {
+      return;
+    }
+
+    if (!token || !channelId || !url) {
+      setStreamError(new Error('Missing Conduit response headers'));
+      return;
+    }
+
+    if (channelIdRef.current !== channelId) {
+      channelIdRef.current = channelId;
+      hasConnectedRef.current = false;
+      lastEventIdRef.current = undefined;
+      lastSequenceRef.current = undefined;
+      seenMessageIdsRef.current.clear();
+    }
+
+    const eventSource = new EventSource(
+      buildConduitUrl({
+        channelId,
+        lastEventId: lastEventIdRef.current,
+        token,
+        url,
+      })
+    );
+
+    const handleOpen = () => {
+      setIsConnected(true);
+      setStreamError(null);
+
+      if (hasConnectedRef.current) {
+        return;
+      }
+
+      hasConnectedRef.current = true;
+      reportConnect();
+    };
+
+    const handleError = () => {
+      setIsConnected(false);
+      setStreamError(new Error('Conduit connection error'));
+    };
+
+    const handleStream = (event: MessageEvent) => {
+      lastEventIdRef.current = event.lastEventId;
+      const envelope = parseEnvelope(event) as StreamEnvelope<TMessage> | null;
+
+      if (!envelope) {
+        setStreamError(new Error('Failed to parse Conduit message'));
+        return;
+      }
+
+      if (envelope.phase === 'PHASE_END') {
+        eventSource.close();
+        setIsConnected(false);
+        reportClose();
+        return;
+      }
+
+      if (seenMessageIdsRef.current.has(envelope.message_id)) {
+        return;
+      }
+
+      if (seenMessageIdsRef.current.size >= MAX_SEEN_MESSAGE_IDS) {
+        seenMessageIdsRef.current.clear();
+      }
+      seenMessageIdsRef.current.add(envelope.message_id);
+
+      if (
+        lastSequenceRef.current !== undefined &&
+        envelope.sequence <= lastSequenceRef.current
+      ) {
+        return;
+      }
+      lastSequenceRef.current = envelope.sequence;
+
+      if (envelope.phase === 'PHASE_DELTA' && envelope.payload !== undefined) {
+        reportMessage(envelope.payload);
+      }
+
+      if (envelope.phase === 'PHASE_ERROR') {
+        setStreamError(new Error('Conduit stream error'));
+      }
+    };
+
+    const handleControl = (event: MessageEvent) => {
+      lastEventIdRef.current = event.lastEventId;
+      const envelope = parseEnvelope(event) as ControlEnvelope | null;
+
+      if (!envelope) {
+        setStreamError(new Error('Failed to parse Conduit control message'));
+        return;
+      }
+
+      if (envelope.control_type === 'server_draining') {
+        eventSource.close();
+        setIsConnected(false);
+        void refetch().finally(() => setConnectionAttempt(value => value + 1));
+      }
+    };
+
+    eventSource.addEventListener('open', handleOpen);
+    eventSource.addEventListener('error', handleError);
+    eventSource.addEventListener('stream', handleStream);
+    eventSource.addEventListener('control', handleControl);
+
+    return () => {
+      eventSource.removeEventListener('open', handleOpen);
+      eventSource.removeEventListener('error', handleError);
+      eventSource.removeEventListener('stream', handleStream);
+      eventSource.removeEventListener('control', handleControl);
+      eventSource.close();
+      setIsConnected(false);
+    };
+  }, [channelId, connectionAttempt, enabled, isError, isPending, refetch, token, url]);
+
+  return {
+    data: queryResponse?.json,
+    error: streamError ?? queryError,
+    fetchStatus,
+    isConnected,
+    isPending,
+    refetch,
+  };
+}

--- a/static/app/views/conduit/conduitDemo.stories.tsx
+++ b/static/app/views/conduit/conduitDemo.stories.tsx
@@ -1,12 +1,12 @@
-import {useMemo, useState} from 'react';
-import {useStream} from 'conduit-client';
+import {useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
-import {getCsrfToken} from 'sentry/utils/getCsrfToken';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useConduitStream} from 'sentry/utils/useConduitStream';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 type Message = {
@@ -19,20 +19,16 @@ export default Storybook.story('Conduit Demo', story => {
     const [messages, setMessages] = useState<Message[]>([]);
     const [isEnabled, setIsEnabled] = useState(false);
 
-    const streamUrl = `/api/0/organizations/${organization.slug}/conduit-demo/`;
-
-    const streamHeaders = useMemo(
-      () => ({
-        'X-CSRFToken': getCsrfToken(),
-      }),
-      []
-    );
-
-    const {error, isConnected} = useStream({
+    const {error, isConnected} = useConduitStream({
       enabled: isEnabled,
-      orgId: Number(organization.id),
-      startStreamUrl: streamUrl,
-      startStreamHeaders: streamHeaders,
+      queryOptions: apiOptions.as<unknown>()(
+        '/organizations/$organizationIdOrSlug/conduit-demo/',
+        {
+          path: {organizationIdOrSlug: organization.slug},
+          method: 'POST',
+          staleTime: 0,
+        }
+      ),
       onMessage: (message: Message) => {
         setMessages(prev => [...prev, message]);
       },


### PR DESCRIPTION
Depends on #122061.

Sentry now owns Conduit streaming through `useConduitStream`, which uses `apiOptions` and TanStack Query for the initialization request and reads credentials from the standard API response headers. The hook retains the protocol-specific behavior for ordered message delivery, deduplication, stream lifecycle handling, server-draining reconnects, and optional fallback polling.

The Conduit demo uses the generated API URL and standard request client through the new hook. The standalone `conduit-client` dependency and its Jest workaround are removed; agentic onboarding will migrate in its existing frontend follow-up.