### PR TITLE
fix(inbox): Expand populated sections by default

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -320,10 +320,7 @@ describe('InboxPage', () => {
     const assignedSection = screen.getByRole('region', {name: 'Assigned'});
 
     await userEvent.click(
-      within(assignedSection).getByRole('button', {name: 'Assigned'})
-    );
-    await userEvent.click(
-      within(assignedSection).getByRole('link', {name: /Assigned issue/})
+      await within(assignedSection).findByRole('link', {name: /Assigned issue/})
     );
 
     return screen.getByRole('complementary', {name: 'Issue preview'});
@@ -342,7 +339,7 @@ describe('InboxPage', () => {
     expect(await screen.findByText('Fix proposed issue')).toBeInTheDocument();
     expect(await screen.findByText('Diagnosed issue')).toBeInTheDocument();
     const assignedIssue = await screen.findByText('Assigned issue');
-    expect(assignedIssue).not.toBeVisible();
+    expect(assignedIssue).toBeVisible();
     expect(screen.getByRole('heading', {name: 'Inbox', level: 1})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Issues', level: 2})).toBeInTheDocument();
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -629,31 +629,31 @@ describe('InboxPage', () => {
     expect(await within(fixSection).findByText('1000+')).toBeInTheDocument();
   });
 
-  it('expands and collapses progress sections', async () => {
+  it('expands non-empty progress sections and collapses empty sections', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
 
     render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
 
+    const fixProposedIssue = await screen.findByText('Fix proposed issue');
+    const identifiedEmptyMessage = await screen.findByText('No identified issues');
     const fixProposedButton = screen.getByRole('button', {
       name: 'Fix Proposed',
     });
-    const assignedButton = screen.getByRole('button', {name: 'Assigned'});
-    const fixProposedIssue = await screen.findByText('Fix proposed issue');
-    const assignedIssue = screen.getByText('Assigned issue');
+    const identifiedButton = screen.getByRole('button', {name: 'Identified'});
 
     expect(fixProposedButton).toHaveAttribute('aria-expanded', 'true');
     expect(fixProposedIssue).toBeVisible();
-    expect(assignedButton).toHaveAttribute('aria-expanded', 'false');
-    expect(assignedIssue).not.toBeVisible();
+    expect(identifiedButton).toHaveAttribute('aria-expanded', 'false');
+    expect(identifiedEmptyMessage).not.toBeVisible();
 
     await userEvent.click(fixProposedButton);
-    await userEvent.click(assignedButton);
+    await userEvent.click(identifiedButton);
 
     expect(fixProposedButton).toHaveAttribute('aria-expanded', 'false');
     expect(fixProposedIssue).not.toBeVisible();
-    expect(assignedButton).toHaveAttribute('aria-expanded', 'true');
-    expect(assignedIssue).toBeVisible();
+    expect(identifiedButton).toHaveAttribute('aria-expanded', 'true');
+    expect(identifiedEmptyMessage).toBeVisible();
   });
 
   it('filters sections by the selected assignee', async () => {

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -86,7 +86,6 @@ interface InboxSectionConfig {
     | 'num_assigned'
     | 'num_identified'
     | 'num_fix_applied';
-  defaultExpanded: boolean;
   emptyMessage: string;
   key: string;
   label: string;
@@ -103,7 +102,6 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     query: 'issue.progress:fix_proposed is:unresolved',
     emptyMessage: t('No issues with a proposed fix'),
     progress: ProgressState.FIX_PROPOSED,
-    defaultExpanded: true,
   },
   {
     analyticsKey: 'num_diagnosed',
@@ -112,7 +110,6 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     query: 'issue.progress:diagnosed is:unresolved',
     emptyMessage: t('No diagnosed issues'),
     progress: ProgressState.DIAGNOSED,
-    defaultExpanded: true,
     hidden: ({hasSeer}) => !hasSeer,
   },
   {
@@ -122,7 +119,6 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     query: 'issue.progress:assigned is:unresolved',
     emptyMessage: t('No assigned issues'),
     progress: ProgressState.ASSIGNED,
-    defaultExpanded: false,
     hidden: ({hasSeer}) => !hasSeer,
   },
   {
@@ -132,7 +128,6 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     query: 'issue.progress:identified is:unresolved',
     emptyMessage: t('No identified issues'),
     progress: ProgressState.IDENTIFIED,
-    defaultExpanded: false,
     hidden: ({hasSeer}) => !hasSeer,
   },
   {
@@ -142,7 +137,6 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     query: 'issue.progress:fix_applied is:unresolved',
     emptyMessage: t('No issues with an applied fix'),
     progress: ProgressState.FIX_APPLIED,
-    defaultExpanded: false,
   },
 ];
 
@@ -486,6 +480,7 @@ function InboxSection({
     refetchOnWindowFocus: true,
   });
   const groups = queryResult.data?.pages.flatMap(page => page.json) ?? [];
+  const hasIssues = groups.length > 0;
   const count = queryResult.data?.pages[0]?.headers['X-Hits'] ?? groups.length;
   const maxCount = queryResult.data?.pages[0]?.headers['X-Max-Hits'];
   useRouteAnalyticsParams({[section.analyticsKey]: count});
@@ -508,9 +503,10 @@ function InboxSection({
 
   return (
     <Disclosure
+      key={`${assignmentFilter}:${queryResult.status}:${hasIssues}`}
       as="section"
       aria-label={section.label}
-      defaultExpanded={section.defaultExpanded}
+      defaultExpanded={!queryResult.isSuccess || hasIssues}
       size="sm"
     >
       <StickySectionHeader

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -1,4 +1,10 @@
-import {type ComponentProps, useEffectEvent, useLayoutEffect, useRef} from 'react';
+import {
+  type ComponentProps,
+  useEffectEvent,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
@@ -373,7 +379,7 @@ function InboxContent() {
           <Stack flex={1} minHeight={0} overflowY="auto" overscrollBehavior="contain">
             {sections.map(section => (
               <InboxSection
-                key={section.key}
+                key={`${assignmentFilter}:${section.key}`}
                 section={section}
                 assignmentFilter={assignmentFilter}
                 selectedIssueId={selectedIssueId}
@@ -481,6 +487,7 @@ function InboxSection({
   });
   const groups = queryResult.data?.pages.flatMap(page => page.json) ?? [];
   const hasIssues = groups.length > 0;
+  const [expanded, setExpanded] = useState<boolean>();
   const count = queryResult.data?.pages[0]?.headers['X-Hits'] ?? groups.length;
   const maxCount = queryResult.data?.pages[0]?.headers['X-Max-Hits'];
   useRouteAnalyticsParams({[section.analyticsKey]: count});
@@ -503,10 +510,10 @@ function InboxSection({
 
   return (
     <Disclosure
-      key={`${assignmentFilter}:${queryResult.status}:${hasIssues}`}
       as="section"
       aria-label={section.label}
-      defaultExpanded={!queryResult.isSuccess || hasIssues}
+      expanded={expanded ?? (!queryResult.isSuccess || hasIssues)}
+      onExpandedChange={setExpanded}
       size="sm"
     >
       <StickySectionHeader


### PR DESCRIPTION
Inbox sections with issues now start expanded. Empty sections start collapsed instead of relying on hard-coded defaults. Do we still want some defaults?

fixes https://linear.app/getsentry/issue/ISWF-3210