### PR TITLE
feat(seer): Make Autofix overview enrichment opt-in via expand

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -108,7 +108,9 @@ def _serialize_pull_request(
     }
 
 
-def _pull_requests_by_seer_run_id(seer_run_ids: list[int]) -> dict[int, list[PullRequestPayload]]:
+def _pull_requests_by_seer_run_id(
+    seer_run_ids: list[int], *, include_scm_info: bool
+) -> dict[int, list[PullRequestPayload]]:
     by_run: dict[int, list[PullRequestPayload]] = defaultdict(list)
     links = list(
         SeerRunPullRequest.objects.filter(seer_run_id__in=seer_run_ids)
@@ -148,11 +150,11 @@ def _pull_requests_by_seer_run_id(seer_run_ids: list[int]) -> dict[int, list[Pul
     status_by_pr_id: dict[int, PullRequestStatus | None] = {
         pr.id: get_stored_pull_request_status(pr) for pr in pull_requests
     }
-    # TODO: this hits the provider (GitHub GraphQL) on every page load. If latency
-    # bites, gate it behind an `expand=checksAndReview` param like the issues endpoint.
-    checks_and_review_by_pr_id = get_checks_and_review(
-        pull_requests, repos_by_id, status_by_pr_id, include_files=True
-    )
+    checks_and_review_by_pr_id: dict[int, PullRequestStatusResult] = {}
+    if include_scm_info:
+        checks_and_review_by_pr_id = get_checks_and_review(
+            pull_requests, repos_by_id, status_by_pr_id, include_files=True
+        )
 
     for link in links:
         pr = link.pull_request
@@ -238,6 +240,9 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         project_ids = [p.id for p in projects]
 
         start, end = get_date_range_from_stats_period(request.GET)
+        expand = request.GET.getlist("expand")
+        include_scm_info = "scmInfo" in expand
+        include_issue_stats = "issueStats" in expand
         latest_run_per_group = self._latest_run_per_group(organization, project_ids, start, end)
 
         # Classify into milestones and cap before the expensive serialize, so the
@@ -258,6 +263,9 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         )
 
         environments = self.get_environments(request, organization)
+        collapse = ["lifetime", "filtered", "unhandled"]
+        if not include_issue_stats:
+            collapse.append("stats")
         serialized_by_id = {
             sg["id"]: sg
             for sg in serialize(
@@ -268,7 +276,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                     start=start,
                     end=end,
                     expand=["owners"],
-                    collapse=["lifetime", "filtered", "unhandled"],
+                    collapse=collapse,
                     organization_id=organization.id,
                     project_ids=project_ids,
                 ),
@@ -277,7 +285,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         }
 
         pull_requests_by_seer_run_id = _pull_requests_by_seer_run_id(
-            [run.seer_run.id for _, run in capped]
+            [run.seer_run.id for _, run in capped], include_scm_info=include_scm_info
         )
 
         runs_by_milestone: dict[str, list[RunPayload]] = {milestone: [] for milestone in _PIPELINE}

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -27,7 +27,7 @@ class IssueProjectPayload(TypedDict):
 
 
 class IssuePayload(TypedDict):
-    count: int | None
+    count: str | None
     userCount: int | None
     lastSeen: str | None
     level: str | None

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -165,9 +165,6 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         assert issue["project"]["id"] == str(group.project_id)
         assert issue["project"]["slug"] == group.project.slug
         assert issue["priority"] == "high"
-        assert "count" in issue
-        assert "userCount" in issue
-        assert "lastSeen" in issue
         assert issue["assignedTo"] is None
         assert issue["owners"] == []
 
@@ -185,16 +182,6 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         assert issue["count"] is None
         assert issue["userCount"] is None
         assert issue["lastSeen"] is None
-
-    def test_issue_stats_absent_collapses_stats(self):
-        group = self.create_group()
-        self._run_for_group(group, "boom")
-        with mock.patch(
-            "sentry.seer.endpoints.organization_seer_autofix_overview.StreamGroupSerializerSnuba",
-            wraps=StreamGroupSerializerSnuba,
-        ) as serializer:
-            self.get_success_response(self.organization.slug)
-        assert "stats" in serializer.call_args.kwargs["collapse"]
 
     def test_issue_stats_expand_requests_snuba_stats(self):
         group = self.create_group()
@@ -235,12 +222,21 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
         return run_data["pullRequests"]
 
-    def test_run_includes_pull_requests(self):
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_run_includes_pull_requests(self, mock_get_integration):
         group = self.create_group()
         run = self._run_for_group(group, "boom")
         self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {"123": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)}
+            ),
+        )
         resp = self.get_success_response(self.organization.slug)
         run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
