### PR TITLE
feat(seer): Include repository name on Autofix overview PRs

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -111,6 +111,7 @@ def _serialize_pull_request(
     number: int,
     url: str | None,
     status: PullRequestStatus | None,
+    repo_name: str | None,
     checks_and_review: PullRequestStatusResult,
 ) -> PullRequestPayload:
     return {
@@ -120,6 +121,7 @@ def _serialize_pull_request(
         "status": status,
         "checksStatus": checks_and_review.checks.value if checks_and_review.checks else None,
         "reviewStatus": checks_and_review.review.value if checks_and_review.review else None,
+        "repoName": repo_name,
         "files": [
             {
                 "path": file.path,
@@ -186,12 +188,14 @@ def _pull_requests_by_seer_run_id(
             number = int(pr.key)
         except (TypeError, ValueError):
             continue
+        repo = repos_by_id.get(pr.repository_id)
         by_run[link.seer_run_id].append(
             _serialize_pull_request(
                 pull_request_id=str(pr.id),
                 number=number,
                 url=_external_url(pr),
                 status=status_by_pr_id[pr.id],
+                repo_name=repo.name if repo else None,
                 checks_and_review=checks_and_review_by_pr_id.get(pr.id, PullRequestStatusResult()),
             )
         )

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -20,6 +20,7 @@ class PullRequestPayload(TypedDict):
     status: str | None
     checksStatus: str | None
     reviewStatus: str | None
+    repoName: str | None
     files: list[PullRequestFilePayload]
 
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -474,6 +474,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
                 "status": "open",
                 "checksStatus": None,
                 "reviewStatus": None,
+                "repoName": "getsentry/sentry",
                 "files": [],
             }
         ]
@@ -659,6 +660,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert client.requested_keys == []
         assert pull_requests[0]["url"] is None
         assert pull_requests[0]["checksStatus"] is None
+        assert pull_requests[0]["repoName"] is None
 
     def test_run_without_pull_requests_has_empty_list(self):
         group = self.create_group()


### PR DESCRIPTION
Adds a `repoName` field to each pull request in the Autofix overview response, sourced from the `Repository` already loaded per PR (no extra query). Generated code changes already carry a repo name; this brings the SCM pull-request case to parity so the overview UI can group both lists by repository.

Part of AIML-3313. Frontend rendering follows in a stacked PR.
