### PR TITLE
feat(seer): Add Autofix overview empty state

### DIFF
--- a/static/app/views/seerWorkflows/overview2/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.spec.tsx
@@ -213,11 +213,6 @@ describe('AutofixOverview2', () => {
     expect(
       await screen.findByText('You don’t have any Autofix runs...yet.')
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Seer hasn’t performed Autofix on any of your issues yet. Check back in tomorrow!'
-      )
-    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'project-slug'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: '14D'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /Sort/})).toBeInTheDocument();

--- a/static/app/views/seerWorkflows/overview2/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.spec.tsx
@@ -181,7 +181,7 @@ describe('AutofixOverview2', () => {
     expect(enrichedRequest).not.toHaveBeenCalled();
   });
 
-  it('renders every section with counts from the single endpoint', async () => {
+  it('renders only populated sections with counts from the single endpoint', async () => {
     mockOverview({
       base: {
         autofix_root_cause: [rootCauseRun],
@@ -197,9 +197,40 @@ describe('AutofixOverview2', () => {
     expect(
       screen.getByRole('button', {name: 'Generate code changes 1'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Create PR 0'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Review Open PRs 0'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Merged 0'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Create PR/})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Review Open PRs/})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Merged/})).not.toBeInTheDocument();
+    expect(screen.queryByText('No issues')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state while keeping the query controls visible', async () => {
+    mockOverview({base: {}});
+
+    renderPage();
+
+    expect(
+      await screen.findByText('You don’t have any Autofix runs...yet.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Seer hasn’t performed Autofix on any of your issues yet. Check back in tomorrow!'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'project-slug'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: '14D'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Sort/})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Create Plan/})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Generate code changes/})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Create PR/})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Review Open PRs/})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Merged/})).not.toBeInTheDocument();
+    expect(screen.queryByText('No issues')).not.toBeInTheDocument();
   });
 
   it('renders card prose and links from the endpoint payload', async () => {

--- a/static/app/views/seerWorkflows/overview2/index.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.tsx
@@ -134,13 +134,7 @@ function AutofixOverview2Content({organization}: {organization: Organization}) {
       ) : isPending ? (
         <LoadingIndicator />
       ) : populatedSections.length === 0 ? (
-        <EmptyState
-          padding="3xl"
-          title={t('You don’t have any Autofix runs...yet.')}
-          description={t(
-            'Seer hasn’t performed Autofix on any of your issues yet. Check back in tomorrow!'
-          )}
-        />
+        <EmptyState padding="3xl" title={t('You don’t have any Autofix runs...yet.')} />
       ) : (
         <Stack gap="lg">
           {populatedSections.map(({key, runs}) => {

--- a/static/app/views/seerWorkflows/overview2/index.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.tsx
@@ -4,7 +4,8 @@ import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {EmptyState} from '@sentry/scraps/emptyState';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -87,6 +88,10 @@ function AutofixOverview2Content({organization}: {organization: Organization}) {
       sort,
       enabled: pageFiltersReady,
     });
+  const populatedSections = OVERVIEW2_SECTIONS.map(section => ({
+    ...section,
+    runs: data?.runsByMilestone[section.milestone] ?? [],
+  })).filter(section => section.runs.length > 0);
 
   const toggleGroup = (groupKey: StatusGroupKey, expanded: boolean) => {
     setCollapsedGroups(previous =>
@@ -128,10 +133,17 @@ function AutofixOverview2Content({organization}: {organization: Organization}) {
         <LoadingError onRetry={refetch} />
       ) : isPending ? (
         <LoadingIndicator />
+      ) : populatedSections.length === 0 ? (
+        <EmptyState
+          padding="3xl"
+          title={t('You don’t have any Autofix runs...yet.')}
+          description={t(
+            'Seer hasn’t performed Autofix on any of your issues yet. Check back in tomorrow!'
+          )}
+        />
       ) : (
         <Stack gap="lg">
-          {OVERVIEW2_SECTIONS.map(({key, milestone}) => {
-            const runs = data?.runsByMilestone[milestone] ?? [];
+          {populatedSections.map(({key, runs}) => {
             const meta = STATUS_GROUP_META[key];
             const groupLabel =
               key === 'needs_investigation' ? t('Create Plan') : meta.label;
@@ -155,26 +167,18 @@ function AutofixOverview2Content({organization}: {organization: Organization}) {
                   </Disclosure.Title>
                 </GroupHeader>
                 <Disclosure.Content>
-                  {runs.length === 0 ? (
-                    <Container padding="md">
-                      <Text as="p" variant="muted" size="sm">
-                        {t('No issues')}
-                      </Text>
-                    </Container>
-                  ) : (
-                    <Stack gap="md" paddingTop="sm">
-                      {runs.map(run => (
-                        <Overview2Card
-                          key={run.seerRunId}
-                          run={run}
-                          orgSlug={organization.slug}
-                          sectionKey={key}
-                          statsPeriod={selection.datetime.period}
-                          enrichmentPending={enrichmentPending}
-                        />
-                      ))}
-                    </Stack>
-                  )}
+                  <Stack gap="md" paddingTop="sm">
+                    {runs.map(run => (
+                      <Overview2Card
+                        key={run.seerRunId}
+                        run={run}
+                        orgSlug={organization.slug}
+                        sectionKey={key}
+                        statsPeriod={selection.datetime.period}
+                        enrichmentPending={enrichmentPending}
+                      />
+                    ))}
+                  </Stack>
                 </Disclosure.Content>
               </StatusGroup>
             );


### PR DESCRIPTION
Hide empty milestone sections and show the overview empty state when no Autofix runs match.

Refs AIML-3330

hidden milestones
<img width="2478" height="1010" alt="CleanShot 2026-08-17 at 17 39 38@2x" src="https://github.com/user-attachments/assets/2a7e2595-2b42-4109-a85c-3d09bfc7dab7" />

no issues (note I'll come back around w copy improvements here)
<img width="2482" height="1014" alt="CleanShot 2026-08-17 at 17 40 10@2x" src="https://github.com/user-attachments/assets/d78b207d-e565-4f27-9eb8-abdfddb25612" />