+        # Default (no expand=scmInfo) must not call the SCM provider.
+        assert client.requested_keys == []
         assert run_data["pullRequests"] == [
             {
                 "number": 123,
@@ -251,28 +247,6 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
                 "files": [],
             }
         ]
-
-    @mock.patch(_INTEGRATION_SERVICE)
-    def test_scm_info_absent_skips_provider_fetch(self, mock_get_integration):
-        group = self.create_group()
-        run = self._run_for_group(group, "boom")
-        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
-        client = self._set_provider_client(
-            mock_get_integration,
-            PullRequestStatusClientFake(
-                {"123": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)}
-            ),
-        )
-
-        pull_requests = self._pull_requests()
-
-        assert client.requested_keys == []
-        assert pull_requests[0]["number"] == 123
-        assert pull_requests[0]["status"] == "open"
-        assert pull_requests[0]["url"] == "https://github.com/getsentry/sentry/pull/123"
-        assert pull_requests[0]["checksStatus"] is None
-        assert pull_requests[0]["reviewStatus"] is None
-        assert pull_requests[0]["files"] == []
 
     @mock.patch(_INTEGRATION_SERVICE)
     def test_open_pull_request_includes_changed_files(self, mock_get_integration):

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from unittest import mock
 
+from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
 from sentry.constants import ObjectStatus
 from sentry.integrations.source_code_management.status_check import (
     AggregateChecksStatus,
@@ -170,6 +171,41 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         assert issue["assignedTo"] is None
         assert issue["owners"] == []
 
+    def test_issue_stats_absent_issues_no_snuba_query(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        with mock.patch(
+            "sentry.api.serializers.models.group."
+            "GroupSerializerSnuba._execute_error_seen_stats_query",
+            return_value={"data": []},
+        ) as execute:
+            resp = self.get_success_response(self.organization.slug)
+        assert execute.call_count == 0
+        issue = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]["issue"]
+        assert issue["count"] is None
+        assert issue["userCount"] is None
+        assert issue["lastSeen"] is None
+
+    def test_issue_stats_absent_collapses_stats(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        with mock.patch(
+            "sentry.seer.endpoints.organization_seer_autofix_overview.StreamGroupSerializerSnuba",
+            wraps=StreamGroupSerializerSnuba,
+        ) as serializer:
+            self.get_success_response(self.organization.slug)
+        assert "stats" in serializer.call_args.kwargs["collapse"]
+
+    def test_issue_stats_expand_requests_snuba_stats(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        with mock.patch(
+            "sentry.seer.endpoints.organization_seer_autofix_overview.StreamGroupSerializerSnuba",
+            wraps=StreamGroupSerializerSnuba,
+        ) as serializer:
+            self.get_success_response(self.organization.slug, qs_params={"expand": "issueStats"})
+        assert "stats" not in serializer.call_args.kwargs["collapse"]
+
     def _pull_request_for_run(self, group, run, *, key="123", **updates):
         repo = self.create_repo(
             project=group.project,
@@ -193,8 +229,9 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         mock_get_integration.return_value = integration
         return client
 
-    def _pull_requests(self):
-        resp = self.get_success_response(self.organization.slug)
+    def _pull_requests(self, *, expand=None):
+        kwargs = {"qs_params": {"expand": expand}} if expand is not None else {}
+        resp = self.get_success_response(self.organization.slug, **kwargs)
         run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
         return run_data["pullRequests"]
 
@@ -214,6 +251,28 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
                 "files": [],
             }
         ]
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_scm_info_absent_skips_provider_fetch(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {"123": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)}
+            ),
+        )
+
+        pull_requests = self._pull_requests()
+
+        assert client.requested_keys == []
+        assert pull_requests[0]["number"] == 123
+        assert pull_requests[0]["status"] == "open"
+        assert pull_requests[0]["url"] == "https://github.com/getsentry/sentry/pull/123"
+        assert pull_requests[0]["checksStatus"] is None
+        assert pull_requests[0]["reviewStatus"] is None
+        assert pull_requests[0]["files"] == []
 
     @mock.patch(_INTEGRATION_SERVICE)
     def test_open_pull_request_includes_changed_files(self, mock_get_integration):
