### PR TITLE
fix(onboarding): Sort SCM platform picker alphabetically

### DIFF
--- a/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
@@ -1,0 +1,18 @@
+import {platforms} from 'sentry/data/platforms';
+
+import {platformOptions} from './scmPlatformHelpers';
+
+describe('platformOptions', () => {
+  it('sorts platforms alphabetically by display name', () => {
+    const names = platformOptions.map(option => option.label);
+
+    expect(names).toEqual(names.toSorted((a, b) => a.localeCompare(b)));
+  });
+
+  it('keeps every platform exactly once', () => {
+    const values = platformOptions.map(option => option.value);
+
+    expect(new Set(values).size).toBe(values.length);
+    expect(values).toHaveLength(platforms.length);
+  });
+});

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
@@ -1,12 +1,20 @@
 import {platforms} from 'sentry/data/platforms';
+import {comparePlatformNames} from 'sentry/utils/platform';
 
 import {platformOptions} from './scmPlatformHelpers';
 
 describe('platformOptions', () => {
-  it('sorts platforms alphabetically by display name', () => {
+  it('sorts platforms like the legacy picker All tab', () => {
     const names = platformOptions.map(option => option.label);
 
-    expect(names).toEqual(names.toSorted((a, b) => a.localeCompare(b)));
+    expect(names).toEqual(names.toSorted(comparePlatformNames));
+
+    // Names starting with punctuation (the .NET family) sort last, not first.
+    const firstPunctuationIndex = names.findIndex(name => name.startsWith('.'));
+    expect(firstPunctuationIndex).toBeGreaterThan(0);
+    expect(names.slice(firstPunctuationIndex).every(name => name.startsWith('.'))).toBe(
+      true
+    );
   });
 
   it('keeps every platform exactly once', () => {

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
@@ -3,7 +3,7 @@ import {comparePlatformNames} from 'sentry/utils/platform';
 import {platformOptions} from './scmPlatformHelpers';
 
 describe('platformOptions', () => {
-  it('sorts platforms like the legacy picker All tab', () => {
+  it('sorts platforms alphabetically with punctuation-prefixed names last', () => {
     const names = platformOptions.map(option => option.label);
 
     expect(names).toEqual(names.toSorted(comparePlatformNames));

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
@@ -1,4 +1,3 @@
-import {platforms} from 'sentry/data/platforms';
 import {comparePlatformNames} from 'sentry/utils/platform';
 
 import {platformOptions} from './scmPlatformHelpers';
@@ -15,12 +14,5 @@ describe('platformOptions', () => {
     expect(names.slice(firstPunctuationIndex).every(name => name.startsWith('.'))).toBe(
       true
     );
-  });
-
-  it('keeps every platform exactly once', () => {
-    const values = platformOptions.map(option => option.value);
-
-    expect(new Set(values).size).toBe(values.length);
-    expect(values).toHaveLength(platforms.length);
   });
 });

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
@@ -33,9 +33,6 @@ const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 
 export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
 
-// The SCM dropdown is one long list, so raw platforms.tsx insertion order
-// reads as random. Sort by display name (same ordering as the legacy
-// picker's All tab) so users can scan it.
 export const platformOptions = platforms
   .toSorted((a, b) => comparePlatformNames(a.name, b.name))
   .map(platform => ({

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
@@ -32,12 +32,16 @@ const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 
 export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
 
-export const platformOptions = platforms.map(platform => ({
-  value: platform.id,
-  label: platform.name,
-  textValue: `${platform.name} ${platform.id}`,
-  leadingItems: <PlatformIcon platform={platform.id} size={16} alt="" />,
-}));
+// The SCM dropdown is one long list, so raw platforms.tsx insertion order
+// reads as random. Sort by display name so users can scan it.
+export const platformOptions = platforms
+  .toSorted((a, b) => a.name.localeCompare(b.name))
+  .map(platform => ({
+    value: platform.id,
+    label: platform.name,
+    textValue: `${platform.name} ${platform.id}`,
+    leadingItems: <PlatformIcon platform={platform.id} size={16} alt="" />,
+  }));
 
 export function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
   return {

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
@@ -6,6 +6,7 @@ import {platforms} from 'sentry/data/platforms';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/platform';
 import type {PlatformIntegration} from 'sentry/types/project';
+import {comparePlatformNames} from 'sentry/utils/platform';
 
 import type {DetectedPlatform} from './useScmPlatformDetection';
 
@@ -33,9 +34,10 @@ const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
 
 // The SCM dropdown is one long list, so raw platforms.tsx insertion order
-// reads as random. Sort by display name so users can scan it.
+// reads as random. Sort by display name (same ordering as the legacy
+// picker's All tab) so users can scan it.
 export const platformOptions = platforms
-  .toSorted((a, b) => a.name.localeCompare(b.name))
+  .toSorted((a, b) => comparePlatformNames(a.name, b.name))
   .map(platform => ({
     value: platform.id,
     label: platform.name,

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -26,6 +26,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformIntegration} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {comparePlatformNames} from 'sentry/utils/platform';
 
 const PlatformList = styled('div')`
   display: grid;
@@ -41,10 +42,6 @@ const PlatformList = styled('div')`
 const selectablePlatforms = platforms.filter(platform =>
   createablePlatforms.has(platform.id)
 );
-
-function startsWithPunctuation(name: string) {
-  return /^\p{P}/u.test(name);
-}
 
 export type Category = (typeof categoryList)[number]['id'];
 
@@ -146,15 +143,7 @@ export function PlatformPicker({
     }
 
     // We only want to sort the platforms alphabetically if users are not viewing the 'popular' tab category
-    return filtered.sort((a, b) => {
-      if (startsWithPunctuation(a.name) && !startsWithPunctuation(b.name)) {
-        return 1;
-      }
-      if (!startsWithPunctuation(a.name) && startsWithPunctuation(b.name)) {
-        return -1;
-      }
-      return a.name.localeCompare(b.name);
-    });
+    return filtered.sort((a, b) => comparePlatformNames(a.name, b.name));
   }, [filter, category, availablePlatforms, showOther]);
 
   const latestValuesRef = useRef({

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -68,6 +68,24 @@ export function isMobilePlatform(platform: string | undefined) {
   return (mobile as string[]).includes(platform);
 }
 
+function startsWithPunctuation(name: string) {
+  return /^\p{P}/u.test(name);
+}
+
+/**
+ * Sort comparator for platform display names, matching the legacy platform
+ * picker's non-popular tabs: alphabetical, except names starting with
+ * punctuation (the .NET family) sort last instead of first.
+ */
+export function comparePlatformNames(a: string, b: string): number {
+  const aStartsWithPunctuation = startsWithPunctuation(a);
+  const bStartsWithPunctuation = startsWithPunctuation(b);
+  if (aStartsWithPunctuation !== bStartsWithPunctuation) {
+    return aStartsWithPunctuation ? 1 : -1;
+  }
+  return a.localeCompare(b);
+}
+
 export function isDisabledGamingPlatform({
   platform,
   enabledConsolePlatforms,


### PR DESCRIPTION
## TLDR

The SCM create-project SDK dropdown listed its roughly 130 platforms in raw `platforms.tsx` insertion order, so the list read as random. It is now sorted by display name with the exact ordering of the legacy platform picker's All tab.

## Details

This is the stopgap layer of a small stack; the follow-up PRs section the dropdown into a curated Popular list plus a sorted remainder. Matching the legacy picker matters because plain `localeCompare` puts the .NET family at the top of the list, while the legacy picker deliberately sorts names starting with punctuation last. That comparator moved out of `platformPicker` into `comparePlatformNames` in `sentry/utils/platform`, and both surfaces now use it, so there is one ordering source. The new spec pins the order and the punctuation rule.

## Stack

- **PR 1 (this):** fix(onboarding): Sort SCM platform picker alphabetically
- [PR 2](https://github.com/getsentry/sentry/pull/122103): feat(onboarding): Support grouped options in ScmVirtualizedMenuList
- [PR 3](https://github.com/getsentry/sentry/pull/122104): feat(onboarding): Section the SCM platform picker into Popular and Other
