### PR TITLE
fix(alerts): Send release environment name, not id, and update API docs

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -367,7 +367,7 @@ ACTION_FILTERS_HELP_TEXT = """The filters to run before the action will fire and
             {
                 "type": "latest_adopted_release",
                 "comparison": {
-                    "environment": "12345",
+                    "environment": "production",
                     "ageComparison": "older",
                     "releaseAgeType": "oldest"
                 },

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.spec.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.spec.tsx
@@ -1,0 +1,77 @@
+import {DataConditionFixture} from 'sentry-fixture/automations';
+import {EnvironmentsFixture} from 'sentry-fixture/environments';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {LatestAdoptedReleaseNode} from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
+import {DataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+describe('LatestAdoptedReleaseNode', () => {
+  const organization = OrganizationFixture();
+  const condition = DataConditionFixture({
+    id: 'latest-adopted-release',
+    type: DataConditionType.LATEST_ADOPTED_RELEASE,
+    comparison: {
+      releaseAgeType: 'oldest',
+      ageComparison: 'newer',
+      environment: '',
+    },
+  });
+  const onUpdate = jest.fn();
+  const removeError = jest.fn();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/environments/`,
+      body: EnvironmentsFixture(),
+    });
+  });
+
+  it('stores the environment name when selected', async () => {
+    render(
+      <AutomationBuilderErrorContext.Provider
+        value={{
+          errors: {},
+          mutationErrors: undefined,
+          setErrors: jest.fn(),
+          removeError,
+        }}
+      >
+        <DataConditionNodeContext.Provider
+          value={{
+            condition,
+            condition_id: condition.id,
+            onUpdate,
+          }}
+        >
+          <LatestAdoptedReleaseNode />
+        </DataConditionNodeContext.Provider>
+      </AutomationBuilderErrorContext.Provider>,
+      {organization}
+    );
+
+    const environmentSelect = await screen.findByRole('textbox', {
+      name: 'Environment',
+    });
+    await userEvent.click(environmentSelect);
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {
+        name: 'production',
+      })
+    );
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith({
+        comparison: {
+          ...condition.comparison,
+          environment: 'production',
+        },
+      });
+    });
+    expect(removeError).toHaveBeenCalledWith(condition.id);
+  });
+});

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -80,8 +80,8 @@ function EnvironmentField() {
   const {removeError} = useAutomationBuilderErrorContext();
 
   const {environments} = useOrganizationEnvironments();
-  const environmentOptions = environments.map(({id, name}) => ({
-    value: id,
+  const environmentOptions = environments.map(({name}) => ({
+    value: name,
     label: name,
   }));
 


### PR DESCRIPTION
The new alerts UI [saves the environment ID](https://github.com/getsentry/sentry/blob/6bd683efc2b599d60e65e06915017aab73dc028a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx#L84), but the backend [expects/saves it as name](https://github.com/getsentry/sentry/blob/3cda549c7f3dc2dced014ca43ba4ceebf7a04a42/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py#L41).

Here we ensure that the frontend sends back `name` instead, preventing further alert corruption. A separate PR will introduce a cleanup script, to be run once this fix is live and we know we aren't doing this anymore. Plus a regression test.

Also, update the API docs to make it clear a string, not id (as a string lol), should be sent.