### PR TITLE
feat(onboarding): Support grouped options in ScmVirtualizedMenuList

### DIFF
--- a/static/app/components/onboarding/scm/scmVirtualizedMenuList.spec.tsx
+++ b/static/app/components/onboarding/scm/scmVirtualizedMenuList.spec.tsx
@@ -1,0 +1,113 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
+
+// Mock the virtualizer so all rows render in JSDOM (no layout engine).
+const mockScrollToIndex = jest.fn();
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({count}: {count: number}) => ({
+    getVirtualItems: () =>
+      Array.from({length: count}, (_, i) => ({
+        key: i,
+        index: i,
+        start: i * 36,
+        size: 36,
+      })),
+    getTotalSize: () => count * 36,
+    measureElement: () => {},
+    scrollToIndex: mockScrollToIndex,
+  }),
+}));
+
+function Heading({children}: {children?: React.ReactNode}) {
+  return <div>{children}</div>;
+}
+
+// Stand-in for react-select's Group element: never rendered itself, the menu
+// list reads its props and renders the extracted heading and option rows.
+function Group(_props: {
+  Heading: React.ComponentType<any>;
+  children: React.ReactNode;
+  headingProps: Record<string, unknown>;
+  label: React.ReactNode;
+}) {
+  return null;
+}
+
+function Option({children}: {children?: React.ReactNode; data?: unknown}) {
+  return <div role="option">{children}</div>;
+}
+
+const reactData = {value: 'react'};
+const vueData = {value: 'vue'};
+const angularData = {value: 'angular'};
+
+const groupedChildren = [
+  <Group key="group-0" Heading={Heading} headingProps={{}} label="Popular">
+    {[
+      <Option key="react" data={reactData}>
+        React
+      </Option>,
+      <Option key="vue" data={vueData}>
+        Vue
+      </Option>,
+    ]}
+  </Group>,
+  <Group key="group-1" Heading={Heading} headingProps={{}} label="Other platforms">
+    {[
+      <Option key="angular" data={angularData}>
+        Angular
+      </Option>,
+    ]}
+  </Group>,
+];
+
+describe('ScmVirtualizedMenuList', () => {
+  beforeEach(() => {
+    mockScrollToIndex.mockClear();
+  });
+
+  it('flattens grouped children into interleaved heading and option rows', () => {
+    const {container} = render(
+      <ScmVirtualizedMenuList>{groupedChildren}</ScmVirtualizedMenuList>
+    );
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).toEqual([
+      'React',
+      'Vue',
+      'Angular',
+    ]);
+    expect(container).toHaveTextContent('PopularReactVueOther platformsAngular');
+  });
+
+  it('scrolls to the focused option by its flattened row index', () => {
+    render(
+      <ScmVirtualizedMenuList focusedOption={angularData}>
+        {groupedChildren}
+      </ScmVirtualizedMenuList>
+    );
+
+    // Rows: Popular(0), React(1), Vue(2), Other platforms(3), Angular(4).
+    expect(mockScrollToIndex).toHaveBeenCalledWith(4, {align: 'auto'});
+  });
+
+  it('still renders ungrouped children as one row each', () => {
+    render(
+      <ScmVirtualizedMenuList>
+        {[
+          <Option key="react" data={reactData}>
+            React
+          </Option>,
+          <Option key="vue" data={vueData}>
+            Vue
+          </Option>,
+        ]}
+      </ScmVirtualizedMenuList>
+    );
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).toEqual([
+      'React',
+      'Vue',
+    ]);
+  });
+});

--- a/static/app/components/onboarding/scm/scmVirtualizedMenuList.spec.tsx
+++ b/static/app/components/onboarding/scm/scmVirtualizedMenuList.spec.tsx
@@ -78,6 +78,11 @@ describe('ScmVirtualizedMenuList', () => {
       'Angular',
     ]);
     expect(container).toHaveTextContent('PopularReactVueOther platformsAngular');
