### PR TITLE
fix(scm-messaging-integration-ui): Enable picking from multiple integrations

### DIFF
--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -355,6 +355,47 @@ describe('ScmMessagingChannelPicker', () => {
       });
     });
 
+    it('falls back to the first survivor and clears the channel when the selected workspace is removed', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+
+      const onConfigured = jest.fn();
+      const {rerender} = render(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration, slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+        />,
+        {organization}
+      );
+
+      // Switch to the second workspace and pick a channel.
+      await selectEvent.select(screen.getByLabelText('workspace'), 'second-workspace');
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+
+      // The second workspace disappears (e.g. after a refetch).
+      rerender(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+        />
+      );
+
+      // Workspace falls back to the first survivor and channel is cleared.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+      });
+
+      // Save writes the surviving integration id.
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '10'})
+      );
+    });
+
     it('only shows the integrations it receives — eligibility is enforced upstream', () => {
       // The row (via the view model) is responsible for filtering to eligibleIntegrations
       // before passing them to the picker. The picker renders whatever it receives.

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -1,8 +1,10 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
+
+import type {OrganizationIntegration} from 'sentry/types/integrations';
 
 import {ScmMessagingChannelPicker} from './scmMessagingChannelPicker';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
@@ -76,17 +78,17 @@ function mockChannelValidate(valid: boolean, integrationId: string) {
 }
 
 function renderPicker({
-  integration = slackIntegration,
+  integrations = [slackIntegration],
   existingSetup,
 }: {
   existingSetup?: ScmMessagingSetup;
-  integration?: typeof slackIntegration;
+  integrations?: OrganizationIntegration[];
 } = {}) {
   const onConfigured = jest.fn();
 
   render(
     <ScmMessagingChannelPicker
-      integration={integration}
+      integrations={integrations}
       onConfigured={onConfigured}
       existingSetup={existingSetup}
     />,
@@ -129,7 +131,7 @@ describe('ScmMessagingChannelPicker', () => {
   describe('staging a new destination', () => {
     it('stores Slack by display name', async () => {
       mockChannels('10', [slackChannel]);
-      const {onConfigured} = renderPicker({integration: slackIntegration});
+      const {onConfigured} = renderPicker({integrations: [slackIntegration]});
 
       await selectEvent.select(screen.getByLabelText('channel'), '#general');
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -145,7 +147,7 @@ describe('ScmMessagingChannelPicker', () => {
 
     it('stores Discord by channel ID', async () => {
       mockChannels('20', [discordChannel]);
-      const {onConfigured} = renderPicker({integration: discordIntegration});
+      const {onConfigured} = renderPicker({integrations: [discordIntegration]});
 
       await selectEvent.select(screen.getByLabelText('channel'), '#general (1234567890)');
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -161,7 +163,7 @@ describe('ScmMessagingChannelPicker', () => {
 
     it('disables Add destination until a channel is chosen', () => {
       mockChannels('10', [slackChannel]);
-      renderPicker({integration: slackIntegration});
+      renderPicker({integrations: [slackIntegration]});
 
       expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
     });
@@ -173,7 +175,7 @@ describe('ScmMessagingChannelPicker', () => {
       // Manual entries validate as you type, via the shared hook's
       // `enabled: !!channel?.new` query.
       mockChannelValidate(true, '20');
-      const {onConfigured} = renderPicker({integration: discordIntegration});
+      const {onConfigured} = renderPicker({integrations: [discordIntegration]});
 
       const channelUrl = 'https://discord.com/channels/111/1234567890';
       // ChannelSelect sets formatCreateLabel to the raw input, so the create
@@ -199,7 +201,7 @@ describe('ScmMessagingChannelPicker', () => {
     it('preserves the Discord channel ID through a no-op edit', async () => {
       mockChannels('20', [discordChannel]);
       const {onConfigured} = renderPicker({
-        integration: discordIntegration,
+        integrations: [discordIntegration],
         existingSetup: selectedDiscordSetup,
       });
 
@@ -217,7 +219,7 @@ describe('ScmMessagingChannelPicker', () => {
     it('preserves the Slack channel name through a no-op edit', async () => {
       mockChannels('10', [slackChannel]);
       const {onConfigured} = renderPicker({
-        integration: slackIntegration,
+        integrations: [slackIntegration],
         existingSetup: selectedSlackSetup,
       });
 
@@ -238,7 +240,7 @@ describe('ScmMessagingChannelPicker', () => {
       // breaks revalidation. An empty /channels/ must not corrupt the saved name.
       mockChannels('30', []);
       const {onConfigured} = renderPicker({
-        integration: msteamsIntegration,
+        integrations: [msteamsIntegration],
         existingSetup: selectedMsTeamsSetup,
       });
 
@@ -258,7 +260,7 @@ describe('ScmMessagingChannelPicker', () => {
       // the stored name rather than overwrite it with the id.
       mockChannels('20', []);
       const {onConfigured} = renderPicker({
-        integration: discordIntegration,
+        integrations: [discordIntegration],
         existingSetup: selectedDiscordSetup,
       });
 
@@ -271,6 +273,112 @@ describe('ScmMessagingChannelPicker', () => {
         channelId: '1234567890',
         channelName: '#general',
       });
+    });
+  });
+
+  describe('multi-workspace', () => {
+    const slackIntegration2 = OrganizationIntegrationsFixture({
+      id: '11',
+      name: 'second-workspace',
+      provider: {
+        key: 'slack',
+        slug: 'slack',
+        name: 'Slack',
+        canAdd: true,
+        canDisable: false,
+        features: [],
+        aspects: {},
+      },
+    });
+
+    it('enables the Workspace select when there are multiple eligible integrations', () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', []);
+      renderPicker({integrations: [slackIntegration, slackIntegration2]});
+
+      expect(screen.getByLabelText('workspace')).toBeEnabled();
+    });
+
+    it('disables the Workspace select when there is only one eligible integration', () => {
+      mockChannels('10', [slackChannel]);
+      renderPicker({integrations: [slackIntegration]});
+
+      expect(screen.getByLabelText('workspace')).toBeDisabled();
+    });
+
+    it('writes the selected workspace integrationId on save', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+      const {onConfigured} = renderPicker({
+        integrations: [slackIntegration, slackIntegration2],
+      });
+
+      // Switch to the second workspace.
+      await selectEvent.select(screen.getByLabelText('workspace'), 'second-workspace');
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'selected',
+          providerKey: 'slack',
+          integrationId: '11',
+        })
+      );
+    });
+
+    it('seeds the channel from the saved workspace and not the other', async () => {
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', []);
+      renderPicker({
+        integrations: [slackIntegration, slackIntegration2],
+        existingSetup: selectedSlackSetup,
+      });
+
+      // The saved workspace (id 10) seeds a channel; wait for channel loading to
+      // settle before checking the Add destination button is enabled.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
+      });
+    });
+
+    it('does not offer ineligible MS Teams tenant workspaces', () => {
+      const msteamsTenant = OrganizationIntegrationsFixture({
+        id: '40',
+        name: 'tenant-workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'tenant'},
+      });
+      const msteamsTeam = OrganizationIntegrationsFixture({
+        id: '41',
+        name: 'team-workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      mockChannels('41', []);
+      renderPicker({integrations: [msteamsTenant, msteamsTeam]});
+
+      // Only the team installation is offered; tenant is filtered out.
+      expect(screen.getByLabelText('workspace')).toBeDisabled(); // only 1 eligible
+      // The workspace select value shows the team workspace, not the tenant.
+      expect(screen.getByText('team-workspace')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -342,21 +342,9 @@ describe('ScmMessagingChannelPicker', () => {
       });
     });
 
-    it('does not offer ineligible MS Teams tenant workspaces', () => {
-      const msteamsTenant = OrganizationIntegrationsFixture({
-        id: '40',
-        name: 'tenant-workspace',
-        provider: {
-          key: 'msteams',
-          slug: 'msteams',
-          name: 'Microsoft Teams',
-          canAdd: true,
-          canDisable: false,
-          features: [],
-          aspects: {},
-        },
-        configData: {installationType: 'tenant'},
-      });
+    it('only shows the integrations it receives — eligibility is enforced upstream', () => {
+      // The row (via the view model) is responsible for filtering to eligibleIntegrations
+      // before passing them to the picker. The picker renders whatever it receives.
       const msteamsTeam = OrganizationIntegrationsFixture({
         id: '41',
         name: 'team-workspace',
@@ -373,11 +361,10 @@ describe('ScmMessagingChannelPicker', () => {
       });
 
       mockChannels('41', []);
-      renderPicker({integrations: [msteamsTenant, msteamsTeam]});
+      // Only the eligible team integration is passed; the tenant was excluded by the row.
+      renderPicker({integrations: [msteamsTeam]});
 
-      // Only the team installation is offered; tenant is filtered out.
-      expect(screen.getByLabelText('workspace')).toBeDisabled(); // only 1 eligible
-      // The workspace select value shows the team workspace, not the tenant.
+      expect(screen.getByLabelText('workspace')).toBeDisabled(); // only 1 workspace
       expect(screen.getByText('team-workspace')).toBeInTheDocument();
     });
   });

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -415,7 +415,9 @@ describe('ScmMessagingChannelPicker', () => {
         {organization}
       );
 
-      // The saved workspace (id 10) seeds the channel; selectedIntegrationId stays undefined.
+      // The saved workspace (id 10) seeds the channel. The user never explicitly
+      // switched workspaces, so selectedIntegrationId is initialized to '10' and
+      // remains at its initial value throughout.
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
       });

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -6,6 +6,7 @@ import {selectEvent} from 'sentry-test/selectEvent';
 
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 
+import type {ScmMessagingProviderKey} from './messagingProviders';
 import {ScmMessagingChannelPicker} from './scmMessagingChannelPicker';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
 
@@ -78,17 +79,20 @@ function mockChannelValidate(valid: boolean, integrationId: string) {
 }
 
 function renderPicker({
-  integrations = [slackIntegration],
+  eligibleIntegrations = [slackIntegration],
   existingSetup,
+  providerKey = 'slack',
 }: {
+  eligibleIntegrations?: OrganizationIntegration[];
   existingSetup?: ScmMessagingSetup;
-  integrations?: OrganizationIntegration[];
+  providerKey?: ScmMessagingProviderKey;
 } = {}) {
   const onConfigured = jest.fn();
 
   render(
     <ScmMessagingChannelPicker
-      integrations={integrations}
+      eligibleIntegrations={eligibleIntegrations}
+      providerKey={providerKey}
       onConfigured={onConfigured}
       existingSetup={existingSetup}
     />,
@@ -131,7 +135,7 @@ describe('ScmMessagingChannelPicker', () => {
   describe('staging a new destination', () => {
     it('stores Slack by display name', async () => {
       mockChannels('10', [slackChannel]);
-      const {onConfigured} = renderPicker({integrations: [slackIntegration]});
+      const {onConfigured} = renderPicker({eligibleIntegrations: [slackIntegration]});
 
       await selectEvent.select(screen.getByLabelText('channel'), '#general');
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -147,7 +151,10 @@ describe('ScmMessagingChannelPicker', () => {
 
     it('stores Discord by channel ID', async () => {
       mockChannels('20', [discordChannel]);
-      const {onConfigured} = renderPicker({integrations: [discordIntegration]});
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        providerKey: 'discord',
+      });
 
       await selectEvent.select(screen.getByLabelText('channel'), '#general (1234567890)');
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -163,7 +170,7 @@ describe('ScmMessagingChannelPicker', () => {
 
     it('disables Add destination until a channel is chosen', () => {
       mockChannels('10', [slackChannel]);
-      renderPicker({integrations: [slackIntegration]});
+      renderPicker({eligibleIntegrations: [slackIntegration]});
 
       expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
     });
@@ -175,7 +182,10 @@ describe('ScmMessagingChannelPicker', () => {
       // Manual entries validate as you type, via the shared hook's
       // `enabled: !!channel?.new` query.
       mockChannelValidate(true, '20');
-      const {onConfigured} = renderPicker({integrations: [discordIntegration]});
+      const {onConfigured} = renderPicker({
+        eligibleIntegrations: [discordIntegration],
+        providerKey: 'discord',
+      });
 
       const channelUrl = 'https://discord.com/channels/111/1234567890';
       // ChannelSelect sets formatCreateLabel to the raw input, so the create
@@ -201,8 +211,9 @@ describe('ScmMessagingChannelPicker', () => {
     it('preserves the Discord channel ID through a no-op edit', async () => {
       mockChannels('20', [discordChannel]);
       const {onConfigured} = renderPicker({
-        integrations: [discordIntegration],
+        eligibleIntegrations: [discordIntegration],
         existingSetup: selectedDiscordSetup,
+        providerKey: 'discord',
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -219,7 +230,7 @@ describe('ScmMessagingChannelPicker', () => {
     it('preserves the Slack channel name through a no-op edit', async () => {
       mockChannels('10', [slackChannel]);
       const {onConfigured} = renderPicker({
-        integrations: [slackIntegration],
+        eligibleIntegrations: [slackIntegration],
         existingSetup: selectedSlackSetup,
       });
 
@@ -240,8 +251,9 @@ describe('ScmMessagingChannelPicker', () => {
       // breaks revalidation. An empty /channels/ must not corrupt the saved name.
       mockChannels('30', []);
       const {onConfigured} = renderPicker({
-        integrations: [msteamsIntegration],
+        eligibleIntegrations: [msteamsIntegration],
         existingSetup: selectedMsTeamsSetup,
+        providerKey: 'msteams',
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -260,8 +272,9 @@ describe('ScmMessagingChannelPicker', () => {
       // the stored name rather than overwrite it with the id.
       mockChannels('20', []);
       const {onConfigured} = renderPicker({
-        integrations: [discordIntegration],
+        eligibleIntegrations: [discordIntegration],
         existingSetup: selectedDiscordSetup,
+        providerKey: 'discord',
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
@@ -294,14 +307,14 @@ describe('ScmMessagingChannelPicker', () => {
     it('enables the Workspace select when there are multiple eligible integrations', () => {
       mockChannels('10', [slackChannel]);
       mockChannels('11', []);
-      renderPicker({integrations: [slackIntegration, slackIntegration2]});
+      renderPicker({eligibleIntegrations: [slackIntegration, slackIntegration2]});
 
       expect(screen.getByLabelText('workspace')).toBeEnabled();
     });
 
     it('disables the Workspace select when there is only one eligible integration', () => {
       mockChannels('10', [slackChannel]);
-      renderPicker({integrations: [slackIntegration]});
+      renderPicker({eligibleIntegrations: [slackIntegration]});
 
       expect(screen.getByLabelText('workspace')).toBeDisabled();
     });
@@ -310,7 +323,7 @@ describe('ScmMessagingChannelPicker', () => {
       mockChannels('10', [slackChannel]);
       mockChannels('11', [slackChannel]);
       const {onConfigured} = renderPicker({
-        integrations: [slackIntegration, slackIntegration2],
+        eligibleIntegrations: [slackIntegration, slackIntegration2],
       });
 
       // Switch to the second workspace.
@@ -331,7 +344,7 @@ describe('ScmMessagingChannelPicker', () => {
       mockChannels('10', [slackChannel]);
       mockChannels('11', []);
       renderPicker({
-        integrations: [slackIntegration, slackIntegration2],
+        eligibleIntegrations: [slackIntegration, slackIntegration2],
         existingSetup: selectedSlackSetup,
       });
 
@@ -362,7 +375,10 @@ describe('ScmMessagingChannelPicker', () => {
 
       mockChannels('41', []);
       // Only the eligible team integration is passed; the tenant was excluded by the row.
-      renderPicker({integrations: [msteamsTeam]});
+      renderPicker({
+        eligibleIntegrations: [msteamsTeam],
+        providerKey: 'msteams',
+      });
 
       expect(screen.getByLabelText('workspace')).toBeDisabled(); // only 1 workspace
       expect(screen.getByText('team-workspace')).toBeInTheDocument();

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -396,6 +396,58 @@ describe('ScmMessagingChannelPicker', () => {
       );
     });
 
+    it('clears the seeded channel and falls back when the default (saved) workspace is removed', async () => {
+      // Regression: when selectedIntegrationId is undefined (user never explicitly
+      // switched workspaces), the removal effect's guard (`selectedIntegrationId &&`)
+      // would short-circuit and leave the seeded channel intact. A subsequent save
+      // would then pair the stale channel with the new fallback integrationId.
+      mockChannels('10', [slackChannel]);
+      mockChannels('11', [slackChannel]);
+
+      const onConfigured = jest.fn();
+      const {rerender} = render(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration, slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+          existingSetup={selectedSlackSetup}
+        />,
+        {organization}
+      );
+
+      // The saved workspace (id 10) seeds the channel; selectedIntegrationId stays undefined.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeEnabled();
+      });
+
+      // Saved workspace (id 10) is removed from the list — e.g. after a refetch.
+      rerender(
+        <ScmMessagingChannelPicker
+          eligibleIntegrations={[slackIntegration2]}
+          providerKey="slack"
+          onConfigured={onConfigured}
+          existingSetup={selectedSlackSetup}
+        />
+      );
+
+      // Channel must be cleared; Add destination disabled.
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Add destination'})).toBeDisabled();
+      });
+
+      // Save must write the surviving workspace id, not the vanished one paired
+      // with the stale channel.
+      await selectEvent.select(screen.getByLabelText('channel'), '#general');
+      await userEvent.click(screen.getByRole('button', {name: 'Add destination'}));
+
+      expect(onConfigured).toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '11'})
+      );
+      expect(onConfigured).not.toHaveBeenCalledWith(
+        expect.objectContaining({integrationId: '10'})
+      );
+    });
+
     it('only shows the integrations it receives — eligibility is enforced upstream', () => {
       // The row (via the view model) is responsible for filtering to eligibleIntegrations
       // before passing them to the picker. The picker renders whatever it receives.

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -58,7 +58,6 @@ export function ScmMessagingChannelPicker({
     eligibleIntegrations.find(i => i.id === savedSelection?.integrationId) ??
     firstIntegration;
 
-  // undefined means "no explicit user selection yet — use the default".
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(
     undefined
   );

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -22,10 +22,13 @@ import {
 
 import type {ScmMessagingProviderKey} from './messagingProviders';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
-import {isEligibleForIssueAlerts} from './useScmMessagingProviders';
 
 export interface ScmMessagingChannelPickerProps {
-  /** All active integrations for this provider; eligible subset is selectable. */
+  /**
+   * Eligible integrations for this provider — already filtered to those that
+   * can receive Issue Alert actions. Must be non-empty (the picker is only
+   * rendered for a `connected` provider).
+   */
   integrations: OrganizationIntegration[];
   onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
   /** Pre-seeds the channel selector when editing an existing destination. */
@@ -40,14 +43,9 @@ export function ScmMessagingChannelPicker({
   onConfigured,
   existingSetup,
 }: ScmMessagingChannelPickerProps) {
-  // Only eligible integrations are offered; the picker only renders for a
-  // 'connected' provider, so this is always non-empty.
-  const eligibleIntegrations = useMemo(
-    () => integrations.filter(isEligibleForIssueAlerts),
-    [integrations]
-  );
-
-  const providerKey = eligibleIntegrations[0]!.provider.key as ScmMessagingProviderKey;
+  const firstIntegration = integrations[0];
+  const providerKey = (firstIntegration?.provider.key ??
+    'slack') as ScmMessagingProviderKey;
   const {channelSelectedBy} = providerDetails[providerKey];
 
   // The saved destination we're editing, if any. Drives both the dropdown seed
@@ -58,23 +56,23 @@ export function ScmMessagingChannelPicker({
       : undefined;
 
   const defaultIntegration =
-    eligibleIntegrations.find(i => i.id === savedSelection?.integrationId) ??
-    eligibleIntegrations[0]!;
+    integrations.find(i => i.id === savedSelection?.integrationId) ?? firstIntegration;
 
-  const [selectedIntegration, setSelectedIntegration] =
-    useState<OrganizationIntegration>(defaultIntegration);
+  const [selectedIntegration, setSelectedIntegration] = useState<
+    OrganizationIntegration | undefined
+  >(defaultIntegration);
 
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(() =>
     // Only seed the channel when the default workspace is the saved one. Switching
     // workspaces starts blank.
-    savedSelection && defaultIntegration.id === savedSelection.integrationId
+    savedSelection && defaultIntegration?.id === savedSelection.integrationId
       ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
       : undefined
   );
 
   const providersToIntegrations = useMemo(
-    () => ({[providerKey]: eligibleIntegrations}),
-    [providerKey, eligibleIntegrations]
+    () => ({[providerKey]: integrations}),
+    [providerKey, integrations]
   );
 
   const {
@@ -106,6 +104,10 @@ export function ScmMessagingChannelPicker({
     querySuccess: true,
     shouldRenderSetupButton: false,
   });
+
+  if (!firstIntegration || !selectedIntegration) {
+    return null;
+  }
 
   const handleSave = () => {
     if (!channel) {

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -58,9 +58,15 @@ export function ScmMessagingChannelPicker({
     eligibleIntegrations.find(i => i.id === savedSelection?.integrationId) ??
     firstIntegration;
 
-  const [selectedIntegration, setSelectedIntegration] = useState<
-    OrganizationIntegration | undefined
-  >(defaultIntegration);
+  // undefined means "no explicit user selection yet — use the default".
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(
+    undefined
+  );
+
+  const selectedIntegration =
+    eligibleIntegrations.find(
+      i => i.id === (selectedIntegrationId ?? defaultIntegration?.id)
+    ) ?? firstIntegration;
 
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(() =>
     // Only seed the channel when the default workspace is the saved one. Switching
@@ -69,6 +75,19 @@ export function ScmMessagingChannelPicker({
       ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
       : undefined
   );
+
+  // If the previously selected workspace is removed from the list (e.g. after a
+  // refetch), clear the explicit selection so the default derivation takes over,
+  // and reset the channel to avoid a stale channel from the vanished workspace.
+  useEffect(() => {
+    if (
+      selectedIntegrationId &&
+      !eligibleIntegrations.some(i => i.id === selectedIntegrationId)
+    ) {
+      setSelectedIntegrationId(undefined);
+      setChannel(undefined);
+    }
+  }, [eligibleIntegrations, selectedIntegrationId]);
 
   const providersToIntegrations = useMemo(
     () => ({[providerKey]: eligibleIntegrations}),
@@ -93,7 +112,7 @@ export function ScmMessagingChannelPicker({
     setChannel,
     setIntegration: i => {
       if (i) {
-        setSelectedIntegration(i);
+        setSelectedIntegrationId(i.id);
       }
     },
     setProvider: () => {},
@@ -105,7 +124,7 @@ export function ScmMessagingChannelPicker({
     shouldRenderSetupButton: false,
   });
 
-  if (!firstIntegration || !selectedIntegration) {
+  if (!selectedIntegration) {
     return null;
   }
 

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -44,7 +44,6 @@ export function ScmMessagingChannelPicker({
   existingSetup,
   providerKey,
 }: ScmMessagingChannelPickerProps) {
-  const firstIntegration = eligibleIntegrations[0];
   const {channelSelectedBy} = providerDetails[providerKey];
 
   // The saved destination we're editing, if any. Drives both the dropdown seed
@@ -54,18 +53,13 @@ export function ScmMessagingChannelPicker({
       ? existingSetup
       : undefined;
 
-  const defaultIntegration =
-    eligibleIntegrations.find(i => i.id === savedSelection?.integrationId) ??
-    firstIntegration;
-
-  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(
-    undefined
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState(
+    savedSelection?.integrationId
   );
 
   const selectedIntegration =
-    eligibleIntegrations.find(
-      i => i.id === (selectedIntegrationId ?? defaultIntegration?.id)
-    ) ?? firstIntegration;
+    eligibleIntegrations.find(i => i.id === selectedIntegrationId) ??
+    eligibleIntegrations[0];
 
   // Keep the chosen channel bound to the workspace it was chosen for. It only
   // surfaces (and is only saved) while its workspace is the selected one, so a

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -22,9 +22,11 @@ import {
 
 import type {ScmMessagingProviderKey} from './messagingProviders';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
+import {isEligibleForIssueAlerts} from './useScmMessagingProviders';
 
 export interface ScmMessagingChannelPickerProps {
-  integration: OrganizationIntegration;
+  /** All active integrations for this provider; eligible subset is selectable. */
+  integrations: OrganizationIntegration[];
   onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
   /** Pre-seeds the channel selector when editing an existing destination. */
   existingSetup?: ScmMessagingSetup;
@@ -33,13 +35,19 @@ export interface ScmMessagingChannelPickerProps {
 }
 
 export function ScmMessagingChannelPicker({
-  integration,
+  integrations,
   onCancel,
   onConfigured,
   existingSetup,
 }: ScmMessagingChannelPickerProps) {
-  const providerKey = integration.provider.key as ScmMessagingProviderKey;
+  // Only eligible integrations are offered; the picker only renders for a
+  // 'connected' provider, so this is always non-empty.
+  const eligibleIntegrations = useMemo(
+    () => integrations.filter(isEligibleForIssueAlerts),
+    [integrations]
+  );
 
+  const providerKey = eligibleIntegrations[0]!.provider.key as ScmMessagingProviderKey;
   const {channelSelectedBy} = providerDetails[providerKey];
 
   // The saved destination we're editing, if any. Drives both the dropdown seed
@@ -49,17 +57,24 @@ export function ScmMessagingChannelPicker({
       ? existingSetup
       : undefined;
 
+  const defaultIntegration =
+    eligibleIntegrations.find(i => i.id === savedSelection?.integrationId) ??
+    eligibleIntegrations[0]!;
+
+  const [selectedIntegration, setSelectedIntegration] =
+    useState<OrganizationIntegration>(defaultIntegration);
+
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(() =>
-    // Seed by whatever field this provider's options are keyed on. Seeding the
-    // wrong one resolves to no option and handleSave rewrites the identifiers.
-    savedSelection
+    // Only seed the channel when the default workspace is the saved one. Switching
+    // workspaces starts blank.
+    savedSelection && defaultIntegration.id === savedSelection.integrationId
       ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
       : undefined
   );
 
   const providersToIntegrations = useMemo(
-    () => ({[providerKey]: [integration]}),
-    [providerKey, integration]
+    () => ({[providerKey]: eligibleIntegrations}),
+    [providerKey, eligibleIntegrations]
   );
 
   const {
@@ -70,14 +85,19 @@ export function ScmMessagingChannelPicker({
     channelError,
     onChannelChange,
     onCreateChannel,
+    onIntegrationChange,
     integrationOptions,
     integrationDisabled,
   } = useMessagingIntegrationAlertRule({
     channel,
-    integration,
+    integration: selectedIntegration,
     provider: providerKey,
     setChannel,
-    setIntegration: () => {},
+    setIntegration: i => {
+      if (i) {
+        setSelectedIntegration(i);
+      }
+    },
     setProvider: () => {},
     providersToIntegrations,
     actions: [],
@@ -101,15 +121,19 @@ export function ScmMessagingChannelPicker({
         );
 
     // Prefer the resolved raw channel. If it can't be resolved (empty/errored
-    // /channels/ or a dropped channel) but the selection is unchanged, keep the
-    // stored identifiers — otherwise id-keyed providers (msteams, discord) would
-    // overwrite channelName with the id and break name-based revalidation. A new
-    // value falls through to itself.
+    // /channels/ or a dropped channel) but the selection and workspace are unchanged,
+    // keep the stored identifiers — otherwise id-keyed providers (msteams, discord)
+    // would overwrite channelName with the id and break name-based revalidation.
+    // A new value falls through to itself.
     let stored: {channelId: string; channelName: string};
 
     if (rawChannel) {
       stored = {channelId: rawChannel.id, channelName: rawChannel.display};
-    } else if (savedSelection && channel.value === savedSelection[channelSelectedBy]) {
+    } else if (
+      savedSelection &&
+      selectedIntegration.id === savedSelection.integrationId &&
+      channel.value === savedSelection[channelSelectedBy]
+    ) {
       stored = {
         channelId: savedSelection.channelId,
         channelName: savedSelection.channelName,
@@ -121,7 +145,7 @@ export function ScmMessagingChannelPicker({
     onConfigured({
       mode: 'selected',
       providerKey,
-      integrationId: integration.id,
+      integrationId: selectedIntegration.id,
       ...stored,
     });
   };
@@ -136,9 +160,9 @@ export function ScmMessagingChannelPicker({
           <Select
             aria-label={t('workspace')}
             disabled={integrationDisabled}
-            value={integration}
+            value={selectedIntegration}
             options={integrationOptions}
-            onChange={() => {}}
+            onChange={onIntegrationChange}
           />
         </Stack>
         <Stack gap="xs">
@@ -179,7 +203,7 @@ export function ScmMessagingChannelPicker({
         <Button
           size="sm"
           variant="primary"
-          disabled={!channel || !!channelError}
+          disabled={!channel || !!channelError || isChannelLoading}
           onClick={handleSave}
         >
           {t('Add destination')}

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -132,9 +132,8 @@ export function ScmMessagingChannelPicker({
     if (rawChannel) {
       stored = {channelId: rawChannel.id, channelName: rawChannel.display};
     } else if (
-      savedSelection &&
-      selectedIntegration.id === savedSelection.integrationId &&
-      channel.value === savedSelection[channelSelectedBy]
+      selectedIntegration.id === savedSelection?.integrationId &&
+      channel.value === savedSelection?.[channelSelectedBy]
     ) {
       stored = {
         channelId: savedSelection.channelId,

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -67,26 +67,32 @@ export function ScmMessagingChannelPicker({
       i => i.id === (selectedIntegrationId ?? defaultIntegration?.id)
     ) ?? firstIntegration;
 
-  const [channel, setChannel] = useState<IntegrationChannel | undefined>(() =>
+  // Keep the chosen channel bound to the workspace it was chosen for. It only
+  // surfaces (and is only saved) while its workspace is the selected one, so a
+  // fallback after the workspace is removed can never pair a stale channel with a
+  // different integration.
+  const [channelState, setChannelState] = useState<{
+    channel: IntegrationChannel | undefined;
+    integrationId: string | undefined;
+  }>(() => ({
+    integrationId: savedSelection?.integrationId,
     // Only seed the channel when the default workspace is the saved one. Switching
     // workspaces starts blank.
-    savedSelection && defaultIntegration?.id === savedSelection.integrationId
+    channel: savedSelection
       ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
-      : undefined
-  );
+      : undefined,
+  }));
 
-  // If the previously selected workspace is removed from the list (e.g. after a
-  // refetch), clear the explicit selection so the default derivation takes over,
-  // and reset the channel to avoid a stale channel from the vanished workspace.
-  useEffect(() => {
-    if (
-      selectedIntegrationId &&
-      !eligibleIntegrations.some(i => i.id === selectedIntegrationId)
-    ) {
-      setSelectedIntegrationId(undefined);
-      setChannel(undefined);
-    }
-  }, [eligibleIntegrations, selectedIntegrationId]);
+  const channel =
+    channelState.integrationId === selectedIntegration?.id
+      ? channelState.channel
+      : undefined;
+
+  const setChannel = useCallback(
+    (nextChannel: IntegrationChannel | undefined) =>
+      setChannelState({channel: nextChannel, integrationId: selectedIntegration?.id}),
+    [selectedIntegration?.id]
+  );
 
   const providersToIntegrations = useMemo(
     () => ({[providerKey]: eligibleIntegrations}),

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -26,11 +26,11 @@ import type {ScmMessagingSetup} from './scmMessagingSetup';
 export interface ScmMessagingChannelPickerProps {
   /**
    * Eligible integrations for this provider — already filtered to those that
-   * can receive Issue Alert actions. Must be non-empty (the picker is only
-   * rendered for a `connected` provider).
+   * can receive Issue Alert actions.
    */
-  integrations: OrganizationIntegration[];
+  eligibleIntegrations: OrganizationIntegration[];
   onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
+  providerKey: ScmMessagingProviderKey;
   /** Pre-seeds the channel selector when editing an existing destination. */
   existingSetup?: ScmMessagingSetup;
   /** When provided a Cancel button is shown (e.g. in Edit mode). */
@@ -38,14 +38,13 @@ export interface ScmMessagingChannelPickerProps {
 }
 
 export function ScmMessagingChannelPicker({
-  integrations,
+  eligibleIntegrations,
   onCancel,
   onConfigured,
   existingSetup,
+  providerKey,
 }: ScmMessagingChannelPickerProps) {
-  const firstIntegration = integrations[0];
-  const providerKey = (firstIntegration?.provider.key ??
-    'slack') as ScmMessagingProviderKey;
+  const firstIntegration = eligibleIntegrations[0];
   const {channelSelectedBy} = providerDetails[providerKey];
 
   // The saved destination we're editing, if any. Drives both the dropdown seed
@@ -56,7 +55,8 @@ export function ScmMessagingChannelPicker({
       : undefined;
 
   const defaultIntegration =
-    integrations.find(i => i.id === savedSelection?.integrationId) ?? firstIntegration;
+    eligibleIntegrations.find(i => i.id === savedSelection?.integrationId) ??
+    firstIntegration;
 
   const [selectedIntegration, setSelectedIntegration] = useState<
     OrganizationIntegration | undefined
@@ -71,8 +71,8 @@ export function ScmMessagingChannelPicker({
   );
 
   const providersToIntegrations = useMemo(
-    () => ({[providerKey]: integrations}),
-    [providerKey, integrations]
+    () => ({[providerKey]: eligibleIntegrations}),
+    [providerKey, eligibleIntegrations]
   );
 
   const {

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -83,16 +83,16 @@ export function ScmMessagingChannelPicker({
       : undefined,
   }));
 
-  const channel =
-    channelState.integrationId === selectedIntegration?.id
-      ? channelState.channel
-      : undefined;
-
   const setChannel = useCallback(
     (nextChannel: IntegrationChannel | undefined) =>
       setChannelState({channel: nextChannel, integrationId: selectedIntegration?.id}),
     [selectedIntegration?.id]
   );
+
+  const channel =
+    channelState.integrationId === selectedIntegration?.id
+      ? channelState.channel
+      : undefined;
 
   const providersToIntegrations = useMemo(
     () => ({[providerKey]: eligibleIntegrations}),

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -55,24 +55,24 @@ const installableSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'installable',
-  activeIntegrations: [],
   eligibleIntegrations: [],
+  permissionLimitedIntegration: undefined,
 };
 
 const connectedSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'connected',
-  activeIntegrations: [slackIntegration],
   eligibleIntegrations: [slackIntegration],
+  permissionLimitedIntegration: undefined,
 };
 
 const permissionLimitedMsteams: ScmMessagingProviderViewModel = {
   providerKey: 'msteams',
   provider: msteamsProvider,
   status: 'permission-limited',
-  activeIntegrations: [msteamsIntegration],
   eligibleIntegrations: [],
+  permissionLimitedIntegration: msteamsIntegration,
 };
 
 const selectedSlackSetup: ScmMessagingSetup = {
@@ -354,20 +354,6 @@ describe('ScmMessagingProviderRow', () => {
     });
 
     it('passes only eligible integrations to the picker when a provider has mixed installations', () => {
-      const msteamsTenantIntegration = OrganizationIntegrationsFixture({
-        id: 'msteams-tenant',
-        name: 'Tenant Workspace',
-        provider: {
-          key: 'msteams',
-          slug: 'msteams',
-          name: 'Microsoft Teams',
-          canAdd: true,
-          canDisable: false,
-          features: [],
-          aspects: {},
-        },
-        configData: {installationType: 'tenant'},
-      });
       const msteamsTeamIntegration = OrganizationIntegrationsFixture({
         id: 'msteams-team',
         name: 'Team Workspace',
@@ -387,8 +373,8 @@ describe('ScmMessagingProviderRow', () => {
         providerKey: 'msteams',
         provider: msteamsProvider,
         status: 'connected',
-        activeIntegrations: [msteamsTenantIntegration, msteamsTeamIntegration],
         eligibleIntegrations: [msteamsTeamIntegration],
+        permissionLimitedIntegration: undefined,
       };
 
       const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
@@ -402,20 +388,6 @@ describe('ScmMessagingProviderRow', () => {
     });
 
     it('does not treat a setup referencing an ineligible integration as configured', () => {
-      const msteamsTenantIntegration = OrganizationIntegrationsFixture({
-        id: 'msteams-tenant',
-        name: 'Tenant Workspace',
-        provider: {
-          key: 'msteams',
-          slug: 'msteams',
-          name: 'Microsoft Teams',
-          canAdd: true,
-          canDisable: false,
-          features: [],
-          aspects: {},
-        },
-        configData: {installationType: 'tenant'},
-      });
       const msteamsTeamIntegration = OrganizationIntegrationsFixture({
         id: 'msteams-team',
         name: 'Team Workspace',
@@ -435,8 +407,8 @@ describe('ScmMessagingProviderRow', () => {
         providerKey: 'msteams',
         provider: msteamsProvider,
         status: 'connected',
-        activeIntegrations: [msteamsTenantIntegration, msteamsTeamIntegration],
         eligibleIntegrations: [msteamsTeamIntegration],
+        permissionLimitedIntegration: undefined,
       };
 
       // A destination previously saved against the tenant (ineligible) integration.

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -55,21 +55,21 @@ const installableSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'installable',
-  integration: undefined,
+  integrations: [],
 };
 
 const connectedSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'connected',
-  integration: slackIntegration,
+  integrations: [slackIntegration],
 };
 
 const permissionLimitedMsteams: ScmMessagingProviderViewModel = {
   providerKey: 'msteams',
   provider: msteamsProvider,
   status: 'permission-limited',
-  integration: msteamsIntegration,
+  integrations: [msteamsIntegration],
 };
 
 const selectedSlackSetup: ScmMessagingSetup = {
@@ -343,7 +343,7 @@ describe('ScmMessagingProviderRow', () => {
       expect(screen.getByText('channel-picker')).toBeInTheDocument();
       expect(renderChannelPicker).toHaveBeenCalledWith(
         expect.objectContaining({
-          integration: slackIntegration,
+          integrations: [slackIntegration],
           onCancel: undefined,
           onConfigured: expect.any(Function),
         })

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -55,21 +55,24 @@ const installableSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'installable',
-  integrations: [],
+  activeIntegrations: [],
+  eligibleIntegrations: [],
 };
 
 const connectedSlack: ScmMessagingProviderViewModel = {
   providerKey: 'slack',
   provider: slackProvider,
   status: 'connected',
-  integrations: [slackIntegration],
+  activeIntegrations: [slackIntegration],
+  eligibleIntegrations: [slackIntegration],
 };
 
 const permissionLimitedMsteams: ScmMessagingProviderViewModel = {
   providerKey: 'msteams',
   provider: msteamsProvider,
   status: 'permission-limited',
-  integrations: [msteamsIntegration],
+  activeIntegrations: [msteamsIntegration],
+  eligibleIntegrations: [],
 };
 
 const selectedSlackSetup: ScmMessagingSetup = {
@@ -348,6 +351,111 @@ describe('ScmMessagingProviderRow', () => {
           onConfigured: expect.any(Function),
         })
       );
+    });
+
+    it('passes only eligible integrations to the picker when a provider has mixed installations', () => {
+      const msteamsTenantIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-tenant',
+        name: 'Tenant Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'tenant'},
+      });
+      const msteamsTeamIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-team',
+        name: 'Team Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      const mixedMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'connected',
+        activeIntegrations: [msteamsTenantIntegration, msteamsTeamIntegration],
+        eligibleIntegrations: [msteamsTeamIntegration],
+      };
+
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(mixedMsteams, UNCONFIGURED_SCM_MESSAGING_SETUP, {renderChannelPicker});
+
+      expect(renderChannelPicker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrations: [msteamsTeamIntegration],
+        })
+      );
+    });
+
+    it('does not treat a setup referencing an ineligible integration as configured', () => {
+      const msteamsTenantIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-tenant',
+        name: 'Tenant Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'tenant'},
+      });
+      const msteamsTeamIntegration = OrganizationIntegrationsFixture({
+        id: 'msteams-team',
+        name: 'Team Workspace',
+        provider: {
+          key: 'msteams',
+          slug: 'msteams',
+          name: 'Microsoft Teams',
+          canAdd: true,
+          canDisable: false,
+          features: [],
+          aspects: {},
+        },
+        configData: {installationType: 'team'},
+      });
+
+      const mixedMsteams: ScmMessagingProviderViewModel = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'connected',
+        activeIntegrations: [msteamsTenantIntegration, msteamsTeamIntegration],
+        eligibleIntegrations: [msteamsTeamIntegration],
+      };
+
+      // A destination previously saved against the tenant (ineligible) integration.
+      const tenantSetup: ScmMessagingSetup = {
+        mode: 'selected',
+        providerKey: 'msteams',
+        integrationId: 'msteams-tenant',
+        channelId: 'C1',
+        channelName: '#general',
+      };
+
+      const renderChannelPicker = jest.fn(() => <div>channel-picker</div>);
+      renderRow(mixedMsteams, tenantSetup, {renderChannelPicker});
+
+      // Should NOT be in configured state — the tenant integration is not eligible.
+      expect(screen.queryByRole('button', {name: /Edit/})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /Remove/})).not.toBeInTheDocument();
+      // Picker is auto-expanded for the unconfigured connected state.
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
     });
 
     it('saves the setup and transitions to configured when onConfigured is called', () => {

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -107,7 +107,7 @@ function deriveVisualState({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    messagingSetup.integrationId === viewModel.integration?.id;
+    viewModel.integrations.some(i => i.id === messagingSetup.integrationId);
 
   if (isConfigured && isConfiguring) {
     return 'configuring'; // Edit mode
@@ -137,7 +137,7 @@ export interface ScmMessagingProviderRowProps {
    * Omitting this prop leaves the configuring state with an empty body.
    */
   renderChannelPicker?: (props: {
-    integration: OrganizationIntegration;
+    integrations: OrganizationIntegration[];
     onCancel: (() => void) | undefined;
     onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
   }) => ReactNode;
@@ -160,7 +160,7 @@ export function ScmMessagingProviderRow({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    messagingSetup.integrationId === viewModel.integration?.id;
+    viewModel.integrations.some(i => i.id === messagingSetup.integrationId);
 
   const visualState = deriveVisualState({
     viewModel,
@@ -294,17 +294,17 @@ export function ScmMessagingProviderRow({
           </Flex>
         )}
 
-        {visualState === 'configuring' && viewModel.integration && (
+        {visualState === 'configuring' && (
           <ChannelPickerSlot>
             {renderChannelPicker ? (
               renderChannelPicker({
-                integration: viewModel.integration,
+                integrations: viewModel.integrations,
                 onCancel: isConfigured ? handleCancelConfiguring : undefined,
                 onConfigured: handleConfigured,
               })
             ) : (
               <ScmMessagingChannelPicker
-                integration={viewModel.integration}
+                integrations={viewModel.integrations}
                 onCancel={isConfigured ? handleCancelConfiguring : undefined}
                 onConfigured={handleConfigured}
                 existingSetup={isConfigured ? messagingSetup : undefined}
@@ -354,7 +354,7 @@ function RowSubtitle({
   if (visualState === 'permission-limited') {
     return (
       <Stack gap="2xs">
-        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text size="sm">{viewModel.integrations[0]?.name}</Text>
         <Text variant="muted" size="sm">
           {t(
             'This Microsoft Teams workspace uses a tenant-level connection and cannot receive issue alerts directly. Reinstall with a team-level connection to enable destinations.'
@@ -367,7 +367,9 @@ function RowSubtitle({
   if (visualState === 'configured' && messagingSetup.mode === 'selected') {
     return (
       <Flex gap="xs" align="center">
-        <Text size="sm">{viewModel.integration?.name}</Text>
+        <Text size="sm">
+          {viewModel.integrations.find(i => i.id === messagingSetup.integrationId)?.name}
+        </Text>
         <Text variant="muted" size="sm" aria-hidden>
           /
         </Text>

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -354,7 +354,7 @@ function RowSubtitle({
   if (visualState === 'permission-limited') {
     return (
       <Stack gap="2xs">
-        <Text size="sm">{viewModel.activeIntegrations[0]?.name}</Text>
+        <Text size="sm">{viewModel.permissionLimitedIntegration?.name}</Text>
         <Text variant="muted" size="sm">
           {t(
             'This Microsoft Teams workspace uses a tenant-level connection and cannot receive issue alerts directly. Reinstall with a team-level connection to enable destinations.'

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -304,7 +304,8 @@ export function ScmMessagingProviderRow({
               })
             ) : (
               <ScmMessagingChannelPicker
-                integrations={viewModel.eligibleIntegrations}
+                eligibleIntegrations={viewModel.eligibleIntegrations}
+                providerKey={viewModel.providerKey}
                 onCancel={isConfigured ? handleCancelConfiguring : undefined}
                 onConfigured={handleConfigured}
                 existingSetup={isConfigured ? messagingSetup : undefined}

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.tsx
@@ -107,7 +107,7 @@ function deriveVisualState({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    viewModel.integrations.some(i => i.id === messagingSetup.integrationId);
+    viewModel.eligibleIntegrations.some(i => i.id === messagingSetup.integrationId);
 
   if (isConfigured && isConfiguring) {
     return 'configuring'; // Edit mode
@@ -130,9 +130,9 @@ export interface ScmMessagingProviderRowProps {
   /**
    * Render prop for the inline channel picker.
    *
-   * When the user opens the configuring state this is called with the active
-   * integration and two callbacks: `onConfigured` (save the chosen destination
-   * to session state) and `onCancel` (close without saving).
+   * Called with the eligible (non-empty) integrations for this provider and two
+   * callbacks: `onConfigured` (save the chosen destination to session state) and
+   * `onCancel` (close without saving). Only invoked when `status === 'connected'`.
    *
    * Omitting this prop leaves the configuring state with an empty body.
    */
@@ -160,7 +160,7 @@ export function ScmMessagingProviderRow({
   const isConfigured =
     messagingSetup.mode === 'selected' &&
     messagingSetup.providerKey === viewModel.providerKey &&
-    viewModel.integrations.some(i => i.id === messagingSetup.integrationId);
+    viewModel.eligibleIntegrations.some(i => i.id === messagingSetup.integrationId);
 
   const visualState = deriveVisualState({
     viewModel,
@@ -298,13 +298,13 @@ export function ScmMessagingProviderRow({
           <ChannelPickerSlot>
             {renderChannelPicker ? (
               renderChannelPicker({
-                integrations: viewModel.integrations,
+                integrations: viewModel.eligibleIntegrations,
                 onCancel: isConfigured ? handleCancelConfiguring : undefined,
                 onConfigured: handleConfigured,
               })
             ) : (
               <ScmMessagingChannelPicker
-                integrations={viewModel.integrations}
+                integrations={viewModel.eligibleIntegrations}
                 onCancel={isConfigured ? handleCancelConfiguring : undefined}
                 onConfigured={handleConfigured}
                 existingSetup={isConfigured ? messagingSetup : undefined}
@@ -354,7 +354,7 @@ function RowSubtitle({
   if (visualState === 'permission-limited') {
     return (
       <Stack gap="2xs">
-        <Text size="sm">{viewModel.integrations[0]?.name}</Text>
+        <Text size="sm">{viewModel.activeIntegrations[0]?.name}</Text>
         <Text variant="muted" size="sm">
           {t(
             'This Microsoft Teams workspace uses a tenant-level connection and cannot receive issue alerts directly. Reinstall with a team-level connection to enable destinations.'
@@ -368,7 +368,11 @@ function RowSubtitle({
     return (
       <Flex gap="xs" align="center">
         <Text size="sm">
-          {viewModel.integrations.find(i => i.id === messagingSetup.integrationId)?.name}
+          {
+            viewModel.eligibleIntegrations.find(
+              i => i.id === messagingSetup.integrationId
+            )?.name
+          }
         </Text>
         <Text variant="muted" size="sm" aria-hidden>
           /

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
@@ -71,8 +71,7 @@ describe('useScmMessagingProviders', () => {
     expect(slack?.status).toBe('connected');
     expect(slack?.eligibleIntegrations).toHaveLength(1);
     expect(slack?.eligibleIntegrations[0]?.id).toBe('10');
-    expect(slack?.activeIntegrations).toHaveLength(1);
-    expect(slack?.activeIntegrations[0]?.id).toBe('10');
+    expect(slack?.permissionLimitedIntegration).toBeUndefined();
 
     result.current.providers
       .filter(p => p.providerKey !== 'slack')
@@ -116,11 +115,9 @@ describe('useScmMessagingProviders', () => {
 
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('permission-limited');
-    // The tenant is in activeIntegrations so the row can show the workspace name.
-    expect(msteams?.activeIntegrations).toHaveLength(1);
-    expect(msteams?.activeIntegrations[0]?.id).toBe('12');
-    // Tenant is ineligible, so eligibleIntegrations is empty.
     expect(msteams?.eligibleIntegrations).toHaveLength(0);
+    // The tenant integration is surfaced for workspace-name display.
+    expect(msteams?.permissionLimitedIntegration?.id).toBe('12');
   });
 
   it('marks a team-type msteams integration as connected', async () => {
@@ -159,7 +156,7 @@ describe('useScmMessagingProviders', () => {
     expect(result.current.providers).toHaveLength(0);
   });
 
-  it('exposes all active integrations when a provider has multiple workspaces', async () => {
+  it('exposes all eligible integrations when a provider has multiple workspaces', async () => {
     mockProviders();
     mockIntegrations([
       OrganizationIntegrationsFixture({
@@ -187,7 +184,7 @@ describe('useScmMessagingProviders', () => {
     // Both workspaces are eligible (Slack has no tenant restriction).
     expect(slack?.eligibleIntegrations).toHaveLength(2);
     expect(slack?.eligibleIntegrations.map(i => i.id)).toEqual(['20', '21']);
-    expect(slack?.activeIntegrations).toHaveLength(2);
+    expect(slack?.permissionLimitedIntegration).toBeUndefined();
   });
 
   it('is connected when msteams has both a tenant and a team installation', async () => {
@@ -217,11 +214,11 @@ describe('useScmMessagingProviders', () => {
 
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('connected');
-    // Both installations are active, but only the team is eligible.
-    expect(msteams?.activeIntegrations).toHaveLength(2);
-    expect(msteams?.activeIntegrations.map(i => i.id)).toEqual(['30', '31']);
+    // Only the team installation is eligible.
     expect(msteams?.eligibleIntegrations).toHaveLength(1);
     expect(msteams?.eligibleIntegrations[0]?.id).toBe('31');
+    // Status is connected (not permission-limited), so this is unset.
+    expect(msteams?.permissionLimitedIntegration).toBeUndefined();
   });
 
   it('preserves provider order matching SCM_MESSAGING_PROVIDER_KEYS', async () => {

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
@@ -69,7 +69,8 @@ describe('useScmMessagingProviders', () => {
 
     const slack = result.current.providers.find(p => p.providerKey === 'slack');
     expect(slack?.status).toBe('connected');
-    expect(slack?.integration?.id).toBe('10');
+    expect(slack?.integrations).toHaveLength(1);
+    expect(slack?.integrations[0]?.id).toBe('10');
 
     result.current.providers
       .filter(p => p.providerKey !== 'slack')
@@ -114,7 +115,8 @@ describe('useScmMessagingProviders', () => {
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('permission-limited');
     // The integration is still exposed so the row can show the workspace name.
-    expect(msteams?.integration?.id).toBe('12');
+    expect(msteams?.integrations).toHaveLength(1);
+    expect(msteams?.integrations[0]?.id).toBe('12');
   });
 
   it('marks a team-type msteams integration as connected', async () => {
@@ -151,6 +153,66 @@ describe('useScmMessagingProviders', () => {
 
     expect(result.current.isError).toBe(true);
     expect(result.current.providers).toHaveLength(0);
+  });
+
+  it('exposes all active integrations when a provider has multiple workspaces', async () => {
+    mockProviders();
+    mockIntegrations([
+      OrganizationIntegrationsFixture({
+        id: '20',
+        name: 'workspace-a',
+        provider: {key: 'slack'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+      }),
+      OrganizationIntegrationsFixture({
+        id: '21',
+        name: 'workspace-b',
+        provider: {key: 'slack'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+      }),
+    ]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    const slack = result.current.providers.find(p => p.providerKey === 'slack');
+    expect(slack?.status).toBe('connected');
+    expect(slack?.integrations).toHaveLength(2);
+    expect(slack?.integrations.map(i => i.id)).toEqual(['20', '21']);
+  });
+
+  it('is connected when msteams has both a tenant and a team installation', async () => {
+    mockProviders();
+    mockIntegrations([
+      OrganizationIntegrationsFixture({
+        id: '30',
+        name: 'tenant',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'tenant'},
+      }),
+      OrganizationIntegrationsFixture({
+        id: '31',
+        name: 'team',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'team'},
+      }),
+    ]);
+
+    const {result} = renderProviders();
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
+    expect(msteams?.status).toBe('connected');
+    expect(msteams?.integrations).toHaveLength(2);
+    expect(msteams?.integrations.map(i => i.id)).toEqual(['30', '31']);
   });
 
   it('preserves provider order matching SCM_MESSAGING_PROVIDER_KEYS', async () => {

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.spec.ts
@@ -69,8 +69,10 @@ describe('useScmMessagingProviders', () => {
 
     const slack = result.current.providers.find(p => p.providerKey === 'slack');
     expect(slack?.status).toBe('connected');
-    expect(slack?.integrations).toHaveLength(1);
-    expect(slack?.integrations[0]?.id).toBe('10');
+    expect(slack?.eligibleIntegrations).toHaveLength(1);
+    expect(slack?.eligibleIntegrations[0]?.id).toBe('10');
+    expect(slack?.activeIntegrations).toHaveLength(1);
+    expect(slack?.activeIntegrations[0]?.id).toBe('10');
 
     result.current.providers
       .filter(p => p.providerKey !== 'slack')
@@ -114,9 +116,11 @@ describe('useScmMessagingProviders', () => {
 
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('permission-limited');
-    // The integration is still exposed so the row can show the workspace name.
-    expect(msteams?.integrations).toHaveLength(1);
-    expect(msteams?.integrations[0]?.id).toBe('12');
+    // The tenant is in activeIntegrations so the row can show the workspace name.
+    expect(msteams?.activeIntegrations).toHaveLength(1);
+    expect(msteams?.activeIntegrations[0]?.id).toBe('12');
+    // Tenant is ineligible, so eligibleIntegrations is empty.
+    expect(msteams?.eligibleIntegrations).toHaveLength(0);
   });
 
   it('marks a team-type msteams integration as connected', async () => {
@@ -180,8 +184,10 @@ describe('useScmMessagingProviders', () => {
 
     const slack = result.current.providers.find(p => p.providerKey === 'slack');
     expect(slack?.status).toBe('connected');
-    expect(slack?.integrations).toHaveLength(2);
-    expect(slack?.integrations.map(i => i.id)).toEqual(['20', '21']);
+    // Both workspaces are eligible (Slack has no tenant restriction).
+    expect(slack?.eligibleIntegrations).toHaveLength(2);
+    expect(slack?.eligibleIntegrations.map(i => i.id)).toEqual(['20', '21']);
+    expect(slack?.activeIntegrations).toHaveLength(2);
   });
 
   it('is connected when msteams has both a tenant and a team installation', async () => {
@@ -211,8 +217,11 @@ describe('useScmMessagingProviders', () => {
 
     const msteams = result.current.providers.find(p => p.providerKey === 'msteams');
     expect(msteams?.status).toBe('connected');
-    expect(msteams?.integrations).toHaveLength(2);
-    expect(msteams?.integrations.map(i => i.id)).toEqual(['30', '31']);
+    // Both installations are active, but only the team is eligible.
+    expect(msteams?.activeIntegrations).toHaveLength(2);
+    expect(msteams?.activeIntegrations.map(i => i.id)).toEqual(['30', '31']);
+    expect(msteams?.eligibleIntegrations).toHaveLength(1);
+    expect(msteams?.eligibleIntegrations[0]?.id).toBe('31');
   });
 
   it('preserves provider order matching SCM_MESSAGING_PROVIDER_KEYS', async () => {

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.ts
@@ -26,9 +26,18 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 type ScmMessagingProviderStatus = 'installable' | 'permission-limited' | 'connected';
 
 export type ScmMessagingProviderViewModel = {
-  // All active integrations for this provider (may include ineligible ones,
-  //  e.g. tenant-type MS Teams). The picker offers the eligible subset.
-  integrations: OrganizationIntegration[];
+  /**
+   * All active integrations for this provider. Includes ineligible ones
+   * (e.g. MS Teams tenant installations) so the permission-limited state can
+   * display the workspace name.
+   */
+  activeIntegrations: OrganizationIntegration[];
+  /**
+   * The eligible subset of `activeIntegrations` — non-empty iff
+   * `status === 'connected'`. Callers operating in the connected state
+   * can safely access index 0 without a non-null assertion.
+   */
+  eligibleIntegrations: OrganizationIntegration[];
   provider: IntegrationProvider;
   providerKey: ScmMessagingProviderKey;
   status: ScmMessagingProviderStatus;
@@ -39,7 +48,7 @@ export type ScmMessagingProviderViewModel = {
  * MS Teams "tenant" installations route notifications differently and
  * cannot be used as an issue-alert destination.
  */
-export function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
+function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
   if (integration.provider.key !== 'msteams') {
     return true;
   }
@@ -105,7 +114,8 @@ export function useScmMessagingProviders(): {
       const active = integrations.filter(
         i => i.provider.key === providerKey && isIntegrationActive(i)
       );
-      const status: ScmMessagingProviderStatus = active.some(isEligibleForIssueAlerts)
+      const eligible = active.filter(isEligibleForIssueAlerts);
+      const status: ScmMessagingProviderStatus = eligible.length
         ? 'connected'
         : active.length
           ? 'permission-limited'
@@ -116,7 +126,8 @@ export function useScmMessagingProviders(): {
           providerKey,
           provider,
           status,
-          integrations: active,
+          activeIntegrations: active,
+          eligibleIntegrations: eligible,
         },
       ];
     });

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.ts
@@ -27,17 +27,15 @@ type ScmMessagingProviderStatus = 'installable' | 'permission-limited' | 'connec
 
 export type ScmMessagingProviderViewModel = {
   /**
-   * All active integrations for this provider. Includes ineligible ones
-   * (e.g. MS Teams tenant installations) so the permission-limited state can
-   * display the workspace name.
-   */
-  activeIntegrations: OrganizationIntegration[];
-  /**
-   * The eligible subset of `activeIntegrations` — non-empty iff
-   * `status === 'connected'`. Callers operating in the connected state
-   * can safely access index 0 without a non-null assertion.
+   * Active integrations that can receive Issue Alert actions.
+   * Non-empty iff `status === 'connected'`.
    */
   eligibleIntegrations: OrganizationIntegration[];
+  /**
+   * The ineligible active integration shown in the `permission-limited` state
+   * so the row can display its workspace name. `undefined` for other statuses.
+   */
+  permissionLimitedIntegration: OrganizationIntegration | undefined;
   provider: IntegrationProvider;
   providerKey: ScmMessagingProviderKey;
   status: ScmMessagingProviderStatus;
@@ -115,7 +113,7 @@ export function useScmMessagingProviders(): {
         i => i.provider.key === providerKey && isIntegrationActive(i)
       );
       const eligible = active.filter(isEligibleForIssueAlerts);
-      const status: ScmMessagingProviderStatus = eligible.length
+      const status = eligible.length
         ? 'connected'
         : active.length
           ? 'permission-limited'
@@ -126,8 +124,9 @@ export function useScmMessagingProviders(): {
           providerKey,
           provider,
           status,
-          activeIntegrations: active,
           eligibleIntegrations: eligible,
+          permissionLimitedIntegration:
+            status === 'permission-limited' ? active[0] : undefined,
         },
       ];
     });

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.ts
@@ -26,8 +26,9 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 type ScmMessagingProviderStatus = 'installable' | 'permission-limited' | 'connected';
 
 export type ScmMessagingProviderViewModel = {
-  /** Defined when status is `connected` or `permission-limited`. */
-  integration: OrganizationIntegration | undefined;
+  // All active integrations for this provider (may include ineligible ones,
+  //  e.g. tenant-type MS Teams). The picker offers the eligible subset.
+  integrations: OrganizationIntegration[];
   provider: IntegrationProvider;
   providerKey: ScmMessagingProviderKey;
   status: ScmMessagingProviderStatus;
@@ -38,20 +39,11 @@ export type ScmMessagingProviderViewModel = {
  * MS Teams "tenant" installations route notifications differently and
  * cannot be used as an issue-alert destination.
  */
-function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
+export function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
   if (integration.provider.key !== 'msteams') {
     return true;
   }
   return integration.configData?.installationType !== 'tenant';
-}
-
-function toStatus(
-  integration: OrganizationIntegration | undefined
-): ScmMessagingProviderStatus {
-  if (!integration) {
-    return 'installable';
-  }
-  return isEligibleForIssueAlerts(integration) ? 'connected' : 'permission-limited';
 }
 
 export function useScmMessagingProviders(): {
@@ -110,18 +102,21 @@ export function useScmMessagingProviders(): {
         return [];
       }
 
-      // Find the first active integration for this provider. Inactive
-      // integrations are treated the same as no integration.
-      const integration = integrations.find(
+      const active = integrations.filter(
         i => i.provider.key === providerKey && isIntegrationActive(i)
       );
+      const status: ScmMessagingProviderStatus = active.some(isEligibleForIssueAlerts)
+        ? 'connected'
+        : active.length
+          ? 'permission-limited'
+          : 'installable';
 
       return [
         {
           providerKey,
           provider,
-          status: toStatus(integration),
-          integration,
+          status,
+          integrations: active,
         },
       ];
     });

--- a/static/app/components/onboarding/scm/useScmMessagingProviders.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingProviders.ts
@@ -5,7 +5,10 @@ import {
   SCM_MESSAGING_PROVIDER_KEYS,
   type ScmMessagingProviderKey,
 } from 'sentry/components/onboarding/scm/messagingProviders';
-import {isIntegrationActive} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
+import {
+  isEligibleForIssueAlerts,
+  isIntegrationActive,
+} from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -40,18 +43,6 @@ export type ScmMessagingProviderViewModel = {
   providerKey: ScmMessagingProviderKey;
   status: ScmMessagingProviderStatus;
 };
-
-/**
- * Returns true when the integration can receive Issue Alert actions.
- * MS Teams "tenant" installations route notifications differently and
- * cannot be used as an issue-alert destination.
- */
-function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
-  if (integration.provider.key !== 'msteams') {
-    return true;
-  }
-  return integration.configData?.installationType !== 'tenant';
-}
 
 export function useScmMessagingProviders(): {
   isError: boolean;

--- a/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
+++ b/static/app/components/onboarding/scm/useScmMessagingSetupValidation.ts
@@ -8,13 +8,29 @@ import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {providerDetails} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
-export type StaleDestinationReason = 'channel' | 'inactiveIntegration' | 'integration';
+export type StaleDestinationReason =
+  | 'channel'
+  | 'inactiveIntegration'
+  | 'ineligibleIntegration'
+  | 'integration';
 
 export function isIntegrationActive(integration: OrganizationIntegration): boolean {
   return (
     integration.status === 'active' &&
     integration.organizationIntegrationStatus === 'active'
   );
+}
+
+/**
+ * Returns true when the integration can receive Issue Alert actions.
+ * MS Teams "tenant" installations route notifications differently and
+ * cannot be used as an issue-alert destination.
+ */
+export function isEligibleForIssueAlerts(integration: OrganizationIntegration): boolean {
+  if (integration.provider.key !== 'msteams') {
+    return true;
+  }
+  return integration.configData?.installationType !== 'tenant';
 }
 
 /**
@@ -34,7 +50,8 @@ function resolveSavedIntegration(
   if (
     candidate.id !== messagingSetup.integrationId ||
     candidate.provider.key !== messagingSetup.providerKey ||
-    !isIntegrationActive(candidate)
+    !isIntegrationActive(candidate) ||
+    !isEligibleForIssueAlerts(candidate)
   ) {
     return undefined;
   }
@@ -98,6 +115,8 @@ export function useScmMessagingSetupValidation({
   const fetchedIntegration = isMissingIntegration ? undefined : integrationQuery.data;
   const hasInactiveIntegration =
     fetchedIntegration !== undefined && !isIntegrationActive(fetchedIntegration);
+  const hasIneligibleIntegration =
+    fetchedIntegration !== undefined && !isEligibleForIssueAlerts(fetchedIntegration);
   const integration = resolveSavedIntegration(fetchedIntegration, messagingSetup);
 
   // A 404 settles the query as conclusively as a successful fetch does; any
@@ -143,7 +162,13 @@ export function useScmMessagingSetupValidation({
     }
 
     if (!integration) {
-      setStaleReason(hasInactiveIntegration ? 'inactiveIntegration' : 'integration');
+      setStaleReason(
+        hasInactiveIntegration
+          ? 'inactiveIntegration'
+          : hasIneligibleIntegration
+            ? 'ineligibleIntegration'
+            : 'integration'
+      );
       onMessagingSetupChange({mode: 'unconfigured'});
       return;
     }
@@ -166,6 +191,7 @@ export function useScmMessagingSetupValidation({
   }, [
     channelValidateQuery.data,
     hasInactiveIntegration,
+    hasIneligibleIntegration,
     integration,
     isChannelSettled,
     isIntegrationSettled,

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -428,4 +428,37 @@ describe('ScmMessaging', () => {
     expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'skipped'});
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
+
+  it('clears an ineligible destination with an explanation', async () => {
+    // A tenant-type MS Teams integration is active but cannot receive issue alerts.
+    const msteamsSetup: ScmMessagingSetup = {
+      mode: 'selected',
+      providerKey: 'msteams',
+      integrationId: '15',
+      channelId: '19:abc@thread.tacv2',
+      channelName: 'General',
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/15/',
+      body: OrganizationIntegrationsFixture({
+        id: '15',
+        provider: {key: 'msteams'} as any,
+        status: 'active',
+        organizationIntegrationStatus: 'active',
+        configData: {installationType: 'tenant'},
+      }),
+    });
+    const onMessagingSetupChange = jest.fn();
+
+    renderMessaging(onMessagingSetupChange, msteamsSetup);
+
+    expect(
+      await screen.findByText(
+        'The saved workspace can no longer receive issue alerts. Choose a destination again.'
+      )
+    ).toBeInTheDocument();
+    expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'unconfigured'});
+    expect(screen.queryByText('Destination selected')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -86,6 +86,13 @@ export function ScmMessaging({
             {t('The saved integration is no longer active. Choose a destination again.')}
           </Alert>
         )}
+        {validation.staleReason === 'ineligibleIntegration' && (
+          <Alert variant="warning" showIcon>
+            {t(
+              'The saved workspace can no longer receive issue alerts. Choose a destination again.'
+            )}
+          </Alert>
+        )}
         {validation.staleReason === 'channel' && (
           <Alert variant="warning" showIcon>
             {t("We couldn't verify the saved channel. Choose a destination again.")}

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -2,10 +2,11 @@ import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
 
-import {Select, SelectOption} from '@sentry/scraps/select';
+import {Select, SelectOption, type SelectValue} from '@sentry/scraps/select';
 
 import {FormField} from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -156,7 +157,7 @@ export function useMessagingIntegrationAlertRule(
     channelError,
     providerDisabled: Object.keys(providersToIntegrations).length === 1,
     integrationDisabled: integrationOptions.length === 1,
-    onProviderChange: (option: any) => {
+    onProviderChange: (option: SelectValue<string>) => {
       setProvider(option.value);
       setIntegration(providersToIntegrations[option.value]![0]);
       setChannel(undefined);
@@ -169,7 +170,7 @@ export function useMessagingIntegrationAlertRule(
         });
       }
     },
-    onIntegrationChange: (option: any) => {
+    onIntegrationChange: (option: SelectValue<OrganizationIntegration>) => {
       setIntegration(option.value);
       setChannel(undefined);
       clearChannelValidation();


### PR DESCRIPTION
**Problem:** The SCM onboarding messaging step only surfaced a single integration per provider, so organizations with multiple active workspaces (e.g., two Slack workspaces) had no way to choose which one receives issue alerts. The `ScmMessagingProviderViewModel` exposed a scalar `integration` field, and the channel picker accepted a single integration, making multi-workspace selection structurally impossible.

**Changes:** `useScmMessagingProviders` now collects all active integrations per provider into an `eligibleIntegrations` array, and `ScmMessagingChannelPicker` renders a workspace `Select` backed by the eligible subset. Channel state is stored as `{channel, integrationId}` and derived against the selected workspace, so switching workspaces clears the channel and a workspace removed by a background refetch can never pair a stale channel with the wrong `integrationId`. Tests cover workspace switching, channel seeding, and both workspace-removal fallback paths.