### PR TITLE
Store agentic onboarding metadata by stage

### DIFF
--- a/src/sentry/api/endpoints/organization_agentic_onboarding.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding.py
@@ -1,4 +1,4 @@
-from typing import Literal, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 from uuid import UUID
 
 from drf_spectacular.utils import extend_schema
@@ -25,7 +25,9 @@ from sentry.onboarding.agentic_progress.model import (
     ProgressUpdate,
     RunStatus,
     Stage,
+    StageExtra,
     StageStatus,
+    get_stage_definition,
     validate_update,
 )
 from sentry.onboarding.agentic_progress.service import (
@@ -62,13 +64,12 @@ class AgenticOnboardingStatusRequest(TypedDict):
     status: StageStatusValue
     run_status: NotRequired[Literal["completed", "failed"]]
     event_note: NotRequired[str]
-    project_slugs: NotRequired[list[str]]
-    issue_ids: NotRequired[list[str]]
+    extra: NotRequired[dict[str, Any]]
 
 
 class AgenticOnboardingStatusData(TypedDict):
     run_token: str
-    update: ProgressUpdate
+    update: ProgressUpdate[Any]
 
 
 class AgenticOnboardingPermission(OrganizationPermission):
@@ -81,6 +82,35 @@ class AgenticOnboardingPermission(OrganizationPermission):
 class AgenticOnboardingRunRequestSerializer(CamelSnakeSerializer[AgenticOnboardingRunRequest]):
     client_run_id = serializers.UUIDField()
     onboarding_code = serializers.RegexField(r"^[A-Za-z0-9]{10}$")
+
+
+class CreateProjectExtraSerializer(CamelSnakeSerializer[dict[str, Any]]):
+    project_slugs = serializers.ListField(child=serializers.SlugField())
+
+
+class VerificationErrorExtraSerializer(CamelSnakeSerializer[dict[str, Any]]):
+    issue_ids = serializers.ListField(child=serializers.CharField())
+
+
+EXTRA_SERIALIZER_BY_STAGE = {
+    Stage.CREATE_PROJECT: CreateProjectExtraSerializer,
+    Stage.RECEIVE_VERIFICATION_ERROR: VerificationErrorExtraSerializer,
+}
+
+
+def deserialize_stage_extra(stage: Stage, value: dict[str, Any]) -> StageExtra:
+    serializer_type = EXTRA_SERIALIZER_BY_STAGE.get(stage)
+    if serializer_type is None:
+        raise serializers.ValidationError(f"Extra data is not valid for the {stage.value} stage")
+
+    serializer = serializer_type(data=value)
+    unknown_fields = set(value) - set(serializer.fields)
+    if unknown_fields:
+        raise serializers.ValidationError(
+            {field: "Unknown extra field" for field in sorted(unknown_fields)}
+        )
+    serializer.is_valid(raise_exception=True)
+    return get_stage_definition(stage).parse_extra(serializer.validated_data)
 
 
 class AgenticOnboardingStatusRequestSerializer(CamelSnakeSerializer[AgenticOnboardingStatusData]):
@@ -100,20 +130,15 @@ class AgenticOnboardingStatusRequestSerializer(CamelSnakeSerializer[AgenticOnboa
     event_note = serializers.CharField(
         required=False, allow_blank=False, max_length=MAX_EVENT_NOTE_LENGTH
     )
-    project_slugs = serializers.ListField(
-        child=serializers.SlugField(), required=False, allow_empty=False, max_length=100
-    )
-    issue_ids = serializers.ListField(
-        child=serializers.CharField(), required=False, allow_empty=False, max_length=100
-    )
+    extra = serializers.DictField(required=False, allow_empty=False)
 
     def validate(self, attrs: AgenticOnboardingStatusRequest) -> AgenticOnboardingStatusData:
+        stage = Stage(attrs["stage"])
         update = ProgressUpdate(
-            stage=Stage(attrs["stage"]),
+            stage=stage,
             status=StageStatus(attrs["status"]),
             event_note=attrs.get("event_note"),
-            project_slugs=tuple(attrs.get("project_slugs", [])),
-            issue_ids=tuple(attrs.get("issue_ids", [])),
+            extra=deserialize_stage_extra(stage, attrs["extra"]) if "extra" in attrs else None,
             run_status=(RunStatus(attrs["run_status"]) if "run_status" in attrs else None),
         )
         try:

--- a/src/sentry/api/serializers/models/agentic_onboarding.py
+++ b/src/sentry/api/serializers/models/agentic_onboarding.py
@@ -2,13 +2,29 @@ from collections.abc import Mapping
 from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer
-from sentry.onboarding.agentic_progress.model import OnboardingRun, RunStatus, Stage, StageStatus
+from sentry.api.serializers.rest_framework import convert_dict_key_case, snake_to_camel_case
+from sentry.onboarding.agentic_progress.model import (
+    OnboardingRun,
+    RunStatus,
+    Stage,
+    StageExtra,
+    StageStatus,
+)
+from sentry.utils import json
 
 
 class AgenticOnboardingStageResponse(TypedDict):
     stage: Stage
     status: StageStatus | None
     eventNote: str | None
+    extra: dict[str, Any] | None
+
+
+def serialize_stage_extra(extra: StageExtra | None) -> dict[str, Any] | None:
+    if extra is None:
+        return None
+
+    return convert_dict_key_case(json.loads(extra.json()), snake_to_camel_case)
 
 
 class AgenticOnboardingRunResponse(TypedDict):
@@ -23,8 +39,6 @@ class AgenticOnboardingRunResponse(TypedDict):
     expiresAt: str
     continueUpdates: bool
     runStatus: RunStatus
-    projectSlugs: list[str]
-    issueIds: list[str]
     stages: list[AgenticOnboardingStageResponse]
 
 
@@ -47,13 +61,12 @@ class AgenticOnboardingRunSerializer(Serializer[AgenticOnboardingRunResponse]):
             expiresAt=obj.expires_at.isoformat(),
             continueUpdates=obj.run_status is RunStatus.ACTIVE,
             runStatus=obj.run_status,
-            projectSlugs=list(obj.project_slugs),
-            issueIds=list(obj.issue_ids),
             stages=[
                 AgenticOnboardingStageResponse(
                     stage=state.stage,
                     status=state.status,
                     eventNote=state.event_note,
+                    extra=serialize_stage_extra(state.extra),
                 )
                 for state in obj.stages
             ],

--- a/src/sentry/onboarding/agentic_progress/model.py
+++ b/src/sentry/onboarding/agentic_progress/model.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any
+from typing import Any, Generic, Literal, Self, TypeVar, overload
+
+from pydantic import (
+    BaseModel,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+    validator,
+)
+from pydantic import (
+    Extra as PydanticExtra,
+)
 
 SCHEMA_VERSION = 1
 MAX_EVENT_NOTE_LENGTH = 256
@@ -71,8 +82,75 @@ class RunStatus(StrEnum):
     CANCELLED = "cancelled"
 
 
+class StageExtra(BaseModel):
+    class Config:
+        extra = PydanticExtra.forbid
+        frozen = True
+
+    def merge(self, incoming: Self) -> Self:
+        raise NotImplementedError
+
+
+class CreateProjectExtra(StageExtra):
+    project_slugs: tuple[StrictStr, ...]
+
+    def merge(self, incoming: Self) -> Self:
+        return type(self)(project_slugs=_merge_unique(self.project_slugs, incoming.project_slugs))
+
+
+class VerificationErrorExtra(StageExtra):
+    issue_ids: tuple[StrictStr, ...]
+
+    def merge(self, incoming: Self) -> Self:
+        return type(self)(issue_ids=_merge_unique(self.issue_ids, incoming.issue_ids))
+
+
+ExtraT = TypeVar("ExtraT", bound=StageExtra)
+ItemT = TypeVar("ItemT")
+
+
+def _merge_unique(current: tuple[ItemT, ...], incoming: tuple[ItemT, ...]) -> tuple[ItemT, ...]:
+    return tuple(dict.fromkeys((*current, *incoming)))
+
+
+class PersistedStageState(BaseModel):
+    stage: StrictStr
+    status: StrictStr | None
+    event_note: StrictStr | None = None
+    extra: dict[str, Any] | None = None
+
+    class Config:
+        extra = PydanticExtra.forbid
+
+
+class PersistedOnboardingRun(BaseModel):
+    run_id: StrictStr
+    channel_id: StrictStr
+    token_hash: StrictStr
+    client_run_id: StrictStr
+    user_id: StrictInt
+    organization_id: StrictInt
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    sequence: StrictInt
+    stages: tuple[PersistedStageState, ...]
+    run_status: StrictStr = RunStatus.ACTIVE
+    schema_version: StrictInt
+
+    class Config:
+        extra = PydanticExtra.forbid
+
+    @validator("created_at", "updated_at", "expires_at")
+    def require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("timestamp must include a timezone")
+
+        return value
+
+
 @dataclass(frozen=True)
-class StageDefinition:
+class StageDefinition(Generic[ExtraT]):
     """Static behavior for a stage in the ordered onboarding flow."""
 
     stage: Stage
@@ -81,22 +159,135 @@ class StageDefinition:
     optional: bool = False
     """Whether later progress may leave this stage without a terminal status."""
 
+    extra_type: type[ExtraT] | None = None
+    """Structured extra data accepted by this stage, when it has any."""
+
+    def state(
+        self,
+        *,
+        status: StageStatus | None = None,
+        event_note: str | None = None,
+        extra: ExtraT | None = None,
+    ) -> StageState[ExtraT]:
+        return StageState(
+            stage=self.stage,
+            status=status,
+            event_note=event_note,
+            extra=extra,
+        )
+
+    def update(
+        self,
+        *,
+        status: StageStatus,
+        event_note: str | None = None,
+        extra: ExtraT | None = None,
+        run_status: RunStatus | None = None,
+    ) -> ProgressUpdate[ExtraT]:
+        return ProgressUpdate(
+            stage=self.stage,
+            status=status,
+            event_note=event_note,
+            extra=extra,
+            run_status=run_status,
+        )
+
+    def extra_from(self, state: StageState[Any]) -> ExtraT | None:
+        if state.stage is not self.stage:
+            raise ValueError(f"Expected extra data for {self.stage.value}")
+        if state.extra is None:
+            return None
+        if self.extra_type is None or not isinstance(state.extra, self.extra_type):
+            raise ValueError(f"Invalid extra data for {self.stage.value}")
+
+        return state.extra
+
+    def extra_for_update(self, update: ProgressUpdate[Any]) -> ExtraT | None:
+        if self.extra_type is None:
+            if update.extra is not None:
+                raise InvalidProgressUpdate(
+                    ProgressUpdateField.EXTRA,
+                    f"Extra data is not valid for the {self.stage.value} stage",
+                )
+
+            return None
+
+        if update.extra is None:
+            return None
+        if not isinstance(update.extra, self.extra_type):
+            raise InvalidProgressUpdate(
+                ProgressUpdateField.EXTRA,
+                f"Extra data is not valid for the {self.stage.value} stage",
+            )
+        return update.extra
+
+    def parse_extra(self, value: object) -> ExtraT:
+        if self.extra_type is None:
+            raise ValueError(f"Extra data is not valid for {self.stage.value}")
+
+        return self.extra_type.parse_obj(value)
+
+    def deserialize_extra(self, value: object) -> ExtraT | None:
+        if value is None:
+            return None
+
+        try:
+            return self.parse_extra(value)
+        except (ValidationError, ValueError) as error:
+            raise InvalidOnboardingRun(f"Invalid extra data for {self.stage.value}") from error
+
+    def merge_extra(self, current: ExtraT | None, incoming: ExtraT | None) -> ExtraT | None:
+        if incoming is None:
+            return current
+        if current is None:
+            return incoming
+        if self.extra_type is None or not isinstance(current, self.extra_type):
+            raise InvalidProgressUpdate(ProgressUpdateField.EXTRA, "Extra data type cannot change")
+
+        return current.merge(incoming)
+
 
 # Tuple order is the onboarding order and therefore part of the persisted schema.
-STAGE_DEFINITIONS: tuple[StageDefinition, ...] = (
+STAGE_DEFINITIONS: tuple[StageDefinition[Any], ...] = (
     StageDefinition(Stage.CONNECT_MCP),
     StageDefinition(Stage.ANALYZE_PROJECT),
-    StageDefinition(Stage.CREATE_PROJECT),
+    StageDefinition(
+        Stage.CREATE_PROJECT,
+        extra_type=CreateProjectExtra,
+    ),
     StageDefinition(Stage.INSTRUMENT_APP),
     StageDefinition(Stage.PLAN_TEST_ERROR),
     StageDefinition(Stage.SEND_VERIFICATION_ERROR),
-    StageDefinition(Stage.RECEIVE_VERIFICATION_ERROR),
+    StageDefinition(
+        Stage.RECEIVE_VERIFICATION_ERROR,
+        extra_type=VerificationErrorExtra,
+    ),
     StageDefinition(Stage.PREPARE_PRODUCTION),
     StageDefinition(Stage.CHECK_STACK_TRACE_QUALITY, optional=True),
 )
 
 STAGE_DEFINITION_BY_STAGE = {definition.stage: definition for definition in STAGE_DEFINITIONS}
 STAGE_INDEX = {definition.stage: index for index, definition in enumerate(STAGE_DEFINITIONS)}
+
+
+@overload
+def get_stage_definition(
+    stage: Literal[Stage.CREATE_PROJECT],
+) -> StageDefinition[CreateProjectExtra]: ...
+
+
+@overload
+def get_stage_definition(
+    stage: Literal[Stage.RECEIVE_VERIFICATION_ERROR],
+) -> StageDefinition[VerificationErrorExtra]: ...
+
+
+@overload
+def get_stage_definition(stage: Stage) -> StageDefinition[Any]: ...
+
+
+def get_stage_definition(stage: Stage) -> StageDefinition[Any]:
+    return STAGE_DEFINITION_BY_STAGE[stage]
 
 
 class InvalidOnboardingRun(ValueError):
@@ -108,8 +299,7 @@ class ProgressUpdateField(StrEnum):
 
     EVENT_NOTE = "event_note"
     STATUS = "status"
-    PROJECT_SLUGS = "project_slugs"
-    ISSUE_IDS = "issue_ids"
+    EXTRA = "extra"
     RUN_STATUS = "run_status"
 
 
@@ -130,7 +320,7 @@ class OnboardingRunTerminal(ValueError):
 
 
 @dataclass(frozen=True)
-class StageState:
+class StageState(Generic[ExtraT]):
     """Persisted UI state for one onboarding stage."""
 
     stage: Stage
@@ -140,11 +330,14 @@ class StageState:
     """Latest status, or None before the stage begins."""
 
     event_note: str | None = None
-    """Short user-visible context for the latest update."""
+    """Short user-visible detail for the latest update."""
+
+    extra: ExtraT | None = None
+    """Structured data whose type is selected by the stage definition."""
 
 
 @dataclass(frozen=True)
-class ProgressUpdate:
+class ProgressUpdate(Generic[ExtraT]):
     """Validated state transition reported by the onboarding tool."""
 
     stage: Stage
@@ -154,13 +347,10 @@ class ProgressUpdate:
     """New state for the stage."""
 
     event_note: str | None = None
-    """Optional user-visible context for the update."""
+    """Optional user-visible detail for the update."""
 
-    project_slugs: tuple[str, ...] = ()
-    """Validated projects selected during the create-project stage."""
-
-    issue_ids: tuple[str, ...] = ()
-    """Validated issues received during the receive-verification-error stage."""
+    extra: ExtraT | None = None
+    """Structured extra data associated with this stage update."""
 
     run_status: RunStatus | None = None
     """Optional terminal transition for the complete run."""
@@ -200,17 +390,11 @@ class OnboardingRun:
     sequence: int
     """Monotonic version used for polling and stale Conduit message rejection."""
 
-    stages: tuple[StageState, ...]
+    stages: tuple[StageState[Any], ...]
     """State for every available stage, in canonical STAGE_DEFINITIONS order."""
 
     run_status: RunStatus = RunStatus.ACTIVE
     """Lifecycle state of the complete onboarding run."""
-
-    project_slugs: tuple[str, ...] = ()
-    """Validated Sentry projects selected for instrumentation."""
-
-    issue_ids: tuple[str, ...] = ()
-    """Validated Sentry issues proving end-to-end event delivery."""
 
     schema_version: int = SCHEMA_VERSION
     """Version of the Redis and public snapshot representation."""
@@ -218,10 +402,11 @@ class OnboardingRun:
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> OnboardingRun:
         try:
+            persisted = PersistedOnboardingRun.parse_obj(value)
             persisted_stages = []
-            for item in value["stages"]:
+            for item in persisted.stages:
                 try:
-                    stage = Stage(item["stage"])
+                    stage = Stage(item.stage)
                 except ValueError:
                     # Active runs may still contain stages removed by a deployment.
                     continue
@@ -229,10 +414,9 @@ class OnboardingRun:
                 persisted_stages.append(
                     StageState(
                         stage=stage,
-                        status=(
-                            StageStatus(item["status"]) if item["status"] is not None else None
-                        ),
-                        event_note=item.get("event_note"),
+                        status=StageStatus(item.status) if item.status is not None else None,
+                        event_note=item.event_note,
+                        extra=_deserialize_extra(stage, item.extra),
                     )
                 )
             expected_stages = tuple(definition.stage for definition in STAGE_DEFINITIONS)
@@ -244,7 +428,7 @@ class OnboardingRun:
             ):
                 raise InvalidOnboardingRun("Persisted onboarding stages are invalid")
             persisted_stage_by_name = {state.stage: state for state in persisted_stages}
-            run_status = RunStatus(value.get("run_status", RunStatus.ACTIVE))
+            run_status = RunStatus(persisted.run_status)
             current_stage_index = max(
                 (
                     STAGE_INDEX[state.stage]
@@ -269,50 +453,58 @@ class OnboardingRun:
                 )
                 for stage in expected_stages
             )
-
             return cls(
-                run_id=value["run_id"],
-                channel_id=value["channel_id"],
-                token_hash=value["token_hash"],
-                client_run_id=value["client_run_id"],
-                user_id=value["user_id"],
-                organization_id=value["organization_id"],
-                created_at=_deserialize_datetime(value["created_at"]),
-                updated_at=_deserialize_datetime(value["updated_at"]),
-                expires_at=_deserialize_datetime(value["expires_at"]),
-                sequence=value["sequence"],
+                run_id=persisted.run_id,
+                channel_id=persisted.channel_id,
+                token_hash=persisted.token_hash,
+                client_run_id=persisted.client_run_id,
+                user_id=persisted.user_id,
+                organization_id=persisted.organization_id,
+                created_at=persisted.created_at,
+                updated_at=persisted.updated_at,
+                expires_at=persisted.expires_at,
+                sequence=persisted.sequence,
                 stages=stages,
                 run_status=run_status,
-                project_slugs=tuple(value.get("project_slugs", [])),
-                issue_ids=tuple(value.get("issue_ids", [])),
-                schema_version=value["schema_version"],
+                schema_version=persisted.schema_version,
             )
         except InvalidOnboardingRun:
             raise
-        except (KeyError, TypeError, ValueError) as error:
+        except (TypeError, ValidationError, ValueError) as error:
             raise InvalidOnboardingRun("Persisted onboarding state is invalid") from error
 
     def to_dict(self) -> dict[str, Any]:
-        value = asdict(self)
-        value["created_at"] = self.created_at.isoformat()
-        value["updated_at"] = self.updated_at.isoformat()
-        value["expires_at"] = self.expires_at.isoformat()
-        return value
+        return {
+            "run_id": self.run_id,
+            "channel_id": self.channel_id,
+            "token_hash": self.token_hash,
+            "client_run_id": self.client_run_id,
+            "user_id": self.user_id,
+            "organization_id": self.organization_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+            "sequence": self.sequence,
+            "stages": [
+                {
+                    "stage": state.stage.value,
+                    "status": state.status.value if state.status is not None else None,
+                    "event_note": state.event_note,
+                    "extra": state.extra.dict() if state.extra is not None else None,
+                }
+                for state in self.stages
+            ],
+            "run_status": self.run_status.value,
+            "schema_version": self.schema_version,
+        }
 
 
-def initial_stages() -> tuple[StageState, ...]:
+def initial_stages() -> tuple[StageState[Any], ...]:
     return tuple(StageState(stage=definition.stage) for definition in STAGE_DEFINITIONS)
 
 
-def _deserialize_datetime(value: object) -> datetime:
-    if not isinstance(value, str):
-        raise InvalidOnboardingRun("Persisted onboarding timestamp is invalid")
-
-    parsed = datetime.fromisoformat(value)
-    if parsed.tzinfo is None or parsed.utcoffset() is None:
-        raise InvalidOnboardingRun("Persisted onboarding timestamp must include a timezone")
-
-    return parsed
+def _deserialize_extra(stage: Stage, value: object) -> StageExtra | None:
+    return get_stage_definition(stage).deserialize_extra(value)
 
 
 def _validate_text(
@@ -326,8 +518,9 @@ def _validate_text(
         raise InvalidProgressUpdate(field, f"{name} cannot contain control characters")
 
 
-def validate_update(update: ProgressUpdate) -> None:
-    definition = STAGE_DEFINITION_BY_STAGE[update.stage]
+def validate_update(update: ProgressUpdate[Any]) -> None:
+    definition = get_stage_definition(update.stage)
+    definition.extra_for_update(update)
     _validate_text(
         update.event_note,
         field=ProgressUpdateField.EVENT_NOTE,
@@ -345,16 +538,6 @@ def validate_update(update: ProgressUpdate) -> None:
     if update.status is StageStatus.BYPASSED:
         raise InvalidProgressUpdate(
             ProgressUpdateField.STATUS, "Bypassed stages are inferred by the backend"
-        )
-    if update.project_slugs and update.stage is not Stage.CREATE_PROJECT:
-        raise InvalidProgressUpdate(
-            ProgressUpdateField.PROJECT_SLUGS,
-            "Project slugs are only valid for the create-project stage",
-        )
-    if update.issue_ids and update.stage is not Stage.RECEIVE_VERIFICATION_ERROR:
-        raise InvalidProgressUpdate(
-            ProgressUpdateField.ISSUE_IDS,
-            "Issue IDs are only valid for the receive-verification-error stage",
         )
     if update.run_status not in {None, RunStatus.COMPLETED, RunStatus.FAILED}:
         raise InvalidProgressUpdate(
@@ -374,8 +557,10 @@ def validate_update(update: ProgressUpdate) -> None:
         )
 
 
-def apply_update(run: OnboardingRun, update: ProgressUpdate, now: datetime) -> OnboardingRun:
+def apply_update(run: OnboardingRun, update: ProgressUpdate[Any], now: datetime) -> OnboardingRun:
     validate_update(update)
+    stage_definition = get_stage_definition(update.stage)
+    update_extra = stage_definition.extra_for_update(update)
     if now >= run.expires_at:
         raise OnboardingRunExpired("Onboarding run has expired")
     if run.run_status is not RunStatus.ACTIVE:
@@ -405,15 +590,14 @@ def apply_update(run: OnboardingRun, update: ProgressUpdate, now: datetime) -> O
         StageStatus.BYPASSED,
     }
     if current.status in frozen_statuses and update.status is not current.status:
-        project_slugs = tuple(dict.fromkeys((*run.project_slugs, *update.project_slugs)))
-        issue_ids = tuple(dict.fromkeys((*run.issue_ids, *update.issue_ids)))
-        if project_slugs == run.project_slugs and issue_ids == run.issue_ids:
+        merged_extra = stage_definition.merge_extra(current.extra, update_extra)
+        if merged_extra == current.extra:
             return run
 
+        stages[update.stage] = replace(current, extra=merged_extra)
         return replace(
             run,
-            project_slugs=project_slugs,
-            issue_ids=issue_ids,
+            stages=tuple(stages[definition.stage] for definition in STAGE_DEFINITIONS),
             updated_at=now.astimezone(timezone.utc),
             sequence=run.sequence + 1,
         )
@@ -423,16 +607,23 @@ def apply_update(run: OnboardingRun, update: ProgressUpdate, now: datetime) -> O
             stage=update.stage,
             status=update.status,
             event_note=update.event_note,
+            extra=stage_definition.merge_extra(current.extra, update_extra),
         )
     elif update.event_note and current.event_note is None:
-        stages[update.stage] = replace(current, event_note=update.event_note)
+        stages[update.stage] = replace(
+            current,
+            event_note=update.event_note,
+            extra=stage_definition.merge_extra(current.extra, update_extra),
+        )
+    elif update_extra is not None:
+        stages[update.stage] = replace(
+            current, extra=stage_definition.merge_extra(current.extra, update_extra)
+        )
 
     candidate = replace(
         run,
         stages=tuple(stages[definition.stage] for definition in STAGE_DEFINITIONS),
         run_status=update.run_status or run.run_status,
-        project_slugs=tuple(dict.fromkeys((*run.project_slugs, *update.project_slugs))),
-        issue_ids=tuple(dict.fromkeys((*run.issue_ids, *update.issue_ids))),
     )
     if candidate == run:
         return run

--- a/src/sentry/onboarding/agentic_progress/service.py
+++ b/src/sentry/onboarding/agentic_progress/service.py
@@ -7,7 +7,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple, cast
 
 from django.conf import settings
 from redis.exceptions import WatchError
@@ -130,7 +130,7 @@ class OnboardingProgressService:
         token: str,
         user_id: int,
         organization_id: int,
-        update: ProgressUpdate,
+        update: ProgressUpdate[Any],
     ) -> UpdatedRun:
         if len(token) != TOKEN_LENGTH or not token.isalnum():
             raise RunNotFound

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
@@ -50,7 +50,7 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
                     "stage": "create_project",
                     "status": "completed",
                     "eventNote": "Project already existed.",
-                    "projectSlugs": ["frontend", "backend"],
+                    "extra": {"projectSlugs": ["frontend", "backend"]},
                 },
             )
 
@@ -59,8 +59,7 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
         assert response.data["stages"][0]["status"] == "bypassed"
         assert response.data["stages"][1]["status"] == "bypassed"
         assert response.data["stages"][2]["status"] == "completed"
-        assert response.data["projectSlugs"] == ["frontend", "backend"]
-        assert response.data["issueIds"] == []
+        assert response.data["stages"][2]["extra"] == {"projectSlugs": ["frontend", "backend"]}
 
     def test_status_rejects_unknown_run(self) -> None:
         path = reverse(

--- a/tests/sentry/onboarding/agentic_progress/test_model.py
+++ b/tests/sentry/onboarding/agentic_progress/test_model.py
@@ -1,12 +1,13 @@
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, assert_type
 
 import pytest
 
 from sentry.onboarding.agentic_progress.model import (
     STAGE_DEFINITIONS,
     STAGE_INDEX,
+    CreateProjectExtra,
     InvalidOnboardingRun,
     InvalidProgressUpdate,
     OnboardingRun,
@@ -16,9 +17,12 @@ from sentry.onboarding.agentic_progress.model import (
     ProgressUpdateField,
     RunStatus,
     Stage,
+    StageDefinition,
     StageState,
     StageStatus,
+    VerificationErrorExtra,
     apply_update,
+    get_stage_definition,
     initial_stages,
     validate_update,
 )
@@ -43,6 +47,17 @@ def make_run(now: datetime) -> OnboardingRun:
 def test_stage_definitions_are_ordered_and_complete() -> None:
     assert [definition.stage for definition in STAGE_DEFINITIONS] == list(Stage)
     assert STAGE_DEFINITIONS[-1].optional is True
+
+
+def test_extra_stage_definition_preserves_its_type() -> None:
+    assert_type(
+        get_stage_definition(Stage.CREATE_PROJECT),
+        StageDefinition[CreateProjectExtra],
+    )
+    assert_type(
+        get_stage_definition(Stage.RECEIVE_VERIFICATION_ERROR),
+        StageDefinition[VerificationErrorExtra],
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,6 +178,53 @@ def test_from_dict_wraps_invalid_persisted_run_status() -> None:
 
     with pytest.raises(InvalidOnboardingRun, match="state is invalid"):
         OnboardingRun.from_dict(persisted)
+
+
+@pytest.mark.parametrize(
+    ("stage", "extra"),
+    [
+        (Stage.CREATE_PROJECT, {"project_slugs": ["project", 1]}),
+        (Stage.CREATE_PROJECT, {"project_slugs": ["project"], "unknown": True}),
+        (Stage.CREATE_PROJECT, {"issue_ids": ["123"]}),
+        (Stage.CONNECT_MCP, {"project_slugs": ["project"]}),
+    ],
+)
+def test_from_dict_rejects_invalid_stage_extra(stage: Stage, extra: dict[str, object]) -> None:
+    persisted = make_run(datetime(2020, 1, 1, tzinfo=timezone.utc)).to_dict()
+    persisted["stages"][STAGE_INDEX[stage]]["extra"] = extra
+
+    with pytest.raises(InvalidOnboardingRun, match=f"Invalid extra data for {stage.value}"):
+        OnboardingRun.from_dict(persisted)
+
+
+def test_stage_extra_round_trips() -> None:
+    now = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    run = apply_update(
+        make_run(now),
+        ProgressUpdate(
+            stage=Stage.CREATE_PROJECT,
+            status=StageStatus.COMPLETED,
+            extra=CreateProjectExtra(project_slugs=("frontend", "backend")),
+        ),
+        now,
+    )
+
+    assert OnboardingRun.from_dict(run.to_dict()) == run
+
+
+def test_empty_stage_extra_round_trips() -> None:
+    now = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    run = apply_update(
+        make_run(now),
+        ProgressUpdate(
+            stage=Stage.CREATE_PROJECT,
+            status=StageStatus.COMPLETED,
+            extra=CreateProjectExtra(project_slugs=()),
+        ),
+        now,
+    )
+
+    assert OnboardingRun.from_dict(run.to_dict()) == run
 
 
 def test_from_dict_rejects_empty_persisted_stage_status() -> None:
@@ -298,7 +360,7 @@ def test_failed_stage_can_be_retried() -> None:
 
 def test_terminal_run_only_accepts_idempotent_replay() -> None:
     now = datetime(2020, 1, 1, tzinfo=timezone.utc)
-    update = ProgressUpdate(
+    update: ProgressUpdate[Any] = ProgressUpdate(
         stage=Stage.ANALYZE_PROJECT,
         status=StageStatus.FAILED,
         event_note="Command failed.",
@@ -380,22 +442,24 @@ def test_inferred_bypass_clears_stale_event_note() -> None:
 
 
 @pytest.mark.parametrize(
-    ("later_stage", "owning_stage", "project_slugs", "issue_ids"),
+    ("later_stage", "owning_stage", "extra"),
     [
-        (Stage.INSTRUMENT_APP, Stage.CREATE_PROJECT, ("example-project",), ()),
+        (
+            Stage.INSTRUMENT_APP,
+            Stage.CREATE_PROJECT,
+            CreateProjectExtra(project_slugs=("example-project",)),
+        ),
         (
             Stage.PREPARE_PRODUCTION,
             Stage.RECEIVE_VERIFICATION_ERROR,
-            (),
-            ("12345",),
+            VerificationErrorExtra(issue_ids=("12345",)),
         ),
     ],
 )
 def test_bypassed_stage_accepts_late_metadata(
     later_stage: Stage,
     owning_stage: Stage,
-    project_slugs: tuple[str, ...],
-    issue_ids: tuple[str, ...],
+    extra: CreateProjectExtra | VerificationErrorExtra,
 ) -> None:
     now = datetime(2020, 1, 1, tzinfo=timezone.utc)
     advanced = apply_update(
@@ -409,16 +473,15 @@ def test_bypassed_stage_accepts_late_metadata(
         ProgressUpdate(
             stage=owning_stage,
             status=StageStatus.COMPLETED,
-            project_slugs=project_slugs,
-            issue_ids=issue_ids,
+            extra=extra,
         ),
         now + timedelta(seconds=1),
     )
 
-    assert enriched.stages[list(Stage).index(owning_stage)].status is StageStatus.BYPASSED
+    stage = enriched.stages[list(Stage).index(owning_stage)]
+    assert stage.status is StageStatus.BYPASSED
+    assert stage.extra == extra
     assert enriched.sequence == advanced.sequence + 1
-    assert enriched.project_slugs == project_slugs
-    assert enriched.issue_ids == issue_ids
 
 
 @pytest.mark.parametrize(
@@ -438,7 +501,7 @@ def test_bypassed_stage_accepts_late_metadata(
         ),
     ],
 )
-def test_update_validation(update: ProgressUpdate, message: str) -> None:
+def test_update_validation(update: ProgressUpdate[Any], message: str) -> None:
     with pytest.raises(ValueError, match=message):
         validate_update(update)
 
@@ -467,13 +530,14 @@ def test_expired_run_rejects_update() -> None:
         )
 
 
-def test_issue_ids_are_scoped_to_verification_receipt() -> None:
-    with pytest.raises(ValueError, match="Issue IDs"):
+def test_verification_extra_is_scoped_to_verification_receipt() -> None:
+    extra = VerificationErrorExtra(issue_ids=("123",))
+    with pytest.raises(ValueError, match="Extra data"):
         validate_update(
             ProgressUpdate(
                 stage=Stage.CREATE_PROJECT,
                 status=StageStatus.COMPLETED,
-                issue_ids=("123",),
+                extra=extra,
             )
         )
 
@@ -481,18 +545,19 @@ def test_issue_ids_are_scoped_to_verification_receipt() -> None:
         ProgressUpdate(
             stage=Stage.RECEIVE_VERIFICATION_ERROR,
             status=StageStatus.COMPLETED,
-            issue_ids=("123",),
+            extra=extra,
         )
     )
 
 
-def test_project_slugs_are_scoped_to_project_creation() -> None:
-    with pytest.raises(ValueError, match="Project slugs"):
+def test_project_extra_is_scoped_to_project_creation() -> None:
+    extra = CreateProjectExtra(project_slugs=("project-one", "project-two"))
+    with pytest.raises(ValueError, match="Extra data"):
         validate_update(
             ProgressUpdate(
                 stage=Stage.INSTRUMENT_APP,
                 status=StageStatus.COMPLETED,
-                project_slugs=("project-one", "project-two"),
+                extra=extra,
             )
         )
 
@@ -500,7 +565,7 @@ def test_project_slugs_are_scoped_to_project_creation() -> None:
         ProgressUpdate(
             stage=Stage.CREATE_PROJECT,
             status=StageStatus.COMPLETED,
-            project_slugs=("project-one", "project-two"),
+            extra=extra,
         )
     )
 
@@ -512,7 +577,7 @@ def test_metadata_accumulates_unique_values() -> None:
         ProgressUpdate(
             stage=Stage.CREATE_PROJECT,
             status=StageStatus.ACTIVE,
-            project_slugs=("frontend", "backend"),
+            extra=CreateProjectExtra(project_slugs=("frontend", "backend")),
         ),
         now,
     )
@@ -522,12 +587,14 @@ def test_metadata_accumulates_unique_values() -> None:
         ProgressUpdate(
             stage=Stage.CREATE_PROJECT,
             status=StageStatus.COMPLETED,
-            project_slugs=("backend", "worker"),
+            extra=CreateProjectExtra(project_slugs=("backend", "worker")),
         ),
         now + timedelta(seconds=1),
     )
 
-    assert updated.project_slugs == ("frontend", "backend", "worker")
+    assert updated.stages[STAGE_INDEX[Stage.CREATE_PROJECT]].extra == CreateProjectExtra(
+        project_slugs=("frontend", "backend", "worker")
+    )
 
 
 @pytest.mark.parametrize("field", ["created_at", "updated_at", "expires_at"])
@@ -535,7 +602,7 @@ def test_from_dict_rejects_invalid_timestamps(field: str) -> None:
     persisted = make_run(datetime(2020, 1, 1, tzinfo=timezone.utc)).to_dict()
     persisted[field] = "2020-01-01T00:00:00"
 
-    with pytest.raises(InvalidOnboardingRun, match="timezone"):
+    with pytest.raises(InvalidOnboardingRun, match="state is invalid"):
         OnboardingRun.from_dict(persisted)
 
 


### PR DESCRIPTION
Agentic onboarding progress now stores structured metadata on the stage that owns it. Status updates accept an `extra` object whose schema is selected by the stage: `create_project` accepts `projectSlugs`, while `receive_verification_error` accepts `issueIds`. Run snapshots return the accumulated `extra` data alongside its stage instead of exposing project slugs and issue IDs at the run level.

Stage definitions preserve the corresponding Python type, and Pydantic validates persisted Redis data before it enters the model. API serializers reject unknown fields and metadata submitted for the wrong stage, while repeated updates merge unique values without regressing completed or bypassed stages.

Refs [VDY-167](https://linear.app/getsentry/issue/VDY-167/add-typed-stage-specific-contexts-to-agentic-onboarding).