### PR TITLE
feat(seer): Add selectable sort to autofix overview endpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -64,9 +64,9 @@ _PIPELINE: tuple[str, ...] = (
 
 _MAX_RUNS_PER_MILESTONE = 100
 
-_DEFAULT_SORT = "seer"
+# The three issue-based sort params, mapped to their search-backend names.
+# Any other value (seer default, empty, unknown) keeps the default order.
 _ISSUE_SORT_TO_SEARCH = {"issue": "date", "events": "freq", "users": "user"}
-_VALID_SORTS = frozenset({_DEFAULT_SORT, *_ISSUE_SORT_TO_SEARCH})
 
 
 @dataclass
@@ -254,9 +254,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         include_issue_stats = "issueStats" in expand
         environments = self.get_environments(request, organization)
 
-        sort = request.GET.get("sort") or _DEFAULT_SORT
-        if sort not in _VALID_SORTS:
-            sort = _DEFAULT_SORT
+        sort = request.GET.get("sort")
 
         latest_run_per_group = self._latest_run_per_group(organization, project_ids, start, end)
         if sort in _ISSUE_SORT_TO_SEARCH:
@@ -378,7 +376,6 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         if not candidate_ids:
             return latest_run_per_group
 
-        # Paginators silently cap at 100; raise it so Snuba sorts the whole candidate set.
         results = search.backend.query(
             projects=projects,
             environments=list(environments) or None,

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import search
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
 from sentry.api.serializers.models.pullrequest import (
@@ -23,8 +26,10 @@ from sentry.integrations.source_code_management.pull_request_status_batch import
     get_checks_and_review,
 )
 from sentry.integrations.source_code_management.status_check import PullRequestStatusResult
+from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.plugins.base import bindings
@@ -58,6 +63,10 @@ _PIPELINE: tuple[str, ...] = (
 )
 
 _MAX_RUNS_PER_MILESTONE = 100
+
+_DEFAULT_SORT = "seer"
+_ISSUE_SORT_TO_SEARCH = {"issue": "date", "events": "freq", "users": "user"}
+_VALID_SORTS = frozenset({_DEFAULT_SORT, *_ISSUE_SORT_TO_SEARCH})
 
 
 @dataclass
@@ -243,7 +252,22 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         expand = request.GET.getlist("expand")
         include_scm_info = "scmInfo" in expand
         include_issue_stats = "issueStats" in expand
+        environments = self.get_environments(request, organization)
+
+        sort = request.GET.get("sort") or _DEFAULT_SORT
+        if sort not in _VALID_SORTS:
+            sort = _DEFAULT_SORT
+
         latest_run_per_group = self._latest_run_per_group(organization, project_ids, start, end)
+        if sort in _ISSUE_SORT_TO_SEARCH:
+            latest_run_per_group = self._reorder_by_issue_sort(
+                latest_run_per_group,
+                _ISSUE_SORT_TO_SEARCH[sort],
+                projects,
+                environments,
+                start,
+                end,
+            )
 
         # Classify into milestones and cap before the expensive serialize, so the
         # Snuba/Postgres work is bounded by the cap rather than the org's history.
@@ -262,7 +286,6 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             .in_bulk()
         )
 
-        environments = self.get_environments(request, organization)
         collapse = ["lifetime", "filtered", "unhandled"]
         if not include_issue_stats:
             collapse.append("stats")
@@ -341,3 +364,35 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             if run.group_id not in latest_per_group:
                 latest_per_group[run.group_id] = run
         return latest_per_group
+
+    def _reorder_by_issue_sort(
+        self,
+        latest_run_per_group: dict[int, _RunMilestones],
+        sort_by: str,
+        projects: Sequence[Project],
+        environments: Sequence[Environment],
+        start: datetime,
+        end: datetime,
+    ) -> dict[int, _RunMilestones]:
+        candidate_ids = list(latest_run_per_group)
+        if not candidate_ids:
+            return latest_run_per_group
+
+        # Paginators silently cap at 100; raise it so Snuba sorts the whole candidate set.
+        results = search.backend.query(
+            projects=projects,
+            environments=list(environments) or None,
+            sort_by=sort_by,
+            limit=len(candidate_ids),
+            paginator_options={"max_limit": len(candidate_ids)},
+            search_filters=[SearchFilter(SearchKey("issue.id"), "IN", SearchValue(candidate_ids))],
+            date_from=start,
+            date_to=end,
+            referrer="seer.autofix-overview",
+        )
+
+        ordered_ids = [group.id for group in results.results]
+        seen = set(ordered_ids)
+        # Candidates with no in-window events are absent from Snuba; keep them, sorted last.
+        ordered_ids.extend(gid for gid in latest_run_per_group if gid not in seen)
+        return {gid: latest_run_per_group[gid] for gid in ordered_ids}

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from unittest import mock
 
+from sentry import search
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
 from sentry.constants import ObjectStatus
 from sentry.integrations.source_code_management.status_check import (
@@ -192,6 +193,24 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         resp = self.get_success_response(self.organization.slug, qs_params={"sort": "events"})
 
         assert self._root_cause_short_ids(resp) == [high.qualified_short_id]
+
+    def test_issue_sort_raises_paginator_cap_to_candidate_count(self):
+        # Without the max_limit override the paginator silently caps at 100 and
+        # candidates beyond it would sort last; assert the endpoint raises it.
+        low = self._group_with_events("low", events=1)
+        high = self._group_with_events("high", events=2)
+        self._run_for_group(low, "low")
+        self._run_for_group(high, "high")
+
+        with mock.patch(
+            "sentry.seer.endpoints.organization_seer_autofix_overview.search.backend.query",
+            wraps=search.backend.query,
+        ) as mock_query:
+            self.get_success_response(self.organization.slug, qs_params={"sort": "events"})
+
+        assert mock_query.call_count == 1
+        assert mock_query.call_args.kwargs["limit"] == 2
+        assert mock_query.call_args.kwargs["paginator_options"] == {"max_limit": 2}
 
     def _solution_state(self, rc, sol):
         from sentry.seer.agent.client_models import Artifact, MemoryBlock, Message, SeerRunState

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -14,7 +14,7 @@ from sentry.integrations.source_code_management.status_check import (
 from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.milestones import reconcile_milestones
 from sentry.seer.models.run import SeerRunMilestoneType
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.group import PriorityLevel
 
@@ -74,7 +74,7 @@ def _root_cause_state(description):
     )
 
 
-class OrganizationSeerAutofixOverviewTest(APITestCase):
+class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-seer-autofix-overview"
 
     def setUp(self):
@@ -87,6 +87,21 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         reconcile_milestones(run, _root_cause_state(description))
         return run
 
+    def _group_with_events(self, fingerprint, *, events, users=1, minutes_ago=1):
+        group = None
+        for i in range(events):
+            event = self.store_event(
+                data={
+                    "fingerprint": [fingerprint],
+                    "timestamp": before_now(minutes=minutes_ago).isoformat(),
+                    "user": {"id": str(i % users)},
+                },
+                project_id=self.project.id,
+            )
+            group = event.group
+        assert group is not None
+        return group
+
     def test_root_cause_run_grouped_under_root_cause_milestone(self):
         group = self.create_group()
         self._run_for_group(group, "the boom")
@@ -96,6 +111,87 @@ class OrganizationSeerAutofixOverviewTest(APITestCase):
         assert runs[0]["shortId"] == group.qualified_short_id
         assert runs[0]["rootCause"]["oneLineDescription"] == "the boom"
         assert runs[0]["proposedFix"] is None
+
+    def _root_cause_short_ids(self, resp):
+        return [r["shortId"] for r in resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]]
+
+    def test_default_sort_orders_by_seer_recent_activity(self):
+        older = self.create_group()
+        newer = self.create_group()
+        run_old = self._run_for_group(older, "old")
+        run_new = self._run_for_group(newer, "new")
+        run_old.update(last_triggered_at=before_now(minutes=10))
+        run_new.update(last_triggered_at=before_now(minutes=1))
+
+        resp = self.get_success_response(self.organization.slug)
+
+        assert self._root_cause_short_ids(resp) == [
+            newer.qualified_short_id,
+            older.qualified_short_id,
+        ]
+
+    def test_invalid_sort_falls_back_to_default(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"sort": "nonsense"})
+
+        assert self._root_cause_short_ids(resp) == [group.qualified_short_id]
+
+    def test_sort_events_orders_by_event_count(self):
+        low = self._group_with_events("low", events=1)
+        high = self._group_with_events("high", events=5)
+        self._run_for_group(low, "low")
+        self._run_for_group(high, "high")
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"sort": "events"})
+
+        assert self._root_cause_short_ids(resp) == [
+            high.qualified_short_id,
+            low.qualified_short_id,
+        ]
+
+    def test_sort_users_orders_by_user_count(self):
+        few = self._group_with_events("few", events=4, users=1)
+        many = self._group_with_events("many", events=4, users=4)
+        self._run_for_group(few, "few")
+        self._run_for_group(many, "many")
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"sort": "users"})
+
+        assert self._root_cause_short_ids(resp) == [
+            many.qualified_short_id,
+            few.qualified_short_id,
+        ]
+
+    def test_sort_issue_orders_by_most_recent_event(self):
+        stale = self._group_with_events("stale", events=1, minutes_ago=60)
+        fresh = self._group_with_events("fresh", events=1, minutes_ago=1)
+        self._run_for_group(stale, "stale")
+        self._run_for_group(fresh, "fresh")
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"sort": "issue"})
+
+        assert self._root_cause_short_ids(resp) == [
+            fresh.qualified_short_id,
+            stale.qualified_short_id,
+        ]
+
+    @mock.patch(
+        "sentry.seer.endpoints.organization_seer_autofix_overview._MAX_RUNS_PER_MILESTONE", 1
+    )
+    def test_events_sort_selects_correct_run_before_cap(self):
+        # The high-event issue is the OLDEST seer run, so a cap-then-sort impl would drop it.
+        high = self._group_with_events("high", events=5)
+        low = self._group_with_events("low", events=1)
+        run_high = self._run_for_group(high, "high")
+        run_low = self._run_for_group(low, "low")
+        run_high.update(last_triggered_at=before_now(minutes=60))
+        run_low.update(last_triggered_at=before_now(minutes=1))
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"sort": "events"})
+
+        assert self._root_cause_short_ids(resp) == [high.qualified_short_id]
 
     def _solution_state(self, rc, sol):
         from sentry.seer.agent.client_models import Artifact, MemoryBlock, Message, SeerRunState


