### PR TITLE
feat(seer): Group Autofix overview file lists by repository

### DIFF
--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -1,0 +1,104 @@
+import {Fragment, type ReactNode, useState} from 'react';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {IconCode} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
+
+interface ChangedFile {
+  additions: number;
+  changeTag: FileChangeTag | null;
+  deletions: number;
+  path: string;
+  renderDiff: () => ReactNode;
+}
+
+export interface RepoFileGroup {
+  files: ChangedFile[];
+  repoName: string | null;
+}
+
+export function useExpandedKeys() {
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() => new Set());
+  const toggle = (key: string, expanded: boolean) =>
+    setExpandedKeys(prev => {
+      const next = new Set(prev);
+      if (expanded) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  return {expandedKeys, toggle};
+}
+
+export function ChangedFilesSection({
+  groups,
+  expandedKeys,
+  onToggle,
+}: {
+  expandedKeys: Set<string>;
+  groups: RepoFileGroup[];
+  onToggle: (key: string, expanded: boolean) => void;
+}) {
+  return (
+    <Stack gap="sm">
+      <Flex gap="xs" align="center">
+        <IconCode size="xs" variant="secondary" aria-hidden />
+        <Text size="xs" bold uppercase variant="secondary">
+          {t('Code changes')}
+        </Text>
+      </Flex>
+      <Container border="primary" radius="md" overflow="hidden" background="secondary">
+        {groups.map((group, groupIndex) => (
+          <Fragment key={groupIndex}>
+            <Flex
+              gap="md"
+              align="center"
+              padding="md xl"
+              borderBottom="primary"
+              borderTop={groupIndex > 0 ? 'primary' : undefined}
+            >
+              {group.repoName ? (
+                <Fragment>
+                  <Tag variant="muted">{group.files.length}</Tag>
+                  <Text size="sm" monospace variant="secondary" ellipsis>
+                    {group.repoName}
+                  </Text>
+                </Fragment>
+              ) : (
+                <Text size="sm" variant="muted">
+                  {group.files.length === 1
+                    ? t('1 file changed')
+                    : t('%s files changed', group.files.length.toLocaleString())}
+                </Text>
+              )}
+            </Flex>
+            {group.files.map((file, index) => {
+              const key = `${groupIndex}:${index}:${file.path}`;
+              const isExpanded = expandedKeys.has(key);
+              return (
+                <ChangedFileRow
+                  key={key}
+                  additions={file.additions}
+                  deletions={file.deletions}
+                  path={file.path}
+                  changeTag={file.changeTag}
+                  expanded={isExpanded}
+                  onExpandedChange={next => onToggle(key, next)}
+                >
+                  {isExpanded ? file.renderDiff() : null}
+                </ChangedFileRow>
+              );
+            })}
+          </Fragment>
+        ))}
+      </Container>
+    </Stack>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -56,7 +56,7 @@ export function ChangedFilesSection({
       </Flex>
       <Container border="primary" radius="md" overflow="hidden" background="secondary">
         {groups.map((group, groupIndex) => (
-          <Fragment key={groupIndex}>
+          <Fragment key={JSON.stringify([group.repoName])}>
             <Flex
               gap="md"
               align="center"
@@ -79,8 +79,8 @@ export function ChangedFilesSection({
                 </Text>
               )}
             </Flex>
-            {group.files.map((file, index) => {
-              const key = `${groupIndex}:${index}:${file.path}`;
+            {group.files.map(file => {
+              const key = JSON.stringify([group.repoName, file.path]);
               const isExpanded = expandedKeys.has(key);
               return (
                 <ChangedFileRow

--- a/static/app/views/seerWorkflows/overview/codeChanges.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/codeChanges.spec.tsx
@@ -8,9 +8,12 @@ import {
 import {CodeChanges} from 'sentry/views/seerWorkflows/overview/codeChanges';
 import type {OverviewCodeChangeFile} from 'sentry/views/seerWorkflows/overview/types';
 
-function fileFixture(overrides: Partial<FilePatch> = {}): OverviewCodeChangeFile {
+function fileFixture(
+  overrides: Partial<FilePatch> = {},
+  repoName = 'getsentry/sentry'
+): OverviewCodeChangeFile {
   return {
-    repoName: 'getsentry/sentry',
+    repoName,
     patch: {
       path: 'src/foo.py',
       source_file: 'src/foo.py',
@@ -52,12 +55,45 @@ describe('CodeChanges', () => {
   it('renders the generated files and expands to a diff', async () => {
     render(<CodeChanges codeChanges={[fileFixture()]} />);
 
-    expect(screen.getByText('1 file changed')).toBeInTheDocument();
+    expect(screen.getByText('getsentry/sentry')).toBeInTheDocument();
     expect(screen.getByText('src/foo.py')).toBeInTheDocument();
     expect(screen.queryByText('new')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: /src\/foo\.py/}));
 
     expect(await screen.findByText('new')).toBeInTheDocument();
+  });
+
+  it('groups files under a header for each repository', () => {
+    render(
+      <CodeChanges
+        codeChanges={[
+          fileFixture({path: 'src/a.py'}, 'getsentry/sentry'),
+          fileFixture({path: 'src/b.py'}, 'getsentry/sentry'),
+          fileFixture({path: 'src/c.py'}, 'getsentry/getsentry'),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('getsentry/sentry')).toBeInTheDocument();
+    expect(screen.getByText('getsentry/getsentry')).toBeInTheDocument();
+    // Each repo header carries its own file count.
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('src/a.py')).toBeInTheDocument();
+    expect(screen.getByText('src/b.py')).toBeInTheDocument();
+    expect(screen.getByText('src/c.py')).toBeInTheDocument();
+  });
+
+  it('renders the deleted-file view for a deleted file', async () => {
+    render(
+      <CodeChanges
+        codeChanges={[fileFixture({type: DiffFileType.DELETED, path: 'src/gone.py'})]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /src\/gone\.py/}));
+
+    expect(await screen.findByText('This file will be deleted.')).toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview/codeChanges.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/codeChanges.spec.tsx
@@ -85,6 +85,26 @@ describe('CodeChanges', () => {
     expect(screen.getByText('src/c.py')).toBeInTheDocument();
   });
 
+  it('preserves expanded files when repositories and files reorder', async () => {
+    const sentryFile = fileFixture({path: 'src/a.py'}, 'getsentry/sentry');
+    const otherSentryFile = fileFixture({path: 'src/b.py'}, 'getsentry/sentry');
+    const getsentryFile = fileFixture({path: 'src/c.py'}, 'getsentry/getsentry');
+    const {rerender} = render(
+      <CodeChanges codeChanges={[sentryFile, otherSentryFile, getsentryFile]} />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /src\/a\.py/}));
+    expect(await screen.findByText('new')).toBeInTheDocument();
+
+    rerender(<CodeChanges codeChanges={[getsentryFile, otherSentryFile, sentryFile]} />);
+
+    expect(screen.getByRole('button', {name: /src\/a\.py/})).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByText('new')).toBeInTheDocument();
+  });
+
   it('renders the deleted-file view for a deleted file', async () => {
     render(
       <CodeChanges

--- a/static/app/views/seerWorkflows/overview/codeChanges.tsx
+++ b/static/app/views/seerWorkflows/overview/codeChanges.tsx
@@ -1,14 +1,13 @@
-import {useState} from 'react';
-
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
-
 import {DiffFileType} from 'sentry/components/events/autofix/types';
-import {IconCode} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
-import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
+import type {FileChangeTag} from './changedFileRow';
+import {
+  ChangedFilesSection,
+  type RepoFileGroup,
+  useExpandedKeys,
+} from './changedFilesSection';
 import type {OverviewCodeChangeFile} from './types';
 
 const DIFF_TYPE_TAG: Record<DiffFileType, FileChangeTag> = {
@@ -17,51 +16,30 @@ const DIFF_TYPE_TAG: Record<DiffFileType, FileChangeTag> = {
   [DiffFileType.DELETED]: {label: t('Deleted'), variant: 'danger'},
 };
 
-export function CodeChanges({codeChanges}: {codeChanges: OverviewCodeChangeFile[]}) {
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(() => new Set());
-
-  const toggle = (index: number, expanded: boolean) =>
-    setExpandedRows(prev => {
-      const next = new Set(prev);
-      if (expanded) {
-        next.add(index);
-      } else {
-        next.delete(index);
-      }
-      return next;
+function groupByRepo(codeChanges: OverviewCodeChangeFile[]): RepoFileGroup[] {
+  const groups = new Map<string | null, RepoFileGroup>();
+  for (const {repoName: rawRepoName, patch} of codeChanges) {
+    const repoName = rawRepoName || null;
+    const group = groups.get(repoName) ?? {repoName, files: []};
+    group.files.push({
+      additions: patch.added,
+      deletions: patch.removed,
+      path: patch.path,
+      changeTag: DIFF_TYPE_TAG[patch.type],
+      renderDiff: () => <FileDiffViewer hideHeader patch={patch} />,
     });
+    groups.set(repoName, group);
+  }
+  return [...groups.values()];
+}
 
+export function CodeChanges({codeChanges}: {codeChanges: OverviewCodeChangeFile[]}) {
+  const {expandedKeys, toggle} = useExpandedKeys();
   return (
-    <Stack gap="sm">
-      <Flex gap="xs" align="center">
-        <IconCode size="xs" variant="secondary" aria-hidden />
-        <Text size="xs" bold uppercase variant="secondary">
-          {t('Code changes')}
-        </Text>
-      </Flex>
-      <Text size="sm" variant="muted">
-        {codeChanges.length === 1
-          ? t('1 file changed')
-          : t('%s files changed', codeChanges.length.toLocaleString())}
-      </Text>
-      <Container border="primary" radius="md" overflow="hidden" background="secondary">
-        {codeChanges.map(({patch}, index) => {
-          const isExpanded = expandedRows.has(index);
-          return (
-            <ChangedFileRow
-              key={`${index}-${patch.path}`}
-              additions={patch.added}
-              deletions={patch.removed}
-              path={patch.path}
-              changeTag={DIFF_TYPE_TAG[patch.type]}
-              expanded={isExpanded}
-              onExpandedChange={next => toggle(index, next)}
-            >
-              {isExpanded ? <FileDiffViewer hideHeader patch={patch} /> : null}
-            </ChangedFileRow>
-          );
-        })}
-      </Container>
-    </Stack>
+    <ChangedFilesSection
+      groups={groupByRepo(codeChanges)}
+      expandedKeys={expandedKeys}
+      onToggle={toggle}
+    />
   );
 }

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -469,6 +469,7 @@ describe('AutofixOverview', () => {
       status: 'open',
       checksStatus: null,
       reviewStatus: null,
+      repoName: 'getsentry/sentry',
       files: [],
     };
 
@@ -512,11 +513,36 @@ describe('AutofixOverview', () => {
 
     enriched.resolve();
 
-    expect(await screen.findByText('2 files changed')).toBeInTheDocument();
+    expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
     expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
     expect(screen.getByText('src/sentry/bar.py')).toBeInTheDocument();
     expect(screen.getByText('+10')).toBeInTheDocument();
     expect(screen.getByText('-2')).toBeInTheDocument();
+  });
+
+  it('falls back to a file count when a pull request has no repo name', async () => {
+    const pullRequest: OverviewPullRequest = {
+      id: '99',
+      number: 99,
+      url: 'https://github.com/getsentry/sentry/pull/99',
+      status: 'open',
+      checksStatus: null,
+      reviewStatus: null,
+      repoName: null,
+      files: [
+        {path: 'src/sentry/foo.py', additions: 1, deletions: 1, changeType: 'MODIFIED'},
+        {path: 'src/sentry/bar.py', additions: 2, deletions: 0, changeType: 'ADDED'},
+      ],
+    };
+    mockOverview({
+      base: {has_pull_request: [{...rootCauseRun, pullRequests: [pullRequest]}]},
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('2 files changed')).toBeInTheDocument();
+    expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
+    expect(screen.queryByText('getsentry/sentry')).not.toBeInTheDocument();
   });
 
   it('renders the newest actionable pull request, not the oldest link', async () => {
@@ -712,7 +738,7 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    expect(await screen.findByText('4 files changed')).toBeInTheDocument();
+    expect(await screen.findByText('src/sentry/new.py')).toBeInTheDocument();
     expect(screen.getByText('Added')).toBeInTheDocument();
     expect(screen.getByText('Deleted')).toBeInTheDocument();
     expect(screen.getByText('Modified')).toBeInTheDocument();
@@ -911,7 +937,7 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    expect(await screen.findByText('1 file changed')).toBeInTheDocument();
+    expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
     // The generated diff comes back inline, so expanding needs no extra request.
     await userEvent.click(
       await screen.findByRole('button', {name: /src\/sentry\/foo\.py/})
@@ -925,7 +951,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     expect(await screen.findByText('TypeError in checkout cart')).toBeInTheDocument();
-    expect(screen.queryByText('1 file changed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Code changes')).not.toBeInTheDocument();
   });
 
   it('defaults to Recent Seer Activity and omits the sort param', async () => {

--- a/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
@@ -1,17 +1,16 @@
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
-import {IconCode} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PullRequestFileChangeType} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
-import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
+import type {FileChangeTag} from './changedFileRow';
+import {ChangedFilesSection, useExpandedKeys} from './changedFilesSection';
 import {parseFilePatch} from './filePatch';
 import {
   type OverviewPullRequest,
@@ -85,7 +84,7 @@ export function PullRequestFiles({
   pullRequest: OverviewPullRequest;
 }) {
   const files = pullRequest.files;
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(() => new Set());
+  const {expandedKeys, toggle} = useExpandedKeys();
 
   const {data, isPending, isError} = useQuery({
     ...apiOptions.as<PullRequestFilesResponse>()(
@@ -95,7 +94,7 @@ export function PullRequestFiles({
         staleTime: QUERY_STALE_TIME,
       }
     ),
-    enabled: expandedRows.size > 0,
+    enabled: expandedKeys.size > 0,
   });
 
   const diffByPath = useMemo(
@@ -103,56 +102,27 @@ export function PullRequestFiles({
     [data]
   );
 
-  const toggle = (index: number, expanded: boolean) =>
-    setExpandedRows(prev => {
-      const next = new Set(prev);
-      if (expanded) {
-        next.add(index);
-      } else {
-        next.delete(index);
-      }
-      return next;
-    });
+  const groups = [
+    {
+      repoName: pullRequest.repoName || null,
+      files: files.map(file => ({
+        additions: file.additions,
+        deletions: file.deletions,
+        path: file.path,
+        changeTag: file.changeType ? FILE_CHANGE_TAG[file.changeType] : null,
+        renderDiff: () => (
+          <FileDiff
+            file={file}
+            diff={diffByPath.get(file.path)}
+            isPending={isPending}
+            isError={isError}
+          />
+        ),
+      })),
+    },
+  ];
 
   return (
-    <Stack gap="sm">
-      <Flex gap="xs" align="center">
-        <IconCode size="xs" variant="secondary" aria-hidden />
-        <Text size="xs" bold uppercase variant="secondary">
-          {t('Code changes')}
-        </Text>
-      </Flex>
-      <Text size="sm" variant="muted">
-        {files.length === 1
-          ? t('1 file changed')
-          : t('%s files changed', files.length.toLocaleString())}
-      </Text>
-      <Container border="primary" radius="md" overflow="hidden" background="secondary">
-        {files.map((file, index) => {
-          const diff = diffByPath.get(file.path);
-          const isExpanded = expandedRows.has(index);
-          return (
-            <ChangedFileRow
-              key={`${index}-${file.path}`}
-              additions={file.additions}
-              deletions={file.deletions}
-              path={file.path}
-              changeTag={file.changeType ? FILE_CHANGE_TAG[file.changeType] : null}
-              expanded={isExpanded}
-              onExpandedChange={next => toggle(index, next)}
-            >
-              {isExpanded ? (
-                <FileDiff
-                  file={file}
-                  diff={diff}
-                  isPending={isPending}
-                  isError={isError}
-                />
-              ) : null}
-            </ChangedFileRow>
-          );
-        })}
-      </Container>
-    </Stack>
+    <ChangedFilesSection groups={groups} expandedKeys={expandedKeys} onToggle={toggle} />
   );
 }

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -149,6 +149,7 @@ export interface OverviewPullRequest {
   reviewStatus: PullRequestReviewStatus | null;
   status: PullRequestStatus | null;
   url: string | null;
+  repoName?: string | null;
 }
 
 export interface PullRequestFileDiff {


### PR DESCRIPTION
Groups the Autofix overview's changed-file lists under a per-repository header, for both the generated code changes and the pull request file list. Introduces a shared `ChangedFilesSection` (the two lists previously duplicated their header, count, and expand state) and renders the repo name from the pull request's new `repoName` field.

Stacked on #122165 (code changes UI). The pull-request `repoName` needs backend #122172; generated code changes already carry theirs. Part of AIML-3313; resolves the "repo name ignored in diffs" review comment on #122165.
