### PR TITLE
feat(ui): Add a naive uwu locale transform

### DIFF
--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -4,6 +4,7 @@ import * as qs from 'query-string';
 
 import {DEFAULT_LOCALE_DATA, setLocale} from 'sentry/locale';
 import type {Config} from 'sentry/types/system';
+import {UWU_LANGUAGE_CODE} from 'sentry/utils/uwu';
 
 // zh-cn => zh_CN
 function convertToDjangoLocaleFormat(language: string) {
@@ -14,8 +15,9 @@ function convertToDjangoLocaleFormat(language: string) {
 async function getTranslations(language: string) {
   language = convertToDjangoLocaleFormat(language);
 
-  // No need to load the english locale
-  if (language === 'en') {
+  // The uwu locale is applied as a transform over the english catalog, so there
+  // is no catalog on disk to fetch for it.
+  if (language === 'en' || language === UWU_LANGUAGE_CODE) {
     return DEFAULT_LOCALE_DATA;
   }
 
@@ -66,7 +68,7 @@ export async function initializeLocale(config: Config) {
     queryStringLang || config.user?.options?.language || config.languageCode || 'en';
 
   try {
-    if (languageCode === 'en') {
+    if (languageCode === 'en' || languageCode === UWU_LANGUAGE_CODE) {
       const translations = await getTranslations(languageCode);
       setLocale(translations);
     } else {

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -72,6 +72,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
+import {toggleUwu} from 'sentry/utils/uwu';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
 import {DEFAULT_PREBUILT_SORT} from 'sentry/views/dashboards/manage/settings';
 import {DashboardFilter} from 'sentry/views/dashboards/types';
@@ -1106,6 +1107,16 @@ export function GlobalCommandPaletteActions() {
           keywords={['locale', 'debug', 'i18n', 'translation', 'markers']}
           onAction={() => {
             toggleLocaleDebug();
+          }}
+        />
+      )}
+
+      {(NODE_ENV === 'development' || user.isStaff) && (
+        <CMDKAction
+          display={{label: t('Toggle UwU Locale'), icon: <IconFlag />}}
+          keywords={['locale', 'uwu', 'owo', 'i18n', 'pseudolocale']}
+          onAction={() => {
+            toggleUwu();
           }}
         />
       )}

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -6,6 +6,7 @@ import {sprintf} from 'sprintf-js';
 
 import {toArray} from 'sentry/utils/array/toArray';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
+import {UWU_ENABLED, uwuify} from 'sentry/utils/uwu';
 
 const markerStyles = {
   background: '#ff801790',
@@ -322,7 +323,8 @@ function format(formatString: string, args: FormatArg[]): React.ReactNode {
  * [0]: https://github.com/alexei/sprintf.js
  */
 function gettext(string: string, ...args: FormatArg[]): string {
-  const val: string = getClient().gettext(string);
+  const translated: string = getClient().gettext(string);
+  const val = UWU_ENABLED ? uwuify(translated) : translated;
 
   if (args.length === 0) {
     staticTranslations.add(val);

--- a/static/app/utils/uwu.spec.ts
+++ b/static/app/utils/uwu.spec.ts
@@ -1,0 +1,35 @@
+import {uwuify} from 'sentry/utils/uwu';
+
+describe('uwuify', () => {
+  it('replaces l and r with w when given lowercase text', () => {
+    const result = uwuify('resolve all errors');
+
+    expect(result).toBe('wesowve aww ewwows');
+  });
+
+  it('preserves case when replacing uppercase L and R', () => {
+    const result = uwuify('Learn More');
+
+    expect(result).toBe('Weawn Mowe');
+  });
+
+  it('inserts y after n when followed by a vowel', () => {
+    const result = uwuify('No nice name');
+
+    expect(result).toBe('Nyo nyice nyame');
+  });
+
+  it('returns the same output when called repeatedly with the same input', () => {
+    const outputs = Array.from({length: 5}, () =>
+      uwuify('Alerts allow you to monitor your errors')
+    );
+
+    expect(new Set(outputs).size).toBe(1);
+  });
+
+  it('returns text unchanged when it contains no transformable characters', () => {
+    const result = uwuify('%s of %s');
+
+    expect(result).toBe('%s of %s');
+  });
+});

--- a/static/app/utils/uwu.ts
+++ b/static/app/utils/uwu.ts
@@ -1,0 +1,45 @@
+import {localStorageWrapper} from 'sentry/utils/localStorage';
+
+export const UWU_LANGUAGE_CODE = 'uwu';
+
+const UWU_STORAGE_KEY = 'uwu';
+
+const UWU_MAP: Array<[RegExp, string]> = [
+  [/(?:r|l)/g, 'w'],
+  [/(?:R|L)/g, 'W'],
+  [/n([aeiou])/g, 'ny$1'],
+  [/N([aeiou])/g, 'Ny$1'],
+  [/N([AEIOU])/g, 'Ny$1'],
+  [/ove/g, 'uv'],
+];
+
+/**
+ * Must stay stable: a given input always maps to the same output. Every rule is
+ * an unconditional replacement, so nothing here may consult a random source.
+ */
+export function uwuify(text: string): string {
+  return UWU_MAP.reduce(
+    (result, [pattern, replacement]) => result.replace(pattern, replacement),
+    text
+  );
+}
+
+function readUwuEnabled(): boolean {
+  if (localStorageWrapper.getItem(UWU_STORAGE_KEY) === '1') {
+    return true;
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).get('lang') === UWU_LANGUAGE_CODE;
+  } catch {
+    return false;
+  }
+}
+
+export const UWU_ENABLED = readUwuEnabled();
+
+export function toggleUwu() {
+  const next = localStorageWrapper.getItem(UWU_STORAGE_KEY) !== '1';
+  localStorageWrapper.setItem(UWU_STORAGE_KEY, next ? '1' : '0');
+  window.location.reload();
+}


### PR DESCRIPTION
Hackweek project, branch 1 of 5. Adds a `?lang=uwu` pseudo-locale that rewrites translated strings into uwu-speak.

## What this does

- `static/app/utils/uwu.ts` — an unconditional regex transform (`l|r → w`, `n`+vowel → `ny`, `ove → uv`). No dependencies. Stability comes for free: there is no random source, so a given string always maps to the same output.
- `locale.tsx` — applies the transform inside `gettext` only, after the Jed lookup.
- Enabled by `?lang=uwu` or a **Toggle UwU Locale** Command+K action, gated to dev and staff like the existing translation-marker toggle.
- `initializeLocale.tsx` treats `uwu` like `en` so it doesn't try to fetch a catalog that isn't on disk.

Off by default; with no `?lang=uwu` the rendered output is byte-identical to `master`.

## What this deliberately does not do

This branch is the naive version, kept naive on purpose so the next one has something to fix. Three known breakages, all visible in the preview:

| Input | Rendered | Problem |
|---|---|---|
| `Deleted %(count)s replays from %(orgSlug)s` | `… %(owgSwug)s` | named sprintf lookup fails |
| `about [link:release health]` | `about [wink:wewease heawth]` | `tct` group name mangled, link renders as literal text |
| `Allow list our IP Addresses:` | `Awwow wist ouw IP Addresses:` | colon-terminated word skipped |

Scope of the first two across `static/app`: 40 named sprintf args and ~1,500 `tct` component-template groups. Positional `%s`/`%d` are unaffected.

## Next

Branch 2 (`feat/uwu-locale-safe`) masks placeholders, transforms `tct` string leaves structurally rather than by regex, and adds a property test over a 2,163-string corpus asserting no placeholder is ever corrupted.