### PR TITLE
fix(gsadmin): never offer a zero org retention

### DIFF
--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
@@ -354,6 +354,95 @@ describe('UpdateRetentionSettingsModal', () => {
     expectSelectValue('Logs Downsampled', null);
   });
 
+  it('does not offer a stored zero org retention', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: 90,
+            downsampled: 0,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: 0, downsampled: null},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    // Other legacy values are kept as a "(current)" choice, but a zero org
+    // retention cannot be written back, so the field reads as no override.
+    expectSelectValue('Org Retention', null);
+    // The same zero on a category is a real value (inherit standard), so it
+    // is still offered there.
+    expectSelectValue('Spans Downsampled', '0 days (current)');
+
+    await selectEvent.openMenu(getSelect('Org Retention'));
+
+    const options = screen
+      .getAllByRole('menuitemradio')
+      .map(option => option.textContent);
+
+    expect(options[0]).toBe('30 days');
+    expect(options).not.toContain('0 days (current)');
+  });
+
+  it('clears a stored zero org retention on save', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: 90,
+            downsampled: 30,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: 0, downsampled: null},
+    });
+
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/retention-settings/`,
+      method: 'POST',
+      body: {},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    // Submitting without touching the field must not send the zero back and
+    // earn a 400; it writes a null, which drops the org-level override.
+    await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(
+        `/_admin/customers/${organization.slug}/retention-settings/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: expect.objectContaining({
+            orgRetention: {
+              standard: null,
+              downsampled: null,
+            },
+          }),
+        })
+      );
+    });
+  });
+
   it('calls api with correct data when updating all fields', async () => {
     const subscription = SubscriptionFixture({
       organization,

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -80,8 +80,14 @@ function UpdateRetentionSettingsModal({
 }: ModalProps) {
   const api = useApi();
 
+  const storedOrgStandard = subscription.orgRetention?.standard ?? null;
+
+  // Zero is the one legacy value this field cannot round-trip: the endpoint
+  // rejects a zero org-level write, and the billing platform has no
+  // representation for it. Read a stored zero as no override so it is never
+  // offered back as a "0 days (current)" choice that cannot be saved.
   const [orgStandard, setOrgStandard] = useState<number | null>(
-    subscription.orgRetention?.standard ?? null
+    storedOrgStandard === 0 ? null : storedOrgStandard
   );
 
   const [logBytesStandard, setLogBytesStandard] = useState<number | null>(
@@ -161,6 +167,10 @@ function UpdateRetentionSettingsModal({
             Update the retention settings for each data category. Retention must be a
             multiple of 30 days. Clearing a field defaults to the plan's retention value
             for the category.
+          </p>
+          <p>
+            Zero is not a valid org retention. An organization still carrying a zero-day
+            org override reads as the plan default here, and saving clears it.
           </p>
         </div>
         <br />


### PR DESCRIPTION
## Problem

Zero is not an organization-level retention. The legacy read serves a stored zero literally as zero-day retention, while the billing platform has no representation for it — its write path skips non-positive values and contract migration nulls them. A stored zero therefore silently diverges the two systems, so the endpoint now rejects the write (getsentry/getsentry#21588).

Picking a fresh zero is already impossible: #122996 turned these fields into selects offering only multiples of 30. But a legacy zero still leaks back in through the option list. Any stored value outside the multiples is re-offered as `N days (current)` so admins don't silently drop it — which means an org carrying a zero-day override opens the modal with **`0 days (current)` selected**, and submitting without touching the field sends that zero straight back for a 400.

## Change

- The org field reads a stored zero as *no override*: it isn't offered as a choice, the field shows the plan default, and saving writes a `null` that drops the bogus override.
- Help copy noting that zero is not a valid org retention and what the modal does with an existing one.
- Category downsampled keeps its zero — there it means inherit-standard, and it is still offered as `0 days (current)`.

## Tests

Two cases: one pins that zero is absent from the org options while `Spans Downsampled` still offers `0 days (current)`; the other pins that an untouched save sends `standard: null`. Both fail without the component change.

Counterpart backend PR: getsentry/getsentry#21588

https://claude.ai/code/session_01TzQr1BYcD9TxByrgDSBKUe
