### PR TITLE
fix(explore): Wrap highlighted JSON attributes

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/inlineJsonHighlight.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/inlineJsonHighlight.tsx
@@ -52,6 +52,7 @@ const InlineCode = styled('code')`
     background: transparent;
     padding: 0;
     white-space: pre-wrap;
+    word-break: break-word;
     font-size: inherit;
   }
 `;


### PR DESCRIPTION
Prevent syntax-highlighted JSON values in expanded log rows from overflowing the attribute table. The inline Prism code renderer now restores word wrapping that is otherwise reset by the global Prism styles.