### PR TITLE
feat(ui): Give the uwu locale a phrase-seeded embellishment budget

### DIFF
--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -6,7 +6,7 @@ import {sprintf} from 'sprintf-js';
 
 import {toArray} from 'sentry/utils/array/toArray';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
-import {isUwuEnabled, uwuify} from 'sentry/utils/uwu';
+import {isUwuEnabled, uwuify, uwuifyLeaves} from 'sentry/utils/uwu';
 
 const markerStyles = {
   background: '#ff801790',
@@ -151,12 +151,20 @@ type ParsedTemplate = Record<string, TemplateSubvalue[]>;
  * non-string subvalues, so they are untouchable by construction rather than by
  * escaping — `[link:…]` can never become `[wink:…]`.
  */
-function uwuifyTemplate(parsed: ParsedTemplate): ParsedTemplate {
+function uwuifyTemplate(parsed: ParsedTemplate, seed: string): ParsedTemplate {
+  const entries = Object.entries(parsed);
+  const leaves = entries.flatMap(([, subvalues]) =>
+    subvalues.filter((subvalue): subvalue is string => typeof subvalue === 'string')
+  );
+  const transformed = uwuifyLeaves(leaves, seed);
+
+  let cursor = 0;
+
   return Object.fromEntries(
-    Object.entries(parsed).map(([group, subvalues]) => [
+    entries.map(([group, subvalues]) => [
       group,
       subvalues.map(subvalue =>
-        typeof subvalue === 'string' ? uwuify(subvalue) : subvalue
+        typeof subvalue === 'string' ? transformed[cursor++]! : subvalue
       ),
     ])
   );
@@ -340,7 +348,7 @@ function format(formatString: string, args: FormatArg[]): React.ReactNode {
  */
 function gettext(string: string, ...args: FormatArg[]): string {
   const translated: string = getClient().gettext(string);
-  const val = isUwuEnabled() ? uwuify(translated) : translated;
+  const val = isUwuEnabled() ? uwuify(translated, string) : translated;
 
   if (args.length === 0) {
     staticTranslations.add(val);
@@ -388,7 +396,7 @@ function ngettext(singular: string, plural: string, ...args: FormatArg[]): strin
   }
 
   const translated: string = getClient().ngettext(singular, plural, countArg);
-  const val = isUwuEnabled() ? uwuify(translated) : translated;
+  const val = isUwuEnabled() ? uwuify(translated, singular) : translated;
 
   // XXX(ts): See XXX in gettext.
   return mark(format(val, args) as string);
@@ -417,7 +425,7 @@ function gettextComponentTemplate(
   const parsedTemplate = parseComponentTemplate(getClient().gettext(template));
   return mark(
     renderTemplate(
-      isUwuEnabled() ? uwuifyTemplate(parsedTemplate) : parsedTemplate,
+      isUwuEnabled() ? uwuifyTemplate(parsedTemplate, template) : parsedTemplate,
       components
     )
   );
@@ -438,7 +446,7 @@ export function tctCode(template: string, components: ComponentMap = {}) {
  */
 function gettextDescription(string: string): string {
   const translated: string = getClient().gettext(string);
-  const val = isUwuEnabled() ? uwuify(translated) : translated;
+  const val = isUwuEnabled() ? uwuify(translated, string) : translated;
   staticTranslations.add(val);
   return mark(val);
 }

--- a/static/app/locale.uwu.spec.tsx
+++ b/static/app/locale.uwu.spec.tsx
@@ -17,13 +17,13 @@ describe('locale with the uwu transform enabled', () => {
   it('transforms the string when calling t', () => {
     const result = t('Resolve all errors');
 
-    expect(result).toBe('Wesowve aww ewwows');
+    expect(result).toBe('Wesowve aww ewwows >w<');
   });
 
   it('leaves the named argument intact when calling t with one', () => {
     const result = t('Deleted %(count)s replays', {count: 4});
 
-    expect(result).toBe('Deweted 4 wepways');
+    expect(result).toBe('Deweted 4 wepways OwO');
   });
 
   it('transforms both forms when calling tn', () => {

--- a/static/app/utils/uwu/embellish.ts
+++ b/static/app/utils/uwu/embellish.ts
@@ -1,0 +1,116 @@
+import type {Random} from './seed';
+import {pick} from './seed';
+import {isUntouchableWord, LETTER, WORD} from './words';
+
+/**
+ * Deliberately no "actions" category. The genre's stock actions are not things
+ * that should ever render in a work tool, even behind a flag.
+ */
+export const FACES = ['UwU', 'OwO', '>w<', '^-^', ':3', 'uwu'] as const;
+
+export const EXCLAMATIONS = ['!!11', '?!?1', '!?', '?!!'] as const;
+
+/**
+ * Replacements applied instead of the phoneme rules, so they are written in
+ * their already-transformed form — running `l -> w` over "smol" would undo it.
+ */
+const LEXICON = new Map([
+  ['small', 'smol'],
+  ['please', 'pwease'],
+  ['friend', 'fwiend'],
+  ['friends', 'fwiends'],
+  ['the', 'da'],
+  ['you', 'yew'],
+  ['cute', 'kawaii'],
+  ['what', 'wat'],
+  ['love', 'wuv'],
+  ['very', 'vewy'],
+  ['really', 'vewwy'],
+  ['have', 'haz'],
+]);
+
+const STUTTER_CHANCE = 0.35;
+const FACE_CHANCE = 0.25;
+
+const TRAILING_EXCLAMATION = /[?!]+$/;
+
+function matchCase(source: string, replacement: string): string {
+  if (source[0] !== source[0]?.toUpperCase()) {
+    return replacement;
+  }
+
+  return replacement[0]!.toUpperCase() + replacement.slice(1);
+}
+
+/**
+ * Applied per word so that trailing punctuation and capitalisation survive.
+ */
+export function applyLexicon(word: string): string | null {
+  const parts = WORD.exec(word);
+
+  if (!parts) {
+    return null;
+  }
+
+  const [, leading, core, trailing] = parts;
+  const replacement = LEXICON.get(core!.toLowerCase());
+
+  if (!replacement) {
+    return null;
+  }
+
+  return leading! + matchCase(core!, replacement) + trailing;
+}
+
+/**
+ * A stutter duplicates the first character of the word, so a word starting with
+ * a digit would come out as "2-2FA" — corruption rather than a joke.
+ */
+function canStutter(word: string): boolean {
+  const parts = WORD.exec(word);
+
+  return parts !== null && LETTER.test(parts[2]![0]!);
+}
+
+function stutter(word: string): string {
+  const parts = WORD.exec(word);
+
+  if (!parts) {
+    return word;
+  }
+
+  const [, leading, core, trailing] = parts;
+
+  return `${leading}${core![0]}-${core}${trailing}`;
+}
+
+/**
+ * Spends at most one embellishment on the phrase. Per-word coin flips gave a
+ * long tail of strings carrying three or more, and tied a given flourish to a
+ * given word everywhere it appeared; a single phrase-level budget removes both.
+ */
+export function embellish(text: string, random: Random): string {
+  if (TRAILING_EXCLAMATION.test(text)) {
+    return text.replace(TRAILING_EXCLAMATION, pick(random, EXCLAMATIONS));
+  }
+
+  const roll = random();
+  const words = text.split(' ');
+  const eligible = words.reduce<number[]>(
+    (indexes, word, index) =>
+      isUntouchableWord(word) || !canStutter(word) ? indexes : [...indexes, index],
+    []
+  );
+
+  if (roll < STUTTER_CHANCE && eligible.length > 2) {
+    const index = pick(random, eligible);
+    words[index] = stutter(words[index]!);
+    return words.join(' ');
+  }
+
+  if (roll < STUTTER_CHANCE + FACE_CHANCE) {
+    return `${text} ${pick(random, FACES)}`;
+  }
+
+  return text;
+}

--- a/static/app/utils/uwu/index.ts
+++ b/static/app/utils/uwu/index.ts
@@ -1,6 +1,6 @@
 import {localStorageWrapper} from 'sentry/utils/localStorage';
 
-export {uwuify} from './transform';
+export {uwuify, uwuifyLeaves} from './transform';
 
 export const UWU_LANGUAGE_CODE = 'uwu';
 

--- a/static/app/utils/uwu/seed.spec.ts
+++ b/static/app/utils/uwu/seed.spec.ts
@@ -1,0 +1,55 @@
+import {createRandom, pick} from './seed';
+
+function take(seed: string, count: number): number[] {
+  const random = createRandom(seed);
+  return Array.from({length: count}, () => random());
+}
+
+describe('createRandom', () => {
+  it('produces the same sequence when given the same seed', () => {
+    const sequences = [take('Resolve all errors', 8), take('Resolve all errors', 8)];
+
+    expect(sequences[0]).toEqual(sequences[1]);
+  });
+
+  it('produces a different sequence when given a different seed', () => {
+    const sequences = [take('Resolve all errors', 8), take('Resolve all error', 8)];
+
+    expect(sequences[0]).not.toEqual(sequences[1]);
+  });
+
+  it('produces values within the unit interval', () => {
+    const values = take('Alerts allow you to monitor your errors', 500);
+
+    expect(values.every(value => value >= 0 && value < 1)).toBe(true);
+  });
+
+  it('does not repeat the first value across the sequence', () => {
+    const values = take('Showing %s of %s events', 50);
+
+    expect(new Set(values).size).toBe(50);
+  });
+});
+
+describe('pick', () => {
+  it('returns the same item when given the same seed', () => {
+    const items = ['UwU', 'OwO', '>w<', '^-^'];
+
+    const picks = [
+      pick(createRandom('release health'), items),
+      pick(createRandom('release health'), items),
+    ];
+
+    expect(picks[0]).toBe(picks[1]);
+  });
+
+  it('returns an item from the list', () => {
+    const items = ['UwU', 'OwO', '>w<', '^-^'];
+
+    const picks = Array.from({length: 50}, (_, index) =>
+      pick(createRandom(`seed ${index}`), items)
+    );
+
+    expect(picks.every(value => items.includes(value))).toBe(true);
+  });
+});

--- a/static/app/utils/uwu/seed.ts
+++ b/static/app/utils/uwu/seed.ts
@@ -1,0 +1,56 @@
+export type Random = () => number;
+
+/**
+ * xmur3, used to expand a string into the four 32-bit words sfc32 needs.
+ *
+ * https://github.com/bryc/code/blob/master/jshash/PRNGs.md
+ */
+function createSeedSource(seed: string): () => number {
+  let h = 1779033703 ^ seed.length;
+
+  for (let index = 0; index < seed.length; index++) {
+    h = Math.imul(h ^ seed.charCodeAt(index), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+/**
+ * sfc32. Seeded from a string rather than from a clock so that a given phrase
+ * always produces the same sequence — the whole feature depends on it.
+ *
+ * https://github.com/bryc/code/blob/master/jshash/PRNGs.md
+ */
+export function createRandom(seed: string): Random {
+  const source = createSeedSource(seed);
+
+  let a = source();
+  let b = source();
+  let c = source();
+  let d = source();
+
+  return () => {
+    // `| 0` wraps to a signed 32-bit integer, which the algorithm relies on.
+    // `Math.trunc` is not a substitute — it would keep values above 2^31.
+    /* eslint-disable unicorn/prefer-math-trunc */
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    /* eslint-enable unicorn/prefer-math-trunc */
+    return (t >>> 0) / 4294967296;
+  };
+}
+
+export function pick<T>(random: Random, items: readonly T[]): T {
+  return items[Math.floor(random() * items.length)]!;
+}

--- a/static/app/utils/uwu/transform.spec.ts
+++ b/static/app/utils/uwu/transform.spec.ts
@@ -1,4 +1,11 @@
-import {getSprintfTokens, getTemplateGroups, uwuify} from './transform';
+import {EXCLAMATIONS, FACES} from './embellish';
+import {
+  getSprintfTokens,
+  getTemplateGroups,
+  uwuify,
+  uwuifyLeaves,
+  uwuifyPhonemes,
+} from './transform';
 
 /**
  * Every sprintf shape present in the extracted `build/javascript.po` catalog, so
@@ -40,84 +47,217 @@ const TEMPLATE_SHAPES = [
   ' committed [commitLink] ',
 ];
 
-describe('uwuify', () => {
+const SPRINTF_INPUTS = SENTENCE_SHAPES.flatMap(sentence =>
+  SPRINTF_SHAPES.map(shape => sentence.replaceAll('<p>', shape))
+);
+
+/**
+ * Counts exactly rather than by pattern-matching for stutters: a hyphenated word
+ * whose halves both start with `w` ("error-waves" -> "ewwow-waves") looks exactly
+ * like a stutter to a regex, so the only reliable check is whether removing one
+ * inserted prefix reproduces the un-embellished string.
+ */
+function countEmbellishments(source: string): number {
+  const phonetic = uwuifyPhonemes(source);
+  const output = uwuify(source);
+
+  if (output === phonetic) {
+    return 0;
+  }
+
+  if (FACES.some(face => output === `${phonetic} ${face}`)) {
+    return 1;
+  }
+
+  const trailing = /[?!]+$/.exec(phonetic);
+  if (trailing) {
+    const stem = phonetic.slice(0, -trailing[0].length);
+    if (EXCLAMATIONS.some(exclamation => output === stem + exclamation)) {
+      return 1;
+    }
+  }
+
+  for (let index = 0; index < output.length - 1; index++) {
+    if (output[index + 1] !== '-') {
+      continue;
+    }
+    if (output.slice(0, index) + output.slice(index + 2) === phonetic) {
+      return 1;
+    }
+  }
+
+  return 2;
+}
+
+describe('uwuifyPhonemes', () => {
   it('replaces l and r with w when given lowercase text', () => {
-    const result = uwuify('resolve all errors');
+    const result = uwuifyPhonemes('resolve all errors');
 
     expect(result).toBe('wesowve aww ewwows');
   });
 
   it('preserves case when replacing uppercase L and R', () => {
-    const result = uwuify('Learn More');
+    const result = uwuifyPhonemes('Learn More');
 
     expect(result).toBe('Weawn Mowe');
   });
 
   it('inserts y after n when followed by a vowel', () => {
-    const result = uwuify('No nice name');
+    const result = uwuifyPhonemes('No nice name');
 
     expect(result).toBe('Nyo nyice nyame');
   });
 
-  it('returns the same output when called repeatedly with the same input', () => {
-    const outputs = Array.from({length: 5}, () =>
-      uwuify('Alerts allow you to monitor your errors')
-    );
+  it('substitutes the lexicon form instead of the phoneme rules', () => {
+    const result = uwuifyPhonemes('A small friend please');
 
-    expect(new Set(outputs).size).toBe(1);
+    expect(result).toBe('A smol fwiend pwease');
   });
 
-  it('leaves every sprintf token untouched when transforming any sentence shape', () => {
-    const corrupted = SENTENCE_SHAPES.flatMap(sentence =>
-      SPRINTF_SHAPES.map(shape => sentence.replaceAll('<p>', shape))
-    ).filter(input => {
-      const before = getSprintfTokens(input);
-      const after = getSprintfTokens(uwuify(input));
-      return before.join(' ') !== after.join(' ');
-    });
+  it('capitalises the lexicon form when the source word is capitalised', () => {
+    const result = uwuifyPhonemes('The small print');
 
-    expect(corrupted).toEqual([]);
+    expect(result).toBe('Da smol pwint');
   });
 
   it('leaves the named argument intact when it contains transformable letters', () => {
-    const result = uwuify('Deleted %(count)s replays from %(orgSlug)s');
+    const result = uwuifyPhonemes('Deleted %(count)s replays from %(orgSlug)s');
 
     expect(result).toBe('Deweted %(count)s wepways fwom %(orgSlug)s');
   });
 
   it('transforms a label ending in a colon', () => {
-    const result = uwuify('Allow list our IP Addresses:');
+    const result = uwuifyPhonemes('Allow list our IP Addresses:');
 
     expect(result).toBe('Awwow wist ouw IP Addwesses:');
   });
 
   it('leaves the group name intact when given a bare template group', () => {
-    const result = uwuify('Seeing this often? [feedbackLink]');
+    const result = uwuifyPhonemes('Seeing this often? [feedbackLink]');
 
     expect(result).toBe('Seeing this often? [feedbackLink]');
   });
 
   it('transforms the group text but not the group name when given both', () => {
-    const result = uwuify('Learn more about [link:release health]');
+    const result = uwuifyPhonemes('Learn more about [link:release health]');
 
     expect(result).toBe('Weawn mowe about [link:wewease heawth]');
   });
 
-  it('leaves every template group intact when transforming any sentence shape', () => {
-    const corrupted = TEMPLATE_SHAPES.filter(input => {
-      const before = getTemplateGroups(input);
-      const after = getTemplateGroups(uwuify(input));
-      return before.join(' ') !== after.join(' ');
-    });
-
-    expect(corrupted).toEqual([]);
-  });
-
   it('leaves urls, mentions, and email addresses untouched', () => {
-    const result = uwuify(
+    const result = uwuifyPhonemes(
       'email hello@sentry.io or @claire at https://sentry.io/welcome'
     );
 
     expect(result).toBe('emaiw hello@sentry.io ow @claire at https://sentry.io/welcome');
+  });
+});
+
+describe('uwuify', () => {
+  it('returns the same output when called repeatedly and interleaved', () => {
+    const outputs = Array.from({length: 100}, (_, index) => {
+      uwuify(`unrelated noise ${index}`);
+      return uwuify('Alerts allow you to monitor your errors');
+    });
+
+    expect(new Set(outputs).size).toBe(1);
+  });
+
+  it('returns the same output for two strings sharing a seed', () => {
+    const outputs = [
+      uwuify('%s error', '%s error'),
+      uwuify('%s error', '%s errors'),
+      uwuify('%s error', '%s error'),
+    ];
+
+    expect(outputs[0]).toBe(outputs[2]);
+  });
+
+  it('leaves every sprintf token untouched when transforming any sentence shape', () => {
+    const corrupted = SPRINTF_INPUTS.filter(
+      input =>
+        getSprintfTokens(input).join(' ') !== getSprintfTokens(uwuify(input)).join(' ')
+    );
+
+    expect(corrupted).toEqual([]);
+  });
+
+  it('leaves every template group intact when transforming any template shape', () => {
+    const corrupted = TEMPLATE_SHAPES.filter(
+      input =>
+        getTemplateGroups(input).join(' ') !== getTemplateGroups(uwuify(input)).join(' ')
+    );
+
+    expect(corrupted).toEqual([]);
+  });
+
+  it('spends at most one embellishment on any sentence shape', () => {
+    const overspent = [...SPRINTF_INPUTS, ...TEMPLATE_SHAPES].filter(
+      input => countEmbellishments(input) > 1
+    );
+
+    expect(overspent).toEqual([]);
+  });
+
+  it('places the face at the end when it spends the budget on one', () => {
+    const result = uwuify('Resolve all errors');
+
+    expect(result).toBe('Wesowve aww ewwows >w<');
+  });
+
+  it('replaces the trailing punctuation run when the phrase ends in one', () => {
+    const result = uwuify('Are you sure you want to delete this alert?');
+
+    expect(result).toBe('Awe yew suwe yew want to dewete this awewt!!11');
+  });
+
+  it('leaves a phrase with no letters alone', () => {
+    const results = ['300', '%s', '1.0.0', '-'].map(source => uwuify(source));
+
+    expect(results).toEqual(['300', '%s', '1.0.0', '-']);
+  });
+
+  it('does not stutter a word that starts with a digit', () => {
+    const sources = [
+      'Defaults to 1',
+      '5 minutes ago',
+      'We recommend adding a backup 2FA method',
+      'Response Codes (3XX, 4XX, 5XX)',
+    ];
+
+    const stuttered = sources
+      .map(source => uwuify(source))
+      .filter(result => /(?:^| |\()(\d)-\1/.test(result));
+
+    expect(stuttered).toEqual([]);
+  });
+
+  it('embellishes a phrase whose only letters sit outside the placeholder', () => {
+    const result = uwuify('%smin');
+
+    expect(result.startsWith('%smin')).toBe(true);
+  });
+
+  it('never stutters an email address', () => {
+    const result = uwuify(
+      'email hello@sentry.io or @claire at https://sentry.io/welcome'
+    );
+
+    expect(result).toContain('hello@sentry.io');
+  });
+});
+
+describe('uwuifyLeaves', () => {
+  it('leaves an empty trailing leaf empty when spending the budget', () => {
+    const result = uwuifyLeaves(['Learn more about ', 'release health', ''], 'seed');
+
+    expect(result[2]).toBe('');
+  });
+
+  it('returns the same leaves when called repeatedly with the same seed', () => {
+    const first = uwuifyLeaves(['Read the ', 'docs'], 'Read the [link:docs]');
+    const second = uwuifyLeaves(['Read the ', 'docs'], 'Read the [link:docs]');
+
+    expect(first).toEqual(second);
   });
 });

--- a/static/app/utils/uwu/transform.ts
+++ b/static/app/utils/uwu/transform.ts
@@ -1,3 +1,8 @@
+import {applyLexicon, embellish} from './embellish';
+import type {Random} from './seed';
+import {createRandom} from './seed';
+import {isUntouchableWord, LETTER} from './words';
+
 const UWU_MAP: Array<[RegExp, string]> = [
   [/(?:r|l)/g, 'w'],
   [/(?:R|L)/g, 'W'],
@@ -25,42 +30,29 @@ const PROTECTED_TOKEN = new RegExp(
   'g'
 );
 
-const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const URL_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
-const BARE_SCHEME = /^(?:mailto|tel):/i;
-
-/**
- * Words that carry meaning a reader has to be able to retype or click. Note this
- * deliberately does not treat every colon-terminated word as a URL — labels like
- * "IP Addresses:" are prose and should be transformed.
- */
-function isUntouchableWord(word: string): boolean {
-  return (
-    word.startsWith('@') ||
-    URL_SCHEME.test(word) ||
-    BARE_SCHEME.test(word) ||
-    EMAIL.test(word)
-  );
-}
-
 function uwuifyWord(word: string): string {
-  return UWU_MAP.reduce(
-    (result, [pattern, replacement]) => result.replace(pattern, replacement),
-    word
+  if (isUntouchableWord(word)) {
+    return word;
+  }
+
+  return (
+    applyLexicon(word) ??
+    UWU_MAP.reduce(
+      (result, [pattern, replacement]) => result.replace(pattern, replacement),
+      word
+    )
   );
 }
 
 function uwuifyProse(text: string): string {
-  return text.replace(/\S+/g, word =>
-    isUntouchableWord(word) ? word : uwuifyWord(word)
-  );
+  return text.replace(/\S+/g, uwuifyWord);
 }
 
 /**
- * Must stay stable: a given input always maps to the same output. Every rule is
- * an unconditional replacement, so nothing here may consult a random source.
+ * Carries no randomness at all, so every caller gets the same answer for a given
+ * string without needing a seed.
  */
-export function uwuify(text: string): string {
+export function uwuifyPhonemes(text: string): string {
   const segments: string[] = [];
   let cursor = 0;
 
@@ -72,6 +64,59 @@ export function uwuify(text: string): string {
   segments.push(uwuifyProse(text.slice(cursor)));
 
   return segments.join('');
+}
+
+function protectedTokens(text: string): string {
+  return JSON.stringify(Array.from(text.matchAll(PROTECTED_TOKEN), match => match[0]));
+}
+
+/**
+ * An embellishment can create a token as well as damage one: appending a face to
+ * "100%" yields "100% uwu", whose "% u" reads as a sprintf token that the source
+ * string never had. Rather than special-casing each adjacency, drop any
+ * embellishment that changes the token list at all.
+ */
+function embellishSafely(text: string, random: Random): string {
+  const embellished = embellish(text, random);
+
+  return protectedTokens(embellished) === protectedTokens(text) ? embellished : text;
+}
+
+/**
+ * Whether anything outside the placeholders is actually prose. "%s" has a letter
+ * in it, but not one a flourish can attach to.
+ */
+function hasProse(text: string): boolean {
+  return LETTER.test(text.replace(PROTECTED_TOKEN, ''));
+}
+
+/**
+ * Seeded on the msgid rather than on the rendered fragment, so a given UI string
+ * looks the same everywhere it appears and `t` and `tct` agree on it.
+ */
+export function uwuify(text: string, seed: string = text): string {
+  const phonetic = uwuifyPhonemes(text);
+
+  return hasProse(phonetic) ? embellishSafely(phonetic, createRandom(seed)) : phonetic;
+}
+
+/**
+ * `tct` arrives as a list of text leaves rather than one string. They share a
+ * single budget, spent on the last non-empty leaf so the flourish still lands at
+ * the end of the rendered sentence.
+ */
+export function uwuifyLeaves(leaves: string[], seed: string): string[] {
+  const random = createRandom(seed);
+  const transformed = leaves.map(uwuifyPhonemes);
+
+  for (let index = transformed.length - 1; index >= 0; index--) {
+    if (hasProse(transformed[index]!)) {
+      transformed[index] = embellishSafely(transformed[index]!, random);
+      break;
+    }
+  }
+
+  return transformed;
 }
 
 export function getSprintfTokens(text: string): string[] {

--- a/static/app/utils/uwu/words.ts
+++ b/static/app/utils/uwu/words.ts
@@ -1,0 +1,33 @@
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const URL_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+const BARE_SCHEME = /^(?:mailto|tel):/i;
+
+/**
+ * Carries a sprintf token or a `tct` group marker, so neither the phoneme rules
+ * nor a stutter may touch it.
+ */
+const PROTECTED = /[%[]/;
+
+export const WORD = /^(\W*)([\w']+)(.*)$/;
+
+/**
+ * A flourish on text with no letters in it reads as breakage rather than as a
+ * joke: "300" rendering as "300 >w<", or "Defaults to 1" as "Defauwts to 1-1",
+ * both look like data bugs.
+ */
+export const LETTER = /\p{L}/u;
+
+/**
+ * Words a reader has to be able to retype or click. Note this deliberately does
+ * not treat every colon-terminated word as a URL — labels like "IP Addresses:"
+ * are prose and should be transformed.
+ */
+export function isUntouchableWord(word: string): boolean {
+  return (
+    word.startsWith('@') ||
+    PROTECTED.test(word) ||
+    URL_SCHEME.test(word) ||
+    BARE_SCHEME.test(word) ||
+    EMAIL.test(word)
+  );
+}


### PR DESCRIPTION
Hackweek project, branch 3 of 5. Stacked on #122157 — **base is `feat/uwu-locale-safe`**.

Branches 1 and 2 got the transform correct. This one makes it *good*, and the argument is measured rather than aesthetic.

## The problem with per-word seeding

Seeding each word from its own characters is stable, but stability is not the same as good:

- A given word draws the same flourish **everywhere it appears**. Sampling `uwuifier`'s output, the word `the` drew `*boops your nose*` in 5 of 6 sentences — one action string repeated across hundreds of UI strings. That is structural, not tunable.
- Independent per-word coin flips leave a long tail. Over 2,163 strings the distribution was `0:1129  1:700  2:247  3:76  4:10  6:1` — 52% got nothing and ~4% got three or more, which is where it stops being funny:

  ```
  "A-A-Avewage d-duwation fow this span uvw the *boops your nose* wast 2-24 houws"
  ```

## What this does instead

- **xmur3 → sfc32 PRNG seeded on the msgid** (`seed.ts`). No clock, no `Math.random`.
- **Seeded on the msgid, not the rendered fragment.** That is what keeps a given UI string identical everywhere and keeps `t` and `tct` in agreement. `tn` seeds both plural forms on the singular msgid so the pair never disagrees.
- **A budget of one embellishment per phrase** — a stutter, a terminal face, or a trailing-punctuation swap, never a combination. Terminal placement is only expressible with phrase context.
- **`tct` leaves share one budget**, spent on the last non-empty leaf so the flourish still lands at the end of the rendered sentence.
- **A lexicon** applied instead of the phoneme rules, so entries are written already-transformed (`l → w` over `smol` would undo it): `small → smol`, `the → da`, `please → pwease`, `you → yew`.
- **No actions category.** The genre's stock actions are not things that should render in a work tool, even behind a flag. Faces only.

## Measured over the full catalog

All 14,606 msgids from `pnpm build-js-po`:

| | per-word (2,163 strings) | this branch (14,606 msgids) |
|---|---|---|
| 0 embellishments | 1,129 | 5,707 (39.1%) |
| 1 | 700 | **8,899 (60.9%)** |
| 2 | 247 | 0 |
| 3 | 76 | 0 |
| 4 | 10 | 0 |
| 6 | 1 | 0 |

Zero sprintf tokens corrupted, zero template groups corrupted. Length inflation 4.39%, up from 1.02% for the phoneme layer alone.

Flourish spread is even — `^-^` 950, `UwU` 917, `uwu` 888, `>w<` 868, `:3` 866 — rather than one flourish dominating.

## Two bugs the sweep caught

Worth calling out, because both were introduced by the embellishment layer and neither was visible in the hand-written tests:

1. **A stutter landed on an email address**, giving `h-hello@sentry.io`. The eligibility check only excluded words carrying `%` or `[`. The word predicate is now shared with the phoneme layer, so anything untouchable there is also ineligible for a stutter.
2. **Appending a face to a string ending in `%` creates a sprintf token.** `"100%"` became `"100% uwu"`, and `"% u"` parses as a space-flagged `%u`. Rather than special-casing that adjacency, any embellishment that changes the protected-token list is now discarded. That guard covers embellishment types nobody has written yet.

## Next

Branch 4 (`feat/uwu-locale-catalog`) moves this to build time and emits a real gettext catalog, using this engine as the validation fallback.