### PR TITLE
fix(api): drop null entries from resolvedWith in event serialization

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -558,7 +558,10 @@ class IssueEventSerializer(SqlFormatEventSerializer):
         frame_data = [frame.get("data") for frame_list in frame_lists for frame in frame_list]
 
         unique_resolution_methods = {
-            frame.get("resolved_with") for frame in frame_data if frame is not None
+            resolved_with
+            for frame in frame_data
+            if frame is not None
+            if (resolved_with := frame.get("resolved_with")) is not None
         }
 
         return list(unique_resolution_methods)

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -458,6 +458,34 @@ class IssueEventSerializerTest(TestCase):
         result = serialize(event, None, IssueEventSerializer())
         assert result["sdkUpdates"] == []
 
+    def test_resolved_with_skips_frames_without_resolution(self) -> None:
+        min_ago = before_now(minutes=1).isoformat()
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": min_ago,
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "stacktrace": {
+                                "frames": [
+                                    {"function": "foo", "data": {"resolved_with": "scraping"}},
+                                    {"function": "bar", "data": {"symbolicated": True}},
+                                    {"function": "baz"},
+                                ]
+                            },
+                        }
+                    ]
+                },
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        result = serialize(event, None, IssueEventSerializer())
+        assert result["resolvedWith"] == ["scraping"]
+
 
 class SqlFormatEventSerializerTest(TestCase):
     def test_event_breadcrumb_formatting(self) -> None:

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -470,8 +470,8 @@ class IssueEventSerializerTest(TestCase):
                             "type": "Error",
                             "stacktrace": {
                                 "frames": [
-                                    {"function": "foo", "data": {"resolved_with": "scraping"}},
-                                    {"function": "bar", "data": {"symbolicated": True}},
+                                    {"function": "foo"},
+                                    {"function": "bar"},
                                     {"function": "baz"},
                                 ]
                             },
@@ -482,6 +482,12 @@ class IssueEventSerializerTest(TestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
+
+        # resolved_with is written into frame data by symbolication, after
+        # normalization; inject it the same way.
+        frames = event.data["exception"]["values"][0]["stacktrace"]["frames"]
+        frames[0].setdefault("data", {})["resolved_with"] = "scraping"
+        frames[1].setdefault("data", {})["symbolicated"] = True
 
         result = serialize(event, None, IssueEventSerializer())
         assert result["resolvedWith"] == ["scraping"]


### PR DESCRIPTION
`_get_resolved_with` collects `frame.get("resolved_with")` for every frame that has a data dict, so any frame whose data lacks `resolved_with` contributes `None` to the set. The API then returns `"resolvedWith": [null]`, contradicting the `list[str]` response type and the published OpenAPI schema, which breaks clients generated from it.

Filter the extracted value rather than just the frame. Adds a serializer test covering frames with and without a resolution method.

Fixes #122123