### PR TITLE
build(ui): Exclude TanStack devtools from production

### DIFF
--- a/static/app/components/tanstackDevtools.tsx
+++ b/static/app/components/tanstackDevtools.tsx
@@ -1,0 +1,20 @@
+import {TanStackDevtools} from '@tanstack/react-devtools';
+import {formDevtoolsPlugin} from '@tanstack/react-form-devtools';
+import {pacerDevtoolsPlugin} from '@tanstack/react-pacer-devtools';
+import {ReactQueryDevtoolsPanel} from '@tanstack/react-query-devtools';
+
+export function SentryTanStackDevtools() {
+  return (
+    <TanStackDevtools
+      config={{position: 'bottom-right'}}
+      plugins={[
+        {
+          name: 'TanStack Query',
+          render: <ReactQueryDevtoolsPanel />,
+        },
+        formDevtoolsPlugin(),
+        pacerDevtoolsPlugin(),
+      ]}
+    />
+  );
+}

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -1,10 +1,6 @@
-import {useEffect, useState} from 'react';
+import {lazy, Suspense, useEffect, useState} from 'react';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import {wrapCreateBrowserRouterV6} from '@sentry/react';
-import {TanStackDevtools} from '@tanstack/react-devtools';
-import {formDevtoolsPlugin} from '@tanstack/react-form-devtools';
-import {pacerDevtoolsPlugin} from '@tanstack/react-pacer-devtools';
-import {ReactQueryDevtoolsPanel} from '@tanstack/react-query-devtools';
 import {NuqsAdapter} from 'nuqs/adapters/react-router/v6';
 
 import {setApiNavigate} from 'sentry/api';
@@ -20,6 +16,17 @@ import {RouteConfigProvider} from 'sentry/router/routeConfigContext';
 import {routes} from 'sentry/router/routes';
 import {ServiceWorkerProvider} from 'sentry/serviceWorker/client/serviceWorkerContext';
 import {createReactRouter3Navigate} from 'sentry/utils/useNavigate';
+
+// Keep the production check at the import site so DefinePlugin can remove the
+// dynamic import from Rspack's production module graph.
+const SentryTanStackDevtools =
+  process.env.NODE_ENV !== 'production' && USE_TANSTACK_DEVTOOL
+    ? lazy(() =>
+        import('sentry/components/tanstackDevtools').then(module => ({
+          default: module.SentryTanStackDevtools,
+        }))
+      )
+    : null;
 
 function buildRouter() {
   const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter);
@@ -49,19 +56,11 @@ export function Main() {
                   </RouteConfigProvider>
                 </CommandPaletteProvider>
               </NuqsAdapter>
-              {USE_TANSTACK_DEVTOOL && (
-                <TanStackDevtools
-                  config={{position: 'bottom-right'}}
-                  plugins={[
-                    {
-                      name: 'TanStack Query',
-                      render: <ReactQueryDevtoolsPanel />,
-                    },
-                    formDevtoolsPlugin(),
-                    pacerDevtoolsPlugin(),
-                  ]}
-                />
-              )}
+              {SentryTanStackDevtools ? (
+                <Suspense fallback={null}>
+                  <SentryTanStackDevtools />
+                </Suspense>
+              ) : null}
             </ThemeAndStyleProvider>
           </ServiceWorkerProvider>
         </FrontendVersionProvider>


### PR DESCRIPTION
TanStack devtools are statically imported into the main application bundle today, so all four packages ship even when `USE_TANSTACK_DEVTOOL` is disabled.

Moves them behind a development-only dynamic import. Keeping the production check directly at the import site lets Rspack remove the devtools from the production module graph while preserving the existing opt-in development behavior.

Measured on a cold production-mode Issues route load:

| JavaScript | Before | After | Savings |
|---|---:|---:|---:|
| Compressed transfer | 3.794 MiB | 3.781 MiB | 13.8 KiB |
| Decoded | 10.834 MiB | 10.792 MiB | 43.3 KiB |