### PR TITLE
feat(action-log): Add dedicated outbox producer rollout

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -34,7 +34,7 @@ _publish_callbacks: ContextVar[tuple[_PublishCallback, ...]] = ContextVar(
 
 # Group Action Log — tracks who did what to an issue and how.
 #
-# publish_action() writes a CellOutbox entry; the outbox receiver creates the
+# publish_action() writes an outbox entry; the outbox receiver creates the
 # GroupActionLogEntry on the (eventually separate) grouplog database and kicks
 # off derived-data processing.
 #
@@ -105,6 +105,8 @@ def publish_action(
     from sentry import features
     from sentry.hybridcloud.models.outbox import CellOutbox, outbox_context
     from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
+    from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
+    from sentry.options.rollout import in_rollout_group
     from sentry.utils import metrics
 
     for callback in _publish_callbacks.get():
@@ -141,6 +143,15 @@ def publish_action(
     if not write_to_db:
         return
 
+    use_dedicated_outbox = in_rollout_group(
+        "issues.action_log.dedicated_outbox_rollout_rate", group_id
+    )
+    outbox_model = GroupActionLogOutbox if use_dedicated_outbox else CellOutbox
+    metrics.incr(
+        "issues.action_log.outbox_write",
+        tags={"route": "dedicated" if use_dedicated_outbox else "shared"},
+    )
+
     payload: GroupActionLogPayload = {
         "group_id": group_id,
         "project_id": project.id,
@@ -155,15 +166,15 @@ def publish_action(
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
 
-    outbox = CellOutbox(
+    outbox = outbox_model(
         shard_scope=OutboxScope.GROUP_SCOPE,
         shard_identifier=group_id,
         category=OutboxCategory.GROUP_ACTION_LOG_EVENT,
-        object_identifier=CellOutbox.next_object_identifier(),
+        object_identifier=outbox_model.next_object_identifier(),
         payload=payload,
     )
     # Flush on commit by default; callers can wrap in outbox_context(flush=False) to defer.
-    with outbox_context(transaction.atomic(router.db_for_write(CellOutbox))):
+    with outbox_context(transaction.atomic(router.db_for_write(outbox_model))):
         outbox.save()
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1364,6 +1364,12 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "issues.action_log.dedicated_outbox_rollout_rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "issues.backfill_group_action_log.killswitch",
     type=Bool,
     default=False,

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -16,6 +16,7 @@ from sentry.issues.action_log import (
     action_context_scope,
     get_action_context,
     publish_action,
+    publish_actions_from_context_bulk,
     resolve_action_actor,
     resolve_action_source,
 )
@@ -656,6 +657,61 @@ class TestPublishActionWrite(TestCase):
         assert entry.data == {}
         assert entry.date_added is not None
 
+    def test_shared_outbox_is_default(self) -> None:
+        with self.feature("projects:issue-action-log-write-to-db"), outbox_context(flush=False):
+            publish_action(
+                ViewAction(),
+                source=ActionSource.API,
+                group_id=self.group.id,
+                project=self.group.project,
+            )
+
+        assert (
+            CellOutbox.objects.filter(category=OutboxCategory.GROUP_ACTION_LOG_EVENT).count() == 1
+        )
+        assert not GroupActionLogOutbox.objects.exists()
+
+    @patch("sentry.options.rollout.in_rollout_group", return_value=True)
+    @patch("sentry.utils.metrics.incr")
+    def test_dedicated_outbox_rollout_routes_one_write(
+        self, mock_incr: MagicMock, mock_in_rollout_group: MagicMock
+    ) -> None:
+        with (
+            self.feature("projects:issue-action-log-write-to-db"),
+            outbox_context(flush=False),
+        ):
+            publish_action(
+                ViewAction(),
+                source=ActionSource.API,
+                group_id=self.group.id,
+                project=self.group.project,
+            )
+
+        assert not CellOutbox.objects.filter(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+        ).exists()
+        assert GroupActionLogOutbox.objects.count() == 1
+        mock_in_rollout_group.assert_called_once_with(
+            "issues.action_log.dedicated_outbox_rollout_rate", self.group.id
+        )
+        mock_incr.assert_any_call("issues.action_log.outbox_write", tags={"route": "dedicated"})
+
+    def test_dedicated_outbox_flushes_on_commit(self) -> None:
+        with (
+            self.options({"issues.action_log.dedicated_outbox_rollout_rate": 1.0}),
+            self.feature("projects:issue-action-log-write-to-db"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            publish_action(
+                ViewAction(),
+                source=ActionSource.API,
+                group_id=self.group.id,
+                project=self.group.project,
+            )
+
+        assert not GroupActionLogOutbox.objects.exists()
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
     def test_system_action(self) -> None:
         with self.feature("projects:issue-action-log-write-to-db"), outbox_runner():
             publish_action(
@@ -708,6 +764,27 @@ class TestPublishActionWrite(TestCase):
         assert not CellOutbox.objects.filter(
             category=OutboxCategory.GROUP_ACTION_LOG_EVENT
         ).exists()
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
+
+    def test_dedicated_outbox_rolled_back_transaction_does_not_persist(self) -> None:
+        with (
+            self.options({"issues.action_log.dedicated_outbox_rollout_rate": 1.0}),
+            self.feature("projects:issue-action-log-write-to-db"),
+        ):
+            try:
+                with transaction.atomic(using=router.db_for_write(GroupActionLogOutbox)):
+                    publish_action(
+                        ViewAction(),
+                        source=ActionSource.API,
+                        group_id=self.group.id,
+                        project=self.group.project,
+                    )
+                    assert GroupActionLogOutbox.objects.exists()
+                    raise IntentionalRollback()
+            except IntentionalRollback:
+                pass
+
+        assert not GroupActionLogOutbox.objects.exists()
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
 
     def test_savepoint_rollback_discards_only_inner(self) -> None:
@@ -769,6 +846,25 @@ class TestPublishActionWrite(TestCase):
                 pass
 
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_bulk_publish_creates_one_dedicated_row_per_action(self) -> None:
+        with (
+            self.options({"issues.action_log.dedicated_outbox_rollout_rate": 1.0}),
+            self.feature("projects:issue-action-log-write-to-db"),
+            action_context_scope(source=ActionSource.API),
+            outbox_context(flush=False),
+        ):
+            publish_actions_from_context_bulk(
+                [
+                    (ViewAction(), self.group.project, self.group.id, None),
+                    (ResolveAction(), self.group.project, self.group.id, None),
+                ]
+            )
+
+        assert GroupActionLogOutbox.objects.count() == 2
+        assert not CellOutbox.objects.filter(
+            category=OutboxCategory.GROUP_ACTION_LOG_EVENT
+        ).exists()
 
     @patch("sentry.issues.derived.processing.process_group_log_task")
     def test_force_async_derived_dispatches_task(self, mock_task: MagicMock) -> None:


### PR DESCRIPTION
We want to gradually start using the new GAL-specific outbox. Add a rollout option to start using it.