### PR TITLE
fix(issue-details): handle null evaluated value in metric detector section

### DIFF
--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -221,6 +221,62 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(screen.getByRole('cell', {name: '250'})).toBeInTheDocument();
   });
 
+  it('omits the evaluated value when the value is null', async () => {
+    const event = EventFixture({
+      occurrence: {
+        id: '1',
+        eventId: 'event-1',
+        fingerprint: ['fingerprint'],
+        issueTitle: 'Test Issue',
+        subtitle: 'Subtitle',
+        resourceId: 'resource-1',
+        evidenceData: {
+          conditions: [condition],
+          dataSources: [dataSource],
+          value: null,
+        },
+        evidenceDisplay: [],
+        type: 8001,
+        detectionTime: '2024-01-01T00:00:00Z',
+      },
+    });
+
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
+
+    expect(
+      await screen.findByRole('region', {name: 'Triggered Condition'})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('cell', {name: 'Evaluated Value'})).not.toBeInTheDocument();
+  });
+
+  it('omits the evaluated value when the anomaly detector value is null', async () => {
+    const event = EventFixture({
+      occurrence: {
+        id: '1',
+        eventId: 'event-1',
+        fingerprint: ['fingerprint'],
+        issueTitle: 'Test Issue',
+        subtitle: 'Subtitle',
+        resourceId: 'resource-1',
+        evidenceData: {
+          conditions: [condition],
+          dataSources: [dataSource],
+          value: {value: null},
+        },
+        evidenceDisplay: [],
+        type: 8001,
+        detectionTime: '2024-01-01T00:00:00Z',
+      },
+    });
+
+    render(<MetricDetectorTriggeredSection {...defaultProps} event={event} />);
+
+    expect(
+      await screen.findByRole('region', {name: 'Triggered Condition'})
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('cell', {name: 'Evaluated Value'})).not.toBeInTheDocument();
+  });
+
   it('renders contributing issues section for errors dataset', async () => {
     // Start date is eventDateCreated minus the timeWindow (60 seconds) minus 1 extra minute
     const startDate = '2023-12-31T23:58:00.000Z';

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -71,8 +71,9 @@ interface MetricDetectorEvidenceData {
    */
   value:
     | number
+    | null
     // XXX: Anomaly detectors will store an object here with other data necessary for processing
-    | {value: number};
+    | {value: number | null};
 }
 
 interface MetricDetectorTriggeredSectionProps {
@@ -135,8 +136,12 @@ function getFormattedEvaluatedValue({
 }: {
   aggregate: string;
   detectionType: MetricDetectorConfig['detectionType'];
-  value: number;
-}): string {
+  value: number | null;
+}): string | null {
+  if (value === null) {
+    return null;
+  }
+
   const unitSuffix = getMetricDetectorSuffix(detectionType, aggregate);
   return `${value.toLocaleString()}${unitSuffix}`;
 }
@@ -498,11 +503,15 @@ function TriggeredConditionDetails({
               ),
               subject: t('Condition'),
             },
-            {
-              key: 'value',
-              value: formattedEvaluatedValue,
-              subject: t('Evaluated Value'),
-            },
+            ...(defined(formattedEvaluatedValue)
+              ? [
+                  {
+                    key: 'value',
+                    value: formattedEvaluatedValue,
+                    subject: t('Evaluated Value'),
+                  },
+                ]
+              : []),
           ]}
         />
       </FoldSection>

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -503,7 +503,7 @@ function TriggeredConditionDetails({
               ),
               subject: t('Condition'),
             },
-            ...(defined(formattedEvaluatedValue)
+            ...(formattedEvaluatedValue
               ? [
                   {
                     key: 'value',


### PR DESCRIPTION
`MetricDetectorEvidenceData.value` was typed as `number | {value: number}`, but the backend stores whatever `extract_value` returns. For metric issues that is `data_packet.packet.values["value"]` ([`grouptype.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/incidents/grouptype.py#L274)), which is `null` when a subscription has no data in the window.

This widens the `value` type to `number | null | {value: number | null}` and handles `null` values nicely.

Closes DE-1536.
