### PR TITLE
feat(seer): Show generated code changes on Autofix overview

### DIFF
--- a/static/app/views/seerWorkflows/overview2/changedFileRow.tsx
+++ b/static/app/views/seerWorkflows/overview2/changedFileRow.tsx
@@ -1,0 +1,80 @@
+import type {ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Flex, Grid} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import type {TagVariant} from 'sentry/utils/theme';
+
+export interface FileChangeTag {
+  label: string;
+  variant: TagVariant;
+}
+
+// A collapsible file row shared by the PR files list and generated code changes:
+// the caller resolves the change tag from its own enum and owns the diff `children`.
+export function ChangedFileRow({
+  additions,
+  deletions,
+  path,
+  changeTag,
+  expanded,
+  onExpandedChange,
+  children,
+}: {
+  additions: number;
+  changeTag: FileChangeTag | null;
+  children: ReactNode;
+  deletions: number;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  path: string;
+}) {
+  return (
+    <FileRow>
+      <Disclosure size="sm" expanded={expanded} onExpandedChange={onExpandedChange}>
+        <Disclosure.Title
+          trailingItems={
+            changeTag ? (
+              <Tag variant={changeTag.variant}>{changeTag.label}</Tag>
+            ) : undefined
+          }
+        >
+          <Grid
+            columns="minmax(60px, auto) minmax(0, 1fr)"
+            gap="xl"
+            align="center"
+            width="100%"
+          >
+            <Flex gap="md" align="center">
+              <Text size="sm" monospace variant="success">
+                +{additions}
+              </Text>
+              <Text size="sm" monospace variant="danger">
+                -{deletions}
+              </Text>
+            </Flex>
+            <FilePath size="sm" monospace ellipsis title={path}>
+              {path}
+            </FilePath>
+          </Grid>
+        </Disclosure.Title>
+        <Disclosure.Content>{children}</Disclosure.Content>
+      </Disclosure>
+    </FileRow>
+  );
+}
+
+const FileRow = styled('div')`
+  & + & {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;
+
+// Truncates the head of the path so the file name stays visible.
+const FilePath = styled(Text)`
+  direction: rtl;
+  text-align: left;
+`;

--- a/static/app/views/seerWorkflows/overview2/changedFileRow.tsx
+++ b/static/app/views/seerWorkflows/overview2/changedFileRow.tsx
@@ -13,8 +13,6 @@ export interface FileChangeTag {
   variant: TagVariant;
 }
 
-// A collapsible file row shared by the PR files list and generated code changes:
-// the caller resolves the change tag from its own enum and owns the diff `children`.
 export function ChangedFileRow({
   additions,
   deletions,

--- a/static/app/views/seerWorkflows/overview2/codeChanges.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/codeChanges.spec.tsx
@@ -1,0 +1,76 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  DiffFileType,
+  DiffLineType,
+  type FilePatch,
+} from 'sentry/components/events/autofix/types';
+import {CodeChanges} from 'sentry/views/seerWorkflows/overview2/codeChanges';
+import type {OverviewCodeChangeFile} from 'sentry/views/seerWorkflows/overview2/types';
+
+function fileFixture(overrides: Partial<FilePatch> = {}): OverviewCodeChangeFile {
+  return {
+    repoName: 'getsentry/sentry',
+    patch: {
+      path: 'src/foo.py',
+      source_file: 'src/foo.py',
+      target_file: 'src/foo.py',
+      type: DiffFileType.MODIFIED,
+      added: 1,
+      removed: 1,
+      hunks: [
+        {
+          source_start: 1,
+          source_length: 1,
+          target_start: 1,
+          target_length: 1,
+          section_header: '',
+          lines: [
+            {
+              line_type: DiffLineType.REMOVED,
+              value: 'old',
+              source_line_no: 1,
+              target_line_no: null,
+              diff_line_no: 1,
+            },
+            {
+              line_type: DiffLineType.ADDED,
+              value: 'new',
+              source_line_no: null,
+              target_line_no: 1,
+              diff_line_no: 2,
+            },
+          ],
+        },
+      ],
+      ...overrides,
+    },
+  };
+}
+
+describe('CodeChanges', () => {
+  it('renders the generated files and expands to a diff', async () => {
+    render(<CodeChanges codeChanges={[fileFixture()]} />);
+
+    expect(screen.getByText('1 file changed')).toBeInTheDocument();
+    expect(screen.getByText('src/foo.py')).toBeInTheDocument();
+    // The diff stays collapsed until the file is expanded.
+    expect(screen.queryByText('new')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /src\/foo\.py/}));
+
+    expect(await screen.findByText('new')).toBeInTheDocument();
+  });
+
+  it('renders the deleted-file view for a deleted file', async () => {
+    render(
+      <CodeChanges
+        codeChanges={[fileFixture({type: DiffFileType.DELETED, path: 'src/gone.py'})]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /src\/gone\.py/}));
+
+    expect(await screen.findByText('This file will be deleted.')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerWorkflows/overview2/codeChanges.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/codeChanges.spec.tsx
@@ -54,23 +54,10 @@ describe('CodeChanges', () => {
 
     expect(screen.getByText('1 file changed')).toBeInTheDocument();
     expect(screen.getByText('src/foo.py')).toBeInTheDocument();
-    // The diff stays collapsed until the file is expanded.
     expect(screen.queryByText('new')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: /src\/foo\.py/}));
 
     expect(await screen.findByText('new')).toBeInTheDocument();
-  });
-
-  it('renders the deleted-file view for a deleted file', async () => {
-    render(
-      <CodeChanges
-        codeChanges={[fileFixture({type: DiffFileType.DELETED, path: 'src/gone.py'})]}
-      />
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: /src\/gone\.py/}));
-
-    expect(await screen.findByText('This file will be deleted.')).toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview2/codeChanges.tsx
+++ b/static/app/views/seerWorkflows/overview2/codeChanges.tsx
@@ -17,8 +17,6 @@ const DIFF_TYPE_TAG: Record<DiffFileType, FileChangeTag> = {
   [DiffFileType.DELETED]: {label: t('Deleted'), variant: 'danger'},
 };
 
-// The generated diffs arrive inline with the overview response, so unlike the
-// PR files list there's no fetch: each row expands straight to its patch.
 export function CodeChanges({codeChanges}: {codeChanges: OverviewCodeChangeFile[]}) {
   const [expandedRows, setExpandedRows] = useState<Set<number>>(() => new Set());
 

--- a/static/app/views/seerWorkflows/overview2/codeChanges.tsx
+++ b/static/app/views/seerWorkflows/overview2/codeChanges.tsx
@@ -1,0 +1,69 @@
+import {useState} from 'react';
+
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {DiffFileType} from 'sentry/components/events/autofix/types';
+import {IconCode} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
+
+import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
+import type {OverviewCodeChangeFile} from './types';
+
+const DIFF_TYPE_TAG: Record<DiffFileType, FileChangeTag> = {
+  [DiffFileType.ADDED]: {label: t('Added'), variant: 'success'},
+  [DiffFileType.MODIFIED]: {label: t('Modified'), variant: 'muted'},
+  [DiffFileType.DELETED]: {label: t('Deleted'), variant: 'danger'},
+};
+
+// The generated diffs arrive inline with the overview response, so unlike the
+// PR files list there's no fetch: each row expands straight to its patch.
+export function CodeChanges({codeChanges}: {codeChanges: OverviewCodeChangeFile[]}) {
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(() => new Set());
+
+  const toggle = (index: number, expanded: boolean) =>
+    setExpandedRows(prev => {
+      const next = new Set(prev);
+      if (expanded) {
+        next.add(index);
+      } else {
+        next.delete(index);
+      }
+      return next;
+    });
+
+  return (
+    <Stack gap="sm">
+      <Flex gap="xs" align="center">
+        <IconCode size="xs" variant="secondary" aria-hidden />
+        <Text size="xs" bold uppercase variant="secondary">
+          {t('Code changes')}
+        </Text>
+      </Flex>
+      <Text size="sm" variant="muted">
+        {codeChanges.length === 1
+          ? t('1 file changed')
+          : t('%s files changed', codeChanges.length.toLocaleString())}
+      </Text>
+      <Container border="primary" radius="md" overflow="hidden" background="secondary">
+        {codeChanges.map(({patch}, index) => {
+          const isExpanded = expandedRows.has(index);
+          return (
+            <ChangedFileRow
+              key={`${index}-${patch.path}`}
+              additions={patch.added}
+              deletions={patch.removed}
+              path={patch.path}
+              changeTag={DIFF_TYPE_TAG[patch.type]}
+              expanded={isExpanded}
+              onExpandedChange={next => toggle(index, next)}
+            >
+              {isExpanded ? <FileDiffViewer hideHeader patch={patch} /> : null}
+            </ChangedFileRow>
+          );
+        })}
+      </Container>
+    </Stack>
+  );
+}

--- a/static/app/views/seerWorkflows/overview2/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.spec.tsx
@@ -11,6 +11,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -808,6 +809,69 @@ describe('AutofixOverview2', () => {
 
     expect(await screen.findByText('This file will be deleted.')).toBeInTheDocument();
     expect(screen.queryByText('No diff available.')).not.toBeInTheDocument();
+  });
+
+  it('renders generated code changes for the Create PR step', async () => {
+    const codeChangesRun = {
+      ...rootCauseRun,
+      codeChanges: [
+        {
+          repoName: 'getsentry/sentry',
+          patch: {
+            path: 'src/sentry/foo.py',
+            source_file: 'src/sentry/foo.py',
+            target_file: 'src/sentry/foo.py',
+            type: DiffFileType.MODIFIED,
+            added: 1,
+            removed: 1,
+            hunks: [
+              {
+                source_start: 1,
+                source_length: 1,
+                target_start: 1,
+                target_length: 1,
+                section_header: '',
+                lines: [
+                  {
+                    line_type: DiffLineType.REMOVED,
+                    value: 'old',
+                    source_line_no: 1,
+                    target_line_no: null,
+                    diff_line_no: 1,
+                  },
+                  {
+                    line_type: DiffLineType.ADDED,
+                    value: 'new',
+                    source_line_no: null,
+                    target_line_no: 1,
+                    diff_line_no: 2,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    mockOverview({base: {autofix_code_changes: [codeChangesRun]}});
+
+    renderPage();
+
+    expect(await screen.findByText('1 file changed')).toBeInTheDocument();
+    // The generated diff comes back inline, so expanding needs no extra request.
+    await userEvent.click(
+      await screen.findByRole('button', {name: /src\/sentry\/foo\.py/})
+    );
+    expect(await screen.findByText('new')).toBeInTheDocument();
+  });
+
+  it('renders a Create PR step run whose code changes are absent', async () => {
+    mockOverview({base: {autofix_code_changes: [rootCauseRun]}});
+
+    renderPage();
+
+    expect(await screen.findByText('TypeError in checkout cart')).toBeInTheDocument();
+    expect(screen.queryByText('1 file changed')).not.toBeInTheDocument();
   });
 
   it('defaults to Recent Seer Activity and omits the sort param', async () => {

--- a/static/app/views/seerWorkflows/overview2/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview2/issueCard.tsx
@@ -40,6 +40,7 @@ import {
 } from 'sentry/views/seerWorkflows/overview/overviewIssuePriority';
 import type {AutofixStateKey} from 'sentry/views/seerWorkflows/overview/types';
 
+import {CodeChanges} from './codeChanges';
 import {periodWindowLabel} from './periods';
 import {PullRequestFiles} from './pullRequestFiles';
 import type {OverviewPullRequest, OverviewRun} from './types';
@@ -407,6 +408,9 @@ export function Overview2Card({
                 {proposedFix}
               </NarrativeBlock>
             )}
+            {sectionKey === 'code_changes_ready' && run.codeChanges?.length ? (
+              <CodeChanges codeChanges={run.codeChanges} />
+            ) : null}
             {enrichmentPending && reviewPullRequest?.url ? (
               <Placeholder height="3rem" />
             ) : reviewPullRequest && changedFiles.length > 0 ? (

--- a/static/app/views/seerWorkflows/overview2/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview2/pullRequestFiles.tsx
@@ -1,10 +1,7 @@
 import {useMemo, useState} from 'react';
-import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
-import {Tag} from '@sentry/scraps/badge';
-import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -12,9 +9,9 @@ import {IconCode} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PullRequestFileChangeType} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {TagVariant} from 'sentry/utils/theme';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
+import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
 import {parseFilePatch} from './filePatch';
 import {
   type OverviewPullRequest,
@@ -24,10 +21,7 @@ import {
   QUERY_STALE_TIME,
 } from './types';
 
-const FILE_CHANGE_TAG: Record<
-  PullRequestFileChangeType,
-  {label: string; variant: TagVariant}
-> = {
+const FILE_CHANGE_TAG: Record<PullRequestFileChangeType, FileChangeTag> = {
   ADDED: {label: t('Added'), variant: 'success'},
   CHANGED: {label: t('Changed'), variant: 'muted'},
   COPIED: {label: t('Copied'), variant: 'muted'},
@@ -135,69 +129,30 @@ export function PullRequestFiles({
       </Text>
       <Container border="primary" radius="md" overflow="hidden" background="secondary">
         {files.map((file, index) => {
-          const changeTag = file.changeType ? FILE_CHANGE_TAG[file.changeType] : null;
           const diff = diffByPath.get(file.path);
           const isExpanded = expandedRows.has(index);
           return (
-            <FileRow key={`${index}-${file.path}`}>
-              <Disclosure
-                size="sm"
-                expanded={isExpanded}
-                onExpandedChange={next => toggle(index, next)}
-              >
-                <Disclosure.Title
-                  trailingItems={
-                    changeTag ? (
-                      <Tag variant={changeTag.variant}>{changeTag.label}</Tag>
-                    ) : undefined
-                  }
-                >
-                  <Grid
-                    columns="minmax(60px, auto) minmax(0, 1fr)"
-                    gap="xl"
-                    align="center"
-                    width="100%"
-                  >
-                    <Flex gap="md" align="center">
-                      <Text size="sm" monospace variant="success">
-                        +{file.additions}
-                      </Text>
-                      <Text size="sm" monospace variant="danger">
-                        -{file.deletions}
-                      </Text>
-                    </Flex>
-                    <FilePath size="sm" monospace ellipsis title={file.path}>
-                      {file.path}
-                    </FilePath>
-                  </Grid>
-                </Disclosure.Title>
-                <Disclosure.Content>
-                  {isExpanded ? (
-                    <FileDiff
-                      file={file}
-                      diff={diff}
-                      isPending={isPending}
-                      isError={isError}
-                    />
-                  ) : null}
-                </Disclosure.Content>
-              </Disclosure>
-            </FileRow>
+            <ChangedFileRow
+              key={`${index}-${file.path}`}
+              additions={file.additions}
+              deletions={file.deletions}
+              path={file.path}
+              changeTag={file.changeType ? FILE_CHANGE_TAG[file.changeType] : null}
+              expanded={isExpanded}
+              onExpandedChange={next => toggle(index, next)}
+            >
+              {isExpanded ? (
+                <FileDiff
+                  file={file}
+                  diff={diff}
+                  isPending={isPending}
+                  isError={isError}
+                />
+              ) : null}
+            </ChangedFileRow>
           );
         })}
       </Container>
     </Stack>
   );
 }
-
-const FileRow = styled('div')`
-  & + & {
-    border-top: 1px solid ${p => p.theme.tokens.border.primary};
-  }
-`;
-
-// Truncates the head of the path so the file name stays visible.
-const FilePath = styled(Text)`
-  direction: rtl;
-  text-align: left;
-`;

--- a/static/app/views/seerWorkflows/overview2/types.ts
+++ b/static/app/views/seerWorkflows/overview2/types.ts
@@ -1,3 +1,4 @@
+import type {FilePatch} from 'sentry/components/events/autofix/types';
 import type {Actor} from 'sentry/types/core';
 import type {Level} from 'sentry/types/event';
 import type {
@@ -74,6 +75,11 @@ export interface PullRequestFilesResponse {
   files: PullRequestFileDiff[];
 }
 
+export interface OverviewCodeChangeFile {
+  patch: FilePatch;
+  repoName: string;
+}
+
 // Issue-side facts the endpoint serializes off the Group; mirrors the fields the
 // reused priority/assignee widgets and the vitals row consume.
 export interface OverviewRunIssue {
@@ -101,6 +107,7 @@ export interface OverviewRun {
   seerRunId: string;
   shortId: string;
   title: string;
+  codeChanges?: OverviewCodeChangeFile[];
 }
 
 export interface AutofixOverviewResponse {


### PR DESCRIPTION
## Summary

Renders the code-generation step's generated diffs on the **"Create PR"** (`code_changes_ready`) cards, so a run's changes are visible before a pull request exists. Previously only real GitHub PRs showed file diffs.

## What changed

- New `CodeChanges` component: a "Code changes" file list, each row expanding to its diff.
- Diffs ride the overview response **inline** (Postgres-only), so they render from the base payload with no extra request. The endpoint returns an already-structured patch, so `toFilePatch` maps it straight onto `FileDiffViewer` — no diff-string parsing.
- Extracts the shared collapsible file row (`ChangedFileRow`) out of `pullRequestFiles`, reused by both.