### PR TITLE
feat(seer): Render PR statuses as tags

### DIFF
--- a/static/app/views/seerWorkflows/overview2/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview2/index.spec.tsx
@@ -163,6 +163,12 @@ describe('AutofixOverview2', () => {
     });
   }
 
+  function getTagForText(text: string) {
+    const tag = screen.getByText(text).closest('[data-test-id="tag-background"]');
+    expect(tag).toBeInTheDocument();
+    return tag!;
+  }
+
   it('gates the page and issues no requests when the feature is disabled', async () => {
     const {baseRequest, enrichedRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
@@ -529,9 +535,57 @@ describe('AutofixOverview2', () => {
       'https://github.com/getsentry/sentry/pull/2'
     );
     expect(screen.queryByRole('button', {name: /Review PR #1/})).not.toBeInTheDocument();
-    expect(screen.getByText('Checks passed')).toBeInTheDocument();
-    expect(screen.getByText('Approved')).toBeInTheDocument();
+    const approvedTag = getTagForText('Approved');
+    const checksPassingTag = getTagForText('Checks Passing');
+    expect(
+      approvedTag.compareDocumentPosition(checksPassingTag) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(approvedTag.className).toEqual(checksPassingTag.className);
     expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
+  });
+
+  it('renders failure and pending statuses with the configured tags', async () => {
+    const failingPullRequest: OverviewPullRequest = {
+      ...pullRequestFixture({number: 3, status: 'open'}),
+      checksStatus: 'failure',
+      reviewStatus: 'changes_requested',
+    };
+    const pendingPullRequest: OverviewPullRequest = {
+      ...pullRequestFixture({number: 4, status: 'open'}),
+      checksStatus: 'pending',
+      reviewStatus: 'review_required',
+    };
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {...rootCauseRun, pullRequests: [failingPullRequest]},
+          {
+            ...rootCauseRun,
+            groupId: '3',
+            shortId: 'PROJ-2',
+            title: 'KeyError in proxy handler',
+            seerRunId: 'run-2',
+            pullRequests: [pendingPullRequest],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Changes Requested')).toBeInTheDocument();
+    const changesRequestedTag = getTagForText('Changes Requested');
+    const checksFailingTag = getTagForText('Checks Failing');
+    const checksRunningTag = getTagForText('Checks Running');
+    expect(
+      changesRequestedTag.compareDocumentPosition(checksFailingTag) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(changesRequestedTag.className).toEqual(checksRunningTag.className);
+    expect(checksFailingTag.className).not.toEqual(changesRequestedTag.className);
+    expect(screen.queryByText(/^\d+ Checks Failing$/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Review Required')).not.toBeInTheDocument();
   });
 
   it('renders a draft pull request as the actionable one', async () => {

--- a/static/app/views/seerWorkflows/overview2/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview2/issueCard.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Tag} from '@sentry/scraps/badge';
+import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
@@ -10,15 +10,14 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ErrorLevel} from 'sentry/components/events/errorLevel';
-import {
-  PullRequestChecksBadge,
-  PullRequestReviewBadge,
-} from 'sentry/components/group/externalIssuesList/pullRequestStatusBadge';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
 import {
   IconBug,
+  IconCheckmark,
+  IconCircle,
   IconClock,
+  IconClose,
   IconCode,
   IconCommit,
   IconGraph,
@@ -27,11 +26,16 @@ import {
   IconPullRequest,
   IconSearch,
   IconSeer,
+  IconThumb,
   IconUser,
 } from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {IssueCategory, IssueType} from 'sentry/types/group';
+import type {
+  PullRequestChecksStatus,
+  PullRequestReviewStatus,
+} from 'sentry/types/integrations';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {OverviewIssueAssignee} from 'sentry/views/seerWorkflows/overview/overviewIssueAssignee';
 import {
@@ -86,6 +90,44 @@ const ACTION_META: Record<Exclude<AutofixStateKey, 'merged'>, ActionMeta> = {
   },
 };
 
+interface PullRequestStatusTagMeta {
+  icon: React.ReactNode;
+  label: string;
+  variant: TagProps['variant'];
+}
+
+const CHECKS_STATUS_TAGS = {
+  failure: {
+    icon: <IconClose />,
+    label: t('Checks Failing'),
+    variant: 'danger',
+  },
+  pending: {
+    icon: <IconCircle />,
+    label: t('Checks Running'),
+    variant: 'warning',
+  },
+  success: {
+    icon: <IconCheckmark />,
+    label: t('Checks Passing'),
+    variant: 'success',
+  },
+} satisfies Record<PullRequestChecksStatus, PullRequestStatusTagMeta>;
+
+const REVIEW_STATUS_TAGS = {
+  approved: {
+    icon: <IconThumb />,
+    label: t('Approved'),
+    variant: 'success',
+  },
+  changes_requested: {
+    icon: <IconClose />,
+    label: t('Changes Requested'),
+    variant: 'warning',
+  },
+  review_required: null,
+} satisfies Record<PullRequestReviewStatus, PullRequestStatusTagMeta | null>;
+
 function Overview2Action({
   sectionKey,
   reviewPullRequest,
@@ -108,6 +150,13 @@ function Overview2Action({
   }
 
   if (sectionKey === 'review_pr' && reviewPullRequest?.url) {
+    const checksStatusTag = reviewPullRequest.checksStatus
+      ? CHECKS_STATUS_TAGS[reviewPullRequest.checksStatus]
+      : null;
+    const reviewStatusTag = reviewPullRequest.reviewStatus
+      ? REVIEW_STATUS_TAGS[reviewPullRequest.reviewStatus]
+      : null;
+
     return (
       <Stack align="end" gap="xs">
         <Tooltip title={ACTION_META.review_pr.description} skipWrapper>
@@ -119,19 +168,23 @@ function Overview2Action({
           </LinkButton>
         </Tooltip>
         {enrichmentPending ? (
-          // Two slots mirror the checks + review badges the enriched response
+          // Two slots mirror the review + checks tags the enriched response
           // typically fills in, so the row height doesn't jump on resolve.
           <Fragment>
-            <Placeholder height="1.25rem" width="7rem" />
             <Placeholder height="1.25rem" width="5.5rem" />
+            <Placeholder height="1.25rem" width="7rem" />
           </Fragment>
         ) : (
           <Fragment>
-            {reviewPullRequest.checksStatus && (
-              <PullRequestChecksBadge status={reviewPullRequest.checksStatus} />
+            {reviewStatusTag && (
+              <Tag variant={reviewStatusTag.variant} icon={reviewStatusTag.icon}>
+                {reviewStatusTag.label}
+              </Tag>
             )}
-            {reviewPullRequest.reviewStatus && (
-              <PullRequestReviewBadge status={reviewPullRequest.reviewStatus} />
+            {checksStatusTag && (
+              <Tag variant={checksStatusTag.variant} icon={checksStatusTag.icon}>
+                {checksStatusTag.label}
+              </Tag>
             )}
           </Fragment>
         )}


### PR DESCRIPTION
Autofix overview PR cards now show review and check states as colored Tags that match the design, with review status above check status. Failing checks use count-free copy until per-check data lands, while the existing linked-PR presentation remains unchanged.

The overview tests cover success, warning, failure, pending, ordering, and suppressed review-required states; frontend lint, typecheck, and prek also pass.

Fixes AIML-3334
