### PR TITLE
fix(symbolication): Bump max decompressed source size

### DIFF
--- a/src/sentry/models/artifactbundle.py
+++ b/src/sentry/models/artifactbundle.py
@@ -28,7 +28,7 @@ NULL_UUID = "00000000-00000000-00000000-00000000"
 NULL_STRING = ""
 
 # Must stay in sync with Symbolicator's `object_file_max_decompressed_source_size`
-MAX_SOURCE_FILE_SIZE = 190 * 1024 * 1024
+MAX_SOURCE_FILE_SIZE = 1024 * 1024 * 1024
 
 
 class SourceFileType(Enum):


### PR DESCRIPTION
See https://github.com/getsentry/symbolicator/pull/2022
