### PR TITLE
test: stop create_span leaking tags between tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import random
 import re
@@ -3330,7 +3331,7 @@ class SpanTestCase(BaseTestCase):
             start_ts = datetime.now() - timedelta(minutes=1)
         if extra_data is None:
             extra_data = {}
-        span = self.base_span.copy()
+        span = copy.deepcopy(self.base_span)
         # Load some defaults
         span.update(
             {

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -75,7 +75,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 0
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
 
     def test_simple_with_eap_as_source_of_truth(self) -> None:
         self.load_trace()
@@ -112,7 +112,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 0
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
 
     def test_no_team(self) -> None:
         self.load_trace()
@@ -124,7 +124,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 0
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
 
     def test_with_errors(self) -> None:
         self.load_trace()
@@ -136,7 +136,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 3
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
 
     def test_with_errors_eap_eval_not_allowlisted_uses_snuba(self) -> None:
         self.load_trace()
@@ -164,7 +164,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 3
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
 
     def test_with_errors_eap_allowlisted_uses_eap(self) -> None:
         self.load_trace()
@@ -192,7 +192,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 1
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
 
     def test_with_default(self) -> None:
         self.load_trace()
@@ -204,7 +204,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         assert data["errorsCount"] == 1
         assert data["performanceIssuesCount"] == 2
         assert data["spansCount"] == 19
-        assert data["spansCountMap"]["http.server"] == 19
+        assert data["spansCountMap"]["http.server"] == 8
         assert len(data["transactionChildCountMap"]) == 8
 
     def test_with_invalid_date(self) -> None:


### PR DESCRIPTION
`SpanTestCase.base_span` is a class attribute holding mutable dicts, and `create_span` shallow copied it:

```python
base_span: dict[str, Any] = {..., "tags": {}, "sentry_tags": {}, "measurements": {}}
...
span = self.base_span.copy()
```

So `span["tags"]` **is** `base_span["tags"]`. Any test that mutates tags in place rather than passing them through `extra_data` permanently contaminates every span created afterwards in the same pytest process. Either file passes on its own, which is why this has stayed hidden. It only bites when CI's selective test runner puts both in the same shard.

This PR fixes things by deep copying the base span. Why use one span when many do trick.

Split out of #122066, which is where this first surfaced for me by coincidence.

Closes ENG-8431.