### PR TITLE
ref(api): Scope auth error handling to protected routes

### DIFF
--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -2,7 +2,7 @@ import fetchMock from 'jest-fetch-mock';
 
 import {setWindowLocation} from 'sentry-test/utils';
 
-import {Client, Request} from 'sentry/api';
+import {Client, registerApiErrorHandler, Request} from 'sentry/api';
 import {PROJECT_MOVED} from 'sentry/constants/apiErrorCodes';
 import type {ResponseMeta} from 'sentry/types/api';
 
@@ -104,5 +104,21 @@ describe('api', () => {
         'test'
       )
     ).not.toThrow();
+  });
+
+  it('registers and unregisters global error handlers', async () => {
+    const errorHandler = jest.fn(() => false);
+    const unregister = registerApiErrorHandler(errorHandler);
+    const client = new Client();
+
+    fetchMock.mockResponseOnce(JSON.stringify({detail: 'Nope'}), {status: 500});
+    await expect(client.requestPromise('/first/')).rejects.toBeDefined();
+    expect(errorHandler).toHaveBeenCalledTimes(1);
+
+    unregister();
+
+    fetchMock.mockResponseOnce(JSON.stringify({detail: 'Still nope'}), {status: 500});
+    await expect(client.requestPromise('/second/')).rejects.toBeDefined();
+    expect(errorHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -68,30 +68,28 @@ function csrfSafeMethod(method?: string): boolean {
   return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method ?? '');
 }
 
-// TODO: Need better way of identifying anonymous pages that don't trigger redirect
-const ALLOWED_ANON_PAGES = [
-  /^\/accept\//,
-  /^\/share\//,
-  /^\/auth\/login\//,
-  /^\/join-request\//,
-  /^\/unsubscribe\//,
-];
-
 /**
  * Return true if we should skip calling the normal error handler
  */
-const globalErrorHandlers: Array<
-  (resp: ResponseMeta, options: RequestOptions) => boolean
-> = [];
+export type ApiErrorHandler = (
+  response: ResponseMeta,
+  options: Readonly<RequestOptions>
+) => boolean;
+
+const globalErrorHandlers = new Set<ApiErrorHandler>();
+
+export function registerApiErrorHandler(handler: ApiErrorHandler) {
+  globalErrorHandlers.add(handler);
+
+  return () => {
+    globalErrorHandlers.delete(handler);
+  };
+}
 
 export const initApiClientErrorHandling = () =>
-  globalErrorHandlers.push((resp: ResponseMeta, options: RequestOptions) => {
-    const pageAllowsAnon = ALLOWED_ANON_PAGES.find(regex =>
-      regex.test(window.location.pathname)
-    );
-
+  registerApiErrorHandler((resp: ResponseMeta, options: RequestOptions) => {
     // Ignore error unless it is a 401
-    if (resp?.status !== 401 || pageAllowsAnon) {
+    if (resp?.status !== 401) {
       return false;
     }
     if (resp && options.allowAuthError && resp.status === 401) {
@@ -586,9 +584,9 @@ export class Client {
               });
             }
 
-            const shouldSkipErrorHandler = globalErrorHandlers
-              .map(handler => handler(responseMeta, options))
-              .some(Boolean);
+            const shouldSkipErrorHandler = Array.from(globalErrorHandlers, handler =>
+              handler(responseMeta, options)
+            ).some(Boolean);
 
             if (!shouldSkipErrorHandler) {
               errorHandler(responseMeta, statusText, errorReason);

--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -150,6 +150,7 @@ describe('buildRoutes()', () => {
       '(layout)',
       '/',
       '(layout)',
+      '(layout)',
       '/:orgId/:projectId/',
       'events/:eventId/',
     ]);

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -15,6 +15,7 @@ import {withDomainRedirect} from 'sentry/utils/withDomainRedirect';
 import {withDomainRequired} from 'sentry/utils/withDomainRequired';
 import {App} from 'sentry/views/app';
 import {AppBodyContentRoute} from 'sentry/views/app/appBodyContent';
+import {AuthenticatedApiErrorHandler} from 'sentry/views/app/authenticatedApiErrorHandler';
 import {AuthLayoutRoute} from 'sentry/views/auth/layout';
 import {authV2Routes} from 'sentry/views/authV2/routes';
 import {automationRoutes} from 'sentry/views/automations/routes';
@@ -150,16 +151,61 @@ function buildRoutes(): RouteObject[] {
       }
     : {};
 
+  const publicRootChildren: SentryRouteObject[] = [
+    {
+      path: '/accept/:orgId/:memberId/:token/',
+      component: make(() => import('sentry/views/acceptOrganizationInvite')),
+    },
+    {
+      path: '/share/group/:shareId/',
+      redirectTo: '/share/issue/:shareId/',
+    },
+    {
+      path: '/share/issue/:shareId/',
+      component: make(() => import('sentry/views/sharedGroupDetails')),
+    },
+    {
+      path: '/unsubscribe/project/:id/',
+      component: make(() => import('sentry/views/unsubscribe/project')),
+      customerDomainOnlyRoute: true,
+    },
+    {
+      path: '/unsubscribe/:orgId/project/:id/',
+      component: make(() => import('sentry/views/unsubscribe/project')),
+    },
+    {
+      path: '/unsubscribe/issue/:id/',
+      component: make(() => import('sentry/views/unsubscribe/issue')),
+      customerDomainOnlyRoute: true,
+    },
+    {
+      path: '/unsubscribe/:orgId/issue/:id/',
+      component: make(() => import('sentry/views/unsubscribe/issue')),
+    },
+    {
+      path: '/join-request/',
+      component: withDomainRequired(
+        make(() => import('sentry/views/organizationJoinRequest'))
+      ),
+      customerDomainOnlyRoute: true,
+    },
+    {
+      path: '/join-request/:orgId/',
+      component: withDomainRedirect(
+        make(() => import('sentry/views/organizationJoinRequest'))
+      ),
+    },
+  ];
+  const publicRootRoutes: SentryRouteObject = {
+    component: errorHandler(AppBodyContentRoute),
+    children: publicRootChildren,
+  };
   const rootChildren: SentryRouteObject[] = [
     {
       index: true,
       component: make(() => import('sentry/views/app/root')),
     },
     routeHook('routes:root'),
-    {
-      path: '/accept/:orgId/:memberId/:token/',
-      component: make(() => import('sentry/views/acceptOrganizationInvite')),
-    },
     {
       path: '/accept-transfer/',
       component: make(() => import('sentry/views/acceptProjectTransfer')),
@@ -181,40 +227,14 @@ function buildRoutes(): RouteObject[] {
       path: '/account/',
       redirectTo: '/settings/account/details/',
     },
-    {
-      path: '/share/group/:shareId/',
-      redirectTo: '/share/issue/:shareId/',
-    },
     // Add redirect from old user feedback to new feedback
     {
       path: '/user-feedback/',
       redirectTo: '/feedback/',
     },
     {
-      path: '/share/issue/:shareId/',
-      component: make(() => import('sentry/views/sharedGroupDetails')),
-    },
-    {
       path: '/organizations/:orgId/share/issue/:shareId/',
       component: make(() => import('sentry/views/sharedGroupDetails')),
-    },
-    {
-      path: '/unsubscribe/project/:id/',
-      component: make(() => import('sentry/views/unsubscribe/project')),
-      customerDomainOnlyRoute: true,
-    },
-    {
-      path: '/unsubscribe/:orgId/project/:id/',
-      component: make(() => import('sentry/views/unsubscribe/project')),
-    },
-    {
-      path: '/unsubscribe/issue/:id/',
-      component: make(() => import('sentry/views/unsubscribe/issue')),
-      customerDomainOnlyRoute: true,
-    },
-    {
-      path: '/unsubscribe/:orgId/issue/:id/',
-      component: make(() => import('sentry/views/unsubscribe/issue')),
     },
     {
       path: '/organizations/new/',
@@ -243,19 +263,6 @@ function buildRoutes(): RouteObject[] {
     {
       path: '/organizations/:orgId/restore/',
       component: make(() => import('sentry/views/organizationRestore')),
-    },
-    {
-      path: '/join-request/',
-      component: withDomainRequired(
-        make(() => import('sentry/views/organizationJoinRequest'))
-      ),
-      customerDomainOnlyRoute: true,
-    },
-    {
-      path: '/join-request/:orgId/',
-      component: withDomainRedirect(
-        make(() => import('sentry/views/organizationJoinRequest'))
-      ),
     },
     {
       path: '/relocation/',
@@ -2966,17 +2973,23 @@ function buildRoutes(): RouteObject[] {
         path: '/',
         component: errorHandler(App),
         children: [
-          rootRoutes,
+          publicRootRoutes,
           authV2Routes,
-          organizationRoutes,
-          legacyRedirectRoutes,
           {
-            path: '*',
-            component: errorHandler(OrganizationLayout),
+            component: AuthenticatedApiErrorHandler,
             children: [
+              rootRoutes,
+              organizationRoutes,
+              legacyRedirectRoutes,
               {
                 path: '*',
-                component: errorHandler(RouteNotFound),
+                component: errorHandler(OrganizationLayout),
+                children: [
+                  {
+                    path: '*',
+                    component: errorHandler(RouteNotFound),
+                  },
+                ],
               },
             ],
           },

--- a/static/app/views/app/authenticatedApiErrorHandler.tsx
+++ b/static/app/views/app/authenticatedApiErrorHandler.tsx
@@ -1,0 +1,10 @@
+import {useEffect} from 'react';
+import {Outlet} from 'react-router-dom';
+
+import {initApiClientErrorHandling} from 'sentry/api';
+
+export function AuthenticatedApiErrorHandler() {
+  useEffect(() => initApiClientErrorHandling(), []);
+
+  return <Outlet />;
+}

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -10,7 +10,6 @@ import {
 } from 'sentry/actionCreators/developmentAlerts';
 import {fetchGuides} from 'sentry/actionCreators/guides';
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
-import {initApiClientErrorHandling} from 'sentry/api';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import Indicators from 'sentry/components/indicators';
 import {Override} from 'sentry/components/override';
@@ -145,7 +144,6 @@ export function App() {
       getOverride('analytics:init-user')?.(user);
     }
 
-    initApiClientErrorHandling();
     fetchGuides();
 
     // When the app is unloaded clear the organizationst list


### PR DESCRIPTION
Authentication failure handling is now scoped to protected routes, so anonymous pages can receive 401 responses without triggering a session-expired redirect. Public routes are grouped outside the authenticated error-handler layout, replacing pathname regex checks while preserving the existing behavior for protected routes.

The handler registration now returns cleanup on unmount, preventing duplicate global handlers from accumulating as application state changes.