### PR TITLE
feat(seer): Expose generated code changes on Autofix overview

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import cast
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -34,7 +35,9 @@ from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.plugins.base import bindings
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
+from sentry.seer.agent.client_models import AgentFilePatch, FilePatch
 from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
+    CodeChangeFilePayload,
     IssuePayload,
     OverviewResponse,
     ProposedFixPayload,
@@ -43,6 +46,7 @@ from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
     RunPayload,
 )
 from sentry.seer.models.run import (
+    CodeChangesArtifactExtras,
     RootCauseArtifactExtras,
     SeerRun,
     SeerRunMilestone,
@@ -91,6 +95,11 @@ class _RunMilestones:
     def solution_artifact(self) -> SolutionArtifactExtras | None:
         extras = self.extras_by_milestone.get(SeerRunMilestoneType.SOLUTION, {})
         return extras.get("solution_artifact")
+
+    @property
+    def code_changes_artifact(self) -> CodeChangesArtifactExtras | None:
+        extras = self.extras_by_milestone.get(SeerRunMilestoneType.CODE_CHANGES, {})
+        return extras.get("code_changes_artifact")
 
 
 def _serialize_pull_request(
@@ -206,6 +215,20 @@ def _serialize_issue(group: Group, serialized_group: dict) -> IssuePayload:
     }
 
 
+def _serialize_code_changes(artifact: CodeChangesArtifactExtras) -> list[CodeChangeFilePayload]:
+    files: list[CodeChangeFilePayload] = []
+    for patches in artifact["diffs_by_repo"].values():
+        for raw in patches:
+            file_patch = AgentFilePatch.parse_obj(raw)
+            files.append(
+                {
+                    "repoName": file_patch.repo_name,
+                    "patch": cast(FilePatch, file_patch.patch.dict()),
+                }
+            )
+    return files
+
+
 def _serialize_run(
     group: Group,
     run: _RunMilestones,
@@ -224,6 +247,11 @@ def _serialize_run(
         {"oneLineSummary": solution_artifact.get("one_line_summary")} if solution_artifact else None
     )
 
+    code_changes_artifact = run.code_changes_artifact
+    code_changes: list[CodeChangeFilePayload] = (
+        _serialize_code_changes(code_changes_artifact) if code_changes_artifact else []
+    )
+
     return {
         "groupId": str(group.id),
         "shortId": group.qualified_short_id,
@@ -233,6 +261,7 @@ def _serialize_run(
         "seerRunId": str(run.seer_run.uuid),
         "lastTriggeredAt": run.seer_run.last_triggered_at,
         "pullRequests": pull_requests,
+        "codeChanges": code_changes,
         "issue": _serialize_issue(group, serialized_group),
     }
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import cast
 
+from pydantic import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -55,6 +57,8 @@ from sentry.seer.models.run import (
     SeerRunPullRequest,
     SolutionArtifactExtras,
 )
+
+logger = logging.getLogger(__name__)
 
 # The autofix pipeline in order. A run is grouped under its furthest-reached
 # milestone; the frontend owns section labels, ordering, and layout.
@@ -217,9 +221,13 @@ def _serialize_issue(group: Group, serialized_group: dict) -> IssuePayload:
 
 def _serialize_code_changes(artifact: CodeChangesArtifactExtras) -> list[CodeChangeFilePayload]:
     files: list[CodeChangeFilePayload] = []
-    for patches in artifact["diffs_by_repo"].values():
+    for patches in artifact.get("diffs_by_repo", {}).values():
         for raw in patches:
-            file_patch = AgentFilePatch.parse_obj(raw)
+            try:
+                file_patch = AgentFilePatch.parse_obj(raw)
+            except ValidationError:
+                logger.warning("seer.autofix_overview.invalid_code_change", exc_info=True)
+                continue
             files.append(
                 {
                     "repoName": file_patch.repo_name,
@@ -247,10 +255,9 @@ def _serialize_run(
         {"oneLineSummary": solution_artifact.get("one_line_summary")} if solution_artifact else None
     )
 
-    code_changes_artifact = run.code_changes_artifact
-    code_changes: list[CodeChangeFilePayload] = (
-        _serialize_code_changes(code_changes_artifact) if code_changes_artifact else []
-    )
+    code_changes: list[CodeChangeFilePayload] = []
+    if run.furthest_milestone == SeerRunMilestoneType.CODE_CHANGES and run.code_changes_artifact:
+        code_changes = _serialize_code_changes(run.code_changes_artifact)
 
     return {
         "groupId": str(group.id),

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TypedDict
 
+from sentry.seer.agent.client_models import FilePatch
+
 
 class PullRequestFilePayload(TypedDict):
     path: str
@@ -42,6 +44,11 @@ class IssuePayload(TypedDict):
     project: IssueProjectPayload
 
 
+class CodeChangeFilePayload(TypedDict):
+    repoName: str
+    patch: FilePatch
+
+
 class RootCausePayload(TypedDict):
     oneLineDescription: str | None
 
@@ -59,6 +66,7 @@ class RunPayload(TypedDict):
     seerRunId: str
     lastTriggeredAt: datetime
     pullRequests: list[PullRequestPayload]
+    codeChanges: list[CodeChangeFilePayload]
     issue: IssuePayload
 
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -245,6 +245,105 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert runs[0]["rootCause"]["oneLineDescription"] == "rc text"
         assert runs[0]["proposedFix"]["oneLineSummary"] == "fix text"
 
+    def _code_changes_state(self, rc):
+        from sentry.seer.agent.client_models import (
+            AgentFilePatch,
+            Artifact,
+            DiffLine,
+            FilePatch,
+            Hunk,
+            MemoryBlock,
+            Message,
+            SeerRunState,
+        )
+
+        patch = AgentFilePatch(
+            repo_name="getsentry/sentry",
+            patch=FilePatch(
+                path="src/foo.py",
+                type="M",
+                added=1,
+                removed=1,
+                hunks=[
+                    Hunk(
+                        source_start=1,
+                        source_length=1,
+                        target_start=1,
+                        target_length=1,
+                        section_header="",
+                        lines=[
+                            DiffLine(
+                                line_type="-",
+                                value="old",
+                                source_line_no=1,
+                                target_line_no=None,
+                                diff_line_no=1,
+                            ),
+                            DiffLine(
+                                line_type="+",
+                                value="new",
+                                source_line_no=None,
+                                target_line_no=1,
+                                diff_line_no=2,
+                            ),
+                        ],
+                    )
+                ],
+            ),
+            diff="@@ -1 +1 @@\n-old\n+new",
+        )
+        return SeerRunState(
+            run_id=1,
+            blocks=[
+                MemoryBlock(
+                    id="b",
+                    message=Message(role="assistant", content="c"),
+                    timestamp="2026-02-10T00:00:00Z",
+                    artifacts=[
+                        Artifact(key="root_cause", data={"one_line_description": rc}, reason="r")
+                    ],
+                    merged_file_patches=[patch],
+                )
+            ],
+            status="completed",
+            updated_at="2026-02-10T00:00:00Z",
+        )
+
+    def _run_with_code_changes(self, group):
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", group=group, project=group.project)
+        reconcile_milestones(run, self._code_changes_state("rc text"))
+        return run
+
+    def test_code_changes_returns_generated_diffs(self):
+        group = self.create_group()
+        self._run_with_code_changes(group)
+
+        resp = self.get_success_response(self.organization.slug)
+        runs = resp.data["runsByMilestone"][SeerRunMilestoneType.CODE_CHANGES]
+        assert len(runs) == 1
+        files = runs[0]["codeChanges"]
+        assert len(files) == 1
+        assert files[0]["repoName"] == "getsentry/sentry"
+        patch = files[0]["patch"]
+        assert patch["path"] == "src/foo.py"
+        assert patch["type"] == "M"
+        assert patch["added"] == 1
+        assert patch["removed"] == 1
+        lines = patch["hunks"][0]["lines"]
+        assert lines[0]["line_type"] == "-"
+        assert lines[1]["line_type"] == "+"
+        assert lines[1]["value"] == "new"
+
+    def test_run_without_code_changes_has_empty_list(self):
+        group = self.create_group()
+        self._run_for_group(group, "no changes yet")
+
+        resp = self.get_success_response(self.organization.slug)
+        runs = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]
+        assert len(runs) == 1
+        assert runs[0]["codeChanges"] == []
+
     def test_only_latest_run_per_group_is_shown(self):
         group = self.create_group()
         self._run_for_group(group, "old run")

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -344,6 +344,19 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert len(runs) == 1
         assert runs[0]["codeChanges"] == []
 
+    def test_code_changes_excluded_once_a_pull_request_exists(self):
+        group = self.create_group()
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", group=group, project=group.project)
+        state = self._code_changes_state("rc text")
+        state.blocks[0].pr_commit_shas = {"getsentry/sentry": "abc123"}
+        reconcile_milestones(run, state)
+
+        resp = self.get_success_response(self.organization.slug)
+        runs = resp.data["runsByMilestone"][SeerRunMilestoneType.HAS_PULL_REQUEST]
+        assert len(runs) == 1
+        assert runs[0]["codeChanges"] == []
+
     def test_only_latest_run_per_group_is_shown(self):
         group = self.create_group()
         self._run_for_group(group, "old run")


### PR DESCRIPTION
## Summary

Serializes the Autofix code-generation ("Create PR") step's generated diffs on the overview endpoint, so the frontend can show a run's changes **before a pull request exists**.

The diffs are already saved to `SeerRunMilestone.extras` and hydrated into memory by the endpoint — it just never serialized them. Today only real GitHub PR files reach the frontend, so a run stopped at code-generation returns nothing renderable.

## What changed

- Add `codeChanges` to `RunPayload`, flattening the stored, already-structured `AgentFilePatch` data per file (`{repoName, path, changeType, additions, deletions, hunks → lines}`; A/M/D → `ADDED`/`MODIFIED`/`DELETED`, camelCase).
- **Always included, not behind an expand:** it comes from Postgres, so there's no extra query and no SCM round-trip. The structured patch feeds the frontend diff viewer directly — no parsing, no second request.

## Rollout

Frontend follow-up (#122165) renders these on the "Create PR" cards. This must land first.
