### PR TITLE
feat(scm): Add PR changed-files endpoint with diff hunks

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -278,6 +278,9 @@ from sentry.integrations.api.endpoints.organization_integration_serverless_funct
 from sentry.integrations.api.endpoints.organization_integrations_index import (
     OrganizationIntegrationsEndpoint,
 )
+from sentry.integrations.api.endpoints.organization_pull_request_files import (
+    OrganizationPullRequestFilesEndpoint,
+)
 from sentry.integrations.api.endpoints.organization_repositories import (
     OrganizationRepositoriesEndpoint,
 )
@@ -2271,6 +2274,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/sent-first-event/$",
         OrganizationProjectsSentFirstEventEndpoint.as_view(),
         name="sentry-api-0-organization-sent-first-event",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/pull-requests/(?P<pull_request_id>[^/]+)/files/$",
+        OrganizationPullRequestFilesEndpoint.as_view(),
+        name="sentry-api-0-organization-pull-request-files",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/repos/$",

--- a/src/sentry/integrations/api/endpoints/organization_pull_request_files.py
+++ b/src/sentry/integrations/api/endpoints/organization_pull_request_files.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+
+from rest_framework.exceptions import APIException, Throttled
+from rest_framework.request import Request
+from rest_framework.response import Response
+from scm import actions as scm_actions
+from scm.errors import ProviderNotFound, RateLimitExceeded, ResourceNotFound, SCMError
+from scm.helpers import iter_all_pages
+from scm.types import GetPullRequestFilesProtocol, PullRequestFile
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import (
+    OrganizationEndpoint,
+    OrganizationIntegrationsLoosePermission,
+)
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.utils import to_valid_int_id
+from sentry.models.organization import Organization
+from sentry.models.pullrequest import PullRequest
+from sentry.scm.factory import new as make_scm
+
+logger = logging.getLogger(__name__)
+
+
+class PullRequestFilesUnavailable(APIException):
+    status_code = 502
+    default_detail = "Failed to fetch pull request files."
+
+
+class PullRequestFileResponse(TypedDict):
+    path: str
+    patch: str | None
+
+
+class PullRequestFilesResponse(TypedDict):
+    files: list[PullRequestFileResponse]
+
+
+def _serialize_file(raw_file: PullRequestFile) -> PullRequestFileResponse:
+    return {"path": raw_file["filename"], "patch": raw_file["patch"]}
+
+
+@cell_silo_endpoint
+class OrganizationPullRequestFilesEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.CODING_WORKFLOWS
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    permission_classes = (OrganizationIntegrationsLoosePermission,)
+
+    def get(
+        self, request: Request, organization: Organization, pull_request_id: str
+    ) -> Response[PullRequestFilesResponse]:
+        try:
+            pull_request = PullRequest.objects.get(
+                id=to_valid_int_id("pull_request_id", pull_request_id, raise_404=True),
+                organization_id=organization.id,
+            )
+        except PullRequest.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        try:
+            scm = make_scm(
+                organization.id, pull_request.repository_id, referrer="pull-request-files"
+            )
+        except ProviderNotFound:
+            # No integration installed, or a provider without SCM support (e.g. Bitbucket).
+            return Response({"files": []})
+        except SCMError:
+            raise ResourceDoesNotExist
+
+        if not isinstance(scm, GetPullRequestFilesProtocol):
+            return Response({"files": []})
+
+        try:
+            files: list[PullRequestFile] = []
+            for page in iter_all_pages(
+                lambda pagination: scm_actions.get_pull_request_files(
+                    scm, pull_request.key, pagination=pagination
+                )
+            ):
+                files.extend(page["data"])
+        except ResourceNotFound:
+            # The PR exists in our records but is gone on the provider.
+            raise ResourceDoesNotExist
+        except RateLimitExceeded:
+            raise Throttled
+        except SCMError:
+            logger.warning(
+                "organization_pull_request_files.fetch_failed",
+                exc_info=True,
+                extra={
+                    "organization_id": organization.id,
+                    "pull_request_id": pull_request.id,
+                },
+            )
+            raise PullRequestFilesUnavailable
+
+        return Response({"files": [_serialize_file(f) for f in files]})

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -94,12 +94,14 @@ class _RunMilestones:
 
 
 def _serialize_pull_request(
+    pull_request_id: str,
     number: int,
     url: str | None,
     status: PullRequestStatus | None,
     checks_and_review: PullRequestStatusResult,
 ) -> PullRequestPayload:
     return {
+        "id": pull_request_id,
         "number": number,
         "url": url,
         "status": status,
@@ -173,6 +175,7 @@ def _pull_requests_by_seer_run_id(
             continue
         by_run[link.seer_run_id].append(
             _serialize_pull_request(
+                pull_request_id=str(pr.id),
                 number=number,
                 url=_external_url(pr),
                 status=status_by_pr_id[pr.id],

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -12,6 +12,7 @@ class PullRequestFilePayload(TypedDict):
 
 
 class PullRequestPayload(TypedDict):
+    id: str
     number: int
     url: str | None
     status: str | None

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -319,6 +319,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/projects/'
   | '/organizations/$organizationIdOrSlug/projects/$projectIdOrSlug/detectors/'
   | '/organizations/$organizationIdOrSlug/prompts-activity/'
+  | '/organizations/$organizationIdOrSlug/pull-requests/$pullRequestId/files/'
   | '/organizations/$organizationIdOrSlug/recent-searches/'
   | '/organizations/$organizationIdOrSlug/related-issues/'
   | '/organizations/$organizationIdOrSlug/relay_usage/'

--- a/tests/sentry/integrations/api/endpoints/test_organization_pull_request_files.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_pull_request_files.py
@@ -1,0 +1,141 @@
+from unittest import mock
+
+from scm.errors import (
+    ProviderNotFound,
+    RateLimitExceeded,
+    RepositoryInactive,
+    ResourceNotFound,
+    SCMError,
+)
+
+from sentry.testutils.cases import APITestCase
+
+_MAKE_SCM = "sentry.integrations.api.endpoints.organization_pull_request_files.make_scm"
+
+
+def _page(files, next_cursor=""):
+    return {"data": files, "meta": {"next_cursor": next_cursor}}
+
+
+class _FakeScm:
+    def __init__(self, pages=None, error=None):
+        self._pages = list(pages or [])
+        self._error = error
+        self.calls: list[str] = []
+
+    def get_pull_request_files(self, pull_request_id, pagination=None, request_options=None):
+        self.calls.append(pull_request_id)
+        if self._error is not None:
+            raise self._error
+        return self._pages.pop(0)
+
+
+class OrganizationPullRequestFilesTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pull-request-files"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=123,
+            url="https://github.com/getsentry/sentry",
+        )
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id,
+            organization_id=self.organization.id,
+            key="42",
+        )
+
+    def _set_scm(self, mock_make_scm, pages=None, error=None):
+        scm = _FakeScm(pages=pages, error=error)
+        mock_make_scm.return_value = scm
+        return scm
+
+    @mock.patch(_MAKE_SCM)
+    def test_returns_files_with_patches(self, mock_make_scm):
+        scm = self._set_scm(
+            mock_make_scm,
+            pages=[_page([{"filename": "src/foo.py", "patch": "@@ -1 +1 @@\n-old\n+new"}])],
+        )
+        response = self.get_success_response(self.organization.slug, self.pull_request.id)
+        assert response.data == {
+            "files": [{"path": "src/foo.py", "patch": "@@ -1 +1 @@\n-old\n+new"}]
+        }
+        mock_make_scm.assert_called_once_with(
+            self.organization.id, self.repo.id, referrer="pull-request-files"
+        )
+        assert scm.calls[0] == "42"
+
+    @mock.patch(_MAKE_SCM)
+    def test_binary_file_patch_is_null(self, mock_make_scm):
+        self._set_scm(mock_make_scm, pages=[_page([{"filename": "image.png", "patch": None}])])
+        response = self.get_success_response(self.organization.slug, self.pull_request.id)
+        assert response.data == {"files": [{"path": "image.png", "patch": None}]}
+
+    @mock.patch(_MAKE_SCM)
+    def test_paginates_across_pages(self, mock_make_scm):
+        self._set_scm(
+            mock_make_scm,
+            pages=[
+                _page([{"filename": "a.py", "patch": "@@a"}], next_cursor="2"),
+                _page([{"filename": "b.py", "patch": "@@b"}]),
+            ],
+        )
+        response = self.get_success_response(self.organization.slug, self.pull_request.id)
+        assert [f["path"] for f in response.data["files"]] == ["a.py", "b.py"]
+
+    def test_pull_request_in_other_org_returns_404(self):
+        other_org = self.create_organization(owner=self.create_user())
+        other_repo = self.create_repo(
+            project=self.create_project(organization=other_org),
+            name="other/repo",
+            provider="integrations:github",
+            integration_id=456,
+        )
+        other_pull_request = self.create_pull_request(
+            repository_id=other_repo.id,
+            organization_id=other_org.id,
+            key="7",
+        )
+        self.get_error_response(self.organization.slug, other_pull_request.id, status_code=404)
+
+    def test_nonexistent_pull_request_returns_404(self):
+        self.get_error_response(self.organization.slug, 999999, status_code=404)
+
+    def test_non_numeric_pull_request_id_returns_404(self):
+        self.get_error_response(self.organization.slug, "not-a-number", status_code=404)
+
+    @mock.patch(_MAKE_SCM)
+    def test_inactive_repository_returns_404(self, mock_make_scm):
+        mock_make_scm.side_effect = RepositoryInactive()
+        self.get_error_response(self.organization.slug, self.pull_request.id, status_code=404)
+
+    @mock.patch(_MAKE_SCM)
+    def test_unsupported_provider_returns_empty(self, mock_make_scm):
+        mock_make_scm.side_effect = ProviderNotFound()
+        response = self.get_success_response(self.organization.slug, self.pull_request.id)
+        assert response.data == {"files": []}
+
+    @mock.patch(_MAKE_SCM)
+    def test_provider_without_files_capability_returns_empty(self, mock_make_scm):
+        mock_make_scm.return_value = object()
+        response = self.get_success_response(self.organization.slug, self.pull_request.id)
+        assert response.data == {"files": []}
+
+    @mock.patch(_MAKE_SCM)
+    def test_provider_error_returns_502(self, mock_make_scm):
+        self._set_scm(mock_make_scm, error=SCMError("boom"))
+        self.get_error_response(self.organization.slug, self.pull_request.id, status_code=502)
+
+    @mock.patch(_MAKE_SCM)
+    def test_pull_request_missing_on_provider_returns_404(self, mock_make_scm):
+        self._set_scm(mock_make_scm, error=ResourceNotFound())
+        self.get_error_response(self.organization.slug, self.pull_request.id, status_code=404)
+
+    @mock.patch(_MAKE_SCM)
+    def test_provider_rate_limited_returns_429(self, mock_make_scm):
+        self._set_scm(mock_make_scm, error=RateLimitExceeded())
+        self.get_error_response(self.organization.slug, self.pull_request.id, status_code=429)

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -341,7 +341,9 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
     def test_run_includes_pull_requests(self, mock_get_integration):
         group = self.create_group()
         run = self._run_for_group(group, "boom")
-        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        pull_request = self._pull_request_for_run(
+            group, run, state=PullRequestLifecycleState.OPEN, draft=False
+        )
         client = self._set_provider_client(
             mock_get_integration,
             PullRequestStatusClientFake(
@@ -354,6 +356,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert client.requested_keys == []
         assert run_data["pullRequests"] == [
             {
+                "id": str(pull_request.id),
                 "number": 123,
                 "url": "https://github.com/getsentry/sentry/pull/123",
                 "status": "open",


### PR DESCRIPTION
Adds a private endpoint `GET /api/0/organizations/{org}/pull-requests/{pull_request_id}/files/` returning a linked PR's changed files, each with its diff `patch` (hunks), from the repository's SCM integration. It powers the Seer autofix overview: the frontend fetches every file's patch in one request on first expand and renders each diff from cache. Generic and reusable (keyed by `PullRequest` id, org-scoped/IDOR).

Files are fetched through the provider-agnostic `scm` package (`scm_actions.get_pull_request_files` via `make_scm`), so **both GitHub and GitLab** repositories are supported — the same abstraction Seer's code-review tooling already uses. Unsupported providers (e.g. Bitbucket) or missing integrations return an empty list; upstream provider failures return `502`.

A stacked frontend PR wires the overview's file rows to fetch and render diffs on expand.
