### PR TITLE
feat(ui): Add an expansion budget to the uwu locale

### DIFF
--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -4,7 +4,7 @@ import * as qs from 'query-string';
 
 import {DEFAULT_LOCALE_DATA, setLocale} from 'sentry/locale';
 import type {Config} from 'sentry/types/system';
-import {setUwuEnabled, UWU_LANGUAGE_CODE} from 'sentry/utils/uwu';
+import {getUwuExpansion, setUwuEnabled, UWU_LANGUAGE_CODE} from 'sentry/utils/uwu';
 
 // zh-cn => zh_CN
 function convertToDjangoLocaleFormat(language: string) {
@@ -39,8 +39,17 @@ async function getTranslations(language: string) {
  * The generated catalog already holds uwu-ified strings, so the runtime
  * transform has to stay off when it loads or every string is transformed twice.
  * It is only a fallback for a build that skipped `pnpm gen:uwu-catalog`.
+ *
+ * `?expand=` is a runtime knob and the catalog was generated without it, so
+ * asking for expansion takes the runtime path instead.
  */
 async function initializeUwuLocale() {
+  if (getUwuExpansion() > 0) {
+    setLocale(DEFAULT_LOCALE_DATA);
+    setUwuEnabled(true);
+    return;
+  }
+
   try {
     setLocale(await import(`sentry-locale/${UWU_LANGUAGE_CODE}/LC_MESSAGES/django.po`));
   } catch {

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -6,7 +6,7 @@ import {sprintf} from 'sprintf-js';
 
 import {toArray} from 'sentry/utils/array/toArray';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
-import {isUwuEnabled, uwuify, uwuifyLeaves} from 'sentry/utils/uwu';
+import {getUwuExpansion, isUwuEnabled, uwuify, uwuifyLeaves} from 'sentry/utils/uwu';
 
 const markerStyles = {
   background: '#ff801790',
@@ -156,7 +156,7 @@ function uwuifyTemplate(parsed: ParsedTemplate, seed: string): ParsedTemplate {
   const leaves = entries.flatMap(([, subvalues]) =>
     subvalues.filter((subvalue): subvalue is string => typeof subvalue === 'string')
   );
-  const transformed = uwuifyLeaves(leaves, seed);
+  const transformed = uwuifyLeaves(leaves, seed, getUwuExpansion());
 
   let cursor = 0;
 
@@ -348,7 +348,7 @@ function format(formatString: string, args: FormatArg[]): React.ReactNode {
  */
 function gettext(string: string, ...args: FormatArg[]): string {
   const translated: string = getClient().gettext(string);
-  const val = isUwuEnabled() ? uwuify(translated, string) : translated;
+  const val = isUwuEnabled() ? uwuify(translated, string, getUwuExpansion()) : translated;
 
   if (args.length === 0) {
     staticTranslations.add(val);
@@ -396,7 +396,9 @@ function ngettext(singular: string, plural: string, ...args: FormatArg[]): strin
   }
 
   const translated: string = getClient().ngettext(singular, plural, countArg);
-  const val = isUwuEnabled() ? uwuify(translated, singular) : translated;
+  const val = isUwuEnabled()
+    ? uwuify(translated, singular, getUwuExpansion())
+    : translated;
 
   // XXX(ts): See XXX in gettext.
   return mark(format(val, args) as string);
@@ -446,7 +448,7 @@ export function tctCode(template: string, components: ComponentMap = {}) {
  */
 function gettextDescription(string: string): string {
   const translated: string = getClient().gettext(string);
-  const val = isUwuEnabled() ? uwuify(translated, string) : translated;
+  const val = isUwuEnabled() ? uwuify(translated, string, getUwuExpansion()) : translated;
   staticTranslations.add(val);
   return mark(val);
 }

--- a/static/app/utils/uwu/embellish.ts
+++ b/static/app/utils/uwu/embellish.ts
@@ -29,6 +29,8 @@ const LEXICON = new Map([
   ['have', 'haz'],
 ]);
 
+const MAX_STUTTER_PASSES = 3;
+
 const STUTTER_CHANCE = 0.35;
 const FACE_CHANCE = 0.25;
 
@@ -84,6 +86,14 @@ function stutter(word: string): string {
   return `${leading}${core![0]}-${core}${trailing}`;
 }
 
+function eligibleIndexes(words: string[]): number[] {
+  return words.reduce<number[]>(
+    (indexes, word, index) =>
+      isUntouchableWord(word) || !canStutter(word) ? indexes : [...indexes, index],
+    []
+  );
+}
+
 /**
  * Spends at most one embellishment on the phrase. Per-word coin flips gave a
  * long tail of strings carrying three or more, and tied a given flourish to a
@@ -96,11 +106,7 @@ export function embellish(text: string, random: Random): string {
 
   const roll = random();
   const words = text.split(' ');
-  const eligible = words.reduce<number[]>(
-    (indexes, word, index) =>
-      isUntouchableWord(word) || !canStutter(word) ? indexes : [...indexes, index],
-    []
-  );
+  const eligible = eligibleIndexes(words);
 
   if (roll < STUTTER_CHANCE && eligible.length > 2) {
     const index = pick(random, eligible);
@@ -113,4 +119,44 @@ export function embellish(text: string, random: Random): string {
   }
 
   return text;
+}
+
+/**
+ * Stutters words until the phrase is `ratio` longer than it started.
+ *
+ * This exists because uwu is naturally length-neutral — the phoneme rules
+ * inflate the catalog by about 1%, and `l -> w` is one character for one. So the
+ * locale is useless as a layout stress test unless the expansion is asked for
+ * explicitly. German runs roughly 30% longer than english, which is the number
+ * worth aiming at.
+ */
+export function expand(text: string, random: Random, ratio: number): string {
+  const words = text.split(' ');
+  const order = eligibleIndexes(words);
+
+  for (let index = order.length - 1; index > 0; index--) {
+    const swap = Math.floor(random() * (index + 1));
+    const held = order[index]!;
+    order[index] = order[swap]!;
+    order[swap] = held;
+  }
+
+  const target = text.length * (1 + ratio);
+  let length = text.length;
+
+  // One stutter per word tops out around 30% inflation, so a word may be
+  // stuttered again ("w-w-word") when a higher target is asked for.
+  for (let pass = 0; pass < MAX_STUTTER_PASSES && length < target; pass++) {
+    for (const index of order) {
+      if (length >= target) {
+        break;
+      }
+
+      const before = words[index]!.length;
+      words[index] = stutter(words[index]!);
+      length += words[index].length - before;
+    }
+  }
+
+  return words.join(' ');
 }

--- a/static/app/utils/uwu/index.ts
+++ b/static/app/utils/uwu/index.ts
@@ -33,6 +33,29 @@ export function setUwuEnabled(enabled: boolean) {
   uwuEnabled = enabled;
 }
 
+/**
+ * `?expand=35` targets strings 35% longer than english, matching roughly what a
+ * real locale like german costs. Capped because past a point every string wraps
+ * and the sweep stops telling you anything.
+ */
+function readUwuExpansion(): number {
+  try {
+    const value = new URLSearchParams(window.location.search).get('expand');
+    const percent = value === null ? 0 : Number.parseFloat(value);
+
+    return Number.isFinite(percent) ? Math.min(Math.max(percent, 0), 200) / 100 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+let uwuExpansion: number | null = null;
+
+export function getUwuExpansion(): number {
+  uwuExpansion ??= readUwuExpansion();
+  return uwuExpansion;
+}
+
 export function toggleUwu() {
   const next = localStorageWrapper.getItem(UWU_STORAGE_KEY) !== '1';
   localStorageWrapper.setItem(UWU_STORAGE_KEY, next ? '1' : '0');

--- a/static/app/utils/uwu/transform.spec.ts
+++ b/static/app/utils/uwu/transform.spec.ts
@@ -261,3 +261,62 @@ describe('uwuifyLeaves', () => {
     expect(first).toEqual(second);
   });
 });
+
+describe('uwuify with expansion', () => {
+  const PHRASES = [
+    'Resolve all errors in this project',
+    'Alerts allow you to monitor your errors',
+    'Showing %s of %s events in the selected period',
+    'Learn more about [link:release health] in our documentation',
+    'Are you sure you want to delete this alert rule?',
+  ];
+
+  it('reaches the requested inflation across a set of phrases', () => {
+    const source = PHRASES.join('').length;
+    const expanded = PHRASES.map(phrase => uwuify(phrase, phrase, 0.35)).join('').length;
+
+    expect(expanded / source).toBeGreaterThanOrEqual(1.3);
+  });
+
+  it('inflates further when asked for more', () => {
+    const lengths = [0.1, 0.35, 0.8].map(
+      ratio => PHRASES.map(phrase => uwuify(phrase, phrase, ratio)).join('').length
+    );
+
+    expect(lengths[0]! < lengths[1]! && lengths[1]! < lengths[2]!).toBe(true);
+  });
+
+  it('leaves every sprintf token untouched when expanding', () => {
+    const corrupted = SPRINTF_INPUTS.filter(
+      input =>
+        getSprintfTokens(input).join(' ') !==
+        getSprintfTokens(uwuify(input, input, 0.8)).join(' ')
+    );
+
+    expect(corrupted).toEqual([]);
+  });
+
+  it('leaves every template group intact when expanding', () => {
+    const corrupted = TEMPLATE_SHAPES.filter(
+      input =>
+        getTemplateGroups(input).join(' ') !==
+        getTemplateGroups(uwuify(input, input, 0.8)).join(' ')
+    );
+
+    expect(corrupted).toEqual([]);
+  });
+
+  it('stutters a word more than once when one pass cannot reach the target', () => {
+    const result = uwuify('Alerts allow you to monitor your errors', undefined, 1.2);
+
+    expect(/(\w)-\1-/.test(result)).toBe(true);
+  });
+
+  it('returns the same output when expanding repeatedly with the same seed', () => {
+    const outputs = Array.from({length: 20}, () =>
+      uwuify('Alerts allow you to monitor your errors', undefined, 0.35)
+    );
+
+    expect(new Set(outputs).size).toBe(1);
+  });
+});

--- a/static/app/utils/uwu/transform.ts
+++ b/static/app/utils/uwu/transform.ts
@@ -1,4 +1,4 @@
-import {applyLexicon, embellish} from './embellish';
+import {applyLexicon, embellish, expand} from './embellish';
 import type {Random} from './seed';
 import {createRandom} from './seed';
 import {isUntouchableWord, LETTER} from './words';
@@ -71,15 +71,21 @@ function protectedTokens(text: string): string {
 }
 
 /**
- * An embellishment can create a token as well as damage one: appending a face to
+ * A decoration can create a token as well as damage one: appending a face to
  * "100%" yields "100% uwu", whose "% u" reads as a sprintf token that the source
  * string never had. Rather than special-casing each adjacency, drop any
- * embellishment that changes the token list at all.
+ * decoration that changes the token list at all.
  */
-function embellishSafely(text: string, random: Random): string {
-  const embellished = embellish(text, random);
+function guard(text: string, apply: () => string): string {
+  const decorated = apply();
 
-  return protectedTokens(embellished) === protectedTokens(text) ? embellished : text;
+  return protectedTokens(decorated) === protectedTokens(text) ? decorated : text;
+}
+
+function decorate(text: string, random: Random, expansion: number): string {
+  return expansion > 0
+    ? guard(text, () => expand(text, random, expansion))
+    : guard(text, () => embellish(text, random));
 }
 
 /**
@@ -94,10 +100,12 @@ function hasProse(text: string): boolean {
  * Seeded on the msgid rather than on the rendered fragment, so a given UI string
  * looks the same everywhere it appears and `t` and `tct` agree on it.
  */
-export function uwuify(text: string, seed: string = text): string {
+export function uwuify(text: string, seed: string = text, expansion = 0): string {
   const phonetic = uwuifyPhonemes(text);
 
-  return hasProse(phonetic) ? embellishSafely(phonetic, createRandom(seed)) : phonetic;
+  return hasProse(phonetic)
+    ? decorate(phonetic, createRandom(seed), expansion)
+    : phonetic;
 }
 
 /**
@@ -105,13 +113,19 @@ export function uwuify(text: string, seed: string = text): string {
  * single budget, spent on the last non-empty leaf so the flourish still lands at
  * the end of the rendered sentence.
  */
-export function uwuifyLeaves(leaves: string[], seed: string): string[] {
+export function uwuifyLeaves(leaves: string[], seed: string, expansion = 0): string[] {
   const random = createRandom(seed);
   const transformed = leaves.map(uwuifyPhonemes);
 
+  if (expansion > 0) {
+    return transformed.map(leaf =>
+      hasProse(leaf) ? decorate(leaf, random, expansion) : leaf
+    );
+  }
+
   for (let index = transformed.length - 1; index >= 0; index--) {
     if (hasProse(transformed[index]!)) {
-      transformed[index] = embellishSafely(transformed[index]!, random);
+      transformed[index] = decorate(transformed[index]!, random, 0);
       break;
     }
   }


### PR DESCRIPTION
Hackweek project, branch 5 of 5. Stacked on #122160 — **base is `feat/uwu-locale-catalog-load`**.

Turns the joke locale into a pseudo-localization layout tool. `?lang=uwu&expand=35` targets strings 35% longer than English.

## Why the expansion has to be asked for

The obvious version of this pitch is wrong, and saying so is the point. **uwu is naturally length-neutral** — `l → w` is one character for one, `ove → uv` actually shrinks, and the phoneme layer inflates the whole catalog by about 1%. So `?lang=uwu` on its own stress-tests nothing. The expansion is a deliberate knob, not a side effect.

German runs roughly 30% longer than English, which is the number worth aiming at.

## Measured over all 14,606 msgids

| `expand=` | actual inflation | tokens corrupted |
|---|---|---|
| _(absent)_ | 4.4% | 0 |
| 10 | 12.3% | 0 |
| 20 | 22.2% | 0 |
| 35 | **37.3%** | 0 |
| 50 | 51.5% | 0 |
| 80 | 77.8% | 0 |

My first implementation **saturated at ~30%** no matter what was asked for — one stutter adds two characters, so once every eligible word is stuttered there is nowhere left to go, and `expand=50` silently did the same thing as `expand=35`. A word may now be stuttered more than once (`w-w-word`), which is genre-appropriate and makes the whole range reachable. Worth knowing that the knob was quietly lying before, because a QA tool that ignores its own input is worse than no tool.

The same token guard from branch 3 applies, so expansion cannot corrupt a placeholder at any level — verified at `expand=80` across the full sprintf and template matrices.

## Behaviour notes

- Expansion takes the **runtime** path rather than the generated catalog, since the catalog was built without it. `?lang=uwu` alone still uses the catalog with no runtime cost.
- Stutters still skip URLs, `@mentions`, email addresses, and any word carrying a placeholder.
- Deterministic: same string and same `expand` value always produce the same output, so a layout bug found once reproduces exactly.

## What this PR does not include

The plan's exit criterion for this branch was *"you can name real layout bugs that uwu-mode surfaced, with issue links."* **I have not done that sweep** — it needs a browser driven against a running instance, which is what the preview environment is for. The mechanism is here and measured; the findings are not. I'd rather leave that box unticked than claim it.

Suggested first pass once the preview is up: `?lang=uwu&expand=35` over issue stream, issue detail, alert rule creation, and project settings — dense-label surfaces are where truncation shows up first.