+
+    // The section boundary divider renders before every heading except the
+    // first, so getByTestId doubles as the only-one-divider assertion.
+    const divider = screen.getByTestId('menu-group-divider');
+    expect(divider.nextElementSibling).toHaveTextContent('Other platforms');
   });
 
   it('scrolls to the focused option by its flattened row index', () => {

--- a/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
+++ b/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
@@ -4,6 +4,11 @@
  * causes ~1s lag with 130+ platform options containing PlatformIcon SVGs.
  * Virtualizing limits mounted components to the visible set.
  *
+ * Supports grouped options: react-select renders each group as a single
+ * <Group> element wrapping its Option children, which would virtualize as one
+ * giant row. Groups are flattened here into heading + option rows instead,
+ * with per-row measurement since headings and options differ in height.
+ *
  * Stopgap until a Combobox scraps component replaces this
  * (see #discuss-design-engineering).
  *
@@ -16,8 +21,78 @@ import {mergeRefs} from '@react-aria/utils';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 const OPTION_HEIGHT = 36;
+const GROUP_HEADING_HEIGHT = 24;
 const MAX_MENU_HEIGHT = 300;
 const MENU_PADDING = 4;
+
+/**
+ * The props react-select's renderMenu passes to each Group element. Only
+ * Group elements carry a Heading component, which is how they are told apart
+ * from Option elements.
+ */
+interface GroupElementProps {
+  Heading: React.ComponentType<any>;
+  children: React.ReactNode;
+  cx: unknown;
+  getStyles: unknown;
+  headingProps: Record<string, unknown>;
+  label: React.ReactNode;
+  selectProps: unknown;
+  theme: unknown;
+}
+
+interface MenuRow {
+  isHeading: boolean;
+  key: React.Key;
+  node: React.ReactNode;
+  /** The react-select option data, used to locate the focused row. */
+  data?: unknown;
+}
+
+function toOptionRow(node: React.ReactNode, fallbackKey: number): MenuRow {
+  const element = isValidElement<{data?: unknown}>(node) ? node : null;
+  return {
+    isHeading: false,
+    key: element?.key ?? fallbackKey,
+    node,
+    data: element?.props.data,
+  };
+}
+
+function flattenMenuRows(children: React.ReactNode[]): MenuRow[] {
+  const rows: MenuRow[] = [];
+  for (const child of children) {
+    if (!isValidElement<Partial<GroupElementProps>>(child) || !child.props.Heading) {
+      rows.push(toOptionRow(child, rows.length));
+      continue;
+    }
+    // Render the group's heading the same way react-select's Group does, so
+    // the Select's groupHeading styles still apply.
+    const {Heading, headingProps, label, selectProps, theme, getStyles, cx} = child.props;
+    rows.push({
+      isHeading: true,
+      key: child.key ?? rows.length,
+      node: (
+        <Heading
+          {...headingProps}
+          selectProps={selectProps}
+          theme={theme}
+          getStyles={getStyles}
+          cx={cx}
+        >
+          {label}
+        </Heading>
+      ),
+    });
+    const groupOptions = Array.isArray(child.props.children)
+      ? child.props.children
+      : [child.props.children];
+    for (const option of groupOptions) {
+      rows.push(toOptionRow(option, rows.length));
+    }
+  }
+  return rows;
+}
 
 interface ScmVirtualizedMenuListProps {
   children: React.ReactNode;
@@ -36,7 +111,7 @@ export function ScmVirtualizedMenuList({
   innerRef,
   innerProps,
 }: ScmVirtualizedMenuListProps) {
-  const items: React.ReactNode[] = Array.isArray(children) ? children : [];
+  const rows = Array.isArray(children) ? flattenMenuRows(children) : [];
   const scrollRef = useRef<HTMLDivElement>(null);
   const combinedRef = mergeRefs(scrollRef, innerRef ?? null);
   const visibleOptionCount = Math.max(
@@ -46,9 +121,14 @@ export function ScmVirtualizedMenuList({
   const alignedMaxHeight = visibleOptionCount * optionHeight + MENU_PADDING * 2;
 
   const virtualizer = useVirtualizer({
-    count: items.length,
+    count: rows.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => optionHeight,
+    // Estimates only; rows are measured on mount below. Headings differ in
+    // height from options, and an empty-label heading collapses to zero.
+    estimateSize: index => (rows[index]?.isHeading ? GROUP_HEADING_HEIGHT : optionHeight),
+    // Keep measurements attached to rows (not indices) when filtering shifts
+    // the list.
+    getItemKey: index => rows[index]?.key ?? index,
     overscan: 5,
     paddingStart: MENU_PADDING,
     paddingEnd: MENU_PADDING,
@@ -58,9 +138,9 @@ export function ScmVirtualizedMenuList({
 
   const virtualItems = virtualizer.getVirtualItems();
   // react-select shares focused option identity with each Option child's data.
-  // The focused DOM node may be virtualized out, so scroll by its child index.
-  const focusedIndex = items.findIndex(
-    item => isValidElement<{data?: unknown}>(item) && item.props.data === focusedOption
+  // The focused DOM node may be virtualized out, so scroll by its row index.
+  const focusedIndex = rows.findIndex(
+    row => !row.isHeading && row.data === focusedOption
   );
 
   useEffect(() => {
@@ -89,6 +169,8 @@ export function ScmVirtualizedMenuList({
         {virtualItems.map(virtualRow => (
           <div
             key={virtualRow.key}
+            ref={virtualizer.measureElement}
+            data-index={virtualRow.index}
             style={{
               position: 'absolute',
               top: 0,
@@ -97,7 +179,7 @@ export function ScmVirtualizedMenuList({
               transform: `translateY(${virtualRow.start}px)`,
             }}
           >
-            {items[virtualRow.index]}
+            {rows[virtualRow.index]?.node}
           </div>
         ))}
       </div>

--- a/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
+++ b/static/app/components/onboarding/scm/scmVirtualizedMenuList.tsx
@@ -16,6 +16,7 @@
  */
 
 import {isValidElement, type Ref, useEffect, useRef} from 'react';
+import {useTheme} from '@emotion/react';
 import {getInteractionModality} from '@react-aria/interactions';
 import {mergeRefs} from '@react-aria/utils';
 import {useVirtualizer} from '@tanstack/react-virtual';
@@ -111,6 +112,7 @@ export function ScmVirtualizedMenuList({
   innerRef,
   innerProps,
 }: ScmVirtualizedMenuListProps) {
+  const theme = useTheme();
   const rows = Array.isArray(children) ? flattenMenuRows(children) : [];
   const scrollRef = useRef<HTMLDivElement>(null);
   const combinedRef = mergeRefs(scrollRef, innerRef ?? null);
@@ -166,22 +168,40 @@ export function ScmVirtualizedMenuList({
       style={{maxHeight: alignedMaxHeight, overflowY: 'auto'}}
     >
       <div style={{height: virtualizer.getTotalSize(), position: 'relative'}}>
-        {virtualItems.map(virtualRow => (
-          <div
-            key={virtualRow.key}
-            ref={virtualizer.measureElement}
-            data-index={virtualRow.index}
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              transform: `translateY(${virtualRow.start}px)`,
-            }}
-          >
-            {rows[virtualRow.index]?.node}
-          </div>
-        ))}
+        {virtualItems.map(virtualRow => {
+          const row = rows[virtualRow.index];
+          return (
+            <div
+              key={virtualRow.key}
+              ref={virtualizer.measureElement}
+              data-index={virtualRow.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {/* Flattening drops react-select's Group wrapper, and with it
+                  the Select's between-group divider (styles.group). Reproduce
+                  it on every heading row after the first, using paddings (not
+                  vertical margins) so measureElement counts the boundary in
+                  the row height. */}
+              {row?.isHeading && virtualRow.index > 0 && (
+                <div
+                  data-test-id="menu-group-divider"
+                  style={{padding: `${theme.space.md} ${theme.space.lg}`}}
+                >
+                  <div
+                    style={{borderTop: `1px solid ${theme.tokens.border.secondary}`}}
+                  />
+                </div>
+              )}
+              {row?.node}
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## TLDR

`ScmVirtualizedMenuList` can now render react-select grouped options, with section headings and options each becoming one virtualized row. Flat option lists render exactly as before.

## Details

react-select renders each option group as a single `Group` element wrapping all of its `Option` children, so the row-per-child virtualizer would treat an entire section as one 36px row. The menu list now flattens `Group` children into heading and option rows, rendering headings the way react-select's own `Group` does so the core Select's `groupHeading` styles still apply. Flattening also skips the group wrapper that carries the Select's between-group divider (`styles.group`), so every heading row after the first reproduces that boundary itself.

Rows are measured on mount (`measureElement`) instead of assuming a fixed height, since headings are shorter than options and an empty-label heading collapses to zero, and `getItemKey` keeps those measurements attached to rows when filtering shifts the list. Keyboard-focus scrolling maps the focused option to its flattened row index, so headings count toward the scroll target. The next PR in the stack uses this to section the SCM platform picker.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/122102): fix(onboarding): Sort SCM platform picker alphabetically
- **PR 2 (this):** feat(onboarding): Support grouped options in ScmVirtualizedMenuList
- [PR 3](https://github.com/getsentry/sentry/pull/122104): feat(onboarding): Section the SCM platform picker into Popular and Other
