### PR TITLE
ref(seerExplorer): Use useLocalStorageState for Seer panel size

### DIFF
--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.tsx
@@ -5,6 +5,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {SplitPanel, type SplitPanelHandle} from '@sentry/scraps/splitPanel';
 
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {SeerExplorerPanel} from 'sentry/views/seerExplorer/components/sidebar/seerExplorerPanel';
 import {useSeerExplorerContext} from 'sentry/views/seerExplorer/useSeerExplorerContext';
 import {
@@ -67,8 +68,9 @@ function SeerExplorerSidebarLayoutInSidebarMode({children}: {children: React.Rea
   const defaultSeerSize = isRight ? DEFAULT_SEER_WIDTH : DEFAULT_SEER_HEIGHT;
   const seerSizeKey = SEER_EXPLORER_SIDEBAR_SEER_SIZE_KEY[orientation];
 
-  const storedSeerSize = parseInt(localStorage.getItem(seerSizeKey) ?? '', 10);
-  const seerSize = storedSeerSize > 0 ? storedSeerSize : defaultSeerSize;
+  const [seerSize, setSeerSize] = useLocalStorageState<number>(seerSizeKey, value =>
+    typeof value === 'number' && value > 0 ? value : defaultSeerSize
+  );
 
   // The app (sized) pane size = available − Seer's size, floored at `minContent`
   // (so a persisted Seer size larger than the viewport can't make it negative).
@@ -96,7 +98,7 @@ function SeerExplorerSidebarLayoutInSidebarMode({children}: {children: React.Rea
       return;
     }
     const seer = Math.max(minSeer, available - contentEndSize);
-    localStorage.setItem(seerSizeKey, String(Math.round(seer)));
+    setSeerSize(Math.round(seer));
   };
 
   // Let the routed app content scroll within its own pane instead of growing the


### PR DESCRIPTION
`SeerExplorerSidebarLayoutInSidebarMode` read and wrote the persisted Seer panel
size via raw `localStorage.getItem`/`setItem`, which throws in Safari private
browsing mode (`window.localStorage` returns `null` there). This swaps both
calls for `useLocalStorageState`, the shared hook other views already use for
this exact purpose, so the read/write is safe in restricted environments.

Behavior is unchanged: the initializer still falls back to the orientation's
default size when there's no valid stored value, and the size is still only
persisted on drag end via `onResizeEnd`.

Fixes JAVASCRIPT-3AX3
