### PR TITLE
feat(snuba): send service auth for snuba deletes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1736,6 +1736,12 @@ SENTRY_SNUBA = os.environ.get("SNUBA", "http://127.0.0.1:1218")
 SENTRY_SNUBA_TIMEOUT = 30
 SENTRY_SNUBA_CACHE_TTL_SECONDS = 60
 
+# Shared secret for short-lived JWTs on Snuba destructive endpoints.
+# Must match snuba DELETE_SERVICE_AUTH_SECRET. Empty fails closed once
+# snuba enforces AuthN.
+SENTRY_SNUBA_DELETE_AUTH_SECRET = env("SENTRY_SNUBA_DELETE_AUTH_SECRET", default="")
+
+
 # Node storage backend
 SENTRY_NODESTORE = "sentry.services.nodestore.django.DjangoNodeStorage"
 SENTRY_NODESTORE_OPTIONS: dict[str, Any] = {}

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1485,17 +1485,29 @@ def _raw_delete_query(
             f"Expected request to contain a DeleteQuery but it was of type {type(request.query)}"
         )
 
-    # Enter hub such that http spans are properly nested
     with metrics.timer("snuba.client.delete_query"):
         referrer = headers.get("referer", "unknown")
         with start_span(op="snuba_delete.validation", name=referrer) as span:
             set_span_tag(span, "snuba.referrer", referrer)
             body = request.serialize()
 
-        with start_span(op="snuba_delete.run", name=body) as span:
+        from sentry.utils.snuba_delete_auth import snuba_delete_auth_headers
+
+        project_ids = list(query.column_conditions.get("project_id") or [])
+        organization_ids = []
+        raw_org = (request.tenant_ids or {}).get("organization_id")
+        if raw_org is not None:
+            organization_ids = [int(raw_org)]
+        auth_headers = snuba_delete_auth_headers(
+            project_ids=project_ids,
+            organization_ids=organization_ids,
+        )
+        outbound_headers = {**headers, **auth_headers}
+
+        with start_span(op="snuba_delete.run", name=referrer) as span:
             set_span_tag(span, "snuba.referrer", referrer)
             return _snuba_pool.urlopen(
-                "DELETE", f"/{query.storage_name}", body=body, headers=headers
+                "DELETE", f"/{query.storage_name}", body=body, headers=outbound_headers
             )
 
 

--- a/src/sentry/utils/snuba_delete_auth.py
+++ b/src/sentry/utils/snuba_delete_auth.py
@@ -1,0 +1,57 @@
+"""Mint short-lived service tokens for Snuba destructive endpoints.
+
+Claims are derived from trusted server-side ids after Sentry has already
+authorized the user/system action. Never pass through request-body tenant
+fields. Mesh workload identity should replace this JWT later.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from django.conf import settings
+
+SNUBA_DELETE_AUDIENCE = "snuba-deletes"
+SNUBA_DELETE_PRINCIPAL = "sentry-delete"
+SNUBA_DELETE_TTL_SECONDS = 60
+
+
+def mint_snuba_delete_token(
+    *,
+    project_ids: Iterable[int],
+    organization_ids: Iterable[int],
+) -> str:
+    secret = getattr(settings, "SENTRY_SNUBA_DELETE_AUTH_SECRET", "") or ""
+    if not secret:
+        raise RuntimeError("SENTRY_SNUBA_DELETE_AUTH_SECRET is not configured")
+
+    now = datetime.now(tz=UTC)
+    payload = {
+        "iss": "sentry",
+        "aud": SNUBA_DELETE_AUDIENCE,
+        "sub": SNUBA_DELETE_PRINCIPAL,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=SNUBA_DELETE_TTL_SECONDS)).timestamp()),
+        "project_ids": [int(pid) for pid in project_ids],
+        "organization_ids": [int(oid) for oid in organization_ids],
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def snuba_delete_auth_headers(
+    *,
+    project_ids: Iterable[int],
+    organization_ids: Iterable[int],
+) -> dict[str, str]:
+    secret = getattr(settings, "SENTRY_SNUBA_DELETE_AUTH_SECRET", "") or ""
+    if not secret:
+        # Allow this PR to land before snuba enforce. Once snuba AuthN is on,
+        # an empty secret makes snuba fail closed (401).
+        return {}
+    token = mint_snuba_delete_token(
+        project_ids=project_ids,
+        organization_ids=organization_ids,
+    )
+    return {"Authorization": f"Bearer {token}"}

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import partial
 from typing import Protocol, TypeVar
@@ -338,7 +339,19 @@ def delete_trace_items_rpc(req: DeleteTraceItemsRequest) -> DeleteTraceItemsResp
     An RPC which deletes trace items matching the filters specified in the request.
     Used for deleting EAP trace items (e.g. occurrences).
     """
-    resp = _make_rpc_request("EndpointDeleteTraceItems", "v1", req.meta.referrer, req)
+    from sentry.utils.snuba_delete_auth import snuba_delete_auth_headers
+
+    extra_headers = snuba_delete_auth_headers(
+        project_ids=list(req.meta.project_ids),
+        organization_ids=[req.meta.organization_id],
+    )
+    resp = _make_rpc_request(
+        "EndpointDeleteTraceItems",
+        "v1",
+        req.meta.referrer,
+        req,
+        extra_headers=extra_headers,
+    )
     response = DeleteTraceItemsResponse()
     response.ParseFromString(resp.data)
     _log_rpc_response("EndpointDeleteTraceItems", req, response.matching_items_count)
