### PR TITLE
fix: Apply color scheme to all React routes

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -15,6 +15,7 @@ import {preload} from 'sentry/router/preload';
 import {RouteConfigProvider} from 'sentry/router/routeConfigContext';
 import {routes} from 'sentry/router/routes';
 import {ServiceWorkerProvider} from 'sentry/serviceWorker/client/serviceWorkerContext';
+import {useColorscheme} from 'sentry/utils/useColorscheme';
 import {createReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 // Keep the production check at the import site so DefinePlugin can remove the
@@ -38,6 +39,7 @@ function buildRouter() {
 
 export function Main() {
   const [router] = useState(buildRouter);
+  useColorscheme();
 
   useEffect(() => {
     preload(router.routes, window.location.pathname);

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -24,7 +24,6 @@ import {onRenderCallback, Profiler} from 'sentry/utils/performanceForSentry';
 import {shouldPreloadData} from 'sentry/utils/shouldPreloadData';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
-import {useColorscheme} from 'sentry/utils/useColorscheme';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
@@ -93,8 +92,6 @@ function AppAlerts() {
  * App is the root level container for all uathenticated routes.
  */
 export function App() {
-  useColorscheme();
-
   const api = useApi();
   const user = useUser();
   const config = useLegacyStore(ConfigStore);


### PR DESCRIPTION
Color-scheme resolution now runs at the application root, allowing React routes outside the main `App` subtree to follow the authenticated preference or anonymous system color scheme. This includes standalone surfaces such as branded-layout previews while preserving live system-theme updates.