@@ -244,7 +303,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
             ),
         )
 
-        pull_requests = self._pull_requests()
+        pull_requests = self._pull_requests(expand="scmInfo")
 
         assert pull_requests[0]["files"] == [
             {
@@ -274,7 +333,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
             ),
         )
 
-        pull_requests = self._pull_requests()
+        pull_requests = self._pull_requests(expand="scmInfo")
 
         assert pull_requests[0]["checksStatus"] == "success"
         assert pull_requests[0]["reviewStatus"] == "approved"
@@ -289,7 +348,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         )
         client = self._set_provider_client(mock_get_integration, PullRequestStatusClientFake())
 
-        pull_requests = self._pull_requests()
+        pull_requests = self._pull_requests(expand="scmInfo")
 
         assert pull_requests[0]["status"] == "merged"
         assert pull_requests[0]["checksStatus"] is None
@@ -305,7 +364,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
             mock_get_integration, PullRequestStatusClientFake(error=RuntimeError("nope"))
         )
 
-        pull_requests = self._pull_requests()
+        pull_requests = self._pull_requests(expand="scmInfo")
 
         assert pull_requests[0]["number"] == 123
         assert pull_requests[0]["status"] == "open"
@@ -360,7 +419,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
             ),
         )
 
-        pull_requests = self._pull_requests()
+        pull_requests = self._pull_requests(expand="scmInfo")
 
         assert client.requested_keys == ["123"]
         assert [pr["number"] for pr in pull_requests] == [123]
@@ -390,7 +449,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
             ),
         )
 
-        pull_requests = self._pull_requests()
+        pull_requests = self._pull_requests(expand="scmInfo")
 
         # A disconnected repo is skipped: no provider call, no url, null enrichment.
         assert client.requested_keys == []
@@ -426,3 +485,23 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         resp = self.get_success_response(self.organization.slug)
 
         assert len(resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]) == 2
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_both_expands_enrich_pull_request_and_request_stats(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {"123": PullRequestStatusResult(checks=AggregateChecksStatus.SUCCESS)}
+            ),
+        )
+        with mock.patch(
+            "sentry.seer.endpoints.organization_seer_autofix_overview.StreamGroupSerializerSnuba",
+            wraps=StreamGroupSerializerSnuba,
+        ) as serializer:
+            pull_requests = self._pull_requests(expand=["scmInfo", "issueStats"])
+        assert client.requested_keys == ["123"]
+        assert pull_requests[0]["checksStatus"] == "success"
+        assert "stats" not in serializer.call_args.kwargs["collapse"]


### PR DESCRIPTION
The Autofix overview endpoint's default response now touches only Postgres. The two expensive enrichments are opt-in via repeatable `expand` query params: `expand=scmInfo` adds pull-request `checksStatus`/`reviewStatus`/`files[]` (GitHub GraphQL), and `expand=issueStats` adds issue `count`/`userCount`/`lastSeen` (Snuba). Without a token, those fields are still present but default to `null`/`[]`, so the response shape never changes.

This lets the overview page paint instantly from cheap Postgres data and fill in the richer SCM and issue-stats fields progressively (the frontend two-request load is companion work). `issueStats` is gated by adding `"stats"` to the existing `StreamGroupSerializerSnuba` collapse set — this keeps every Postgres field (priority, owners, assignee, level) while short-circuiting only the Snuba seen-stats query; `scmInfo` gates the batched `get_checks_and_review` call, mirroring the existing `group_pull_requests` endpoint.

Basic pull-request fields (number, url, merge status) stay in the default because they are pure Postgres. Pull-request file `changeType` is passed through as GitHub's raw value; the frontend owns how it's rendered.

Follow-up from review: corrects the `IssuePayload.count` annotation to `str | None`, matching the string the serializer actually emits (`str(times_seen)`).

Worth a look: the collapse-based Snuba gating in `get()`, and the `include_scm_info` threading through `_pull_requests_by_seer_run_id`.