### PR TITLE
feat(onboarding): Section the SCM platform picker into Popular and Other

### DIFF
--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
@@ -44,7 +44,11 @@ jest.mock('sentry/data/platforms', () => {
     ...actual,
     platforms: actual.platforms.filter(
       (p: {id: string}) =>
-        p.id === 'javascript' || p.id === 'python' || p.id === 'python-django'
+        p.id === 'javascript' ||
+        p.id === 'python' ||
+        p.id === 'python-django' ||
+        // Not in the curated popular list, so the picker gets both sections.
+        p.id === 'deno'
     ),
   };
 });
@@ -193,6 +197,17 @@ describe('ScmPlatformFeaturesCore', () => {
       'growth.select_platform',
       expect.anything()
     );
+  });
+
+  it('sections the manual picker dropdown into Popular and Other platforms', async () => {
+    render(<ScmPlatformFeaturesCore {...defaultProps({selectedPlatform: undefined})} />, {
+      organization,
+    });
+
+    await userEvent.click(screen.getByRole('textbox'));
+
+    expect(screen.getByText('Popular')).toBeInTheDocument();
+    expect(screen.getByText('Other platforms')).toBeInTheDocument();
   });
 
   it('tracks one debounced manual platform search with its result count', async () => {

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -35,7 +35,6 @@ import {
   platformOptionGroups,
   platformOptions,
   shouldSuggestFramework,
-  toPlatformOption,
   toSelectedSdk,
 } from './scmPlatformHelpers';
 import {ScmSearchControl} from './scmSearchControl';
@@ -323,33 +322,15 @@ export function ScmPlatformFeaturesCore({
     }
   };
 
-  // Ensure the selected platform is always present in the dropdown options
-  // so the Select can resolve and display it. When the framework suggestion
-  // modal picks a key not in the static list, prepend it in an unlabeled
-  // section (the Select's groupHeading style hides empty headings).
-  const manualPickerOptionGroups = useMemo(() => {
-    const key = currentPlatformKey;
-    if (!key || platformOptions.some(o => o.value === key)) {
-      return platformOptionGroups;
-    }
-    const info = getPlatformInfo(key);
-    if (!info) {
-      return platformOptionGroups;
-    }
-    return [{label: '', options: [toPlatformOption(info)]}, ...platformOptionGroups];
-  }, [currentPlatformKey]);
-
   const manualPickerFilteredOptions = useMemo(
     () =>
-      manualPickerOptionGroups
-        .flatMap(group => group.options)
-        .filter(option =>
-          matchesPlatformOption(
-            {label: option.label, value: option.value, data: option},
-            manualPickerFilter
-          )
-        ),
-    [manualPickerFilter, manualPickerOptionGroups]
+      platformOptions.filter(option =>
+        matchesPlatformOption(
+          {label: option.label, value: option.value, data: option},
+          manualPickerFilter
+        )
+      ),
+    [manualPickerFilter]
   );
 
   const latestSearchValuesRef = useRef({
@@ -524,7 +505,7 @@ export function ScmPlatformFeaturesCore({
       {detectedPlatformKey ? (
         <Select<(typeof platformOptions)[number]>
           placeholder={t('Search SDKs...')}
-          options={manualPickerOptionGroups}
+          options={platformOptionGroups}
           value={currentPlatformKey ?? null}
           onChange={handleManualPickerChange}
           onInputChange={handleManualPickerSearch}
@@ -535,7 +516,7 @@ export function ScmPlatformFeaturesCore({
       ) : (
         <Select<(typeof platformOptions)[number]>
           placeholder={t('Search SDKs...')}
-          options={manualPickerOptionGroups}
+          options={platformOptionGroups}
           value={currentPlatformKey ?? null}
           onChange={handleManualPickerChange}
           onInputChange={handleManualPickerSearch}

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {motion} from 'framer-motion';
 import debounce from 'lodash/debounce';
-import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
@@ -32,8 +31,10 @@ import {ScmPlatformCard} from './scmPlatformCard';
 import {
   DEFAULT_SCM_FEATURES,
   getPlatformInfo,
+  platformOptionGroups,
   platformOptions,
   shouldSuggestFramework,
+  toPlatformOption,
   toSelectedSdk,
 } from './scmPlatformHelpers';
 import {ScmSearchControl} from './scmSearchControl';
@@ -322,36 +323,31 @@ export function ScmPlatformFeaturesCore({
 
   // Ensure the selected platform is always present in the dropdown options
   // so the Select can resolve and display it. When the framework suggestion
-  // modal picks a key not in the static list, prepend it.
-  const manualPickerOptions = useMemo(() => {
+  // modal picks a key not in the static list, prepend it in an unlabeled
+  // section (the Select's groupHeading style hides empty headings).
+  const manualPickerOptionGroups = useMemo(() => {
     const key = currentPlatformKey;
     if (!key || platformOptions.some(o => o.value === key)) {
-      return platformOptions;
+      return platformOptionGroups;
     }
     const info = getPlatformInfo(key);
     if (!info) {
-      return platformOptions;
+      return platformOptionGroups;
     }
-    return [
-      {
-        value: info.id,
-        label: info.name,
-        textValue: `${info.name} ${info.id}`,
-        leadingItems: <PlatformIcon platform={info.id} size={16} alt="" />,
-      },
-      ...platformOptions,
-    ];
+    return [{label: '', options: [toPlatformOption(info)]}, ...platformOptionGroups];
   }, [currentPlatformKey]);
 
   const manualPickerFilteredOptions = useMemo(
     () =>
-      manualPickerOptions.filter(option =>
-        matchesPlatformOption(
-          {label: option.label, value: option.value, data: option},
-          manualPickerFilter
-        )
-      ),
-    [manualPickerFilter, manualPickerOptions]
+      manualPickerOptionGroups
+        .flatMap(group => group.options)
+        .filter(option =>
+          matchesPlatformOption(
+            {label: option.label, value: option.value, data: option},
+            manualPickerFilter
+          )
+        ),
+    [manualPickerFilter, manualPickerOptionGroups]
   );
 
   const latestSearchValuesRef = useRef({
@@ -507,7 +503,7 @@ export function ScmPlatformFeaturesCore({
       {detectedPlatformKey ? (
         <Select<(typeof platformOptions)[number]>
           placeholder={t('Search SDKs...')}
-          options={manualPickerOptions}
+          options={manualPickerOptionGroups}
           value={currentPlatformKey ?? null}
           onChange={handleManualPickerChange}
           onInputChange={handleManualPickerSearch}
@@ -518,7 +514,7 @@ export function ScmPlatformFeaturesCore({
       ) : (
         <Select<(typeof platformOptions)[number]>
           placeholder={t('Search SDKs...')}
-          options={manualPickerOptions}
+          options={manualPickerOptionGroups}
           value={currentPlatformKey ?? null}
           onChange={handleManualPickerChange}
           onInputChange={handleManualPickerSearch}

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -1,11 +1,12 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import {motion} from 'framer-motion';
 import debounce from 'lodash/debounce';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
-import {Select} from '@sentry/scraps/select';
+import {Select, type StylesConfig} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
@@ -86,6 +87,7 @@ export function ScmPlatformFeaturesCore({
   selectedRepository,
 }: ScmPlatformFeaturesCoreProps) {
   const isOnboarding = analyticsFlow === 'onboarding';
+  const theme = useTheme();
   const {openModal} = useModal();
   const organization = useOrganization();
 
@@ -397,6 +399,18 @@ export function ScmPlatformFeaturesCore({
     debounceManualPickerSearch();
   }
 
+  // Indent section headings past the options' reserved checkmark column (1em
+  // at the item font size, i.e. form.md.fontSize) plus the leading-items gap,
+  // so heading text aligns with the platform icons instead of hanging left of
+  // them. Shared by both manual-picker Select variants below.
+  const manualPickerStyles: StylesConfig = {
+    container: base => ({...base, width: '100%'}),
+    groupHeading: base => ({
+      ...base,
+      paddingLeft: `calc(${theme.space.lg} + ${theme.space.md} + ${theme.form.md.fontSize})`,
+    }),
+  };
+
   // When the active platform is a manual (non-detected) pick, show the manual
   // picker so the selection stays visible (see showDetectedPlatforms below).
   const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
@@ -509,7 +523,7 @@ export function ScmPlatformFeaturesCore({
           onInputChange={handleManualPickerSearch}
           searchable
           components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
-          styles={{container: base => ({...base, width: '100%'})}}
+          styles={manualPickerStyles}
         />
       ) : (
         <Select<(typeof platformOptions)[number]>
@@ -521,7 +535,7 @@ export function ScmPlatformFeaturesCore({
           clearable
           searchable
           components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
-          styles={{container: base => ({...base, width: '100%'})}}
+          styles={manualPickerStyles}
         />
       )}
     </MotionStack>

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -402,12 +402,15 @@ export function ScmPlatformFeaturesCore({
   // Indent section headings past the options' reserved checkmark column (1em
   // at the item font size, i.e. form.md.fontSize) plus the leading-items gap,
   // so heading text aligns with the platform icons instead of hanging left of
-  // them. Shared by both manual-picker Select variants below.
+  // them. Must override the padding shorthand, not paddingLeft: base already
+  // holds a paddingLeft key from react-select's defaults, so an overridden
+  // paddingLeft keeps that key's early position and the later padding
+  // shorthand resets it. Shared by both manual-picker Select variants below.
   const manualPickerStyles: StylesConfig = {
     container: base => ({...base, width: '100%'}),
     groupHeading: base => ({
       ...base,
-      paddingLeft: `calc(${theme.space.lg} + ${theme.space.md} + ${theme.form.md.fontSize})`,
+      padding: `${theme.space.xs} ${theme.space.lg} ${theme.space.xs} calc(${theme.space.lg} + ${theme.space.md} + ${theme.form.md.fontSize})`,
     }),
   };
 

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -399,18 +399,22 @@ export function ScmPlatformFeaturesCore({
     debounceManualPickerSearch();
   }
 
-  // Indent section headings past the options' reserved checkmark column (1em
-  // at the item font size, i.e. form.md.fontSize) plus the leading-items gap,
-  // so heading text aligns with the platform icons instead of hanging left of
-  // them. Must override the padding shorthand, not paddingLeft: base already
-  // holds a paddingLeft key from react-select's defaults, so an overridden
-  // paddingLeft keeps that key's early position and the later padding
-  // shorthand resets it. Shared by both manual-picker Select variants below.
+  // Align the platform icons and section headings with the input text. Options
+  // reserve space for the menu-item inset, inner inset, checkmark, and
+  // leading-item gap. Must override the group padding shorthand: base already
+  // has a paddingLeft key before its padding shorthand, which would reset a
+  // paddingLeft override. Shared by both manual-picker Select variants below.
   const manualPickerStyles: StylesConfig = {
     container: base => ({...base, width: '100%'}),
+    menu: base => ({
+      ...base,
+      '& [role="menuitemradio"]': {
+        paddingLeft: theme.space.md,
+      },
+    }),
     groupHeading: base => ({
       ...base,
-      padding: `${theme.space.xs} ${theme.space.lg} ${theme.space.xs} calc(${theme.space.lg} + ${theme.space.md} + ${theme.form.md.fontSize})`,
+      padding: `${theme.space.xs} ${theme.space.lg} ${theme.space.xs} calc(${theme.space.md} + ${theme.space.lg} + ${theme.form.md.fontSize} + ${theme.space.md})`,
     }),
   };
 

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
@@ -14,10 +14,17 @@ describe('platformOptionGroups', () => {
     );
   });
 
-  it('sorts the remaining section like the legacy picker All tab', () => {
+  it('sorts the Other section alphabetically with punctuation-prefixed names last', () => {
     expect(otherGroup!.label).toBe('Other platforms');
     const names = otherGroup!.options.map(option => option.label);
     expect(names).toEqual(names.toSorted(comparePlatformNames));
+
+    // Names starting with punctuation (the .NET family) sort last, not first.
+    const firstPunctuationIndex = names.findIndex(name => name.startsWith('.'));
+    expect(firstPunctuationIndex).toBeGreaterThan(0);
+    expect(names.slice(firstPunctuationIndex).every(name => name.startsWith('.'))).toBe(
+      true
+    );
   });
 
   it('keeps every platform exactly once across sections', () => {

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.spec.tsx
@@ -1,18 +1,28 @@
+import {popularPlatformCategories} from 'sentry/data/platformPickerCategories';
+import {platforms} from 'sentry/data/platforms';
 import {comparePlatformNames} from 'sentry/utils/platform';
 
-import {platformOptions} from './scmPlatformHelpers';
+import {platformOptionGroups, platformOptions} from './scmPlatformHelpers';
 
-describe('platformOptions', () => {
-  it('sorts platforms alphabetically with punctuation-prefixed names last', () => {
-    const names = platformOptions.map(option => option.label);
+describe('platformOptionGroups', () => {
+  const [popularGroup, otherGroup] = platformOptionGroups;
 
-    expect(names).toEqual(names.toSorted(comparePlatformNames));
-
-    // Names starting with punctuation (the .NET family) sort last, not first.
-    const firstPunctuationIndex = names.findIndex(name => name.startsWith('.'));
-    expect(firstPunctuationIndex).toBeGreaterThan(0);
-    expect(names.slice(firstPunctuationIndex).every(name => name.startsWith('.'))).toBe(
-      true
+  it('leads with the curated popular section in Popular-tab order', () => {
+    expect(popularGroup!.label).toBe('Popular');
+    expect(popularGroup!.options.map(option => option.value)).toEqual(
+      Array.from(popularPlatformCategories)
     );
+  });
+
+  it('sorts the remaining section like the legacy picker All tab', () => {
+    expect(otherGroup!.label).toBe('Other platforms');
+    const names = otherGroup!.options.map(option => option.label);
+    expect(names).toEqual(names.toSorted(comparePlatformNames));
+  });
+
+  it('keeps every platform exactly once across sections', () => {
+    const values = platformOptions.map(option => option.value);
+    expect(new Set(values).size).toBe(values.length);
+    expect(values).toHaveLength(platforms.length);
   });
 });

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
@@ -35,7 +35,7 @@ const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 
 export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
 
-export const toPlatformOption = (platform: PlatformIntegration) => ({
+const toPlatformOption = (platform: PlatformIntegration) => ({
   value: platform.id,
   label: platform.name,
   textValue: `${platform.name} ${platform.id}`,

--- a/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformHelpers.tsx
@@ -2,7 +2,9 @@ import {PlatformIcon} from 'platformicons';
 
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {popularPlatformCategories} from 'sentry/data/platformPickerCategories';
 import {platforms} from 'sentry/data/platforms';
+import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {PlatformKey} from 'sentry/types/platform';
 import type {PlatformIntegration} from 'sentry/types/project';
@@ -33,14 +35,36 @@ const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 
 export const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
 
-export const platformOptions = platforms
-  .toSorted((a, b) => comparePlatformNames(a.name, b.name))
-  .map(platform => ({
-    value: platform.id,
-    label: platform.name,
-    textValue: `${platform.name} ${platform.id}`,
-    leadingItems: <PlatformIcon platform={platform.id} size={16} alt="" />,
-  }));
+export const toPlatformOption = (platform: PlatformIntegration) => ({
+  value: platform.id,
+  label: platform.name,
+  textValue: `${platform.name} ${platform.id}`,
+  leadingItems: <PlatformIcon platform={platform.id} size={16} alt="" />,
+});
+
+// A flat A-Z list buries the platforms most users want, and a popularity sort
+// reads as random without a visible boundary. Section the dropdown instead:
+// the existing curated Popular list first (same order as the legacy Popular
+// tab), then everything else under a labeled heading, ordered like the legacy
+// picker's All tab.
+export const platformOptionGroups = [
+  {
+    label: t('Popular'),
+    options: Array.from(popularPlatformCategories)
+      .map(key => platformsByKey.get(key))
+      .filter(platform => platform !== undefined)
+      .map(toPlatformOption),
+  },
+  {
+    label: t('Other platforms'),
+    options: platforms
+      .filter(platform => !popularPlatformCategories.has(platform.id))
+      .toSorted((a, b) => comparePlatformNames(a.name, b.name))
+      .map(toPlatformOption),
+  },
+].filter(group => group.options.length > 0);
+
+export const platformOptions = platformOptionGroups.flatMap(group => group.options);
 
 export function toSelectedSdk(info: PlatformIntegration): OnboardingSelectedSDK {
   return {

--- a/static/app/data/platformPickerCategories.tsx
+++ b/static/app/data/platformPickerCategories.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import type {PlatformKey} from 'sentry/types/platform';
 
-const popularPlatformCategories = new Set<PlatformKey>([
+export const popularPlatformCategories = new Set<PlatformKey>([
   'javascript-nextjs',
   'javascript-react',
   'react-native',


### PR DESCRIPTION
## TLDR

The SCM create-project SDK dropdown is now split into two labeled sections: the curated Popular list first, in the same order as the legacy Popular tab, then every other platform ordered like the legacy picker's All tab.

## Details

A popularity-first flat sort reads as random without a visible boundary, so the split is made explicit with react-select option groups, which the core Select already styles (headings, section dividers) and the previous PR taught `ScmVirtualizedMenuList` to render. `platformOptionGroups` reuses `popularPlatformCategories` and `comparePlatformNames` rather than inventing a new ranking source, and each platform appears in exactly one section, so search and keyboard navigation see no duplicates. react-select drops a section while filtering once it has no matches. The stock headings sit flush with the row edge while options reserve a leading checkmark column, so the picker overrides the heading padding to line heading text up with the platform icons.

The manual picker previously carried a fallback that prepended the selected platform when its key was missing from the static options. That branch could never run: the options and the `getPlatformInfo` lookup derive from the same complete platforms list, so any resolvable key is already present. The picker now passes `platformOptionGroups` to the Select directly.

## Stack

- [PR 1](https://github.com/getsentry/sentry/pull/122102): fix(onboarding): Sort SCM platform picker alphabetically
- [PR 2](https://github.com/getsentry/sentry/pull/122103): feat(onboarding): Support grouped options in ScmVirtualizedMenuList
- **PR 3 (this):** feat(onboarding): Section the SCM platform picker into Popular and Other
