### PR TITLE
perf(onboarding): Defer JavaScript beautifier

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.spec.tsx
@@ -1,4 +1,23 @@
-import {replaceTokensWithSpan} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {
+  OnboardingCodeSnippet,
+  replaceTokensWithSpan,
+} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
+
+describe('OnboardingCodeSnippet', () => {
+  it('beautifies JavaScript snippets', async () => {
+    render(
+      <OnboardingCodeSnippet language="javascript">
+        {'const options={enabled:true};'}
+      </OnboardingCodeSnippet>
+    );
+
+    expect(
+      await screen.findByText('const options = { enabled: true };')
+    ).toBeInTheDocument();
+  });
+});
 
 describe('replaceTokenWithSpan', () => {
   it('replaces __ORG_AUTH_TOKEN___ token', () => {

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -1,5 +1,6 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import {createPortal} from 'react-dom';
+import {useQuery} from '@tanstack/react-query';
 
 import {CodeBlock} from '@sentry/scraps/code';
 
@@ -38,10 +39,13 @@ export function OnboardingCodeSnippet({
   ...props
 }: OnboardingCodeSnippetProps) {
   const [authTokenNodes, setAuthTokenNodes] = useState<HTMLSpanElement[]>([]);
-  const [beautifiedJavaScript, setBeautifiedJavaScript] = useState<{
-    input: string;
-    output: string;
-  }>();
+
+  const {data: beautify} = useQuery({
+    queryKey: ['onboarding-code-snippet', 'js-beautify'],
+    queryFn: () => import('js-beautify').then(module => module.default),
+    enabled: language === 'javascript',
+    staleTime: Infinity,
+  });
 
   const handleAfterHighlight = useCallback((element: HTMLElement) => {
     setAuthTokenNodes(replaceTokensWithSpan(element));
@@ -52,36 +56,13 @@ export function OnboardingCodeSnippet({
     [children]
   );
 
-  useEffect(() => {
-    if (language !== 'javascript') {
-      return;
-    }
-
-    let cancelled = false;
-
-    import('js-beautify')
-      .then(({default: beautify}) => {
-        if (!cancelled) {
-          setBeautifiedJavaScript({
-            input: children,
-            output: beautify.js(children, {
-              indent_size: 2,
-              e4x: true,
-              brace_style: 'preserve-inline',
-            }),
-          });
-        }
-      })
-      .catch(() => null);
-
-    return () => {
-      cancelled = true;
-    };
-  }, [children, language]);
-
   const displayedCode =
-    language === 'javascript' && beautifiedJavaScript?.input === children
-      ? beautifiedJavaScript.output
+    language === 'javascript' && beautify
+      ? beautify.js(children, {
+          indent_size: 2,
+          e4x: true,
+          brace_style: 'preserve-inline',
+        })
       : children.trim();
 
   return (

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -1,6 +1,5 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {createPortal} from 'react-dom';
-import beautify from 'js-beautify';
 
 import {CodeBlock} from '@sentry/scraps/code';
 
@@ -39,6 +38,10 @@ export function OnboardingCodeSnippet({
   ...props
 }: OnboardingCodeSnippetProps) {
   const [authTokenNodes, setAuthTokenNodes] = useState<HTMLSpanElement[]>([]);
+  const [beautifiedJavaScript, setBeautifiedJavaScript] = useState<{
+    input: string;
+    output: string;
+  }>();
 
   const handleAfterHighlight = useCallback((element: HTMLElement) => {
     setAuthTokenNodes(replaceTokensWithSpan(element));
@@ -48,6 +51,38 @@ export function OnboardingCodeSnippet({
     () => children.includes(PACKAGE_LOADING_PLACEHOLDER),
     [children]
   );
+
+  useEffect(() => {
+    if (language !== 'javascript') {
+      return;
+    }
+
+    let cancelled = false;
+
+    import('js-beautify')
+      .then(({default: beautify}) => {
+        if (!cancelled) {
+          setBeautifiedJavaScript({
+            input: children,
+            output: beautify.js(children, {
+              indent_size: 2,
+              e4x: true,
+              brace_style: 'preserve-inline',
+            }),
+          });
+        }
+      })
+      .catch(() => null);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [children, language]);
+
+  const displayedCode =
+    language === 'javascript' && beautifiedJavaScript?.input === children
+      ? beautifiedJavaScript.output
+      : children.trim();
 
   return (
     <Fragment>
@@ -59,14 +94,7 @@ export function OnboardingCodeSnippet({
         {...props}
         onAfterHighlight={handleAfterHighlight}
       >
-        {/* Trim whitespace from code snippets and beautify javascript code */}
-        {language === 'javascript'
-          ? beautify.js(children, {
-              indent_size: 2,
-              e4x: true,
-              brace_style: 'preserve-inline',
-            })
-          : children.trim()}
+        {displayedCode}
       </CodeBlock>
       {authTokenNodes.map(node => createPortal(<AuthTokenGenerator />, node))}
     </Fragment>


### PR DESCRIPTION
OnboardingCodeSnippet is part of the application initialization graph, so `js-beautify` was loaded on Issues even when no onboarding snippet was rendered.

Loads the formatter only when a JavaScript snippet is displayed. The snippet renders its trimmed source while the chunk arrives, then keeps the same beautified output.

| Issues initialization JS | Before | After | Savings |
|---|---:|---:|---:|
| Minified | 205.3 KiB | 107.3 KiB | 98.0 KiB |
| Gzip | 60.5 KiB | 36.4 KiB | 24.1 KiB |

The Issues route still makes 41 JavaScript requests.