@@ -408,6 +421,7 @@ def _make_rpc_request(
     thread_isolation_scope: sentry_sdk.Scope | None = None,
     thread_current_scope: sentry_sdk.Scope | None = None,
     debug: str | bool = False,
+    extra_headers: Mapping[str, str] | None = None,
 ) -> BaseHTTPResponse:
     try:
         logger_extra: dict[str, object] = {
@@ -444,17 +458,16 @@ def _make_rpc_request(
                     set_span_tag(span, "snuba.referrer", referrer)
                     set_span_data(span, "snuba.query", req)
                 try:
+                    headers: dict[str, str] = {}
+                    if referrer:
+                        headers["referer"] = referrer
+                    if extra_headers:
+                        headers.update(extra_headers)
                     http_resp = _snuba_pool.urlopen(
                         "POST",
                         f"/rpc/{endpoint_name}/{class_version}",
                         body=req.SerializeToString(),
-                        headers=(
-                            {
-                                "referer": referrer,
-                            }
-                            if referrer
-                            else {}
-                        ),
+                        headers=headers,
                     )
                 except urllib3.exceptions.HTTPError as err:
                     if isinstance(err, urllib3.exceptions.ReadTimeoutError):

--- a/tests/sentry/utils/test_snuba_delete_auth.py
+++ b/tests/sentry/utils/test_snuba_delete_auth.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import jwt
+import pytest
+from django.test import override_settings
+
+from sentry.utils.snuba_delete_auth import (
+    SNUBA_DELETE_AUDIENCE,
+    SNUBA_DELETE_PRINCIPAL,
+    mint_snuba_delete_token,
+    snuba_delete_auth_headers,
+)
+
+
+@override_settings(SENTRY_SNUBA_DELETE_AUTH_SECRET="sentry-test-snuba-delete-secret")
+def test_mint_token_contains_authorized_ids() -> None:
+    token = mint_snuba_delete_token(project_ids=[11], organization_ids=[22])
+    payload = jwt.decode(
+        token,
+        "sentry-test-snuba-delete-secret",
+        algorithms=["HS256"],
+        audience=SNUBA_DELETE_AUDIENCE,
+    )
+    assert payload["sub"] == SNUBA_DELETE_PRINCIPAL
+    assert payload["iss"] == "sentry"
+    assert payload["project_ids"] == [11]
+    assert payload["organization_ids"] == [22]
+    assert payload["exp"] - payload["iat"] <= 60
+
+
+@override_settings(SENTRY_SNUBA_DELETE_AUTH_SECRET="sentry-test-snuba-delete-secret")
+def test_auth_headers_are_bearer() -> None:
+    headers = snuba_delete_auth_headers(project_ids=[1], organization_ids=[2])
+    assert set(headers) == {"Authorization"}
+    assert headers["Authorization"].startswith("Bearer ")
+
+
+@override_settings(SENTRY_SNUBA_DELETE_AUTH_SECRET="")
+def test_missing_secret_omits_headers() -> None:
+    assert snuba_delete_auth_headers(project_ids=[1], organization_ids=[2]) == {}
+
+
+@override_settings(SENTRY_SNUBA_DELETE_AUTH_SECRET="")
+def test_missing_secret_mint_fails_closed() -> None:
+    with pytest.raises(RuntimeError, match="SENTRY_SNUBA_DELETE_AUTH_SECRET"):
+        mint_snuba_delete_token(project_ids=[1], organization_ids=[2])


### PR DESCRIPTION
## summary

Sentry now mints a short-lived `aud=snuba-deletes` JWT for Snuba destructive calls only.

- HTTP `DELETE /{storage}` via `_raw_delete_query`
- RPC `EndpointDeleteTraceItems` via `delete_trace_items_rpc`
- Claims are `project_ids` / `organization_ids` taken from the **already-authorized** server-side delete request, not from a user body passthrough
- Read/query Snuba pools are unchanged
- If `SENTRY_SNUBA_DELETE_AUTH_SECRET` is unset, no header is sent so this PR can land before snuba enforce

Pairs with getsentry/snuba#8310 (AuthN) and #8311 (predicate AuthZ).

## threat addressed

Without this, snuba AuthN has no legitimate caller and product deletes 401 after #8310. Tokens carry the tenant ids AuthZ will check.

## non-goals

- Does not put delete credentials on the read pool
- Does not implement mesh identity
- Does not change product delete UX

## rollout

1. Set `SENTRY_SNUBA_DELETE_AUTH_SECRET` to the same value as snuba `SNUBA_DELETE_SERVICE_AUTH_SECRET`.
2. Deploy this PR (safe with or without snuba AuthN: extra header is ignored until #8310).
3. Deploy snuba #8310 then #8311.

## rollback

Revert this PR. If snuba AuthN is already enforced, deletes 401 until the secret/header path is restored.

## test plan

- `test_mint_token_contains_authorized_ids`
- `test_auth_headers_are_bearer`
- `test_missing_secret_omits_headers`
- `test_missing_secret_mint_fails_closed`

## residual risk

- A compromised sentry-delete secret can mint tokens for any project/org. Keep the secret in env, not options, and rotate independently of query credentials.
- Mesh still needs distinct `sentry-query` vs `sentry-delete` identities (PR F).
- Callers must only pass ids they already authorized. Current callers (`delete_request`, `delete_groups_from_eap_rpc`, preprod artifact delete) build those ids from trusted server-side arguments.