### PR TITLE
fix(inbox): Improved autofix in-progress busy states

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -968,6 +968,10 @@ export function useExplorerAutofix(
      */
     isLoading: isPending || (isFetching && !runState),
     /**
+     * Whether a step was started but the backend has not returned its first run state yet.
+     */
+    isWaitingForRun: waitingForResponse && !runState,
+    /**
      * Whether we're actively processing (used for UI indicators).
      */
     isPolling:

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -111,6 +111,7 @@ const mockAutofix: ReturnType<typeof useExplorerAutofix> = {
   runState: null,
   autofixFormatted: null,
   isLoading: false,
+  isWaitingForRun: false,
   isPolling: false,
   startStep: jest.fn(),
   createPR: jest.fn(),

--- a/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
@@ -127,6 +127,7 @@ function makeAutofix(
     runState,
     autofixFormatted: null,
     isLoading: false,
+    isWaitingForRun: false,
     isPolling: false,
     // Async no-ops — none of these are invoked by the static examples below.
     startStep: () => Promise.resolve(0),

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -29,6 +29,7 @@ function makeAutofix(
     dismissCodingAgentError: jest.fn(),
     warnings: [],
     isLoading: false,
+    isWaitingForRun: false,
     isPolling: false,
   };
   return {...base, ...overrides};

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -22,6 +22,7 @@ function makeAutofix(
     dismissCodingAgentError: jest.fn(),
     warnings: [],
     isLoading: false,
+    isWaitingForRun: false,
     isPolling: false,
     ...overrides,
   };

--- a/static/app/components/events/autofix/v3/useAutoTriggerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/v3/useAutoTriggerAutofix.spec.tsx
@@ -19,6 +19,7 @@ function makeAutofix(
     dismissCodingAgentError: jest.fn(),
     warnings: [],
     isLoading: false,
+    isWaitingForRun: false,
     isPolling: false,
   };
   return {...base, ...overrides};

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -20,6 +20,7 @@ function makeAutofix(
     dismissCodingAgentError: jest.fn(),
     warnings: [],
     isLoading: false,
+    isWaitingForRun: false,
     isPolling: false,
   };
   return {...base, ...overrides};

--- a/static/app/views/issueDetails/issuePreview/issuePreviewActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewActions.tsx
@@ -91,6 +91,7 @@ function StartAutofixAction({
   label,
   onContinueInSeer,
   tooltip,
+  waiting,
 }: Omit<AutofixActionProps, 'linkedPullRequestsData'> & {
   action: () => unknown | Promise<unknown>;
   analyticsAction: string;
@@ -102,11 +103,12 @@ function StartAutofixAction({
   icon?: ReactNode;
   tooltip?: string | null;
   variant?: 'primary' | 'secondary';
+  waiting?: boolean;
 }) {
   const organization = useOrganization();
   const [isStartingAction, setIsStartingAction] = useState(false);
   const runId = autofix.runState?.run_id;
-  const busy = autofix.isPolling || isStartingAction;
+  const isProcessing = autofix.isPolling || isStartingAction;
   const {codingAgentIntegrations, codingAgentDisabledReason, handleCodingAgentHandoff} =
     useCodingAgents({
       autofix,
@@ -158,8 +160,8 @@ function StartAutofixAction({
         group,
       })}
       icon={icon}
-      busy={busy}
-      disabled={disabled || busy}
+      busy={isStartingAction || waiting}
+      disabled={disabled || isProcessing}
       onClick={handleClick}
       tooltipProps={tooltip ? {title: tooltip} : undefined}
       variant={variant}
@@ -185,7 +187,7 @@ function StartAutofixAction({
             size="sm"
             icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
             aria-label={t('More code fix options')}
-            disabled={disabled || busy || defined(codingAgentDisabledReason)}
+            disabled={disabled || isProcessing || defined(codingAgentDisabledReason)}
             tooltipProps={{title: codingAgentDisabledReason}}
           />
         )}
@@ -219,10 +221,10 @@ function NextAutofixStepButton({
   disabled?: boolean;
   variant?: 'primary' | 'secondary';
 }) {
-  const {runState} = autofix;
+  const {runState, isWaitingForRun} = autofix;
   const sections = getOrderedAutofixSections(runState);
 
-  if (!runState || sections.length === 0) {
+  if (!runState) {
     return (
       <StartAutofixAction
         action={() => autofix.startStep('root_cause')}
@@ -235,6 +237,7 @@ function NextAutofixStepButton({
         label={t('Find Root Cause')}
         onContinueInSeer={onContinueInSeer}
         variant={variant}
+        waiting={isWaitingForRun}
       />
     );
   }
@@ -346,6 +349,31 @@ function NextAutofixStepButton({
   }
 
   const nextStep = getAutofixNextStep({sections});
+  if (autofix.isPolling) {
+    const label =
+      nextStep?.action === 'solution'
+        ? t('Make a Plan')
+        : nextStep?.action === 'code_changes'
+          ? t('Write a Code Fix')
+          : t('Find Root Cause');
+
+    return (
+      <StartAutofixAction
+        action={() => {}}
+        analyticsAction="polling"
+        analyticsEventKey="issue_inbox.start_fix_clicked"
+        analyticsEventName="Issue Inbox: Start Fix Clicked"
+        autofix={autofix}
+        disabled
+        group={group}
+        label={label}
+        onContinueInSeer={onContinueInSeer}
+        variant={variant}
+        waiting
+      />
+    );
+  }
+
   switch (nextStep?.action) {
     case 'create_pr':
       return (
@@ -480,7 +508,7 @@ export function IssuePreviewActions({
   const {data: linkedPullRequestsData, isPending: pullRequestsPending} =
     useLinkedPullRequests({group});
 
-  if (autofix.isLoading || pullRequestsPending) {
+  if ((autofix.isLoading && !autofix.isWaitingForRun) || pullRequestsPending) {
     return <Placeholder width="120px" height="32px" />;
   }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofixSummary.tsx
@@ -29,8 +29,19 @@ export function IssuePreviewAutofixSummary({
   const planSection = sections.findLast(isSolutionSection);
   const rootCauseSection = sections.findLast(isRootCauseSection);
 
-  if (!runState) {
+  if (!runState && !autofix.isWaitingForRun) {
     return null;
+  }
+
+  if (!runState) {
+    return (
+      <IssuePreviewAutofixRootCauseSection
+        autofix={autofix}
+        defaultExpanded
+        groupId={groupId}
+        section={{artifacts: [], blocks: [], status: 'processing', step: 'root_cause'}}
+      />
+    );
   }
 
   const defaultExpandedSection = proposalSection

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeer.tsx
@@ -23,7 +23,7 @@ export function useIssuePreviewSeer(group: Group, project: Project) {
       (aiConfig.hasGithubIntegration && !aiConfig.seerReposLinked)
     ) {
       state = 'configure';
-    } else if (!autofix.runState) {
+    } else if (!autofix.runState && !autofix.isWaitingForRun) {
       state = 'start';
     }
   }

--- a/static/app/views/issueDetails/issuePreview/issuePreviewSeer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewSeer.tsx
@@ -34,7 +34,8 @@ export function useIssuePreviewSeer(group: Group, project: Project) {
     hasAutofix: aiConfig.hasAutofix,
     isLoading:
       aiConfig.hasAutofix &&
-      (aiConfig.isAutofixSetupLoading || (state !== 'configure' && autofix.isLoading)),
+      (aiConfig.isAutofixSetupLoading ||
+        (state !== 'configure' && autofix.isLoading && !autofix.isWaitingForRun)),
     shouldShowSeerActions:
       aiConfig.hasAutofix && (state === 'start' || state === 'summary'),
     state,

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -967,6 +967,30 @@ describe('InboxPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows root cause generation after starting Autofix for an assigned issue', async () => {
+    mockAssignedPreview(AutofixSetupFixture({}));
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${assignedGroup.id}/autofix/`,
+      body: ExplorerAutofixResponseFixture({autofix: null}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${assignedGroup.id}/autofix/`,
+      method: 'POST',
+      body: {run_id: 42},
+      asyncDelay: 100,
+    });
+
+    render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
+
+    const preview = await openAssignedPreview();
+    await userEvent.click(
+      await within(preview).findByRole('button', {name: 'Find Root Cause'})
+    );
+
+    expect(within(preview).getByText('Generating root cause...')).toBeInTheDocument();
+    expect(within(preview).queryByText('Have Seer...')).not.toBeInTheDocument();
+  });
+
   it('waits for Seer setup before showing assigned issue actions', async () => {
     const autofixSetupDelay = Promise.withResolvers<void>();
     mockAssignedPreview(

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -973,11 +973,10 @@ describe('InboxPage', () => {
       url: `/organizations/org-slug/issues/${assignedGroup.id}/autofix/`,
       body: ExplorerAutofixResponseFixture({autofix: null}),
     });
-    MockApiClient.addMockResponse({
+    const startAutofixRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${assignedGroup.id}/autofix/`,
       method: 'POST',
       body: {run_id: 42},
-      asyncDelay: 100,
     });
 
     render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
@@ -988,7 +987,12 @@ describe('InboxPage', () => {
     );
 
     expect(within(preview).getByText('Generating root cause...')).toBeInTheDocument();
-    expect(within(preview).queryByText('Have Seer...')).not.toBeInTheDocument();
+    await waitFor(() => expect(startAutofixRequest).toHaveBeenCalledTimes(1));
+
+    // Immediately sets "find root cause" button to busy state.
+    const startButton = within(preview).getByRole('button', {name: 'Find Root Cause'});
+    expect(startButton).toBeDisabled();
+    expect(startButton).toHaveAttribute('aria-busy', 'true');
   });
 
   it('waits for Seer setup before showing assigned issue actions', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -942,6 +942,7 @@ describe('InboxPage', () => {
 
     expect(within(preview).queryByRole('tab', {name: 'Autofix'})).not.toBeInTheDocument();
     expect(within(preview).getByRole('button', {name: 'Find Root Cause'})).toBeDisabled();
+    expect(within(preview).getByText('Generating root cause...')).toBeInTheDocument();
     await waitFor(() =>
       expect(startAutofixRequest).toHaveBeenCalledWith(
         expect.anything(),

--- a/tests/js/fixtures/autofix.ts
+++ b/tests/js/fixtures/autofix.ts
@@ -19,6 +19,7 @@ export function ExplorerAutofixFixture(
     dismissCodingAgentError: jest.fn(),
     warnings: [],
     isLoading: false,
+    isWaitingForRun: false,
     isPolling: false,
     ...params,
   };


### PR DESCRIPTION
Closes ISWF-3261

Starting root cause generation from an issue preview briefly replaced the entire preview with a loading spinner while waiting for the first Autofix run state. This exposes more info from the useAutofixExplorer hook so that we can display our loading state while waiting for the server in that case.

The experience feels much more responsive and smooth, with no elements popping in/out:

https://github.com/user-attachments/assets/a815929a-5d7a-41e0-af9b-2eb44ffdc99d

