### PR TITLE
ref(preprod): Graduate snapshot archive manifest flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -236,8 +236,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-size-analysis-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Include the snapshot manifest in downloaded snapshot archives
-    manager.add("organizations:preprod-snapshot-archive-manifest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -14,7 +14,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -64,7 +64,6 @@ from sentry.preprod.snapshots.comparison_categorizer import (
 )
 from sentry.preprod.snapshots.constants import (
     MISSING_BASE_GRACE_PERIOD_SECONDS,
-    SNAPSHOT_ARCHIVE_MANIFEST_FEATURE,
     SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
 )
 from sentry.preprod.snapshots.manifest import (
@@ -735,9 +734,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         images = data.get("images", {})
         diff_threshold = data.get("diff_threshold")
 
-        if features.has(SNAPSHOT_ARCHIVE_MANIFEST_FEATURE, project.organization) and (
-            SNAPSHOT_ARCHIVE_MANIFEST_FILENAME in images
-        ):
+        if SNAPSHOT_ARCHIVE_MANIFEST_FILENAME in images:
             return Response(
                 {"detail": f"The filename {SNAPSHOT_ARCHIVE_MANIFEST_FILENAME} is reserved."},
                 status=400,

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -10,7 +10,7 @@ from objectstore_client import RequestError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -21,7 +21,6 @@ from sentry.models.organization import Organization
 from sentry.objectstore import get_preprod_session
 from sentry.preprod.analytics import PreprodArtifactApiSnapshotArchiveDownloadEvent
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.snapshots.constants import SNAPSHOT_ARCHIVE_MANIFEST_FEATURE
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.preprod.snapshots.zip_builder import archive_exists, archive_object_key
 from sentry.preprod.snapshots.zip_tasks import build_snapshot_images_zip
@@ -145,18 +144,17 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
             return resolved
         artifact, _metrics = resolved
         user_id = getattr(request.user, "id", None)
-        task_kwargs = {
-            "org_id": artifact.project.organization_id,
-            "project_id": artifact.project_id,
-            "artifact_id": artifact.id,
-            "user_id": user_id,
-        }
-        include_manifest = features.has(SNAPSHOT_ARCHIVE_MANIFEST_FEATURE, organization)
-        if include_manifest:
-            task_kwargs["include_manifest"] = True
-
         try:
-            build_snapshot_images_zip.apply_async(kwargs=task_kwargs)
+            build_snapshot_images_zip.apply_async(
+                kwargs={
+                    "org_id": artifact.project.organization_id,
+                    "project_id": artifact.project_id,
+                    "artifact_id": artifact.id,
+                    "user_id": user_id,
+                    # TODO: Remove after this change has been fully deployed.
+                    "include_manifest": True,
+                }
+            )
         except Exception:
             logger.exception(
                 "preprod_snapshot_zip.enqueue_failed",
@@ -165,7 +163,6 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                     "organization_id": artifact.project.organization_id,
                     "project_id": artifact.project_id,
                     "user_id": user_id,
-                    "include_manifest": include_manifest,
                 },
             )
             return Response(
@@ -179,7 +176,6 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
                 "organization_id": artifact.project.organization_id,
                 "project_id": artifact.project_id,
                 "user_id": user_id,
-                "include_manifest": include_manifest,
             },
         )
         return Response(

--- a/src/sentry/preprod/snapshots/constants.py
+++ b/src/sentry/preprod/snapshots/constants.py
@@ -2,5 +2,4 @@ from __future__ import annotations
 
 MISSING_BASE_GRACE_PERIOD_SECONDS = 600
 RECONSTRUCTION_RETRY_COUNTDOWN_SECONDS = 60
-SNAPSHOT_ARCHIVE_MANIFEST_FEATURE = "organizations:preprod-snapshot-archive-manifest"
 SNAPSHOT_ARCHIVE_MANIFEST_FILENAME = "manifest.json"

--- a/src/sentry/preprod/snapshots/zip_builder.py
+++ b/src/sentry/preprod/snapshots/zip_builder.py
@@ -40,9 +40,9 @@ def build_snapshot_zip(
     key_prefix: str,
     out: IO[bytes],
     artifact_id: int,
-    manifest_bytes: bytes | None = None,
+    manifest_bytes: bytes,
 ) -> None:
-    """Build an archive of snapshot images and an optional manifest into ``out``.
+    """Build an archive of snapshot images and its manifest into ``out``.
 
     Images sharing a content hash are fetched once and written under each
     original filename. Raises SnapshotZipBuildError if any image fails to
@@ -50,7 +50,7 @@ def build_snapshot_zip(
     """
     hash_to_filenames: dict[str, list[str]] = defaultdict(list)
     for filename, meta in manifest.images.items():
-        if manifest_bytes is not None and filename == SNAPSHOT_ARCHIVE_MANIFEST_FILENAME:
+        if filename == SNAPSHOT_ARCHIVE_MANIFEST_FILENAME:
             raise SnapshotZipBuildError(
                 f"snapshot image filename conflicts with {SNAPSHOT_ARCHIVE_MANIFEST_FILENAME}"
             )
@@ -89,12 +89,11 @@ def build_snapshot_zip(
                 )
             for filename in hash_to_filenames[image_hash]:
                 zf.writestr(filename, data)
-        if manifest_bytes is not None:
-            zf.writestr(
-                SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
-                manifest_bytes,
-                compress_type=zipfile.ZIP_DEFLATED,
-            )
+        zf.writestr(
+            SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
+            manifest_bytes,
+            compress_type=zipfile.ZIP_DEFLATED,
+        )
         logger.info(
             "preprod_snapshot_zip.zip_build_completed",
             extra={"preprod_artifact_id": artifact_id, "image_hash_count": len(unique_hashes)},

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -118,7 +118,6 @@ def build_snapshot_images_zip(
     project_id: int,
     artifact_id: int,
     user_id: int | None = None,
-    include_manifest: bool = False,
     **kwargs: Any,
 ) -> None:
     logger.info(
@@ -128,7 +127,6 @@ def build_snapshot_images_zip(
             "organization_id": org_id,
             "project_id": project_id,
             "user_id": user_id,
-            "include_manifest": include_manifest,
         },
     )
     try:
@@ -141,7 +139,6 @@ def build_snapshot_images_zip(
                 "organization_id": org_id,
                 "project_id": project_id,
                 "user_id": user_id,
-                "include_manifest": include_manifest,
             },
         )
         return
@@ -186,7 +183,7 @@ def build_snapshot_images_zip(
                     f"{org_id}/{project_id}",
                     tmp,
                     artifact_id=artifact_id,
-                    manifest_bytes=manifest_bytes if include_manifest else None,
+                    manifest_bytes=manifest_bytes,
                 )
                 tmp.flush()
                 tmp.seek(0)
@@ -230,7 +227,6 @@ def build_snapshot_images_zip(
             "organization_id": org_id,
             "project_id": project_id,
             "user_id": user_id,
-            "include_manifest": include_manifest,
         },
     )
     _send_archive_email(organization, user_id, artifact_id, ready=True)

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -61,16 +61,9 @@ class SnapshotArchiveTriggerTest(BaseSnapshotArchiveTest):
                 "project_id": self.project.id,
                 "artifact_id": artifact.id,
                 "user_id": self.user.id,
+                "include_manifest": True,
             }
         )
-
-    @patch(ENQUEUE_TARGET)
-    def test_post_enqueues_manifest_archive_when_feature_enabled(self, mock_task):
-        artifact = self._artifact()
-        with self.feature("organizations:preprod-snapshot-archive-manifest"):
-            response = self.client.post(self._url(artifact.id))
-        assert response.status_code == 202
-        assert mock_task.apply_async.call_args.kwargs["kwargs"]["include_manifest"] is True
 
     @patch(ENQUEUE_TARGET)
     def test_post_returns_503_when_enqueue_fails(self, mock_task):

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -78,28 +78,11 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-snapshot-archive-manifest"):
-            response = self.client.post(self._get_create_url(), data, format="json")
+        response = self.client.post(self._get_create_url(), data, format="json")
 
         assert response.status_code == 400
         assert response.data["detail"] == "The filename manifest.json is reserved."
         assert not PreprodArtifact.objects.filter(project=self.project).exists()
-
-    def test_snapshot_upload_allows_reserved_archive_filename_when_feature_disabled(self) -> None:
-        data = {
-            "app_id": "com.example.app",
-            "images": {
-                "manifest.json": {
-                    "content_hash": "abc123def456",
-                    "width": 375,
-                    "height": 812,
-                },
-            },
-        }
-
-        response = self.client.post(self._get_create_url(), data, format="json")
-
-        assert response.status_code == 200
 
     def _compressible_snapshot_payload(self) -> bytes:
         data = {

--- a/tests/sentry/preprod/snapshots/test_zip_builder.py
+++ b/tests/sentry/preprod/snapshots/test_zip_builder.py
@@ -102,7 +102,14 @@ def test_build_snapshot_zip_raises_on_fetch_failure() -> None:
     session = _session({})  # every get raises
 
     with pytest.raises(SnapshotZipBuildError):
-        build_snapshot_zip(manifest, session, "1/2", BytesIO(), artifact_id=99)
+        build_snapshot_zip(
+            manifest,
+            session,
+            "1/2",
+            BytesIO(),
+            artifact_id=99,
+            manifest_bytes=b'{"images":{}}',
+        )
 
 
 def test_build_snapshot_zip_rejects_manifest_filename_collision() -> None:

--- a/tests/sentry/preprod/snapshots/test_zip_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_zip_tasks.py
@@ -64,7 +64,7 @@ class BuildSnapshotImagesZipTest(TestCase):
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
-    def test_build_includes_manifest_when_requested(self, mock_session, mock_email):
+    def test_build_includes_manifest(self, mock_session, mock_email):
         session = self._session()
         mock_session.return_value = session
         build_snapshot_images_zip(
@@ -72,7 +72,6 @@ class BuildSnapshotImagesZipTest(TestCase):
             project_id=self.project.id,
             artifact_id=self.artifact.id,
             user_id=self.user.id,
-            include_manifest=True,
         )
         session.initiate_multipart_upload.assert_called_once()
         kwargs = session.initiate_multipart_upload.call_args.kwargs
@@ -92,28 +91,7 @@ class BuildSnapshotImagesZipTest(TestCase):
 
     @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
     @patch(SESSION_TARGET)
-    def test_build_omits_manifest_by_default(self, mock_session, mock_email):
-        session = self._session()
-        mock_session.return_value = session
-
-        build_snapshot_images_zip(
-            org_id=self.org.id,
-            project_id=self.project.id,
-            artifact_id=self.artifact.id,
-            user_id=self.user.id,
-        )
-
-        kwargs = session.initiate_multipart_upload.call_args.kwargs
-        assert kwargs["key"] == f"snapshot_archives/{self.artifact.id}.zip"
-        upload = session.initiate_multipart_upload.return_value
-        archive_bytes = b"".join(call.args[0] for call in upload.put_part.call_args_list)
-        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
-            assert archive.namelist() == ["a.png"]
-        assert mock_email.call_args.kwargs["ready"] is True
-
-    @patch("sentry.preprod.snapshots.zip_tasks._send_archive_email")
-    @patch(SESSION_TARGET)
-    def test_reuses_existing_archive_when_manifest_requested(self, mock_session, mock_email):
+    def test_reuses_existing_archive(self, mock_session, mock_email):
         session = self._session(existing_archive_key=f"snapshot_archives/{self.artifact.id}.zip")
         mock_session.return_value = session
         build_snapshot_images_zip(
@@ -121,7 +99,6 @@ class BuildSnapshotImagesZipTest(TestCase):
             project_id=self.project.id,
             artifact_id=self.artifact.id,
             user_id=self.user.id,
-            include_manifest=True,
         )
         session.initiate_multipart_upload.assert_not_called()
         mock_email.assert_called_once()


### PR DESCRIPTION
Snapshot archives now always include their `manifest.json`, and snapshot uploads always reserve that filename. This removes the graduated feature registration and the conditional task and ZIP-builder paths while preserving existing archive caching behavior.

The API temporarily continues sending `include_manifest=True` so workers running the previous task implementation behave correctly during a rolling deployment. That compatibility argument can be removed after this change is fully deployed.

Refs EME-1246
