### PR TITLE
feat(autofix): Link merged overview cards to pull requests

### DIFF
--- a/static/app/views/seerWorkflows/overview2/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview2/issueCard.tsx
@@ -88,16 +88,50 @@ const ACTION_META: Record<Exclude<AutofixStateKey, 'merged'>, ActionMeta> = {
 
 function Overview2Action({
   sectionKey,
+  pullRequests,
   reviewPullRequest,
   issueUrl,
   enrichmentPending,
 }: {
   enrichmentPending: boolean;
   issueUrl: string;
+  pullRequests: OverviewPullRequest[];
   reviewPullRequest: OverviewPullRequest | undefined;
   sectionKey: AutofixStateKey;
 }) {
   if (sectionKey === 'merged') {
+    if (pullRequests.length > 0) {
+      return (
+        <Stack gap="xs" align="end">
+          {pullRequests.map(pullRequest => {
+            const label = t('Merged #%s', pullRequest.number);
+            return (
+              <Tooltip
+                key={pullRequest.id}
+                title={t('The pull request for this fix was merged.')}
+                skipWrapper
+              >
+                {pullRequest.url ? (
+                  <LinkButton
+                    size="sm"
+                    variant="secondary"
+                    icon={<IconMerge />}
+                    href={pullRequest.url}
+                    external
+                  >
+                    {label}
+                  </LinkButton>
+                ) : (
+                  <Tag variant="muted" icon={<IconMerge />}>
+                    {label}
+                  </Tag>
+                )}
+              </Tooltip>
+            );
+          })}
+        </Stack>
+      );
+    }
     return (
       <Tooltip title={t('The pull request for this fix was merged.')}>
         <Tag variant="success" icon={<IconMerge />}>
@@ -385,6 +419,7 @@ export function Overview2Card({
           <Stack gap="lg" align="end" justify="between" flexShrink={0} minWidth="0">
             <Overview2Action
               sectionKey={sectionKey}
+              pullRequests={run.pullRequests}
               reviewPullRequest={reviewPullRequest}
               issueUrl={issueUrl}
               enrichmentPending={enrichmentPending}


### PR DESCRIPTION
Show each merged pull request as an external action when its URL is available, with a numbered non-interactive fallback otherwise.

<img width="2352" height="924" alt="CleanShot 2026-08-17 at 17 16 08@2x" src="https://github.com/user-attachments/assets/5d40f501-def7-48e7-a89f-48894ebdae1d" />

AIML-3321