### PR DESCRIPTION
Adds a `sort` query param to the autofix overview endpoint (`GET .../seer/autofix-overview/`), which previously always ordered by most-recent seer-run activity with no override.

| `sort` | Orders by |
|---|---|
| `seer` _(default, may be omitted)_ | Most recent seer-run activity (`SeerRun.last_triggered_at`) |
| `issue` | Most recent issue event (`last_seen`) |
| `events` | Event count |
| `users` | Distinct user count |

The three issue-based sorts reuse the issue-stream search backend (`search.backend.query`, same as the homepage `freq`/`user` sorts), constrained to the candidate group IDs via an `issue.id IN (...)` filter. The sort runs **before** the per-milestone cap so the cap keeps the correct top runs for the chosen sort, not the 100 most-recently-triggered; `paginator_options={\"max_limit\": ...}` prevents the paginator from silently truncating candidates to 100. The default `seer` sort keeps the existing Postgres ordering and adds no Snuba work. Invalid values fall back to `seer`.

Issue-based sorts count only events **within the page's selected date window**, not lifetime totals (consistent with the windowed counts the endpoint already returns); candidates with no in-window events sort last.

The frontend overview2 sort dropdown ships as a separate stacked PR — frontend/backend are not atomically deployed, so this lands first.

Tests cover ordering per sort value, invalid-value fallback, the pre-cap correctness case (a high-event issue surfaces even as the oldest seer run), and a guard that the paginator cap is raised to the candidate count.