### PR TITLE
build(ui): Avoid duplicate platformicons bundle

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -150,6 +150,10 @@ const restrictedImportPaths = [
     message: 'Please import moment-timezone instead of moment',
   },
   {
+    name: 'platformicons/build/platformIcon',
+    message: "Import {PlatformIcon} from 'platformicons' instead.",
+  },
+  {
     name: 'sentry/views/insights/common/components/insightsTimeSeriesWidget',
     message:
       'Do not use this directly in your view component, see https://sentry.sentry.io/stories/shared/views/dashboards/widgets/timeserieswidget/timeserieswidgetvisualization#deeplinking for more information',

--- a/static/app/components/core/badge/projectsBadge.tsx
+++ b/static/app/components/core/badge/projectsBadge.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import PlatformIcon from 'platformicons/build/platformIcon';
+import {PlatformIcon} from 'platformicons';
 
 import {Container, Stack} from '@sentry/scraps/layout';
 


### PR DESCRIPTION
ProjectsBadge imported the CommonJS subpath while every other consumer uses the ESM package export, causing Rspack to ship a duplicate platformicons implementation on Issues.

Switches to the named ESM export and bans that exact CommonJS subpath in ESLint.

Production build impact on Issues: 44.5 KiB less minified JS and 14.7 KiB less gzip.