### PR TITLE
feat(issues): Build the LLM Cache Usage issue page

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -111,6 +111,8 @@ export enum IssueCategory {
   PREPROD = 'preprod',
 
   CONFIGURATION = 'configuration',
+
+  GEN_AI = 'gen_ai',
 }
 
 /**
@@ -149,6 +151,9 @@ export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {
   [IssueCategory.PREPROD]: t('Problems detected via static analysis.'),
   [IssueCategory.CONFIGURATION]: t(
     'Issues detected from SDK/tooling configuration problems.'
+  ),
+  [IssueCategory.GEN_AI]: t(
+    'Wasteful or costly use of generative-AI providers, such as poor prompt-cache utilization.'
   ),
 };
 
@@ -214,6 +219,9 @@ export enum IssueType {
   // Configuration Issues
   SOURCEMAP_CONFIGURATION = 'sourcemap_configuration',
   LOW_VALUE_SPAN_CONFIGURATION = 'low_value_span_configuration',
+
+  // Gen AI
+  LLM_CACHE_USAGE = 'llm_cache_usage',
 }
 
 // Issue types that should not be visible to users anywhere in the UI
@@ -227,6 +235,7 @@ const HIDDEN_ISSUE_TYPES: IssueType[] = [
   IssueType.AI_DETECTED_SECURITY,
   IssueType.AI_DETECTED_CODE_HEALTH,
   IssueType.AI_DETECTED_GENERAL,
+  IssueType.LLM_CACHE_USAGE,
 ];
 
 export const AI_DETECTED_ISSUE_TYPES = new Set<IssueType>([
@@ -300,6 +309,9 @@ export enum IssueTitle {
   // Configuration Issues
   SOURCEMAP_CONFIGURATION = 'Missing or Broken Source Maps',
   LOW_VALUE_SPAN_CONFIGURATION = 'AI Detected Low-Value Span',
+
+  // Gen AI
+  LLM_CACHE_USAGE = 'LLM Cache Usage',
 }
 
 const ISSUE_TYPE_TO_ISSUE_TITLE = {
@@ -353,6 +365,8 @@ const ISSUE_TYPE_TO_ISSUE_TITLE = {
 
   sourcemap_configuration: IssueTitle.SOURCEMAP_CONFIGURATION,
   low_value_span_configuration: IssueTitle.LOW_VALUE_SPAN_CONFIGURATION,
+
+  llm_cache_usage: IssueTitle.LLM_CACHE_USAGE,
 };
 
 export function getIssueTitleFromType(issueType: string): IssueTitle | undefined {
@@ -397,6 +411,7 @@ const OCCURRENCE_TYPE_TO_ISSUE_TYPE = {
   11001: IssueType.PREPROD_STATIC,
   11002: IssueType.PREPROD_DELTA,
   11003: IssueType.PREPROD_SIZE_ANALYSIS,
+  14001: IssueType.LLM_CACHE_USAGE,
 };
 
 const PERFORMANCE_REGRESSION_TYPE_IDS = new Set([1017, 1018, 2010, 2011]);

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -152,9 +152,7 @@ export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {
   [IssueCategory.CONFIGURATION]: t(
     'Issues detected from SDK/tooling configuration problems.'
   ),
-  [IssueCategory.GEN_AI]: t(
-    'Wasteful or costly use of generative-AI providers, such as poor prompt-cache utilization.'
-  ),
+  [IssueCategory.GEN_AI]: t('Wasteful or costly use of generative-AI providers.'),
 };
 
 export enum IssueType {

--- a/static/app/utils/issueTypeConfig/genAiConfig.tsx
+++ b/static/app/utils/issueTypeConfig/genAiConfig.tsx
@@ -1,0 +1,53 @@
+import {t} from 'sentry/locale';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+
+export const genAiConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {enabled: true},
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for Gen AI issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not yet supported for Gen AI issues'),
+      },
+      ignore: {enabled: true},
+      resolve: {enabled: true},
+      resolveInRelease: {
+        enabled: false,
+        disabledReason: t('Gen AI issues are not associated with a release'),
+      },
+      share: {enabled: true},
+    },
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: true},
+      openPeriods: {enabled: false},
+      checkIns: {enabled: false},
+      uptimeChecks: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: false},
+      replays: {enabled: false},
+      tagsTab: {enabled: false},
+    },
+    // Occurrences are synthesized from aggregated span data. There is no stack
+    // trace and no span tree, so Seer has nothing to reason about.
+    autofix: false,
+    issueSummary: {enabled: false},
+    stacktrace: {enabled: false},
+    spanEvidence: {enabled: false},
+    // The detector attaches a fully populated evidence_display to every occurrence.
+    evidence: {title: t('Cache Usage')},
+    // Fingerprints are chosen by the detector, so grouping variants say nothing useful.
+    groupingInfo: {enabled: false},
+    // Synthesized occurrences are not queryable in Discover.
+    discover: {enabled: false},
+    mergedIssues: {enabled: false},
+    similarIssues: {enabled: false},
+    usesIssuePlatform: true,
+  },
+};

--- a/static/app/utils/issueTypeConfig/genAiConfig.tsx
+++ b/static/app/utils/issueTypeConfig/genAiConfig.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {IssueType} from 'sentry/types/group';
 import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
 import {Tab} from 'sentry/views/issueDetails/types';
 
@@ -49,5 +50,44 @@ export const genAiConfig: IssueCategoryConfigMapping = {
     mergedIssues: {enabled: false},
     similarIssues: {enabled: false},
     usesIssuePlatform: true,
+  },
+  [IssueType.LLM_CACHE_USAGE]: {
+    // The issue page renders the finding itself -- the problem, a healthy
+    // comparison, live cache activity, example calls and the fix. The generic
+    // evidence table would repeat all of it as an unordered list of numbers.
+    // The category default keeps that table for contexts that resolve config by
+    // occurrence type alone, like the shared-issue page.
+    evidence: null,
+    header: {
+      // One occurrence per open period, so an occurrence histogram is a single
+      // bar. The cache activity chart in the body is the graph worth showing.
+      graph: {enabled: false},
+      filterBar: {enabled: false},
+      eventNavigation: {enabled: false},
+      tagDistribution: {enabled: false},
+      occurrenceSummary: {enabled: false},
+    },
+    // One synthesized event, no users.
+    eventAndUserCounts: {enabled: false},
+    // The only tags are the transaction and the model, both of which the
+    // Problem section already shows as first-class rows.
+    tags: {enabled: false},
+    contexts: {enabled: false},
+    // The trace preview locates a trace by the event's timestamp, which here is
+    // detection time rather than the time of the sampled call. Example Calls
+    // links to the traces with their own timestamps instead.
+    trace: {enabled: false},
+    resources: {
+      description: t(
+        'Prompt caching lets a provider re-use the unchanging start of a prompt across calls, billed at a fraction of the normal input rate. It only engages when that prefix is byte-identical every time, so small amounts of per-call content near the top of a prompt can quietly disable it.'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: AI Agents'),
+          link: 'https://docs.sentry.io/product/insights/agents/',
+        },
+      ],
+      linksByPlatform: {},
+    },
   },
 };

--- a/static/app/utils/issueTypeConfig/genAiConfig.tsx
+++ b/static/app/utils/issueTypeConfig/genAiConfig.tsx
@@ -67,8 +67,8 @@ export const genAiConfig: IssueCategoryConfigMapping = {
     },
     // One synthesized event, no users.
     eventAndUserCounts: {enabled: false},
-    // The only tags are the transaction and the model, both of which the
-    // Problem section already shows as first-class rows.
+    // The only tags are the call site's own label and the model, both of which
+    // the Problem section already shows as first-class rows.
     tags: {enabled: false},
     contexts: {enabled: false},
     // The trace preview locates a trace by the event's timestamp, which here is

--- a/static/app/utils/issueTypeConfig/genAiConfig.tsx
+++ b/static/app/utils/issueTypeConfig/genAiConfig.tsx
@@ -52,11 +52,9 @@ export const genAiConfig: IssueCategoryConfigMapping = {
     usesIssuePlatform: true,
   },
   [IssueType.LLM_CACHE_USAGE]: {
-    // The issue page renders the finding itself -- the problem, a healthy
-    // comparison, live cache activity, example calls and the fix. The generic
-    // evidence table would repeat all of it as an unordered list of numbers.
-    // The category default keeps that table for contexts that resolve config by
-    // occurrence type alone, like the shared-issue page.
+    // The issue page renders the finding itself, so the generic evidence table
+    // would repeat it as an unordered list of numbers. The category default
+    // keeps that table for surfaces that resolve config without a group.
     evidence: null,
     header: {
       // One occurrence per open period, so an occurrence histogram is a single

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry/utils/issueTypeConfig/errorConfig';
 import {feedbackConfig} from 'sentry/utils/issueTypeConfig/feedbackConfig';
 import {frontendConfig} from 'sentry/utils/issueTypeConfig/frontendConfig';
+import {genAiConfig} from 'sentry/utils/issueTypeConfig/genAiConfig';
 import {httpClientConfig} from 'sentry/utils/issueTypeConfig/httpClientConfig';
 import {metricConfig} from 'sentry/utils/issueTypeConfig/metricConfig';
 import {metricIssueConfig} from 'sentry/utils/issueTypeConfig/metricIssueConfig';
@@ -114,6 +115,7 @@ const issueTypeConfig: Config = {
   [IssueCategory.AI_DETECTED]: aiDetectedConfig,
   [IssueCategory.PREPROD]: preprodConfig,
   [IssueCategory.CONFIGURATION]: configurationIssuesConfig,
+  [IssueCategory.GEN_AI]: genAiConfig,
 };
 
 /**
@@ -137,6 +139,12 @@ function shouldShowCustomErrorResourceConfig(
 }
 
 const eventOccurrenceTypeToIssueCategory = (eventOccurrenceType: number) => {
+  // Shared issues and the trace drawer have no group to read the category from.
+  // Without this they fall through to the performance config, which disables the
+  // evidence section that Gen AI occurrences rely on.
+  if (eventOccurrenceType >= 14000 && eventOccurrenceType < 15000) {
+    return IssueCategory.GEN_AI;
+  }
   if (eventOccurrenceType >= 1000) {
     return IssueCategory.PERFORMANCE;
   }

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -113,6 +113,8 @@ export enum SpanFields {
   GEN_AI_COST_TOTAL_TOKENS = 'gen_ai.cost.total_tokens',
   GEN_AI_USAGE_INPUT_TOKENS = 'gen_ai.usage.input_tokens',
   GEN_AI_USAGE_INPUT_TOKENS_CACHED = 'gen_ai.usage.input_tokens.cached',
+  GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = 'gen_ai.usage.cache_read.input_tokens',
+  GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = 'gen_ai.usage.cache_creation.input_tokens',
   GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens',
   GEN_AI_USAGE_OUTPUT_TOKENS_REASONING = 'gen_ai.usage.output_tokens.reasoning',
   GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens',
@@ -261,6 +263,8 @@ type SpanNumberFields =
   | SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS
   | SpanFields.GEN_AI_USAGE_TOTAL_TOKENS
   | SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED
+  | SpanFields.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+  | SpanFields.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
   | SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING
   | SpanFields.TOTAL_SCORE
   | SpanFields.INP_SCORE

--- a/static/app/views/issueDetails/context.tsx
+++ b/static/app/views/issueDetails/context.tsx
@@ -72,6 +72,7 @@ export const enum SectionKey {
   PROCESSING_ERROR = 'processing-error',
   CONFIGURATION_PROBLEM = 'configuration-problem',
   LLM_CACHE_PROBLEM = 'llm-cache-problem', // Only LLM Cache Usage issues
+  LLM_CACHE_PROMPT_SHAPE = 'llm-cache-prompt-shape',
   LLM_CACHE_COMPARISON = 'llm-cache-comparison',
   LLM_CACHE_ACTIVITY = 'llm-cache-activity',
   LLM_CACHE_EXAMPLE_CALLS = 'llm-cache-example-calls',

--- a/static/app/views/issueDetails/context.tsx
+++ b/static/app/views/issueDetails/context.tsx
@@ -71,6 +71,11 @@ export const enum SectionKey {
   GROUPING_INFO = 'grouping-info',
   PROCESSING_ERROR = 'processing-error',
   CONFIGURATION_PROBLEM = 'configuration-problem',
+  LLM_CACHE_PROBLEM = 'llm-cache-problem', // Only LLM Cache Usage issues
+  LLM_CACHE_COMPARISON = 'llm-cache-comparison',
+  LLM_CACHE_ACTIVITY = 'llm-cache-activity',
+  LLM_CACHE_EXAMPLE_CALLS = 'llm-cache-example-calls',
+  LLM_CACHE_TROUBLESHOOTING = 'llm-cache-troubleshooting',
   CONFIGURATION_TROUBLESHOOTING = 'configuration-troubleshooting',
   RRWEB = 'rrweb', // Legacy integration prior to replays
 

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/callSiteMetric.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/callSiteMetric.tsx
@@ -1,0 +1,46 @@
+import {InfoTip} from '@sentry/scraps/info';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {KeyValueData} from 'sentry/components/keyValueData';
+
+interface CallSiteMetricProps {
+  id: string;
+  label: string;
+  value: string;
+  /**
+   * Set on the figure the finding turns on, so the row that explains the issue
+   * stands out from the ones that merely describe the call site.
+   */
+  emphasized?: boolean;
+  tooltip?: string;
+}
+
+/**
+ * One measured figure about the call site, as a row of the diagnostics grid.
+ */
+export function CallSiteMetric({
+  id,
+  label,
+  value,
+  emphasized,
+  tooltip,
+}: CallSiteMetricProps) {
+  return (
+    <KeyValueData.Content
+      disableFormattedData
+      item={{
+        key: id,
+        subject: label,
+        value: (
+          <Flex align="center" gap="xs">
+            <Text monospace bold={emphasized}>
+              {value}
+            </Text>
+            {tooltip && <InfoTip size="xs" title={tooltip} />}
+          </Flex>
+        ),
+      }}
+    />
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.spec.tsx
@@ -1,0 +1,77 @@
+import {EventFixture} from 'sentry-fixture/event';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheUsageSections} from './index';
+
+const evidenceData = {
+  outcome: 'not_caching',
+  agentLabel: 'Planner',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  hitRate: 0,
+  avgInputTokens: 12_000,
+  uncachedTokens: 8_700_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 0,
+  sumCacheCreationTokens: 0,
+  windowDays: 7,
+  windowStart: '2026-08-10T00:00:00+00:00',
+  windowEnd: '2026-08-17T00:00:00+00:00',
+};
+
+function eventWith(overrides: Record<string, unknown> = {}) {
+  return EventFixture({
+    occurrence: {evidenceData: {...evidenceData, ...overrides}, evidenceDisplay: []},
+  });
+}
+
+describe('LlmCacheUsageSections', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {timeSeries: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
+    });
+  });
+
+  it('shows cache activity for a call site the live query can be scoped to', () => {
+    render(<LlmCacheUsageSections event={eventWith()} />);
+
+    expect(screen.getByText('Cache Activity')).toBeInTheDocument();
+  });
+
+  it('leaves out cache activity when the occurrence carries no window', () => {
+    // The chart renders nothing without one, and the section around it would be
+    // a heading over empty space plus a nav entry that scrolls to it.
+    render(<LlmCacheUsageSections event={eventWith({windowStart: null})} />);
+
+    expect(screen.queryByText('Cache Activity')).not.toBeInTheDocument();
+    expect(screen.getByText('Problem')).toBeInTheDocument();
+  });
+
+  it('leaves out cache activity for a call site the grammar cannot express', () => {
+    render(
+      <LlmCacheUsageSections event={eventWith({spanName: 'generate_content claude\\'})} />
+    );
+
+    expect(screen.queryByText('Cache Activity')).not.toBeInTheDocument();
+  });
+
+  it('leaves out the sections an occurrence carries no data for', () => {
+    render(<LlmCacheUsageSections event={eventWith()} />);
+
+    expect(screen.queryByText('Prompt Shape')).not.toBeInTheDocument();
+    expect(screen.queryByText('Healthy Comparison')).not.toBeInTheDocument();
+    expect(screen.queryByText('Example Calls')).not.toBeInTheDocument();
+    // Always rendered: neither depends on data beyond the finding itself.
+    expect(screen.getByText('Problem')).toBeInTheDocument();
+    expect(screen.getByText('Troubleshooting')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.tsx
@@ -1,0 +1,67 @@
+import {Fragment} from 'react';
+
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import {SectionKey} from 'sentry/views/issueDetails/context';
+import {FoldSection} from 'sentry/views/issueDetails/foldSection';
+
+import {LlmCacheActivityChart} from './llmCacheActivityChart';
+import {LlmCacheComparisonSection} from './llmCacheComparisonSection';
+import {LlmCacheExampleCalls} from './llmCacheExampleCalls';
+import {LlmCacheProblemSection} from './llmCacheProblemSection';
+import {LlmCacheTroubleshootingSection} from './llmCacheTroubleshootingSection';
+import {getLlmCacheEvidenceData} from './utils';
+
+interface LlmCacheUsageSectionsProps {
+  event: Event;
+}
+
+/**
+ * The body of an LLM Cache Usage issue.
+ *
+ * Both findings share this layout: they are alternative readings of one call
+ * site and the same issue can present as either between runs, so only the copy
+ * and the emphasis change, never the structure.
+ */
+export function LlmCacheUsageSections({event}: LlmCacheUsageSectionsProps) {
+  const evidenceData = getLlmCacheEvidenceData(event.occurrence?.evidenceData);
+
+  return (
+    <Fragment>
+      <FoldSection sectionKey={SectionKey.LLM_CACHE_PROBLEM} title={t('Problem')}>
+        <LlmCacheProblemSection evidenceData={evidenceData} />
+      </FoldSection>
+      {evidenceData.anchor !== null && (
+        <FoldSection
+          sectionKey={SectionKey.LLM_CACHE_COMPARISON}
+          title={t('Healthy Comparison')}
+        >
+          <LlmCacheComparisonSection evidenceData={evidenceData} />
+        </FoldSection>
+      )}
+      <ErrorBoundary mini>
+        <FoldSection
+          sectionKey={SectionKey.LLM_CACHE_ACTIVITY}
+          title={t('Cache Activity')}
+        >
+          <LlmCacheActivityChart evidenceData={evidenceData} />
+        </FoldSection>
+      </ErrorBoundary>
+      {evidenceData.sampleCalls.length > 0 && (
+        <FoldSection
+          sectionKey={SectionKey.LLM_CACHE_EXAMPLE_CALLS}
+          title={t('Example Calls')}
+        >
+          <LlmCacheExampleCalls evidenceData={evidenceData} />
+        </FoldSection>
+      )}
+      <FoldSection
+        sectionKey={SectionKey.LLM_CACHE_TROUBLESHOOTING}
+        title={t('Troubleshooting')}
+      >
+        <LlmCacheTroubleshootingSection evidenceData={evidenceData} />
+      </FoldSection>
+    </Fragment>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 
-import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import {SectionKey} from 'sentry/views/issueDetails/context';
@@ -12,7 +11,7 @@ import {LlmCacheExampleCalls} from './llmCacheExampleCalls';
 import {LlmCacheProblemSection} from './llmCacheProblemSection';
 import {LlmCachePromptShapeSection} from './llmCachePromptShapeSection';
 import {LlmCacheTroubleshootingSection} from './llmCacheTroubleshootingSection';
-import {getLlmCacheEvidenceData} from './utils';
+import {canQueryCallSite, getLlmCacheEvidenceData} from './utils';
 
 interface LlmCacheUsageSectionsProps {
   event: Event;
@@ -49,14 +48,14 @@ export function LlmCacheUsageSections({event}: LlmCacheUsageSectionsProps) {
           <LlmCacheComparisonSection evidenceData={evidenceData} />
         </FoldSection>
       )}
-      <ErrorBoundary mini>
+      {canQueryCallSite(evidenceData) && (
         <FoldSection
           sectionKey={SectionKey.LLM_CACHE_ACTIVITY}
           title={t('Cache Activity')}
         >
           <LlmCacheActivityChart evidenceData={evidenceData} />
         </FoldSection>
-      </ErrorBoundary>
+      )}
       {evidenceData.sampleCalls.length > 0 && (
         <FoldSection
           sectionKey={SectionKey.LLM_CACHE_EXAMPLE_CALLS}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/index.tsx
@@ -10,6 +10,7 @@ import {LlmCacheActivityChart} from './llmCacheActivityChart';
 import {LlmCacheComparisonSection} from './llmCacheComparisonSection';
 import {LlmCacheExampleCalls} from './llmCacheExampleCalls';
 import {LlmCacheProblemSection} from './llmCacheProblemSection';
+import {LlmCachePromptShapeSection} from './llmCachePromptShapeSection';
 import {LlmCacheTroubleshootingSection} from './llmCacheTroubleshootingSection';
 import {getLlmCacheEvidenceData} from './utils';
 
@@ -32,6 +33,14 @@ export function LlmCacheUsageSections({event}: LlmCacheUsageSectionsProps) {
       <FoldSection sectionKey={SectionKey.LLM_CACHE_PROBLEM} title={t('Problem')}>
         <LlmCacheProblemSection evidenceData={evidenceData} />
       </FoldSection>
+      {evidenceData.promptDivergence !== null && (
+        <FoldSection
+          sectionKey={SectionKey.LLM_CACHE_PROMPT_SHAPE}
+          title={t('Prompt Shape')}
+        >
+          <LlmCachePromptShapeSection evidenceData={evidenceData} />
+        </FoldSection>
+      )}
       {evidenceData.anchor !== null && (
         <FoldSection
           sectionKey={SectionKey.LLM_CACHE_COMPARISON}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
@@ -25,7 +25,7 @@ const evidence: LlmCacheEvidenceData = {
   anchor: null,
 };
 
-function series(yAxis: string, values: number[]) {
+function series(yAxis: string, values: Array<number | null>) {
   return {
     yAxis,
     values: values.map((value, index) => ({
@@ -64,6 +64,46 @@ describe('LlmCacheActivityChart', () => {
         }),
       })
     );
+  });
+
+  it('says so when the call site reported nothing in the period', async () => {
+    // The backend emits null, not 0, for empty buckets. A call site that was
+    // renamed, fixed, or has aged past retention comes back entirely null --
+    // and the visualization throws rather than renders when it has nothing to
+    // draw, which would blank the section behind an error boundary.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          series('sum(gen_ai.usage.input_tokens)', [null, null]),
+          series('sum(gen_ai.usage.cache_read.input_tokens)', [null, null]),
+          series('sum(gen_ai.usage.cache_creation.input_tokens)', [null, null]),
+        ],
+      },
+    });
+
+    render(<LlmCacheActivityChart evidenceData={evidence} />);
+
+    expect(
+      await screen.findByText(
+        'No cache activity recorded for this call site in this period.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('says so when the response carries no series at all', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {timeSeries: []},
+    });
+
+    render(<LlmCacheActivityChart evidenceData={evidence} />);
+
+    expect(
+      await screen.findByText(
+        'No cache activity recorded for this call site in this period.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('renders nothing when the occurrence predates the emitted window', () => {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
@@ -24,6 +24,7 @@ const evidence: LlmCacheEvidenceData = {
   windowDays: 7,
   windowStart: '2026-08-10T00:00:00+00:00',
   windowEnd: '2026-08-17T00:00:00+00:00',
+  promptDivergence: null,
   sampleCalls: [],
   anchor: null,
 };

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
@@ -1,0 +1,78 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheActivityChart} from './llmCacheActivityChart';
+import type {LlmCacheEvidenceData} from './types';
+
+const evidence: LlmCacheEvidenceData = {
+  outcome: 'thrash',
+  transaction: 'agent.execute_step',
+  spanDescription: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  hitRate: 0.0487,
+  writeReadRatio: 12,
+  avgInputTokens: 4096,
+  uncachedTokens: 3_200_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 424_400,
+  sumCacheCreationTokens: 5_100_000,
+  estimatedSavingsUsd: null,
+  overpayVsNoCacheUsd: null,
+  windowDays: 7,
+  windowStart: '2026-08-10T00:00:00+00:00',
+  windowEnd: '2026-08-17T00:00:00+00:00',
+  sampleCalls: [],
+  anchor: null,
+};
+
+function series(yAxis: string, values: number[]) {
+  return {
+    yAxis,
+    values: values.map((value, index) => ({
+      timestamp: 1_760_000_000_000 + index * 3_600_000,
+      value,
+    })),
+    meta: {interval: 3_600_000, valueType: 'number', valueUnit: null},
+  };
+}
+
+describe('LlmCacheActivityChart', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('queries the call site over the detection window', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          series('sum(gen_ai.usage.input_tokens)', [1000, 1000]),
+          series('sum(gen_ai.usage.cache_read.input_tokens)', [100, 100]),
+          series('sum(gen_ai.usage.cache_creation.input_tokens)', [400, 400]),
+        ],
+      },
+    });
+
+    render(<LlmCacheActivityChart evidenceData={evidence} />);
+
+    expect(await screen.findByText(/Live data for this call site/)).toBeInTheDocument();
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: expect.stringContaining('agent.execute_step'),
+        }),
+      })
+    );
+  });
+
+  it('renders nothing when the occurrence predates the emitted window', () => {
+    const {container} = render(
+      <LlmCacheActivityChart
+        evidenceData={{...evidence, windowStart: null, windowEnd: null}}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
@@ -1,5 +1,7 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+
 import {LlmCacheActivityChart} from './llmCacheActivityChart';
 import type {LlmCacheEvidenceData} from './types';
 
@@ -43,6 +45,7 @@ function series(yAxis: string, values: Array<number | null>) {
 describe('LlmCacheActivityChart', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
   });
 
   it('queries the call site over the detection window', async () => {
@@ -66,6 +69,31 @@ describe('LlmCacheActivityChart', () => {
         query: expect.objectContaining({
           query: expect.stringContaining('gen_ai.agent.name:Executor'),
         }),
+      })
+    );
+  });
+
+  it('ignores the environment the reader has pinned elsewhere', async () => {
+    // The detector applied no environment filter, and this page renders no
+    // filter bar. Inheriting one would quietly chart a slice of the traffic the
+    // finding was measured over, with nothing on screen to say so.
+    PageFiltersStore.onInitializeUrlState({
+      projects: [],
+      environments: ['production'],
+      datetime: {start: null, end: null, period: '14d', utc: null},
+    });
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {timeSeries: [series('sum(gen_ai.usage.input_tokens)', [1000, 1000])]},
+    });
+
+    render(<LlmCacheActivityChart evidenceData={evidence} />);
+
+    expect(await screen.findByText(/Live data for this call site/)).toBeInTheDocument();
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-timeseries/',
+      expect.objectContaining({
+        query: expect.objectContaining({environment: []}),
       })
     );
   });

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
@@ -5,8 +5,9 @@ import type {LlmCacheEvidenceData} from './types';
 
 const evidence: LlmCacheEvidenceData = {
   outcome: 'thrash',
-  transaction: 'agent.execute_step',
-  spanDescription: 'generate_content claude-sonnet-4',
+  agentLabel: 'Executor',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
   hitRate: 0.0487,
@@ -60,7 +61,7 @@ describe('LlmCacheActivityChart', () => {
       '/organizations/org-slug/events-timeseries/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: expect.stringContaining('agent.execute_step'),
+          query: expect.stringContaining('gen_ai.agent.name:Executor'),
         }),
       })
     );

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.spec.tsx
@@ -10,6 +10,8 @@ const evidence: LlmCacheEvidenceData = {
   spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
+  warmCallCount: 1951,
+  cacheableShare: 0.92,
   hitRate: 0.0487,
   writeReadRatio: 12,
   avgInputTokens: 4096,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
@@ -14,6 +14,10 @@ import type {LlmCacheEvidenceData} from './types';
 import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {buildCallSiteQuery, LLM_CACHE_REFERRER} from './utils';
 
+// The canonical attribute names, which are also the ones the detector summed.
+// Most SDKs write the deprecated aliases instead, but the resolver back-fills
+// those onto these, so the chart plots the same data the finding was derived
+// from rather than a subset of it.
 const INPUT_TOKENS = `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})` as const;
 const CACHE_READ_TOKENS =
   `sum(${SpanFields.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS})` as const;

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
@@ -87,8 +87,7 @@ function ActivityPlot({isPending, hasError, plottables}: ActivityPlotProps) {
   }
   // The visualization throws rather than renders when it has nothing to draw,
   // and every bucket comes back null once the call site stops reporting -- after
-  // a rename, after retention drops the window, or after the reader ships the
-  // fix. That is an ordinary outcome here, so it gets a sentence, not a crash.
+  // a rename, past retention, or once the fix ships. All ordinary here.
   if (plottables.every(plottable => plottable.isEmpty)) {
     return (
       <Text variant="muted">

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
@@ -15,8 +15,9 @@ import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {buildCallSiteQuery, LLM_CACHE_REFERRER} from './utils';
 
 // The canonical attribute names, which are also the ones the detector summed.
-// Most SDKs write the deprecated aliases instead, but the resolver back-fills
-// those onto these, so the chart plots the same data the finding was derived
+// Most SDKs write the deprecated aliases instead; those are declared in
+// sentry_conventions as back-filled onto these, and the back-fill is applied to
+// the stored span, so the chart plots the same data the finding was derived
 // from rather than a subset of it.
 const INPUT_TOKENS = `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})` as const;
 const CACHE_READ_TOKENS =

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
@@ -1,0 +1,135 @@
+import {useMemo} from 'react';
+
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {useFetchSpanTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {SpanFields} from 'sentry/views/insights/types';
+
+import type {LlmCacheEvidenceData} from './types';
+import {useCallSitePageFilters} from './useCallSitePageFilters';
+import {buildCallSiteQuery, LLM_CACHE_REFERRER} from './utils';
+
+const INPUT_TOKENS = `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})` as const;
+const CACHE_READ_TOKENS =
+  `sum(${SpanFields.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS})` as const;
+const CACHE_CREATION_TOKENS =
+  `sum(${SpanFields.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS})` as const;
+
+// A week of history either side of the detection window, so the reader can see
+// what the call site looked like before it was flagged and after they ship.
+const PADDING_DAYS = 7;
+
+interface LlmCacheActivityChartProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+function findSeries(timeSeries: TimeSeries[] | undefined, yAxis: string) {
+  return timeSeries?.find(series => series.yAxis === yAxis);
+}
+
+/**
+ * Derive the uncached band by subtracting cache traffic from total input.
+ *
+ * Clamped at zero for the same reason the detector clamps it: some providers
+ * report input tokens exclusive of the cached ones.
+ */
+function deriveUncachedSeries(
+  input: TimeSeries | undefined,
+  reads: TimeSeries | undefined,
+  writes: TimeSeries | undefined
+): TimeSeries | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  const readsByTimestamp = new Map(
+    reads?.values.map(item => [item.timestamp, item.value])
+  );
+  const writesByTimestamp = new Map(
+    writes?.values.map(item => [item.timestamp, item.value])
+  );
+
+  return {
+    ...input,
+    yAxis: 'uncached',
+    values: input.values.map(item => ({
+      ...item,
+      value:
+        item.value === null
+          ? null
+          : Math.max(
+              item.value -
+                (readsByTimestamp.get(item.timestamp) ?? 0) -
+                (writesByTimestamp.get(item.timestamp) ?? 0),
+              0
+            ),
+    })),
+  };
+}
+
+/**
+ * How the call site's input tokens were billed over time.
+ *
+ * This is the only part of the page that moves after the reader ships a fix,
+ * which is why it is worth a live query rather than numbers frozen at
+ * detection time.
+ */
+export function LlmCacheActivityChart({evidenceData}: LlmCacheActivityChartProps) {
+  const pageFilters = useCallSitePageFilters(evidenceData, {padDays: PADDING_DAYS});
+  const query = buildCallSiteQuery(evidenceData);
+  const enabled = query !== null && pageFilters !== undefined;
+
+  const {data, isPending, error} = useFetchSpanTimeSeries(
+    {
+      yAxis: [INPUT_TOKENS, CACHE_READ_TOKENS, CACHE_CREATION_TOKENS],
+      query: query ?? undefined,
+      pageFilters,
+      enabled,
+    },
+    LLM_CACHE_REFERRER
+  );
+
+  const plottables = useMemo(() => {
+    const reads = findSeries(data?.timeSeries, CACHE_READ_TOKENS);
+    const writes = findSeries(data?.timeSeries, CACHE_CREATION_TOKENS);
+    const uncached = deriveUncachedSeries(
+      findSeries(data?.timeSeries, INPUT_TOKENS),
+      reads,
+      writes
+    );
+
+    return [
+      uncached && new Bars(uncached, {alias: t('Uncached'), stack: 'tokens'}),
+      writes && new Bars(writes, {alias: t('Cache writes'), stack: 'tokens'}),
+      reads && new Bars(reads, {alias: t('Cache reads'), stack: 'tokens'}),
+    ].filter(plottable => plottable !== undefined);
+  }, [data]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md">
+      <div style={{height: 190}}>
+        {isPending ? (
+          <TimeSeriesWidgetVisualization.LoadingPlaceholder />
+        ) : error ? (
+          <Text variant="danger">{t('Unable to load cache activity')}</Text>
+        ) : (
+          <TimeSeriesWidgetVisualization plottables={plottables} />
+        )}
+      </div>
+      <Text size="sm" variant="muted">
+        {t(
+          'Live data for this call site. It may differ slightly from the numbers captured when this issue was detected.'
+        )}
+      </Text>
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
@@ -72,6 +72,33 @@ function deriveUncachedSeries(
   };
 }
 
+interface ActivityPlotProps {
+  hasError: boolean;
+  isPending: boolean;
+  plottables: Bars[];
+}
+
+function ActivityPlot({isPending, hasError, plottables}: ActivityPlotProps) {
+  if (isPending) {
+    return <TimeSeriesWidgetVisualization.LoadingPlaceholder />;
+  }
+  if (hasError) {
+    return <Text variant="danger">{t('Unable to load cache activity')}</Text>;
+  }
+  // The visualization throws rather than renders when it has nothing to draw,
+  // and every bucket comes back null once the call site stops reporting -- after
+  // a rename, after retention drops the window, or after the reader ships the
+  // fix. That is an ordinary outcome here, so it gets a sentence, not a crash.
+  if (plottables.every(plottable => plottable.isEmpty)) {
+    return (
+      <Text variant="muted">
+        {t('No cache activity recorded for this call site in this period.')}
+      </Text>
+    );
+  }
+  return <TimeSeriesWidgetVisualization plottables={plottables} />;
+}
+
 /**
  * How the call site's input tokens were billed over time.
  *
@@ -114,26 +141,14 @@ export function LlmCacheActivityChart({evidenceData}: LlmCacheActivityChartProps
     return null;
   }
 
-  // The visualization throws rather than renders when it has nothing to draw,
-  // and every bucket comes back null once the call site stops reporting -- after
-  // a rename, after retention drops the window, or after the reader ships the
-  // fix. That is an ordinary outcome here, so it gets a sentence, not a crash.
-  const hasSomethingToPlot = plottables.some(plottable => !plottable.isEmpty);
-
   return (
     <Stack gap="md">
       <Container height="190px">
-        {isPending ? (
-          <TimeSeriesWidgetVisualization.LoadingPlaceholder />
-        ) : error ? (
-          <Text variant="danger">{t('Unable to load cache activity')}</Text>
-        ) : hasSomethingToPlot ? (
-          <TimeSeriesWidgetVisualization plottables={plottables} />
-        ) : (
-          <Text variant="muted">
-            {t('No cache activity recorded for this call site in this period.')}
-          </Text>
-        )}
+        <ActivityPlot
+          isPending={isPending}
+          hasError={error !== null}
+          plottables={plottables}
+        />
       </Container>
       <Text size="sm" variant="muted">
         {t(

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActivityChart.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -114,17 +114,27 @@ export function LlmCacheActivityChart({evidenceData}: LlmCacheActivityChartProps
     return null;
   }
 
+  // The visualization throws rather than renders when it has nothing to draw,
+  // and every bucket comes back null once the call site stops reporting -- after
+  // a rename, after retention drops the window, or after the reader ships the
+  // fix. That is an ordinary outcome here, so it gets a sentence, not a crash.
+  const hasSomethingToPlot = plottables.some(plottable => !plottable.isEmpty);
+
   return (
     <Stack gap="md">
-      <div style={{height: 190}}>
+      <Container height="190px">
         {isPending ? (
           <TimeSeriesWidgetVisualization.LoadingPlaceholder />
         ) : error ? (
           <Text variant="danger">{t('Unable to load cache activity')}</Text>
-        ) : (
+        ) : hasSomethingToPlot ? (
           <TimeSeriesWidgetVisualization plottables={plottables} />
+        ) : (
+          <Text variant="muted">
+            {t('No cache activity recorded for this call site in this period.')}
+          </Text>
         )}
-      </div>
+      </Container>
       <Text size="sm" variant="muted">
         {t(
           'Live data for this call site. It may differ slightly from the numbers captured when this issue was detected.'

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActualSpend.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActualSpend.tsx
@@ -1,0 +1,86 @@
+import {InfoTip} from '@sentry/scraps/info';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {KeyValueData} from 'sentry/components/keyValueData';
+import {Placeholder} from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {SpanFields} from 'sentry/views/insights/types';
+
+import type {LlmCacheEvidenceData} from './types';
+import {useCallSitePageFilters} from './useCallSitePageFilters';
+import {buildCallSiteQuery, formatUsd, LLM_CACHE_REFERRER} from './utils';
+
+const INPUT_COST_FIELD = `sum(${SpanFields.GEN_AI_COST_INPUT_TOKENS})` as const;
+
+interface LlmCacheActualSpendProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+/**
+ * What the call site actually spent on input tokens over the window.
+ *
+ * The avoidable figure beside it is an estimate; anchoring it against real
+ * billed spend is what makes it credible. Renders nothing when the pipeline
+ * never priced these spans, which is the case for models the metadata feed
+ * does not know.
+ */
+export function LlmCacheActualSpend({evidenceData}: LlmCacheActualSpendProps) {
+  const pageFilters = useCallSitePageFilters(evidenceData);
+  const query = buildCallSiteQuery(evidenceData);
+
+  const {data, isPending, isError} = useSpans(
+    {
+      fields: [INPUT_COST_FIELD],
+      search: query ?? undefined,
+      pageFilters,
+      limit: 1,
+      enabled: query !== null && pageFilters !== undefined,
+    },
+    LLM_CACHE_REFERRER
+  );
+
+  if (query === null || pageFilters === undefined || isError) {
+    return null;
+  }
+
+  if (isPending) {
+    return (
+      <KeyValueData.Content
+        disableFormattedData
+        item={{
+          key: 'actual-spend',
+          subject: t('Spend'),
+          value: <Placeholder height="1rem" width="80px" />,
+        }}
+      />
+    );
+  }
+
+  const spend = data?.[0]?.[INPUT_COST_FIELD];
+  if (typeof spend !== 'number' || spend <= 0) {
+    return null;
+  }
+
+  return (
+    <KeyValueData.Content
+      disableFormattedData
+      item={{
+        key: 'actual-spend',
+        subject: t('Spend'),
+        value: (
+          <Flex align="center" gap="xs">
+            <Text monospace>{formatUsd(spend)}</Text>
+            <InfoTip
+              size="xs"
+              title={t(
+                'Input-token spend recorded for this call site over the detection window.'
+              )}
+            />
+          </Flex>
+        ),
+      }}
+    />
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActualSpend.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActualSpend.tsx
@@ -19,9 +19,8 @@ interface LlmCacheActualSpendProps {
  * What the call site actually spent on input tokens over the window.
  *
  * The avoidable figure beside it is an estimate; anchoring it against real
- * billed spend is what makes it credible. Renders nothing when the pipeline
- * never priced these spans, which is the case for models the metadata feed
- * does not know.
+ * billed spend is what makes it credible. Absent for models the metadata feed
+ * does not price.
  */
 export function LlmCacheActualSpend({evidenceData}: LlmCacheActualSpendProps) {
   const pageFilters = useCallSitePageFilters(evidenceData);

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActualSpend.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheActualSpend.tsx
@@ -1,13 +1,10 @@
-import {InfoTip} from '@sentry/scraps/info';
-import {Flex} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
-
 import {KeyValueData} from 'sentry/components/keyValueData';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanFields} from 'sentry/views/insights/types';
 
+import {CallSiteMetric} from './callSiteMetric';
 import type {LlmCacheEvidenceData} from './types';
 import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {buildCallSiteQuery, formatUsd, LLM_CACHE_REFERRER} from './utils';
@@ -64,23 +61,13 @@ export function LlmCacheActualSpend({evidenceData}: LlmCacheActualSpendProps) {
   }
 
   return (
-    <KeyValueData.Content
-      disableFormattedData
-      item={{
-        key: 'actual-spend',
-        subject: t('Spend'),
-        value: (
-          <Flex align="center" gap="xs">
-            <Text monospace>{formatUsd(spend)}</Text>
-            <InfoTip
-              size="xs"
-              title={t(
-                'Input-token spend recorded for this call site over the detection window.'
-              )}
-            />
-          </Flex>
-        ),
-      }}
+    <CallSiteMetric
+      id="actual-spend"
+      label={t('Spend')}
+      value={formatUsd(spend)}
+      tooltip={t(
+        'Input-token spend recorded for this call site over the detection window.'
+      )}
     />
   );
 }

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
@@ -10,6 +10,8 @@ const evidence: LlmCacheEvidenceData = {
   spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
+  warmCallCount: 1951,
+  cacheableShare: 0.92,
   hitRate: 0.0487,
   writeReadRatio: null,
   avgInputTokens: 4096,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
@@ -5,8 +5,9 @@ import type {LlmCacheEvidenceData} from './types';
 
 const evidence: LlmCacheEvidenceData = {
   outcome: 'not_caching',
-  transaction: 'agent.plan',
-  spanDescription: 'generate_content claude-sonnet-4',
+  agentLabel: 'Planner',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
   hitRate: 0.0487,
@@ -24,8 +25,9 @@ const evidence: LlmCacheEvidenceData = {
   sampleCalls: [],
   anchor: {
     model: 'claude-sonnet-4',
-    transaction: 'agent.summarize',
-    spanDescription: 'generate_content claude-sonnet-4',
+    agentLabel: 'Summarizer',
+    agentLabelSource: 'gen_ai.agent.name',
+    spanName: 'generate_content claude-sonnet-4',
     hitRate: 0.8301,
     callCount: 1743,
     avgInputTokens: 2900,
@@ -39,7 +41,7 @@ describe('LlmCacheComparisonSection', () => {
     expect(screen.getByText('4.87%')).toBeInTheDocument();
     expect(screen.getByText('83.01%')).toBeInTheDocument();
     expect(
-      screen.getByText('agent.summarize | generate_content claude-sonnet-4')
+      screen.getByText('Summarizer | generate_content claude-sonnet-4')
     ).toBeInTheDocument();
     expect(screen.getByText('1,743 calls · ~2.9K avg tokens')).toBeInTheDocument();
     expect(

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
@@ -1,0 +1,86 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheComparisonSection} from './llmCacheComparisonSection';
+import type {LlmCacheEvidenceData} from './types';
+
+const evidence: LlmCacheEvidenceData = {
+  outcome: 'not_caching',
+  transaction: 'agent.plan',
+  spanDescription: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  hitRate: 0.0487,
+  writeReadRatio: null,
+  avgInputTokens: 4096,
+  uncachedTokens: 8_700_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 0,
+  sumCacheCreationTokens: 0,
+  estimatedSavingsUsd: null,
+  overpayVsNoCacheUsd: null,
+  windowDays: 7,
+  windowStart: '2026-08-10T00:00:00+00:00',
+  windowEnd: '2026-08-17T00:00:00+00:00',
+  sampleCalls: [],
+  anchor: {
+    model: 'claude-sonnet-4',
+    transaction: 'agent.summarize',
+    spanDescription: 'generate_content claude-sonnet-4',
+    hitRate: 0.8301,
+    callCount: 1743,
+    avgInputTokens: 2900,
+  },
+};
+
+describe('LlmCacheComparisonSection', () => {
+  it('sets the flagged call site against a healthy one on the same model', () => {
+    render(<LlmCacheComparisonSection evidenceData={evidence} />);
+
+    expect(screen.getByText('4.87%')).toBeInTheDocument();
+    expect(screen.getByText('83.01%')).toBeInTheDocument();
+    expect(
+      screen.getByText('agent.summarize | generate_content claude-sonnet-4')
+    ).toBeInTheDocument();
+    expect(screen.getByText('1,743 calls · ~2.9K avg tokens')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Both call sites run claude-sonnet-4 in this project. The difference is how each one builds its prompt.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('links each call site to its samples', () => {
+    render(<LlmCacheComparisonSection evidenceData={evidence} />);
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute(
+      'href',
+      expect.stringContaining('gen_ai.request.model')
+    );
+  });
+
+  it('renders nothing without an anchor rather than an empty state', () => {
+    const {container} = render(
+      <LlmCacheComparisonSection evidenceData={{...evidence, anchor: null}} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('omits the volume line when an older occurrence has no anchor stats', () => {
+    render(
+      <LlmCacheComparisonSection
+        evidenceData={{
+          ...evidence,
+          anchor: {...evidence.anchor!, callCount: null, avgInputTokens: null},
+        }}
+      />
+    );
+
+    // The flagged side still has its own volume; only the anchor's is missing.
+    expect(screen.queryByText(/1,743 calls/)).not.toBeInTheDocument();
+    expect(screen.getByText('2,121 calls · ~4.1K avg tokens')).toBeInTheDocument();
+    expect(screen.getByText('83.01%')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.spec.tsx
@@ -24,6 +24,7 @@ const evidence: LlmCacheEvidenceData = {
   windowDays: 7,
   windowStart: '2026-08-10T00:00:00+00:00',
   windowEnd: '2026-08-17T00:00:00+00:00',
+  promptDivergence: null,
   sampleCalls: [],
   anchor: {
     model: 'claude-sonnet-4',

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.tsx
@@ -2,13 +2,13 @@ import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {LlmCacheEvidenceData} from './types';
+import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {buildCallSiteQuery, formatRate, formatTokens, LLM_CACHE_REFERRER} from './utils';
 
 interface LlmCacheComparisonSectionProps {
@@ -61,10 +61,10 @@ function CallSiteColumn({
       {callCount !== null && (
         <Text size="sm" variant="muted">
           {avgInputTokens === null || avgInputTokens === undefined
-            ? t('%s calls', callCount.toLocaleString())
+            ? tn('%s call', '%s calls', callCount)
             : t(
-                '%s calls · %s avg tokens',
-                callCount.toLocaleString(),
+                '%s · %s avg tokens',
+                tn('%s call', '%s calls', callCount),
                 formatTokens(avgInputTokens)
               )}
         </Text>
@@ -81,7 +81,9 @@ export function LlmCacheComparisonSection({
   evidenceData,
 }: LlmCacheComparisonSectionProps) {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  // Pinned to the detection window for the same reason the chart is: the two
+  // columns are only comparable over the period the finding measured.
+  const selection = useCallSitePageFilters(evidenceData);
   const {anchor} = evidenceData;
 
   if (anchor === null) {
@@ -89,7 +91,7 @@ export function LlmCacheComparisonSection({
   }
 
   const toExploreUrl = (query: string | null) =>
-    query
+    query && selection
       ? getExploreUrl({
           organization,
           selection,
@@ -110,9 +112,11 @@ export function LlmCacheComparisonSection({
       >
         <CallSiteColumn
           heading={t('This call site')}
-          label={[evidenceData.transaction, evidenceData.spanDescription]
-            .filter(Boolean)
-            .join(' | ')}
+          label={
+            [evidenceData.transaction, evidenceData.spanDescription]
+              .filter(Boolean)
+              .join(' | ') || t('Unknown')
+          }
           hitRate={evidenceData.hitRate}
           callCount={evidenceData.callCount}
           avgInputTokens={evidenceData.avgInputTokens}
@@ -121,7 +125,10 @@ export function LlmCacheComparisonSection({
         />
         <CallSiteColumn
           heading={t('Caching normally')}
-          label={[anchor.transaction, anchor.spanDescription].filter(Boolean).join(' | ')}
+          label={
+            [anchor.transaction, anchor.spanDescription].filter(Boolean).join(' | ') ||
+            t('Unknown')
+          }
           hitRate={anchor.hitRate}
           callCount={anchor.callCount}
           avgInputTokens={anchor.avgInputTokens}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.tsx
@@ -1,0 +1,146 @@
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+import type {LlmCacheEvidenceData} from './types';
+import {buildCallSiteQuery, formatRate, formatTokens, LLM_CACHE_REFERRER} from './utils';
+
+interface LlmCacheComparisonSectionProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+interface CallSiteColumnProps {
+  callCount: number | null;
+  exploreUrl: string | undefined;
+  heading: string;
+  hitRate: number | null;
+  label: string;
+  variant: 'danger' | 'success';
+  avgInputTokens?: number | null;
+}
+
+function CallSiteColumn({
+  heading,
+  label,
+  hitRate,
+  callCount,
+  avgInputTokens,
+  exploreUrl,
+  variant,
+}: CallSiteColumnProps) {
+  return (
+    <Stack gap="xs">
+      <Text size="sm" variant="muted" uppercase>
+        {heading}
+      </Text>
+      {exploreUrl ? (
+        <Link to={exploreUrl}>
+          <Text monospace size="sm">
+            {label}
+          </Text>
+        </Link>
+      ) : (
+        <Text monospace size="sm">
+          {label}
+        </Text>
+      )}
+      <Flex align="baseline" gap="sm">
+        <Text size="xl" bold variant={variant}>
+          {formatRate(hitRate)}
+        </Text>
+        <Text size="sm" variant="muted">
+          {t('cache hit rate')}
+        </Text>
+      </Flex>
+      {callCount !== null && (
+        <Text size="sm" variant="muted">
+          {avgInputTokens === null || avgInputTokens === undefined
+            ? t('%s calls', callCount.toLocaleString())
+            : t(
+                '%s calls · %s avg tokens',
+                callCount.toLocaleString(),
+                formatTokens(avgInputTokens)
+              )}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+/**
+ * The finding's rebuttal to "maybe this model just doesn't cache well here":
+ * another call site on the same model, in the same project, caching fine.
+ */
+export function LlmCacheComparisonSection({
+  evidenceData,
+}: LlmCacheComparisonSectionProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {anchor} = evidenceData;
+
+  if (anchor === null) {
+    return null;
+  }
+
+  const toExploreUrl = (query: string | null) =>
+    query
+      ? getExploreUrl({
+          organization,
+          selection,
+          mode: Mode.SAMPLES,
+          query,
+          referrer: LLM_CACHE_REFERRER,
+        })
+      : undefined;
+
+  return (
+    <Stack gap="md">
+      <Grid
+        columns={{xs: '1fr', sm: '1fr 1fr'}}
+        gap="xl"
+        border="primary"
+        radius="md"
+        padding="lg"
+      >
+        <CallSiteColumn
+          heading={t('This call site')}
+          label={[evidenceData.transaction, evidenceData.spanDescription]
+            .filter(Boolean)
+            .join(' | ')}
+          hitRate={evidenceData.hitRate}
+          callCount={evidenceData.callCount}
+          avgInputTokens={evidenceData.avgInputTokens}
+          exploreUrl={toExploreUrl(buildCallSiteQuery(evidenceData))}
+          variant="danger"
+        />
+        <CallSiteColumn
+          heading={t('Caching normally')}
+          label={[anchor.transaction, anchor.spanDescription].filter(Boolean).join(' | ')}
+          hitRate={anchor.hitRate}
+          callCount={anchor.callCount}
+          avgInputTokens={anchor.avgInputTokens}
+          exploreUrl={toExploreUrl(
+            buildCallSiteQuery({
+              transaction: anchor.transaction,
+              spanDescription: anchor.spanDescription,
+              model: anchor.model,
+            })
+          )}
+          variant="success"
+        />
+      </Grid>
+      <Text size="sm" variant="muted">
+        {t(
+          'Both call sites run %s in this project. The difference is how each one builds its prompt.',
+          anchor.model
+        )}
+      </Text>
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheComparisonSection.tsx
@@ -4,25 +4,37 @@ import {Text} from '@sentry/scraps/text';
 
 import {t, tn} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {LlmCacheEvidenceData} from './types';
 import {useCallSitePageFilters} from './useCallSitePageFilters';
-import {buildCallSiteQuery, formatRate, formatTokens, LLM_CACHE_REFERRER} from './utils';
+import {
+  buildCallSiteQuery,
+  formatCallSiteLabel,
+  formatRate,
+  formatTokens,
+  getCallSiteExploreUrl,
+} from './utils';
 
 interface LlmCacheComparisonSectionProps {
   evidenceData: LlmCacheEvidenceData;
 }
 
 interface CallSiteColumnProps {
+  avgInputTokens: number | null;
   callCount: number | null;
   exploreUrl: string | undefined;
   heading: string;
   hitRate: number | null;
   label: string;
   variant: 'danger' | 'success';
-  avgInputTokens?: number | null;
+}
+
+function formatCallVolume(callCount: number, avgInputTokens: number | null): string {
+  const calls = tn('%s call', '%s calls', callCount);
+  if (avgInputTokens === null) {
+    return calls;
+  }
+  return t('%s · %s avg tokens', calls, formatTokens(avgInputTokens));
 }
 
 function CallSiteColumn({
@@ -34,22 +46,18 @@ function CallSiteColumn({
   exploreUrl,
   variant,
 }: CallSiteColumnProps) {
+  const callSite = (
+    <Text monospace size="sm">
+      {label}
+    </Text>
+  );
+
   return (
     <Stack gap="xs">
       <Text size="sm" variant="muted" uppercase>
         {heading}
       </Text>
-      {exploreUrl ? (
-        <Link to={exploreUrl}>
-          <Text monospace size="sm">
-            {label}
-          </Text>
-        </Link>
-      ) : (
-        <Text monospace size="sm">
-          {label}
-        </Text>
-      )}
+      {exploreUrl ? <Link to={exploreUrl}>{callSite}</Link> : callSite}
       <Flex align="baseline" gap="sm">
         <Text size="xl" bold variant={variant}>
           {formatRate(hitRate)}
@@ -60,13 +68,7 @@ function CallSiteColumn({
       </Flex>
       {callCount !== null && (
         <Text size="sm" variant="muted">
-          {avgInputTokens === null || avgInputTokens === undefined
-            ? tn('%s call', '%s calls', callCount)
-            : t(
-                '%s · %s avg tokens',
-                tn('%s call', '%s calls', callCount),
-                formatTokens(avgInputTokens)
-              )}
+          {formatCallVolume(callCount, avgInputTokens)}
         </Text>
       )}
     </Stack>
@@ -81,25 +83,13 @@ export function LlmCacheComparisonSection({
   evidenceData,
 }: LlmCacheComparisonSectionProps) {
   const organization = useOrganization();
-  // Pinned to the detection window for the same reason the chart is: the two
-  // columns are only comparable over the period the finding measured.
+  // The two columns are only comparable over the period the finding measured.
   const selection = useCallSitePageFilters(evidenceData);
   const {anchor} = evidenceData;
 
   if (anchor === null) {
     return null;
   }
-
-  const toExploreUrl = (query: string | null) =>
-    query && selection
-      ? getExploreUrl({
-          organization,
-          selection,
-          mode: Mode.SAMPLES,
-          query,
-          referrer: LLM_CACHE_REFERRER,
-        })
-      : undefined;
 
   return (
     <Stack gap="md">
@@ -112,33 +102,28 @@ export function LlmCacheComparisonSection({
       >
         <CallSiteColumn
           heading={t('This call site')}
-          label={
-            [evidenceData.transaction, evidenceData.spanDescription]
-              .filter(Boolean)
-              .join(' | ') || t('Unknown')
-          }
+          label={formatCallSiteLabel(evidenceData)}
           hitRate={evidenceData.hitRate}
           callCount={evidenceData.callCount}
           avgInputTokens={evidenceData.avgInputTokens}
-          exploreUrl={toExploreUrl(buildCallSiteQuery(evidenceData))}
+          exploreUrl={getCallSiteExploreUrl({
+            organization,
+            selection,
+            query: buildCallSiteQuery(evidenceData),
+          })}
           variant="danger"
         />
         <CallSiteColumn
           heading={t('Caching normally')}
-          label={
-            [anchor.transaction, anchor.spanDescription].filter(Boolean).join(' | ') ||
-            t('Unknown')
-          }
+          label={formatCallSiteLabel(anchor)}
           hitRate={anchor.hitRate}
           callCount={anchor.callCount}
           avgInputTokens={anchor.avgInputTokens}
-          exploreUrl={toExploreUrl(
-            buildCallSiteQuery({
-              transaction: anchor.transaction,
-              spanDescription: anchor.spanDescription,
-              model: anchor.model,
-            })
-          )}
+          exploreUrl={getCallSiteExploreUrl({
+            organization,
+            selection,
+            query: buildCallSiteQuery(anchor),
+          })}
           variant="success"
         />
       </Grid>

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
@@ -1,0 +1,79 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheExampleCalls} from './llmCacheExampleCalls';
+import type {LlmCacheEvidenceData} from './types';
+
+const evidence: LlmCacheEvidenceData = {
+  outcome: 'thrash',
+  transaction: 'agent.execute_step',
+  spanDescription: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  hitRate: 0.0487,
+  writeReadRatio: 12,
+  avgInputTokens: 4096,
+  uncachedTokens: 3_200_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 424_400,
+  sumCacheCreationTokens: 5_100_000,
+  estimatedSavingsUsd: null,
+  overpayVsNoCacheUsd: null,
+  windowDays: 7,
+  windowStart: '2026-08-10T00:00:00+00:00',
+  windowEnd: '2026-08-17T00:00:00+00:00',
+  anchor: null,
+  sampleCalls: [
+    {
+      traceId: 'abcdef01'.padEnd(32, '0'),
+      spanId: '1'.repeat(16),
+      timestamp: '2026-08-15T12:00:00+00:00',
+      inputTokens: 12_400,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 8_000,
+    },
+  ],
+};
+
+describe('LlmCacheExampleCalls', () => {
+  it('links a sample to the span that made the call, not just its trace', () => {
+    render(<LlmCacheExampleCalls evidenceData={evidence} />);
+
+    const link = screen.getByRole('link', {name: 'abcdef01'});
+    // The span id is what lands the reader on the gen-AI call inside the trace,
+    // and the timestamp is how the trace view finds a trace this old at all.
+    expect(link).toHaveAttribute('href', expect.stringContaining('1111111111111111'));
+    expect(link).toHaveAttribute('href', expect.stringContaining('timestamp'));
+    expect(screen.getByText('~12.4K input · 0 cached')).toBeInTheDocument();
+  });
+
+  it('still links bare trace ids from older occurrences', () => {
+    render(
+      <LlmCacheExampleCalls
+        evidenceData={{
+          ...evidence,
+          sampleCalls: [
+            {
+              traceId: 'beefbeef'.padEnd(32, '0'),
+              spanId: null,
+              timestamp: null,
+              inputTokens: null,
+              cacheReadTokens: null,
+              cacheCreationTokens: null,
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByRole('link', {name: 'beefbeef'})).toBeInTheDocument();
+    expect(screen.getByText('View trace')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the detector attached no samples', () => {
+    const {container} = render(
+      <LlmCacheExampleCalls evidenceData={{...evidence, sampleCalls: []}} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
@@ -38,18 +38,21 @@ const evidence: LlmCacheEvidenceData = {
 };
 
 describe('LlmCacheExampleCalls', () => {
-  it('links a sample to the span that made the call, not just its trace', () => {
+  it('names a sample for the span that made the call, not for its trace', () => {
     render(<LlmCacheExampleCalls evidenceData={evidence} />);
 
-    const link = screen.getByRole('link', {name: 'abcdef01'});
+    const link = screen.getByRole('link', {name: '1'.repeat(16)});
     // The span id is what lands the reader on the gen-AI call inside the trace,
     // and the timestamp is how the trace view finds a trace this old at all.
+    expect(link).toHaveAttribute('href', expect.stringContaining('abcdef01'));
     expect(link).toHaveAttribute('href', expect.stringContaining('1111111111111111'));
     expect(link).toHaveAttribute('href', expect.stringContaining('timestamp'));
+    // A trace id under a heading that says calls is the confusion being avoided.
+    expect(screen.queryByText('abcdef01')).not.toBeInTheDocument();
     expect(screen.getByText('~12.4K input · 0 cached')).toBeInTheDocument();
   });
 
-  it('still links bare trace ids from older occurrences', () => {
+  it('offers the trace by name when a sample carries no span id', () => {
     render(
       <LlmCacheExampleCalls
         evidenceData={{
@@ -68,8 +71,8 @@ describe('LlmCacheExampleCalls', () => {
       />
     );
 
-    expect(screen.getByRole('link', {name: 'beefbeef'})).toBeInTheDocument();
-    expect(screen.getByText('View trace')).toBeInTheDocument();
+    const link = screen.getByRole('link', {name: 'View trace'});
+    expect(link).toHaveAttribute('href', expect.stringContaining('beefbeef'));
   });
 
   it('renders nothing when the detector attached no samples', () => {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
@@ -25,6 +25,7 @@ const evidence: LlmCacheEvidenceData = {
   windowStart: '2026-08-10T00:00:00+00:00',
   windowEnd: '2026-08-17T00:00:00+00:00',
   anchor: null,
+  promptDivergence: null,
   sampleCalls: [
     {
       traceId: 'abcdef01'.padEnd(32, '0'),

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
@@ -5,8 +5,9 @@ import type {LlmCacheEvidenceData} from './types';
 
 const evidence: LlmCacheEvidenceData = {
   outcome: 'thrash',
-  transaction: 'agent.execute_step',
-  spanDescription: 'generate_content claude-sonnet-4',
+  agentLabel: 'Executor',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
   hitRate: 0.0487,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.spec.tsx
@@ -10,6 +10,8 @@ const evidence: LlmCacheEvidenceData = {
   spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
+  warmCallCount: 1951,
+  cacheableShare: 0.92,
   hitRate: 0.0487,
   writeReadRatio: 12,
   avgInputTokens: 4096,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.tsx
@@ -34,20 +34,27 @@ function SampleRow({sample}: {sample: LlmCacheSampleCall}) {
 
   return (
     <Flex justify="between" align="center" gap="lg" wrap="wrap">
+      {/* A row is one call, so it is named for the span that made it rather than
+          for the trace around it, which holds the whole request. A sample with no
+          span id can only offer that trace, and says which it is offering. */}
       <Link to={target}>
-        <Text monospace size="sm">
-          {sample.traceId.slice(0, 8)}
-        </Text>
+        {sample.spanId ? (
+          <Text monospace size="sm">
+            {sample.spanId}
+          </Text>
+        ) : (
+          <Text size="sm">{t('View trace')}</Text>
+        )}
       </Link>
-      <Text size="sm" variant="muted">
-        {sample.inputTokens === null
-          ? t('View trace')
-          : t(
-              '%s input · %s cached',
-              formatTokens(sample.inputTokens),
-              formatTokens(sample.cacheReadTokens ?? 0)
-            )}
-      </Text>
+      {sample.inputTokens !== null && (
+        <Text size="sm" variant="muted">
+          {t(
+            '%s input · %s cached',
+            formatTokens(sample.inputTokens),
+            formatTokens(sample.cacheReadTokens ?? 0)
+          )}
+        </Text>
+      )}
       {sample.timestamp && (
         <Text size="sm" variant="muted">
           <DateTime date={sample.timestamp} />

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheExampleCalls.tsx
@@ -1,0 +1,85 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {DateTime} from 'sentry/components/dateTime';
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
+
+import type {LlmCacheEvidenceData, LlmCacheSampleCall} from './types';
+import {formatTokens} from './utils';
+
+interface LlmCacheExampleCallsProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+function SampleRow({sample}: {sample: LlmCacheSampleCall}) {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  const target = getTraceDetailsUrl({
+    organization,
+    traceSlug: sample.traceId,
+    // The occurrence's own timestamp is detection time, days after the call, so
+    // the trace can only be located by the sample's timestamp.
+    timestamp: sample.timestamp ?? undefined,
+    spanId: sample.spanId ?? undefined,
+    dateSelection: {},
+    location,
+    source: TraceViewSources.ISSUE_DETAILS,
+  });
+
+  return (
+    <Flex justify="between" align="center" gap="lg" wrap="wrap">
+      <Link to={target}>
+        <Text monospace size="sm">
+          {sample.traceId.slice(0, 8)}
+        </Text>
+      </Link>
+      <Text size="sm" variant="muted">
+        {sample.inputTokens === null
+          ? t('View trace')
+          : t(
+              '%s input · %s cached',
+              formatTokens(sample.inputTokens),
+              formatTokens(sample.cacheReadTokens ?? 0)
+            )}
+      </Text>
+      {sample.timestamp && (
+        <Text size="sm" variant="muted">
+          <DateTime date={sample.timestamp} />
+        </Text>
+      )}
+    </Flex>
+  );
+}
+
+/**
+ * A few of the call site's largest calls, as a way in to the raw request.
+ *
+ * Comparing two of them is the first troubleshooting step for thrash: whatever
+ * differs near the start of the prompt is what invalidates the cached prefix.
+ */
+export function LlmCacheExampleCalls({evidenceData}: LlmCacheExampleCallsProps) {
+  const {sampleCalls} = evidenceData;
+
+  if (sampleCalls.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" variant="muted">
+        {t('The largest calls from this call site in the detection window.')}
+      </Text>
+      <Stack gap="sm" border="primary" radius="md" padding="md">
+        {sampleCalls.map(sample => (
+          <SampleRow key={sample.traceId} sample={sample} />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
@@ -24,6 +24,7 @@ const baseEvidence: LlmCacheEvidenceData = {
   windowDays: 7,
   windowStart: '2026-08-10T00:00:00+00:00',
   windowEnd: '2026-08-17T00:00:00+00:00',
+  promptDivergence: null,
   sampleCalls: [],
   anchor: null,
 };

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
@@ -10,6 +10,8 @@ const baseEvidence: LlmCacheEvidenceData = {
   spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
+  warmCallCount: 1951,
+  cacheableShare: 0.92,
   hitRate: 0,
   writeReadRatio: null,
   avgInputTokens: 4096,
@@ -86,6 +88,23 @@ describe('LlmCacheProblemSection', () => {
     expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
     expect(screen.getByText('4.87%')).toBeInTheDocument();
     expect(screen.getByText('2,121')).toBeInTheDocument();
+  });
+
+  it('says how many calls had a warm cache to hit', async () => {
+    // The hit rate above it counts every call, so this row is what tells the
+    // reader the rate is a broken cache and not sparse traffic.
+    renderSection({hitRate: 0.0487});
+
+    expect(await screen.findByText('Cache-eligible calls')).toBeInTheDocument();
+    expect(screen.getByText('1,951 (92.00% of calls)')).toBeInTheDocument();
+  });
+
+  it('leaves out the eligible-calls row for an occurrence without one', async () => {
+    renderSection({warmCallCount: null, cacheableShare: null});
+
+    await screen.findByText('Planner | generate_content claude-sonnet-4');
+
+    expect(screen.queryByText('Cache-eligible calls')).not.toBeInTheDocument();
   });
 
   it('says when the call site is named after an operation rather than an agent', async () => {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
@@ -1,12 +1,13 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {LlmCacheProblemSection} from './llmCacheProblemSection';
 import type {LlmCacheEvidenceData} from './types';
 
 const baseEvidence: LlmCacheEvidenceData = {
   outcome: 'not_caching',
-  transaction: 'agent.plan',
-  spanDescription: 'generate_content claude-sonnet-4',
+  agentLabel: 'Planner',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
   hitRate: 0,
@@ -80,11 +81,36 @@ describe('LlmCacheProblemSection', () => {
     renderSection({hitRate: 0.0487});
 
     expect(
-      await screen.findByText('agent.plan | generate_content claude-sonnet-4')
+      await screen.findByText('Planner | generate_content claude-sonnet-4')
     ).toBeInTheDocument();
     expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
     expect(screen.getByText('4.87%')).toBeInTheDocument();
     expect(screen.getByText('2,121')).toBeInTheDocument();
+  });
+
+  it('says when the call site is named after an operation rather than an agent', async () => {
+    // The label reads like an agent but names none, and the group can hold
+    // calls from several -- the reader has to be told before they go looking.
+    renderSection({
+      agentLabel: 'generate_content',
+      agentLabelSource: 'gen_ai.operation.name',
+      spanName: 'generate_content gemini',
+    });
+
+    const callSite = await screen.findByText('generate_content gemini');
+    await userEvent.hover(
+      within(callSite.parentElement!).getByLabelText('More information')
+    );
+
+    expect(await screen.findByText(/no gen_ai.agent.name/)).toBeInTheDocument();
+  });
+
+  it('does not explain the label when an agent named the call site', async () => {
+    renderSection({hitRate: 0.0487});
+
+    await screen.findByText('Planner | generate_content claude-sonnet-4');
+
+    expect(screen.queryByText(/no gen_ai.agent.name/)).not.toBeInTheDocument();
   });
 
   it('reads as a sentence when the occurrence carries no window length', async () => {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
@@ -87,6 +87,38 @@ describe('LlmCacheProblemSection', () => {
     expect(screen.getByText('2,121')).toBeInTheDocument();
   });
 
+  it('reads as a sentence when the occurrence carries no window length', async () => {
+    // Each variant supplies its own article, so the fallback has to be a bare
+    // noun -- "over the last the detection window" otherwise.
+    const {container} = renderSection({windowDays: null, estimatedSavingsUsd: null});
+    await screen.findByText(/almost never hits the prompt cache/);
+
+    expect(container).toHaveTextContent('Over the last detection window');
+    expect(container).not.toHaveTextContent('the last the detection window');
+  });
+
+  it('drops the quantity clause rather than reporting an Unknown token count', async () => {
+    const {container} = renderSection({estimatedSavingsUsd: null, uncachedTokens: null});
+    await screen.findByText(/almost never hits the prompt cache/);
+
+    expect(container).not.toHaveTextContent('Unknown');
+    expect(container).toHaveTextContent(
+      'cached input tokens typically cost a fraction of fresh ones'
+    );
+  });
+
+  it('drops the thrash quantity clause when the write total is missing', async () => {
+    const {container} = renderSection({
+      outcome: 'thrash',
+      estimatedSavingsUsd: null,
+      sumCacheCreationTokens: null,
+    });
+    await screen.findByText(/invalidates the cached prefix/);
+
+    expect(container).not.toHaveTextContent('Unknown of cache writes');
+    expect(container).toHaveTextContent('invalidates the cached prefix.');
+  });
+
   it('shows the token composition of the window', async () => {
     renderSection({
       sumInputTokens: 10_000_000,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.spec.tsx
@@ -1,0 +1,101 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheProblemSection} from './llmCacheProblemSection';
+import type {LlmCacheEvidenceData} from './types';
+
+const baseEvidence: LlmCacheEvidenceData = {
+  outcome: 'not_caching',
+  transaction: 'agent.plan',
+  spanDescription: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  hitRate: 0,
+  writeReadRatio: null,
+  avgInputTokens: 4096,
+  uncachedTokens: 8_700_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 0,
+  sumCacheCreationTokens: 0,
+  estimatedSavingsUsd: null,
+  overpayVsNoCacheUsd: null,
+  windowDays: 7,
+  windowStart: '2026-08-10T00:00:00+00:00',
+  windowEnd: '2026-08-17T00:00:00+00:00',
+  sampleCalls: [],
+  anchor: null,
+};
+
+function mockSpendRequest(body: Record<string, unknown> = {data: []}) {
+  MockApiClient.addMockResponse({url: '/organizations/org-slug/events/', body});
+}
+
+function renderSection(overrides: Partial<LlmCacheEvidenceData> = {}) {
+  return render(
+    <LlmCacheProblemSection evidenceData={{...baseEvidence, ...overrides}} />
+  );
+}
+
+describe('LlmCacheProblemSection', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    mockSpendRequest();
+  });
+
+  it('leads with the dollar figure when the model is priced', async () => {
+    renderSection({estimatedSavingsUsd: 412.5});
+
+    expect(await screen.findByText(/could have saved up to/)).toBeInTheDocument();
+    expect(screen.getAllByText('$412.50').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to tokens when the model is not priced', async () => {
+    renderSection();
+
+    expect(await screen.findByText(/never came from cache/)).toBeInTheDocument();
+    expect(screen.queryByText('Avoidable spend')).not.toBeInTheDocument();
+  });
+
+  it('describes cache thrash in terms of the invalidated prefix', async () => {
+    renderSection({
+      outcome: 'thrash',
+      hitRate: 0.0487,
+      writeReadRatio: 12,
+      sumCacheReadTokens: 424_400,
+      sumCacheCreationTokens: 5_100_000,
+    });
+
+    expect(await screen.findByText(/invalidates the cached prefix/)).toBeInTheDocument();
+    expect(screen.getByText('12.0:1')).toBeInTheDocument();
+  });
+
+  it('calls out thrash that costs more than not caching', async () => {
+    renderSection({outcome: 'thrash', writeReadRatio: 12, overpayVsNoCacheUsd: 3.5});
+
+    expect(
+      await screen.findByText('Right now, caching here costs more than turning it off.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the call site, model and diagnostics', async () => {
+    renderSection({hitRate: 0.0487});
+
+    expect(
+      await screen.findByText('agent.plan | generate_content claude-sonnet-4')
+    ).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-4')).toBeInTheDocument();
+    expect(screen.getByText('4.87%')).toBeInTheDocument();
+    expect(screen.getByText('2,121')).toBeInTheDocument();
+  });
+
+  it('shows the token composition of the window', async () => {
+    renderSection({
+      sumInputTokens: 10_000_000,
+      sumCacheReadTokens: 1_000_000,
+      sumCacheCreationTokens: 4_000_000,
+    });
+
+    expect(await screen.findByText(/Uncached ~5.0M \(50%\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Cache writes ~4.0M \(40%\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Cache reads ~1.0M \(10%\)/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
@@ -1,0 +1,230 @@
+import {Alert} from '@sentry/scraps/alert';
+import {InfoTip} from '@sentry/scraps/info';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {KeyValueData} from 'sentry/components/keyValueData';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t, tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+import {LlmCacheActualSpend} from './llmCacheActualSpend';
+import {LlmCacheTokenBar} from './llmCacheTokenBar';
+import type {LlmCacheEvidenceData} from './types';
+import {
+  buildCallSiteQuery,
+  formatRate,
+  formatTokens,
+  formatUsd,
+  formatWriteReadRatio,
+  LLM_CACHE_REFERRER,
+} from './utils';
+
+interface LlmCacheProblemSectionProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+function ProblemStatement({evidenceData}: LlmCacheProblemSectionProps) {
+  const {outcome, estimatedSavingsUsd, sumInputTokens, uncachedTokens, windowDays} =
+    evidenceData;
+  const windowLabel =
+    windowDays === null ? t('the detection window') : t('%s days', windowDays);
+  const priced = estimatedSavingsUsd !== null;
+
+  if (outcome === 'thrash') {
+    return (
+      <Stack gap="sm">
+        <Text>
+          {priced
+            ? tct(
+                'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. A stable prefix could have saved about [savings] over the last [window].',
+                {
+                  savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
+                  window: windowLabel,
+                }
+              )
+            : tct(
+                'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. Over the last [window], [tokens] of cache writes were never paid back by reads.',
+                {
+                  tokens: (
+                    <Text bold>{formatTokens(evidenceData.sumCacheCreationTokens)}</Text>
+                  ),
+                  window: windowLabel,
+                }
+              )}
+        </Text>
+        {evidenceData.overpayVsNoCacheUsd !== null && (
+          <Text bold>{t('Right now, caching here costs more than turning it off.')}</Text>
+        )}
+      </Stack>
+    );
+  }
+
+  return (
+    <Text>
+      {priced
+        ? tct(
+            'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it sent [tokens] of input at the full rate — caching the repeated part of the prompt could have saved up to [savings].',
+            {
+              window: windowLabel,
+              tokens: <Text bold>{formatTokens(sumInputTokens)}</Text>,
+              savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
+            }
+          )
+        : tct(
+            'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it re-sent [tokens] that never came from cache, and cached input tokens typically cost a fraction of fresh ones.',
+            {
+              window: windowLabel,
+              tokens: <Text bold>{formatTokens(uncachedTokens)}</Text>,
+            }
+          )}
+    </Text>
+  );
+}
+
+export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {
+    transaction,
+    spanDescription,
+    model,
+    outcome,
+    callCount,
+    hitRate,
+    writeReadRatio,
+    avgInputTokens,
+    estimatedSavingsUsd,
+  } = evidenceData;
+
+  const callSiteQuery = buildCallSiteQuery({transaction, spanDescription, model});
+  const callSiteExploreUrl = callSiteQuery
+    ? getExploreUrl({
+        organization,
+        selection,
+        mode: Mode.SAMPLES,
+        query: callSiteQuery,
+        referrer: LLM_CACHE_REFERRER,
+      })
+    : undefined;
+
+  return (
+    <Stack gap="lg">
+      <Alert variant="muted" showIcon>
+        <ProblemStatement evidenceData={evidenceData} />
+      </Alert>
+      <Grid columns="fit-content(50%) 1fr" border="primary" radius="md" padding="sm">
+        <KeyValueData.Content
+          disableFormattedData
+          item={{
+            action: callSiteExploreUrl ? {link: callSiteExploreUrl} : undefined,
+            key: 'call-site',
+            subject: t('Call site'),
+            value:
+              [transaction, spanDescription].filter(Boolean).join(' | ') || t('Unknown'),
+          }}
+        />
+        <KeyValueData.Content
+          disableFormattedData
+          item={{key: 'model', subject: t('Model'), value: model ?? t('Unknown')}}
+        />
+        <KeyValueData.Content
+          disableFormattedData
+          item={{
+            key: 'cache-hit-rate',
+            subject: t('Cache hit rate'),
+            value: (
+              <Flex align="center" gap="xs">
+                <Text monospace bold={outcome === 'not_caching'}>
+                  {formatRate(hitRate)}
+                </Text>
+                <InfoTip
+                  size="xs"
+                  title={t(
+                    'Share of input tokens served from the prompt cache over the detection window.'
+                  )}
+                />
+              </Flex>
+            ),
+          }}
+        />
+        <KeyValueData.Content
+          disableFormattedData
+          item={{
+            key: 'cache-write-read-ratio',
+            subject: t('Cache write:read ratio'),
+            value: (
+              <Flex align="center" gap="xs">
+                <Text monospace bold={outcome === 'thrash'}>
+                  {formatWriteReadRatio(writeReadRatio)}
+                </Text>
+                <InfoTip
+                  size="xs"
+                  title={t(
+                    'Cache writes bill at a premium over plain input tokens, and only pay for themselves once they are read back.'
+                  )}
+                />
+              </Flex>
+            ),
+          }}
+        />
+        <KeyValueData.Content
+          disableFormattedData
+          item={{
+            key: 'calls',
+            subject: t('Calls'),
+            value: (
+              <Flex align="center" gap="xs">
+                <Text monospace>
+                  {callCount === null ? t('Unknown') : callCount.toLocaleString()}
+                </Text>
+                <InfoTip
+                  size="xs"
+                  title={t(
+                    'Calls in the detection window. Only call sites busy enough to keep a cache warm are evaluated.'
+                  )}
+                />
+              </Flex>
+            ),
+          }}
+        />
+        <KeyValueData.Content
+          disableFormattedData
+          item={{
+            key: 'avg-input-tokens',
+            subject: t('Avg input tokens'),
+            value: formatTokens(avgInputTokens),
+          }}
+        />
+        {estimatedSavingsUsd !== null && (
+          <KeyValueData.Content
+            disableFormattedData
+            item={{
+              key: 'avoidable-spend',
+              subject: t('Avoidable spend'),
+              value: (
+                <Flex align="center" gap="xs">
+                  <Text monospace>{formatUsd(estimatedSavingsUsd)}</Text>
+                  <InfoTip
+                    size="xs"
+                    title={t(
+                      'Estimated from current model prices for input, cache reads and cache writes. It assumes the repeated part of each prompt could be cached, so treat it as an upper bound.'
+                    )}
+                  />
+                </Flex>
+              ),
+            }}
+          />
+        )}
+        <LlmCacheActualSpend evidenceData={evidenceData} />
+      </Grid>
+      <LlmCacheTokenBar
+        inputTokens={evidenceData.sumInputTokens}
+        cacheReadTokens={evidenceData.sumCacheReadTokens}
+        cacheCreationTokens={evidenceData.sumCacheCreationTokens}
+      />
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
@@ -1,7 +1,8 @@
 import type {ReactNode} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {InfoTip} from '@sentry/scraps/info';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {KeyValueData} from 'sentry/components/keyValueData';
@@ -21,6 +22,7 @@ import {
   formatUsd,
   formatWriteReadRatio,
   getCallSiteExploreUrl,
+  usesOperationNameFallback,
 } from './utils';
 
 interface LlmCacheProblemSectionProps {
@@ -140,7 +142,19 @@ export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionPro
             action: callSiteExploreUrl ? {link: callSiteExploreUrl} : undefined,
             key: 'call-site',
             subject: t('Call site'),
-            value: formatCallSiteLabel(evidenceData),
+            value: (
+              <Flex align="center" gap="xs">
+                <Text>{formatCallSiteLabel(evidenceData)}</Text>
+                {usesOperationNameFallback(evidenceData.agentLabelSource) && (
+                  <InfoTip
+                    size="xs"
+                    title={t(
+                      'These spans carry no gen_ai.agent.name, so this call site is named after the operation instead. Calls from more than one agent can land here — set the agent name to split them apart.'
+                    )}
+                  />
+                )}
+              </Flex>
+            ),
           }}
         />
         <KeyValueData.Content

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
@@ -4,8 +4,7 @@ import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {KeyValueData} from 'sentry/components/keyValueData';
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -13,6 +12,7 @@ import {getExploreUrl} from 'sentry/views/explore/utils';
 import {LlmCacheActualSpend} from './llmCacheActualSpend';
 import {LlmCacheTokenBar} from './llmCacheTokenBar';
 import type {LlmCacheEvidenceData} from './types';
+import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {
   buildCallSiteQuery,
   formatRate,
@@ -29,32 +29,16 @@ interface LlmCacheProblemSectionProps {
 function ProblemStatement({evidenceData}: LlmCacheProblemSectionProps) {
   const {outcome, estimatedSavingsUsd, sumInputTokens, uncachedTokens, windowDays} =
     evidenceData;
+  // Every sentence below supplies the article, so this has to read as a bare
+  // noun: "over the last the detection window" otherwise.
   const windowLabel =
-    windowDays === null ? t('the detection window') : t('%s days', windowDays);
+    windowDays === null ? t('detection window') : tn('%s day', '%s days', windowDays);
   const priced = estimatedSavingsUsd !== null;
 
   if (outcome === 'thrash') {
     return (
       <Stack gap="sm">
-        <Text>
-          {priced
-            ? tct(
-                'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. A stable prefix could have saved about [savings] over the last [window].',
-                {
-                  savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
-                  window: windowLabel,
-                }
-              )
-            : tct(
-                'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. Over the last [window], [tokens] of cache writes were never paid back by reads.',
-                {
-                  tokens: (
-                    <Text bold>{formatTokens(evidenceData.sumCacheCreationTokens)}</Text>
-                  ),
-                  window: windowLabel,
-                }
-              )}
-        </Text>
+        <Text>{thrashStatement()}</Text>
         {evidenceData.overpayVsNoCacheUsd !== null && (
           <Text bold>{t('Right now, caching here costs more than turning it off.')}</Text>
         )}
@@ -62,31 +46,60 @@ function ProblemStatement({evidenceData}: LlmCacheProblemSectionProps) {
     );
   }
 
-  return (
-    <Text>
-      {priced
-        ? tct(
-            'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it sent [tokens] of input at the full rate — caching the repeated part of the prompt could have saved up to [savings].',
-            {
-              window: windowLabel,
-              tokens: <Text bold>{formatTokens(sumInputTokens)}</Text>,
-              savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
-            }
-          )
-        : tct(
-            'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it re-sent [tokens] that never came from cache, and cached input tokens typically cost a fraction of fresh ones.',
-            {
-              window: windowLabel,
-              tokens: <Text bold>{formatTokens(uncachedTokens)}</Text>,
-            }
-          )}
-    </Text>
-  );
+  return <Text>{notCachingStatement()}</Text>;
+
+  function thrashStatement() {
+    if (priced) {
+      return tct(
+        'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. A stable prefix could have saved about [savings] over the last [window].',
+        {savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>, window: windowLabel}
+      );
+    }
+    // Without a quantity there is no clause to put it in: naming the shape of
+    // the problem beats reporting that its size is "Unknown".
+    if (evidenceData.sumCacheCreationTokens === null) {
+      return t(
+        'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix.'
+      );
+    }
+    return tct(
+      'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. Over the last [window], [tokens] of cache writes were never paid back by reads.',
+      {
+        tokens: <Text bold>{formatTokens(evidenceData.sumCacheCreationTokens)}</Text>,
+        window: windowLabel,
+      }
+    );
+  }
+
+  function notCachingStatement() {
+    if (priced && sumInputTokens !== null) {
+      return tct(
+        'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it sent [tokens] of input at the full rate — caching the repeated part of the prompt could have saved up to [savings].',
+        {
+          window: windowLabel,
+          tokens: <Text bold>{formatTokens(sumInputTokens)}</Text>,
+          savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
+        }
+      );
+    }
+    if (uncachedTokens === null) {
+      return t(
+        'Sentry found an LLM call site that almost never hits the prompt cache, and cached input tokens typically cost a fraction of fresh ones.'
+      );
+    }
+    return tct(
+      'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it re-sent [tokens] that never came from cache, and cached input tokens typically cost a fraction of fresh ones.',
+      {window: windowLabel, tokens: <Text bold>{formatTokens(uncachedTokens)}</Text>}
+    );
+  }
 }
 
 export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionProps) {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  // Pinned to the detection window, like the page's other live queries: the
+  // reader's own range would send them to an Explore view that answers a
+  // different question than the issue is making a claim about.
+  const selection = useCallSitePageFilters(evidenceData);
   const {
     transaction,
     spanDescription,
@@ -100,15 +113,16 @@ export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionPro
   } = evidenceData;
 
   const callSiteQuery = buildCallSiteQuery({transaction, spanDescription, model});
-  const callSiteExploreUrl = callSiteQuery
-    ? getExploreUrl({
-        organization,
-        selection,
-        mode: Mode.SAMPLES,
-        query: callSiteQuery,
-        referrer: LLM_CACHE_REFERRER,
-      })
-    : undefined;
+  const callSiteExploreUrl =
+    callSiteQuery && selection
+      ? getExploreUrl({
+          organization,
+          selection,
+          mode: Mode.SAMPLES,
+          query: callSiteQuery,
+          referrer: LLM_CACHE_REFERRER,
+        })
+      : undefined;
 
   return (
     <Stack gap="lg">

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
@@ -1,44 +1,104 @@
+import type {ReactNode} from 'react';
+
 import {Alert} from '@sentry/scraps/alert';
-import {InfoTip} from '@sentry/scraps/info';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {KeyValueData} from 'sentry/components/keyValueData';
 import {t, tct, tn} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {getExploreUrl} from 'sentry/views/explore/utils';
 
+import {CallSiteMetric} from './callSiteMetric';
 import {LlmCacheActualSpend} from './llmCacheActualSpend';
 import {LlmCacheTokenBar} from './llmCacheTokenBar';
 import type {LlmCacheEvidenceData} from './types';
 import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {
   buildCallSiteQuery,
+  formatCallSiteLabel,
   formatRate,
   formatTokens,
   formatUsd,
   formatWriteReadRatio,
-  LLM_CACHE_REFERRER,
+  getCallSiteExploreUrl,
 } from './utils';
 
 interface LlmCacheProblemSectionProps {
   evidenceData: LlmCacheEvidenceData;
 }
 
-function ProblemStatement({evidenceData}: LlmCacheProblemSectionProps) {
-  const {outcome, estimatedSavingsUsd, sumInputTokens, uncachedTokens, windowDays} =
-    evidenceData;
-  // Every sentence below supplies the article, so this has to read as a bare
-  // noun: "over the last the detection window" otherwise.
-  const windowLabel =
-    windowDays === null ? t('detection window') : tn('%s day', '%s days', windowDays);
-  const priced = estimatedSavingsUsd !== null;
+/**
+ * Every sentence below supplies the article, so this has to read as a bare
+ * noun: "over the last the detection window" otherwise.
+ */
+function getWindowLabel(windowDays: number | null): string {
+  return windowDays === null
+    ? t('detection window')
+    : tn('%s day', '%s days', windowDays);
+}
 
-  if (outcome === 'thrash') {
+function thrashStatement(evidenceData: LlmCacheEvidenceData): ReactNode {
+  const {estimatedSavingsUsd, sumCacheCreationTokens, windowDays} = evidenceData;
+  const windowLabel = getWindowLabel(windowDays);
+
+  if (estimatedSavingsUsd !== null) {
+    return tct(
+      'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. A stable prefix could have saved about [savings] over the last [window].',
+      {
+        savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
+        window: windowLabel,
+      }
+    );
+  }
+  // Without a quantity there is no clause to put it in: naming the shape of the
+  // problem beats reporting that its size is "Unknown".
+  if (sumCacheCreationTokens === null) {
+    return t(
+      'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix.'
+    );
+  }
+  return tct(
+    'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. Over the last [window], [tokens] of cache writes were never paid back by reads.',
+    {
+      tokens: <Text bold>{formatTokens(sumCacheCreationTokens)}</Text>,
+      window: windowLabel,
+    }
+  );
+}
+
+function notCachingStatement(evidenceData: LlmCacheEvidenceData): ReactNode {
+  const {estimatedSavingsUsd, sumInputTokens, uncachedTokens, windowDays} = evidenceData;
+  const windowLabel = getWindowLabel(windowDays);
+
+  if (estimatedSavingsUsd !== null && sumInputTokens !== null) {
+    return tct(
+      'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it sent [tokens] of input at the full rate — caching the repeated part of the prompt could have saved up to [savings].',
+      {
+        window: windowLabel,
+        tokens: <Text bold>{formatTokens(sumInputTokens)}</Text>,
+        savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
+      }
+    );
+  }
+  if (uncachedTokens === null) {
+    return t(
+      'Sentry found an LLM call site that almost never hits the prompt cache, and cached input tokens typically cost a fraction of fresh ones.'
+    );
+  }
+  return tct(
+    'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it re-sent [tokens] that never came from cache, and cached input tokens typically cost a fraction of fresh ones.',
+    {
+      window: windowLabel,
+      tokens: <Text bold>{formatTokens(uncachedTokens)}</Text>,
+    }
+  );
+}
+
+function ProblemStatement({evidenceData}: LlmCacheProblemSectionProps) {
+  if (evidenceData.outcome === 'thrash') {
     return (
       <Stack gap="sm">
-        <Text>{thrashStatement()}</Text>
+        <Text>{thrashStatement(evidenceData)}</Text>
         {evidenceData.overpayVsNoCacheUsd !== null && (
           <Text bold>{t('Right now, caching here costs more than turning it off.')}</Text>
         )}
@@ -46,63 +106,13 @@ function ProblemStatement({evidenceData}: LlmCacheProblemSectionProps) {
     );
   }
 
-  return <Text>{notCachingStatement()}</Text>;
-
-  function thrashStatement() {
-    if (priced) {
-      return tct(
-        'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. A stable prefix could have saved about [savings] over the last [window].',
-        {savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>, window: windowLabel}
-      );
-    }
-    // Without a quantity there is no clause to put it in: naming the shape of
-    // the problem beats reporting that its size is "Unknown".
-    if (evidenceData.sumCacheCreationTokens === null) {
-      return t(
-        'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix.'
-      );
-    }
-    return tct(
-      'This call site keeps paying to write the prompt cache but rarely reads it back — something near the start of the prompt changes between calls and invalidates the cached prefix. Over the last [window], [tokens] of cache writes were never paid back by reads.',
-      {
-        tokens: <Text bold>{formatTokens(evidenceData.sumCacheCreationTokens)}</Text>,
-        window: windowLabel,
-      }
-    );
-  }
-
-  function notCachingStatement() {
-    if (priced && sumInputTokens !== null) {
-      return tct(
-        'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it sent [tokens] of input at the full rate — caching the repeated part of the prompt could have saved up to [savings].',
-        {
-          window: windowLabel,
-          tokens: <Text bold>{formatTokens(sumInputTokens)}</Text>,
-          savings: <Text bold>{formatUsd(estimatedSavingsUsd)}</Text>,
-        }
-      );
-    }
-    if (uncachedTokens === null) {
-      return t(
-        'Sentry found an LLM call site that almost never hits the prompt cache, and cached input tokens typically cost a fraction of fresh ones.'
-      );
-    }
-    return tct(
-      'Sentry found an LLM call site that almost never hits the prompt cache. Over the last [window] it re-sent [tokens] that never came from cache, and cached input tokens typically cost a fraction of fresh ones.',
-      {window: windowLabel, tokens: <Text bold>{formatTokens(uncachedTokens)}</Text>}
-    );
-  }
+  return <Text>{notCachingStatement(evidenceData)}</Text>;
 }
 
 export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionProps) {
   const organization = useOrganization();
-  // Pinned to the detection window, like the page's other live queries: the
-  // reader's own range would send them to an Explore view that answers a
-  // different question than the issue is making a claim about.
   const selection = useCallSitePageFilters(evidenceData);
   const {
-    transaction,
-    spanDescription,
     model,
     outcome,
     callCount,
@@ -112,17 +122,11 @@ export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionPro
     estimatedSavingsUsd,
   } = evidenceData;
 
-  const callSiteQuery = buildCallSiteQuery({transaction, spanDescription, model});
-  const callSiteExploreUrl =
-    callSiteQuery && selection
-      ? getExploreUrl({
-          organization,
-          selection,
-          mode: Mode.SAMPLES,
-          query: callSiteQuery,
-          referrer: LLM_CACHE_REFERRER,
-        })
-      : undefined;
+  const callSiteExploreUrl = getCallSiteExploreUrl({
+    organization,
+    selection,
+    query: buildCallSiteQuery(evidenceData),
+  });
 
   return (
     <Stack gap="lg">
@@ -136,100 +140,52 @@ export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionPro
             action: callSiteExploreUrl ? {link: callSiteExploreUrl} : undefined,
             key: 'call-site',
             subject: t('Call site'),
-            value:
-              [transaction, spanDescription].filter(Boolean).join(' | ') || t('Unknown'),
+            value: formatCallSiteLabel(evidenceData),
           }}
         />
         <KeyValueData.Content
           disableFormattedData
           item={{key: 'model', subject: t('Model'), value: model ?? t('Unknown')}}
         />
-        <KeyValueData.Content
-          disableFormattedData
-          item={{
-            key: 'cache-hit-rate',
-            subject: t('Cache hit rate'),
-            value: (
-              <Flex align="center" gap="xs">
-                <Text monospace bold={outcome === 'not_caching'}>
-                  {formatRate(hitRate)}
-                </Text>
-                <InfoTip
-                  size="xs"
-                  title={t(
-                    'Share of input tokens served from the prompt cache over the detection window.'
-                  )}
-                />
-              </Flex>
-            ),
-          }}
+        <CallSiteMetric
+          id="cache-hit-rate"
+          label={t('Cache hit rate')}
+          value={formatRate(hitRate)}
+          emphasized={outcome === 'not_caching'}
+          tooltip={t(
+            'Share of input tokens served from the prompt cache over the detection window.'
+          )}
         />
-        <KeyValueData.Content
-          disableFormattedData
-          item={{
-            key: 'cache-write-read-ratio',
-            subject: t('Cache write:read ratio'),
-            value: (
-              <Flex align="center" gap="xs">
-                <Text monospace bold={outcome === 'thrash'}>
-                  {formatWriteReadRatio(writeReadRatio)}
-                </Text>
-                <InfoTip
-                  size="xs"
-                  title={t(
-                    'Cache writes bill at a premium over plain input tokens, and only pay for themselves once they are read back.'
-                  )}
-                />
-              </Flex>
-            ),
-          }}
+        <CallSiteMetric
+          id="cache-write-read-ratio"
+          label={t('Cache write:read ratio')}
+          value={formatWriteReadRatio(writeReadRatio)}
+          emphasized={outcome === 'thrash'}
+          tooltip={t(
+            'Cache writes bill at a premium over plain input tokens, and only pay for themselves once they are read back.'
+          )}
         />
-        <KeyValueData.Content
-          disableFormattedData
-          item={{
-            key: 'calls',
-            subject: t('Calls'),
-            value: (
-              <Flex align="center" gap="xs">
-                <Text monospace>
-                  {callCount === null ? t('Unknown') : callCount.toLocaleString()}
-                </Text>
-                <InfoTip
-                  size="xs"
-                  title={t(
-                    'Calls in the detection window. Only call sites busy enough to keep a cache warm are evaluated.'
-                  )}
-                />
-              </Flex>
-            ),
-          }}
+        <CallSiteMetric
+          id="calls"
+          label={t('Calls')}
+          value={callCount === null ? t('Unknown') : callCount.toLocaleString()}
+          tooltip={t(
+            'Calls in the detection window. Only call sites busy enough to keep a cache warm are evaluated.'
+          )}
         />
-        <KeyValueData.Content
-          disableFormattedData
-          item={{
-            key: 'avg-input-tokens',
-            subject: t('Avg input tokens'),
-            value: formatTokens(avgInputTokens),
-          }}
+        <CallSiteMetric
+          id="avg-input-tokens"
+          label={t('Avg input tokens')}
+          value={formatTokens(avgInputTokens)}
         />
         {estimatedSavingsUsd !== null && (
-          <KeyValueData.Content
-            disableFormattedData
-            item={{
-              key: 'avoidable-spend',
-              subject: t('Avoidable spend'),
-              value: (
-                <Flex align="center" gap="xs">
-                  <Text monospace>{formatUsd(estimatedSavingsUsd)}</Text>
-                  <InfoTip
-                    size="xs"
-                    title={t(
-                      'Estimated from current model prices for input, cache reads and cache writes. It assumes the repeated part of each prompt could be cached, so treat it as an upper bound.'
-                    )}
-                  />
-                </Flex>
-              ),
-            }}
+          <CallSiteMetric
+            id="avoidable-spend"
+            label={t('Avoidable spend')}
+            value={formatUsd(estimatedSavingsUsd)}
+            tooltip={t(
+              'Estimated from current model prices for input, cache reads and cache writes. It assumes the repeated part of each prompt could be cached, so treat it as an upper bound.'
+            )}
           />
         )}
         <LlmCacheActualSpend evidenceData={evidenceData} />

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheProblemSection.tsx
@@ -16,6 +16,7 @@ import type {LlmCacheEvidenceData} from './types';
 import {useCallSitePageFilters} from './useCallSitePageFilters';
 import {
   buildCallSiteQuery,
+  formatCacheEligibleCalls,
   formatCallSiteLabel,
   formatRate,
   formatTokens,
@@ -118,6 +119,8 @@ export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionPro
     model,
     outcome,
     callCount,
+    warmCallCount,
+    cacheableShare,
     hitRate,
     writeReadRatio,
     avgInputTokens,
@@ -183,10 +186,18 @@ export function LlmCacheProblemSection({evidenceData}: LlmCacheProblemSectionPro
           id="calls"
           label={t('Calls')}
           value={callCount === null ? t('Unknown') : callCount.toLocaleString()}
-          tooltip={t(
-            'Calls in the detection window. Only call sites busy enough to keep a cache warm are evaluated.'
-          )}
+          tooltip={t('Calls this call site made over the detection window.')}
         />
+        {warmCallCount !== null && (
+          <CallSiteMetric
+            id="cache-eligible-calls"
+            label={t('Cache-eligible calls')}
+            value={formatCacheEligibleCalls(warmCallCount, cacheableShare)}
+            tooltip={t(
+              'Calls that arrived soon enough after an earlier one to find the cache still warm. The hit rate counts every call, so a call site whose calls mostly arrive in isolation is not evaluated at all: there was no warm cache for them to hit.'
+            )}
+          />
+        )}
         <CallSiteMetric
           id="avg-input-tokens"
           label={t('Avg input tokens')}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.spec.tsx
@@ -99,6 +99,29 @@ describe('LlmCachePromptShapeSection', () => {
     expect(screen.queryByText('Identical block after it')).not.toBeInTheDocument();
   });
 
+  it('does not name a divergence the classifier could not recognise', () => {
+    render(
+      <LlmCachePromptShapeSection
+        evidenceData={{
+          ...evidence,
+          promptDivergence: {...divergence, kind: 'other'},
+        }}
+      />
+    );
+
+    // `other` is the residual of a handful of patterns, so there is nothing to
+    // put after "first differ at". The measured lengths still stand on their own.
+    expect(screen.queryByText('Prompts first differ at')).not.toBeInTheDocument();
+    expect(screen.queryByText(/changing text/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Moving it in front of the changing part is what makes it cacheable/
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('142 chars (0.30% of the prompt)')).toBeInTheDocument();
+    expect(screen.getByText('Identical block after it')).toBeInTheDocument();
+  });
+
   it('renders nothing for an occurrence that carries no prompt diagnosis', () => {
     const {container} = render(
       <LlmCachePromptShapeSection evidenceData={{...evidence, promptDivergence: null}} />

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.spec.tsx
@@ -8,7 +8,7 @@ const divergence: LlmCachePromptDivergence = {
   commonPrefixChars: 142,
   shortestChars: 48_000,
   prefixShare: 0.003,
-  stableSuffixChars: 6_200,
+  stableBlockChars: 6_200,
   templateMisordered: true,
   sampleCount: 4,
 };
@@ -50,7 +50,7 @@ describe('LlmCachePromptShapeSection', () => {
     expect(screen.getByText('142 chars (0.30% of the prompt)')).toBeInTheDocument();
     expect(screen.getByText('Prompts first differ at')).toBeInTheDocument();
     expect(screen.getAllByText('an ISO-8601 timestamp').length).toBeGreaterThan(0);
-    expect(screen.getByText('Identical content after it')).toBeInTheDocument();
+    expect(screen.getByText('Identical block after it')).toBeInTheDocument();
     // Both the sentence and the row carry it.
     expect(screen.getAllByText('~6.2K chars')).toHaveLength(2);
     expect(
@@ -84,7 +84,7 @@ describe('LlmCachePromptShapeSection', () => {
           promptDivergence: {
             ...divergence,
             kind: 'none',
-            stableSuffixChars: 0,
+            stableBlockChars: 0,
             templateMisordered: false,
           },
         }}
@@ -96,7 +96,7 @@ describe('LlmCachePromptShapeSection', () => {
     ).toBeInTheDocument();
     // There is no first difference to name, and nothing follows one.
     expect(screen.queryByText('Prompts first differ at')).not.toBeInTheDocument();
-    expect(screen.queryByText('Identical content after it')).not.toBeInTheDocument();
+    expect(screen.queryByText('Identical block after it')).not.toBeInTheDocument();
   });
 
   it('renders nothing for an occurrence that carries no prompt diagnosis', () => {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.spec.tsx
@@ -1,0 +1,109 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCachePromptShapeSection} from './llmCachePromptShapeSection';
+import type {LlmCacheEvidenceData, LlmCachePromptDivergence} from './types';
+
+const divergence: LlmCachePromptDivergence = {
+  kind: 'iso_timestamp',
+  commonPrefixChars: 142,
+  shortestChars: 48_000,
+  prefixShare: 0.003,
+  stableSuffixChars: 6_200,
+  templateMisordered: true,
+  sampleCount: 4,
+};
+
+const evidence: LlmCacheEvidenceData = {
+  outcome: 'not_caching',
+  agentLabel: 'Planner',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  warmCallCount: 1951,
+  cacheableShare: 0.92,
+  hitRate: 0,
+  writeReadRatio: null,
+  avgInputTokens: 12_000,
+  uncachedTokens: 8_700_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 0,
+  sumCacheCreationTokens: 0,
+  estimatedSavingsUsd: null,
+  overpayVsNoCacheUsd: null,
+  windowDays: 7,
+  windowStart: null,
+  windowEnd: null,
+  sampleCalls: [],
+  anchor: null,
+  promptDivergence: divergence,
+};
+
+describe('LlmCachePromptShapeSection', () => {
+  it('says the stable content is sitting behind the part that changes', () => {
+    render(<LlmCachePromptShapeSection evidenceData={evidence} />);
+
+    expect(
+      screen.getByText(/The stable part of this prompt sits behind the part that changes/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Shared prompt prefix')).toBeInTheDocument();
+    expect(screen.getByText('142 chars (0.30% of the prompt)')).toBeInTheDocument();
+    expect(screen.getByText('Prompts first differ at')).toBeInTheDocument();
+    expect(screen.getAllByText('an ISO-8601 timestamp').length).toBeGreaterThan(0);
+    expect(screen.getByText('Identical content after it')).toBeInTheDocument();
+    // Both the sentence and the row carry it.
+    expect(screen.getAllByText('~6.2K chars')).toHaveLength(2);
+    expect(
+      screen.getByText('Measured on 4 recent invocations of this call site.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not blame the template when the shared prefix is already long enough', () => {
+    render(
+      <LlmCachePromptShapeSection
+        evidenceData={{
+          ...evidence,
+          promptDivergence: {...divergence, templateMisordered: false},
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText(/A provider caches a prefix and only a prefix/)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/The stable part of this prompt sits behind/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('points away from the prompt when the samples never diverged', () => {
+    render(
+      <LlmCachePromptShapeSection
+        evidenceData={{
+          ...evidence,
+          promptDivergence: {
+            ...divergence,
+            kind: 'none',
+            stableSuffixChars: 0,
+            templateMisordered: false,
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText(/the prompt text is not what breaks the cache here/)
+    ).toBeInTheDocument();
+    // There is no first difference to name, and nothing follows one.
+    expect(screen.queryByText('Prompts first differ at')).not.toBeInTheDocument();
+    expect(screen.queryByText('Identical content after it')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for an occurrence that carries no prompt diagnosis', () => {
+    const {container} = render(
+      <LlmCachePromptShapeSection evidenceData={{...evidence, promptDivergence: null}} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.tsx
@@ -14,7 +14,7 @@ interface LlmCachePromptShapeSectionProps {
 }
 
 function divergenceStatement(divergence: LlmCachePromptDivergence): ReactNode {
-  const {kind, commonPrefixChars, stableSuffixChars, templateMisordered} = divergence;
+  const {kind, commonPrefixChars, stableBlockChars, templateMisordered} = divergence;
 
   if (kind === 'none') {
     return t(
@@ -22,13 +22,13 @@ function divergenceStatement(divergence: LlmCachePromptDivergence): ReactNode {
     );
   }
 
-  if (templateMisordered && stableSuffixChars !== null) {
+  if (templateMisordered && stableBlockChars !== null) {
     return tct(
-      'The stable part of this prompt sits behind the part that changes. The prompts start differing [prefix] in, at [kind], and [suffix] of identical content follow. Moving that content in front of the changing part is what makes it cacheable.',
+      'The stable part of this prompt sits behind the part that changes. The prompts start differing [prefix] in, at [kind], and a [block] block that is identical on every call sits after that point. Moving it in front of the changing part is what makes it cacheable.',
       {
         prefix: <Text bold>{formatCharacters(commonPrefixChars)}</Text>,
         kind: getPromptDivergenceDescription(kind),
-        suffix: <Text bold>{formatCharacters(stableSuffixChars)}</Text>,
+        block: <Text bold>{formatCharacters(stableBlockChars)}</Text>,
       }
     );
   }
@@ -66,7 +66,7 @@ export function LlmCachePromptShapeSection({
     return null;
   }
 
-  const {kind, sampleCount, stableSuffixChars} = divergence;
+  const {kind, sampleCount, stableBlockChars} = divergence;
 
   return (
     <Stack gap="md">
@@ -88,13 +88,13 @@ export function LlmCachePromptShapeSection({
             value={getPromptDivergenceDescription(kind)}
           />
         )}
-        {stableSuffixChars !== null && stableSuffixChars > 0 && (
+        {stableBlockChars !== null && stableBlockChars > 0 && (
           <CallSiteMetric
-            id="prompt-stable-suffix"
-            label={t('Identical content after it')}
-            value={formatCharacters(stableSuffixChars)}
+            id="prompt-stable-block"
+            label={t('Identical block after it')}
+            value={formatCharacters(stableBlockChars)}
             tooltip={t(
-              'Content that is the same on every sampled call but arrives after the first difference, so no cache can reach it. A lower bound: long prompts are truncated in storage.'
+              'The largest run of content that is the same on every sampled call but sits after the first difference, so no cache can reach it. A lower bound: prompts are aligned in whole pieces, and long ones are truncated in storage.'
             )}
           />
         )}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.tsx
@@ -22,24 +22,34 @@ function divergenceStatement(divergence: LlmCachePromptDivergence): ReactNode {
     );
   }
 
+  // Each variant is a whole sentence rather than an optional clause spliced
+  // into one: where the phrase lands in the sentence is the translator's to
+  // decide, and a fragment passed through `tct` takes that away from them.
+  const prefix = <Text bold>{formatCharacters(commonPrefixChars)}</Text>;
+  const description = getPromptDivergenceDescription(kind);
+
   if (templateMisordered && stableBlockChars !== null) {
-    return tct(
-      'The stable part of this prompt sits behind the part that changes. The prompts start differing [prefix] in, at [kind], and a [block] block that is identical on every call sits after that point. Moving it in front of the changing part is what makes it cacheable.',
-      {
-        prefix: <Text bold>{formatCharacters(commonPrefixChars)}</Text>,
-        kind: getPromptDivergenceDescription(kind),
-        block: <Text bold>{formatCharacters(stableBlockChars)}</Text>,
-      }
-    );
+    const block = <Text bold>{formatCharacters(stableBlockChars)}</Text>;
+    return description === null
+      ? tct(
+          'The stable part of this prompt sits behind the part that changes. The prompts start differing [prefix] in, and a [block] block that is identical on every call sits after that point. Moving it in front of the changing part is what makes it cacheable.',
+          {prefix, block}
+        )
+      : tct(
+          'The stable part of this prompt sits behind the part that changes. The prompts start differing [prefix] in, at [kind], and a [block] block that is identical on every call sits after that point. Moving it in front of the changing part is what makes it cacheable.',
+          {prefix, kind: description, block}
+        );
   }
 
-  return tct(
-    'The sampled prompts stop matching [prefix] in, at [kind]. A provider caches a prefix and only a prefix, so nothing past that point can be held between calls.',
-    {
-      prefix: <Text bold>{formatCharacters(commonPrefixChars)}</Text>,
-      kind: getPromptDivergenceDescription(kind),
-    }
-  );
+  return description === null
+    ? tct(
+        'The sampled prompts stop matching [prefix] in. A provider caches a prefix and only a prefix, so nothing past that point can be held between calls.',
+        {prefix}
+      )
+    : tct(
+        'The sampled prompts stop matching [prefix] in, at [kind]. A provider caches a prefix and only a prefix, so nothing past that point can be held between calls.',
+        {prefix, kind: description}
+      );
 }
 
 function formatSharedPrefix(divergence: LlmCachePromptDivergence): string {
@@ -67,6 +77,7 @@ export function LlmCachePromptShapeSection({
   }
 
   const {kind, sampleCount, stableBlockChars} = divergence;
+  const divergenceDescription = getPromptDivergenceDescription(kind);
 
   return (
     <Stack gap="md">
@@ -81,11 +92,11 @@ export function LlmCachePromptShapeSection({
             'How much of the prompt is identical across the sampled calls before the first difference. Providers cache an exact prefix, so this is the most a cache could hold.'
           )}
         />
-        {kind !== 'none' && (
+        {divergenceDescription !== null && (
           <CallSiteMetric
             id="prompt-divergence-kind"
             label={t('Prompts first differ at')}
-            value={getPromptDivergenceDescription(kind)}
+            value={divergenceDescription}
           />
         )}
         {stableBlockChars !== null && stableBlockChars > 0 && (

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCachePromptShapeSection.tsx
@@ -1,0 +1,113 @@
+import type {ReactNode} from 'react';
+
+import {Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct, tn} from 'sentry/locale';
+
+import {CallSiteMetric} from './callSiteMetric';
+import type {LlmCacheEvidenceData, LlmCachePromptDivergence} from './types';
+import {formatCharacters, formatRate, getPromptDivergenceDescription} from './utils';
+
+interface LlmCachePromptShapeSectionProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+function divergenceStatement(divergence: LlmCachePromptDivergence): ReactNode {
+  const {kind, commonPrefixChars, stableSuffixChars, templateMisordered} = divergence;
+
+  if (kind === 'none') {
+    return t(
+      'The sampled prompts were identical for as far as they could be compared, so the prompt text is not what breaks the cache here. Look at whether caching is switched on for this call at all.'
+    );
+  }
+
+  if (templateMisordered && stableSuffixChars !== null) {
+    return tct(
+      'The stable part of this prompt sits behind the part that changes. The prompts start differing [prefix] in, at [kind], and [suffix] of identical content follow. Moving that content in front of the changing part is what makes it cacheable.',
+      {
+        prefix: <Text bold>{formatCharacters(commonPrefixChars)}</Text>,
+        kind: getPromptDivergenceDescription(kind),
+        suffix: <Text bold>{formatCharacters(stableSuffixChars)}</Text>,
+      }
+    );
+  }
+
+  return tct(
+    'The sampled prompts stop matching [prefix] in, at [kind]. A provider caches a prefix and only a prefix, so nothing past that point can be held between calls.',
+    {
+      prefix: <Text bold>{formatCharacters(commonPrefixChars)}</Text>,
+      kind: getPromptDivergenceDescription(kind),
+    }
+  );
+}
+
+function formatSharedPrefix(divergence: LlmCachePromptDivergence): string {
+  const prefix = formatCharacters(divergence.commonPrefixChars);
+  if (divergence.prefixShare === null) {
+    return prefix;
+  }
+  return t('%s (%s of the prompt)', prefix, formatRate(divergence.prefixShare));
+}
+
+/**
+ * Why the cache misses, read off the prompts themselves.
+ *
+ * Only ever rendered for a call site whose spans carried prompt text, which is
+ * opt-in and usually off — so this section is the exception on the page, not
+ * part of its skeleton.
+ */
+export function LlmCachePromptShapeSection({
+  evidenceData,
+}: LlmCachePromptShapeSectionProps) {
+  const divergence = evidenceData.promptDivergence;
+
+  if (divergence === null) {
+    return null;
+  }
+
+  const {kind, sampleCount, stableSuffixChars} = divergence;
+
+  return (
+    <Stack gap="md">
+      <Text>{divergenceStatement(divergence)}</Text>
+      <Grid columns="fit-content(50%) 1fr" border="primary" radius="md" padding="sm">
+        <CallSiteMetric
+          id="prompt-shared-prefix"
+          label={t('Shared prompt prefix')}
+          value={formatSharedPrefix(divergence)}
+          emphasized={divergence.templateMisordered}
+          tooltip={t(
+            'How much of the prompt is identical across the sampled calls before the first difference. Providers cache an exact prefix, so this is the most a cache could hold.'
+          )}
+        />
+        {kind !== 'none' && (
+          <CallSiteMetric
+            id="prompt-divergence-kind"
+            label={t('Prompts first differ at')}
+            value={getPromptDivergenceDescription(kind)}
+          />
+        )}
+        {stableSuffixChars !== null && stableSuffixChars > 0 && (
+          <CallSiteMetric
+            id="prompt-stable-suffix"
+            label={t('Identical content after it')}
+            value={formatCharacters(stableSuffixChars)}
+            tooltip={t(
+              'Content that is the same on every sampled call but arrives after the first difference, so no cache can reach it. A lower bound: long prompts are truncated in storage.'
+            )}
+          />
+        )}
+      </Grid>
+      {sampleCount !== null && (
+        <Text size="sm" variant="muted">
+          {tn(
+            'Measured on %s recent invocation of this call site.',
+            'Measured on %s recent invocations of this call site.',
+            sampleCount
+          )}
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.spec.tsx
@@ -1,0 +1,87 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheTokenBar} from './llmCacheTokenBar';
+
+function getPercentages() {
+  return screen
+    .getAllByText(/\(\d+%\)$/)
+    .map(element => Number(/\((\d+)%\)$/.exec(element.textContent ?? '')?.[1]));
+}
+
+describe('LlmCacheTokenBar', () => {
+  it('renders one labelled band per way the tokens were billed', () => {
+    render(
+      <LlmCacheTokenBar
+        inputTokens={10_000}
+        cacheReadTokens={2_500}
+        cacheCreationTokens={2_500}
+      />
+    );
+
+    expect(screen.getByText('Uncached ~5.0K (50%)')).toBeInTheDocument();
+    expect(screen.getByText('Cache writes ~2.5K (25%)')).toBeInTheDocument();
+    expect(screen.getByText('Cache reads ~2.5K (25%)')).toBeInTheDocument();
+  });
+
+  it('omits a band that carries no tokens', () => {
+    render(
+      <LlmCacheTokenBar
+        inputTokens={10_000}
+        cacheReadTokens={0}
+        cacheCreationTokens={0}
+      />
+    );
+
+    expect(screen.getByText('Uncached ~10.0K (100%)')).toBeInTheDocument();
+    expect(screen.queryByText(/Cache writes/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cache reads/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the percentages adding up to 100 when every share rounds up', () => {
+    // 33% / 33.5% / 33.5%: rounding each on its own reads 33/34/34 under a bar
+    // that is visibly full.
+    render(
+      <LlmCacheTokenBar inputTokens={200} cacheReadTokens={67} cacheCreationTokens={67} />
+    );
+
+    expect(getPercentages().reduce((sum, value) => sum + value, 0)).toBe(100);
+  });
+
+  it('keeps the percentages adding up to 100 when every share rounds down', () => {
+    // Three equal thirds each floor to 33, leaving a percent to hand out.
+    render(
+      <LlmCacheTokenBar
+        inputTokens={300}
+        cacheReadTokens={100}
+        cacheCreationTokens={100}
+      />
+    );
+
+    expect(getPercentages().reduce((sum, value) => sum + value, 0)).toBe(100);
+  });
+
+  it('clamps uncached tokens for providers that report input exclusive of cache', () => {
+    render(
+      <LlmCacheTokenBar
+        inputTokens={1_000}
+        cacheReadTokens={4_000}
+        cacheCreationTokens={1_000}
+      />
+    );
+
+    expect(screen.queryByText(/Uncached/)).not.toBeInTheDocument();
+    expect(getPercentages().reduce((sum, value) => sum + value, 0)).toBe(100);
+  });
+
+  it('renders nothing without an input token total', () => {
+    const {container} = render(
+      <LlmCacheTokenBar
+        inputTokens={null}
+        cacheReadTokens={100}
+        cacheCreationTokens={100}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
@@ -16,10 +16,9 @@ interface LlmCacheTokenBarProps {
 /**
  * Whole-percent shares that add up to exactly 100.
  *
- * Rounding each share on its own lets the three labels read 37/59/5 under a bar
- * that visibly fills its track. The leftover percent goes to whichever shares
- * were cut by the most, so the one that absorbs it is the one with the best
- * claim to it.
+ * Rounding each share on its own lets the labels read 37/59/5 under a bar that
+ * visibly fills its track, so the leftover percent goes to whichever share was
+ * cut by the most.
  */
 function toWholePercentages(values: number[], total: number): number[] {
   const exact = values.map(value => (value / total) * 100);

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
@@ -1,0 +1,105 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+import {formatTokens} from './utils';
+
+interface LlmCacheTokenBarProps {
+  cacheCreationTokens: number | null;
+  cacheReadTokens: number | null;
+  inputTokens: number | null;
+}
+
+/**
+ * The window's input tokens split by how they were billed.
+ *
+ * This is the finding in one picture: a call site that never caches is almost
+ * entirely uncached, and one that thrashes is a fat write band next to a sliver
+ * of reads.
+ */
+export function LlmCacheTokenBar({
+  inputTokens,
+  cacheReadTokens,
+  cacheCreationTokens,
+}: LlmCacheTokenBarProps) {
+  const theme = useTheme();
+
+  if (inputTokens === null) {
+    return null;
+  }
+
+  const reads = cacheReadTokens ?? 0;
+  const writes = cacheCreationTokens ?? 0;
+  // Providers that report input exclusive of cached tokens would drive this
+  // negative; the detector clamps it the same way.
+  const uncached = Math.max(inputTokens - reads - writes, 0);
+  const total = reads + writes + uncached;
+
+  if (total <= 0) {
+    return null;
+  }
+
+  const segments = [
+    {
+      key: 'uncached',
+      label: t('Uncached'),
+      value: uncached,
+      color: theme.tokens.graphics.neutral.moderate,
+    },
+    {
+      key: 'writes',
+      label: t('Cache writes'),
+      value: writes,
+      color: theme.tokens.graphics.promotion.vibrant,
+    },
+    {
+      key: 'reads',
+      label: t('Cache reads'),
+      value: reads,
+      color: theme.tokens.graphics.success.vibrant,
+    },
+  ].filter(segment => segment.value > 0);
+
+  return (
+    <Stack gap="sm">
+      <Flex height="12px" radius="sm" overflow="hidden">
+        {segments.map(segment => (
+          <Segment
+            key={segment.key}
+            style={{flexGrow: segment.value, background: segment.color}}
+          />
+        ))}
+      </Flex>
+      <Flex gap="lg" wrap="wrap">
+        {segments.map(segment => (
+          <Flex key={segment.key} align="center" gap="xs">
+            <Swatch style={{background: segment.color}} />
+            <Text size="sm" variant="muted">
+              {t(
+                '%s %s (%s)',
+                segment.label,
+                formatTokens(segment.value),
+                `${((segment.value / total) * 100).toFixed(0)}%`
+              )}
+            </Text>
+          </Flex>
+        ))}
+      </Flex>
+    </Stack>
+  );
+}
+
+const Segment = styled('div')`
+  min-width: 2px;
+`;
+
+const Swatch = styled('div')`
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+`;

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
@@ -15,6 +15,30 @@ interface LlmCacheTokenBarProps {
 }
 
 /**
+ * Whole-percent shares that add up to exactly 100.
+ *
+ * Rounding each share on its own lets the three labels read 37/59/5 under a bar
+ * that visibly fills its track. The leftover percent goes to whichever shares
+ * were cut by the most, so the one that absorbs it is the one with the best
+ * claim to it.
+ */
+function toWholePercentages(values: number[], total: number): number[] {
+  const exact = values.map(value => (value / total) * 100);
+  const percentages = exact.map(Math.floor);
+  const leftover = 100 - percentages.reduce((sum, value) => sum + value, 0);
+
+  const byLargestRemainder = exact
+    .map((value, index) => ({index, remainder: value - Math.floor(value)}))
+    .sort((a, b) => b.remainder - a.remainder);
+
+  for (const {index} of byLargestRemainder.slice(0, leftover)) {
+    percentages[index]! += 1;
+  }
+
+  return percentages;
+}
+
+/**
  * The window's input tokens split by how they were billed.
  *
  * This is the finding in one picture: a call site that never caches is almost
@@ -64,6 +88,11 @@ export function LlmCacheTokenBar({
     },
   ].filter(segment => segment.value > 0);
 
+  const percentages = toWholePercentages(
+    segments.map(segment => segment.value),
+    total
+  );
+
   return (
     <Stack gap="sm">
       <Flex height="12px" radius="sm" overflow="hidden">
@@ -75,7 +104,7 @@ export function LlmCacheTokenBar({
         ))}
       </Flex>
       <Flex gap="lg" wrap="wrap">
-        {segments.map(segment => (
+        {segments.map((segment, index) => (
           <Flex key={segment.key} align="center" gap="xs">
             <Swatch style={{background: segment.color}} />
             <Text size="sm" variant="muted">
@@ -83,7 +112,7 @@ export function LlmCacheTokenBar({
                 '%s %s (%s)',
                 segment.label,
                 formatTokens(segment.value),
-                `${((segment.value / total) * 100).toFixed(0)}%`
+                `${percentages[index]}%`
               )}
             </Text>
           </Flex>

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTokenBar.tsx
@@ -1,7 +1,6 @@
 import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -92,27 +91,38 @@ export function LlmCacheTokenBar({
     segments.map(segment => segment.value),
     total
   );
+  const bands = segments.map((segment, index) => ({
+    ...segment,
+    percentage: percentages[index]!,
+  }));
 
   return (
     <Stack gap="sm">
       <Flex height="12px" radius="sm" overflow="hidden">
-        {segments.map(segment => (
-          <Segment
-            key={segment.key}
-            style={{flexGrow: segment.value, background: segment.color}}
+        {bands.map(band => (
+          <Container
+            key={band.key}
+            minWidth="2px"
+            style={{flexGrow: band.value, background: band.color}}
           />
         ))}
       </Flex>
       <Flex gap="lg" wrap="wrap">
-        {segments.map((segment, index) => (
-          <Flex key={segment.key} align="center" gap="xs">
-            <Swatch style={{background: segment.color}} />
+        {bands.map(band => (
+          <Flex key={band.key} align="center" gap="xs">
+            <Container
+              width="10px"
+              height="10px"
+              radius="2xs"
+              flexShrink={0}
+              style={{background: band.color}}
+            />
             <Text size="sm" variant="muted">
               {t(
                 '%s %s (%s)',
-                segment.label,
-                formatTokens(segment.value),
-                `${percentages[index]}%`
+                band.label,
+                formatTokens(band.value),
+                `${band.percentage}%`
               )}
             </Text>
           </Flex>
@@ -121,14 +131,3 @@ export function LlmCacheTokenBar({
     </Stack>
   );
 }
-
-const Segment = styled('div')`
-  min-width: 2px;
-`;
-
-const Swatch = styled('div')`
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-  flex-shrink: 0;
-`;

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
@@ -5,8 +5,9 @@ import type {LlmCacheEvidenceData} from './types';
 
 const evidence: LlmCacheEvidenceData = {
   outcome: 'not_caching',
-  transaction: 'agent.plan',
-  spanDescription: 'generate_content claude-sonnet-4',
+  agentLabel: 'Planner',
+  agentLabelSource: 'gen_ai.agent.name',
+  spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
   hitRate: 0,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
@@ -24,6 +24,7 @@ const evidence: LlmCacheEvidenceData = {
   windowDays: 7,
   windowStart: null,
   windowEnd: null,
+  promptDivergence: null,
   sampleCalls: [],
   anchor: null,
 };

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
@@ -10,6 +10,8 @@ const evidence: LlmCacheEvidenceData = {
   spanName: 'generate_content claude-sonnet-4',
   model: 'claude-sonnet-4',
   callCount: 2121,
+  warmCallCount: 1951,
+  cacheableShare: 0.92,
   hitRate: 0,
   writeReadRatio: null,
   avgInputTokens: 4096,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.spec.tsx
@@ -1,0 +1,71 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LlmCacheTroubleshootingSection} from './llmCacheTroubleshootingSection';
+import type {LlmCacheEvidenceData} from './types';
+
+const evidence: LlmCacheEvidenceData = {
+  outcome: 'not_caching',
+  transaction: 'agent.plan',
+  spanDescription: 'generate_content claude-sonnet-4',
+  model: 'claude-sonnet-4',
+  callCount: 2121,
+  hitRate: 0,
+  writeReadRatio: null,
+  avgInputTokens: 4096,
+  uncachedTokens: 8_700_000,
+  sumInputTokens: 8_700_000,
+  sumCacheReadTokens: 0,
+  sumCacheCreationTokens: 0,
+  estimatedSavingsUsd: null,
+  overpayVsNoCacheUsd: null,
+  windowDays: 7,
+  windowStart: null,
+  windowEnd: null,
+  sampleCalls: [],
+  anchor: null,
+};
+
+describe('LlmCacheTroubleshootingSection', () => {
+  it('tells a never-caching call site how to turn caching on', () => {
+    render(<LlmCacheTroubleshootingSection evidenceData={evidence} />);
+
+    expect(screen.getByText('1. Check that caching is enabled')).toBeInTheDocument();
+    expect(screen.getByText(/cache_control breakpoint/)).toBeInTheDocument();
+    expect(screen.getByText('2. Put stable content first')).toBeInTheDocument();
+  });
+
+  it('tells a thrashing call site to find what changes at the top of the prompt', () => {
+    render(
+      <LlmCacheTroubleshootingSection evidenceData={{...evidence, outcome: 'thrash'}} />
+    );
+
+    expect(
+      screen.getByText('1. Find what changes at the top of the prompt')
+    ).toBeInTheDocument();
+    expect(screen.getByText('3. Stop caching per-session content')).toBeInTheDocument();
+    expect(screen.queryByText(/cache_control breakpoint/)).not.toBeInTheDocument();
+  });
+
+  it('points at the docs for the provider the model belongs to', () => {
+    render(
+      <LlmCacheTroubleshootingSection
+        evidenceData={{...evidence, model: 'gemini-2.5-pro'}}
+      />
+    );
+
+    expect(screen.getByText(/Newer Gemini models cache implicitly/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'Read the Gemini context caching docs'})
+    ).toHaveAttribute('href', 'https://ai.google.dev/gemini-api/docs/caching');
+  });
+
+  it('stays useful for a model it cannot attribute to a provider', () => {
+    render(
+      <LlmCacheTroubleshootingSection
+        evidenceData={{...evidence, model: 'some-self-hosted-model'}}
+      />
+    );
+
+    expect(screen.getByText(/Check whether this provider caches/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/llmCacheTroubleshootingSection.tsx
@@ -1,0 +1,122 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {IconDocs} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import type {LlmCacheEvidenceData} from './types';
+import {
+  getCacheProvider,
+  getPromptCachingDocsLabel,
+  getPromptCachingDocsUrl,
+} from './utils';
+
+interface LlmCacheTroubleshootingSectionProps {
+  evidenceData: LlmCacheEvidenceData;
+}
+
+interface Step {
+  body: string;
+  title: string;
+}
+
+function getEnableCachingBody(model: string | null): string {
+  switch (getCacheProvider(model)) {
+    case 'anthropic':
+      return t(
+        'Add a cache_control breakpoint to the last stable block of the request — the system prompt or the tool definitions. Without one, nothing is cached.'
+      );
+    case 'openai':
+      return t(
+        'Caching is automatic for prompts over 1024 tokens. A near-zero hit rate means the first 1024 tokens differ on every call.'
+      );
+    case 'google':
+      return t(
+        'Newer Gemini models cache implicitly; for the others, create an explicit cached-content object for the shared prefix.'
+      );
+    default:
+      return t(
+        "Check whether this provider caches automatically or needs an explicit cache breakpoint, and that the SDK path you're using sets one."
+      );
+  }
+}
+
+function getSteps(evidenceData: LlmCacheEvidenceData): Step[] {
+  if (evidenceData.outcome === 'thrash') {
+    return [
+      {
+        title: t('Find what changes at the top of the prompt'),
+        body: t(
+          'Compare two of the example calls above. Look for timestamps, session ids, retrieved documents, or tools serialized in a different order — any difference invalidates the cached prefix behind it.'
+        ),
+      },
+      {
+        title: t('Move changing content below the cache breakpoint'),
+        body: t(
+          'Everything before the breakpoint has to be byte-identical across calls. Move dynamic content after it, or into the user turn.'
+        ),
+      },
+      {
+        title: t('Stop caching per-session content'),
+        body: t(
+          'A prefix unique to one user or session pays the cache-write premium on every call and is rarely read back. Cache only what is shared across calls.'
+        ),
+      },
+      {
+        title: t('Verify the fix'),
+        body: t(
+          'Watch the cache activity chart above: the write:read ratio should fall below 1 once the prefix is stable.'
+        ),
+      },
+    ];
+  }
+
+  return [
+    {
+      title: t('Check that caching is enabled'),
+      body: getEnableCachingBody(evidenceData.model),
+    },
+    {
+      title: t('Put stable content first'),
+      body: t(
+        'Order the request so the parts that never change — system prompt, tool definitions, reference documents — come before per-call content. Caches match on an exact prefix.'
+      ),
+    },
+    {
+      title: t('Keep the prefix byte-identical'),
+      body: t(
+        'Remove timestamps, request ids and user-specific values from the shared prefix, and serialize tool definitions in a fixed order.'
+      ),
+    },
+    {
+      title: t('Verify the fix'),
+      body: t(
+        'Watch the cache activity chart above: the hit rate should climb within a few hours of deploying.'
+      ),
+    },
+  ];
+}
+
+export function LlmCacheTroubleshootingSection({
+  evidenceData,
+}: LlmCacheTroubleshootingSectionProps) {
+  const steps = getSteps(evidenceData);
+
+  return (
+    <Stack gap="lg">
+      {steps.map((step, index) => (
+        <Stack key={step.title} gap="xs" padding="sm 0">
+          <Heading as="h4">{t('%s. %s', index + 1, step.title)}</Heading>
+          <Text variant="muted">{step.body}</Text>
+        </Stack>
+      ))}
+      <Flex align="center" gap="xs">
+        <IconDocs size="xs" />
+        <ExternalLink href={getPromptCachingDocsUrl(evidenceData.model)}>
+          {getPromptCachingDocsLabel(evidenceData.model)}
+        </ExternalLink>
+      </Flex>
+    </Stack>
+  );
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
@@ -44,6 +44,8 @@ export interface LlmCacheEvidenceData {
   agentLabelSource: LlmCacheAgentLabelSource | null;
   anchor: LlmCacheContrastAnchor | null;
   avgInputTokens: number | null;
+  /** Share of all calls that had a warm cache to hit. */
+  cacheableShare: number | null;
   callCount: number | null;
   estimatedSavingsUsd: number | null;
   hitRate: number | null;
@@ -56,6 +58,13 @@ export interface LlmCacheEvidenceData {
   sumCacheReadTokens: number | null;
   sumInputTokens: number | null;
   uncachedTokens: number | null;
+  /**
+   * Calls that arrived within the cache TTL of an earlier one at the same call
+   * site, so a warm cache was there to hit. The hit rate is read against every
+   * call, which makes this the figure that separates a broken cache from
+   * traffic too sparse to have one.
+   */
+  warmCallCount: number | null;
   windowDays: number | null;
   windowEnd: string | null;
   windowStart: string | null;

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
@@ -14,16 +14,23 @@ export interface LlmCacheSampleCall {
 }
 
 /**
+ * How a call site got the name it is grouped and displayed under: an agent
+ * somebody named, or the operation name standing in where there is none.
+ */
+export type LlmCacheAgentLabelSource = 'gen_ai.agent.name' | 'gen_ai.operation.name';
+
+/**
  * A healthy call site on the same model in the same project. Its whole job is
  * to answer "maybe this model just doesn't cache well here".
  */
 export interface LlmCacheContrastAnchor {
+  agentLabel: string;
+  agentLabelSource: LlmCacheAgentLabelSource | null;
   avgInputTokens: number | null;
   callCount: number | null;
   hitRate: number;
   model: string;
-  spanDescription: string;
-  transaction: string;
+  spanName: string;
 }
 
 /**
@@ -33,6 +40,8 @@ export interface LlmCacheContrastAnchor {
  * rendering, they just render less.
  */
 export interface LlmCacheEvidenceData {
+  agentLabel: string | null;
+  agentLabelSource: LlmCacheAgentLabelSource | null;
   anchor: LlmCacheContrastAnchor | null;
   avgInputTokens: number | null;
   callCount: number | null;
@@ -42,11 +51,10 @@ export interface LlmCacheEvidenceData {
   outcome: LlmCacheOutcome | null;
   overpayVsNoCacheUsd: number | null;
   sampleCalls: LlmCacheSampleCall[];
-  spanDescription: string | null;
+  spanName: string | null;
   sumCacheCreationTokens: number | null;
   sumCacheReadTokens: number | null;
   sumInputTokens: number | null;
-  transaction: string | null;
   uncachedTokens: number | null;
   windowDays: number | null;
   windowEnd: string | null;

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
@@ -64,11 +64,12 @@ export interface LlmCachePromptDivergence {
   sampleCount: number | null;
   shortestChars: number | null;
   /**
-   * Identical content trailing the divergence. A lower bound: the span store
-   * truncates long attribute values, so a sampled prompt can be a prefix of the
-   * real one.
+   * The largest identical block sitting anywhere after the divergence -- which
+   * is where stranded content usually is, since a prompt ends with the caller's
+   * own text. A lower bound: prompts are aligned in whole pieces, and the span
+   * store truncates long attribute values.
    */
-  stableSuffixChars: number | null;
+  stableBlockChars: number | null;
   /** Stable content sitting behind the variable part rather than in front. */
   templateMisordered: boolean;
 }

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
@@ -1,0 +1,55 @@
+export type LlmCacheOutcome = 'not_caching' | 'thrash';
+
+/**
+ * One example call from the flagged call site, enough to deep-link into the
+ * span that made it.
+ */
+export interface LlmCacheSampleCall {
+  cacheCreationTokens: number | null;
+  cacheReadTokens: number | null;
+  inputTokens: number | null;
+  spanId: string | null;
+  timestamp: string | null;
+  traceId: string;
+}
+
+/**
+ * A healthy call site on the same model in the same project. Its whole job is
+ * to answer "maybe this model just doesn't cache well here".
+ */
+export interface LlmCacheContrastAnchor {
+  avgInputTokens: number | null;
+  callCount: number | null;
+  hitRate: number;
+  model: string;
+  spanDescription: string;
+  transaction: string;
+}
+
+/**
+ * What the detector knows about a call site, as carried on the occurrence.
+ *
+ * Every field is nullable: occurrences produced before a field existed keep
+ * rendering, they just render less.
+ */
+export interface LlmCacheEvidenceData {
+  anchor: LlmCacheContrastAnchor | null;
+  avgInputTokens: number | null;
+  callCount: number | null;
+  estimatedSavingsUsd: number | null;
+  hitRate: number | null;
+  model: string | null;
+  outcome: LlmCacheOutcome | null;
+  overpayVsNoCacheUsd: number | null;
+  sampleCalls: LlmCacheSampleCall[];
+  spanDescription: string | null;
+  sumCacheCreationTokens: number | null;
+  sumCacheReadTokens: number | null;
+  sumInputTokens: number | null;
+  transaction: string | null;
+  uncachedTokens: number | null;
+  windowDays: number | null;
+  windowEnd: string | null;
+  windowStart: string | null;
+  writeReadRatio: number | null;
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/types.ts
@@ -34,6 +34,46 @@ export interface LlmCacheContrastAnchor {
 }
 
 /**
+ * What sits at the point where a call site's sampled prompts stop agreeing.
+ * `none` means they never did, as far as the sampled text went.
+ */
+export type LlmCachePromptDivergenceKind =
+  | 'none'
+  | 'iso_timestamp'
+  | 'epoch_timestamp'
+  | 'uuid'
+  | 'identifier'
+  | 'counter'
+  | 'other';
+
+/**
+ * Where a handful of the call site's prompts stop agreeing, and what sits there.
+ *
+ * A provider caches a prefix, so this is the deterministic half of "why": the
+ * shared prefix is all a cache could ever hold, and identical content trailing
+ * the divergence is content the template put in the wrong order.
+ *
+ * Character lengths, not tokens — the detector measures the serialized message
+ * list, and converting would dress a tokenizer-dependent guess up as a count.
+ */
+export interface LlmCachePromptDivergence {
+  commonPrefixChars: number;
+  kind: LlmCachePromptDivergenceKind;
+  /** How much of the shortest sampled prompt the shared prefix covers. */
+  prefixShare: number | null;
+  sampleCount: number | null;
+  shortestChars: number | null;
+  /**
+   * Identical content trailing the divergence. A lower bound: the span store
+   * truncates long attribute values, so a sampled prompt can be a prefix of the
+   * real one.
+   */
+  stableSuffixChars: number | null;
+  /** Stable content sitting behind the variable part rather than in front. */
+  templateMisordered: boolean;
+}
+
+/**
  * What the detector knows about a call site, as carried on the occurrence.
  *
  * Every field is nullable: occurrences produced before a field existed keep
@@ -52,6 +92,8 @@ export interface LlmCacheEvidenceData {
   model: string | null;
   outcome: LlmCacheOutcome | null;
   overpayVsNoCacheUsd: number | null;
+  /** Absent whenever the spans carry no prompt text, which is the common case. */
+  promptDivergence: LlmCachePromptDivergence | null;
   sampleCalls: LlmCacheSampleCall[];
   spanName: string | null;
   sumCacheCreationTokens: number | null;

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
@@ -4,21 +4,27 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {PageFilters} from 'sentry/types/core';
 
 import type {LlmCacheEvidenceData} from './types';
+import {getCallSiteWindow} from './utils';
 
 /**
  * Page filters pinned to the window the finding was derived from.
  *
- * The reader's own date selection would silently answer a different question
- * than the issue is making a claim about, so live queries on this page ignore
- * it and use the detection window instead. `padDays` widens the range so a
- * chart can show what the call site looked like before detection.
+ * The reader's own selection would silently answer a different question than
+ * the issue is making a claim about, so live queries on this page ignore it.
+ * The date range comes from the detection window, and the environment is
+ * cleared because the detector applied none -- narrowed to one, the chart would
+ * show a slice of the traffic the finding was measured over, and this page
+ * renders no filter bar to explain why. `padDays` widens the range so a chart
+ * can show what the call site looked like before detection.
  */
 export function useCallSitePageFilters(
   evidenceData: LlmCacheEvidenceData,
   {padDays = 0}: {padDays?: number} = {}
 ): PageFilters | undefined {
   const {selection} = usePageFilters();
-  const {windowStart, windowEnd} = evidenceData;
+  const window = getCallSiteWindow(evidenceData);
+  const windowStart = window?.start.valueOf() ?? null;
+  const windowEnd = window?.end.valueOf() ?? null;
 
   return useMemo(() => {
     if (windowStart === null || windowEnd === null) {
@@ -27,11 +33,6 @@ export function useCallSitePageFilters(
 
     const start = new Date(windowStart);
     const end = new Date(windowEnd);
-    // The parser only promises a string, not a parseable one, and an invalid
-    // date here would reach the API as an unbounded range.
-    if (Number.isNaN(start.valueOf()) || Number.isNaN(end.valueOf())) {
-      return;
-    }
     start.setDate(start.getDate() - padDays);
     // Padded forward as well as back, so the range can reach past detection and
     // show whether a fix took. Clamped to now because a range ending in the
@@ -44,6 +45,7 @@ export function useCallSitePageFilters(
 
     return {
       ...selection,
+      environments: [],
       datetime: {start, end, period: null, utc: true},
     };
   }, [selection, windowStart, windowEnd, padDays]);

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
@@ -27,6 +27,8 @@ export function useCallSitePageFilters(
 
     const start = new Date(windowStart);
     const end = new Date(windowEnd);
+    // The parser only promises a string, not a parseable one, and an invalid
+    // date here would reach the API as an unbounded range.
     if (Number.isNaN(start.valueOf()) || Number.isNaN(end.valueOf())) {
       return;
     }

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
@@ -31,6 +31,14 @@ export function useCallSitePageFilters(
       return;
     }
     start.setDate(start.getDate() - padDays);
+    // Padded forward as well as back, so the range can reach past detection and
+    // show whether a fix took. Clamped to now because a range ending in the
+    // future would draw a run of empty buckets after the real data.
+    end.setDate(end.getDate() + padDays);
+    const now = new Date();
+    if (end > now) {
+      end.setTime(now.getTime());
+    }
 
     return {
       ...selection,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/useCallSitePageFilters.tsx
@@ -1,0 +1,40 @@
+import {useMemo} from 'react';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
+
+import type {LlmCacheEvidenceData} from './types';
+
+/**
+ * Page filters pinned to the window the finding was derived from.
+ *
+ * The reader's own date selection would silently answer a different question
+ * than the issue is making a claim about, so live queries on this page ignore
+ * it and use the detection window instead. `padDays` widens the range so a
+ * chart can show what the call site looked like before detection.
+ */
+export function useCallSitePageFilters(
+  evidenceData: LlmCacheEvidenceData,
+  {padDays = 0}: {padDays?: number} = {}
+): PageFilters | undefined {
+  const {selection} = usePageFilters();
+  const {windowStart, windowEnd} = evidenceData;
+
+  return useMemo(() => {
+    if (windowStart === null || windowEnd === null) {
+      return;
+    }
+
+    const start = new Date(windowStart);
+    const end = new Date(windowEnd);
+    if (Number.isNaN(start.valueOf()) || Number.isNaN(end.valueOf())) {
+      return;
+    }
+    start.setDate(start.getDate() - padDays);
+
+    return {
+      ...selection,
+      datetime: {start, end, period: null, utc: true},
+    };
+  }, [selection, windowStart, windowEnd, padDays]);
+}

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -97,7 +97,7 @@ describe('getLlmCacheEvidenceData', () => {
       promptShortestChars: 48_000,
       promptPrefixShare: 0.003,
       promptDivergenceKind: 'iso_timestamp',
-      promptStableSuffixChars: 6_200,
+      promptStableBlockChars: 6_200,
       promptTemplateMisordered: true,
     });
 
@@ -106,7 +106,7 @@ describe('getLlmCacheEvidenceData', () => {
       commonPrefixChars: 142,
       shortestChars: 48_000,
       prefixShare: 0.003,
-      stableSuffixChars: 6_200,
+      stableBlockChars: 6_200,
       templateMisordered: true,
       sampleCount: 4,
     });
@@ -121,7 +121,7 @@ describe('getLlmCacheEvidenceData', () => {
     expect(
       getLlmCacheEvidenceData({
         promptDivergenceKind: 'uuid',
-        promptStableSuffixChars: 6_200,
+        promptStableBlockChars: 6_200,
       }).promptDivergence
     ).toBeNull();
   });
@@ -143,7 +143,7 @@ describe('getLlmCacheEvidenceData', () => {
     });
 
     expect(parsed.promptDivergence?.templateMisordered).toBe(false);
-    expect(parsed.promptDivergence?.stableSuffixChars).toBeNull();
+    expect(parsed.promptDivergence?.stableBlockChars).toBeNull();
   });
 
   it('ignores an unrecognized outcome', () => {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -1,0 +1,115 @@
+import {getCacheProvider, getLlmCacheEvidenceData} from './utils';
+
+describe('getLlmCacheEvidenceData', () => {
+  it('reads a fully populated occurrence', () => {
+    const parsed = getLlmCacheEvidenceData({
+      outcome: 'thrash',
+      transaction: 'agent.execute_step',
+      spanDescription: 'generate_content claude-sonnet-4',
+      model: 'claude-sonnet-4',
+      callCount: 2121,
+      hitRate: 0.0487,
+      writeReadRatio: 12,
+      avgInputTokens: 4096,
+      uncachedTokens: 3_200_000,
+      sumInputTokens: 8_700_000,
+      sumCacheReadTokens: 424_400,
+      sumCacheCreationTokens: 5_100_000,
+      estimatedSavingsUsd: 41.2,
+      overpayVsNoCacheUsd: 3.5,
+      windowDays: 7,
+      windowStart: '2026-08-10T00:00:00+00:00',
+      windowEnd: '2026-08-17T00:00:00+00:00',
+      sampleTraces: [
+        {
+          traceId: 'a'.repeat(32),
+          spanId: '1'.repeat(16),
+          timestamp: '2026-08-15T00:00:00+00:00',
+          inputTokens: 4709,
+          cacheReadTokens: 229,
+          cacheCreationTokens: 2759,
+        },
+      ],
+      contrastModel: 'claude-sonnet-4',
+      contrastTransaction: 'agent.summarize',
+      contrastSpanDescription: 'generate_content claude-sonnet-4',
+      contrastHitRate: 0.83,
+      contrastCallCount: 1743,
+      contrastAvgInputTokens: 2900,
+    });
+
+    expect(parsed.outcome).toBe('thrash');
+    expect(parsed.sampleCalls).toHaveLength(1);
+    expect(parsed.sampleCalls[0]!.spanId).toBe('1'.repeat(16));
+    expect(parsed.anchor).toEqual({
+      model: 'claude-sonnet-4',
+      transaction: 'agent.summarize',
+      spanDescription: 'generate_content claude-sonnet-4',
+      hitRate: 0.83,
+      callCount: 1743,
+      avgInputTokens: 2900,
+    });
+  });
+
+  it('falls back to bare trace ids from older occurrences', () => {
+    // Occurrences produced before the detector emitted per-call detail still
+    // have to render something linkable.
+    const parsed = getLlmCacheEvidenceData({
+      sampleTraceIds: ['a'.repeat(32), 'b'.repeat(32)],
+    });
+
+    expect(parsed.sampleCalls).toEqual([
+      {
+        traceId: 'a'.repeat(32),
+        spanId: null,
+        timestamp: null,
+        inputTokens: null,
+        cacheReadTokens: null,
+        cacheCreationTokens: null,
+      },
+      {
+        traceId: 'b'.repeat(32),
+        spanId: null,
+        timestamp: null,
+        inputTokens: null,
+        cacheReadTokens: null,
+        cacheCreationTokens: null,
+      },
+    ]);
+  });
+
+  it('drops a partial contrast anchor rather than rendering half a comparison', () => {
+    const parsed = getLlmCacheEvidenceData({
+      contrastModel: 'claude-sonnet-4',
+      contrastTransaction: 'agent.summarize',
+    });
+
+    expect(parsed.anchor).toBeNull();
+  });
+
+  it('ignores an unrecognized outcome', () => {
+    expect(getLlmCacheEvidenceData({outcome: 'something-new'}).outcome).toBeNull();
+  });
+
+  it('tolerates an empty occurrence', () => {
+    const parsed = getLlmCacheEvidenceData(undefined);
+
+    expect(parsed.outcome).toBeNull();
+    expect(parsed.anchor).toBeNull();
+    expect(parsed.sampleCalls).toEqual([]);
+    expect(parsed.hitRate).toBeNull();
+  });
+});
+
+describe('getCacheProvider', () => {
+  it.each([
+    ['claude-sonnet-4', 'anthropic'],
+    ['anthropic/claude-3-5-haiku', 'anthropic'],
+    ['gemini-2.5-pro', 'google'],
+    ['gpt-4o-mini', 'openai'],
+    ['o3-pro', 'openai'],
+    ['some-self-hosted-model', 'unknown'],
+  ])('maps %s to %s', (model, expected) => {
+    expect(getCacheProvider(model)).toBe(expected);
+  });
+});

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -1,5 +1,6 @@
 import {
   buildCallSiteQuery,
+  formatCallSiteLabel,
   formatRate,
   formatTokens,
   getCacheProvider,
@@ -10,8 +11,9 @@ describe('getLlmCacheEvidenceData', () => {
   it('reads a fully populated occurrence', () => {
     const parsed = getLlmCacheEvidenceData({
       outcome: 'thrash',
-      transaction: 'agent.execute_step',
-      spanDescription: 'generate_content claude-sonnet-4',
+      agentLabel: 'Executor',
+      agentLabelSource: 'gen_ai.agent.name',
+      spanName: 'generate_content claude-sonnet-4',
       model: 'claude-sonnet-4',
       callCount: 2121,
       hitRate: 0.0487,
@@ -37,8 +39,9 @@ describe('getLlmCacheEvidenceData', () => {
         },
       ],
       contrastModel: 'claude-sonnet-4',
-      contrastTransaction: 'agent.summarize',
-      contrastSpanDescription: 'generate_content claude-sonnet-4',
+      contrastAgentLabel: 'Summarizer',
+      contrastAgentLabelSource: 'gen_ai.agent.name',
+      contrastSpanName: 'generate_content claude-sonnet-4',
       contrastHitRate: 0.83,
       contrastCallCount: 1743,
       contrastAvgInputTokens: 2900,
@@ -49,12 +52,27 @@ describe('getLlmCacheEvidenceData', () => {
     expect(parsed.sampleCalls[0]!.spanId).toBe('1'.repeat(16));
     expect(parsed.anchor).toEqual({
       model: 'claude-sonnet-4',
-      transaction: 'agent.summarize',
-      spanDescription: 'generate_content claude-sonnet-4',
+      agentLabel: 'Summarizer',
+      agentLabelSource: 'gen_ai.agent.name',
+      spanName: 'generate_content claude-sonnet-4',
       hitRate: 0.83,
       callCount: 1743,
       avgInputTokens: 2900,
     });
+  });
+
+  it('reads an unrecognized label source as unknown provenance', () => {
+    // The source decides how the call site is queried, so a value the page does
+    // not understand must not be passed through as if it were an attribute.
+    const parsed = getLlmCacheEvidenceData({
+      agentLabel: 'Executor',
+      agentLabelSource: 'gen_ai.function_id',
+      spanName: 'generate_content claude-sonnet-4',
+      model: 'claude-sonnet-4',
+    });
+
+    expect(parsed.agentLabelSource).toBeNull();
+    expect(buildCallSiteQuery(parsed)).toBeNull();
   });
 
   it('falls back to bare trace ids from older occurrences', () => {
@@ -87,7 +105,7 @@ describe('getLlmCacheEvidenceData', () => {
   it('drops a partial contrast anchor rather than rendering half a comparison', () => {
     const parsed = getLlmCacheEvidenceData({
       contrastModel: 'claude-sonnet-4',
-      contrastTransaction: 'agent.summarize',
+      contrastAgentLabel: 'Summarizer',
     });
 
     expect(parsed.anchor).toBeNull();
@@ -124,36 +142,52 @@ describe('buildCallSiteQuery', () => {
   it('quotes values so a call site with spaces stays one term', () => {
     expect(
       buildCallSiteQuery({
-        transaction: 'agent.execute step',
-        spanDescription: 'chat claude sonnet',
+        agentLabel: 'Execute Step',
+        agentLabelSource: 'gen_ai.agent.name',
+        spanName: 'chat claude sonnet',
         model: 'claude-sonnet-4',
       })
     ).toBe(
-      'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens transaction:"agent.execute step" span.description:"chat claude sonnet" gen_ai.request.model:claude-sonnet-4'
+      'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens gen_ai.agent.name:"Execute Step" span.name:"chat claude sonnet" gen_ai.request.model:claude-sonnet-4'
     );
   });
 
-  it('escapes a wildcard so a clustered transaction cannot match its siblings', () => {
-    // `transaction` and `span.description` are wildcard-allowed fields, so an
-    // unescaped `*` from the transaction clusterer would silently become a LIKE
-    // and pull in every sibling route.
+  it('requires the agent name to be absent for an operation-name label', () => {
+    // Without the absence term the query also returns the spans that do name an
+    // agent and happen to share the operation, which are another call site.
+    expect(
+      buildCallSiteQuery({
+        agentLabel: 'generate_content',
+        agentLabelSource: 'gen_ai.operation.name',
+        spanName: 'generate_content gemini',
+        model: 'gemini-2.5-pro',
+      })
+    ).toBe(
+      'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens !has:gen_ai.agent.name gen_ai.operation.name:generate_content span.name:"generate_content gemini" gen_ai.request.model:gemini-2.5-pro'
+    );
+  });
+
+  it('escapes a wildcard so a call site cannot match its siblings', () => {
+    // An unescaped `*` would silently become a LIKE and pull in every sibling.
     const query = buildCallSiteQuery({
-      transaction: '/api/v1/*/chat',
-      spanDescription: 'chat gpt-4',
+      agentLabel: 'Chat',
+      agentLabelSource: 'gen_ai.agent.name',
+      spanName: 'chat */gpt-4',
       model: 'gpt-4',
     });
 
-    expect(query).toContain(String.raw`transaction:"/api/v1/\*/chat"`);
+    expect(query).toContain(String.raw`span.name:"chat \*/gpt-4"`);
   });
 
   it('escapes a quote so the term cannot be terminated early', () => {
     const query = buildCallSiteQuery({
-      transaction: 'say "hi"',
-      spanDescription: 'chat gpt-4',
+      agentLabel: 'say "hi"',
+      agentLabelSource: 'gen_ai.agent.name',
+      spanName: 'chat gpt-4',
       model: 'gpt-4',
     });
 
-    expect(query).toContain(String.raw`transaction:"say \"hi\""`);
+    expect(query).toContain(String.raw`gen_ai.agent.name:"say \"hi\""`);
   });
 
   it('declines a value the grammar cannot match exactly', () => {
@@ -161,15 +195,17 @@ describe('buildCallSiteQuery', () => {
     // before a star is an escaped wildcard however the star is written.
     expect(
       buildCallSiteQuery({
-        transaction: 'C:\\path\\',
-        spanDescription: 'chat gpt-4',
+        agentLabel: 'C:\\path\\',
+        agentLabelSource: 'gen_ai.agent.name',
+        spanName: 'chat gpt-4',
         model: 'gpt-4',
       })
     ).toBeNull();
     expect(
       buildCallSiteQuery({
-        transaction: String.raw`literal\*star`,
-        spanDescription: 'chat gpt-4',
+        agentLabel: String.raw`literal\*star`,
+        agentLabelSource: 'gen_ai.agent.name',
+        spanName: 'chat gpt-4',
         model: 'gpt-4',
       })
     ).toBeNull();
@@ -177,8 +213,37 @@ describe('buildCallSiteQuery', () => {
 
   it('declines when the call site is not fully known', () => {
     expect(
-      buildCallSiteQuery({transaction: null, spanDescription: 'chat', model: 'gpt-4'})
+      buildCallSiteQuery({
+        agentLabel: null,
+        agentLabelSource: 'gen_ai.agent.name',
+        spanName: 'chat gpt-4',
+        model: 'gpt-4',
+      })
     ).toBeNull();
+  });
+});
+
+describe('formatCallSiteLabel', () => {
+  it('does not repeat an agent the span name already carries', () => {
+    expect(
+      formatCallSiteLabel({
+        agentLabel: 'Lightweight RCA',
+        spanName: 'invoke_agent Lightweight RCA',
+      })
+    ).toBe('invoke_agent Lightweight RCA');
+  });
+
+  it('names the agent when the span name is only the SDK wrapper', () => {
+    expect(
+      formatCallSiteLabel({agentLabel: 'Explorer', spanName: 'generate_content gemini'})
+    ).toBe('Explorer | generate_content gemini');
+  });
+
+  it('renders whichever half an older occurrence carries', () => {
+    expect(formatCallSiteLabel({agentLabel: 'Explorer', spanName: null})).toBe(
+      'Explorer'
+    );
+    expect(formatCallSiteLabel({agentLabel: null, spanName: null})).toBe('Unknown');
   });
 });
 

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -1,4 +1,10 @@
-import {getCacheProvider, getLlmCacheEvidenceData} from './utils';
+import {
+  buildCallSiteQuery,
+  formatRate,
+  formatTokens,
+  getCacheProvider,
+  getLlmCacheEvidenceData,
+} from './utils';
 
 describe('getLlmCacheEvidenceData', () => {
   it('reads a fully populated occurrence', () => {
@@ -111,5 +117,82 @@ describe('getCacheProvider', () => {
     ['some-self-hosted-model', 'unknown'],
   ])('maps %s to %s', (model, expected) => {
     expect(getCacheProvider(model)).toBe(expected);
+  });
+});
+
+describe('buildCallSiteQuery', () => {
+  it('quotes values so a call site with spaces stays one term', () => {
+    expect(
+      buildCallSiteQuery({
+        transaction: 'agent.execute step',
+        spanDescription: 'chat claude sonnet',
+        model: 'claude-sonnet-4',
+      })
+    ).toBe(
+      'span.op:gen_ai.generate_content transaction:"agent.execute step" span.description:"chat claude sonnet" gen_ai.request.model:claude-sonnet-4'
+    );
+  });
+
+  it('escapes a wildcard so a clustered transaction cannot match its siblings', () => {
+    // `transaction` and `span.description` are wildcard-allowed fields, so an
+    // unescaped `*` from the transaction clusterer would silently become a LIKE
+    // and pull in every sibling route.
+    const query = buildCallSiteQuery({
+      transaction: '/api/v1/*/chat',
+      spanDescription: 'chat gpt-4',
+      model: 'gpt-4',
+    });
+
+    expect(query).toContain(String.raw`transaction:"/api/v1/\*/chat"`);
+  });
+
+  it('escapes a quote so the term cannot be terminated early', () => {
+    const query = buildCallSiteQuery({
+      transaction: 'say "hi"',
+      spanDescription: 'chat gpt-4',
+      model: 'gpt-4',
+    });
+
+    expect(query).toContain(String.raw`transaction:"say \"hi\""`);
+  });
+
+  it('declines a value the grammar cannot match exactly', () => {
+    // A trailing backslash escapes the term's own closing quote; a backslash
+    // before a star is an escaped wildcard however the star is written.
+    expect(
+      buildCallSiteQuery({
+        transaction: 'C:\\path\\',
+        spanDescription: 'chat gpt-4',
+        model: 'gpt-4',
+      })
+    ).toBeNull();
+    expect(
+      buildCallSiteQuery({
+        transaction: String.raw`literal\*star`,
+        spanDescription: 'chat gpt-4',
+        model: 'gpt-4',
+      })
+    ).toBeNull();
+  });
+
+  it('declines when the call site is not fully known', () => {
+    expect(
+      buildCallSiteQuery({transaction: null, spanDescription: 'chat', model: 'gpt-4'})
+    ).toBeNull();
+  });
+});
+
+describe('formatTokens', () => {
+  it('rolls up to millions rather than printing 1000.0K', () => {
+    expect(formatTokens(999_999)).toBe('~1.0M');
+    expect(formatTokens(999_400)).toBe('~999.4K');
+  });
+});
+
+describe('formatRate', () => {
+  it('clamps a hit rate above 100%', () => {
+    // Providers that report input exclusive of cached tokens can drive reads
+    // past input.
+    expect(formatRate(2.5)).toBe('100.00%');
   });
 });

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -2,6 +2,7 @@ import {
   buildCallSiteQuery,
   formatCacheEligibleCalls,
   formatCallSiteLabel,
+  formatCharacters,
   formatRate,
   formatTokens,
   getCacheProvider,
@@ -87,6 +88,62 @@ describe('getLlmCacheEvidenceData', () => {
     });
 
     expect(parsed.anchor).toBeNull();
+  });
+
+  it('reads the prompt diagnosis', () => {
+    const parsed = getLlmCacheEvidenceData({
+      promptSampleCount: 4,
+      promptCommonPrefixChars: 142,
+      promptShortestChars: 48_000,
+      promptPrefixShare: 0.003,
+      promptDivergenceKind: 'iso_timestamp',
+      promptStableSuffixChars: 6_200,
+      promptTemplateMisordered: true,
+    });
+
+    expect(parsed.promptDivergence).toEqual({
+      kind: 'iso_timestamp',
+      commonPrefixChars: 142,
+      shortestChars: 48_000,
+      prefixShare: 0.003,
+      stableSuffixChars: 6_200,
+      templateMisordered: true,
+      sampleCount: 4,
+    });
+  });
+
+  it('has no prompt diagnosis when the spans carried no prompt text', () => {
+    // The common case: sending prompts is opt-in and mostly off.
+    expect(getLlmCacheEvidenceData({hitRate: 0}).promptDivergence).toBeNull();
+  });
+
+  it('drops a prompt diagnosis missing the parts every sentence is built from', () => {
+    expect(
+      getLlmCacheEvidenceData({
+        promptDivergenceKind: 'uuid',
+        promptStableSuffixChars: 6_200,
+      }).promptDivergence
+    ).toBeNull();
+  });
+
+  it('reads an unrecognized divergence kind as no diagnosis at all', () => {
+    // A kind the page cannot describe would render a sentence with a hole in it.
+    expect(
+      getLlmCacheEvidenceData({
+        promptDivergenceKind: 'semver',
+        promptCommonPrefixChars: 142,
+      }).promptDivergence
+    ).toBeNull();
+  });
+
+  it('reads a missing misordering verdict as no verdict', () => {
+    const parsed = getLlmCacheEvidenceData({
+      promptDivergenceKind: 'counter',
+      promptCommonPrefixChars: 142,
+    });
+
+    expect(parsed.promptDivergence?.templateMisordered).toBe(false);
+    expect(parsed.promptDivergence?.stableSuffixChars).toBeNull();
   });
 
   it('ignores an unrecognized outcome', () => {
@@ -229,6 +286,14 @@ describe('formatTokens', () => {
   it('rolls up to millions rather than printing 1000.0K', () => {
     expect(formatTokens(999_999)).toBe('~1.0M');
     expect(formatTokens(999_400)).toBe('~999.4K');
+  });
+});
+
+describe('formatCharacters', () => {
+  it('reads as a length rather than a bare number', () => {
+    expect(formatCharacters(142)).toBe('142 chars');
+    expect(formatCharacters(6_200)).toBe('~6.2K chars');
+    expect(formatCharacters(null)).toBe('Unknown');
   });
 });
 

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -129,7 +129,7 @@ describe('buildCallSiteQuery', () => {
         model: 'claude-sonnet-4',
       })
     ).toBe(
-      'span.op:gen_ai.generate_content transaction:"agent.execute step" span.description:"chat claude sonnet" gen_ai.request.model:claude-sonnet-4'
+      'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens transaction:"agent.execute step" span.description:"chat claude sonnet" gen_ai.request.model:claude-sonnet-4'
     );
   });
 

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -1,5 +1,6 @@
 import {
   buildCallSiteQuery,
+  canQueryCallSite,
   formatCacheEligibleCalls,
   formatCallSiteLabel,
   formatCharacters,
@@ -255,6 +256,39 @@ describe('buildCallSiteQuery', () => {
         model: 'gpt-4',
       })
     ).toBeNull();
+  });
+});
+
+describe('canQueryCallSite', () => {
+  const queryable = getLlmCacheEvidenceData({
+    outcome: 'not_caching',
+    agentLabel: 'Planner',
+    agentLabelSource: 'gen_ai.agent.name',
+    spanName: 'generate_content claude-sonnet-4',
+    model: 'claude-sonnet-4',
+    windowStart: '2026-08-10T00:00:00+00:00',
+    windowEnd: '2026-08-17T00:00:00+00:00',
+  });
+
+  it('accepts an occurrence carrying a call site and a window', () => {
+    expect(canQueryCallSite(queryable)).toBe(true);
+  });
+
+  it('rejects a call site the search grammar cannot express', () => {
+    // A trailing backslash would escape the term's own closing quote.
+    expect(canQueryCallSite({...queryable, spanName: 'generate_content claude\\'})).toBe(
+      false
+    );
+  });
+
+  it('rejects an occurrence with no detection window', () => {
+    expect(canQueryCallSite({...queryable, windowStart: null})).toBe(false);
+  });
+
+  it('rejects a window that does not parse', () => {
+    // The parser promises a string, not a date, and an unbounded range would
+    // otherwise reach the API.
+    expect(canQueryCallSite({...queryable, windowEnd: 'the other tuesday'})).toBe(false);
   });
 });
 

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -1,5 +1,6 @@
 import {
   buildCallSiteQuery,
+  formatCacheEligibleCalls,
   formatCallSiteLabel,
   formatRate,
   formatTokens,
@@ -16,6 +17,8 @@ describe('getLlmCacheEvidenceData', () => {
       spanName: 'generate_content claude-sonnet-4',
       model: 'claude-sonnet-4',
       callCount: 2121,
+      warmCallCount: 1951,
+      cacheableShare: 0.92,
       hitRate: 0.0487,
       writeReadRatio: 12,
       avgInputTokens: 4096,
@@ -48,6 +51,8 @@ describe('getLlmCacheEvidenceData', () => {
     });
 
     expect(parsed.outcome).toBe('thrash');
+    expect(parsed.warmCallCount).toBe(1951);
+    expect(parsed.cacheableShare).toBe(0.92);
     expect(parsed.sampleCalls).toHaveLength(1);
     expect(parsed.sampleCalls[0]!.spanId).toBe('1'.repeat(16));
     expect(parsed.anchor).toEqual({
@@ -259,5 +264,19 @@ describe('formatRate', () => {
     // Providers that report input exclusive of cached tokens can drive reads
     // past input.
     expect(formatRate(2.5)).toBe('100.00%');
+  });
+});
+
+describe('formatCacheEligibleCalls', () => {
+  it('reads as a count against the whole workload', () => {
+    expect(formatCacheEligibleCalls(1951, 0.92)).toBe('1,951 (92.00% of calls)');
+  });
+
+  it('keeps the count when an occurrence carries no share', () => {
+    expect(formatCacheEligibleCalls(1951, null)).toBe('1,951');
+  });
+
+  it('has nothing to say without a count', () => {
+    expect(formatCacheEligibleCalls(null, 0.92)).toBe('Unknown');
   });
 });

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.spec.tsx
@@ -80,33 +80,6 @@ describe('getLlmCacheEvidenceData', () => {
     expect(buildCallSiteQuery(parsed)).toBeNull();
   });
 
-  it('falls back to bare trace ids from older occurrences', () => {
-    // Occurrences produced before the detector emitted per-call detail still
-    // have to render something linkable.
-    const parsed = getLlmCacheEvidenceData({
-      sampleTraceIds: ['a'.repeat(32), 'b'.repeat(32)],
-    });
-
-    expect(parsed.sampleCalls).toEqual([
-      {
-        traceId: 'a'.repeat(32),
-        spanId: null,
-        timestamp: null,
-        inputTokens: null,
-        cacheReadTokens: null,
-        cacheCreationTokens: null,
-      },
-      {
-        traceId: 'b'.repeat(32),
-        spanId: null,
-        timestamp: null,
-        inputTokens: null,
-        cacheReadTokens: null,
-        cacheCreationTokens: null,
-      },
-    ]);
-  });
-
   it('drops a partial contrast anchor rather than rendering half a comparison', () => {
     const parsed = getLlmCacheEvidenceData({
       contrastModel: 'claude-sonnet-4',

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -39,14 +39,19 @@ function getOutcome(value: unknown): LlmCacheOutcome | null {
   return value === 'not_caching' || value === 'thrash' ? value : null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[] {
   if (Array.isArray(value)) {
-    return value.flatMap(entry => {
-      const traceId = getStringValue((entry as Record<string, unknown>)?.traceId);
-      if (traceId === null) {
+    const samples: unknown[] = value;
+    return samples.flatMap(entry => {
+      const sample = isRecord(entry) ? entry : null;
+      const traceId = getStringValue(sample?.traceId);
+      if (sample === null || traceId === null) {
         return [];
       }
-      const sample = entry as Record<string, unknown>;
       return [
         {
           traceId,
@@ -63,7 +68,8 @@ function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[]
   // Occurrences produced before the detector emitted the richer samples carry
   // bare trace ids; they still link somewhere useful.
   if (Array.isArray(traceIds)) {
-    return traceIds.flatMap(entry => {
+    const ids: unknown[] = traceIds;
+    return ids.flatMap(entry => {
       const traceId = getStringValue(entry);
       return traceId === null
         ? []
@@ -111,7 +117,7 @@ function getAnchor(data: Record<string, unknown>): LlmCacheContrastAnchor | null
 export function getLlmCacheEvidenceData(
   evidenceData: EventOccurrence['evidenceData'] | null | undefined
 ): LlmCacheEvidenceData {
-  const data = (evidenceData ?? {}) as Record<string, unknown>;
+  const data = isRecord(evidenceData) ? evidenceData : {};
 
   return {
     outcome: getOutcome(data.outcome),

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -259,6 +259,42 @@ export function buildCallSiteQuery({
 }
 
 /**
+ * The detection window as dates, or null when the occurrence carries none this
+ * page can query with.
+ *
+ * The parser only promises a string, not a parseable one, and an invalid date
+ * would reach the API as an unbounded range.
+ */
+export function getCallSiteWindow(
+  evidenceData: LlmCacheEvidenceData
+): {end: Date; start: Date} | null {
+  const {windowStart, windowEnd} = evidenceData;
+  if (windowStart === null || windowEnd === null) {
+    return null;
+  }
+  const start = new Date(windowStart);
+  const end = new Date(windowEnd);
+  if (Number.isNaN(start.valueOf()) || Number.isNaN(end.valueOf())) {
+    return null;
+  }
+  return {start, end};
+}
+
+/**
+ * Whether this page's live queries can be scoped to the call site at all.
+ *
+ * They need both a call site the search grammar can express and a window that
+ * parses, and an occurrence carrying neither is ordinary rather than broken.
+ * Sections that hold nothing but a live query test this so they can be left out
+ * entirely, rather than rendering a heading with nothing under it.
+ */
+export function canQueryCallSite(evidenceData: LlmCacheEvidenceData): boolean {
+  return (
+    buildCallSiteQuery(evidenceData) !== null && getCallSiteWindow(evidenceData) !== null
+  );
+}
+
+/**
  * How a call site is written on the page, mirroring the issue's own subtitle.
  *
  * Gen-AI span names conventionally embed the agent (`invoke_agent Planner`), so

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -30,7 +30,11 @@ const OPERATION_NAME_ATTRIBUTE = 'gen_ai.operation.name';
 const GEN_AI_CALL_FILTER =
   'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens';
 
-export const LLM_CACHE_REFERRER = 'llm-cache-usage-issue';
+// Spelled the way the backend registers it. An unregistered referrer is not an
+// error -- the events endpoints quietly rewrite it to the generic one -- so a
+// near miss here would cost this page its own cost attribution and rate limit
+// without anything failing.
+export const LLM_CACHE_REFERRER = 'api.llm-cache-usage-issue';
 
 /**
  * Whether the call site is named after its operation because its spans carry no

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -18,6 +18,7 @@ export const INPUT_TOKENS_ATTRIBUTE = 'gen_ai.usage.input_tokens';
 export const CACHE_READ_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_read.input_tokens';
 export const CACHE_CREATION_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_creation.input_tokens';
 const GEN_AI_CALL_OP = 'gen_ai.generate_content';
+const MODEL_ATTRIBUTE = 'gen_ai.request.model';
 
 export const LLM_CACHE_REFERRER = 'llm-cache-usage-issue';
 
@@ -39,6 +40,21 @@ function getOutcome(value: unknown): LlmCacheOutcome | null {
   return value === 'not_caching' || value === 'thrash' ? value : null;
 }
 
+/**
+ * A timestamp only counts if it can be parsed.
+ *
+ * Consumers hand these to date helpers that throw on an unparseable value, and
+ * a throw here blanks the whole issue body -- so an unusable timestamp has to
+ * become null at the boundary, like every other malformed field.
+ */
+function getTimestampValue(value: unknown): string | null {
+  const timestamp = getStringValue(value);
+  if (timestamp === null || Number.isNaN(new Date(timestamp).valueOf())) {
+    return null;
+  }
+  return timestamp;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -56,7 +72,7 @@ function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[]
         {
           traceId,
           spanId: getStringValue(sample.spanId),
-          timestamp: getStringValue(sample.timestamp),
+          timestamp: getTimestampValue(sample.timestamp),
           inputTokens: getNumberValue(sample.inputTokens),
           cacheReadTokens: getNumberValue(sample.cacheReadTokens),
           cacheCreationTokens: getNumberValue(sample.cacheCreationTokens),
@@ -135,16 +151,30 @@ export function getLlmCacheEvidenceData(
     estimatedSavingsUsd: getNumberValue(data.estimatedSavingsUsd),
     overpayVsNoCacheUsd: getNumberValue(data.overpayVsNoCacheUsd),
     windowDays: getNumberValue(data.windowDays),
-    windowStart: getStringValue(data.windowStart),
-    windowEnd: getStringValue(data.windowEnd),
+    windowStart: getTimestampValue(data.windowStart),
+    windowEnd: getTimestampValue(data.windowEnd),
     sampleCalls: getSampleCalls(data.sampleTraces, data.sampleTraceIds),
     anchor: getAnchor(data),
   };
 }
 
 /**
+ * Whether the search grammar can match this value exactly.
+ *
+ * Mirrors the detector's own rule: a trailing backslash escapes the term's
+ * closing quote, and a backslash before a `*` reads as an escaped wildcard
+ * however the star is written, so the literal cannot be expressed at all.
+ */
+function isExpressible(value: string): boolean {
+  return !value.endsWith('\\') && !value.includes('\\*');
+}
+
+/**
  * The exact filter for one call site. The detector groups by this triple, so it
  * is also what makes live queries line up with the finding.
+ *
+ * Returns null when a value cannot be matched exactly, because a query that
+ * quietly matches the wrong spans is worse than no link at all.
  */
 export function buildCallSiteQuery({
   transaction,
@@ -158,13 +188,21 @@ export function buildCallSiteQuery({
   if (transaction === null || spanDescription === null || model === null) {
     return null;
   }
+  if (![transaction, spanDescription, model].every(isExpressible)) {
+    return null;
+  }
 
-  return MutableSearch.fromQueryObject({
-    'span.op': GEN_AI_CALL_OP,
-    transaction,
-    'span.description': spanDescription,
-    'gen_ai.request.model': model,
-  }).formatString();
+  const search = new MutableSearch('');
+  search.addFilterValue('span.op', GEN_AI_CALL_OP);
+  // `transaction` and `span.description` are wildcard-allowed fields, so the
+  // usual helpers deliberately leave `*` unescaped in them. These values are
+  // exact call-site names -- a transaction the clusterer rewrote to `/api/*/chat`
+  // would otherwise match every sibling route and inflate every number on the
+  // page -- so each is escaped explicitly instead.
+  search.addFilterValue('transaction', transaction, true);
+  search.addFilterValue('span.description', spanDescription, true);
+  search.addFilterValue(MODEL_ATTRIBUTE, model, true);
+  return search.formatString();
 }
 
 export function formatTokens(tokens: number | null): string {
@@ -174,8 +212,11 @@ export function formatTokens(tokens: number | null): string {
   if (tokens < 1000) {
     return tokens.toLocaleString(undefined, {maximumFractionDigits: 0});
   }
-  if (tokens < 1_000_000) {
-    return t('~%sK', (tokens / 1000).toFixed(1));
+  // Guard on the rounded figure, not the raw one: 999,999 tokens round to
+  // 1000.0K, which should read as 1.0M.
+  const thousands = (tokens / 1_000).toFixed(1);
+  if (Number(thousands) < 1_000) {
+    return t('~%sK', thousands);
   }
   return t('~%sM', (tokens / 1_000_000).toFixed(1));
 }
@@ -190,7 +231,9 @@ export function formatRate(rate: number | null): string {
   if (rate < 0.0001) {
     return t('<0.01%');
   }
-  return `${(rate * 100).toFixed(2)}%`;
+  // Providers that report input exclusive of cached tokens can drive reads past
+  // input; the detector clamps the token split the same way.
+  return `${(Math.min(rate, 1) * 100).toFixed(2)}%`;
 }
 
 export function formatWriteReadRatio(ratio: number | null): string {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -11,6 +11,8 @@ import type {
   LlmCacheContrastAnchor,
   LlmCacheEvidenceData,
   LlmCacheOutcome,
+  LlmCachePromptDivergence,
+  LlmCachePromptDivergenceKind,
   LlmCacheSampleCall,
 } from './types';
 
@@ -135,6 +137,48 @@ function getAnchor(data: Record<string, unknown>): LlmCacheContrastAnchor | null
   };
 }
 
+const PROMPT_DIVERGENCE_KINDS: readonly LlmCachePromptDivergenceKind[] = [
+  'none',
+  'iso_timestamp',
+  'epoch_timestamp',
+  'uuid',
+  'identifier',
+  'counter',
+  'other',
+];
+
+function getPromptDivergenceKind(value: unknown): LlmCachePromptDivergenceKind | null {
+  return PROMPT_DIVERGENCE_KINDS.find(kind => kind === value) ?? null;
+}
+
+/**
+ * The prompt diagnosis, or null when the occurrence carries none.
+ *
+ * The kind and the shared prefix are what every sentence on the page is built
+ * from, so an occurrence missing either has nothing to say and is dropped whole
+ * rather than rendered half-empty.
+ */
+function getPromptDivergence(
+  data: Record<string, unknown>
+): LlmCachePromptDivergence | null {
+  const kind = getPromptDivergenceKind(data.promptDivergenceKind);
+  const commonPrefixChars = getNumberValue(data.promptCommonPrefixChars);
+
+  if (kind === null || commonPrefixChars === null) {
+    return null;
+  }
+
+  return {
+    kind,
+    commonPrefixChars,
+    sampleCount: getNumberValue(data.promptSampleCount),
+    shortestChars: getNumberValue(data.promptShortestChars),
+    prefixShare: getNumberValue(data.promptPrefixShare),
+    stableSuffixChars: getNumberValue(data.promptStableSuffixChars),
+    templateMisordered: data.promptTemplateMisordered === true,
+  };
+}
+
 export function getLlmCacheEvidenceData(
   evidenceData: EventOccurrence['evidenceData'] | null | undefined
 ): LlmCacheEvidenceData {
@@ -163,6 +207,7 @@ export function getLlmCacheEvidenceData(
     windowEnd: getTimestampValue(data.windowEnd),
     sampleCalls: getSampleCalls(data.sampleTraces),
     anchor: getAnchor(data),
+    promptDivergence: getPromptDivergence(data),
   };
 }
 
@@ -265,20 +310,36 @@ export function getCallSiteExploreUrl({
   });
 }
 
+function formatApproximateCount(value: number): string {
+  if (value < 1000) {
+    return value.toLocaleString(undefined, {maximumFractionDigits: 0});
+  }
+  // Guard on the rounded figure, not the raw one: 999,999 round to 1000.0K,
+  // which should read as 1.0M.
+  const thousands = (value / 1_000).toFixed(1);
+  if (Number(thousands) < 1_000) {
+    return t('~%sK', thousands);
+  }
+  return t('~%sM', (value / 1_000_000).toFixed(1));
+}
+
 export function formatTokens(tokens: number | null): string {
   if (tokens === null) {
     return t('Unknown');
   }
-  if (tokens < 1000) {
-    return tokens.toLocaleString(undefined, {maximumFractionDigits: 0});
+  return formatApproximateCount(tokens);
+}
+
+/**
+ * A prompt length, on the same approximate scale as token counts: it is read
+ * off a few sampled prompts the span store may have truncated, so exact digits
+ * would claim more than the measurement supports.
+ */
+export function formatCharacters(characters: number | null): string {
+  if (characters === null) {
+    return t('Unknown');
   }
-  // Guard on the rounded figure, not the raw one: 999,999 tokens round to
-  // 1000.0K, which should read as 1.0M.
-  const thousands = (tokens / 1_000).toFixed(1);
-  if (Number(thousands) < 1_000) {
-    return t('~%sK', thousands);
-  }
-  return t('~%sM', (tokens / 1_000_000).toFixed(1));
+  return t('%s chars', formatApproximateCount(characters));
 }
 
 export function formatRate(rate: number | null): string {
@@ -369,6 +430,31 @@ const PROMPT_CACHING_DOCS: Record<CacheProvider, string> = {
 
 export function getPromptCachingDocsUrl(model: string | null): string {
   return PROMPT_CACHING_DOCS[getCacheProvider(model)];
+}
+
+/**
+ * Reads as the tail of "the prompts first differ at ...".
+ *
+ * `none` is deliberately unhandled: there is nothing to name, and the callers
+ * that would use this say something else entirely in that case.
+ */
+export function getPromptDivergenceDescription(
+  kind: LlmCachePromptDivergenceKind
+): string {
+  switch (kind) {
+    case 'iso_timestamp':
+      return t('an ISO-8601 timestamp');
+    case 'epoch_timestamp':
+      return t('a Unix timestamp');
+    case 'uuid':
+      return t('a UUID');
+    case 'identifier':
+      return t('a request or trace id');
+    case 'counter':
+      return t('a changing number');
+    default:
+      return t('changing text');
+  }
 }
 
 export function getPromptCachingDocsLabel(model: string | null): string {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -168,6 +168,8 @@ export function getLlmCacheEvidenceData(
     spanName: getStringValue(data.spanName),
     model: getStringValue(data.model),
     callCount: getNumberValue(data.callCount),
+    warmCallCount: getNumberValue(data.warmCallCount),
+    cacheableShare: getNumberValue(data.cacheableShare),
     hitRate: getNumberValue(data.hitRate),
     writeReadRatio: getNumberValue(data.writeReadRatio),
     avgInputTokens: getNumberValue(data.avgInputTokens),
@@ -313,6 +315,26 @@ export function formatRate(rate: number | null): string {
   // Providers that report input exclusive of cached tokens can drive reads past
   // input; the detector clamps the token split the same way.
   return `${(Math.min(rate, 1) * 100).toFixed(2)}%`;
+}
+
+/**
+ * The calls a warm cache was available to, as a count and a share of all calls.
+ * The share carries the meaning -- a bare count says nothing about whether the
+ * rest of the traffic ever had a cache to hit -- so it is left out only when an
+ * occurrence does not carry one.
+ */
+export function formatCacheEligibleCalls(
+  warmCallCount: number | null,
+  cacheableShare: number | null
+): string {
+  if (warmCallCount === null) {
+    return t('Unknown');
+  }
+  const calls = Math.round(warmCallCount).toLocaleString();
+  if (cacheableShare === null) {
+    return calls;
+  }
+  return t('%s (%s of calls)', calls, formatRate(cacheableShare));
 }
 
 export function formatWriteReadRatio(ratio: number | null): string {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -7,6 +7,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {
+  LlmCacheAgentLabelSource,
   LlmCacheContrastAnchor,
   LlmCacheEvidenceData,
   LlmCacheOutcome,
@@ -22,6 +23,9 @@ export const INPUT_TOKENS_ATTRIBUTE = 'gen_ai.usage.input_tokens';
 export const CACHE_READ_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_read.input_tokens';
 export const CACHE_CREATION_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_creation.input_tokens';
 const MODEL_ATTRIBUTE = 'gen_ai.request.model';
+const SPAN_NAME_ATTRIBUTE = 'span.name';
+const AGENT_NAME_ATTRIBUTE = 'gen_ai.agent.name';
+const OPERATION_NAME_ATTRIBUTE = 'gen_ai.operation.name';
 /**
  * The detector's own span filter, verbatim -- any divergence means the page's
  * live queries answer a different question than the finding.
@@ -33,6 +37,17 @@ const GEN_AI_CALL_FILTER =
   'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens';
 
 export const LLM_CACHE_REFERRER = 'llm-cache-usage-issue';
+
+/**
+ * Whether the call site is named after its operation because its spans carry no
+ * agent name. Worth surfacing: the label reads like an agent but names none, and
+ * the group can hold calls from several.
+ */
+export function usesOperationNameFallback(
+  source: LlmCacheAgentLabelSource | null
+): boolean {
+  return source === OPERATION_NAME_ATTRIBUTE;
+}
 
 function getStringValue(value: unknown): string | null {
   if (typeof value !== 'string' || value.length === 0) {
@@ -50,6 +65,12 @@ function getNumberValue(value: unknown): number | null {
 
 function getOutcome(value: unknown): LlmCacheOutcome | null {
   return value === 'not_caching' || value === 'thrash' ? value : null;
+}
+
+function getAgentLabelSource(value: unknown): LlmCacheAgentLabelSource | null {
+  return value === AGENT_NAME_ATTRIBUTE || value === OPERATION_NAME_ATTRIBUTE
+    ? value
+    : null;
 }
 
 /**
@@ -116,23 +137,19 @@ function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[]
 
 function getAnchor(data: Record<string, unknown>): LlmCacheContrastAnchor | null {
   const model = getStringValue(data.contrastModel);
-  const transaction = getStringValue(data.contrastTransaction);
-  const spanDescription = getStringValue(data.contrastSpanDescription);
+  const agentLabel = getStringValue(data.contrastAgentLabel);
+  const spanName = getStringValue(data.contrastSpanName);
   const hitRate = getNumberValue(data.contrastHitRate);
 
-  if (
-    model === null ||
-    transaction === null ||
-    spanDescription === null ||
-    hitRate === null
-  ) {
+  if (model === null || agentLabel === null || spanName === null || hitRate === null) {
     return null;
   }
 
   return {
     model,
-    transaction,
-    spanDescription,
+    agentLabel,
+    agentLabelSource: getAgentLabelSource(data.contrastAgentLabelSource),
+    spanName,
     hitRate,
     callCount: getNumberValue(data.contrastCallCount),
     avgInputTokens: getNumberValue(data.contrastAvgInputTokens),
@@ -146,8 +163,9 @@ export function getLlmCacheEvidenceData(
 
   return {
     outcome: getOutcome(data.outcome),
-    transaction: getStringValue(data.transaction),
-    spanDescription: getStringValue(data.spanDescription),
+    agentLabel: getStringValue(data.agentLabel),
+    agentLabelSource: getAgentLabelSource(data.agentLabelSource),
+    spanName: getStringValue(data.spanName),
     model: getStringValue(data.model),
     callCount: getNumberValue(data.callCount),
     hitRate: getNumberValue(data.hitRate),
@@ -186,43 +204,59 @@ function isExpressible(value: string): boolean {
  * quietly matches the wrong spans is worse than no link at all.
  */
 export function buildCallSiteQuery({
-  transaction,
-  spanDescription,
+  agentLabel,
+  agentLabelSource,
+  spanName,
   model,
 }: {
+  agentLabel: string | null;
+  agentLabelSource: LlmCacheAgentLabelSource | null;
   model: string | null;
-  spanDescription: string | null;
-  transaction: string | null;
+  spanName: string | null;
 }): string | null {
-  if (transaction === null || spanDescription === null || model === null) {
+  if (agentLabel === null || agentLabelSource === null || spanName === null) {
     return null;
   }
-  if (![transaction, spanDescription, model].every(isExpressible)) {
+  if (model === null || ![agentLabel, spanName, model].every(isExpressible)) {
     return null;
   }
 
   const search = new MutableSearch(GEN_AI_CALL_FILTER);
-  // `transaction` and `span.description` are wildcard-allowed fields, so the
-  // usual helpers leave `*` unescaped in them. A transaction the clusterer
-  // rewrote to `/api/*/chat` would then match every sibling route.
-  search.addFilterValue('transaction', transaction, true);
-  search.addFilterValue('span.description', spanDescription, true);
+  if (agentLabelSource === OPERATION_NAME_ATTRIBUTE) {
+    // The operation name only stands in for an agent on spans that carry no
+    // agent name, so the absence is part of the group: without it the query
+    // also returns the named spans sharing the operation.
+    search.addFilterValue('!has', AGENT_NAME_ATTRIBUTE);
+  }
+  // Escaped rather than passed through: these are literals off a span, and an
+  // unescaped `*` in one would silently widen the match to its siblings.
+  search.addFilterValue(agentLabelSource, agentLabel, true);
+  search.addFilterValue(SPAN_NAME_ATTRIBUTE, spanName, true);
   search.addFilterValue(MODEL_ATTRIBUTE, model, true);
   return search.formatString();
 }
 
 /**
- * How a call site is written on the page. Either half can be missing on an
- * older occurrence, so the label falls back to whichever one there is.
+ * How a call site is written on the page, mirroring the issue's own subtitle.
+ *
+ * Gen-AI span names conventionally embed the agent (`invoke_agent Planner`), so
+ * naming it again just spends width on a duplicate. Either half can be missing
+ * on an older occurrence, so the label falls back to whichever one there is.
  */
 export function formatCallSiteLabel({
-  transaction,
-  spanDescription,
+  agentLabel,
+  spanName,
 }: {
-  spanDescription: string | null;
-  transaction: string | null;
+  agentLabel: string | null;
+  spanName: string | null;
 }): string {
-  return [transaction, spanDescription].filter(Boolean).join(' | ') || t('Unknown');
+  if (spanName === null) {
+    return agentLabel ?? t('Unknown');
+  }
+  if (agentLabel === null || spanName.toLowerCase().includes(agentLabel.toLowerCase())) {
+    return spanName;
+  }
+  return `${agentLabel} | ${spanName}`;
 }
 
 /**

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -89,7 +89,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[] {
+function getSampleCalls(value: unknown): LlmCacheSampleCall[] {
   if (Array.isArray(value)) {
     const samples: unknown[] = value;
     return samples.flatMap(entry => {
@@ -108,27 +108,6 @@ function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[]
           cacheCreationTokens: getNumberValue(sample.cacheCreationTokens),
         },
       ];
-    });
-  }
-
-  // Occurrences produced before the detector emitted the richer samples carry
-  // bare trace ids; they still link somewhere useful.
-  if (Array.isArray(traceIds)) {
-    const ids: unknown[] = traceIds;
-    return ids.flatMap(entry => {
-      const traceId = getStringValue(entry);
-      return traceId === null
-        ? []
-        : [
-            {
-              traceId,
-              spanId: null,
-              timestamp: null,
-              inputTokens: null,
-              cacheReadTokens: null,
-              cacheCreationTokens: null,
-            },
-          ];
     });
   }
 
@@ -182,7 +161,7 @@ export function getLlmCacheEvidenceData(
     windowDays: getNumberValue(data.windowDays),
     windowStart: getTimestampValue(data.windowStart),
     windowEnd: getTimestampValue(data.windowEnd),
-    sampleCalls: getSampleCalls(data.sampleTraces, data.sampleTraceIds),
+    sampleCalls: getSampleCalls(data.sampleTraces),
     anchor: getAnchor(data),
   };
 }

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -174,7 +174,7 @@ function getPromptDivergence(
     sampleCount: getNumberValue(data.promptSampleCount),
     shortestChars: getNumberValue(data.promptShortestChars),
     prefixShare: getNumberValue(data.promptPrefixShare),
-    stableSuffixChars: getNumberValue(data.promptStableSuffixChars),
+    stableBlockChars: getNumberValue(data.promptStableBlockChars),
     templateMisordered: data.promptTemplateMisordered === true,
   };
 }

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -23,11 +23,11 @@ export const CACHE_READ_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_read.input_tokens
 export const CACHE_CREATION_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_creation.input_tokens';
 const MODEL_ATTRIBUTE = 'gen_ai.request.model';
 /**
- * The detector's own span filter, verbatim.
+ * The detector's own span filter, verbatim -- any divergence means the page's
+ * live queries answer a different question than the finding.
  *
  * `gen_ai.operation.type` is added during ingestion from the op, so it matches
- * an LLM call whichever op the SDK chose. Any divergence from the detector here
- * means the page's live queries answer a different question than the finding.
+ * an LLM call whichever op the SDK chose.
  */
 const GEN_AI_CALL_FILTER =
   'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens';
@@ -53,11 +53,8 @@ function getOutcome(value: unknown): LlmCacheOutcome | null {
 }
 
 /**
- * A timestamp only counts if it can be parsed.
- *
- * Consumers hand these to date helpers that throw on an unparseable value, and
- * a throw here blanks the whole issue body -- so an unusable timestamp has to
- * become null at the boundary, like every other malformed field.
+ * A timestamp only counts if it can be parsed: consumers hand these to date
+ * helpers that throw, and a throw here blanks the whole issue body.
  */
 function getTimestampValue(value: unknown): string | null {
   const timestamp = getStringValue(value);
@@ -206,10 +203,8 @@ export function buildCallSiteQuery({
 
   const search = new MutableSearch(GEN_AI_CALL_FILTER);
   // `transaction` and `span.description` are wildcard-allowed fields, so the
-  // usual helpers deliberately leave `*` unescaped in them. These values are
-  // exact call-site names -- a transaction the clusterer rewrote to `/api/*/chat`
-  // would otherwise match every sibling route and inflate every number on the
-  // page -- so each is escaped explicitly instead.
+  // usual helpers leave `*` unescaped in them. A transaction the clusterer
+  // rewrote to `/api/*/chat` would then match every sibling route.
   search.addFilterValue('transaction', transaction, true);
   search.addFilterValue('span.description', spanDescription, true);
   search.addFilterValue(MODEL_ATTRIBUTE, model, true);
@@ -232,9 +227,7 @@ export function formatCallSiteLabel({
 
 /**
  * A link to the spans a query matches, over the window the finding covers.
- *
- * Undefined without both, because a link that quietly answers a different
- * question than the issue is making a claim about is worse than no link.
+ * Undefined without both: a link to the wrong spans is worse than no link.
  */
 export function getCallSiteExploreUrl({
   organization,

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -433,14 +433,17 @@ export function getPromptCachingDocsUrl(model: string | null): string {
 }
 
 /**
- * Reads as the tail of "the prompts first differ at ...".
+ * Reads as the tail of "the prompts first differ at ...", or null when there is
+ * no honest tail to write.
  *
- * `none` is deliberately unhandled: there is nothing to name, and the callers
- * that would use this say something else entirely in that case.
+ * `none` has no first difference to name. `other` is the residual of a handful
+ * of patterns rather than a finding: naming it would claim the divergence is
+ * neither an id nor a timestamp, when all that is known is that none of the
+ * patterns matched near it. Callers drop the phrase rather than fill it.
  */
 export function getPromptDivergenceDescription(
   kind: LlmCachePromptDivergenceKind
-): string {
+): string | null {
   switch (kind) {
     case 'iso_timestamp':
       return t('an ISO-8601 timestamp');
@@ -453,7 +456,7 @@ export function getPromptDivergenceDescription(
     case 'counter':
       return t('a changing number');
     default:
-      return t('changing text');
+      return null;
   }
 }
 

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -1,6 +1,10 @@
 import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
 import type {EventOccurrence} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {
   LlmCacheContrastAnchor,
@@ -210,6 +214,47 @@ export function buildCallSiteQuery({
   search.addFilterValue('span.description', spanDescription, true);
   search.addFilterValue(MODEL_ATTRIBUTE, model, true);
   return search.formatString();
+}
+
+/**
+ * How a call site is written on the page. Either half can be missing on an
+ * older occurrence, so the label falls back to whichever one there is.
+ */
+export function formatCallSiteLabel({
+  transaction,
+  spanDescription,
+}: {
+  spanDescription: string | null;
+  transaction: string | null;
+}): string {
+  return [transaction, spanDescription].filter(Boolean).join(' | ') || t('Unknown');
+}
+
+/**
+ * A link to the spans a query matches, over the window the finding covers.
+ *
+ * Undefined without both, because a link that quietly answers a different
+ * question than the issue is making a claim about is worse than no link.
+ */
+export function getCallSiteExploreUrl({
+  organization,
+  selection,
+  query,
+}: {
+  organization: Organization;
+  query: string | null;
+  selection: PageFilters | undefined;
+}): string | undefined {
+  if (query === null || selection === undefined) {
+    return undefined;
+  }
+  return getExploreUrl({
+    organization,
+    selection,
+    mode: Mode.SAMPLES,
+    query,
+    referrer: LLM_CACHE_REFERRER,
+  });
 }
 
 export function formatTokens(tokens: number | null): string {

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -16,14 +16,6 @@ import type {
   LlmCacheSampleCall,
 } from './types';
 
-/**
- * Span attributes the detector aggregates. The resolver back-fills the
- * deprecated aliases onto these names, so querying them here reads the same
- * data the finding was derived from.
- */
-export const INPUT_TOKENS_ATTRIBUTE = 'gen_ai.usage.input_tokens';
-export const CACHE_READ_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_read.input_tokens';
-export const CACHE_CREATION_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_creation.input_tokens';
 const MODEL_ATTRIBUTE = 'gen_ai.request.model';
 const SPAN_NAME_ATTRIBUTE = 'span.name';
 const AGENT_NAME_ATTRIBUTE = 'gen_ai.agent.name';

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -17,8 +17,16 @@ import type {
 export const INPUT_TOKENS_ATTRIBUTE = 'gen_ai.usage.input_tokens';
 export const CACHE_READ_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_read.input_tokens';
 export const CACHE_CREATION_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_creation.input_tokens';
-const GEN_AI_CALL_OP = 'gen_ai.generate_content';
 const MODEL_ATTRIBUTE = 'gen_ai.request.model';
+/**
+ * The detector's own span filter, verbatim.
+ *
+ * `gen_ai.operation.type` is added during ingestion from the op, so it matches
+ * an LLM call whichever op the SDK chose. Any divergence from the detector here
+ * means the page's live queries answer a different question than the finding.
+ */
+const GEN_AI_CALL_FILTER =
+  'gen_ai.operation.type:ai_client !gen_ai.operation.name:embeddings has:gen_ai.usage.input_tokens';
 
 export const LLM_CACHE_REFERRER = 'llm-cache-usage-issue';
 
@@ -192,8 +200,7 @@ export function buildCallSiteQuery({
     return null;
   }
 
-  const search = new MutableSearch('');
-  search.addFilterValue('span.op', GEN_AI_CALL_OP);
+  const search = new MutableSearch(GEN_AI_CALL_FILTER);
   // `transaction` and `span.description` are wildcard-allowed fields, so the
   // usual helpers deliberately leave `*` unescaped in them. These values are
   // exact call-site names -- a transaction the clusterer rewrote to `/api/*/chat`

--- a/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
+++ b/static/app/views/issueDetails/genAiIssues/llmCacheUsage/utils.tsx
@@ -1,0 +1,256 @@
+import {t} from 'sentry/locale';
+import type {EventOccurrence} from 'sentry/types/event';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+
+import type {
+  LlmCacheContrastAnchor,
+  LlmCacheEvidenceData,
+  LlmCacheOutcome,
+  LlmCacheSampleCall,
+} from './types';
+
+/**
+ * Span attributes the detector aggregates. The resolver back-fills the
+ * deprecated aliases onto these names, so querying them here reads the same
+ * data the finding was derived from.
+ */
+export const INPUT_TOKENS_ATTRIBUTE = 'gen_ai.usage.input_tokens';
+export const CACHE_READ_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_read.input_tokens';
+export const CACHE_CREATION_TOKENS_ATTRIBUTE = 'gen_ai.usage.cache_creation.input_tokens';
+const GEN_AI_CALL_OP = 'gen_ai.generate_content';
+
+export const LLM_CACHE_REFERRER = 'llm-cache-usage-issue';
+
+function getStringValue(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+  return value;
+}
+
+function getNumberValue(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}
+
+function getOutcome(value: unknown): LlmCacheOutcome | null {
+  return value === 'not_caching' || value === 'thrash' ? value : null;
+}
+
+function getSampleCalls(value: unknown, traceIds: unknown): LlmCacheSampleCall[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(entry => {
+      const traceId = getStringValue((entry as Record<string, unknown>)?.traceId);
+      if (traceId === null) {
+        return [];
+      }
+      const sample = entry as Record<string, unknown>;
+      return [
+        {
+          traceId,
+          spanId: getStringValue(sample.spanId),
+          timestamp: getStringValue(sample.timestamp),
+          inputTokens: getNumberValue(sample.inputTokens),
+          cacheReadTokens: getNumberValue(sample.cacheReadTokens),
+          cacheCreationTokens: getNumberValue(sample.cacheCreationTokens),
+        },
+      ];
+    });
+  }
+
+  // Occurrences produced before the detector emitted the richer samples carry
+  // bare trace ids; they still link somewhere useful.
+  if (Array.isArray(traceIds)) {
+    return traceIds.flatMap(entry => {
+      const traceId = getStringValue(entry);
+      return traceId === null
+        ? []
+        : [
+            {
+              traceId,
+              spanId: null,
+              timestamp: null,
+              inputTokens: null,
+              cacheReadTokens: null,
+              cacheCreationTokens: null,
+            },
+          ];
+    });
+  }
+
+  return [];
+}
+
+function getAnchor(data: Record<string, unknown>): LlmCacheContrastAnchor | null {
+  const model = getStringValue(data.contrastModel);
+  const transaction = getStringValue(data.contrastTransaction);
+  const spanDescription = getStringValue(data.contrastSpanDescription);
+  const hitRate = getNumberValue(data.contrastHitRate);
+
+  if (
+    model === null ||
+    transaction === null ||
+    spanDescription === null ||
+    hitRate === null
+  ) {
+    return null;
+  }
+
+  return {
+    model,
+    transaction,
+    spanDescription,
+    hitRate,
+    callCount: getNumberValue(data.contrastCallCount),
+    avgInputTokens: getNumberValue(data.contrastAvgInputTokens),
+  };
+}
+
+export function getLlmCacheEvidenceData(
+  evidenceData: EventOccurrence['evidenceData'] | null | undefined
+): LlmCacheEvidenceData {
+  const data = (evidenceData ?? {}) as Record<string, unknown>;
+
+  return {
+    outcome: getOutcome(data.outcome),
+    transaction: getStringValue(data.transaction),
+    spanDescription: getStringValue(data.spanDescription),
+    model: getStringValue(data.model),
+    callCount: getNumberValue(data.callCount),
+    hitRate: getNumberValue(data.hitRate),
+    writeReadRatio: getNumberValue(data.writeReadRatio),
+    avgInputTokens: getNumberValue(data.avgInputTokens),
+    uncachedTokens: getNumberValue(data.uncachedTokens),
+    sumInputTokens: getNumberValue(data.sumInputTokens),
+    sumCacheReadTokens: getNumberValue(data.sumCacheReadTokens),
+    sumCacheCreationTokens: getNumberValue(data.sumCacheCreationTokens),
+    estimatedSavingsUsd: getNumberValue(data.estimatedSavingsUsd),
+    overpayVsNoCacheUsd: getNumberValue(data.overpayVsNoCacheUsd),
+    windowDays: getNumberValue(data.windowDays),
+    windowStart: getStringValue(data.windowStart),
+    windowEnd: getStringValue(data.windowEnd),
+    sampleCalls: getSampleCalls(data.sampleTraces, data.sampleTraceIds),
+    anchor: getAnchor(data),
+  };
+}
+
+/**
+ * The exact filter for one call site. The detector groups by this triple, so it
+ * is also what makes live queries line up with the finding.
+ */
+export function buildCallSiteQuery({
+  transaction,
+  spanDescription,
+  model,
+}: {
+  model: string | null;
+  spanDescription: string | null;
+  transaction: string | null;
+}): string | null {
+  if (transaction === null || spanDescription === null || model === null) {
+    return null;
+  }
+
+  return MutableSearch.fromQueryObject({
+    'span.op': GEN_AI_CALL_OP,
+    transaction,
+    'span.description': spanDescription,
+    'gen_ai.request.model': model,
+  }).formatString();
+}
+
+export function formatTokens(tokens: number | null): string {
+  if (tokens === null) {
+    return t('Unknown');
+  }
+  if (tokens < 1000) {
+    return tokens.toLocaleString(undefined, {maximumFractionDigits: 0});
+  }
+  if (tokens < 1_000_000) {
+    return t('~%sK', (tokens / 1000).toFixed(1));
+  }
+  return t('~%sM', (tokens / 1_000_000).toFixed(1));
+}
+
+export function formatRate(rate: number | null): string {
+  if (rate === null) {
+    return t('Unknown');
+  }
+  if (rate === 0) {
+    return '0%';
+  }
+  if (rate < 0.0001) {
+    return t('<0.01%');
+  }
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+export function formatWriteReadRatio(ratio: number | null): string {
+  if (ratio === null) {
+    return t('no cache reads');
+  }
+  return t('%s:1', ratio.toFixed(1));
+}
+
+export function formatUsd(amount: number | null): string {
+  if (amount === null) {
+    return t('Unknown');
+  }
+  if (amount > 0 && amount < 0.01) {
+    return t('<$0.01');
+  }
+  return amount.toLocaleString(undefined, {
+    currency: 'USD',
+    maximumFractionDigits: amount >= 1000 ? 0 : 2,
+    minimumFractionDigits: amount >= 1000 ? 0 : 2,
+    style: 'currency',
+  });
+}
+
+type CacheProvider = 'anthropic' | 'openai' | 'google' | 'unknown';
+
+/**
+ * Which provider's caching rules apply, inferred from the model name.
+ *
+ * Crude on purpose, and mirrors the marker matching the detector already does:
+ * nothing on the span states the provider.
+ */
+export function getCacheProvider(model: string | null): CacheProvider {
+  const normalized = model?.toLowerCase() ?? '';
+  if (normalized.includes('claude') || normalized.includes('anthropic')) {
+    return 'anthropic';
+  }
+  if (normalized.includes('gemini') || normalized.includes('google')) {
+    return 'google';
+  }
+  if (/gpt|^o\d|[^a-z]o\d/.test(normalized) || normalized.includes('openai')) {
+    return 'openai';
+  }
+  return 'unknown';
+}
+
+const PROMPT_CACHING_DOCS: Record<CacheProvider, string> = {
+  anthropic: 'https://docs.claude.com/en/docs/build-with-claude/prompt-caching',
+  openai: 'https://platform.openai.com/docs/guides/prompt-caching',
+  google: 'https://ai.google.dev/gemini-api/docs/caching',
+  unknown: 'https://docs.sentry.io/product/insights/agents/',
+};
+
+export function getPromptCachingDocsUrl(model: string | null): string {
+  return PROMPT_CACHING_DOCS[getCacheProvider(model)];
+}
+
+export function getPromptCachingDocsLabel(model: string | null): string {
+  switch (getCacheProvider(model)) {
+    case 'anthropic':
+      return t('Read the Anthropic prompt caching docs');
+    case 'openai':
+      return t('Read the OpenAI prompt caching docs');
+    case 'google':
+      return t('Read the Gemini context caching docs');
+    default:
+      return t('Read the AI Agents docs');
+  }
+}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -74,6 +74,7 @@ import {SourceMapIssueDetails} from 'sentry/views/issueDetails/configurationIssu
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {EventDetails} from 'sentry/views/issueDetails/eventDetails';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
+import {LlmCacheUsageSections} from 'sentry/views/issueDetails/genAiIssues/llmCacheUsage';
 import {useCopyIssueDetails} from 'sentry/views/issueDetails/hooks/useCopyIssueDetails';
 import {
   getHangProfileData,
@@ -164,6 +165,11 @@ export function EventDetailsContent({
         </FoldSection>
       )}
       <EventEvidence event={event} group={group} project={project} />
+      {group.issueType === IssueType.LLM_CACHE_USAGE && (
+        <ErrorBoundary customComponent={() => null}>
+          <LlmCacheUsageSections event={event} />
+        </ErrorBoundary>
+      )}
       {group.issueType === IssueType.UPTIME_DOMAIN_FAILURE && (
         <UptimeAssertionsSection event={event} />
       )}

--- a/static/app/views/issueList/utils/useFetchIssueTags.spec.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.spec.tsx
@@ -1,0 +1,62 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {IssueCategory, IssueType} from 'sentry/types/group';
+import type {Organization} from 'sentry/types/organization';
+import {useFetchIssueTags} from 'sentry/views/issueList/utils/useFetchIssueTags';
+
+describe('useFetchIssueTags', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [],
+    });
+  });
+
+  async function fetchTagValues(organization: Organization) {
+    const {result} = renderHookWithProviders(useFetchIssueTags, {
+      initialProps: {org: organization, projectIds: []},
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.tags['issue.type']).toBeDefined());
+
+    const valuesFor = (key: string) =>
+      (result.current.tags[key]?.values ?? []).map(value =>
+        typeof value === 'string' ? value : value.value
+      );
+
+    return {
+      issueTypes: valuesFor('issue.type'),
+      issueCategories: valuesFor('issue.category'),
+    };
+  }
+
+  it('offers the LLM cache filters when the detection feature is enabled', async () => {
+    const organization = OrganizationFixture({features: ['llm-cache-detection']});
+
+    const {issueTypes, issueCategories} = await fetchTagValues(organization);
+
+    expect(issueTypes).toContain(IssueType.LLM_CACHE_USAGE);
+    expect(issueCategories).toContain(IssueCategory.GEN_AI);
+  });
+
+  it('hides the LLM cache filters without the detection feature', async () => {
+    const organization = OrganizationFixture({features: []});
+
+    const {issueTypes, issueCategories} = await fetchTagValues(organization);
+
+    expect(issueTypes).not.toContain(IssueType.LLM_CACHE_USAGE);
+    expect(issueCategories).not.toContain(IssueCategory.GEN_AI);
+  });
+});

--- a/static/app/views/issueList/utils/useFetchIssueTags.spec.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.spec.tsx
@@ -42,8 +42,10 @@ describe('useFetchIssueTags', () => {
     };
   }
 
-  it('offers the LLM cache filters when the detection feature is enabled', async () => {
-    const organization = OrganizationFixture({features: ['llm-cache-detection']});
+  it('offers the LLM cache filters when the issues are visible', async () => {
+    const organization = OrganizationFixture({
+      features: ['issue-llm-cache-usage-visible'],
+    });
 
     const {issueTypes, issueCategories} = await fetchTagValues(organization);
 
@@ -51,8 +53,20 @@ describe('useFetchIssueTags', () => {
     expect(issueCategories).toContain(IssueCategory.GEN_AI);
   });
 
-  it('hides the LLM cache filters without the detection feature', async () => {
+  it('hides the LLM cache filters when the issues are not visible', async () => {
     const organization = OrganizationFixture({features: []});
+
+    const {issueTypes, issueCategories} = await fetchTagValues(organization);
+
+    expect(issueTypes).not.toContain(IssueType.LLM_CACHE_USAGE);
+    expect(issueCategories).not.toContain(IssueCategory.GEN_AI);
+  });
+
+  it('hides the LLM cache filters for an org that only runs the detector', async () => {
+    // Search resolves neither the category nor the type without the visibility
+    // flag, so offering them here would be a filter that always comes back
+    // empty for reasons the reader has no way to see.
+    const organization = OrganizationFixture({features: ['llm-cache-detection']});
 
     const {issueTypes, issueCategories} = await fetchTagValues(organization);
 

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -8,6 +8,7 @@ import {
   getIssueTitleFromType,
   ISSUE_CATEGORY_TO_DESCRIPTION,
   IssueCategory,
+  IssueType,
   PriorityLevel,
   VALID_ISSUE_CATEGORIES,
   AI_DETECTED_ISSUE_TYPES,
@@ -245,6 +246,10 @@ function builtInIssuesFields({
   currentTags: TagCollection;
   organization: Organization;
 }): TagCollection {
+  // The type is hidden by default, so only orgs the detector runs for are
+  // offered a filter that can return anything.
+  const hasLLMCacheDetection = organization.features.includes('llm-cache-detection');
+
   const semverFields: TagCollection = Object.values(SEMVER_TAGS).reduce<TagCollection>(
     (acc, tag) => {
       return {
@@ -313,7 +318,10 @@ function builtInIssuesFields({
     [FieldKey.ISSUE_CATEGORY]: {
       ...PREDEFINED_FIELDS[FieldKey.ISSUE_CATEGORY]!,
       name: 'Issue Category',
-      values: SEARCHABLE_ISSUE_CATEGORIES.map(value => ({
+      values: [
+        ...SEARCHABLE_ISSUE_CATEGORIES,
+        ...(hasLLMCacheDetection ? [IssueCategory.GEN_AI] : []),
+      ].map(value => ({
         icon: null,
         title: value,
         name: value,
@@ -333,6 +341,7 @@ function builtInIssuesFields({
         !organization.hideAiFeatures
           ? [...AI_DETECTED_ISSUE_TYPES]
           : []),
+        ...(hasLLMCacheDetection ? [IssueType.LLM_CACHE_USAGE] : []),
       ].map(value => ({
         icon: null,
         title: value,

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -246,9 +246,12 @@ function builtInIssuesFields({
   currentTags: TagCollection;
   organization: Organization;
 }): TagCollection {
-  // The type is hidden by default, so only orgs the detector runs for are
-  // offered a filter that can return anything.
-  const hasLLMCacheDetection = organization.features.includes('llm-cache-detection');
+  // The type is hidden by default, and this is the flag that unhides it: search
+  // drops the category and the type for anyone without it, so gating on
+  // anything else would offer a filter that returns nothing and says why.
+  const hasLLMCacheUsageIssues = organization.features.includes(
+    'issue-llm-cache-usage-visible'
+  );
 
   const semverFields: TagCollection = Object.values(SEMVER_TAGS).reduce<TagCollection>(
     (acc, tag) => {
@@ -320,7 +323,7 @@ function builtInIssuesFields({
       name: 'Issue Category',
       values: [
         ...SEARCHABLE_ISSUE_CATEGORIES,
-        ...(hasLLMCacheDetection ? [IssueCategory.GEN_AI] : []),
+        ...(hasLLMCacheUsageIssues ? [IssueCategory.GEN_AI] : []),
       ].map(value => ({
         icon: null,
         title: value,
@@ -341,7 +344,7 @@ function builtInIssuesFields({
         !organization.hideAiFeatures
           ? [...AI_DETECTED_ISSUE_TYPES]
           : []),
-        ...(hasLLMCacheDetection ? [IssueType.LLM_CACHE_USAGE] : []),
+        ...(hasLLMCacheUsageIssues ? [IssueType.LLM_CACHE_USAGE] : []),
       ].map(value => ({
         icon: null,
         title: value,


### PR DESCRIPTION
The issue page for `llm_cache_usage`, plus the type registration and the feature-gated search filters. The detector that produces these findings is #122137, which this is stacked on and must merge first.

Without this the issue falls back to the generic config, and a finding that lives entirely in the occurrence's evidence renders as an unordered table of numbers.

## The page

Organised around what the reader asks in order: do I believe this, which failure mode is it, what is it costing me, how do I fix it, how will I know the fix worked.

- **Problem** — the finding in one sentence with the money figure inline, the diagnostics as a key-value grid, and a stacked bar of how the window's input tokens were billed. The bar is the difference between the two failure modes at a glance: never-caching is almost entirely uncached, thrash is a fat write band beside a sliver of reads.
- **Healthy Comparison** — the contrast anchor, side by side with the flagged call site. This is the page's answer to the reader's first objection, that maybe this model just doesn't cache well here.
- **Cache Activity** — the only thing on the page that moves after a fix ships, so it is queried live rather than frozen at detection time.
- **Example Calls** — the largest calls, each linked to the span that made it. Comparing two of them is the first troubleshooting step for thrash.
- **Troubleshooting** — numbered steps keyed to the outcome, with provider-specific guidance inferred from the model name.

The Problem grid states the cache-eligible calls next to the raw call count. The hit rate above them counts every call the call site made, including ones that arrived too long after the last to find a warm cache, so the share that *could* have hit is what separates a broken cache from traffic too sparse to have one — and it is the figure a reader who knows their workload is bursty will want to check the finding against. The occurrence carries the count and the share; older ones carry neither and simply render without the row, as every evidence field is optional.

One issue can present as `not_caching` in one open period and `thrash` in the next, because the fingerprint excludes the outcome. Two bodies would mean the structure changes under the reader between visits, so only the copy and the emphasis are outcome-keyed.

The live queries reuse the detector's span filter verbatim and are pinned to the detection window rather than the reader's date selection. Either divergence would make "live data for this call site" answer a different question than the issue is claiming.

## Registration

`IssueCategory.GEN_AI` and `IssueType.LLM_CACHE_USAGE`, matching the backend category and group-type slugs, with `autofix` and `issueSummary` both disabled — occurrences are synthesized from aggregates with no stack trace or span tree, so there is nothing for Seer to reason about. Disabling only one of the two still surfaces Seer.

`trace` is disabled for this type. The Trace Preview section renders by default, but it locates the trace by the *event's* timestamp, which for a synthesized occurrence is detection time, up to a week after the sampled call. Example Calls links to the same traces by their own timestamps instead.

`eventOccurrenceTypeToIssueCategory` gains a branch guarded to 14000–14999, for the surfaces that resolve config without a group (the shared-issue page, the trace drawer). These previously resolved to `performanceConfig`, whose `evidence` is `null`, silently dropping the evidence section.

## Search filters are gated, not omitted

The type is hidden by default, which keeps it out of every dropdown — but flipping those lists on release would turn it on for everyone at once, and until then an org running the detector sees these issues in its stream while being unable to pick the type from search autocomplete.

So the `issue.type` and `issue.category` filters splice the new values in behind the detector's org flag, mirroring how `AI_DETECTED_ISSUE_TYPES` is spliced in a few lines above. Deliberately not also gated on `hideAiFeatures`, unlike that splice: the toggle governs Sentry's own AI features, whereas this is a deterministic detector about the customer's AI spend. An org that turned Seer off still wants to know its prompt cache is broken.

## Naming the call site

The detector keys on `gen_ai.agent.name` × `span.name` × `gen_ai.request.model`, so that is what the page reads and what its Explore links filter on. Where an agent name is missing, the occurrence carries `gen_ai.operation.name` as the label along with the attribute it came from; the link then also pins `!has:gen_ai.agent.name`, because without it the query returns the spans that *do* name an agent and happen to share the operation — a different call site than the finding is about.

An operation name presented as a call site reads like an agent nobody can find in their code, so the Problem section says when that is what it is. The label itself drops the agent when the span name already carries it, matching the issue's subtitle: `invoke_agent Lightweight RCA`, not the name twice.

Every evidence field is optional, so the parser is tolerant and the sections render less rather than crashing; the specs cover both outcomes, priced and unpriced, anchor present and absent, both label sources, and the degraded payloads older occurrences produce. An unrecognised label source is read as unknown rather than passed through as an attribute name, so a future third source cannot end up in a live query.

Retarget to `master` once #122137 merges.

