### PR TITLE
feat(ui): Load the generated uwu catalog instead of transforming at runtime

### DIFF
--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -15,9 +15,8 @@ function convertToDjangoLocaleFormat(language: string) {
 async function getTranslations(language: string) {
   language = convertToDjangoLocaleFormat(language);
 
-  // The uwu locale is applied as a transform over the english catalog, so there
-  // is no catalog on disk to fetch for it.
-  if (language === 'en' || language === UWU_LANGUAGE_CODE) {
+  // No need to load the english locale
+  if (language === 'en') {
     return DEFAULT_LOCALE_DATA;
   }
 
@@ -33,6 +32,20 @@ async function getTranslations(language: string) {
 
     // Default locale if not found
     return DEFAULT_LOCALE_DATA;
+  }
+}
+
+/**
+ * The generated catalog already holds uwu-ified strings, so the runtime
+ * transform has to stay off when it loads or every string is transformed twice.
+ * It is only a fallback for a build that skipped `pnpm gen:uwu-catalog`.
+ */
+async function initializeUwuLocale() {
+  try {
+    setLocale(await import(`sentry-locale/${UWU_LANGUAGE_CODE}/LC_MESSAGES/django.po`));
+  } catch {
+    setLocale(DEFAULT_LOCALE_DATA);
+    setUwuEnabled(true);
   }
 }
 
@@ -67,12 +80,10 @@ export async function initializeLocale(config: Config) {
   const languageCode =
     queryStringLang || config.user?.options?.language || config.languageCode || 'en';
 
-  if (languageCode === UWU_LANGUAGE_CODE) {
-    setUwuEnabled(true);
-  }
-
   try {
-    if (languageCode === 'en' || languageCode === UWU_LANGUAGE_CODE) {
+    if (languageCode === UWU_LANGUAGE_CODE) {
+      await initializeUwuLocale();
+    } else if (languageCode === 'en') {
       const translations = await getTranslations(languageCode);
       setLocale(translations);
     } else {


### PR DESCRIPTION
Hackweek project, branch 4 of 5, part 2 of 2. Stacked on #122159 — **base is `feat/uwu-locale-catalog`**.

Frontend-only, so it deploys independently of the catalog PR per the split rule in `AGENTS.md`. The catalog has to land first.

## What this does

`?lang=uwu` now loads `sentry-locale/uwu/LC_MESSAGES/django.po` like any other locale, and the runtime transform stays **off** when it loads. Leaving it on would transform every string twice — the catalog already holds uwu-ified text.

If the catalog is missing (a build that skipped `pnpm gen:uwu-catalog`), the import fails and it falls back to the English data plus the runtime transform, so the locale still works from a plain checkout. That fallback is the only reason the branch-1..3 engine stays in the bundle.

Net effect at this point in the stack: **zero runtime transform cost on the happy path.**

## One thing worth flagging

I nearly shipped a silently-broken catalog here. `build-utils/po-catalog-loader.ts` drops any message whose `#:` reference comment doesn't point at a JS/TS file:

```ts
const reference = message.comments?.reference;
if (!reference || !FRONTEND_REFERENCE.test(reference)) {
  continue;
}
```

The first version of the generator didn't carry reference comments through, so the compiled catalog had **0** of them — every message would have been skipped and `?lang=uwu` would have quietly rendered plain English with no error anywhere. Fixed in the catalog PR (it now preserves `comments`), which is why that branch was force-pushed.

Verified by running the loader's own filter over the generated file: **13,722 messages kept**, 674 skipped for pointing at non-frontend files (correct — that's what the filter is for), 0 skipped for an empty msgstr. `Language` and `Plural-Forms` headers both resolve.

## Not verified here

I checked the loader logic against the catalog directly rather than running a full `pnpm build`, so the end-to-end rspack path is confirmed by simulation rather than by a real bundle. The preview environment is the real test — that's what this PR is for.