### PR TITLE
Add dedicated symbolication namespaces

### DIFF
--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -322,6 +322,16 @@ symbolication_tasks = app.taskregistry.create_namespace(
     app_feature="errors",
 )
 
+symbolication_js_tasks = app.taskregistry.create_namespace(
+    "symbolication.js",
+    app_feature="errors",
+)
+
+symbolication_jvm_tasks = app.taskregistry.create_namespace(
+    "symbolication.jvm",
+    app_feature="errors",
+)
+
 telemetry_experience_tasks = app.taskregistry.create_namespace(
     "telemetry-experience",
     app_feature="transactions",


### PR DESCRIPTION
We are trying to split symbolication into three namespaces: symbolication, symbolication js and symbolication jvm
