### PR TITLE
feat(investigations): add query-backed detail bootstrap

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2335,6 +2335,12 @@ function buildRoutes(): RouteObject[] {
     children: exploreChildren,
   };
 
+  const investigationRoutes: SentryRouteObject = {
+    path: '/seer/investigation/:investigationId/',
+    withOrgPath: true,
+    component: make(() => import('sentry/views/investigations/detail')),
+  };
+
   const preprodChildren: SentryRouteObject[] = [
     {
       path: 'size/:artifactId/',
@@ -2807,6 +2813,7 @@ function buildRoutes(): RouteObject[] {
       domainViewRoutes,
       tracesRoutes,
       exploreRoutes,
+      investigationRoutes,
       llmMonitoringRedirects,
       profilingRoutes,
       gettingStartedRoutes,

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -37,6 +37,7 @@ type ParamKeys =
   | 'installationId'
   | 'integrationId'
   | 'integrationSlug'
+  | 'investigationId'
   | 'invoiceGuid'
   | 'issueId'
   | 'memberId'

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -6,7 +6,10 @@ import {
 
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
-import type {InvestigationListItem} from 'sentry/views/investigations/types';
+import type {
+  InvestigationDetail,
+  InvestigationListItem,
+} from 'sentry/views/investigations/types';
 
 type ListOptions = {
   organizationSlug: string;
@@ -25,6 +28,22 @@ export function investigationListQueryOptions({
       path: {organizationIdOrSlug: organizationSlug},
       query: {status: 'active', cursor, query},
       staleTime: 0,
+    }
+  );
+}
+
+export function investigationDetailQueryOptions(
+  organizationSlug: string,
+  investigationId: string
+) {
+  return apiOptions.as<InvestigationDetail>()(
+    '/organizations/$organizationIdOrSlug/investigations/$investigationId/',
+    {
+      path: {
+        organizationIdOrSlug: organizationSlug,
+        investigationId,
+      },
+      staleTime: 30_000,
     }
   );
 }

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -1,0 +1,190 @@
+import {QueryClientProvider} from '@tanstack/react-query';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import InvestigationDetailView from 'sentry/views/investigations/detail';
+import type {InvestigationDetail} from 'sentry/views/investigations/types';
+
+const organization = OrganizationFixture({
+  features: ['investigations'],
+  openMembership: true,
+});
+const detailUrl = '/organizations/org-slug/investigations/investigation-1/';
+
+function InvestigationDetailFixture(overrides: Partial<InvestigationDetail> = {}) {
+  return {
+    id: 'investigation-1',
+    title: 'Investigate database latency',
+    status: 'active',
+    sourceType: 'manual',
+    createdBy: '1',
+    dateCreated: '2026-08-13T20:00:00Z',
+    dateUpdated: '2026-08-13T21:00:00Z',
+    version: 1,
+    blockCount: 2,
+    isFavorited: false,
+    blocks: [
+      {
+        id: 'block-1',
+        position: 0,
+        kind: 'text',
+        title: 'Summary',
+        content: 'Initial notes',
+        generationPrompt: '',
+        generatedContent: '',
+        output: null,
+        outputStatus: 'notRun',
+        currentExecution: null,
+        config: {},
+        display: {type: 'markdown'},
+        dependencies: [],
+        parameterKeys: [],
+        version: 1,
+        staleAt: null,
+        createdBy: '1',
+        lastEditedBy: '1',
+      },
+      {
+        id: 'block-2',
+        position: 1,
+        kind: 'query',
+        title: 'Latency query',
+        content: '',
+        generationPrompt: 'Find slow spans',
+        generatedContent: '',
+        output: null,
+        outputStatus: 'notRun',
+        currentExecution: null,
+        config: {},
+        display: {type: 'table'},
+        dependencies: [],
+        parameterKeys: [],
+        version: 1,
+        staleAt: null,
+        createdBy: '1',
+        lastEditedBy: '1',
+      },
+    ],
+    filters: {},
+    parameters: [],
+    projectIds: [],
+    source: {type: 'manual', ref: {}, revision: null},
+    template: null,
+    titleGeneration: {status: null},
+    ...overrides,
+  };
+}
+
+function renderView(
+  renderOrganization = organization,
+  queryClient = makeTestQueryClient()
+) {
+  const result = render(<InvestigationDetailView />, {
+    additionalWrapper: ({children}) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    organization: renderOrganization,
+    initialRouterConfig: {
+      location: {
+        pathname: '/organizations/org-slug/seer/investigation/investigation-1/',
+      },
+      route: '/organizations/:orgId/seer/investigation/:investigationId/',
+    },
+  });
+
+  return {...result, queryClient};
+}
+
+describe('Investigation detail', () => {
+  it('loads and renders the complete investigation response', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+
+    renderView();
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(await screen.findByText('Investigate database latency')).toBeInTheDocument();
+    expect(screen.getByText(/"id": "investigation-1"/)).toBeInTheDocument();
+    expect(screen.getByText(/"blocks":/)).toBeInTheDocument();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses an investigation prefetched before the detail page mounts', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+    const queryClient = makeTestQueryClient();
+
+    await queryClient.prefetchQuery(
+      investigationDetailQueryOptions('org-slug', 'investigation-1')
+    );
+    renderView(organization, queryClient);
+
+    expect(screen.getByText('Investigate database latency')).toBeInTheDocument();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the initial load error', async () => {
+    MockApiClient.addMockResponse({url: detailUrl, statusCode: 500});
+
+    renderView();
+
+    expect(await screen.findByText('Oops! Something went wrong')).toBeInTheDocument();
+  });
+
+  it('retains cached data when a background refetch fails', async () => {
+    const queryClient = makeTestQueryClient();
+    const options = investigationDetailQueryOptions('org-slug', 'investigation-1');
+    queryClient.setQueryData(options.queryKey, {
+      headers: {},
+      json: InvestigationDetailFixture(),
+    });
+    const request = MockApiClient.addMockResponse({url: detailUrl, statusCode: 500});
+
+    renderView(organization, queryClient);
+    expect(screen.getByText('Investigate database latency')).toBeInTheDocument();
+
+    await act(() => queryClient.invalidateQueries({queryKey: options.queryKey}));
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Investigate database latency')).toBeInTheDocument();
+    expect(screen.queryByText('Oops! Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('does not bootstrap when the feature is disabled', () => {
+    const request = MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+
+    renderView(OrganizationFixture({features: [], openMembership: true}));
+
+    expect(
+      screen.getByText('This feature is not enabled on your Sentry installation.')
+    ).toBeInTheDocument();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('does not bootstrap for a closed-membership organization', () => {
+    const request = MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+
+    renderView(
+      OrganizationFixture({features: ['investigations'], openMembership: false})
+    );
+
+    expect(
+      screen.getByText(
+        'Investigations are only available to organizations with open membership.'
+      )
+    ).toBeInTheDocument();
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -1,0 +1,100 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Alert} from '@sentry/scraps/alert';
+import {CodeBlock} from '@sentry/scraps/code';
+import {Stack} from '@sentry/scraps/layout';
+
+import Feature from 'sentry/components/acl/feature';
+import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
+import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {RouteError} from 'sentry/views/routeError';
+
+function FeatureDisabledPage() {
+  return (
+    <Stack flex={1} padding="2xl 3xl">
+      <FeatureDisabled
+        features="organizations:investigations"
+        featureName={t('Investigations')}
+      />
+    </Stack>
+  );
+}
+
+function ClosedMembershipPage() {
+  return (
+    <Stack flex={1} padding="2xl 3xl">
+      <Alert.Container>
+        <Alert variant="warning">
+          {t('Investigations are only available to organizations with open membership.')}
+        </Alert>
+      </Alert.Container>
+    </Stack>
+  );
+}
+
+function InvestigationBootstrapPage({investigationId}: {investigationId: string}) {
+  const organization = useOrganization();
+  const {
+    data: investigation,
+    error,
+    isError,
+    isPending,
+  } = useQuery(investigationDetailQueryOptions(organization.slug, investigationId));
+
+  if (isPending && !investigation) {
+    return <LoadingIndicator />;
+  }
+  if (isError && !investigation) {
+    return (
+      <Stack flex={1} padding="2xl 3xl">
+        <RouteError error={error} />
+      </Stack>
+    );
+  }
+  if (!investigation) {
+    return null;
+  }
+
+  return (
+    <SentryDocumentTitle title={investigation.title} orgSlug={organization.slug}>
+      <Stack flex={1}>
+        <Layout.Title>{investigation.title}</Layout.Title>
+        <Layout.Body>
+          <Layout.Main width="full">
+            <CodeBlock language="json">
+              {JSON.stringify(investigation, null, 2)}
+            </CodeBlock>
+          </Layout.Main>
+        </Layout.Body>
+      </Stack>
+    </SentryDocumentTitle>
+  );
+}
+
+export default function InvestigationDetailView() {
+  const organization = useOrganization();
+  const {investigationId} = useParams<{investigationId: string}>();
+
+  return (
+    <AnalyticsArea name="investigations.details" overrideParent>
+      <Feature
+        organization={organization}
+        features="organizations:investigations"
+        renderDisabled={() => <FeatureDisabledPage />}
+      >
+        {organization.openMembership ? (
+          <InvestigationBootstrapPage investigationId={investigationId} />
+        ) : (
+          <ClosedMembershipPage />
+        )}
+      </Feature>
+    </AnalyticsArea>
+  );
+}

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -1,5 +1,7 @@
+import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {
   render,
   renderGlobalModal,
@@ -11,7 +13,11 @@ import {
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {Organization} from 'sentry/types/organization';
 import InvestigationsView from 'sentry/views/investigations';
-import type {InvestigationListItem} from 'sentry/views/investigations/types';
+import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import type {
+  InvestigationDetail,
+  InvestigationListItem,
+} from 'sentry/views/investigations/types';
 import {getPaginationPageLink} from 'sentry/views/organizationStats/utils';
 
 const organization = OrganizationFixture({
@@ -24,7 +30,11 @@ function renderView({
   renderOrganization = organization,
   query = {},
 }: {query?: Record<string, string>; renderOrganization?: Organization} = {}) {
-  return render(<InvestigationsView />, {
+  const queryClient = makeTestQueryClient();
+  const result = render(<InvestigationsView />, {
+    additionalWrapper: ({children}) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
     organization: renderOrganization,
     initialRouterConfig: {
       location: {
@@ -33,6 +43,8 @@ function renderView({
       },
     },
   });
+
+  return {...result, queryClient};
 }
 
 function InvestigationFixture(
@@ -101,7 +113,7 @@ describe('Explore Investigations', () => {
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(
       await screen.findByRole('link', {name: 'Database latency investigation'})
-    ).toHaveAttribute('href', '/organizations/org-slug/seer/1/');
+    ).toHaveAttribute('href', '/organizations/org-slug/seer/investigation/1/');
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
@@ -169,6 +181,33 @@ describe('Explore Investigations', () => {
     expect(router.location.query).toEqual({cursor: '0:10:0'});
   });
 
+  it('prefetches the investigation when opening it', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [InvestigationFixture()],
+    });
+    const detailRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/',
+      body: {
+        ...InvestigationFixture(),
+        blocks: [],
+        filters: {},
+        parameters: [],
+        projectIds: [],
+        source: {type: 'manual', ref: {}, revision: null},
+        template: null,
+        titleGeneration: {status: null},
+      },
+    });
+
+    renderView();
+    await userEvent.click(
+      await screen.findByRole('link', {name: 'Database latency investigation'})
+    );
+
+    await waitFor(() => expect(detailRequest).toHaveBeenCalledTimes(1));
+  });
+
   it('creates an untitled investigation and refreshes the list', async () => {
     MockApiClient.addMockResponse({
       url: listUrl,
@@ -180,7 +219,13 @@ describe('Explore Investigations', () => {
       body: InvestigationFixture({title: 'Untitled investigation'}),
     });
 
-    const {router} = renderView();
+    const {queryClient, router} = renderView();
+    const unrelatedOptions = investigationDetailQueryOptions('org-slug', 'existing');
+    const unrelatedDetail = InvestigationFixture({id: 'existing'});
+    queryClient.setQueryData(unrelatedOptions.queryKey, {
+      headers: {},
+      json: unrelatedDetail,
+    });
     await screen.findByText('Sorry, no investigations match your filters.');
     MockApiClient.addMockResponse({
       url: listUrl,
@@ -197,6 +242,9 @@ describe('Explore Investigations', () => {
     expect(await screen.findByText('Untitled investigation')).toBeInTheDocument();
     expect(router.location.pathname).toBe(
       '/organizations/org-slug/explore/investigations/'
+    );
+    expect(queryClient.getQueryData(unrelatedOptions.queryKey)?.json).toBe(
+      unrelatedDetail
     );
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Investigation created.');
   });
@@ -249,6 +297,32 @@ describe('Explore Investigations', () => {
     ).toBeInTheDocument();
   });
 
+  it('updates a cached investigation after favoriting it', async () => {
+    const investigation = InvestigationFixture();
+    MockApiClient.addMockResponse({url: listUrl, body: [investigation]});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/favorite/',
+      method: 'PUT',
+    });
+
+    const {queryClient} = renderView();
+    const detailOptions = investigationDetailQueryOptions('org-slug', '1');
+    queryClient.setQueryData(detailOptions.queryKey, {
+      headers: {Link: 'preserved'},
+      json: investigation satisfies InvestigationDetail,
+    });
+    await userEvent.click(
+      await screen.findByLabelText('Favorite Database latency investigation')
+    );
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(detailOptions.queryKey)).toEqual({
+        headers: {Link: 'preserved'},
+        json: {...investigation, isFavorited: true},
+      })
+    );
+  });
+
   it('duplicates from the overflow menu', async () => {
     MockApiClient.addMockResponse({
       url: listUrl,
@@ -260,7 +334,13 @@ describe('Explore Investigations', () => {
       body: InvestigationFixture({id: '2'}),
     });
 
-    renderView();
+    const {queryClient} = renderView();
+    const unrelatedOptions = investigationDetailQueryOptions('org-slug', 'existing');
+    const unrelatedDetail = InvestigationFixture({id: 'existing'});
+    queryClient.setQueryData(unrelatedOptions.queryKey, {
+      headers: {},
+      json: unrelatedDetail,
+    });
     await screen.findByText('Database latency investigation');
     MockApiClient.addMockResponse({
       url: listUrl,
@@ -278,6 +358,9 @@ describe('Explore Investigations', () => {
     expect(
       await screen.findByText('Database latency investigation copy')
     ).toBeInTheDocument();
+    expect(queryClient.getQueryData(unrelatedOptions.queryKey)?.json).toBe(
+      unrelatedDetail
+    );
   });
 
   it('copies the investigation link from the overflow menu', async () => {
@@ -299,7 +382,7 @@ describe('Explore Investigations', () => {
 
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        `${window.location.origin}/organizations/org-slug/seer/1/`
+        `${window.location.origin}/organizations/org-slug/seer/investigation/1/`
       )
     );
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
@@ -336,6 +419,32 @@ describe('Explore Investigations', () => {
     );
     await waitFor(() =>
       expect(screen.queryByText('Database latency investigation')).not.toBeInTheDocument()
+    );
+  });
+
+  it('removes the deleted investigation from the detail cache', async () => {
+    const investigation = InvestigationFixture();
+    MockApiClient.addMockResponse({url: listUrl, body: [investigation]});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/',
+      method: 'DELETE',
+    });
+
+    const {queryClient} = renderView();
+    const detailOptions = investigationDetailQueryOptions('org-slug', '1');
+    queryClient.setQueryData(detailOptions.queryKey, {
+      headers: {},
+      json: investigation satisfies InvestigationDetail,
+    });
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(detailOptions.queryKey)).toBeUndefined()
     );
   });
 

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {parseAsString, useQueryStates} from 'nuqs';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -14,6 +14,7 @@ import {Text} from '@sentry/scraps/text';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import Feature from 'sentry/components/acl/feature';
 import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
+import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
@@ -35,12 +36,14 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
+  investigationDetailQueryOptions,
   investigationListQueryOptions,
   useCreateInvestigationMutation,
   useDeleteInvestigationMutation,
   useDuplicateInvestigationMutation,
   useSetInvestigationFavoriteMutation,
 } from 'sentry/views/investigations/api';
+import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
 import type {InvestigationListItem} from 'sentry/views/investigations/types';
 import {RouteError} from 'sentry/views/routeError';
 
@@ -67,7 +70,9 @@ const TableWrapper = styled('div')`
 `;
 
 function getInvestigationPath(organizationSlug: string, investigationId: string) {
-  return normalizeUrl(`/organizations/${organizationSlug}/seer/${investigationId}/`);
+  return normalizeUrl(
+    `/organizations/${organizationSlug}/seer/investigation/${investigationId}/`
+  );
 }
 
 function FeatureDisabledPage() {
@@ -95,6 +100,7 @@ function ClosedMembershipPage() {
 
 function InvestigationsPage() {
   const organization = useOrganization();
+  const queryClient = useQueryClient();
   const {copy} = useCopyToClipboard();
   const [{query, cursor}, setQueryParams] = useQueryStates({
     query: parseAsString,
@@ -117,7 +123,15 @@ function InvestigationsPage() {
   });
 
   const favoriteMutation = useSetInvestigationFavoriteMutation(organization.slug, {
-    onSuccess: () => addSuccessMessage(t('Investigation favorite updated.')),
+    onSuccess: (_data, {investigation, shouldFavorite}) => {
+      updateInvestigationCache(
+        queryClient,
+        organization.slug,
+        investigation.id,
+        current => ({...current, isFavorited: shouldFavorite})
+      );
+      addSuccessMessage(t('Investigation favorite updated.'));
+    },
     onError: () => addErrorMessage(t('Unable to update investigation favorite.')),
   });
 
@@ -127,7 +141,14 @@ function InvestigationsPage() {
   });
 
   const deleteMutation = useDeleteInvestigationMutation(organization.slug, {
-    onSuccess: () => addSuccessMessage(t('Investigation deleted.')),
+    onSuccess: (_data, investigation) => {
+      queryClient.removeQueries({
+        queryKey: investigationDetailQueryOptions(organization.slug, investigation.id)
+          .queryKey,
+        exact: true,
+      });
+      addSuccessMessage(t('Investigation deleted.'));
+    },
     onError: () => addErrorMessage(t('Unable to delete investigation.')),
   });
 
@@ -193,7 +214,14 @@ function InvestigationsPage() {
       case ColumnKey.NAME:
         return (
           <Text ellipsis>
-            <Link to={getInvestigationPath(organization.slug, investigation.id)}>
+            <Link
+              to={getInvestigationPath(organization.slug, investigation.id)}
+              onClick={() =>
+                void queryClient.prefetchQuery(
+                  investigationDetailQueryOptions(organization.slug, investigation.id)
+                )
+              }
+            >
               {investigation.title}
             </Link>
           </Text>
@@ -341,12 +369,14 @@ export default function InvestigationsView() {
   const organization = useOrganization();
 
   return (
-    <Feature
-      organization={organization}
-      features="organizations:investigations"
-      renderDisabled={() => <FeatureDisabledPage />}
-    >
-      {organization.openMembership ? <InvestigationsPage /> : <ClosedMembershipPage />}
-    </Feature>
+    <AnalyticsArea name="investigations.list" overrideParent>
+      <Feature
+        organization={organization}
+        features="organizations:investigations"
+        renderDisabled={() => <FeatureDisabledPage />}
+      >
+        {organization.openMembership ? <InvestigationsPage /> : <ClosedMembershipPage />}
+      </Feature>
+    </AnalyticsArea>
   );
 }

--- a/static/app/views/investigations/investigationCache.spec.ts
+++ b/static/app/views/investigations/investigationCache.spec.ts
@@ -1,0 +1,55 @@
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+
+import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
+import type {InvestigationDetail} from 'sentry/views/investigations/types';
+
+const investigation: InvestigationDetail = {
+  blockCount: 1,
+  createdBy: '1',
+  dateCreated: '2026-08-13T20:00:00Z',
+  dateUpdated: '2026-08-13T21:00:00Z',
+  id: 'investigation-1',
+  isFavorited: false,
+  sourceType: 'manual',
+  status: 'active',
+  title: 'Investigate database latency',
+  version: 1,
+};
+
+describe('updateInvestigationCache', () => {
+  it('immutably updates the response JSON and preserves headers', () => {
+    const queryClient = makeTestQueryClient();
+    const options = investigationDetailQueryOptions('org-slug', 'investigation-1');
+    const cachedResponse = {
+      headers: {Link: 'preserved'},
+      json: investigation,
+    };
+    queryClient.setQueryData(options.queryKey, cachedResponse);
+
+    updateInvestigationCache(queryClient, 'org-slug', 'investigation-1', current => ({
+      ...current,
+      isFavorited: true,
+    }));
+
+    const updatedResponse = queryClient.getQueryData(options.queryKey);
+    expect(updatedResponse).toEqual({
+      headers: {Link: 'preserved'},
+      json: {...investigation, isFavorited: true},
+    });
+    expect(updatedResponse).not.toBe(cachedResponse);
+    expect(updatedResponse?.headers).toBe(cachedResponse.headers);
+    expect(updatedResponse?.json).not.toBe(investigation);
+  });
+
+  it('does not seed a partial investigation when the query is not cached', () => {
+    const queryClient = makeTestQueryClient();
+    const options = investigationDetailQueryOptions('org-slug', 'investigation-1');
+    const update = jest.fn((current: InvestigationDetail) => current);
+
+    updateInvestigationCache(queryClient, 'org-slug', 'investigation-1', update);
+
+    expect(queryClient.getQueryData(options.queryKey)).toBeUndefined();
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/investigations/investigationCache.ts
+++ b/static/app/views/investigations/investigationCache.ts
@@ -1,0 +1,22 @@
+import type {QueryClient} from '@tanstack/react-query';
+
+import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import type {InvestigationDetail} from 'sentry/views/investigations/types';
+
+export function updateInvestigationCache(
+  queryClient: QueryClient,
+  organizationSlug: string,
+  investigationId: string,
+  update: (current: InvestigationDetail) => InvestigationDetail
+) {
+  const options = investigationDetailQueryOptions(organizationSlug, investigationId);
+
+  queryClient.setQueryData(options.queryKey, previous =>
+    previous
+      ? {
+          ...previous,
+          json: update(previous.json),
+        }
+      : previous
+  );
+}

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -10,3 +10,7 @@ export type InvestigationListItem = {
   title: string;
   version: number;
 };
+
+// Expand this response type as the detail UI begins consuming additional fields.
+// The complete server response is retained at runtime in the query cache.
+export type InvestigationDetail = InvestigationListItem;

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -175,7 +175,7 @@ export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {
                 makeNavigationItemProps(
                   'explore',
                   `/${prefix}/explore/${getDefaultExploreRoute(organization)}/`,
-                  `/${prefix}/explore`
+                  [`/${prefix}/explore`, `/${prefix}/seer/investigation/`]
                 ),
                 tourProps
               )}

--- a/static/app/views/navigation/primary/useActivateNavigationGroupOnHover.tsx
+++ b/static/app/views/navigation/primary/useActivateNavigationGroupOnHover.tsx
@@ -45,11 +45,11 @@ export function useActivateNavigationGroupOnHover({
   return function makeNavigationItemProps(
     group: ReturnType<typeof usePrimaryNavigation>['activeGroup'],
     to: string,
-    activeTo?: string
+    activeTo?: string | string[]
   ): Omit<Partial<LinkProps>, 'to'> {
-    const isActive = isPrimaryNavigationLinkActive(
-      normalizeUrl(activeTo ?? to),
-      location.pathname
+    const activePaths = Array.isArray(activeTo) ? activeTo : [activeTo ?? to];
+    const isActive = activePaths.some(path =>
+      isPrimaryNavigationLinkActive(normalizeUrl(path), location.pathname)
     );
 
     const onMouseEnter = (e: React.MouseEvent<HTMLAnchorElement>) => {

--- a/static/app/views/navigation/primaryNavigationContext.tsx
+++ b/static/app/views/navigation/primaryNavigationContext.tsx
@@ -21,6 +21,16 @@ const PRIMARY_NAVIGATION_GROUP_CONFIG = {
 
 type NavigationGroup = keyof typeof PRIMARY_NAVIGATION_GROUP_CONFIG;
 
+const PRIMARY_NAVIGATION_ROUTE_OVERRIDES: Array<{
+  group: NavigationGroup;
+  pattern: RegExp;
+}> = [
+  {
+    group: 'explore',
+    pattern: /(?:^|\/)seer\/investigation\/[^/]+\/?$/,
+  },
+];
+
 interface PrimaryNavigationFeatures {
   /** Whether the device supports hover interactions (false on touch-only devices) */
   hover: boolean;
@@ -93,6 +103,13 @@ const getPrimaryRoutePath = (path: string): string | undefined => {
 
 function useActiveNavigationGroup(): NavigationGroup {
   const location = useLocation();
+  const routeOverride = PRIMARY_NAVIGATION_ROUTE_OVERRIDES.find(({pattern}) =>
+    pattern.test(location.pathname)
+  );
+  if (routeOverride) {
+    return routeOverride.group;
+  }
+
   const primaryPath = getPrimaryRoutePath(location.pathname);
 
   if (!primaryPath) {

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -91,6 +91,41 @@ describe('ExploreSecondaryNavigation', () => {
     expect(screen.getByLabelText('beta')).toBeInTheDocument();
   });
 
+  it('keeps Explore and Investigations active on investigation detail pages', () => {
+    const {organization: investigationsOrganization} = initializeOrg({
+      organization: {
+        features: ['performance-view', 'visibility-explore-view', 'investigations'],
+        openMembership: true,
+      },
+    });
+
+    render(
+      <PrimaryNavigationContextProvider>
+        <SecondaryNavigationContextProvider>
+          <Navigation />
+          <div id="main" />
+        </SecondaryNavigationContextProvider>
+      </PrimaryNavigationContextProvider>,
+      {
+        organization: investigationsOrganization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/seer/investigation/investigation-1/',
+          },
+        },
+      }
+    );
+
+    expect(screen.getByRole('link', {name: 'Explore'})).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    expect(screen.getByRole('link', {name: /Investigations/})).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
   it('hides Investigations for a closed-membership organization', () => {
     const {organization: closedMembershipOrganization} = initializeOrg({
       organization: {

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -157,7 +157,10 @@ export function ExploreSecondaryNavigation() {
                 <SecondaryNavigation.ListItem>
                   <SecondaryNavigation.Link
                     to={`${baseUrl}/investigations/`}
-                    activeTo={`${baseUrl}/investigations/`}
+                    activeTo={[
+                      `${baseUrl}/investigations/`,
+                      `/organizations/${organization.slug}/seer/investigation/`,
+                    ]}
                     analyticsItemName="explore_investigations"
                     trailingItems={<FeatureBadge type="beta" />}
                   >


### PR DESCRIPTION
## Summary

- make TanStack Query the sole owner of investigation detail responses, subscriptions, request deduplication, and retention
- prefetch investigation detail with the shared query options when a user opens an investigation
- add the feature-gated detail route at /organizations/:orgId/seer/investigation/:investigationId/
- render the cached investigation response as formatted JSON while the full UI is built
- add a thin cache updater that preserves API response headers for future optimistic edits and Conduit messages
- keep favorite and delete mutations consistent with any cached detail response
- retain Explore and Investigations navigation state on the detail route

## Scope

This is the query-cache/bootstrap foundation only. Conduit, block editing, optimistic mutation concurrency, and the full investigation UI are intentionally deferred to smaller follow-up PRs.

The list and detail live under different URL families and share no layout state, so this PR adds separate investigations.list and investigations.details analytics boundaries without introducing a shared Outlet layout.

## Test plan

- 72 focused frontend tests across list/detail queries, cache updates, mutations, routes, navigation, and organization layout
- ESLint and formatting
- TypeScript
- Knip
- pre-commit and pre-push hooks