### PR TITLE
feat(investigations): build interactive investigation detail view

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -230,7 +230,7 @@ export type RequestOptions = RequestCallbacks & {
   /**
    * The HTTP method to use when making the API request
    */
-  method?: 'DELETE' | 'GET' | 'POST' | 'PUT';
+  method?: 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
   /**
    * Because of the async nature of API requests, errors will happen outside of
    * the stack that initated the request. a preservedError can be passed to

--- a/static/app/components/seer/markdown/embeds/components/chart.tsx
+++ b/static/app/components/seer/markdown/embeds/components/chart.tsx
@@ -1,7 +1,10 @@
 import {Container, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
 import {DurationUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {CategoricalSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization';
@@ -47,90 +50,111 @@ function getSeriesLabel(series: {label: string} | {name: string}): string {
   return 'label' in series ? series.label : series.name;
 }
 
+export function ChartContent({
+  data: {title, subtitle, visualization, x_axis: xAxis, y_axis_unit: yAxisUnit, series},
+  showHeader = true,
+}: {
+  data: EmbedOutput<'chart'>;
+  showHeader?: boolean;
+}) {
+  const metadata = UNIT_METADATA[yAxisUnit];
+
+  const visualizationComponent =
+    xAxis === 'category' ? (
+      <CategoricalSeriesWidgetVisualization
+        plottables={series.map((item, index) => {
+          const categoricalSeries: CategoricalSeries = {
+            valueAxis: `seer-chart-series-${index}`,
+            meta: metadata,
+            values: item.data.map(point => ({
+              category: point.x,
+              value: normalizeValue(point.y, yAxisUnit),
+            })),
+          };
+          return new CategoricalBars(categoricalSeries, {
+            alias: getSeriesLabel(item),
+          });
+        })}
+      />
+    ) : (
+      <TimeSeriesWidgetVisualization
+        onZoom={() => {}}
+        pageFilters={{
+          datetime: {
+            start: new Date(
+              Math.min(
+                ...series.flatMap(item =>
+                  item.data.map(point => Date.parse(String(point.x)))
+                )
+              )
+            ).toISOString(),
+            end: new Date(
+              Math.max(
+                ...series.flatMap(item =>
+                  item.data.map(point => Date.parse(String(point.x)))
+                )
+              )
+            ).toISOString(),
+            period: null,
+            utc: true,
+          },
+          environments: [],
+          projects: [],
+        }}
+        plottables={series
+          .map((item, index) => {
+            const values = item.data
+              .map(point => ({
+                timestamp: Date.parse(String(point.x)),
+                value: normalizeValue(point.y, yAxisUnit),
+              }))
+              .toSorted((left, right) => left.timestamp - right.timestamp);
+            const timeSeries: TimeSeries = {
+              yAxis: `seer-chart-series-${index}`,
+              meta: {
+                ...metadata,
+                interval: getInterval(values.map(point => point.timestamp)),
+              },
+              values,
+            };
+            return createPlottableFromTimeSeries(
+              DISPLAY_TYPES[visualization],
+              timeSeries,
+              {
+                alias: getSeriesLabel(item),
+                name: `seer-chart-series-${index}`,
+              }
+            );
+          })
+          .filter((plottable): plottable is Plottable => plottable !== null)}
+        showReleaseAs="none"
+      />
+    );
+
+  return (
+    <Stack gap="0" width="100%">
+      {showHeader ? (
+        <Stack gap="2xs" paddingBottom="sm">
+          <Heading as="h3" size="md">
+            {title}
+          </Heading>
+          {subtitle ? (
+            <Text size="sm" variant="muted">
+              {subtitle}
+            </Text>
+          ) : null}
+        </Stack>
+      ) : null}
+      <Container data-test-id="seer-chart-content" height="220px" width="100%">
+        {visualizationComponent}
+      </Container>
+    </Stack>
+  );
+}
+
 export const Chart = defineSeerEmbed({
   name: 'chart',
-  render({
-    title,
-    subtitle,
-    visualization,
-    x_axis: xAxis,
-    y_axis_unit: yAxisUnit,
-    series,
-  }) {
-    const metadata = UNIT_METADATA[yAxisUnit];
-
-    const visualizationComponent =
-      xAxis === 'category' ? (
-        <CategoricalSeriesWidgetVisualization
-          plottables={series.map((item, index) => {
-            const categoricalSeries: CategoricalSeries = {
-              valueAxis: `seer-chart-series-${index}`,
-              meta: metadata,
-              values: item.data.map(point => ({
-                category: point.x,
-                value: normalizeValue(point.y, yAxisUnit),
-              })),
-            };
-            return new CategoricalBars(categoricalSeries, {
-              alias: getSeriesLabel(item),
-            });
-          })}
-        />
-      ) : (
-        <TimeSeriesWidgetVisualization
-          onZoom={() => {}}
-          pageFilters={{
-            datetime: {
-              start: new Date(
-                Math.min(
-                  ...series.flatMap(item =>
-                    item.data.map(point => Date.parse(String(point.x)))
-                  )
-                )
-              ).toISOString(),
-              end: new Date(
-                Math.max(
-                  ...series.flatMap(item =>
-                    item.data.map(point => Date.parse(String(point.x)))
-                  )
-                )
-              ).toISOString(),
-              period: null,
-              utc: true,
-            },
-            environments: [],
-            projects: [],
-          }}
-          plottables={series
-            .map((item, index) => {
-              const values = item.data
-                .map(point => ({
-                  timestamp: Date.parse(String(point.x)),
-                  value: normalizeValue(point.y, yAxisUnit),
-                }))
-                .toSorted((left, right) => left.timestamp - right.timestamp);
-              const timeSeries: TimeSeries = {
-                yAxis: `seer-chart-series-${index}`,
-                meta: {
-                  ...metadata,
-                  interval: getInterval(values.map(point => point.timestamp)),
-                },
-                values,
-              };
-              return createPlottableFromTimeSeries(
-                DISPLAY_TYPES[visualization],
-                timeSeries,
-                {
-                  alias: getSeriesLabel(item),
-                  name: `seer-chart-series-${index}`,
-                }
-              );
-            })
-            .filter((plottable): plottable is Plottable => plottable !== null)}
-          showReleaseAs="none"
-        />
-      );
-
+  render(data) {
     return (
       <Container
         as="section"
@@ -141,17 +165,7 @@ export const Chart = defineSeerEmbed({
         padding="lg xl md"
         radius="md"
       >
-        <Stack gap="2xs" paddingBottom="sm">
-          <Heading as="h3" size="md">
-            {title}
-          </Heading>
-          {subtitle && (
-            <Text size="sm" variant="muted">
-              {subtitle}
-            </Text>
-          )}
-        </Stack>
-        <Container height="220px">{visualizationComponent}</Container>
+        <ChartContent data={data} />
       </Container>
     );
   },

--- a/static/app/components/seer/markdown/index.tsx
+++ b/static/app/components/seer/markdown/index.tsx
@@ -121,14 +121,15 @@ const SEER_EMBED_COMPONENTS: MarkdownProps['components'] = {
 };
 
 export function SeerMarkdown({
+  components,
   structuredContent = null,
   ...props
-}: Omit<MarkdownProps, 'components'> & {
+}: MarkdownProps & {
   structuredContent?: Record<string, unknown> | null;
 }) {
   return (
     <StructuredContentContext.Provider value={structuredContent}>
-      <Markdown {...props} components={SEER_EMBED_COMPONENTS} />
+      <Markdown {...props} components={{...SEER_EMBED_COMPONENTS, ...components}} />
     </StructuredContentContext.Provider>
   );
 }

--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 import type {getApiUrl} from 'sentry/utils/api/getApiUrl';
 
-export type RequestMethod = 'DELETE' | 'GET' | 'POST' | 'PUT';
+export type RequestMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
 
 type ApiUrl = ReturnType<typeof getApiUrl>;
 

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -147,7 +147,7 @@ export function setApiQueryData<TResponseData>(
 }
 
 type ApiMutationVariables = {
-  method: 'PUT' | 'POST' | 'DELETE';
+  method: 'PUT' | 'POST' | 'PATCH' | 'DELETE';
   url: string;
   data?: Record<string, unknown>;
   options?: Pick<

--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -35,7 +35,7 @@ export class RequestError extends Error {
   statusText?: string;
 
   constructor(
-    method: 'POST' | 'GET' | 'DELETE' | 'PUT' | undefined,
+    method: 'POST' | 'GET' | 'DELETE' | 'PATCH' | 'PUT' | undefined,
     path: string,
     cause: Error,
     responseMetadata?: ResponseMeta

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -38,7 +38,7 @@ export function investigationListQueryOptions({
   );
 }
 
-export function investigationDetailQueryOptions(
+export function getInvestigationDetailQueryOptions(
   organizationSlug: string,
   investigationId: string
 ) {
@@ -210,7 +210,7 @@ export function useRenameInvestigationMutation(
   options?: MutationOptions<InvestigationDetail, string>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -259,7 +259,7 @@ export function useAddInvestigationBlockMutation(
   options?: MutationOptions<InvestigationBlock, AddBlockVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -305,7 +305,7 @@ export function useDuplicateInvestigationBlockMutation(
   options?: MutationOptions<InvestigationBlock, BlockIdVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -365,7 +365,7 @@ export function useDeleteInvestigationBlockMutation(
   options?: MutationOptions<void, BlockIdVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -422,7 +422,7 @@ export function useRunInvestigationBlockMutation(
   options?: MutationOptions<InvestigationBlockExecutionStart, RunBlockVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -480,7 +480,7 @@ export function useUpdateInvestigationBlockPromptMutation(
   options?: MutationOptions<InvestigationBlock, UpdateBlockPromptVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -529,7 +529,7 @@ export function useRenameInvestigationBlockMutation(
   options?: MutationOptions<RenameBlockResult, RenameBlockVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );
@@ -620,7 +620,7 @@ export function useStopInvestigationExecutionMutation(
   options?: MutationOptions<void, StopExecutionVariables>
 ) {
   const queryClient = useQueryClient();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organizationSlug,
     investigationId
   );

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -8,7 +8,11 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {
   InvestigationCandidate,
+  InvestigationBlock,
+  InvestigationBlockExecutionStart,
+  InvestigationBlockKind,
   InvestigationDetail,
+  InvestigationExecutionDetail,
   InvestigationListItem,
   MetricOpenPeriodInvestigationSource,
 } from 'sentry/views/investigations/types';
@@ -50,6 +54,31 @@ export function investigationDetailQueryOptions(
   );
 }
 
+export function investigationExecutionDetailQueryOptions({
+  organizationSlug,
+  investigationId,
+  blockId,
+  executionId,
+}: {
+  blockId: string;
+  executionId: string;
+  investigationId: string;
+  organizationSlug: string;
+}) {
+  return apiOptions.as<InvestigationExecutionDetail>()(
+    '/organizations/$organizationIdOrSlug/investigations/$investigationId/blocks/$blockId/executions/$executionId/',
+    {
+      path: {
+        organizationIdOrSlug: organizationSlug,
+        investigationId,
+        blockId,
+        executionId,
+      },
+      staleTime: 0,
+    }
+  );
+}
+
 export function investigationCandidatesQueryOptions({
   organizationSlug,
   sources,
@@ -75,6 +104,44 @@ export function investigationCandidatesQueryOptions({
 type FavoriteVariables = {
   investigation: InvestigationListItem;
   shouldFavorite: boolean;
+};
+
+type AddBlockVariables = {
+  investigation: InvestigationDetail;
+  kind: InvestigationBlockKind;
+  prompt: string;
+  title: string;
+};
+
+type RunBlockVariables = {
+  block: InvestigationBlock;
+  investigationVersion: number;
+};
+
+type UpdateBlockPromptVariables = {
+  block: InvestigationBlock;
+  investigationVersion: number;
+  prompt: string;
+};
+
+type RenameBlockVariables = {
+  blockId: string;
+  title: string;
+};
+
+type RenameBlockResult = {
+  block: InvestigationBlock;
+  requestedBlockVersion: number;
+  requestedInvestigationVersion: number;
+};
+
+type BlockIdVariables = {
+  blockId: string;
+};
+
+type StopExecutionVariables = {
+  blockId: string;
+  executionId: string;
 };
 
 type MutationOptions<TData, TVariables> = Omit<
@@ -182,6 +249,402 @@ export function useRenameInvestigationMutation(
         queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
       });
       await options?.onSuccess?.(updated, savedTitle, onMutateResult, context);
+    },
+  });
+}
+
+export function useAddInvestigationBlockMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<InvestigationBlock, AddBlockVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({investigation, kind, prompt, title}) =>
+      fetchMutation<InvestigationBlock>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/`,
+        method: 'POST',
+        data: {
+          investigationVersion: investigation.version,
+          kind,
+          title,
+          generationPrompt: prompt,
+        },
+      }),
+    onSuccess: async (block, variables, onMutateResult, context) => {
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blockCount: current.json.blockCount + 1,
+                blocks: [...(current.json.blocks ?? []), block],
+                version: current.json.version + 1,
+              },
+            }
+          : current
+      );
+      await queryClient.invalidateQueries({
+        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
+      });
+      await options?.onSuccess?.(block, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useDuplicateInvestigationBlockMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<InvestigationBlock, BlockIdVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({blockId}) => {
+      const investigation = queryClient.getQueryData(detailOptions.queryKey)?.json;
+      const block = investigation?.blocks?.find(item => item.id === blockId);
+      if (!investigation || !block) {
+        throw new Error('Investigation block is not cached.');
+      }
+
+      return fetchMutation<InvestigationBlock>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/`,
+        method: 'POST',
+        data: {
+          investigationVersion: investigation.version,
+          kind: block.kind,
+          title: block.title,
+          content: block.content,
+          generationPrompt: block.generationPrompt,
+          config: block.config,
+          display: block.display,
+        },
+      });
+    },
+    onSuccess: async (duplicate, variables, onMutateResult, context) => {
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blockCount: current.json.blockCount + 1,
+                blocks: [...(current.json.blocks ?? []), duplicate],
+                version: current.json.version + 1,
+              },
+            }
+          : current
+      );
+      await queryClient.invalidateQueries({
+        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
+      });
+      await options?.onSuccess?.(duplicate, variables, onMutateResult, context);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      await options?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useDeleteInvestigationBlockMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<void, BlockIdVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({blockId}) => {
+      const investigation = queryClient.getQueryData(detailOptions.queryKey)?.json;
+      const block = investigation?.blocks?.find(item => item.id === blockId);
+      if (!investigation || !block) {
+        throw new Error('Investigation block is not cached.');
+      }
+
+      return fetchMutation<void>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/`,
+        method: 'DELETE',
+        data: {
+          investigationVersion: investigation.version,
+          version: block.version,
+        },
+      });
+    },
+    onSuccess: async (_data, variables, onMutateResult, context) => {
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blockCount: Math.max(0, current.json.blockCount - 1),
+                blocks: current.json.blocks?.filter(
+                  block => block.id !== variables.blockId
+                ),
+                version: current.json.version + 1,
+              },
+            }
+          : current
+      );
+      await queryClient.invalidateQueries({
+        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
+      });
+      await options?.onSuccess?.(_data, variables, onMutateResult, context);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      await options?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useRunInvestigationBlockMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<InvestigationBlockExecutionStart, RunBlockVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({block, investigationVersion}) =>
+      fetchMutation<InvestigationBlockExecutionStart>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${block.id}/executions/`,
+        method: 'POST',
+        data: {
+          investigationVersion,
+          version: block.version,
+        },
+      }),
+    onSuccess: async (execution, variables, onMutateResult, context) => {
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blocks: current.json.blocks?.map(block =>
+                  block.id === variables.block.id
+                    ? {
+                        ...block,
+                        outputStatus: execution.status,
+                        currentExecution: {
+                          id: execution.id,
+                          status: execution.status,
+                          startedAt: null,
+                          completedAt: null,
+                          error: null,
+                        },
+                      }
+                    : block
+                ),
+              },
+            }
+          : current
+      );
+      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      await options?.onSuccess?.(execution, variables, onMutateResult, context);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      await options?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useUpdateInvestigationBlockPromptMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<InvestigationBlock, UpdateBlockPromptVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({block, investigationVersion, prompt}) =>
+      fetchMutation<InvestigationBlock>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${block.id}/`,
+        method: 'PUT',
+        data: {
+          investigationVersion,
+          version: block.version,
+          generationPrompt: prompt,
+        },
+      }),
+    onSuccess: async (updatedBlock, variables, onMutateResult, context) => {
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blocks: current.json.blocks?.map(block =>
+                  block.id === updatedBlock.id ? updatedBlock : block
+                ),
+                version:
+                  current.json.version +
+                  (updatedBlock.version === variables.block.version ? 0 : 1),
+              },
+            }
+          : current
+      );
+      await options?.onSuccess?.(updatedBlock, variables, onMutateResult, context);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      await options?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useRenameInvestigationBlockMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<RenameBlockResult, RenameBlockVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    scope: {id: `rename-investigation-block-${investigationId}`},
+    mutationFn: async ({blockId, title}) => {
+      const investigation = queryClient.getQueryData(detailOptions.queryKey)?.json;
+      const block = investigation?.blocks?.find(item => item.id === blockId);
+      if (!investigation || !block) {
+        throw new Error('Investigation block is not cached.');
+      }
+
+      const updated = await fetchMutation<InvestigationBlock>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/`,
+        method: 'PUT',
+        data: {
+          investigationVersion: investigation.version,
+          version: block.version,
+          title: title.trim(),
+        },
+      });
+      return {
+        block: updated,
+        requestedBlockVersion: block.version,
+        requestedInvestigationVersion: investigation.version,
+      };
+    },
+    onMutate: async variables => {
+      await queryClient.cancelQueries({queryKey: detailOptions.queryKey});
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blocks: current.json.blocks?.map(block =>
+                  block.id === variables.blockId
+                    ? {...block, title: variables.title}
+                    : block
+                ),
+              },
+            }
+          : current
+      );
+    },
+    onSuccess: async (result, variables, onMutateResult, context) => {
+      const versionDelta = result.block.version === result.requestedBlockVersion ? 0 : 1;
+      queryClient.setQueryData(detailOptions.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {
+                ...current.json,
+                blocks: current.json.blocks?.map(block =>
+                  block.id === result.block.id
+                    ? {
+                        ...result.block,
+                        // Keep a newer optimistic edit while this save was in flight.
+                        title:
+                          block.title === variables.title
+                            ? result.block.title
+                            : block.title,
+                      }
+                    : block
+                ),
+                version: Math.max(
+                  current.json.version,
+                  result.requestedInvestigationVersion + versionDelta
+                ),
+              },
+            }
+          : current
+      );
+      await options?.onSuccess?.(result, variables, onMutateResult, context);
+    },
+    onError: async (error, variables, onMutateResult, context) => {
+      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      await options?.onError?.(error, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useStopInvestigationExecutionMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<void, StopExecutionVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({blockId, executionId}) =>
+      fetchMutation<void>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/executions/${executionId}/`,
+        method: 'DELETE',
+      }),
+    onSuccess: async (_data, variables, onMutateResult, context) => {
+      await Promise.all([
+        queryClient.invalidateQueries({queryKey: detailOptions.queryKey}),
+        queryClient.invalidateQueries({
+          queryKey: investigationExecutionDetailQueryOptions({
+            organizationSlug,
+            investigationId,
+            blockId: variables.blockId,
+            executionId: variables.executionId,
+          }).queryKey,
+        }),
+      ]);
+      await options?.onSuccess?.(_data, variables, onMutateResult, context);
     },
   });
 }

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -144,6 +144,11 @@ type StopExecutionVariables = {
   executionId: string;
 };
 
+type ResumeExecutionVariables = StopExecutionVariables & {
+  inputId: string;
+  responseData: {answers: string[]};
+};
+
 type MutationOptions<TData, TVariables> = Omit<
   UseMutationOptions<TData, Error, TVariables>,
   'mutationFn'
@@ -295,66 +300,6 @@ export function useAddInvestigationBlockMutation(
         queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
       });
       await options?.onSuccess?.(block, variables, onMutateResult, context);
-    },
-  });
-}
-
-export function useDuplicateInvestigationBlockMutation(
-  organizationSlug: string,
-  investigationId: string,
-  options?: MutationOptions<InvestigationBlock, BlockIdVariables>
-) {
-  const queryClient = useQueryClient();
-  const detailOptions = getInvestigationDetailQueryOptions(
-    organizationSlug,
-    investigationId
-  );
-
-  return useMutation({
-    ...options,
-    mutationFn: ({blockId}) => {
-      const investigation = queryClient.getQueryData(detailOptions.queryKey)?.json;
-      const block = investigation?.blocks?.find(item => item.id === blockId);
-      if (!investigation || !block) {
-        throw new Error('Investigation block is not cached.');
-      }
-
-      return fetchMutation<InvestigationBlock>({
-        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/`,
-        method: 'POST',
-        data: {
-          investigationVersion: investigation.version,
-          kind: block.kind,
-          title: block.title,
-          content: block.content,
-          generationPrompt: block.generationPrompt,
-          config: block.config,
-          display: block.display,
-        },
-      });
-    },
-    onSuccess: async (duplicate, variables, onMutateResult, context) => {
-      queryClient.setQueryData(detailOptions.queryKey, current =>
-        current
-          ? {
-              ...current,
-              json: {
-                ...current.json,
-                blockCount: current.json.blockCount + 1,
-                blocks: [...(current.json.blocks ?? []), duplicate],
-                version: current.json.version + 1,
-              },
-            }
-          : current
-      );
-      await queryClient.invalidateQueries({
-        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
-      });
-      await options?.onSuccess?.(duplicate, variables, onMutateResult, context);
-    },
-    onError: async (error, variables, onMutateResult, context) => {
-      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
-      await options?.onError?.(error, variables, onMutateResult, context);
     },
   });
 }
@@ -631,6 +576,42 @@ export function useStopInvestigationExecutionMutation(
       fetchMutation<void>({
         url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/executions/${executionId}/`,
         method: 'DELETE',
+      }),
+    onSuccess: async (_data, variables, onMutateResult, context) => {
+      await Promise.all([
+        queryClient.invalidateQueries({queryKey: detailOptions.queryKey}),
+        queryClient.invalidateQueries({
+          queryKey: investigationExecutionDetailQueryOptions({
+            organizationSlug,
+            investigationId,
+            blockId: variables.blockId,
+            executionId: variables.executionId,
+          }).queryKey,
+        }),
+      ]);
+      await options?.onSuccess?.(_data, variables, onMutateResult, context);
+    },
+  });
+}
+
+export function useResumeInvestigationExecutionMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<void, ResumeExecutionVariables>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = getInvestigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    mutationFn: ({blockId, executionId, inputId, responseData}) =>
+      fetchMutation<void>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/executions/${executionId}/`,
+        method: 'PATCH',
+        data: {input_id: inputId, response_data: responseData},
       }),
     onSuccess: async (_data, variables, onMutateResult, context) => {
       await Promise.all([

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -124,8 +124,9 @@ type UpdateBlockPromptVariables = {
   prompt: string;
 };
 
-type BlockIdVariables = {
-  blockId: string;
+type DeleteBlockVariables = {
+  block: InvestigationBlock;
+  investigationVersion: number;
 };
 
 type StopExecutionVariables = {
@@ -300,7 +301,7 @@ export function useAddInvestigationBlockMutation(
 export function useDeleteInvestigationBlockMutation(
   organizationSlug: string,
   investigationId: string,
-  options?: MutationOptions<void, BlockIdVariables>
+  options?: MutationOptions<void, DeleteBlockVariables>
 ) {
   const queryClient = useQueryClient();
   const detailOptions = getInvestigationDetailQueryOptions(
@@ -310,18 +311,12 @@ export function useDeleteInvestigationBlockMutation(
 
   return useMutation({
     ...options,
-    mutationFn: ({blockId}) => {
-      const investigation = queryClient.getQueryData(detailOptions.queryKey)?.json;
-      const block = investigation?.blocks?.find(item => item.id === blockId);
-      if (!investigation || !block) {
-        throw new Error('Investigation block is not cached.');
-      }
-
+    mutationFn: ({block, investigationVersion}) => {
       return fetchMutation<void>({
-        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/`,
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${block.id}/`,
         method: 'DELETE',
         data: {
-          investigationVersion: investigation.version,
+          investigationVersion,
           version: block.version,
         },
       });
@@ -335,7 +330,7 @@ export function useDeleteInvestigationBlockMutation(
                 ...current.json,
                 blockCount: Math.max(0, current.json.blockCount - 1),
                 blocks: current.json.blocks?.filter(
-                  block => block.id !== variables.blockId
+                  block => block.id !== variables.block.id
                 ),
                 version: current.json.version + 1,
               },

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -124,17 +124,6 @@ type UpdateBlockPromptVariables = {
   prompt: string;
 };
 
-type RenameBlockVariables = {
-  blockId: string;
-  title: string;
-};
-
-type RenameBlockResult = {
-  block: InvestigationBlock;
-  requestedBlockVersion: number;
-  requestedInvestigationVersion: number;
-};
-
 type BlockIdVariables = {
   blockId: string;
 };
@@ -460,97 +449,6 @@ export function useUpdateInvestigationBlockPromptMutation(
           : current
       );
       await options?.onSuccess?.(updatedBlock, variables, onMutateResult, context);
-    },
-    onError: async (error, variables, onMutateResult, context) => {
-      await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
-      await options?.onError?.(error, variables, onMutateResult, context);
-    },
-  });
-}
-
-export function useRenameInvestigationBlockMutation(
-  organizationSlug: string,
-  investigationId: string,
-  options?: MutationOptions<RenameBlockResult, RenameBlockVariables>
-) {
-  const queryClient = useQueryClient();
-  const detailOptions = getInvestigationDetailQueryOptions(
-    organizationSlug,
-    investigationId
-  );
-
-  return useMutation({
-    ...options,
-    scope: {id: `rename-investigation-block-${investigationId}`},
-    mutationFn: async ({blockId, title}) => {
-      const investigation = queryClient.getQueryData(detailOptions.queryKey)?.json;
-      const block = investigation?.blocks?.find(item => item.id === blockId);
-      if (!investigation || !block) {
-        throw new Error('Investigation block is not cached.');
-      }
-
-      const updated = await fetchMutation<InvestigationBlock>({
-        url: `/organizations/${organizationSlug}/investigations/${investigationId}/blocks/${blockId}/`,
-        method: 'PUT',
-        data: {
-          investigationVersion: investigation.version,
-          version: block.version,
-          title: title.trim(),
-        },
-      });
-      return {
-        block: updated,
-        requestedBlockVersion: block.version,
-        requestedInvestigationVersion: investigation.version,
-      };
-    },
-    onMutate: async variables => {
-      await queryClient.cancelQueries({queryKey: detailOptions.queryKey});
-      queryClient.setQueryData(detailOptions.queryKey, current =>
-        current
-          ? {
-              ...current,
-              json: {
-                ...current.json,
-                blocks: current.json.blocks?.map(block =>
-                  block.id === variables.blockId
-                    ? {...block, title: variables.title}
-                    : block
-                ),
-              },
-            }
-          : current
-      );
-    },
-    onSuccess: async (result, variables, onMutateResult, context) => {
-      const versionDelta = result.block.version === result.requestedBlockVersion ? 0 : 1;
-      queryClient.setQueryData(detailOptions.queryKey, current =>
-        current
-          ? {
-              ...current,
-              json: {
-                ...current.json,
-                blocks: current.json.blocks?.map(block =>
-                  block.id === result.block.id
-                    ? {
-                        ...result.block,
-                        // Keep a newer optimistic edit while this save was in flight.
-                        title:
-                          block.title === variables.title
-                            ? result.block.title
-                            : block.title,
-                      }
-                    : block
-                ),
-                version: Math.max(
-                  current.json.version,
-                  result.requestedInvestigationVersion + versionDelta
-                ),
-              },
-            }
-          : current
-      );
-      await options?.onSuccess?.(result, variables, onMutateResult, context);
     },
     onError: async (error, variables, onMutateResult, context) => {
       await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -234,6 +234,10 @@ export function useRenameInvestigationMutation(
           headers: current.headers,
           json: {
             ...updated,
+            // Preserve newer optimistic block state while the rename was in flight.
+            blocks: current.json.blocks,
+            blockCount: current.json.blockCount,
+            version: Math.max(current.json.version, updated.version),
             // Keep a newer optimistic title while this save was in flight.
             title: current.json.title === savedTitle ? updated.title : current.json.title,
           },

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -137,6 +137,55 @@ export function useLaunchInvestigationMutation(
   );
 }
 
+export function useRenameInvestigationMutation(
+  organizationSlug: string,
+  investigationId: string,
+  options?: MutationOptions<InvestigationDetail, string>
+) {
+  const queryClient = useQueryClient();
+  const detailOptions = investigationDetailQueryOptions(
+    organizationSlug,
+    investigationId
+  );
+
+  return useMutation({
+    ...options,
+    scope: {id: `rename-investigation-${investigationId}`},
+    mutationFn: title => {
+      const current = queryClient.getQueryData(detailOptions.queryKey)?.json;
+      if (!current) {
+        throw new Error('Investigation detail is not cached.');
+      }
+
+      return fetchMutation<InvestigationDetail>({
+        url: `/organizations/${organizationSlug}/investigations/${investigationId}/`,
+        method: 'PUT',
+        data: {title, investigationVersion: current.version},
+      });
+    },
+    onSuccess: async (updated, savedTitle, onMutateResult, context) => {
+      queryClient.setQueryData(detailOptions.queryKey, current => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          headers: current.headers,
+          json: {
+            ...updated,
+            // Keep a newer optimistic title while this save was in flight.
+            title: current.json.title === savedTitle ? updated.title : current.json.title,
+          },
+        };
+      });
+      await queryClient.invalidateQueries({
+        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
+      });
+      await options?.onSuccess?.(updated, savedTitle, onMutateResult, context);
+    },
+  });
+}
+
 export function useSetInvestigationFavoriteMutation(
   organizationSlug: string,
   options?: MutationOptions<void, FavoriteVariables>

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -12,6 +12,7 @@ import {TextArea} from '@sentry/scraps/textarea';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {Duration} from 'sentry/components/duration';
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
 import {ALL_SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
@@ -27,7 +28,7 @@ import {
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
-  investigationDetailQueryOptions,
+  getInvestigationDetailQueryOptions,
   investigationExecutionDetailQueryOptions,
   useDeleteInvestigationBlockMutation,
   useDuplicateInvestigationBlockMutation,
@@ -466,7 +467,7 @@ function RefinementPanel({
   useEffect(() => {
     if (status && !isExecutionActive(status) && status !== 'notRun') {
       void queryClient.invalidateQueries({
-        queryKey: investigationDetailQueryOptions(organizationSlug, investigation.id)
+        queryKey: getInvestigationDetailQueryOptions(organizationSlug, investigation.id)
           .queryKey,
       });
     }
@@ -514,7 +515,7 @@ function RefinementPanel({
             <IconSeer size="xs" />
             <Text monospace>{t('Ask Seer to refine')}</Text>
           </Flex>
-          {elapsed ? <TimerText monospace>{elapsed}</TimerText> : null}
+          {elapsed === null ? null : <ElapsedDuration milliseconds={elapsed} />}
         </Flex>
         <Stack gap="md">
           <RefinementPrompt>
@@ -563,7 +564,7 @@ function RefinementPanel({
         leadingItems={<IconSeer size="xs" animation={active ? 'waiting' : undefined} />}
         trailingItems={
           <Flex align="center" gap="sm">
-            {elapsed ? <TimerText monospace>{elapsed}</TimerText> : null}
+            {elapsed === null ? null : <ElapsedDuration milliseconds={elapsed} />}
             <Button
               size="xs"
               variant="transparent"
@@ -652,11 +653,17 @@ function Transcript({
   }
 
   return (
-    <TraceSurface data-test-id="investigation-transcript">
+    <TraceSurface
+      gap="md"
+      padding="md"
+      background="secondary"
+      radius="lg"
+      data-test-id="investigation-transcript"
+    >
       {explorerBlocks.map((block, index) => {
         const end =
           visibleBlocks[index + 1]?.timestamp ?? completedAt ?? (active ? now : null);
-        const duration = formatDurationBetween(block.timestamp, end);
+        const duration = getElapsedMilliseconds(block.timestamp, end);
         return (
           <TranscriptRow key={block.id}>
             <BlockComponent
@@ -666,7 +673,7 @@ function Transcript({
               readOnly
               showThinking
             />
-            {duration ? <TimerText monospace>{duration}</TimerText> : null}
+            {duration === null ? null : <ElapsedDuration milliseconds={duration} />}
           </TranscriptRow>
         );
       })}
@@ -733,7 +740,7 @@ function adaptTranscriptBlock(block: InvestigationTranscriptBlock): Block {
 
 function useElapsedTime(start: string | null, end: string | null, active: boolean) {
   const now = useNow(active);
-  return formatDurationBetween(start, end ?? (active ? now : null));
+  return getElapsedMilliseconds(start, end ?? (active ? now : null));
 }
 
 function useNow(active: boolean) {
@@ -748,7 +755,7 @@ function useNow(active: boolean) {
   return now;
 }
 
-function formatDurationBetween(start: string | null, end: string | null) {
+function getElapsedMilliseconds(start: string | null, end: string | null) {
   if (!start || !end) {
     return null;
   }
@@ -756,7 +763,15 @@ function formatDurationBetween(start: string | null, end: string | null) {
   if (!Number.isFinite(duration) || duration < 0) {
     return null;
   }
-  return `${(duration / 1000).toFixed(1)}s`;
+  return duration;
+}
+
+function ElapsedDuration({milliseconds}: {milliseconds: number}) {
+  return (
+    <Text monospace variant="muted">
+      <Duration seconds={milliseconds / 1000} fixedDigits={1} abbreviation />
+    </Text>
+  );
 }
 
 function getExecutionTitle(status: InvestigationExecutionStatus | undefined) {
@@ -936,11 +951,6 @@ const RefinementDisclosureContent = styled(Disclosure.Content)`
 `;
 
 const TraceSurface = styled(Stack)`
-  gap: ${p => p.theme.space.md};
-  padding: ${p => p.theme.space.md};
-  background: ${p => p.theme.tokens.background.secondary};
-  border-radius: ${p => p.theme.radius.lg};
-
   &,
   & * {
     font-family: ${p => p.theme.font.family.mono};
@@ -952,9 +962,4 @@ const TranscriptRow = styled('div')`
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
   gap: ${p => p.theme.space.md};
-`;
-
-const TimerText = styled(Text)`
-  flex-shrink: 0;
-  color: ${p => p.theme.tokens.content.secondary};
 `;

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -5,7 +5,7 @@ import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
@@ -746,7 +746,7 @@ function Transcript({
           visibleBlocks[index + 1]?.timestamp ?? completedAt ?? (active ? now : null);
         const duration = getElapsedMilliseconds(block.timestamp, end);
         return (
-          <TranscriptRow key={block.id}>
+          <Grid key={block.id} columns="minmax(0, 1fr) auto" align="start" gap="md">
             <BlockComponent
               block={block}
               blockIndex={index}
@@ -755,7 +755,7 @@ function Transcript({
               showThinking
             />
             {duration === null ? null : <ElapsedDuration milliseconds={duration} />}
-          </TranscriptRow>
+          </Grid>
         );
       })}
     </TraceSurface>
@@ -1036,11 +1036,4 @@ const TraceSurface = styled(Stack)`
   & * {
     font-family: ${p => p.theme.font.family.mono};
   }
-`;
-
-const TranscriptRow = styled('div')`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: ${p => p.theme.space.md};
 `;

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -771,6 +771,7 @@ function getSeriesName(series: {label: string} | {name: string}) {
 
 const CellSection = styled('section')<{$withDivider: boolean}>`
   width: 100%;
+  margin-bottom: ${p => (p.$withDivider ? p.theme.space.xl : 0)};
   padding: ${p => (p.$withDivider ? p.theme.space.xl : 0)} 0;
   border-bottom: ${p =>
     p.$withDivider ? `1px solid ${p.theme.tokens.border.primary}` : 'none'};

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 
@@ -31,7 +31,7 @@ import {
   getInvestigationDetailQueryOptions,
   investigationExecutionDetailQueryOptions,
   useDeleteInvestigationBlockMutation,
-  useDuplicateInvestigationBlockMutation,
+  useResumeInvestigationExecutionMutation,
   useRunInvestigationBlockMutation,
   useStopInvestigationExecutionMutation,
   useUpdateInvestigationBlockPromptMutation,
@@ -39,12 +39,15 @@ import {
 import type {
   InvestigationBlock,
   InvestigationDetail,
+  InvestigationExecutionDetail,
   InvestigationExecutionStatus,
   InvestigationQueryOutput,
   InvestigationTranscriptBlock,
 } from 'sentry/views/investigations/types';
 import {visibleCallRecords} from 'sentry/views/seerExplorer/callRecords';
+import {AskUserQuestionBlock} from 'sentry/views/seerExplorer/components/askUserQuestionBlock';
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import {usePendingUserInput} from 'sentry/views/seerExplorer/hooks/usePendingUserInput';
 import type {Block} from 'sentry/views/seerExplorer/types';
 
 type InvestigationCellProps = {
@@ -81,11 +84,6 @@ export function InvestigationCell({
     organizationSlug,
     investigation.id,
     {onError: () => addErrorMessage(t('Unable to rerun this cell.'))}
-  );
-  const duplicateMutation = useDuplicateInvestigationBlockMutation(
-    organizationSlug,
-    investigation.id,
-    {onError: () => addErrorMessage(t('Unable to duplicate this cell.'))}
   );
   const deleteMutation = useDeleteInvestigationBlockMutation(
     organizationSlug,
@@ -156,12 +154,6 @@ export function InvestigationCell({
           'aria-label': t('Cell actions for %s', displayTitle),
         }}
         items={[
-          {
-            key: 'duplicate',
-            label: t('Duplicate'),
-            disabled: !canRun || duplicateMutation.isPending,
-            onAction: () => duplicateMutation.mutate({blockId: block.id}),
-          },
           {
             key: 'delete',
             label: t('Delete'),
@@ -239,7 +231,7 @@ function CellResult({
   progressState: CellProgressState;
   refinementButton: React.ReactNode;
 }) {
-  const markdown = getTextOutput(block.output);
+  const markdown = getTextOutput(block.output) ?? (block.content.trim() || null);
   return (
     <Stack
       position="relative"
@@ -440,6 +432,11 @@ function RefinementPanel({
       onError: () => addErrorMessage(t('Unable to stop this Seer run.')),
     }
   );
+  const resumeMutation = useResumeInvestigationExecutionMutation(
+    organizationSlug,
+    investigation.id,
+    {onError: () => addErrorMessage(t('Unable to resume this Seer run.'))}
+  );
   const executionId = traceExecutionId;
   const executionOptions = investigationExecutionDetailQueryOptions({
     organizationSlug,
@@ -584,6 +581,20 @@ function RefinementPanel({
             completedAt={currentExecution?.completedAt ?? null}
             active={active}
           />
+          {executionId && execution?.pendingUserInput ? (
+            <PendingInvestigationQuestion
+              pendingInput={execution.pendingUserInput}
+              responding={resumeMutation.isPending}
+              onRespond={(inputId, responseData) =>
+                resumeMutation.mutate({
+                  blockId: block.id,
+                  executionId,
+                  inputId,
+                  responseData,
+                })
+              }
+            />
+          ) : null}
           {execution?.transcriptTruncated ? (
             <Text size="sm" variant="muted">
               {t('Earlier steps are not shown.')}
@@ -626,6 +637,76 @@ function RefinementPanel({
         </Stack>
       </RefinementDisclosureContent>
     </RefinementDisclosure>
+  );
+}
+
+function PendingInvestigationQuestion({
+  onRespond,
+  pendingInput,
+  responding,
+}: {
+  onRespond: (inputId: string, responseData: {answers: string[]}) => void;
+  pendingInput: NonNullable<InvestigationExecutionDetail['pendingUserInput']>;
+  responding: boolean;
+}) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const userScrolledUpRef = useRef(false);
+  const {
+    canSubmitQuestion,
+    currentQuestion,
+    customText,
+    handleQuestionBack,
+    handleQuestionCustomTextChange,
+    handleQuestionNext,
+    handleQuestionSelectOption,
+    isOtherSelected,
+    questionIndex,
+    selectedOption,
+    totalQuestions,
+  } = usePendingUserInput({
+    isAwaitingUserInput: true,
+    pendingInput,
+    respondToUserInput: (inputId, responseData) => {
+      if (responseData && 'answers' in responseData) {
+        onRespond(inputId, responseData);
+      }
+    },
+    scrollContainerRef,
+    userScrolledUpRef,
+  });
+
+  if (!currentQuestion) {
+    return null;
+  }
+
+  return (
+    <Stack ref={scrollContainerRef} gap="sm" data-test-id="investigation-question">
+      <AskUserQuestionBlock
+        currentQuestion={currentQuestion}
+        customText={customText}
+        isOtherSelected={isOtherSelected}
+        onCustomTextChange={handleQuestionCustomTextChange}
+        onSelectOption={handleQuestionSelectOption}
+        questionIndex={questionIndex}
+        selectedOption={selectedOption}
+      />
+      <Flex align="center" justify="end" gap="sm">
+        {questionIndex > 0 ? (
+          <Button size="sm" onClick={handleQuestionBack} disabled={responding}>
+            {t('Back')}
+          </Button>
+        ) : null}
+        <Button
+          size="sm"
+          variant="primary"
+          busy={responding}
+          disabled={!canSubmitQuestion}
+          onClick={handleQuestionNext}
+        >
+          {questionIndex + 1 === totalQuestions ? t('Submit') : t('Next')}
+        </Button>
+      </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -1,0 +1,910 @@
+import {Fragment, useEffect, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+import {TextArea} from '@sentry/scraps/textarea';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
+import {ALL_SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
+import {
+  IconArrow,
+  IconChevron,
+  IconClose,
+  IconEllipsis,
+  IconRefresh,
+  IconReturn,
+  IconSeer,
+} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  investigationDetailQueryOptions,
+  investigationExecutionDetailQueryOptions,
+  useDeleteInvestigationBlockMutation,
+  useDuplicateInvestigationBlockMutation,
+  useRunInvestigationBlockMutation,
+  useStopInvestigationExecutionMutation,
+  useUpdateInvestigationBlockPromptMutation,
+} from 'sentry/views/investigations/api';
+import type {
+  InvestigationBlock,
+  InvestigationDetail,
+  InvestigationExecutionStatus,
+  InvestigationQueryOutput,
+  InvestigationTranscriptBlock,
+} from 'sentry/views/investigations/types';
+import {visibleCallRecords} from 'sentry/views/seerExplorer/callRecords';
+import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import type {Block, CallRecord} from 'sentry/views/seerExplorer/types';
+
+type InvestigationCellProps = {
+  block: InvestigationBlock;
+  canRun: boolean;
+  investigation: InvestigationDetail;
+};
+
+export function InvestigationCell({
+  block,
+  canRun,
+  investigation,
+}: InvestigationCellProps) {
+  const organizationSlug = useOrganization().slug;
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [traceExecutionId, setTraceExecutionId] = useState<string | null>(null);
+  const [showPrompt, setShowPrompt] = useState(true);
+  const [prompt, setPrompt] = useState(() =>
+    block.outputStatus === 'notRun' ? block.generationPrompt : ''
+  );
+
+  const chartTitle =
+    block.kind === 'query'
+      ? getRenderableChart(getQueryOutput(block.output)?.chart ?? null)?.title
+      : null;
+  const displayTitle =
+    block.title ||
+    chartTitle ||
+    (block.kind === 'query' ? t('Untitled query') : t('Untitled cell'));
+  const rerunMutation = useRunInvestigationBlockMutation(
+    organizationSlug,
+    investigation.id,
+    {onError: () => addErrorMessage(t('Unable to rerun this cell.'))}
+  );
+  const duplicateMutation = useDuplicateInvestigationBlockMutation(
+    organizationSlug,
+    investigation.id,
+    {onError: () => addErrorMessage(t('Unable to duplicate this cell.'))}
+  );
+  const deleteMutation = useDeleteInvestigationBlockMutation(
+    organizationSlug,
+    investigation.id,
+    {onError: () => addErrorMessage(t('Unable to delete this cell.'))}
+  );
+
+  function openPanel() {
+    setPanelOpen(true);
+    if (block.currentExecution && isExecutionActive(block.currentExecution.status)) {
+      setTraceExecutionId(block.currentExecution.id);
+      setShowPrompt(false);
+      return;
+    }
+    setShowPrompt(true);
+    setPrompt(block.outputStatus === 'notRun' ? block.generationPrompt : '');
+  }
+
+  async function rerun() {
+    try {
+      const execution = await rerunMutation.mutateAsync({
+        block,
+        investigationVersion: investigation.version,
+      });
+      setPanelOpen(true);
+      setTraceExecutionId(execution.id);
+      setShowPrompt(false);
+    } catch {
+      // The mutation owns user-facing error handling.
+    }
+  }
+
+  const refinementButton = (
+    <Button
+      size="xs"
+      variant="transparent"
+      icon={<IconSeer size="xs" />}
+      aria-label={t('Ask Seer about %s', displayTitle)}
+      onClick={panelOpen ? () => setPanelOpen(false) : openPanel}
+    />
+  );
+
+  const queryHeaderActions = (
+    <Flex align="center" gap="xs" flexShrink={0}>
+      {refinementButton}
+      <Button
+        size="xs"
+        variant="transparent"
+        icon={<IconRefresh size="xs" />}
+        aria-label={t('Rerun %s', displayTitle)}
+        busy={rerunMutation.isPending}
+        disabled={
+          !canRun ||
+          isExecutionActive(block.currentExecution?.status) ||
+          !(block.generationPrompt || block.content).trim()
+        }
+        onClick={() => void rerun()}
+      />
+      <DropdownMenu
+        position="bottom-end"
+        usePortal
+        triggerProps={{
+          size: 'xs',
+          variant: 'transparent',
+          showChevron: false,
+          icon: <IconEllipsis size="xs" />,
+          'aria-label': t('Cell actions for %s', displayTitle),
+        }}
+        items={[
+          {
+            key: 'duplicate',
+            label: t('Duplicate'),
+            disabled: !canRun || duplicateMutation.isPending,
+            onAction: () => duplicateMutation.mutate({blockId: block.id}),
+          },
+          {
+            key: 'delete',
+            label: t('Delete'),
+            priority: 'danger',
+            disabled:
+              !canRun ||
+              deleteMutation.isPending ||
+              isExecutionActive(block.currentExecution?.status),
+            onAction: () =>
+              openConfirmModal({
+                message: t('Are you sure you want to delete this cell?'),
+                priority: 'danger',
+                confirmText: t('Delete'),
+                onConfirm: () => deleteMutation.mutate({blockId: block.id}),
+              }),
+          },
+        ]}
+      />
+    </Flex>
+  );
+
+  const panel = panelOpen ? (
+    <RefinementPanel
+      block={block}
+      canRun={canRun}
+      investigation={investigation}
+      prompt={prompt}
+      setPrompt={setPrompt}
+      showPrompt={showPrompt}
+      setShowPrompt={setShowPrompt}
+      traceExecutionId={traceExecutionId}
+      setTraceExecutionId={setTraceExecutionId}
+      onClose={() => setPanelOpen(false)}
+    />
+  ) : null;
+
+  return (
+    <CellSection
+      $withDivider={block.kind === 'query'}
+      data-test-id={`investigation-cell-${block.id}`}
+      data-has-divider={block.kind === 'query'}
+    >
+      {block.kind === 'query' ? (
+        <Fragment>
+          <QueryResult actions={queryHeaderActions} block={block} />
+          {panel}
+        </Fragment>
+      ) : (
+        <Fragment>
+          <CellResult block={block} refinementButton={refinementButton} />
+          {panel}
+        </Fragment>
+      )}
+    </CellSection>
+  );
+}
+
+function CellResult({
+  block,
+  refinementButton,
+}: {
+  block: InvestigationBlock;
+  refinementButton: React.ReactNode;
+}) {
+  const markdown = getTextOutput(block.output);
+  return (
+    <TextResult data-test-id="text-cell-result" data-cell-variant="unbordered">
+      <TextCellAction>{refinementButton}</TextCellAction>
+      {markdown ? (
+        <SeerMarkdown raw={markdown} />
+      ) : (
+        <Text variant="muted">{t('This cell has no output yet.')}</Text>
+      )}
+    </TextResult>
+  );
+}
+
+function QueryResult({
+  actions,
+  block,
+}: {
+  actions: React.ReactNode;
+  block: InvestigationBlock;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const output = getQueryOutput(block.output);
+  const chart =
+    output?.preferredView === 'chart' ? getRenderableChart(output.chart) : null;
+  const title = block.title || chart?.title || t('Untitled query');
+  const chartHeaderTitle = getDisplayText(block.display, 'title') || chart?.title;
+  const chartHeaderMetadata =
+    getDisplayText(block.display, 'subtitle') ||
+    chart?.subtitle ||
+    getChartMetadata(chart);
+
+  return (
+    <QueryResultContainer>
+      <QueryDisclosureButton
+        type="button"
+        aria-label={t('Toggle %s', title)}
+        aria-expanded={expanded}
+        onClick={() => setExpanded(value => !value)}
+      >
+        <IconChevron direction={expanded ? 'down' : 'right'} size="xs" />
+        <QueryCellTitle data-test-id="query-cell-title" size="sm" tabular>
+          {title}
+        </QueryCellTitle>
+      </QueryDisclosureButton>
+      {expanded ? (
+        <QueryResultCard data-test-id="query-cell-result" data-cell-variant="bordered">
+          <QueryResultHeader
+            align="start"
+            justify="between"
+            gap="md"
+            data-test-id="query-cell-header"
+          >
+            <Stack gap="2xs" minWidth={0} flex={1}>
+              <Heading as="h3" size="md">
+                {chartHeaderTitle || title}
+              </Heading>
+              {chartHeaderMetadata ? (
+                <Text size="sm" variant="muted">
+                  {chartHeaderMetadata}
+                </Text>
+              ) : null}
+            </Stack>
+            {actions}
+          </QueryResultHeader>
+          <QueryResultBody $withPadding={Boolean(chart)}>
+            {chart ? (
+              <ChartContent data={chart} showHeader={false} />
+            ) : output?.tableMarkdown ? (
+              <SeerMarkdown raw={output.tableMarkdown} components={{Table: FlushTable}} />
+            ) : (
+              <Text variant="muted">{t('This cell has no output yet.')}</Text>
+            )}
+          </QueryResultBody>
+        </QueryResultCard>
+      ) : null}
+    </QueryResultContainer>
+  );
+}
+
+function FlushTable({children}: {children: React.ReactNode}) {
+  return (
+    <Container overflowX="auto">
+      <QueryTable>{children}</QueryTable>
+    </Container>
+  );
+}
+
+type RefinementPanelProps = {
+  block: InvestigationBlock;
+  canRun: boolean;
+  investigation: InvestigationDetail;
+  onClose: () => void;
+  prompt: string;
+  setPrompt: (prompt: string) => void;
+  setShowPrompt: (showPrompt: boolean) => void;
+  setTraceExecutionId: (executionId: string | null) => void;
+  showPrompt: boolean;
+  traceExecutionId: string | null;
+};
+
+function RefinementPanel({
+  block,
+  canRun,
+  investigation,
+  onClose,
+  prompt,
+  setPrompt,
+  setShowPrompt,
+  setTraceExecutionId,
+  showPrompt,
+  traceExecutionId,
+}: RefinementPanelProps) {
+  const organizationSlug = useOrganization().slug;
+  const queryClient = useQueryClient();
+  const updatePromptMutation = useUpdateInvestigationBlockPromptMutation(
+    organizationSlug,
+    investigation.id
+  );
+  const runMutation = useRunInvestigationBlockMutation(
+    organizationSlug,
+    investigation.id
+  );
+  const stopMutation = useStopInvestigationExecutionMutation(
+    organizationSlug,
+    investigation.id,
+    {
+      onError: () => addErrorMessage(t('Unable to stop this Seer run.')),
+    }
+  );
+  const executionId = traceExecutionId;
+  const executionOptions = investigationExecutionDetailQueryOptions({
+    organizationSlug,
+    investigationId: investigation.id,
+    blockId: block.id,
+    executionId: executionId ?? 'disabled',
+  });
+  const executionQuery = useQuery({
+    ...executionOptions,
+    enabled: Boolean(executionId),
+    refetchInterval: query =>
+      isExecutionActive(query.state.data?.json.status) ? 1000 : false,
+  });
+  const execution = executionQuery.data;
+  const currentExecution =
+    block.currentExecution?.id === executionId ? block.currentExecution : null;
+  const status = execution?.status ?? currentExecution?.status;
+  const active = isExecutionActive(status);
+  const elapsed = useElapsedTime(
+    currentExecution?.startedAt ?? execution?.blocks[0]?.timestamp ?? null,
+    currentExecution?.completedAt ?? null,
+    active
+  );
+
+  useEffect(() => {
+    if (status && !isExecutionActive(status) && status !== 'notRun') {
+      void queryClient.invalidateQueries({
+        queryKey: investigationDetailQueryOptions(organizationSlug, investigation.id)
+          .queryKey,
+      });
+    }
+  }, [investigation.id, organizationSlug, queryClient, status]);
+
+  async function submit() {
+    const nextPrompt = prompt.trim();
+    if (!nextPrompt) {
+      return;
+    }
+
+    try {
+      const updatedBlock = await updatePromptMutation.mutateAsync({
+        block,
+        investigationVersion: investigation.version,
+        prompt: nextPrompt,
+      });
+      const investigationVersion =
+        investigation.version + (updatedBlock.version === block.version ? 0 : 1);
+      const started = await runMutation.mutateAsync({
+        block: updatedBlock,
+        investigationVersion,
+      });
+      setTraceExecutionId(started.id);
+      setShowPrompt(false);
+    } catch {
+      addErrorMessage(t('Unable to start this Seer run.'));
+    }
+  }
+
+  function handlePromptKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      void submit();
+    }
+  }
+
+  const isSubmitting = updatePromptMutation.isPending || runMutation.isPending;
+
+  if (showPrompt) {
+    return (
+      <RefinementComposer>
+        <Flex align="center" justify="between" gap="sm">
+          <Flex align="center" gap="sm">
+            <IconSeer size="xs" />
+            <Text monospace>{t('Ask Seer to refine')}</Text>
+          </Flex>
+          {elapsed ? <TimerText monospace>{elapsed}</TimerText> : null}
+        </Flex>
+        <Stack gap="md">
+          <RefinementPrompt>
+            <RefinementTextArea
+              aria-label={t('Instructions for Seer')}
+              autosize
+              autoFocus
+              rows={3}
+              placeholder={t(
+                "Tell Seer how you'd like to refine or explore this analysis"
+              )}
+              value={prompt}
+              onChange={event => setPrompt(event.target.value)}
+              onKeyDown={handlePromptKeyDown}
+            />
+            <RefinementReturnIcon aria-hidden="true">
+              <IconReturn size="xs" />
+            </RefinementReturnIcon>
+          </RefinementPrompt>
+          <Flex align="center" gap="sm">
+            <Button
+              size="sm"
+              icon={<IconClose size="xs" />}
+              aria-label={t('Cancel Seer request')}
+              onClick={onClose}
+              disabled={isSubmitting}
+            />
+            <Button
+              size="sm"
+              icon={<IconArrow direction="right" size="xs" />}
+              busy={isSubmitting}
+              disabled={!canRun || !prompt.trim()}
+              onClick={() => void submit()}
+            >
+              {t('Submit')}
+            </Button>
+          </Flex>
+        </Stack>
+      </RefinementComposer>
+    );
+  }
+
+  return (
+    <RefinementDisclosure defaultExpanded size="sm">
+      <Disclosure.Title
+        leadingItems={<IconSeer size="xs" animation={active ? 'waiting' : undefined} />}
+        trailingItems={
+          <Flex align="center" gap="sm">
+            {elapsed ? <TimerText monospace>{elapsed}</TimerText> : null}
+            <Button
+              size="xs"
+              variant="transparent"
+              icon={<IconClose size="xs" />}
+              aria-label={t('Close Seer panel')}
+              onClick={onClose}
+            />
+          </Flex>
+        }
+      >
+        <Text monospace>{getExecutionTitle(status)}</Text>
+      </Disclosure.Title>
+      <RefinementDisclosureContent>
+        <Stack gap="md">
+          <Transcript
+            blocks={execution?.blocks ?? []}
+            completedAt={currentExecution?.completedAt ?? null}
+            active={active}
+          />
+          {execution?.transcriptTruncated ? (
+            <Text size="sm" variant="muted">
+              {t('Earlier steps are not shown.')}
+            </Text>
+          ) : null}
+          {status === 'failed' || status === 'cancelled' ? (
+            <Alert.Container>
+              <Alert variant={status === 'failed' ? 'danger' : 'warning'}>
+                {status === 'failed'
+                  ? execution?.error?.message ||
+                    currentExecution?.error?.message ||
+                    t('This Seer run failed.')
+                  : t('This Seer run was cancelled.')}
+              </Alert>
+            </Alert.Container>
+          ) : null}
+          <Flex align="center" gap="sm">
+            {active && executionId ? (
+              <Button
+                size="sm"
+                busy={stopMutation.isPending}
+                onClick={() => stopMutation.mutate({blockId: block.id, executionId})}
+              >
+                {t('Stop')}
+              </Button>
+            ) : null}
+            {status && !active ? (
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => {
+                  setPrompt('');
+                  setShowPrompt(true);
+                }}
+              >
+                {t('Ask Seer again')}
+              </Button>
+            ) : null}
+          </Flex>
+        </Stack>
+      </RefinementDisclosureContent>
+    </RefinementDisclosure>
+  );
+}
+
+function Transcript({
+  active,
+  blocks,
+  completedAt,
+}: {
+  active: boolean;
+  blocks: InvestigationTranscriptBlock[];
+  completedAt: string | null;
+}) {
+  const now = useNow(active);
+  const visibleBlocks = useMemo(
+    () => blocks.filter(isRenderableTranscriptBlock),
+    [blocks]
+  );
+  const explorerBlocks = useMemo(
+    () => visibleBlocks.map(adaptTranscriptBlock),
+    [visibleBlocks]
+  );
+
+  if (visibleBlocks.length === 0) {
+    return <Text variant="muted">{active ? t('Starting Seer…') : t('No steps')}</Text>;
+  }
+
+  return (
+    <TraceSurface data-test-id="investigation-transcript">
+      {explorerBlocks.map((block, index) => {
+        const end =
+          visibleBlocks[index + 1]?.timestamp ?? completedAt ?? (active ? now : null);
+        const duration = formatDurationBetween(block.timestamp, end);
+        return (
+          <TranscriptRow key={block.id}>
+            <BlockComponent
+              block={block}
+              blockIndex={index}
+              blocks={explorerBlocks}
+              readOnly
+              showThinking
+            />
+            {duration ? <TimerText monospace>{duration}</TimerText> : null}
+          </TranscriptRow>
+        );
+      })}
+    </TraceSurface>
+  );
+}
+
+function isInternalPromptBlock(block: InvestigationTranscriptBlock, index: number) {
+  return (
+    index === 0 &&
+    block.message.role === 'user' &&
+    typeof block.message.content === 'string' &&
+    block.message.content.includes('<investigation_context>')
+  );
+}
+
+function isRenderableTranscriptBlock(block: InvestigationTranscriptBlock, index: number) {
+  if (isInternalPromptBlock(block, index)) {
+    return false;
+  }
+  if (block.loading || block.message.content?.trim()) {
+    return true;
+  }
+  if (block.message.role !== 'tool_use') {
+    return false;
+  }
+  if (block.message.thinking_content?.trim() || block.toolLinks?.some(Boolean)) {
+    return true;
+  }
+
+  const codeModeFunctions = new Set(['sentry_api_execute', 'sentry_api_search']);
+  if (block.message.tool_calls?.some(call => !codeModeFunctions.has(call.function))) {
+    return true;
+  }
+
+  return Boolean(
+    block.toolResults?.some(result => {
+      const structuredContent = result?.structuredContent;
+      if (!structuredContent) {
+        return false;
+      }
+      const calls = Array.isArray(structuredContent.calls)
+        ? (structuredContent.calls as CallRecord[])
+        : [];
+      return (
+        visibleCallRecords(calls).length > 0 ||
+        (Array.isArray(structuredContent.links) && structuredContent.links.length > 0) ||
+        (Array.isArray(structuredContent.todos) && structuredContent.todos.length > 0) ||
+        result.content.trimStart().startsWith('{%')
+      );
+    })
+  );
+}
+
+function adaptTranscriptBlock(block: InvestigationTranscriptBlock): Block {
+  return {
+    id: block.id,
+    timestamp: block.timestamp,
+    loading: block.loading,
+    message: block.message,
+    artifacts: block.artifacts,
+    tool_links: block.toolLinks,
+    tool_results: block.toolResults,
+  };
+}
+
+function useElapsedTime(start: string | null, end: string | null, active: boolean) {
+  const now = useNow(active);
+  return formatDurationBetween(start, end ?? (active ? now : null));
+}
+
+function useNow(active: boolean) {
+  const [now, setNow] = useState(() => new Date().toISOString());
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const interval = window.setInterval(() => setNow(new Date().toISOString()), 250);
+    return () => window.clearInterval(interval);
+  }, [active]);
+  return now;
+}
+
+function formatDurationBetween(start: string | null, end: string | null) {
+  if (!start || !end) {
+    return null;
+  }
+  const duration = Date.parse(end) - Date.parse(start);
+  if (!Number.isFinite(duration) || duration < 0) {
+    return null;
+  }
+  return `${(duration / 1000).toFixed(1)}s`;
+}
+
+function getExecutionTitle(status: InvestigationExecutionStatus | undefined) {
+  if (isExecutionActive(status)) {
+    return t('Working on this analysis…');
+  }
+  if (status === 'failed') {
+    return t('Seer run failed');
+  }
+  if (status === 'cancelled') {
+    return t('Seer run cancelled');
+  }
+  return t('Analysis complete');
+}
+
+function isExecutionActive(status: InvestigationExecutionStatus | undefined) {
+  return Boolean(
+    status && ['pending', 'running', 'awaiting_input', 'stopping'].includes(status)
+  );
+}
+
+function getTextOutput(output: unknown): string | null {
+  if (!output || typeof output !== 'object') {
+    return null;
+  }
+  return 'markdown' in output && typeof output.markdown === 'string'
+    ? output.markdown
+    : null;
+}
+
+function getQueryOutput(output: unknown): InvestigationQueryOutput | null {
+  if (
+    !output ||
+    typeof output !== 'object' ||
+    !('tableMarkdown' in output) ||
+    typeof output.tableMarkdown !== 'string' ||
+    !('preferredView' in output) ||
+    (output.preferredView !== 'chart' && output.preferredView !== 'table')
+  ) {
+    return null;
+  }
+  return output as InvestigationQueryOutput;
+}
+
+function getRenderableChart(chart: Record<string, unknown> | null) {
+  if (!chart) {
+    return null;
+  }
+  const {subtitle, ...chartWithoutSubtitle} = chart;
+  const normalizedChart = subtitle === null ? chartWithoutSubtitle : chart;
+  const parsed = ALL_SEER_EMBED_SCHEMAS.chart.schema.safeParse(normalizedChart);
+  return parsed.success ? parsed.data : null;
+}
+
+function getDisplayText(display: Record<string, unknown>, field: string) {
+  const value = display[field];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function getChartMetadata(chart: ReturnType<typeof getRenderableChart>) {
+  if (!chart) {
+    return null;
+  }
+
+  const values = chart.series.flatMap(series => series.data.map(point => point.y));
+  const total = values.reduce((sum, value) => sum + value, 0);
+  const firstSeries = chart.series[0];
+  const seriesName = firstSeries ? getSeriesName(firstSeries) : null;
+  const totalMetadata = Number.isFinite(total)
+    ? seriesName
+      ? t('%s total %s', new Intl.NumberFormat().format(total), seriesName)
+      : t('%s total', new Intl.NumberFormat().format(total))
+    : null;
+
+  if (chart.x_axis !== 'time') {
+    return totalMetadata;
+  }
+
+  const timestamps = chart.series
+    .flatMap(series => series.data.map(point => Date.parse(String(point.x))))
+    .filter(Number.isFinite);
+  if (timestamps.length === 0) {
+    return totalMetadata;
+  }
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  const start = formatter.format(new Date(Math.min(...timestamps)));
+  const end = formatter.format(new Date(Math.max(...timestamps)));
+  const range = start === end ? start : `${start}–${end}`;
+  return totalMetadata ? `${range} | ${totalMetadata}` : range;
+}
+
+function getSeriesName(series: {label: string} | {name: string}) {
+  return 'label' in series ? series.label : series.name;
+}
+
+const CellSection = styled('section')<{$withDivider: boolean}>`
+  width: 100%;
+  padding: ${p => (p.$withDivider ? p.theme.space.xl : 0)} 0;
+  border-bottom: ${p =>
+    p.$withDivider ? `1px solid ${p.theme.tokens.border.primary}` : 'none'};
+`;
+
+const TextResult = styled(Stack)`
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const TextCellAction = styled('div')`
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
+
+const QueryResultContainer = styled(Stack)`
+  width: 100%;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const QueryDisclosureButton = styled('button')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  width: 100%;
+  margin: 0;
+  padding: ${p => p.theme.space.sm};
+  color: ${p => p.theme.tokens.content.primary};
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: ${p => p.theme.radius.md};
+  cursor: pointer;
+
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+`;
+
+const QueryCellTitle = styled(Text)`
+  color: ${p => p.theme.tokens.content.primary};
+  font-style: normal;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  line-height: 1.4;
+  letter-spacing: normal;
+  vertical-align: middle;
+  font-variant-numeric: lining-nums tabular-nums;
+`;
+
+const QueryResultCard = styled(Stack)`
+  width: 100%;
+  flex: 1;
+  min-width: 0;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+`;
+
+const QueryResultHeader = styled(Flex)`
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  background: ${p => p.theme.tokens.background.secondary};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const QueryResultBody = styled('div')<{$withPadding: boolean}>`
+  box-sizing: border-box;
+  width: 100%;
+  overflow: hidden;
+  padding: ${p => (p.$withPadding ? `${p.theme.space.md} ${p.theme.space.lg}` : 0)};
+`;
+
+const QueryTable = styled('table')`
+  min-width: 100%;
+  border-collapse: collapse;
+`;
+
+const RefinementDisclosure = styled(Disclosure)`
+  width: 100%;
+  margin-top: ${p => p.theme.space.lg};
+`;
+
+const RefinementComposer = styled(Stack)`
+  width: 100%;
+  margin-top: ${p => p.theme.space.lg};
+  gap: ${p => p.theme.space.md};
+`;
+
+const RefinementPrompt = styled('div')`
+  position: relative;
+`;
+
+const RefinementTextArea = styled(TextArea)`
+  width: 100%;
+  padding-right: ${p => p.theme.space['2xl']};
+`;
+
+const RefinementReturnIcon = styled('span')`
+  position: absolute;
+  top: ${p => p.theme.space.md};
+  right: ${p => p.theme.space.md};
+  color: ${p => p.theme.tokens.content.secondary};
+  pointer-events: none;
+`;
+
+const RefinementDisclosureContent = styled(Disclosure.Content)`
+  && {
+    padding: ${p => p.theme.space.sm} 0 0;
+  }
+`;
+
+const TraceSurface = styled(Stack)`
+  gap: ${p => p.theme.space.md};
+  padding: ${p => p.theme.space.md};
+  background: ${p => p.theme.tokens.background.secondary};
+  border-radius: ${p => p.theme.radius.lg};
+
+  &,
+  & * {
+    font-family: ${p => p.theme.font.family.mono};
+  }
+`;
+
+const TranscriptRow = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: ${p => p.theme.space.md};
+`;
+
+const TimerText = styled(Text)`
+  flex-shrink: 0;
+  color: ${p => p.theme.tokens.content.secondary};
+`;

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -64,6 +64,9 @@ export function InvestigationCell({
   const [prompt, setPrompt] = useState(() =>
     block.outputStatus === 'notRun' ? block.generationPrompt : ''
   );
+  const progressState = getCellProgressState(block, investigation.blocks ?? []);
+  const waitingForDependencies =
+    progressState === 'waiting' || progressState === 'blocked';
 
   const chartTitle =
     block.kind === 'query'
@@ -120,6 +123,7 @@ export function InvestigationCell({
       variant="transparent"
       icon={<IconSeer size="xs" />}
       aria-label={t('Ask Seer about %s', displayTitle)}
+      disabled={waitingForDependencies}
       onClick={panelOpen ? () => setPanelOpen(false) : openPanel}
     />
   );
@@ -201,12 +205,20 @@ export function InvestigationCell({
     >
       {block.kind === 'query' ? (
         <Fragment>
-          <QueryResult actions={queryHeaderActions} block={block} />
+          <QueryResult
+            actions={queryHeaderActions}
+            block={block}
+            progressState={progressState}
+          />
           {panel}
         </Fragment>
       ) : (
         <Fragment>
-          <CellResult block={block} refinementButton={refinementButton} />
+          <CellResult
+            block={block}
+            progressState={progressState}
+            refinementButton={refinementButton}
+          />
           {panel}
         </Fragment>
       )}
@@ -216,9 +228,11 @@ export function InvestigationCell({
 
 function CellResult({
   block,
+  progressState,
   refinementButton,
 }: {
   block: InvestigationBlock;
+  progressState: CellProgressState;
   refinementButton: React.ReactNode;
 }) {
   const markdown = getTextOutput(block.output);
@@ -228,7 +242,7 @@ function CellResult({
       {markdown ? (
         <SeerMarkdown raw={markdown} />
       ) : (
-        <Text variant="muted">{t('This cell has no output yet.')}</Text>
+        <CellProgress state={progressState} />
       )}
     </TextResult>
   );
@@ -237,9 +251,11 @@ function CellResult({
 function QueryResult({
   actions,
   block,
+  progressState,
 }: {
   actions: React.ReactNode;
   block: InvestigationBlock;
+  progressState: CellProgressState;
 }) {
   const [expanded, setExpanded] = useState(true);
   const output = getQueryOutput(block.output);
@@ -291,13 +307,63 @@ function QueryResult({
             ) : output?.tableMarkdown ? (
               <SeerMarkdown raw={output.tableMarkdown} components={{Table: FlushTable}} />
             ) : (
-              <Text variant="muted">{t('This cell has no output yet.')}</Text>
+              <QueryCellProgress>
+                <CellProgress state={progressState} />
+              </QueryCellProgress>
             )}
           </QueryResultBody>
         </QueryResultCard>
       ) : null}
     </QueryResultContainer>
   );
+}
+
+type CellProgressState = 'running' | 'waiting' | 'blocked' | null;
+
+function CellProgress({state}: {state: CellProgressState}) {
+  if (!state) {
+    return <Text variant="muted">{t('This cell has no output yet.')}</Text>;
+  }
+  let message = t('Waiting for a successful result from previous cells.');
+  if (state === 'running') {
+    message = t('Seer is working on this cell…');
+  } else if (state === 'waiting') {
+    message = t('Waiting for previous cells…');
+  }
+  return (
+    <Flex align="center" gap="xs" data-test-id={`cell-progress-${state}`}>
+      <IconSeer size="xs" animation={state === 'blocked' ? undefined : 'waiting'} />
+      <Text variant="muted">{message}</Text>
+    </Flex>
+  );
+}
+
+function getCellProgressState(
+  block: InvestigationBlock,
+  blocks: InvestigationBlock[]
+): CellProgressState {
+  if (isExecutionActive(block.currentExecution?.status)) {
+    return 'running';
+  }
+  if (
+    block.currentExecution ||
+    block.config.autoRun !== true ||
+    block.dependencies.length === 0
+  ) {
+    return null;
+  }
+  const dependencies = block.dependencies.flatMap(dependencyId => {
+    const dependency = blocks.find(candidate => candidate.id === dependencyId);
+    return dependency ? [dependency] : [];
+  });
+  if (
+    dependencies.some(dependency =>
+      ['failed', 'cancelled'].includes(dependency.currentExecution?.status ?? '')
+    )
+  ) {
+    return 'blocked';
+  }
+  return 'waiting';
 }
 
 function FlushTable({children}: {children: React.ReactNode}) {
@@ -845,6 +911,10 @@ const QueryResultBody = styled('div')<{$withPadding: boolean}>`
   width: 100%;
   overflow: hidden;
   padding: ${p => (p.$withPadding ? `${p.theme.space.md} ${p.theme.space.lg}` : 0)};
+`;
+
+const QueryCellProgress = styled('div')`
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
 `;
 
 const QueryTable = styled('table')`

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -44,7 +44,7 @@ import type {
 } from 'sentry/views/investigations/types';
 import {visibleCallRecords} from 'sentry/views/seerExplorer/callRecords';
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
-import type {Block, CallRecord} from 'sentry/views/seerExplorer/types';
+import type {Block} from 'sentry/views/seerExplorer/types';
 
 type InvestigationCellProps = {
   block: InvestigationBlock;
@@ -198,8 +198,11 @@ export function InvestigationCell({
   ) : null;
 
   return (
-    <CellSection
-      $withDivider={block.kind === 'query'}
+    <Stack
+      as="section"
+      width="100%"
+      padding={block.kind === 'query' ? 'xl 0' : '0'}
+      borderBottom={block.kind === 'query' ? 'primary' : undefined}
       data-test-id={`investigation-cell-${block.id}`}
       data-has-divider={block.kind === 'query'}
     >
@@ -222,7 +225,7 @@ export function InvestigationCell({
           {panel}
         </Fragment>
       )}
-    </CellSection>
+    </Stack>
   );
 }
 
@@ -237,14 +240,23 @@ function CellResult({
 }) {
   const markdown = getTextOutput(block.output);
   return (
-    <TextResult data-test-id="text-cell-result" data-cell-variant="unbordered">
-      <TextCellAction>{refinementButton}</TextCellAction>
+    <Stack
+      position="relative"
+      flex={1}
+      minWidth={0}
+      gap="sm"
+      data-test-id="text-cell-result"
+      data-cell-variant="unbordered"
+    >
+      <Container position="absolute" top={0} right={0}>
+        {refinementButton}
+      </Container>
       {markdown ? (
         <SeerMarkdown raw={markdown} />
       ) : (
         <CellProgress state={progressState} />
       )}
-    </TextResult>
+    </Stack>
   );
 }
 
@@ -269,20 +281,31 @@ function QueryResult({
     getChartMetadata(chart);
 
   return (
-    <QueryResultContainer>
+    <Stack width="100%" gap="sm">
       <QueryDisclosureButton
-        type="button"
+        size="sm"
+        variant="transparent"
+        icon={<IconChevron direction={expanded ? 'down' : 'right'} size="xs" />}
         aria-label={t('Toggle %s', title)}
         aria-expanded={expanded}
         onClick={() => setExpanded(value => !value)}
       >
-        <IconChevron direction={expanded ? 'down' : 'right'} size="xs" />
-        <QueryCellTitle data-test-id="query-cell-title" size="sm" tabular>
+        <Text data-test-id="query-cell-title" size="sm" tabular>
           {title}
-        </QueryCellTitle>
+        </Text>
       </QueryDisclosureButton>
       {expanded ? (
-        <QueryResultCard data-test-id="query-cell-result" data-cell-variant="bordered">
+        <Stack
+          width="100%"
+          flex={1}
+          minWidth={0}
+          gap="0"
+          overflow="hidden"
+          border="primary"
+          radius="md"
+          data-test-id="query-cell-result"
+          data-cell-variant="bordered"
+        >
           <QueryResultHeader
             align="start"
             justify="between"
@@ -312,9 +335,9 @@ function QueryResult({
               </QueryCellProgress>
             )}
           </QueryResultBody>
-        </QueryResultCard>
+        </Stack>
       ) : null}
-    </QueryResultContainer>
+    </Stack>
   );
 }
 
@@ -685,9 +708,7 @@ function isRenderableTranscriptBlock(block: InvestigationTranscriptBlock, index:
       if (!structuredContent) {
         return false;
       }
-      const calls = Array.isArray(structuredContent.calls)
-        ? (structuredContent.calls as CallRecord[])
-        : [];
+      const calls = structuredContent.calls ?? [];
       return (
         visibleCallRecords(calls).length > 0 ||
         (Array.isArray(structuredContent.links) && structuredContent.links.length > 0) ||
@@ -766,7 +787,12 @@ function getTextOutput(output: unknown): string | null {
     : null;
 }
 
-function getQueryOutput(output: unknown): InvestigationQueryOutput | null {
+type RenderableQueryOutput = Pick<
+  InvestigationQueryOutput,
+  'chart' | 'preferredView' | 'tableMarkdown'
+>;
+
+function getQueryOutput(output: unknown): RenderableQueryOutput | null {
   if (
     !output ||
     typeof output !== 'object' ||
@@ -777,7 +803,19 @@ function getQueryOutput(output: unknown): InvestigationQueryOutput | null {
   ) {
     return null;
   }
-  return output as InvestigationQueryOutput;
+  const chart =
+    'chart' in output && (output.chart === null || isRecord(output.chart))
+      ? output.chart
+      : null;
+  return {
+    chart,
+    preferredView: output.preferredView,
+    tableMarkdown: output.tableMarkdown,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function getRenderableChart(chart: Record<string, unknown> | null) {
@@ -835,69 +873,10 @@ function getSeriesName(series: {label: string} | {name: string}) {
   return 'label' in series ? series.label : series.name;
 }
 
-const CellSection = styled('section')<{$withDivider: boolean}>`
+const QueryDisclosureButton = styled(Button)`
   width: 100%;
-  margin-bottom: ${p => (p.$withDivider ? p.theme.space.xl : 0)};
-  padding: ${p => (p.$withDivider ? p.theme.space.xl : 0)} 0;
-  border-bottom: ${p =>
-    p.$withDivider ? `1px solid ${p.theme.tokens.border.primary}` : 'none'};
-`;
-
-const TextResult = styled(Stack)`
-  position: relative;
-  flex: 1;
-  min-width: 0;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const TextCellAction = styled('div')`
-  position: absolute;
-  top: 0;
-  right: 0;
-`;
-
-const QueryResultContainer = styled(Stack)`
-  width: 100%;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const QueryDisclosureButton = styled('button')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  width: 100%;
-  margin: 0;
-  padding: ${p => p.theme.space.sm};
-  color: ${p => p.theme.tokens.content.primary};
+  justify-content: flex-start;
   text-align: left;
-  background: transparent;
-  border: 0;
-  border-radius: ${p => p.theme.radius.md};
-  cursor: pointer;
-
-  &:hover {
-    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
-  }
-`;
-
-const QueryCellTitle = styled(Text)`
-  color: ${p => p.theme.tokens.content.primary};
-  font-style: normal;
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  line-height: 1.4;
-  letter-spacing: normal;
-  vertical-align: middle;
-  font-variant-numeric: lining-nums tabular-nums;
-`;
-
-const QueryResultCard = styled(Stack)`
-  width: 100%;
-  flex: 1;
-  min-width: 0;
-  gap: 0;
-  overflow: hidden;
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
 `;
 
 const QueryResultHeader = styled(Flex)`

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -167,7 +167,11 @@ export function InvestigationCell({
                 message: t('Are you sure you want to delete this cell?'),
                 priority: 'danger',
                 confirmText: t('Delete'),
-                onConfirm: () => deleteMutation.mutate({blockId: block.id}),
+                onConfirm: () =>
+                  deleteMutation.mutate({
+                    block,
+                    investigationVersion: investigation.version,
+                  }),
               }),
           },
         ]}

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -299,10 +299,13 @@ function QueryResult({
           data-test-id="query-cell-result"
           data-cell-variant="bordered"
         >
-          <QueryResultHeader
+          <Flex
             align="start"
             justify="between"
             gap="md"
+            padding="md lg"
+            background="secondary"
+            borderBottom="primary"
             data-test-id="query-cell-header"
           >
             <Stack gap="2xs" minWidth={0} flex={1}>
@@ -316,25 +319,31 @@ function QueryResult({
               ) : null}
             </Stack>
             {actions}
-          </QueryResultHeader>
-          <QueryResultBody $withPadding={Boolean(chart)}>
+          </Flex>
+          <Container width="100%" overflow="hidden" padding={chart ? 'md lg' : '0'}>
             {chart ? (
               <ChartContent data={chart} showHeader={false} />
             ) : output?.tableMarkdown ? (
               <SeerMarkdown raw={output.tableMarkdown} components={{Table: FlushTable}} />
             ) : (
-              <QueryCellProgress>
+              <Container padding="md lg">
                 <CellProgress state={progressState} />
-              </QueryCellProgress>
+              </Container>
             )}
-          </QueryResultBody>
+          </Container>
         </Stack>
       ) : null}
     </Stack>
   );
 }
 
-type CellProgressState = 'running' | 'waiting' | 'blocked' | null;
+type CellProgressState =
+  | 'running'
+  | 'waiting'
+  | 'blocked'
+  | 'failed'
+  | 'cancelled'
+  | null;
 
 function CellProgress({state}: {state: CellProgressState}) {
   if (!state) {
@@ -345,10 +354,17 @@ function CellProgress({state}: {state: CellProgressState}) {
     message = t('Seer is working on this cell…');
   } else if (state === 'waiting') {
     message = t('Waiting for previous cells…');
+  } else if (state === 'failed') {
+    message = t('This cell failed to run.');
+  } else if (state === 'cancelled') {
+    message = t('This cell run was cancelled.');
   }
   return (
     <Flex align="center" gap="xs" data-test-id={`cell-progress-${state}`}>
-      <IconSeer size="xs" animation={state === 'blocked' ? undefined : 'waiting'} />
+      <IconSeer
+        size="xs"
+        animation={['running', 'waiting'].includes(state) ? 'waiting' : undefined}
+      />
       <Text variant="muted">{message}</Text>
     </Flex>
   );
@@ -360,6 +376,12 @@ function getCellProgressState(
 ): CellProgressState {
   if (isExecutionActive(block.currentExecution?.status)) {
     return 'running';
+  }
+  if (block.currentExecution?.status === 'failed') {
+    return 'failed';
+  }
+  if (block.currentExecution?.status === 'cancelled') {
+    return 'cancelled';
   }
   if (
     block.currentExecution ||
@@ -380,6 +402,14 @@ function getCellProgressState(
     return 'blocked';
   }
   return 'waiting';
+}
+
+export function shouldPollInvestigationBlocks(blocks: InvestigationBlock[]) {
+  return blocks.some(
+    block =>
+      isExecutionActive(block.outputStatus) ||
+      getCellProgressState(block, blocks) === 'waiting'
+  );
 }
 
 function FlushTable({children}: {children: React.ReactNode}) {
@@ -506,7 +536,7 @@ function RefinementPanel({
 
   if (showPrompt) {
     return (
-      <RefinementComposer>
+      <Stack width="100%" marginTop="lg" gap="md">
         <Flex align="center" justify="between" gap="sm">
           <Flex align="center" gap="sm">
             <IconSeer size="xs" />
@@ -551,7 +581,7 @@ function RefinementPanel({
             </Button>
           </Flex>
         </Stack>
-      </RefinementComposer>
+      </Stack>
     );
   }
 
@@ -975,23 +1005,6 @@ const QueryDisclosureButton = styled(Button)`
   text-align: left;
 `;
 
-const QueryResultHeader = styled(Flex)`
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
-  background: ${p => p.theme.tokens.background.secondary};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-`;
-
-const QueryResultBody = styled('div')<{$withPadding: boolean}>`
-  box-sizing: border-box;
-  width: 100%;
-  overflow: hidden;
-  padding: ${p => (p.$withPadding ? `${p.theme.space.md} ${p.theme.space.lg}` : 0)};
-`;
-
-const QueryCellProgress = styled('div')`
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
-`;
-
 const QueryTable = styled('table')`
   min-width: 100%;
   border-collapse: collapse;
@@ -1000,12 +1013,6 @@ const QueryTable = styled('table')`
 const RefinementDisclosure = styled(Disclosure)`
   width: 100%;
   margin-top: ${p => p.theme.space.lg};
-`;
-
-const RefinementComposer = styled(Stack)`
-  width: 100%;
-  margin-top: ${p => p.theme.space.lg};
-  gap: ${p => p.theme.space.md};
 `;
 
 const RefinementPrompt = styled('div')`

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -2,11 +2,21 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
+import * as indicators from 'sentry/actionCreators/indicator';
 import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
 import InvestigationDetailView from 'sentry/views/investigations/detail';
 import type {InvestigationDetail} from 'sentry/views/investigations/types';
+
+jest.unmock('@tanstack/react-pacer');
 
 const organization = OrganizationFixture({
   features: ['investigations'],
@@ -99,6 +109,11 @@ function renderView(
 }
 
 describe('Investigation detail', () => {
+  beforeEach(() => {
+    jest.spyOn(indicators, 'addSuccessMessage').mockImplementation();
+    jest.spyOn(indicators, 'addErrorMessage').mockImplementation();
+  });
+
   it('loads and renders the complete investigation response', async () => {
     const request = MockApiClient.addMockResponse({
       url: detailUrl,
@@ -109,9 +124,39 @@ describe('Investigation detail', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText('Investigate database latency')).toBeInTheDocument();
-    expect(screen.getByText(/"id": "investigation-1"/)).toBeInTheDocument();
-    expect(screen.getByText(/"blocks":/)).toBeInTheDocument();
+    const debugPanel = screen.getByRole('button', {name: 'Investigation JSON'});
+    expect(screen.getByText(/"id": "investigation-1"/)).not.toBeVisible();
+
+    await userEvent.click(debugPanel);
+
+    expect(screen.getByText(/"id": "investigation-1"/)).toBeVisible();
+    expect(screen.getByText(/"blocks":/)).toBeVisible();
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders block output instead of block content', async () => {
+    const investigation = InvestigationDetailFixture();
+    const firstBlock = investigation.blocks[0];
+    if (!firstBlock) {
+      throw new Error('Expected an investigation block fixture.');
+    }
+    investigation.blocks[0] = {
+      ...firstBlock,
+      content: 'Prompt-side content that should not render',
+      generatedContent: 'Generated content that should not render',
+      output: {schemaVersion: 1, markdown: 'Actual persisted block output'},
+    };
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(await screen.findByText('Actual persisted block output')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Prompt-side content that should not render')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Generated content that should not render')
+    ).not.toBeInTheDocument();
   });
 
   it('reuses an investigation prefetched before the detail page mounts', async () => {
@@ -128,6 +173,110 @@ describe('Investigation detail', () => {
 
     expect(screen.getByText('Investigate database latency')).toBeInTheDocument();
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('optimistically renames and debounces persistence', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+    const renameRequest = MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'PUT',
+      body: InvestigationDetailFixture({
+        title: 'Regional latency investigation',
+        version: 2,
+      }),
+    });
+
+    renderView();
+    const titleInput = await screen.findByLabelText('Investigation title');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, 'Regional latency investigation');
+
+    expect(titleInput).toHaveValue('Regional latency investigation');
+    expect(renameRequest).not.toHaveBeenCalled();
+
+    await waitFor(
+      () =>
+        expect(renameRequest).toHaveBeenCalledWith(
+          detailUrl,
+          expect.objectContaining({
+            data: {
+              title: 'Regional latency investigation',
+              investigationVersion: 1,
+            },
+          })
+        ),
+      {timeout: 1500}
+    );
+  });
+
+  it('duplicates and opens the duplicate from the title menu', async () => {
+    MockApiClient.addMockResponse({url: detailUrl, body: InvestigationDetailFixture()});
+    MockApiClient.addMockResponse({
+      url: `${detailUrl}duplicate/`,
+      method: 'POST',
+      body: InvestigationDetailFixture({id: 'investigation-2'}),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/investigation-2/',
+      body: InvestigationDetailFixture({id: 'investigation-2'}),
+    });
+
+    const {router} = renderView();
+    await userEvent.click(await screen.findByLabelText('Investigation actions'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Duplicate'}));
+
+    await waitFor(() =>
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/seer/investigation/investigation-2/'
+      )
+    );
+  });
+
+  it('copies the link from the title menu', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {writeText},
+      writable: true,
+    });
+    MockApiClient.addMockResponse({url: detailUrl, body: InvestigationDetailFixture()});
+
+    renderView();
+    await userEvent.click(await screen.findByLabelText('Investigation actions'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Copy link'}));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/organizations/org-slug/seer/investigation/investigation-1/`
+      )
+    );
+  });
+
+  it('deletes after confirmation and returns to the list', async () => {
+    MockApiClient.addMockResponse({url: detailUrl, body: InvestigationDetailFixture()});
+    const deleteRequest = MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'DELETE',
+    });
+
+    const {router} = renderView();
+    await userEvent.click(await screen.findByLabelText('Investigation actions'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+    expect(deleteRequest).not.toHaveBeenCalled();
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(deleteRequest).toHaveBeenCalledWith(
+        detailUrl,
+        expect.objectContaining({data: {investigationVersion: 1}})
+      )
+    );
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/explore/investigations/'
+    );
   });
 
   it('renders the initial load error', async () => {

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -193,6 +193,58 @@ describe('Investigation detail', () => {
     expect(screen.getByRole('button', {name: 'Ask Seer about Synthesis'})).toBeDisabled();
   });
 
+  it('keeps polling while an auto-run cell is waiting to start', async () => {
+    const investigation = InvestigationDetailFixture({
+      template: {key: 'breached_metric', version: 1},
+    });
+    investigation.blocks = [
+      {
+        ...investigation.blocks[0]!,
+        outputStatus: 'completed',
+        currentExecution: {
+          id: 'execution-completed',
+          status: 'completed',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: '2026-08-17T10:00:10Z',
+          error: null,
+        },
+      },
+      {
+        ...investigation.blocks[1]!,
+        config: {autoRun: true},
+        dependencies: ['block-1'],
+      },
+    ];
+    const request = MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(await screen.findByText('Waiting for previous cells…')).toBeInTheDocument();
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2), {timeout: 3000});
+  });
+
+  it('shows a failed state when a cell has no output', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks = [
+      {
+        ...investigation.blocks[1]!,
+        outputStatus: 'failed',
+        currentExecution: {
+          id: 'execution-failed',
+          status: 'failed',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: '2026-08-17T10:00:10Z',
+          error: {message: 'Query failed'},
+        },
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(await screen.findByText('This cell failed to run.')).toBeInTheDocument();
+  });
+
   it('keeps the refinement composer expanded while editing', async () => {
     MockApiClient.addMockResponse({
       url: detailUrl,
@@ -965,6 +1017,62 @@ describe('Investigation detail', () => {
     );
   });
 
+  it('preserves newer block state when a rename completes', async () => {
+    const queryClient = makeTestQueryClient();
+    const options = getInvestigationDetailQueryOptions('org-slug', 'investigation-1');
+    const investigation = InvestigationDetailFixture();
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'PUT',
+      body: () => {
+        queryClient.setQueryData(options.queryKey, current =>
+          current
+            ? {
+                ...current,
+                json: {
+                  ...current.json,
+                  blocks: current.json.blocks?.map(block =>
+                    block.id === 'block-1'
+                      ? {
+                          ...block,
+                          outputStatus: 'running' as const,
+                          currentExecution: {
+                            id: 'execution-running',
+                            status: 'running' as const,
+                            startedAt: '2026-08-17T10:00:00Z',
+                            completedAt: null,
+                            error: null,
+                          },
+                        }
+                      : block
+                  ),
+                  version: 3,
+                },
+              }
+            : current
+        );
+        return InvestigationDetailFixture({
+          title: 'Renamed investigation',
+          version: 2,
+        });
+      },
+    });
+
+    renderView(organization, queryClient);
+    const titleInput = await screen.findByLabelText('Investigation title');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, 'Renamed investigation');
+    fireEvent.blur(titleInput);
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData(options.queryKey)?.json.blocks?.[0]?.currentExecution?.id
+      ).toBe('execution-running')
+    );
+    expect(queryClient.getQueryData(options.queryKey)?.json.version).toBe(3);
+  });
+
   it('flushes a pending title change when the page unmounts', async () => {
     MockApiClient.addMockResponse({
       url: detailUrl,
@@ -1080,8 +1188,17 @@ describe('Investigation detail', () => {
       url: detailUrl,
       method: 'DELETE',
     });
+    const renameRequest = MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'PUT',
+      body: InvestigationDetailFixture({title: 'Pending rename', version: 2}),
+    });
 
     const {router} = renderView();
+    fireEvent.change(await screen.findByLabelText('Investigation title'), {
+      target: {value: 'Pending rename'},
+    });
+    expect(renameRequest).not.toHaveBeenCalled();
     await userEvent.click(await screen.findByLabelText('Investigation actions'));
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
     expect(deleteRequest).not.toHaveBeenCalled();
@@ -1097,6 +1214,8 @@ describe('Investigation detail', () => {
     expect(router.location.pathname).toBe(
       '/organizations/org-slug/explore/investigations/'
     );
+    await act(async () => new Promise(resolve => setTimeout(resolve, 600)));
+    expect(renameRequest).not.toHaveBeenCalled();
   });
 
   it('renders the initial load error', async () => {

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -151,6 +151,7 @@ describe('Investigation detail', () => {
     investigation.blocks = [
       {
         ...textBlock,
+        content: '',
         config: {autoRun: true},
         outputStatus: 'running',
         currentExecution: {
@@ -178,6 +179,7 @@ describe('Investigation detail', () => {
         id: 'block-3',
         position: 2,
         title: 'Synthesis',
+        content: '',
         config: {autoRun: true},
         dependencies: ['block-1', 'block-2'],
       },
@@ -458,43 +460,6 @@ describe('Investigation detail', () => {
     );
   });
 
-  it('duplicates a query cell from its actions menu', async () => {
-    const investigation = InvestigationDetailFixture();
-    const block = investigation.blocks[1]!;
-    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
-    const duplicateRequest = MockApiClient.addMockResponse({
-      url: `${detailUrl}blocks/`,
-      method: 'POST',
-      body: {...block, id: 'duplicated-block', position: 2},
-    });
-
-    renderView();
-    await userEvent.click(await screen.findByLabelText('Cell actions for Latency query'));
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Duplicate'}));
-
-    await waitFor(() =>
-      expect(duplicateRequest).toHaveBeenCalledWith(
-        `${detailUrl}blocks/`,
-        expect.objectContaining({
-          data: {
-            investigationVersion: 1,
-            kind: 'query',
-            title: 'Latency query',
-            content: '',
-            generationPrompt: 'Find slow spans',
-            config: {},
-            display: {type: 'table'},
-          },
-        })
-      )
-    );
-    expect(
-      screen
-        .getAllByTestId('query-cell-title')
-        .filter(element => element.textContent === 'Latency query')
-    ).toHaveLength(2);
-  });
-
   it('deletes a query cell from its actions menu after confirmation', async () => {
     const investigation = InvestigationDetailFixture();
     const block = investigation.blocks[1]!;
@@ -673,8 +638,9 @@ describe('Investigation detail', () => {
       {
         ...block,
         version: 3,
+        content: 'Previous successful result',
         outputStatus: 'completed',
-        output: {schemaVersion: 1, markdown: 'Previous successful result'},
+        output: null,
         currentExecution: {
           id: 'execution-2',
           status: 'completed',
@@ -876,6 +842,76 @@ describe('Investigation detail', () => {
     expect(screen.getByText('Stable result')).toBeInTheDocument();
   });
 
+  it('answers a question while an execution is awaiting input', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks = [
+      {
+        ...investigation.blocks[0]!,
+        outputStatus: 'awaiting_input',
+        currentExecution: {
+          id: 'execution-awaiting-input',
+          status: 'awaiting_input',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: null,
+          error: null,
+        },
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const executionUrl = `${detailUrl}blocks/block-1/executions/execution-awaiting-input/`;
+    MockApiClient.addMockResponse({
+      url: executionUrl,
+      body: {
+        id: 'execution-awaiting-input',
+        status: 'awaiting_input',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: {
+          id: 'input-1',
+          input_type: 'ask_user_question',
+          data: {
+            questions: [
+              {
+                question: 'Which environment should I inspect?',
+                options: [
+                  {label: 'Production', description: 'Use production events'},
+                  {label: 'Staging', description: 'Use staging events'},
+                ],
+              },
+            ],
+          },
+        },
+        partialMarkdown: null,
+        error: null,
+      },
+    });
+    const resumeRequest = MockApiClient.addMockResponse({
+      url: executionUrl,
+      method: 'PATCH',
+    });
+
+    renderView();
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Ask Seer about Summary'})
+    );
+    expect(
+      await screen.findByText('Which environment should I inspect?')
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+    await waitFor(() =>
+      expect(resumeRequest).toHaveBeenCalledWith(
+        executionUrl,
+        expect.objectContaining({
+          data: {
+            input_id: 'input-1',
+            response_data: {answers: ['Production']},
+          },
+        })
+      )
+    );
+  });
+
   it('reuses an investigation prefetched before the detail page mounts', async () => {
     const request = MockApiClient.addMockResponse({
       url: detailUrl,
@@ -927,6 +963,64 @@ describe('Investigation detail', () => {
         ),
       {timeout: 1500}
     );
+  });
+
+  it('flushes a pending title change when the page unmounts', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+    const renameRequest = MockApiClient.addMockResponse({
+      url: detailUrl,
+      method: 'PUT',
+      body: InvestigationDetailFixture({title: 'Saved before leaving', version: 2}),
+    });
+
+    const {unmount} = renderView();
+    const titleInput = await screen.findByLabelText('Investigation title');
+    await userEvent.clear(titleInput);
+    await userEvent.type(titleInput, 'Saved before leaving');
+    expect(renameRequest).not.toHaveBeenCalled();
+
+    unmount();
+
+    await waitFor(() =>
+      expect(renameRequest).toHaveBeenCalledWith(
+        detailUrl,
+        expect.objectContaining({
+          data: {title: 'Saved before leaving', investigationVersion: 1},
+        })
+      )
+    );
+  });
+
+  it('polls for and displays a generated title after block execution finishes', async () => {
+    let requestCount = 0;
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: () => {
+        requestCount += 1;
+        return requestCount === 1
+          ? InvestigationDetailFixture({
+              title: 'Untitled Investigation',
+              titleGeneration: {status: 'running'},
+            })
+          : InvestigationDetailFixture({
+              title: 'Generated latency investigation',
+              titleGeneration: {status: 'completed'},
+            });
+      },
+    });
+
+    renderView();
+    expect(await screen.findByDisplayValue('Untitled Investigation')).toBeInTheDocument();
+
+    expect(
+      await screen.findByDisplayValue('Generated latency investigation', undefined, {
+        timeout: 3000,
+      })
+    ).toBeInTheDocument();
+    expect(requestCount).toBeGreaterThan(1);
   });
 
   it('duplicates and opens the duplicate from the title menu', async () => {

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -512,20 +512,32 @@ describe('Investigation detail', () => {
     );
   });
 
-  it('deletes a query cell from its actions menu after confirmation', async () => {
+  it('deletes a query cell when it is no longer present in the cache', async () => {
     const investigation = InvestigationDetailFixture();
     const block = investigation.blocks[1]!;
+    const queryClient = makeTestQueryClient();
+    const options = getInvestigationDetailQueryOptions('org-slug', 'investigation-1');
     MockApiClient.addMockResponse({url: detailUrl, body: investigation});
     const deleteRequest = MockApiClient.addMockResponse({
       url: `${detailUrl}blocks/${block.id}/`,
       method: 'DELETE',
     });
 
-    renderView();
+    renderView(organization, queryClient);
     await userEvent.click(await screen.findByLabelText('Cell actions for Latency query'));
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
     expect(deleteRequest).not.toHaveBeenCalled();
     renderGlobalModal();
+    act(() => {
+      queryClient.setQueryData(options.queryKey, current =>
+        current
+          ? {
+              ...current,
+              json: {...current.json, blocks: undefined, version: 2},
+            }
+          : current
+      );
+    });
     await userEvent.click(await screen.findByTestId('confirm-button'));
 
     await waitFor(() =>

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -4,17 +4,22 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {
   act,
+  fireEvent,
   render,
   renderGlobalModal,
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
 import InvestigationDetailView from 'sentry/views/investigations/detail';
-import type {InvestigationDetail} from 'sentry/views/investigations/types';
+import type {
+  InvestigationBlock,
+  InvestigationDetail,
+} from 'sentry/views/investigations/types';
 
 jest.unmock('@tanstack/react-pacer');
 
@@ -24,7 +29,9 @@ const organization = OrganizationFixture({
 });
 const detailUrl = '/organizations/org-slug/investigations/investigation-1/';
 
-function InvestigationDetailFixture(overrides: Partial<InvestigationDetail> = {}) {
+function InvestigationDetailFixture(
+  overrides: Partial<InvestigationDetail> = {}
+): InvestigationDetail & {blocks: InvestigationBlock[]} {
   return {
     id: 'investigation-1',
     title: 'Investigate database latency',
@@ -124,14 +131,38 @@ describe('Investigation detail', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText('Investigate database latency')).toBeInTheDocument();
-    const debugPanel = screen.getByRole('button', {name: 'Investigation JSON'});
-    expect(screen.getByText(/"id": "investigation-1"/)).not.toBeVisible();
-
-    await userEvent.click(debugPanel);
-
-    expect(screen.getByText(/"id": "investigation-1"/)).toBeVisible();
-    expect(screen.getByText(/"blocks":/)).toBeVisible();
+    expect(
+      screen.getByRole('button', {name: 'Ask Seer about Summary'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Ask Seer about Latency query'})
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Ask Seer')).not.toBeInTheDocument();
+    expect(screen.queryByText(/"blocks":/)).not.toBeInTheDocument();
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the refinement composer expanded while editing', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+
+    renderView();
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: 'Ask Seer about Latency query',
+      })
+    );
+
+    const prompt = screen.getByLabelText('Instructions for Seer');
+    expect(screen.getByText('Ask Seer to refine')).toBeInTheDocument();
+    expect(prompt).toHaveValue('Find slow spans');
+    expect(prompt).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'Ask Seer'})).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel Seer request'}));
+    expect(screen.queryByLabelText('Instructions for Seer')).not.toBeInTheDocument();
   });
 
   it('renders block output instead of block content', async () => {
@@ -157,6 +188,643 @@ describe('Investigation detail', () => {
     expect(
       screen.queryByText('Generated content that should not render')
     ).not.toBeInTheDocument();
+  });
+
+  it('uses compact breadcrumbs and renders text and table results without prompt data', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks = [
+      {
+        ...investigation.blocks[0]!,
+        title: '',
+        generationPrompt: 'Secret text-generation prompt',
+        output: {schemaVersion: 1, markdown: 'Rendered **analysis**'},
+      },
+      {
+        ...investigation.blocks[1]!,
+        title: 'Database latency',
+        generationPrompt: 'Secret query-generation prompt',
+        output: {
+          schemaVersion: 1,
+          preferredView: 'table',
+          tableMarkdown: '| p95 | count |\n| --- | --- |\n| 820ms | 12 |',
+          chart: null,
+          chartUnavailableReason: null,
+          isEmpty: false,
+          queryLinks: [],
+        },
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(await screen.findByText('Rendered')).toBeInTheDocument();
+    expect(screen.queryByText('Investigation step 1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('text-cell-result')).toHaveAttribute(
+      'data-cell-variant',
+      'unbordered'
+    );
+    expect(screen.getByTestId('query-cell-result')).toHaveAttribute(
+      'data-cell-variant',
+      'bordered'
+    );
+    expect(screen.getByTestId('query-cell-header')).toContainElement(
+      screen.getByRole('button', {name: 'Ask Seer about Database latency'})
+    );
+    expect(screen.getByTestId('investigation-cell-block-1')).toHaveAttribute(
+      'data-has-divider',
+      'false'
+    );
+    expect(screen.getByTestId('investigation-cell-block-2')).toHaveAttribute(
+      'data-has-divider',
+      'true'
+    );
+    expect(screen.getByText('820ms')).toBeInTheDocument();
+    expect(screen.queryByText('Secret text-generation prompt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Secret query-generation prompt')).not.toBeInTheDocument();
+    expect(screen.getByTestId('investigation-breadcrumbs')).toHaveAttribute(
+      'data-text-size',
+      'md'
+    );
+
+    expect(screen.getByTestId('query-cell-title')).toHaveTextContent('Database latency');
+    expect(screen.queryByText('Evidence/Database latency')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('query-cell-title'));
+    expect(screen.queryByText('820ms')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle Database latency'}));
+    expect(screen.getByText('820ms')).toBeVisible();
+  });
+
+  it('renders the outer query title as non-editable text', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
+    renderView();
+    expect(await screen.findByTestId('query-cell-title')).toHaveTextContent(
+      'Latency query'
+    );
+    expect(
+      screen.queryByLabelText('Cell title for Latency query')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a preferred chart and falls back to its table when unavailable', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks = [
+      {
+        ...investigation.blocks[1]!,
+        id: 'chart-block',
+        output: {
+          schemaVersion: 1,
+          preferredView: 'chart',
+          tableMarkdown: '| fallback |\n| --- |\n| table |',
+          chartUnavailableReason: null,
+          isEmpty: false,
+          queryLinks: [],
+          chart: {
+            title: 'Latency over time',
+            visualization: 'line',
+            x_axis: 'time',
+            y_axis_unit: 'duration',
+            series: [
+              {
+                label: 'p95',
+                data: [
+                  {x: '2026-08-17T10:00:00Z', y: 400},
+                  {x: '2026-08-17T10:05:00Z', y: 800},
+                ],
+              },
+            ],
+          },
+        },
+      },
+      {
+        ...investigation.blocks[1]!,
+        id: 'fallback-block',
+        title: 'Unavailable chart',
+        output: {
+          schemaVersion: 1,
+          preferredView: 'chart',
+          tableMarkdown: '| fallback |\n| --- |\n| shown |',
+          chart: null,
+          chartUnavailableReason: 'No numeric columns',
+          isEmpty: false,
+          queryLinks: [],
+        },
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+    expect(screen.getAllByTestId('query-cell-title')[0]).toHaveTextContent(
+      'Latency query'
+    );
+    expect(screen.getByText('Latency over time')).toBeInTheDocument();
+    expect(
+      within(screen.getAllByTestId('query-cell-header')[0]!).getByText(
+        /Aug 17.*1,200 total p95/
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('shown')).toBeInTheDocument();
+  });
+
+  it('renders chart metadata and reruns the query from the header', async () => {
+    const investigation = InvestigationDetailFixture();
+    const block = {
+      ...investigation.blocks[1]!,
+      outputStatus: 'completed' as const,
+      output: {
+        schemaVersion: 1,
+        preferredView: 'chart',
+        tableMarkdown: '| total |\n| ---: |\n| 363 |',
+        chartUnavailableReason: null,
+        isEmpty: false,
+        queryLinks: [],
+        chart: {
+          title: 'Top Issues in spike window',
+          subtitle: '3:57pm–4:12pm PST  |  363 Total Events',
+          visualization: 'line',
+          x_axis: 'time',
+          y_axis_unit: 'number',
+          series: [
+            {
+              label: 'Events',
+              data: [
+                {x: '2026-08-17T10:00:00Z', y: 120},
+                {x: '2026-08-17T10:05:00Z', y: 243},
+              ],
+            },
+          ],
+        },
+      },
+    };
+    investigation.blocks = [block];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const runUrl = `${detailUrl}blocks/${block.id}/executions/`;
+    const rerunRequest = MockApiClient.addMockResponse({
+      url: runUrl,
+      method: 'POST',
+      body: {id: 'rerun-1', status: 'running'},
+    });
+    MockApiClient.addMockResponse({
+      url: `${runUrl}rerun-1/`,
+      body: {
+        id: 'rerun-1',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
+
+    renderView();
+    const chartHeader = await screen.findByTestId('query-cell-header');
+    expect(
+      within(chartHeader).getByRole('heading', {
+        name: 'Top Issues in spike window',
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(chartHeader).getByText(/3:57pm–4:12pm PST\s+\|\s+363 Total Events/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Ask Seer about Latency query'})
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Cell actions for Latency query')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Rerun Latency query'}));
+    await waitFor(() =>
+      expect(rerunRequest).toHaveBeenCalledWith(
+        runUrl,
+        expect.objectContaining({
+          data: {investigationVersion: 1, version: 1},
+        })
+      )
+    );
+  });
+
+  it('duplicates a query cell from its actions menu', async () => {
+    const investigation = InvestigationDetailFixture();
+    const block = investigation.blocks[1]!;
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const duplicateRequest = MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/`,
+      method: 'POST',
+      body: {...block, id: 'duplicated-block', position: 2},
+    });
+
+    renderView();
+    await userEvent.click(await screen.findByLabelText('Cell actions for Latency query'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Duplicate'}));
+
+    await waitFor(() =>
+      expect(duplicateRequest).toHaveBeenCalledWith(
+        `${detailUrl}blocks/`,
+        expect.objectContaining({
+          data: {
+            investigationVersion: 1,
+            kind: 'query',
+            title: 'Latency query',
+            content: '',
+            generationPrompt: 'Find slow spans',
+            config: {},
+            display: {type: 'table'},
+          },
+        })
+      )
+    );
+    expect(
+      screen
+        .getAllByTestId('query-cell-title')
+        .filter(element => element.textContent === 'Latency query')
+    ).toHaveLength(2);
+  });
+
+  it('deletes a query cell from its actions menu after confirmation', async () => {
+    const investigation = InvestigationDetailFixture();
+    const block = investigation.blocks[1]!;
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const deleteRequest = MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/${block.id}/`,
+      method: 'DELETE',
+    });
+
+    renderView();
+    await userEvent.click(await screen.findByLabelText('Cell actions for Latency query'));
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+    expect(deleteRequest).not.toHaveBeenCalled();
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(deleteRequest).toHaveBeenCalledWith(
+        `${detailUrl}blocks/${block.id}/`,
+        expect.objectContaining({
+          data: {investigationVersion: 1, version: 1},
+        })
+      )
+    );
+    expect(screen.queryByDisplayValue('Latency query')).not.toBeInTheDocument();
+  });
+
+  it('adds text and query cells and starts a never-run cell from its stored prompt', async () => {
+    const fixture = InvestigationDetailFixture();
+    const textTemplate = fixture.blocks[0];
+    const queryTemplate = fixture.blocks[1];
+    if (!textTemplate || !queryTemplate) {
+      throw new Error('Expected text and query block fixtures.');
+    }
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({blocks: [], blockCount: 0}),
+    });
+    const blocksUrl = `${detailUrl}blocks/`;
+    const textBlock = {
+      ...textTemplate,
+      id: 'text-block',
+      title: 'Working theory',
+      generationPrompt: 'Summarize the current evidence',
+    };
+    const textRequest = MockApiClient.addMockResponse({
+      url: blocksUrl,
+      method: 'POST',
+      body: textBlock,
+    });
+
+    renderView();
+    await userEvent.click(await screen.findByRole('button', {name: 'Text cell'}));
+    await userEvent.type(screen.getByLabelText('Cell title'), 'Working theory');
+    await userEvent.type(
+      screen.getByLabelText('Cell instructions'),
+      'Summarize the current evidence'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Add cell'}));
+
+    await waitFor(() =>
+      expect(textRequest).toHaveBeenCalledWith(
+        blocksUrl,
+        expect.objectContaining({
+          data: {
+            investigationVersion: 1,
+            kind: 'text',
+            title: 'Working theory',
+            generationPrompt: 'Summarize the current evidence',
+          },
+        })
+      )
+    );
+    expect(
+      await screen.findByRole('button', {name: 'Ask Seer about Working theory'})
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Working theory')).not.toBeInTheDocument();
+
+    const queryBlock = {
+      ...queryTemplate,
+      id: 'query-block',
+      title: 'Error volume',
+      generationPrompt: 'Show errors over the last 24 hours',
+    };
+    const queryRequest = MockApiClient.addMockResponse({
+      url: blocksUrl,
+      method: 'POST',
+      body: queryBlock,
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Query cell'}));
+    await userEvent.type(screen.getByLabelText('Cell title'), 'Error volume');
+    await userEvent.type(
+      screen.getByLabelText('Cell instructions'),
+      'Show errors over the last 24 hours'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Add cell'}));
+
+    await waitFor(() =>
+      expect(queryRequest).toHaveBeenCalledWith(
+        blocksUrl,
+        expect.objectContaining({
+          data: {
+            investigationVersion: 2,
+            kind: 'query',
+            title: 'Error volume',
+            generationPrompt: 'Show errors over the last 24 hours',
+          },
+        })
+      )
+    );
+    expect(
+      (await screen.findAllByTestId('query-cell-title')).some(
+        element => element.textContent === 'Error volume'
+      )
+    ).toBe(true);
+
+    const updateUrl = `${blocksUrl}query-block/`;
+    const updateRequest = MockApiClient.addMockResponse({
+      url: updateUrl,
+      method: 'PUT',
+      body: queryBlock,
+    });
+    const runUrl = `${updateUrl}executions/`;
+    const runRequest = MockApiClient.addMockResponse({
+      url: runUrl,
+      method: 'POST',
+      body: {id: 'execution-1', status: 'running'},
+    });
+    MockApiClient.addMockResponse({
+      url: `${runUrl}execution-1/`,
+      body: {
+        id: 'execution-1',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Ask Seer about Error volume'})
+    );
+    expect(screen.getByLabelText('Instructions for Seer')).toHaveValue(
+      'Show errors over the last 24 hours'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+    await waitFor(() =>
+      expect(updateRequest).toHaveBeenCalledWith(
+        updateUrl,
+        expect.objectContaining({
+          data: {
+            investigationVersion: 3,
+            version: 1,
+            generationPrompt: 'Show errors over the last 24 hours',
+          },
+        })
+      )
+    );
+
+    await waitFor(() =>
+      expect(runRequest).toHaveBeenCalledWith(
+        runUrl,
+        expect.objectContaining({
+          data: {investigationVersion: 3, version: 1},
+        })
+      )
+    );
+  });
+
+  it('keeps the previous result visible while showing a timed completed transcript', async () => {
+    const investigation = InvestigationDetailFixture({version: 7});
+    const block = investigation.blocks[0]!;
+    investigation.blocks = [
+      {
+        ...block,
+        version: 3,
+        outputStatus: 'completed',
+        output: {schemaVersion: 1, markdown: 'Previous successful result'},
+        currentExecution: {
+          id: 'execution-2',
+          status: 'completed',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: '2026-08-17T10:00:10Z',
+          error: null,
+        },
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const blockUrl = `${detailUrl}blocks/block-1/`;
+    const updateRequest = MockApiClient.addMockResponse({
+      url: blockUrl,
+      method: 'PUT',
+      body: {...investigation.blocks[0]!, version: 4},
+    });
+    const runUrl = `${blockUrl}executions/`;
+    const runRequest = MockApiClient.addMockResponse({
+      url: runUrl,
+      method: 'POST',
+      body: {id: 'execution-2', status: 'running'},
+    });
+    MockApiClient.addMockResponse({
+      url: `${runUrl}execution-2/`,
+      body: {
+        id: 'execution-2',
+        status: 'completed',
+        blocks: [
+          {
+            id: 'internal-prompt',
+            timestamp: '2026-08-17T10:00:00Z',
+            loading: false,
+            message: {
+              role: 'user',
+              content:
+                'Private agent instructions\n<investigation_context>{}</investigation_context>',
+            },
+            artifacts: [],
+            toolLinks: null,
+            toolResults: null,
+          },
+          {
+            id: 'step-1',
+            timestamp: '2026-08-17T10:00:00Z',
+            loading: false,
+            message: {role: 'user', content: 'Compare against deploys'},
+            artifacts: [],
+            toolLinks: null,
+            toolResults: null,
+          },
+          {
+            id: 'empty-code-mode-step-1',
+            timestamp: '2026-08-17T10:00:02Z',
+            loading: false,
+            message: {
+              role: 'tool_use',
+              content: null,
+              tool_calls: [{id: 'empty-1', function: 'sentry_api_execute', args: '{}'}],
+            },
+            artifacts: [],
+            toolLinks: null,
+            toolResults: [
+              {
+                tool_call_id: 'empty-1',
+                tool_call_function: 'sentry_api_execute',
+                content: '',
+                structuredContent: {calls: []},
+              },
+            ],
+          },
+          {
+            id: 'step-2',
+            timestamp: '2026-08-17T10:00:04Z',
+            loading: false,
+            message: {role: 'assistant', content: 'The deploy lines up.'},
+            artifacts: [],
+            toolLinks: null,
+            toolResults: null,
+          },
+          {
+            id: 'empty-code-mode-step-2',
+            timestamp: '2026-08-17T10:00:07Z',
+            loading: false,
+            message: {
+              role: 'tool_use',
+              content: null,
+              tool_calls: [{id: 'empty-2', function: 'sentry_api_execute', args: '{}'}],
+            },
+            artifacts: [],
+            toolLinks: null,
+            toolResults: [
+              {
+                tool_call_id: 'empty-2',
+                tool_call_function: 'sentry_api_execute',
+                content: '',
+                structuredContent: {calls: []},
+              },
+            ],
+          },
+        ],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
+
+    renderView();
+    expect(await screen.findByText('Previous successful result')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Ask Seer about Summary'}));
+    expect(screen.getByLabelText('Instructions for Seer')).toHaveValue('');
+    const promptInput = screen.getByLabelText('Instructions for Seer');
+    await userEvent.type(promptInput, 'Compare against deploys');
+    fireEvent.keyDown(promptInput, {key: 'Enter'});
+
+    await waitFor(() => expect(updateRequest).toHaveBeenCalledTimes(1));
+    expect(updateRequest).toHaveBeenCalledWith(
+      blockUrl,
+      expect.objectContaining({
+        data: {
+          investigationVersion: 7,
+          version: 3,
+          generationPrompt: 'Compare against deploys',
+        },
+      })
+    );
+    await waitFor(() => expect(runRequest).toHaveBeenCalledTimes(1));
+    expect(runRequest).toHaveBeenCalledWith(
+      runUrl,
+      expect.objectContaining({data: {investigationVersion: 8, version: 4}})
+    );
+    expect(screen.getByText('Previous successful result')).toBeInTheDocument();
+    expect(await screen.findByText('Compare against deploys')).toBeInTheDocument();
+    expect(screen.getByText('The deploy lines up.')).toBeInTheDocument();
+    expect(screen.queryByText(/Private agent instructions/)).not.toBeInTheDocument();
+    expect(screen.getByText('10.0s')).toBeInTheDocument();
+    expect(screen.getByText('4.0s')).toBeInTheDocument();
+    expect(screen.getByText('6.0s')).toBeInTheDocument();
+    expect(screen.queryByText('2.0s')).not.toBeInTheDocument();
+    expect(screen.queryByText('3.0s')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Ask Seer again'})).toBeInTheDocument();
+    expect(screen.queryByLabelText('Instructions for Seer')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Ask Seer again'}));
+    expect(screen.getByLabelText('Instructions for Seer')).toHaveValue('');
+  });
+
+  it('stops an active refinement and leaves the rendered result visible', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks = [
+      {
+        ...investigation.blocks[0]!,
+        outputStatus: 'completed',
+        output: {schemaVersion: 1, markdown: 'Stable result'},
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const blockUrl = `${detailUrl}blocks/block-1/`;
+    MockApiClient.addMockResponse({
+      url: blockUrl,
+      method: 'PUT',
+      body: {...investigation.blocks[0]!, version: 2},
+    });
+    const runUrl = `${blockUrl}executions/`;
+    MockApiClient.addMockResponse({
+      url: runUrl,
+      method: 'POST',
+      body: {id: 'execution-running', status: 'running'},
+    });
+    MockApiClient.addMockResponse({
+      url: `${runUrl}execution-running/`,
+      body: {
+        id: 'execution-running',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
+    const stopRequest = MockApiClient.addMockResponse({
+      url: `${runUrl}execution-running/`,
+      method: 'DELETE',
+    });
+
+    renderView();
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Ask Seer about Summary'})
+    );
+    await userEvent.type(
+      screen.getByLabelText('Instructions for Seer'),
+      'Try another angle'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Stop'}));
+
+    await waitFor(() => expect(stopRequest).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Stable result')).toBeInTheDocument();
   });
 
   it('reuses an investigation prefetched before the detail page mounts', async () => {
@@ -213,7 +881,10 @@ describe('Investigation detail', () => {
   });
 
   it('duplicates and opens the duplicate from the title menu', async () => {
-    MockApiClient.addMockResponse({url: detailUrl, body: InvestigationDetailFixture()});
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
     MockApiClient.addMockResponse({
       url: `${detailUrl}duplicate/`,
       method: 'POST',
@@ -241,7 +912,10 @@ describe('Investigation detail', () => {
       value: {writeText},
       writable: true,
     });
-    MockApiClient.addMockResponse({url: detailUrl, body: InvestigationDetailFixture()});
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
 
     renderView();
     await userEvent.click(await screen.findByLabelText('Investigation actions'));
@@ -255,7 +929,10 @@ describe('Investigation detail', () => {
   });
 
   it('deletes after confirmation and returns to the list', async () => {
-    MockApiClient.addMockResponse({url: detailUrl, body: InvestigationDetailFixture()});
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture(),
+    });
     const deleteRequest = MockApiClient.addMockResponse({
       url: detailUrl,
       method: 'DELETE',
@@ -294,7 +971,10 @@ describe('Investigation detail', () => {
       headers: {},
       json: InvestigationDetailFixture(),
     });
-    const request = MockApiClient.addMockResponse({url: detailUrl, statusCode: 500});
+    const request = MockApiClient.addMockResponse({
+      url: detailUrl,
+      statusCode: 500,
+    });
 
     renderView(organization, queryClient);
     expect(screen.getByText('Investigate database latency')).toBeInTheDocument();
@@ -326,7 +1006,10 @@ describe('Investigation detail', () => {
     });
 
     renderView(
-      OrganizationFixture({features: ['investigations'], openMembership: false})
+      OrganizationFixture({
+        features: ['investigations'],
+        openMembership: false,
+      })
     );
 
     expect(

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -14,7 +14,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
-import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {getInvestigationDetailQueryOptions} from 'sentry/views/investigations/api';
 import InvestigationDetailView from 'sentry/views/investigations/detail';
 import type {
   InvestigationBlock,
@@ -884,7 +884,7 @@ describe('Investigation detail', () => {
     const queryClient = makeTestQueryClient();
 
     await queryClient.prefetchQuery(
-      investigationDetailQueryOptions('org-slug', 'investigation-1')
+      getInvestigationDetailQueryOptions('org-slug', 'investigation-1')
     );
     renderView(organization, queryClient);
 
@@ -1015,7 +1015,7 @@ describe('Investigation detail', () => {
 
   it('retains cached data when a background refetch fails', async () => {
     const queryClient = makeTestQueryClient();
-    const options = investigationDetailQueryOptions('org-slug', 'investigation-1');
+    const options = getInvestigationDetailQueryOptions('org-slug', 'investigation-1');
     queryClient.setQueryData(options.queryKey, {
       headers: {},
       json: InvestigationDetailFixture(),

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -142,6 +142,55 @@ describe('Investigation detail', () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
+  it('shows running and dependency-waiting states for auto-run cells', async () => {
+    const investigation = InvestigationDetailFixture({
+      template: {key: 'breached_metric', version: 1},
+    });
+    const textBlock = investigation.blocks[0]!;
+    const queryBlock = investigation.blocks[1]!;
+    investigation.blocks = [
+      {
+        ...textBlock,
+        config: {autoRun: true},
+        outputStatus: 'running',
+        currentExecution: {
+          id: 'execution-1',
+          status: 'running',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: null,
+          error: null,
+        },
+      },
+      {
+        ...queryBlock,
+        config: {autoRun: true},
+        outputStatus: 'pending',
+        currentExecution: {
+          id: 'execution-2',
+          status: 'pending',
+          startedAt: null,
+          completedAt: null,
+          error: null,
+        },
+      },
+      {
+        ...textBlock,
+        id: 'block-3',
+        position: 2,
+        title: 'Synthesis',
+        config: {autoRun: true},
+        dependencies: ['block-1', 'block-2'],
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(await screen.findAllByText('Seer is working on this cell…')).toHaveLength(2);
+    expect(screen.getByText('Waiting for previous cells…')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Ask Seer about Synthesis'})).toBeDisabled();
+  });
+
   it('keeps the refinement composer expanded while editing', async () => {
     MockApiClient.addMockResponse({
       url: detailUrl,

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -300,7 +300,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
                 />
               ) : null}
 
-              <Stack gap="0">
+              <Stack gap="xl">
                 {notebookCells.map(block => (
                   <InvestigationCell
                     key={block.id}

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -7,7 +7,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
@@ -36,7 +36,10 @@ import {
   useDuplicateInvestigationMutation,
   useRenameInvestigationMutation,
 } from 'sentry/views/investigations/api';
-import {InvestigationCell} from 'sentry/views/investigations/detail/cell';
+import {
+  InvestigationCell,
+  shouldPollInvestigationBlocks,
+} from 'sentry/views/investigations/detail/cell';
 import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
 import type {
   InvestigationBlockKind,
@@ -82,7 +85,7 @@ function InvestigationBootstrapPage({investigationId}: {investigationId: string}
     ...detailOptions,
     refetchInterval: query => {
       const data = query.state.data?.json;
-      return data?.blocks?.some(block => isExecutionActive(block.outputStatus)) ||
+      return shouldPollInvestigationBlocks(data?.blocks ?? []) ||
         isTitleGenerationActive(data?.titleGeneration?.status)
         ? 2000
         : false;
@@ -157,6 +160,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
     onError: () => addErrorMessage(t('Unable to duplicate investigation.')),
   });
   const deleteMutation = useDeleteInvestigationMutation(organization.slug, {
+    onMutate: () => renameDebouncer.cancel(),
     onSuccess: () => {
       queryClient.removeQueries({
         queryKey: detailOptions.queryKey,
@@ -284,7 +288,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
             />
           </HeaderBreadcrumbs>
         </Layout.Title>
-        <NotebookHeader>
+        <Container as="header" width="100%" padding="xl" borderBottom="primary">
           <Grid
             columns="minmax(0, 1fr) auto"
             align="start"
@@ -319,7 +323,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
               <IconSeer size="sm" />
             </Flex>
           </Grid>
-        </NotebookHeader>
+        </Container>
         <Layout.Body>
           <Layout.Main width="full">
             <InvestigationCanvas>
@@ -445,10 +449,6 @@ function AddCellComposer({
   );
 }
 
-function isExecutionActive(status: string) {
-  return ['pending', 'running', 'awaiting_input', 'stopping'].includes(status);
-}
-
 function isTitleGenerationActive(status: string | null | undefined) {
   return status === 'pending' || status === 'running';
 }
@@ -524,12 +524,6 @@ const HeaderInvestigationTitle = styled('span')`
   text-decoration-color: ${p => p.theme.tokens.border.primary};
   text-underline-offset: 5px;
   text-overflow: ellipsis;
-`;
-
-const NotebookHeader = styled('header')`
-  width: 100%;
-  padding: ${p => p.theme.space.xl};
-  border-bottom: 1px solid #f8f8fa;
 `;
 
 const NotebookTitleInput = styled(Input)`

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -30,7 +30,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {
-  investigationDetailQueryOptions,
+  getInvestigationDetailQueryOptions,
   useAddInvestigationBlockMutation,
   useDeleteInvestigationMutation,
   useDuplicateInvestigationMutation,
@@ -69,7 +69,7 @@ function ClosedMembershipPage() {
 
 function InvestigationBootstrapPage({investigationId}: {investigationId: string}) {
   const organization = useOrganization();
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organization.slug,
     investigationId
   );
@@ -110,7 +110,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   const {copy} = useCopyToClipboard();
   const [draftTitle, setDraftTitle] = useState(investigation.title);
   const persistedTitle = useRef(investigation.title);
-  const detailOptions = investigationDetailQueryOptions(
+  const detailOptions = getInvestigationDetailQueryOptions(
     organization.slug,
     investigation.id
   );

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -1,6 +1,6 @@
-import {useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {useDebouncedCallback} from '@tanstack/react-pacer';
+import {useDebouncer} from '@tanstack/react-pacer';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -80,10 +80,13 @@ function InvestigationBootstrapPage({investigationId}: {investigationId: string}
     isPending,
   } = useQuery({
     ...detailOptions,
-    refetchInterval: query =>
-      query.state.data?.json.blocks?.some(block => isExecutionActive(block.outputStatus))
+    refetchInterval: query => {
+      const data = query.state.data?.json;
+      return data?.blocks?.some(block => isExecutionActive(block.outputStatus)) ||
+        isTitleGenerationActive(data?.titleGeneration?.status)
         ? 2000
-        : false,
+        : false;
+    },
   });
 
   if (isPending && !investigation) {
@@ -125,16 +128,27 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
       onError: () => addErrorMessage(t('Unable to rename investigation.')),
     }
   );
-  const renameInvestigation = renameMutation.mutate;
-  const debouncedRename = useDebouncedCallback(
+  const renameDebouncer = useDebouncer(
     (nextTitle: string) => {
       const title = nextTitle.trim();
       if (title && title !== persistedTitle.current) {
-        renameInvestigation(title);
+        renameMutation.mutate(title);
       }
     },
-    {wait: 500}
+    {wait: 500, onUnmount: debouncer => debouncer.flush()}
   );
+
+  useEffect(() => {
+    if (
+      draftTitle === persistedTitle.current &&
+      investigation.title !== persistedTitle.current
+    ) {
+      persistedTitle.current = investigation.title;
+      // Keep an in-progress user edit, but adopt a generated title while the draft is clean.
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
+      setDraftTitle(investigation.title);
+    }
+  }, [draftTitle, investigation.title]);
   const duplicateMutation = useDuplicateInvestigationMutation(organization.slug, {
     onSuccess: duplicate => {
       addSuccessMessage(t('Investigation duplicated.'));
@@ -167,14 +181,24 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
       investigation.id,
       current => ({...current, title: nextTitle})
     );
-    debouncedRename(nextTitle);
+    renameDebouncer.maybeExecute(nextTitle);
   }
 
   function handleTitleBlur() {
+    renameDebouncer.cancel();
     const title = draftTitle.trim();
     if (title) {
       if (title !== draftTitle) {
-        handleTitleChange(title);
+        setDraftTitle(title);
+        updateInvestigationCache(
+          queryClient,
+          organization.slug,
+          investigation.id,
+          current => ({...current, title})
+        );
+      }
+      if (title !== persistedTitle.current) {
+        renameMutation.mutate(title);
       }
       return;
     }
@@ -416,6 +440,10 @@ function AddCellComposer({
 
 function isExecutionActive(status: string) {
   return ['pending', 'running', 'awaiting_input', 'stopping'].includes(status);
+}
+
+function isTitleGenerationActive(status: string | null | undefined) {
+  return status === 'pending' || status === 'running';
 }
 
 function getInvestigationPath(organizationSlug: string, investigationId: string) {

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -7,7 +7,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
@@ -285,7 +285,14 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
           </HeaderBreadcrumbs>
         </Layout.Title>
         <NotebookHeader>
-          <NotebookHeaderContent>
+          <Grid
+            columns="minmax(0, 1fr) auto"
+            align="start"
+            gap="lg"
+            width="100%"
+            maxWidth="885px"
+            margin="0 auto"
+          >
             <Stack gap="xs" minWidth={0}>
               <NotebookTitleInput
                 aria-label={t('Investigation title')}
@@ -311,7 +318,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
               </Badge>
               <IconSeer size="sm" />
             </Flex>
-          </NotebookHeaderContent>
+          </Grid>
         </NotebookHeader>
         <Layout.Body>
           <Layout.Main width="full">
@@ -523,15 +530,6 @@ const NotebookHeader = styled('header')`
   width: 100%;
   padding: ${p => p.theme.space.xl};
   border-bottom: 1px solid #f8f8fa;
-`;
-
-const NotebookHeaderContent = styled('div')`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: ${p => p.theme.space.lg};
-  width: min(100%, 885px);
-  margin: 0 auto;
 `;
 
 const NotebookTitleInput = styled(Input)`

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -1,19 +1,46 @@
-import {useQuery} from '@tanstack/react-query';
+import {useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {useDebouncedCallback} from '@tanstack/react-pacer';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Badge} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Stack} from '@sentry/scraps/layout';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Input} from '@sentry/scraps/input';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import Feature from 'sentry/components/acl/feature';
 import {FeatureDisabled} from 'sentry/components/acl/featureDisabled';
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import {openConfirmModal} from 'sentry/components/confirm';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {IconSeer, IconStack} from 'sentry/icons';
+import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {
+  investigationDetailQueryOptions,
+  useDeleteInvestigationMutation,
+  useDuplicateInvestigationMutation,
+  useRenameInvestigationMutation,
+} from 'sentry/views/investigations/api';
+import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
+import type {
+  InvestigationBlock,
+  InvestigationDetail,
+} from 'sentry/views/investigations/types';
 import {RouteError} from 'sentry/views/routeError';
 
 function FeatureDisabledPage() {
@@ -62,21 +89,416 @@ function InvestigationBootstrapPage({investigationId}: {investigationId: string}
     return null;
   }
 
+  return <InvestigationPageContent investigation={investigation} />;
+}
+
+function InvestigationPageContent({investigation}: {investigation: InvestigationDetail}) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const {copy} = useCopyToClipboard();
+  const [draftTitle, setDraftTitle] = useState(investigation.title);
+  const persistedTitle = useRef(investigation.title);
+  const detailOptions = investigationDetailQueryOptions(
+    organization.slug,
+    investigation.id
+  );
+
+  const renameMutation = useRenameInvestigationMutation(
+    organization.slug,
+    investigation.id,
+    {
+      onSuccess: updated => {
+        persistedTitle.current = updated.title;
+      },
+      onError: () => addErrorMessage(t('Unable to rename investigation.')),
+    }
+  );
+  const renameInvestigation = renameMutation.mutate;
+  const debouncedRename = useDebouncedCallback(
+    (nextTitle: string) => {
+      const title = nextTitle.trim();
+      if (title && title !== persistedTitle.current) {
+        renameInvestigation(title);
+      }
+    },
+    {wait: 500}
+  );
+  const duplicateMutation = useDuplicateInvestigationMutation(organization.slug, {
+    onSuccess: duplicate => {
+      addSuccessMessage(t('Investigation duplicated.'));
+      navigate(getInvestigationPath(organization.slug, duplicate.id));
+    },
+    onError: () => addErrorMessage(t('Unable to duplicate investigation.')),
+  });
+  const deleteMutation = useDeleteInvestigationMutation(organization.slug, {
+    onSuccess: () => {
+      queryClient.removeQueries({queryKey: detailOptions.queryKey, exact: true});
+      addSuccessMessage(t('Investigation deleted.'));
+      navigate(`/organizations/${organization.slug}/explore/investigations/`);
+    },
+    onError: () => addErrorMessage(t('Unable to delete investigation.')),
+  });
+
+  function handleTitleChange(nextTitle: string) {
+    setDraftTitle(nextTitle);
+    updateInvestigationCache(
+      queryClient,
+      organization.slug,
+      investigation.id,
+      current => ({...current, title: nextTitle})
+    );
+    debouncedRename(nextTitle);
+  }
+
+  function handleTitleBlur() {
+    const title = draftTitle.trim();
+    if (title) {
+      if (title !== draftTitle) {
+        handleTitleChange(title);
+      }
+      return;
+    }
+    handleTitleChange(persistedTitle.current);
+  }
+
+  const blocks = investigation.blocks ?? [];
+  const summaryBlock = blocks[0];
+
   return (
-    <SentryDocumentTitle title={investigation.title} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={draftTitle} orgSlug={organization.slug}>
       <Stack flex={1}>
-        <Layout.Title>{investigation.title}</Layout.Title>
+        <Layout.Title>
+          <HeaderBreadcrumbs align="center" gap="sm" minWidth={0}>
+            <IconStack size="md" />
+            <HeaderBreadcrumbLink
+              to={`/organizations/${organization.slug}/explore/investigations/`}
+            >
+              {t('Investigations')}
+            </HeaderBreadcrumbLink>
+            <HeaderDivider>/</HeaderDivider>
+            <HeaderInvestigationTitle>{draftTitle}</HeaderInvestigationTitle>
+            <DropdownMenu
+              items={[
+                {
+                  key: 'copy-link',
+                  label: t('Copy link'),
+                  onAction: () =>
+                    copy(
+                      `${window.location.origin}${getInvestigationPath(
+                        organization.slug,
+                        investigation.id
+                      )}`,
+                      {successMessage: t('Investigation link copied.')}
+                    ),
+                },
+                {
+                  key: 'duplicate',
+                  label: t('Duplicate'),
+                  onAction: () => duplicateMutation.mutate(investigation),
+                },
+                {
+                  key: 'delete',
+                  label: t('Delete'),
+                  priority: 'danger',
+                  onAction: () =>
+                    openConfirmModal({
+                      message: t('Are you sure you want to delete this investigation?'),
+                      priority: 'danger',
+                      confirmText: t('Delete'),
+                      onConfirm: () => deleteMutation.mutate(investigation),
+                    }),
+                },
+              ]}
+              triggerProps={{
+                size: 'sm',
+                showChevron: false,
+                variant: 'transparent',
+                icon: <IconEllipsis />,
+                'aria-label': t('Investigation actions'),
+              }}
+              position="bottom-end"
+              usePortal
+            />
+          </HeaderBreadcrumbs>
+        </Layout.Title>
+        <NotebookHeader>
+          <NotebookHeaderContent>
+            <Stack gap="xs" minWidth={0}>
+              <NotebookTitleInput
+                aria-label={t('Investigation title')}
+                value={draftTitle}
+                onChange={event => handleTitleChange(event.target.value)}
+                onBlur={handleTitleBlur}
+                maxLength={200}
+                aria-busy={renameMutation.isPending}
+              />
+              <Flex align="center" gap="sm" wrap="wrap">
+                <Text variant="muted">{formatSourceType(investigation.sourceType)}</Text>
+                <MetaDivider />
+                <Text variant="muted">{t('%s blocks', investigation.blockCount)}</Text>
+                <MetaDivider />
+                <Text variant="muted">
+                  {t('Last update: %s', formatNotebookDate(investigation.dateUpdated))}
+                </Text>
+              </Flex>
+            </Stack>
+            <Flex align="center" gap="sm">
+              <Badge variant={getStatusVariant(investigation.status)}>
+                {formatStatus(investigation.status)}
+              </Badge>
+              <IconSeer size="sm" />
+            </Flex>
+          </NotebookHeaderContent>
+        </NotebookHeader>
         <Layout.Body>
           <Layout.Main width="full">
+            <InvestigationCanvas>
+              {summaryBlock ? <CurrentUnderstanding block={summaryBlock} /> : null}
+
+              <Stack gap="0">
+                {blocks.slice(1).map((block, index) => (
+                  <InvestigationCell key={block.id} block={block} index={index} />
+                ))}
+              </Stack>
+            </InvestigationCanvas>
+          </Layout.Main>
+        </Layout.Body>
+        <DebugPanel size="sm" variant="outline">
+          <Disclosure.Title>
+            <Text size="sm" monospace bold>
+              {t('Investigation JSON')}
+            </Text>
+          </Disclosure.Title>
+          <DebugPanelContent>
             <CodeBlock language="json">
               {JSON.stringify(investigation, null, 2)}
             </CodeBlock>
-          </Layout.Main>
-        </Layout.Body>
+          </DebugPanelContent>
+        </DebugPanel>
       </Stack>
     </SentryDocumentTitle>
   );
 }
+
+function CurrentUnderstanding({block}: {block: InvestigationBlock}) {
+  const output = getBlockOutputMarkdown(block.output);
+
+  return (
+    <UnderstandingCard>
+      <Stack gap="sm">
+        <Text size="sm" variant="muted">
+          {t('Current understanding')}
+        </Text>
+        <Heading as="h2" size="lg">
+          {block.title || t('Investigation summary')}
+        </Heading>
+        {output ? (
+          <SeerMarkdown raw={output} />
+        ) : (
+          <Text variant="muted">{t('This block has no output yet.')}</Text>
+        )}
+      </Stack>
+      <Flex align="center" gap="xs" alignSelf="start">
+        <Text bold>{t('View causal chain')}</Text>
+      </Flex>
+    </UnderstandingCard>
+  );
+}
+
+function InvestigationCell({block, index}: {block: InvestigationBlock; index: number}) {
+  const output = getBlockOutputMarkdown(block.output);
+
+  return (
+    <Cell>
+      <Stack gap="sm">
+        <Heading as="h2" size="lg">
+          {block.title || t('Investigation step %s', index + 2)}
+        </Heading>
+        {output ? (
+          <SeerMarkdown raw={output} />
+        ) : (
+          <Text variant="muted">{t('This block has no output yet.')}</Text>
+        )}
+      </Stack>
+    </Cell>
+  );
+}
+
+function getBlockOutputMarkdown(output: unknown): string | null {
+  if (typeof output === 'string') {
+    return output;
+  }
+  if (!output || typeof output !== 'object') {
+    return null;
+  }
+  if ('markdown' in output && typeof output.markdown === 'string') {
+    return output.markdown;
+  }
+  if ('tableMarkdown' in output && typeof output.tableMarkdown === 'string') {
+    return output.tableMarkdown;
+  }
+  return null;
+}
+
+function getInvestigationPath(organizationSlug: string, investigationId: string) {
+  return normalizeUrl(
+    `/organizations/${organizationSlug}/seer/investigation/${investigationId}/`
+  );
+}
+
+function formatSourceType(sourceType: string) {
+  if (sourceType === 'metric_open_period') {
+    return t('Breached metric');
+  }
+  if (sourceType === 'manual') {
+    return t('Manual investigation');
+  }
+  return sourceType.replaceAll('_', ' ');
+}
+
+function formatStatus(status: string) {
+  return status.replaceAll('_', ' ').replace(/^./, character => character.toUpperCase());
+}
+
+function formatNotebookDate(date: string) {
+  return new Date(date).toISOString().slice(0, 10).replaceAll('-', '.');
+}
+
+function getStatusVariant(status: string): 'success' | 'warning' | 'muted' {
+  if (status === 'completed' || status === 'active') {
+    return 'success';
+  }
+  if (status === 'pending') {
+    return 'warning';
+  }
+  return 'muted';
+}
+
+const InvestigationCanvas = styled(Stack)`
+  width: min(100%, 884px);
+  margin: 0 auto;
+`;
+
+const HeaderBreadcrumbs = styled(Flex)`
+  height: 32px;
+  overflow: hidden;
+  font-size: ${p => p.theme.font.size.lg};
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  line-height: 32px;
+  white-space: nowrap;
+`;
+
+const HeaderBreadcrumbLink = styled(Link)`
+  overflow: hidden;
+  color: ${p => p.theme.tokens.content.secondary};
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: ${p => p.theme.tokens.border.primary};
+  text-underline-offset: 5px;
+  text-overflow: ellipsis;
+`;
+
+const HeaderDivider = styled('span')`
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const HeaderInvestigationTitle = styled('span')`
+  overflow: hidden;
+  color: ${p => p.theme.tokens.content.primary};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: ${p => p.theme.tokens.border.primary};
+  text-underline-offset: 5px;
+  text-overflow: ellipsis;
+`;
+
+const NotebookHeader = styled('header')`
+  width: 100%;
+  padding: ${p => p.theme.space.xl};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const NotebookHeaderContent = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: ${p => p.theme.space.lg};
+  width: min(100%, 885px);
+  margin: 0 auto;
+`;
+
+const NotebookTitleInput = styled(Input)`
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  color: ${p => p.theme.tokens.content.primary};
+  background: transparent;
+  border-color: transparent;
+  border-radius: ${p => p.theme.radius.sm};
+  box-shadow: none;
+  font-size: ${p => p.theme.font.size['2xl']};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  line-height: 1.25;
+
+  &:hover,
+  &:focus {
+    background: ${p => p.theme.tokens.background.secondary};
+    border-color: ${p => p.theme.tokens.border.primary};
+  }
+`;
+
+const MetaDivider = styled('span')`
+  height: 16px;
+  border-left: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const UnderstandingCard = styled('section')`
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: ${p => p.theme.space.xl};
+  width: 100%;
+  margin: 0 0 ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space.xl};
+  overflow: hidden;
+  border: 1px solid ${p => p.theme.tokens.border.accent.muted};
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: ${p => p.theme.shadow.low};
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 4px;
+    background: ${p => p.theme.tokens.background.accent.vibrant};
+  }
+`;
+
+const Cell = styled('section')`
+  width: min(100%, 862px);
+  margin: 0 auto;
+  padding: ${p => p.theme.space.xl} 0;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const DebugPanel = styled(Disclosure)`
+  position: fixed;
+  right: ${p => p.theme.space.xl};
+  bottom: ${p => p.theme.space.xl};
+  z-index: ${p => p.theme.zIndex.dropdown};
+  width: min(560px, calc(100vw - 32px));
+  background: ${p => p.theme.tokens.background.primary};
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: ${p => p.theme.shadow.high};
+`;
+
+const DebugPanelContent = styled(Disclosure.Content)`
+  max-height: min(60vh, 640px);
+  overflow: auto;
+`;
 
 export default function InvestigationDetailView() {
   const organization = useOrganization();

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -5,12 +5,12 @@ import {useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
-import {CodeBlock} from '@sentry/scraps/code';
-import {Disclosure} from '@sentry/scraps/disclosure';
+import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
+import {TextArea} from '@sentry/scraps/textarea';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import Feature from 'sentry/components/acl/feature';
@@ -20,9 +20,8 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {IconSeer, IconStack} from 'sentry/icons';
+import {IconAdd, IconSeer, IconStack} from 'sentry/icons';
 import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t} from 'sentry/locale';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -32,13 +31,15 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {
   investigationDetailQueryOptions,
+  useAddInvestigationBlockMutation,
   useDeleteInvestigationMutation,
   useDuplicateInvestigationMutation,
   useRenameInvestigationMutation,
 } from 'sentry/views/investigations/api';
+import {InvestigationCell} from 'sentry/views/investigations/detail/cell';
 import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
 import type {
-  InvestigationBlock,
+  InvestigationBlockKind,
   InvestigationDetail,
 } from 'sentry/views/investigations/types';
 import {RouteError} from 'sentry/views/routeError';
@@ -68,12 +69,22 @@ function ClosedMembershipPage() {
 
 function InvestigationBootstrapPage({investigationId}: {investigationId: string}) {
   const organization = useOrganization();
+  const detailOptions = investigationDetailQueryOptions(
+    organization.slug,
+    investigationId
+  );
   const {
     data: investigation,
     error,
     isError,
     isPending,
-  } = useQuery(investigationDetailQueryOptions(organization.slug, investigationId));
+  } = useQuery({
+    ...detailOptions,
+    refetchInterval: query =>
+      query.state.data?.json.blocks?.some(block => isExecutionActive(block.outputStatus))
+        ? 2000
+        : false,
+  });
 
   if (isPending && !investigation) {
     return <LoadingIndicator />;
@@ -133,12 +144,20 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   });
   const deleteMutation = useDeleteInvestigationMutation(organization.slug, {
     onSuccess: () => {
-      queryClient.removeQueries({queryKey: detailOptions.queryKey, exact: true});
+      queryClient.removeQueries({
+        queryKey: detailOptions.queryKey,
+        exact: true,
+      });
       addSuccessMessage(t('Investigation deleted.'));
       navigate(`/organizations/${organization.slug}/explore/investigations/`);
     },
     onError: () => addErrorMessage(t('Unable to delete investigation.')),
   });
+  const addBlockMutation = useAddInvestigationBlockMutation(
+    organization.slug,
+    investigation.id,
+    {onError: () => addErrorMessage(t('Unable to add cell.'))}
+  );
 
   function handleTitleChange(nextTitle: string) {
     setDraftTitle(nextTitle);
@@ -163,13 +182,32 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   }
 
   const blocks = investigation.blocks ?? [];
-  const summaryBlock = blocks[0];
+  const summaryBlock = investigation.template ? blocks[0] : undefined;
+  const notebookCells = summaryBlock ? blocks.slice(1) : blocks;
+
+  async function handleAddBlock({
+    kind,
+    prompt,
+    title,
+  }: {
+    kind: InvestigationBlockKind;
+    prompt: string;
+    title: string;
+  }) {
+    await addBlockMutation.mutateAsync({investigation, kind, prompt, title});
+  }
 
   return (
     <SentryDocumentTitle title={draftTitle} orgSlug={organization.slug}>
       <Stack flex={1}>
         <Layout.Title>
-          <HeaderBreadcrumbs align="center" gap="sm" minWidth={0}>
+          <HeaderBreadcrumbs
+            align="center"
+            gap="sm"
+            minWidth={0}
+            data-test-id="investigation-breadcrumbs"
+            data-text-size="md"
+          >
             <IconStack size="md" />
             <HeaderBreadcrumbLink
               to={`/organizations/${organization.slug}/explore/investigations/`}
@@ -254,91 +292,130 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
         <Layout.Body>
           <Layout.Main width="full">
             <InvestigationCanvas>
-              {summaryBlock ? <CurrentUnderstanding block={summaryBlock} /> : null}
+              {summaryBlock ? (
+                <InvestigationCell
+                  block={summaryBlock}
+                  canRun={investigation.status === 'active'}
+                  investigation={investigation}
+                />
+              ) : null}
 
               <Stack gap="0">
-                {blocks.slice(1).map((block, index) => (
-                  <InvestigationCell key={block.id} block={block} index={index} />
+                {notebookCells.map(block => (
+                  <InvestigationCell
+                    key={block.id}
+                    block={block}
+                    canRun={investigation.status === 'active'}
+                    investigation={investigation}
+                  />
                 ))}
               </Stack>
+              {investigation.status === 'active' ? (
+                <AddCellComposer
+                  isAdding={addBlockMutation.isPending}
+                  onAdd={handleAddBlock}
+                />
+              ) : null}
             </InvestigationCanvas>
           </Layout.Main>
         </Layout.Body>
-        <DebugPanel size="sm" variant="outline">
-          <Disclosure.Title>
-            <Text size="sm" monospace bold>
-              {t('Investigation JSON')}
-            </Text>
-          </Disclosure.Title>
-          <DebugPanelContent>
-            <CodeBlock language="json">
-              {JSON.stringify(investigation, null, 2)}
-            </CodeBlock>
-          </DebugPanelContent>
-        </DebugPanel>
       </Stack>
     </SentryDocumentTitle>
   );
 }
 
-function CurrentUnderstanding({block}: {block: InvestigationBlock}) {
-  const output = getBlockOutputMarkdown(block.output);
+function AddCellComposer({
+  isAdding,
+  onAdd,
+}: {
+  isAdding: boolean;
+  onAdd: (cell: {
+    kind: InvestigationBlockKind;
+    prompt: string;
+    title: string;
+  }) => Promise<void>;
+}) {
+  const [kind, setKind] = useState<InvestigationBlockKind | null>(null);
+  const [title, setTitle] = useState('');
+  const [prompt, setPrompt] = useState('');
+
+  function reset() {
+    setKind(null);
+    setTitle('');
+    setPrompt('');
+  }
+
+  async function handleAdd() {
+    if (!kind || !prompt.trim()) {
+      return;
+    }
+    try {
+      await onAdd({kind, title: title.trim(), prompt: prompt.trim()});
+      reset();
+    } catch {
+      // The mutation owns user-facing error handling and leaves the draft intact.
+    }
+  }
+
+  if (!kind) {
+    return (
+      <AddCellActions align="center" justify="center" gap="sm">
+        <Button size="sm" icon={<IconAdd />} onClick={() => setKind('text')}>
+          {t('Text cell')}
+        </Button>
+        <Button size="sm" icon={<IconAdd />} onClick={() => setKind('query')}>
+          {t('Query cell')}
+        </Button>
+      </AddCellActions>
+    );
+  }
 
   return (
-    <UnderstandingCard>
-      <Stack gap="sm">
-        <Text size="sm" variant="muted">
-          {t('Current understanding')}
-        </Text>
-        <Heading as="h2" size="lg">
-          {block.title || t('Investigation summary')}
+    <CellComposer>
+      <Stack gap="md">
+        <Heading as="h2" size="md">
+          {kind === 'text' ? t('Add text cell') : t('Add query cell')}
         </Heading>
-        {output ? (
-          <SeerMarkdown raw={output} />
-        ) : (
-          <Text variant="muted">{t('This block has no output yet.')}</Text>
-        )}
+        <Input
+          aria-label={t('Cell title')}
+          placeholder={t('Title (optional)')}
+          value={title}
+          onChange={event => setTitle(event.target.value)}
+        />
+        <TextArea
+          aria-label={t('Cell instructions')}
+          autosize
+          autoFocus
+          rows={3}
+          placeholder={
+            kind === 'text'
+              ? t('Describe the text to generate')
+              : t('Describe the query to run')
+          }
+          value={prompt}
+          onChange={event => setPrompt(event.target.value)}
+        />
+        <Flex align="center" justify="end" gap="sm">
+          <Button size="sm" onClick={reset} disabled={isAdding}>
+            {t('Cancel')}
+          </Button>
+          <Button
+            size="sm"
+            variant="primary"
+            busy={isAdding}
+            disabled={!prompt.trim()}
+            onClick={() => void handleAdd()}
+          >
+            {t('Add cell')}
+          </Button>
+        </Flex>
       </Stack>
-      <Flex align="center" gap="xs" alignSelf="start">
-        <Text bold>{t('View causal chain')}</Text>
-      </Flex>
-    </UnderstandingCard>
+    </CellComposer>
   );
 }
 
-function InvestigationCell({block, index}: {block: InvestigationBlock; index: number}) {
-  const output = getBlockOutputMarkdown(block.output);
-
-  return (
-    <Cell>
-      <Stack gap="sm">
-        <Heading as="h2" size="lg">
-          {block.title || t('Investigation step %s', index + 2)}
-        </Heading>
-        {output ? (
-          <SeerMarkdown raw={output} />
-        ) : (
-          <Text variant="muted">{t('This block has no output yet.')}</Text>
-        )}
-      </Stack>
-    </Cell>
-  );
-}
-
-function getBlockOutputMarkdown(output: unknown): string | null {
-  if (typeof output === 'string') {
-    return output;
-  }
-  if (!output || typeof output !== 'object') {
-    return null;
-  }
-  if ('markdown' in output && typeof output.markdown === 'string') {
-    return output.markdown;
-  }
-  if ('tableMarkdown' in output && typeof output.tableMarkdown === 'string') {
-    return output.tableMarkdown;
-  }
-  return null;
+function isExecutionActive(status: string) {
+  return ['pending', 'running', 'awaiting_input', 'stopping'].includes(status);
 }
 
 function getInvestigationPath(organizationSlug: string, investigationId: string) {
@@ -383,7 +460,7 @@ const InvestigationCanvas = styled(Stack)`
 const HeaderBreadcrumbs = styled(Flex)`
   height: 32px;
   overflow: hidden;
-  font-size: ${p => p.theme.font.size.lg};
+  font-size: ${p => p.theme.font.size.md};
   font-weight: ${p => p.theme.font.weight.sans.regular};
   line-height: 32px;
   white-space: nowrap;
@@ -417,7 +494,7 @@ const HeaderInvestigationTitle = styled('span')`
 const NotebookHeader = styled('header')`
   width: 100%;
   padding: ${p => p.theme.space.xl};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  border-bottom: 1px solid #f8f8fa;
 `;
 
 const NotebookHeaderContent = styled('div')`
@@ -455,49 +532,17 @@ const MetaDivider = styled('span')`
   border-left: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
-const UnderstandingCard = styled('section')`
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: ${p => p.theme.space.xl};
-  width: 100%;
-  margin: 0 0 ${p => p.theme.space.xl};
-  padding: ${p => p.theme.space.xl};
-  overflow: hidden;
-  border: 1px solid ${p => p.theme.tokens.border.accent.muted};
-  border-radius: ${p => p.theme.radius.md};
-  box-shadow: ${p => p.theme.shadow.low};
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 4px;
-    background: ${p => p.theme.tokens.background.accent.vibrant};
-  }
-`;
-
-const Cell = styled('section')`
-  width: min(100%, 862px);
-  margin: 0 auto;
+const AddCellActions = styled(Flex)`
   padding: ${p => p.theme.space.xl} 0;
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
-const DebugPanel = styled(Disclosure)`
-  position: fixed;
-  right: ${p => p.theme.space.xl};
-  bottom: ${p => p.theme.space.xl};
-  z-index: ${p => p.theme.zIndex.dropdown};
-  width: min(560px, calc(100vw - 32px));
-  background: ${p => p.theme.tokens.background.primary};
+const CellComposer = styled('section')`
+  width: min(100%, 862px);
+  margin: ${p => p.theme.space.lg} auto 0;
+  padding: ${p => p.theme.space.xl};
+  background: ${p => p.theme.tokens.background.secondary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
   border-radius: ${p => p.theme.radius.md};
-  box-shadow: ${p => p.theme.shadow.high};
-`;
-
-const DebugPanelContent = styled(Disclosure.Content)`
-  max-height: min(60vh, 640px);
-  overflow: auto;
 `;
 
 export default function InvestigationDetailView() {

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -13,7 +13,7 @@ import {
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {Organization} from 'sentry/types/organization';
 import InvestigationsView from 'sentry/views/investigations';
-import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {getInvestigationDetailQueryOptions} from 'sentry/views/investigations/api';
 import type {
   InvestigationDetail,
   InvestigationListItem,
@@ -220,7 +220,7 @@ describe('Explore Investigations', () => {
     });
 
     const {queryClient, router} = renderView();
-    const unrelatedOptions = investigationDetailQueryOptions('org-slug', 'existing');
+    const unrelatedOptions = getInvestigationDetailQueryOptions('org-slug', 'existing');
     const unrelatedDetail = InvestigationFixture({id: 'existing'});
     queryClient.setQueryData(unrelatedOptions.queryKey, {
       headers: {},
@@ -310,7 +310,7 @@ describe('Explore Investigations', () => {
     });
 
     const {queryClient} = renderView();
-    const detailOptions = investigationDetailQueryOptions('org-slug', '1');
+    const detailOptions = getInvestigationDetailQueryOptions('org-slug', '1');
     queryClient.setQueryData(detailOptions.queryKey, {
       headers: {Link: 'preserved'},
       json: investigation satisfies InvestigationDetail,
@@ -339,7 +339,7 @@ describe('Explore Investigations', () => {
     });
 
     const {queryClient} = renderView();
-    const unrelatedOptions = investigationDetailQueryOptions('org-slug', 'existing');
+    const unrelatedOptions = getInvestigationDetailQueryOptions('org-slug', 'existing');
     const unrelatedDetail = InvestigationFixture({id: 'existing'});
     queryClient.setQueryData(unrelatedOptions.queryKey, {
       headers: {},
@@ -435,7 +435,7 @@ describe('Explore Investigations', () => {
     });
 
     const {queryClient} = renderView();
-    const detailOptions = investigationDetailQueryOptions('org-slug', '1');
+    const detailOptions = getInvestigationDetailQueryOptions('org-slug', '1');
     queryClient.setQueryData(detailOptions.queryKey, {
       headers: {},
       json: investigation satisfies InvestigationDetail,

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -208,7 +208,7 @@ describe('Explore Investigations', () => {
     await waitFor(() => expect(detailRequest).toHaveBeenCalledTimes(1));
   });
 
-  it('creates an untitled investigation and refreshes the list', async () => {
+  it('creates an untitled investigation and opens it', async () => {
     MockApiClient.addMockResponse({
       url: listUrl,
       body: [],
@@ -231,6 +231,10 @@ describe('Explore Investigations', () => {
       url: listUrl,
       body: [InvestigationFixture({title: 'Untitled investigation'})],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/',
+      body: InvestigationFixture({title: 'Untitled investigation'}),
+    });
     await userEvent.click(screen.getByRole('button', {name: 'Launch investigation'}));
 
     await waitFor(() =>
@@ -241,7 +245,7 @@ describe('Explore Investigations', () => {
     );
     expect(await screen.findByText('Untitled investigation')).toBeInTheDocument();
     expect(router.location.pathname).toBe(
-      '/organizations/org-slug/explore/investigations/'
+      '/organizations/org-slug/seer/investigation/1/'
     );
     expect(queryClient.getQueryData(unrelatedOptions.queryKey)?.json).toBe(
       unrelatedDetail

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -34,6 +34,7 @@ import {t} from 'sentry/locale';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   investigationDetailQueryOptions,
@@ -100,6 +101,7 @@ function ClosedMembershipPage() {
 
 function InvestigationsPage() {
   const organization = useOrganization();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const {copy} = useCopyToClipboard();
   const [{query, cursor}, setQueryParams] = useQueryStates({
@@ -118,7 +120,10 @@ function InvestigationsPage() {
   });
 
   const createMutation = useCreateInvestigationMutation(organization.slug, {
-    onSuccess: () => addSuccessMessage(t('Investigation created.')),
+    onSuccess: investigation => {
+      addSuccessMessage(t('Investigation created.'));
+      navigate(getInvestigationPath(organization.slug, investigation.id));
+    },
     onError: () => addErrorMessage(t('Unable to create investigation.')),
   });
 

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -37,7 +37,7 @@ import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
-  investigationDetailQueryOptions,
+  getInvestigationDetailQueryOptions,
   investigationListQueryOptions,
   useCreateInvestigationMutation,
   useDeleteInvestigationMutation,
@@ -148,7 +148,7 @@ function InvestigationsPage() {
   const deleteMutation = useDeleteInvestigationMutation(organization.slug, {
     onSuccess: (_data, investigation) => {
       queryClient.removeQueries({
-        queryKey: investigationDetailQueryOptions(organization.slug, investigation.id)
+        queryKey: getInvestigationDetailQueryOptions(organization.slug, investigation.id)
           .queryKey,
         exact: true,
       });
@@ -223,7 +223,7 @@ function InvestigationsPage() {
               to={getInvestigationPath(organization.slug, investigation.id)}
               onClick={() =>
                 void queryClient.prefetchQuery(
-                  investigationDetailQueryOptions(organization.slug, investigation.id)
+                  getInvestigationDetailQueryOptions(organization.slug, investigation.id)
                 )
               }
             >

--- a/static/app/views/investigations/investigationCache.spec.ts
+++ b/static/app/views/investigations/investigationCache.spec.ts
@@ -1,6 +1,6 @@
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 
-import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {getInvestigationDetailQueryOptions} from 'sentry/views/investigations/api';
 import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
 import type {InvestigationDetail} from 'sentry/views/investigations/types';
 
@@ -20,7 +20,7 @@ const investigation: InvestigationDetail = {
 describe('updateInvestigationCache', () => {
   it('immutably updates the response JSON and preserves headers', () => {
     const queryClient = makeTestQueryClient();
-    const options = investigationDetailQueryOptions('org-slug', 'investigation-1');
+    const options = getInvestigationDetailQueryOptions('org-slug', 'investigation-1');
     const cachedResponse = {
       headers: {Link: 'preserved'},
       json: investigation,
@@ -44,7 +44,7 @@ describe('updateInvestigationCache', () => {
 
   it('does not seed a partial investigation when the query is not cached', () => {
     const queryClient = makeTestQueryClient();
-    const options = investigationDetailQueryOptions('org-slug', 'investigation-1');
+    const options = getInvestigationDetailQueryOptions('org-slug', 'investigation-1');
     const update = jest.fn((current: InvestigationDetail) => current);
 
     updateInvestigationCache(queryClient, 'org-slug', 'investigation-1', update);

--- a/static/app/views/investigations/investigationCache.ts
+++ b/static/app/views/investigations/investigationCache.ts
@@ -1,6 +1,6 @@
 import type {QueryClient} from '@tanstack/react-query';
 
-import {investigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {getInvestigationDetailQueryOptions} from 'sentry/views/investigations/api';
 import type {InvestigationDetail} from 'sentry/views/investigations/types';
 
 export function updateInvestigationCache(
@@ -9,7 +9,7 @@ export function updateInvestigationCache(
   investigationId: string,
   update: (current: InvestigationDetail) => InvestigationDetail
 ) {
-  const options = investigationDetailQueryOptions(organizationSlug, investigationId);
+  const options = getInvestigationDetailQueryOptions(organizationSlug, investigationId);
 
   queryClient.setQueryData(options.queryKey, previous =>
     previous

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -13,7 +13,19 @@ export type InvestigationListItem = {
 
 // Expand this response type as the detail UI begins consuming additional fields.
 // The complete server response is retained at runtime in the query cache.
-export type InvestigationDetail = InvestigationListItem;
+export type InvestigationBlock = {
+  content: string;
+  generatedContent: string;
+  id: string;
+  kind: string;
+  output: unknown;
+  outputStatus: string;
+  title: string;
+};
+
+export type InvestigationDetail = InvestigationListItem & {
+  blocks?: InvestigationBlock[];
+};
 
 export type MetricOpenPeriodInvestigationSource = {
   ref: {

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -1,3 +1,5 @@
+import type {ToolResult} from 'sentry/views/seerExplorer/types';
+
 export type InvestigationListItem = {
   blockCount: number;
   createdBy: string | null;
@@ -91,7 +93,7 @@ export type InvestigationTranscriptBlock = {
     content: string;
     tool_call_function: string;
     tool_call_id: string;
-    structuredContent?: Record<string, unknown> | null;
+    structuredContent?: ToolResult['structuredContent'];
   } | null> | null;
 };
 

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -14,17 +14,121 @@ export type InvestigationListItem = {
 // Expand this response type as the detail UI begins consuming additional fields.
 // The complete server response is retained at runtime in the query cache.
 export type InvestigationBlock = {
+  config: Record<string, unknown>;
   content: string;
+  createdBy: string | null;
+  currentExecution: InvestigationBlockExecution | null;
+  dependencies: string[];
+  display: Record<string, unknown>;
   generatedContent: string;
+  generationPrompt: string;
   id: string;
-  kind: string;
+  kind: InvestigationBlockKind;
+  lastEditedBy: string | null;
   output: unknown;
-  outputStatus: string;
+  outputStatus: InvestigationExecutionStatus;
+  parameterKeys: string[];
+  position: number;
+  staleAt: string | null;
   title: string;
+  version: number;
+};
+
+export type InvestigationBlockKind = 'query' | 'text';
+
+export type InvestigationBlockExecutionStart = {
+  id: string;
+  status: InvestigationExecutionStatus;
+};
+
+export type InvestigationExecutionStatus =
+  | 'notRun'
+  | 'available'
+  | 'restricted'
+  | 'pending'
+  | 'running'
+  | 'awaiting_input'
+  | 'stopping'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type InvestigationBlockExecution = {
+  completedAt: string | null;
+  error: {code?: string; message?: string} | null;
+  id: string;
+  startedAt: string | null;
+  status: InvestigationExecutionStatus;
+  executor?: string;
+  schemaVersion?: number;
+};
+
+export type InvestigationTranscriptBlock = {
+  artifacts: Array<{
+    data: Record<string, unknown> | null;
+    key: string;
+    reason: string;
+  }>;
+  id: string;
+  loading: boolean;
+  message: {
+    content: string | null;
+    role: 'user' | 'assistant' | 'tool_use';
+    metadata?: Record<string, string> | null;
+    thinking_content?: string | null;
+    tool_calls?: Array<{
+      args: string;
+      function: string;
+      id?: string | null;
+    }> | null;
+  };
+  timestamp: string;
+  toolLinks: Array<{
+    kind: string;
+    params: Record<string, unknown>;
+  } | null> | null;
+  toolResults: Array<{
+    content: string;
+    tool_call_function: string;
+    tool_call_id: string;
+    structuredContent?: Record<string, unknown> | null;
+  } | null> | null;
+};
+
+export type InvestigationPendingUserInput = {
+  data: Record<string, unknown>;
+  id: string;
+  input_type: string;
+};
+
+export type InvestigationExecutionDetail = {
+  blocks: InvestigationTranscriptBlock[];
+  error: {code?: string; message?: string} | null;
+  id: string;
+  partialMarkdown: string | null;
+  pendingUserInput: InvestigationPendingUserInput | null;
+  status: InvestigationExecutionStatus;
+  transcriptTruncated: boolean;
+};
+
+export type InvestigationQueryOutput = {
+  chart: Record<string, unknown> | null;
+  chartUnavailableReason: string | null;
+  isEmpty: boolean;
+  preferredView: 'chart' | 'table';
+  queryLinks: Array<{kind: string; params: Record<string, unknown>}>;
+  schemaVersion: number;
+  tableMarkdown: string;
 };
 
 export type InvestigationDetail = InvestigationListItem & {
   blocks?: InvestigationBlock[];
+  filters?: Record<string, unknown>;
+  parameters?: unknown[];
+  projectIds?: number[];
+  source?: Record<string, unknown>;
+  template?: {key: string; version: number} | null;
+  titleGeneration?: Record<string, unknown>;
 };
 
 export type MetricOpenPeriodInvestigationSource = {

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -100,7 +100,7 @@ export type InvestigationTranscriptBlock = {
 export type InvestigationPendingUserInput = {
   data: Record<string, unknown>;
   id: string;
-  input_type: string;
+  input_type: 'ask_user_question';
 };
 
 export type InvestigationExecutionDetail = {
@@ -130,7 +130,7 @@ export type InvestigationDetail = InvestigationListItem & {
   projectIds?: number[];
   source?: Record<string, unknown>;
   template?: {key: string; version: number} | null;
-  titleGeneration?: Record<string, unknown>;
+  titleGeneration?: {status: string | null};
 };
 
 export type MetricOpenPeriodInvestigationSource = {

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -55,7 +55,7 @@ export type InvestigationExecutionStatus =
   | 'failed'
   | 'cancelled';
 
-export type InvestigationBlockExecution = {
+type InvestigationBlockExecution = {
   completedAt: string | null;
   error: {code?: string; message?: string} | null;
   id: string;
@@ -97,7 +97,7 @@ export type InvestigationTranscriptBlock = {
   } | null> | null;
 };
 
-export type InvestigationPendingUserInput = {
+type InvestigationPendingUserInput = {
   data: Record<string, unknown>;
   id: string;
   input_type: 'ask_user_question';

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -56,7 +56,7 @@ import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {getDiscoverDeprecation} from 'sentry/views/discover/utils';
 import {
   investigationCandidatesQueryOptions,
-  investigationDetailQueryOptions,
+  getInvestigationDetailQueryOptions,
   useLaunchInvestigationMutation,
 } from 'sentry/views/investigations/api';
 import type {MetricOpenPeriodInvestigationSource} from 'sentry/views/investigations/types';
@@ -627,7 +627,7 @@ function SeerInvestigationSection({
         headers: {},
       });
       queryClient.setQueryData(
-        investigationDetailQueryOptions(organization.slug, launchedInvestigation.id)
+        getInvestigationDetailQueryOptions(organization.slug, launchedInvestigation.id)
           .queryKey,
         {json: launchedInvestigation, headers: {}}
       );


### PR DESCRIPTION
Investigation details now render as an interactive notebook: text output remains lightweight, while query blocks use full-width collapsible chart/table cards with chart metadata, rerun and Seer actions, and duplicate/delete controls. Refinement uses an inline composer with Enter-to-submit behavior and a compact execution transcript, and investigation-level editing and actions update optimistically.

Automatically launched cells expose their progress in the notebook: active cells show a running state, dependent cells wait for successful parent results, and refinement stays disabled until the dependency chain is ready. The chart presentation reuses the shared Seer visualization components while keeping the block title and generated chart title as separate UI concepts.

## Screenshot

<img width="1575" height="2109" alt="CleanShot 2026-08-24 at 14 06 04" src="https://github.com/user-attachments/assets/cfadc21f-ac47-4436-923f-a887f1ffbb44" />