### PR TITLE
fix(sdk): ignore stale ECharts tooltip errors

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -44,6 +44,29 @@ describe('initializeSdk', () => {
       })
     );
   });
+
+  it('ignores the ECharts tooltip error thrown when a chart replaces its series', () => {
+    initializeSdk({
+      ...window.__initialData,
+      apmSampling: 1,
+      sentryConfig: {
+        allowUrls: [],
+        dsn: '',
+        release: '',
+        tracePropagationTargets: [],
+      },
+    });
+
+    const ignoreErrors = jest.mocked(Sentry.init).mock.lastCall?.[0]?.ignoreErrors ?? [];
+    const message =
+      "TypeError: Cannot read properties of undefined (reading 'getDataParams')";
+
+    expect(
+      ignoreErrors.some(pattern =>
+        typeof pattern === 'string' ? message.includes(pattern) : pattern.test(message)
+      )
+    ).toBe(true);
+  });
 });
 
 describe('isFilteredRequestErrorEvent', () => {

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -160,6 +160,17 @@ export function initializeSdk(config: Config) {
        */
       "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
       "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      /**
+       * ECharts re-shows the last tooltip a tick after every `setOption`,
+       * reusing the series indices it captured before the update. Under
+       * `notMerge: false` (see `chartZoomConfig`) the tooltip component
+       * survives an update that replaces the series, so those indices can
+       * outlive the series they point at and reading them throws.
+       *
+       * Transient and self-healing: the tooltip corrects itself as soon as
+       * the pointer moves.
+       */
+      /Cannot read properties of undefined \(reading 'getDataParams'\)/,
     ],
 
     beforeBreadcrumb(crumb) {


### PR DESCRIPTION
Filters `TypeError: Cannot read properties of undefined (reading 'getDataParams')` out of frontend error reporting.

See https://github.com/apache/echarts/issues/21732 for the crash on the ECharts side. Until that's resolved (🤞), there's not much we can do.

Closes JAVASCRIPT-3A3N.