### PR TITLE
feat(investigations): add breached metric entrypoints

### DIFF
--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -1,4 +1,5 @@
 import {
+  queryOptions,
   useMutation,
   useQueryClient,
   type UseMutationOptions,
@@ -7,8 +8,10 @@ import {
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {
+  InvestigationCandidate,
   InvestigationDetail,
   InvestigationListItem,
+  MetricOpenPeriodInvestigationSource,
 } from 'sentry/views/investigations/types';
 
 type ListOptions = {
@@ -46,6 +49,29 @@ export function investigationDetailQueryOptions(
       staleTime: 30_000,
     }
   );
+}
+
+export function investigationCandidatesQueryOptions({
+  organizationSlug,
+  sources,
+}: {
+  organizationSlug: string;
+  sources: MetricOpenPeriodInvestigationSource[];
+}) {
+  return queryOptions({
+    queryKey: ['investigation-candidates', organizationSlug, sources] as const,
+    queryFn: () =>
+      fetchMutation<{items: InvestigationCandidate[]}>({
+        url: `/organizations/${organizationSlug}/investigations/candidates/`,
+        method: 'POST',
+        data: {
+          templateKey: 'breached_metric',
+          templateVersion: 1,
+          sources,
+        },
+      }),
+    staleTime: 30_000,
+  });
 }
 
 type FavoriteVariables = {
@@ -88,6 +114,26 @@ export function useCreateInvestigationMutation(
         url: `/organizations/${organizationSlug}/investigations/`,
         method: 'POST',
         data: {title: 'Untitled investigation'},
+      }),
+    options
+  );
+}
+
+export function useLaunchInvestigationMutation(
+  organizationSlug: string,
+  options?: MutationOptions<InvestigationDetail, MetricOpenPeriodInvestigationSource>
+) {
+  return useInvestigationMutation(
+    organizationSlug,
+    source =>
+      fetchMutation<InvestigationDetail>({
+        url: `/organizations/${organizationSlug}/investigations/`,
+        method: 'POST',
+        data: {
+          templateKey: 'breached_metric',
+          templateVersion: 1,
+          source,
+        },
       }),
     options
   );

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -1,5 +1,4 @@
 import {
-  queryOptions,
   useMutation,
   useQueryClient,
   type UseMutationOptions,
@@ -58,20 +57,19 @@ export function investigationCandidatesQueryOptions({
   organizationSlug: string;
   sources: MetricOpenPeriodInvestigationSource[];
 }) {
-  return queryOptions({
-    queryKey: ['investigation-candidates', organizationSlug, sources] as const,
-    queryFn: () =>
-      fetchMutation<{items: InvestigationCandidate[]}>({
-        url: `/organizations/${organizationSlug}/investigations/candidates/`,
-        method: 'POST',
-        data: {
-          templateKey: 'breached_metric',
-          templateVersion: 1,
-          sources,
-        },
-      }),
-    staleTime: 30_000,
-  });
+  return apiOptions.as<{items: InvestigationCandidate[]}>()(
+    '/organizations/$organizationIdOrSlug/investigations/candidates/',
+    {
+      path: {organizationIdOrSlug: organizationSlug},
+      method: 'POST',
+      data: {
+        templateKey: 'breached_metric',
+        templateVersion: 1,
+        sources,
+      },
+      staleTime: 30_000,
+    }
+  );
 }
 
 type FavoriteVariables = {

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -14,3 +14,16 @@ export type InvestigationListItem = {
 // Expand this response type as the detail UI begins consuming additional fields.
 // The complete server response is retained at runtime in the query cache.
 export type InvestigationDetail = InvestigationListItem;
+
+export type MetricOpenPeriodInvestigationSource = {
+  ref: {
+    groupId: string;
+    openPeriodId: string;
+  };
+  type: 'metric_open_period';
+};
+
+export type InvestigationCandidate =
+  | {status: 'investigate'}
+  | {status: 'unavailable'}
+  | {investigationId: string; status: 'view'};

--- a/static/app/views/issueDetails/foldSection.spec.tsx
+++ b/static/app/views/issueDetails/foldSection.spec.tsx
@@ -58,6 +58,27 @@ describe('FoldSection', () => {
       );
 
       expect(screen.getByText('Custom Title')).toBeVisible();
+      expect(screen.getByRole('button')).toHaveAccessibleName('Collapse Section');
+    });
+
+    it('uses titleLabel for a custom JSX title', () => {
+      render(
+        <FoldSection
+          title={<span>Custom Title</span>}
+          titleLabel="Accessible Title"
+          sectionKey={SectionKey.HIGHLIGHTS}
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.getByRole('region')).toHaveAccessibleName('Accessible Title');
+      expect(screen.getByRole('button')).toHaveAccessibleName(
+        'Collapse Accessible Title Section'
+      );
     });
 
     it('applies accessibility attributes to container', () => {

--- a/static/app/views/issueDetails/foldSection.spec.tsx
+++ b/static/app/views/issueDetails/foldSection.spec.tsx
@@ -61,6 +61,22 @@ describe('FoldSection', () => {
       expect(screen.getByRole('button')).toHaveAccessibleName('Collapse Section');
     });
 
+    it('does not wrap a custom block title in inline typography', () => {
+      render(
+        <FoldSection
+          title={<div>Custom Block Title</div>}
+          sectionKey={SectionKey.HIGHLIGHTS}
+        >
+          <div>Test Content</div>
+        </FoldSection>,
+        {
+          organization: OrganizationFixture(),
+        }
+      );
+
+      expect(screen.getByText('Custom Block Title')).toBeVisible();
+    });
+
     it('uses titleLabel for a custom JSX title', () => {
       render(
         <FoldSection

--- a/static/app/views/issueDetails/foldSection.tsx
+++ b/static/app/views/issueDetails/foldSection.tsx
@@ -215,7 +215,11 @@ export function FoldSection({
             ) : undefined
           }
         >
-          <Text size="lg">{title}</Text>
+          {typeof title === 'string' ? (
+            <Text size="lg">{title}</Text>
+          ) : (
+            (title ?? undefined)
+          )}
         </Disclosure.Title>
         <Disclosure.Content>
           <ErrorBoundary mini>{expanded ? children : null}</ErrorBoundary>

--- a/static/app/views/issueDetails/foldSection.tsx
+++ b/static/app/views/issueDetails/foldSection.tsx
@@ -57,6 +57,8 @@ interface FoldSectionProps {
    */
   preventCollapse?: boolean;
   ref?: React.Ref<HTMLDivElement>;
+  /** Accessible label used when the visible title is not a string. */
+  titleLabel?: string;
   /**
    * Interactive content displayed beside the title whether the section is open or closed.
    */
@@ -118,6 +120,7 @@ export function FoldSection({
   ref,
   children,
   title,
+  titleLabel,
   actions,
   titleTrailingItems,
   sectionKey,
@@ -181,8 +184,9 @@ export function FoldSection({
     setIsCollapsed(!isCollapsed);
   }, [organization, sectionKey, setIsCollapsed, preventCollapse, isCollapsed]);
 
+  const accessibleTitle = titleLabel ?? (typeof title === 'string' ? title : sectionKey);
   const labelPrefix = expanded ? t('Collapse') : t('View');
-  const labelSuffix = typeof title === 'string' ? title + t(' Section') : t('Section');
+  const labelSuffix = accessibleTitle + t(' Section');
 
   return (
     <Fragment>
@@ -193,8 +197,7 @@ export function FoldSection({
         ref={mergeRefs(ref, scrollToSection)}
         id={sectionKey + additionalIdentifier}
         className={className}
-        // XXX: We should eventually only use titles as string, or explicitly pass them to stay accessible
-        aria-label={typeof title === 'string' ? title : sectionKey}
+        aria-label={accessibleTitle}
         data-test-id={dataTestId ?? sectionKey + additionalIdentifier}
         scrollMargin={navScrollMargin ?? 0}
         expanded={expanded}

--- a/static/app/views/issueDetails/foldSection.tsx
+++ b/static/app/views/issueDetails/foldSection.tsx
@@ -185,8 +185,9 @@ export function FoldSection({
   }, [organization, sectionKey, setIsCollapsed, preventCollapse, isCollapsed]);
 
   const accessibleTitle = titleLabel ?? (typeof title === 'string' ? title : sectionKey);
+  const labelTitle = titleLabel ?? (typeof title === 'string' ? title : null);
   const labelPrefix = expanded ? t('Collapse') : t('View');
-  const labelSuffix = accessibleTitle + t(' Section');
+  const labelSuffix = labelTitle ? t('%s Section', labelTitle) : t('Section');
 
   return (
     <Fragment>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -80,7 +80,10 @@ import {
   MetricKitHangProfileSection,
 } from 'sentry/views/issueDetails/metricKitHangProfileSection';
 import {ProfilePreviewSection} from 'sentry/views/issueDetails/profilePreviewSection';
-import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/sidebar/metricDetectorTriggeredSection';
+import {
+  MetricDetectorTriggeredSection,
+  MetricIssueSeerInvestigationSection,
+} from 'sentry/views/issueDetails/sidebar/metricDetectorTriggeredSection';
 import {SizeAnalysisTriggeredSection} from 'sentry/views/issueDetails/sidebar/sizeAnalysisTriggeredSection';
 import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
@@ -166,6 +169,11 @@ export function EventDetailsContent({
       <EventEvidence event={event} group={group} project={project} />
       {group.issueType === IssueType.UPTIME_DOMAIN_FAILURE && (
         <UptimeAssertionsSection event={event} />
+      )}
+      {group.issueType === IssueType.METRIC_ISSUE && (
+        <Feature features="organizations:investigations">
+          <MetricIssueSeerInvestigationSection group={group} event={event} />
+        </Feature>
       )}
       {defined(eventEntries[EntryType.MESSAGE]) && (
         <EntryErrorBoundary type={EntryType.MESSAGE}>

--- a/static/app/views/issueDetails/groupOpenPeriods.spec.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.spec.tsx
@@ -65,6 +65,7 @@ describe('GroupOpenPeriods', () => {
     for (const column of ['Open Period', 'Event ID', 'Description', 'Start', 'End']) {
       expect(screen.getByText(column)).toBeInTheDocument();
     }
+    expect(screen.queryByText('Investigation')).not.toBeInTheDocument();
 
     const rows = await screen.findAllByTestId('grid-body-row');
 
@@ -75,7 +76,9 @@ describe('GroupOpenPeriods', () => {
     expect(within(statusRow).getByText('Priority updated to high')).toBeInTheDocument();
     expect(within(statusRow).queryByText('#open-period-1')).not.toBeInTheDocument();
     expect(
-      within(statusRow).getByRole('link', {name: getShortEventId(statusChangeEventId)})
+      within(statusRow).getByRole('link', {
+        name: getShortEventId(statusChangeEventId),
+      })
     ).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/issues/${groupId}/events/${statusChangeEventId}/`
@@ -84,7 +87,9 @@ describe('GroupOpenPeriods', () => {
     expect(within(openedRow).getByText('#open-period-1')).toBeInTheDocument();
     expect(within(openedRow).getByText('Issue regressed')).toBeInTheDocument();
     expect(
-      within(openedRow).getByRole('link', {name: getShortEventId(openedEventId)})
+      within(openedRow).getByRole('link', {
+        name: getShortEventId(openedEventId),
+      })
     ).toHaveAttribute(
       'href',
       `/organizations/${organization.slug}/issues/${groupId}/events/${openedEventId}/`
@@ -92,5 +97,59 @@ describe('GroupOpenPeriods', () => {
 
     expect(screen.queryByText('Resolved')).not.toBeInTheDocument();
     expect(screen.getByText('Showing 1-1 matching open periods')).toBeInTheDocument();
+  });
+
+  it('links investigations for open periods when Investigations is enabled', async () => {
+    const featureOrganization = OrganizationFixture({
+      slug: organization.slug,
+      features: ['investigations'],
+    });
+    const openPeriod = GroupOpenPeriodFixture({
+      id: 'open-period-1',
+      activities: [
+        GroupOpenPeriodActivityFixture({
+          id: 'activity-1',
+          type: 'opened',
+          dateCreated: '2024-01-01T00:00:00Z',
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/open-periods/`,
+      body: [openPeriod],
+      match: [MockApiClient.matchQuery({groupId, per_page: 10})],
+    });
+    const candidatesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/investigations/candidates/`,
+      method: 'POST',
+      body: {items: [{status: 'view', investigationId: '4567'}]},
+    });
+
+    render(<GroupOpenPeriods />, {
+      organization: featureOrganization,
+      initialRouterConfig,
+    });
+
+    expect(await screen.findByText('Investigation')).toBeInTheDocument();
+    expect(await screen.findByRole('link', {name: '4567'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/seer/investigation/4567/`
+    );
+    expect(candidatesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          templateKey: 'breached_metric',
+          templateVersion: 1,
+          sources: [
+            {
+              type: 'metric_open_period',
+              ref: {groupId, openPeriodId: 'open-period-1'},
+            },
+          ],
+        },
+      })
+    );
   });
 });

--- a/static/app/views/issueDetails/groupOpenPeriods.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.tsx
@@ -3,12 +3,15 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import orderBy from 'lodash/orderBy';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import {DateTime} from 'sentry/components/dateTime';
 import {
   COL_WIDTH_UNDEFINED,
   GridEditable,
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
+import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {GroupOpenPeriodActivity} from 'sentry/types/group';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
@@ -19,12 +22,16 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {openPeriodsApiOptions} from 'sentry/views/detectors/hooks/useOpenPeriods';
+import {investigationCandidatesQueryOptions} from 'sentry/views/investigations/api';
+import type {MetricOpenPeriodInvestigationSource} from 'sentry/views/investigations/types';
 import {EventListTable} from 'sentry/views/issueDetails/eventListTable';
 
 interface OpenPeriodDisplayData {
   description: string;
   end: React.ReactNode;
   eventId: React.ReactNode;
+  investigation: React.ReactNode;
+  openPeriod: React.ReactNode;
   start: React.ReactNode;
 }
 
@@ -61,8 +68,23 @@ function IssueOpenPeriodsList() {
     select: selectJsonWithHeaders,
   });
   const openPeriods = response?.json ?? [];
+  const investigationsEnabled = organization.features.includes('investigations');
+  const candidateSources: MetricOpenPeriodInvestigationSource[] = openPeriods.map(
+    period => ({
+      type: 'metric_open_period',
+      ref: {groupId: params.groupId, openPeriodId: period.id},
+    })
+  );
+  const {data: candidates} = useQuery({
+    ...investigationCandidatesQueryOptions({
+      organizationSlug: organization.slug,
+      sources: candidateSources,
+    }),
+    enabled: investigationsEnabled && candidateSources.length > 0,
+  });
 
-  const data = openPeriods.flatMap(period => {
+  const data = openPeriods.flatMap((period, periodIndex) => {
+    const candidate = candidates?.items[periodIndex];
     const periodActivities = orderBy(
       period.activities.filter(activity => activity.type !== 'closed'),
       'dateCreated',
@@ -88,9 +110,37 @@ function IssueOpenPeriodsList() {
         description: getOpenPeriodActivityTypeLabel(activity),
         start: <DateTime date={startDate} />,
         end: endDate ? <DateTime date={endDate} /> : undefined,
+        investigation:
+          activity.type === 'opened' && candidate?.status === 'view' ? (
+            <Link
+              to={`/organizations/${organization.slug}/seer/investigation/${candidate.investigationId}/`}
+            >
+              <Flex as="span" align="center" gap="xs">
+                <IconSeer size="xs" />
+                {candidate.investigationId}
+              </Flex>
+            </Link>
+          ) : undefined,
       };
     });
   });
+
+  const columnOrder: Array<GridColumnOrder<string>> = [
+    {key: 'openPeriod', width: COL_WIDTH_UNDEFINED, name: t('Open Period')},
+    {key: 'eventId', width: 100, name: t('Event ID')},
+    {key: 'description', width: COL_WIDTH_UNDEFINED, name: t('Description')},
+    {key: 'start', width: COL_WIDTH_UNDEFINED, name: t('Start')},
+    {key: 'end', width: COL_WIDTH_UNDEFINED, name: t('End')},
+    ...(investigationsEnabled
+      ? [
+          {
+            key: 'investigation',
+            width: COL_WIDTH_UNDEFINED,
+            name: t('Investigation'),
+          },
+        ]
+      : []),
+  ];
 
   const renderHeadCell = (col: GridColumnOrder) => {
     return <AlignLeft>{col.name}</AlignLeft>;
@@ -128,13 +178,7 @@ function IssueOpenPeriodsList() {
         isLoading={isPending}
         data={data}
         error={error}
-        columnOrder={[
-          {key: 'openPeriod', width: COL_WIDTH_UNDEFINED, name: t('Open Period')},
-          {key: 'eventId', width: 100, name: t('Event ID')},
-          {key: 'description', width: COL_WIDTH_UNDEFINED, name: t('Description')},
-          {key: 'start', width: COL_WIDTH_UNDEFINED, name: t('Start')},
-          {key: 'end', width: COL_WIDTH_UNDEFINED, name: t('End')},
-        ]}
+        columnOrder={columnOrder}
         columnSortBy={[]}
         grid={{
           renderHeadCell,

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -2,8 +2,9 @@ import type {ComponentProps} from 'react';
 import {SnubaQueryDataSourceFixture} from 'sentry-fixture/detectors';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import {
@@ -12,7 +13,10 @@ import {
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
-import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/sidebar/metricDetectorTriggeredSection';
+import {
+  MetricDetectorTriggeredSection,
+  MetricIssueSeerInvestigationSection,
+} from 'sentry/views/issueDetails/sidebar/metricDetectorTriggeredSection';
 
 describe('MetricDetectorTriggeredSection', () => {
   const condition: MetricCondition = {
@@ -86,6 +90,116 @@ describe('MetricDetectorTriggeredSection', () => {
     });
   });
 
+  it('links to an existing investigation for the selected open period', async () => {
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'view', investigationId: '4567'}]},
+    });
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
+      organization,
+    });
+
+    await screen.findByRole('region', {
+      name: 'Seer Investigation',
+    });
+    expect(await screen.findByText('Different investigation title')).toBeInTheDocument();
+    expect(screen.getByText('Different investigation summary text')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: 'View Investigation'})
+    ).toHaveAttribute('href', '/organizations/org-slug/seer/investigation/4567/');
+  });
+
+  it('launches an investigation for the selected open period', async () => {
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'investigate'}]},
+    });
+    const launchMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/',
+      method: 'POST',
+      body: {id: '4567'},
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
+      organization,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Launch Investigation'})
+    );
+
+    await waitFor(() => {
+      expect(launchMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            templateKey: 'breached_metric',
+            templateVersion: 1,
+            source: {
+              type: 'metric_open_period',
+              ref: {groupId: defaultGroup.id, openPeriodId: '101'},
+            },
+          },
+        })
+      );
+    });
+  });
+
+  it('uses the latest open period when the displayed event is not linked to one', async () => {
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    const event = {...defaultEvent, id: 'unlinked-event', eventID: 'unlinked-event'};
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({
+          groupId: defaultGroup.id,
+          eventId: 'unlinked-event',
+          per_page: 1,
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [
+        {
+          id: 'latest-period',
+          start: openPeriodStartDate,
+          end: openPeriodEndDate,
+          isOpen: false,
+          activities: [],
+        },
+      ],
+      match: [MockApiClient.matchQuery({groupId: defaultGroup.id})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'investigate'}]},
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} event={event} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Launch Investigation'})
+    ).toBeInTheDocument();
+  });
+
   it('renders nothing when event has no occurrence', () => {
     const event = EventFixture({
       occurrence: null,
@@ -95,6 +209,27 @@ describe('MetricDetectorTriggeredSection', () => {
       <MetricDetectorTriggeredSection {...defaultProps} event={event} />
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the investigation entrypoint when a metric event has no occurrence', async () => {
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    const event = EventFixture({occurrence: null});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'investigate'}]},
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} event={event} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByRole('region', {name: 'Seer Investigation'})
+    ).toBeInTheDocument();
   });
 
   it('renders only message when conditions are missing but subtitle exists', () => {

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -183,7 +183,7 @@ describe('MetricDetectorTriggeredSection', () => {
           activities: [],
         },
       ],
-      match: [MockApiClient.matchQuery({groupId: defaultGroup.id})],
+      match: [MockApiClient.matchQuery({groupId: defaultGroup.id, per_page: 1})],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/investigations/candidates/',
@@ -198,6 +198,39 @@ describe('MetricDetectorTriggeredSection', () => {
     expect(
       await screen.findByRole('button', {name: 'Launch Investigation'})
     ).toBeInTheDocument();
+  });
+
+  it('does not fall back to an unrelated open period when the event lookup fails', async () => {
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    const event = {...defaultEvent, id: 'failed-event', eventID: 'failed-event'};
+    const latestPeriodMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      body: [],
+      match: [MockApiClient.matchQuery({groupId: defaultGroup.id, per_page: 1})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/open-periods/',
+      statusCode: 500,
+      match: [
+        MockApiClient.matchQuery({
+          groupId: defaultGroup.id,
+          eventId: 'failed-event',
+          per_page: 1,
+        }),
+      ],
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} event={event} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText('Unable to load investigation information.')
+    ).toBeInTheDocument();
+    expect(latestPeriodMock).not.toHaveBeenCalled();
   });
 
   it('renders nothing when event has no occurrence', () => {

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -562,11 +562,7 @@ const GroupListWrapper = styled('div')`
 `;
 
 const InvestigationSummaryCard = styled(Stack)`
-  position: relative;
-  overflow: hidden;
   padding: 14px 16px;
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: 8px;
   box-shadow: ${p => p.theme.shadow.low};
 
   &::before {
@@ -588,19 +584,19 @@ function SeerInvestigationSection({
   const organization = useOrganization();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const {data: eventOpenPeriod, isPending: isEventOpenPeriodPending} = useEventOpenPeriod(
-    {
-      groupId,
-      eventId,
-    }
+  const eventOpenPeriodQuery = useEventOpenPeriod({groupId, eventId});
+  const shouldLoadLatest =
+    eventOpenPeriodQuery.isSuccess && eventOpenPeriodQuery.data === null;
+  const groupOpenPeriodsQuery = useOpenPeriods(
+    {groupId, limit: 1},
+    {enabled: shouldLoadLatest}
   );
-  const {data: groupOpenPeriods, isPending: isGroupOpenPeriodsPending} = useOpenPeriods(
-    {groupId},
-    {enabled: !isEventOpenPeriodPending && !eventOpenPeriod}
-  );
-  const openPeriod = eventOpenPeriod ?? groupOpenPeriods?.[0] ?? null;
+  const openPeriod = eventOpenPeriodQuery.data ?? groupOpenPeriodsQuery.data?.[0] ?? null;
   const isOpenPeriodPending =
-    isEventOpenPeriodPending || (!eventOpenPeriod && isGroupOpenPeriodsPending);
+    eventOpenPeriodQuery.isPending ||
+    (shouldLoadLatest && groupOpenPeriodsQuery.isPending);
+  const isOpenPeriodError =
+    eventOpenPeriodQuery.isError || (shouldLoadLatest && groupOpenPeriodsQuery.isError);
   const source = useMemo<MetricOpenPeriodInvestigationSource | null>(
     () =>
       openPeriod
@@ -615,15 +611,20 @@ function SeerInvestigationSection({
     organizationSlug: organization.slug,
     sources: source ? [source] : [],
   });
-  const {data, isPending: isCandidatePending} = useQuery({
+  const {
+    data: candidate,
+    isPending: isCandidatePending,
+    isError: isCandidateError,
+  } = useQuery({
     ...candidateOptions,
     enabled: source !== null,
+    select: response => response.json.items[0],
   });
-  const candidate = data?.items[0];
   const launchMutation = useLaunchInvestigationMutation(organization.slug, {
     onSuccess: launchedInvestigation => {
       queryClient.setQueryData(candidateOptions.queryKey, {
-        items: [{status: 'view', investigationId: launchedInvestigation.id}],
+        json: {items: [{status: 'view', investigationId: launchedInvestigation.id}]},
+        headers: {},
       });
       queryClient.setQueryData(
         investigationDetailQueryOptions(organization.slug, launchedInvestigation.id)
@@ -659,9 +660,21 @@ function SeerInvestigationSection({
     >
       {isOpenPeriodPending || (source !== null && isCandidatePending) ? (
         <Placeholder height="40px" width="160px" />
+      ) : isOpenPeriodError || isCandidateError ? (
+        <Alert.Container>
+          <Alert variant="danger" showIcon>
+            {t('Unable to load investigation information.')}
+          </Alert>
+        </Alert.Container>
       ) : (
         <Stack gap="md">
-          <InvestigationSummaryCard gap="xs">
+          <InvestigationSummaryCard
+            position="relative"
+            overflow="hidden"
+            border="primary"
+            radius="md"
+            gap="xs"
+          >
             <Text size="lg" bold>
               {t('Different investigation title')}
             </Text>

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -1,12 +1,14 @@
 import {Fragment, useEffect, useEffectEvent, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import type {LocationDescriptor} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
-import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import Feature from 'sentry/components/acl/feature';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
@@ -18,6 +20,7 @@ import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
 import {treeResultLocator} from 'sentry/components/searchSyntax/utils';
+import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event, EventOccurrence} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
@@ -44,10 +47,19 @@ import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/de
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
-import {useEventOpenPeriod} from 'sentry/views/detectors/hooks/useOpenPeriods';
+import {
+  useEventOpenPeriod,
+  useOpenPeriods,
+} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {getDiscoverDeprecation} from 'sentry/views/discover/utils';
+import {
+  investigationCandidatesQueryOptions,
+  investigationDetailQueryOptions,
+  useLaunchInvestigationMutation,
+} from 'sentry/views/investigations/api';
+import type {MetricOpenPeriodInvestigationSource} from 'sentry/views/investigations/types';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
 
 import {AttributeComparisonSection} from './attributeComparisonSection';
@@ -549,11 +561,148 @@ const GroupListWrapper = styled('div')`
   margin-top: ${p => p.theme.space.md};
 `;
 
+const InvestigationSummaryCard = styled(Stack)`
+  position: relative;
+  overflow: hidden;
+  padding: 14px 16px;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: 8px;
+  box-shadow: ${p => p.theme.shadow.low};
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 4px;
+    background: ${p => p.theme.tokens.background.accent.vibrant};
+  }
+`;
+
+function SeerInvestigationSection({
+  eventId,
+  groupId,
+}: {
+  eventId: string;
+  groupId: string;
+}) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const {data: eventOpenPeriod, isPending: isEventOpenPeriodPending} = useEventOpenPeriod(
+    {
+      groupId,
+      eventId,
+    }
+  );
+  const {data: groupOpenPeriods, isPending: isGroupOpenPeriodsPending} = useOpenPeriods(
+    {groupId},
+    {enabled: !isEventOpenPeriodPending && !eventOpenPeriod}
+  );
+  const openPeriod = eventOpenPeriod ?? groupOpenPeriods?.[0] ?? null;
+  const isOpenPeriodPending =
+    isEventOpenPeriodPending || (!eventOpenPeriod && isGroupOpenPeriodsPending);
+  const source = useMemo<MetricOpenPeriodInvestigationSource | null>(
+    () =>
+      openPeriod
+        ? {
+            type: 'metric_open_period',
+            ref: {groupId, openPeriodId: openPeriod.id},
+          }
+        : null,
+    [groupId, openPeriod]
+  );
+  const candidateOptions = investigationCandidatesQueryOptions({
+    organizationSlug: organization.slug,
+    sources: source ? [source] : [],
+  });
+  const {data, isPending: isCandidatePending} = useQuery({
+    ...candidateOptions,
+    enabled: source !== null,
+  });
+  const candidate = data?.items[0];
+  const launchMutation = useLaunchInvestigationMutation(organization.slug, {
+    onSuccess: launchedInvestigation => {
+      queryClient.setQueryData(candidateOptions.queryKey, {
+        items: [{status: 'view', investigationId: launchedInvestigation.id}],
+      });
+      queryClient.setQueryData(
+        investigationDetailQueryOptions(organization.slug, launchedInvestigation.id)
+          .queryKey,
+        {json: launchedInvestigation, headers: {}}
+      );
+      navigate(
+        normalizeUrl(
+          `/organizations/${organization.slug}/seer/investigation/${launchedInvestigation.id}/`
+        )
+      );
+    },
+    onError: () => addErrorMessage(t('Unable to launch investigation.')),
+  });
+
+  const investigationPath =
+    candidate?.status === 'view'
+      ? normalizeUrl(
+          `/organizations/${organization.slug}/seer/investigation/${candidate.investigationId}/`
+        )
+      : null;
+
+  return (
+    <FoldSection
+      title={
+        <Flex align="center" gap="xs">
+          <IconSeer aria-hidden size="sm" />
+          {t('Seer Investigation')}
+        </Flex>
+      }
+      titleLabel={t('Seer Investigation')}
+      sectionKey="seer_investigation"
+    >
+      {isOpenPeriodPending || (source !== null && isCandidatePending) ? (
+        <Placeholder height="40px" width="160px" />
+      ) : (
+        <Stack gap="md">
+          <InvestigationSummaryCard gap="xs">
+            <Text size="lg" bold>
+              {t('Different investigation title')}
+            </Text>
+            <Text size="md">{t('Different investigation summary text')}</Text>
+          </InvestigationSummaryCard>
+          <Flex>
+            {investigationPath ? (
+              <LinkButton size="md" variant="primary" to={investigationPath}>
+                {t('View Investigation')}
+              </LinkButton>
+            ) : (
+              <Button
+                size="md"
+                variant="primary"
+                busy={launchMutation.isPending}
+                disabled={!source || candidate?.status === 'unavailable'}
+                onClick={() => source && launchMutation.mutate(source)}
+              >
+                {t('Launch Investigation')}
+              </Button>
+            )}
+          </Flex>
+        </Stack>
+      )}
+    </FoldSection>
+  );
+}
+
+export function MetricIssueSeerInvestigationSection({
+  group,
+  event,
+}: MetricDetectorTriggeredSectionProps) {
+  return <SeerInvestigationSection eventId={event.eventID} groupId={group.id} />;
+}
+
 export function MetricDetectorTriggeredSection({
   group,
   event,
 }: MetricDetectorTriggeredSectionProps) {
   const evidenceData = event.occurrence?.evidenceData;
+
   if (!isMetricDetectorEvidenceData(evidenceData)) {
     return null;
   }

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -652,7 +652,7 @@ function SeerInvestigationSection({
       title={
         <Flex align="center" gap="xs">
           <IconSeer aria-hidden size="sm" />
-          {t('Seer Investigation')}
+          <Text size="lg">{t('Seer Investigation')}</Text>
         </Flex>
       }
       titleLabel={t('Seer Investigation')}


### PR DESCRIPTION
## Summary

- add a feature-gated Seer Investigation section above Message on breached metric issue details
- launch or view the investigation associated with the selected metric open period
- show linked investigations in the Open Periods table

Stacked on #122112.

## Follow-up required before rollout

The investigation card currently contains filler title and summary text because those fields are not available yet. We must replace that filler with the real investigation title and summary in a follow-up PR before shipping or enabling this experience for users.

## Tests

- `node_modules/.bin/jest static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx static/app/views/issueDetails/groupOpenPeriods.spec.tsx --runInBand`
- ESLint
- TypeScript
- pre-commit hooks
- pre-push hooks