### PR TITLE
build(ui): Add AVIF asset support

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -260,7 +260,7 @@ const config: Config.InitialOptions = {
   coverageReporters: ['html', 'cobertura'],
   coverageDirectory: '.artifacts/coverage',
   moduleNameMapper: {
-    '\\.(css|less|png|gif|jpg|woff|mp4)$':
+    '\\.(css|less|png|gif|jpg|avif|woff|mp4)$':
       '<rootDir>/tests/js/sentry-test/mocks/importStyleMock.js',
     '^sentry/stories/storyManifest\\.generated$':
       '<rootDir>/tests/js/sentry-test/mocks/storyManifestMock.ts',

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -392,7 +392,7 @@ const appConfig: Configuration = {
         ],
       },
       {
-        test: /\.(?:woff2?|ttf|eot|svg|png|gif|ico|jpg|mp4)$/,
+        test: /\.(?:woff2?|ttf|eot|svg|png|gif|ico|jpe?g|avif|mp4)$/,
         type: 'asset',
       },
     ],

--- a/static/app/types/fileLoader.d.ts
+++ b/static/app/types/fileLoader.d.ts
@@ -2,6 +2,7 @@
 // TS compatibility for https://github.com/webpack-contrib/file-loader
 
 declare module '*.css';
+declare module '*.avif';
 declare module '*.png';
 declare module '*.gif';
 declare module '*.jpg';


### PR DESCRIPTION
AVIF imports now work consistently in production builds, TypeScript, and Jest so frontend code can use compressed AVIF image assets without loader or test failures.