### PR TITLE
ref(seer): Remove ProjectRepository fallback for free cohort orgs

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -586,34 +586,6 @@ def build_repo_definition_from_project_repo(
     )
 
 
-def build_repo_definition_from_project_repo_fallback(
-    project_repo: ProjectRepository,
-) -> SeerRepoDefinition | None:
-    """Build a SeerRepoDefinition from a ProjectRepository → Repository, without
-    Seer-specific fields. Used as a fallback for free cohort orgs that have no
-    SeerProjectRepository rows.
-
-    Returns None if Repository name is invalid."""
-    repo = project_repo.repository
-    repo_name_sections = get_repo_url_path(repo).split("/")
-    if len(repo_name_sections) < 2:
-        sentry_sdk.capture_exception(ValueError(f"Invalid repository name format: {repo.name}"))
-        return None
-
-    return SeerRepoDefinition(
-        repository_id=repo.id,
-        organization_id=repo.organization_id,
-        integration_id=str(repo.integration_id) if repo.integration_id is not None else None,
-        provider=repo.provider or "",
-        owner=repo_name_sections[0],
-        name="/".join(repo_name_sections[1:]),
-        external_id=repo.external_id or "",
-        branch_name=None,
-        instructions=None,
-        branch_overrides=[],
-    )
-
-
 def get_automation_handoff(
     get_option: Callable[[str], Any],
 ) -> SeerAutomationHandoffConfiguration | None:
@@ -635,32 +607,19 @@ def get_automation_handoff(
 
 def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference:
     """Read a single project's Seer preferences from Sentry DB."""
-    if is_free_cohort_org(project.organization):
-        # Free cohort orgs have no SeerProjectRepository rows — use
-        # ProjectRepository → Repository directly.
-        project_repo_qs = ProjectRepository.objects.filter(
-            project=project,
-            repository__status=ObjectStatus.ACTIVE,
-        ).select_related("repository")
-        repo_definitions = [
-            repo_def
-            for pr in project_repo_qs
-            if (repo_def := build_repo_definition_from_project_repo_fallback(pr)) is not None
-        ]
-    else:
-        seer_project_repo_qs = (
-            SeerProjectRepository.objects.filter(
-                project_repository__project=project,
-                project_repository__repository__status=ObjectStatus.ACTIVE,
-            )
-            .select_related("project_repository", "project_repository__repository")
-            .prefetch_related("branch_overrides")
+    seer_project_repo_qs = (
+        SeerProjectRepository.objects.filter(
+            project_repository__project=project,
+            project_repository__repository__status=ObjectStatus.ACTIVE,
         )
-        repo_definitions = [
-            repo_def
-            for project_repo in seer_project_repo_qs
-            if (repo_def := build_repo_definition_from_project_repo(project_repo)) is not None
-        ]
+        .select_related("project_repository", "project_repository__repository")
+        .prefetch_related("branch_overrides")
+    )
+    repo_definitions = [
+        repo_def
+        for project_repo in seer_project_repo_qs
+        if (repo_def := build_repo_definition_from_project_repo(project_repo)) is not None
+    ]
 
     return SeerProjectPreference(
         organization_id=project.organization_id,
@@ -682,33 +641,18 @@ def bulk_read_preferences_from_sentry_db(
     projects = list(Project.objects.filter(id__in=project_ids, organization_id=organization_id))
 
     repo_definitions_by_project: defaultdict[int, list[SeerRepoDefinition]] = defaultdict(list)
-    org = Organization.objects.filter(id=organization_id).first()
-    if org is not None and is_free_cohort_org(org):
-        # Free cohort orgs have no SeerProjectRepository rows — use
-        # ProjectRepository → Repository directly.
-        fallback_qs = ProjectRepository.objects.filter(
-            project_id__in=project_ids,
-            repository__status=ObjectStatus.ACTIVE,
-        ).select_related("repository")
-        for pr in fallback_qs:
-            repo_def = build_repo_definition_from_project_repo_fallback(pr)
-            if repo_def is not None:
-                repo_definitions_by_project[pr.project_id].append(repo_def)
-    else:
-        seer_repo_qs = (
-            SeerProjectRepository.objects.filter(
-                project_repository__project_id__in=project_ids,
-                project_repository__repository__status=ObjectStatus.ACTIVE,
-            )
-            .select_related("project_repository", "project_repository__repository")
-            .prefetch_related("branch_overrides")
+    seer_repo_qs = (
+        SeerProjectRepository.objects.filter(
+            project_repository__project_id__in=project_ids,
+            project_repository__repository__status=ObjectStatus.ACTIVE,
         )
-        for seer_repo in seer_repo_qs:
-            repo_def = build_repo_definition_from_project_repo(seer_repo)
-            if repo_def is not None:
-                repo_definitions_by_project[seer_repo.project_repository.project_id].append(
-                    repo_def
-                )
+        .select_related("project_repository", "project_repository__repository")
+        .prefetch_related("branch_overrides")
+    )
+    for seer_repo in seer_repo_qs:
+        repo_def = build_repo_definition_from_project_repo(seer_repo)
+        if repo_def is not None:
+            repo_definitions_by_project[seer_repo.project_repository.project_id].append(repo_def)
 
     # get_value_bulk_id returns None for missing options, unlike project.get_option
     # which automatically falls back to the registered well-known key default.
@@ -927,30 +871,13 @@ def replace_all_seer_project_repos(
 
 
 def has_project_connected_repos(organization: Organization, project: Project) -> bool:
-    """Check if a project has connected repositories for Seer automation.
-
-    For free cohort orgs (no SeerProjectRepository rows), falls back to
-    checking ProjectRepository directly.
-    """
-    has_seer_repos = SeerProjectRepository.objects.filter(
+    """Check if a project has connected repositories for Seer automation."""
+    return SeerProjectRepository.objects.filter(
         project_repository__project=project,
         project_repository__project__organization_id=organization.id,
         project_repository__project__status=ObjectStatus.ACTIVE,
         project_repository__repository__status=ObjectStatus.ACTIVE,
     ).exists()
-    if has_seer_repos:
-        return True
-
-    # Free cohort orgs have ProjectRepository rows but no SeerProjectRepository rows.
-    if is_free_cohort_org(organization):
-        return ProjectRepository.objects.filter(
-            project=project,
-            project__organization_id=organization.id,
-            project__status=ObjectStatus.ACTIVE,
-            repository__status=ObjectStatus.ACTIVE,
-        ).exists()
-
-    return False
 
 
 def get_autofix_repos_from_project_code_mappings(

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -98,7 +98,6 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
 
         # Free cohort orgs have no subscription — quota check always fails. Return hasAutofixQuota
         # True only when a run exists (so they see results), False otherwise (shows paywall).
-        # Also set seerReposLinked=True since night shift resolves repos at runtime.
         is_free_cohort = is_free_cohort_org(org)
         if is_free_cohort:
             # Night shift can go through either the regular autofix path (source="autofix") or
@@ -113,9 +112,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
             )
 
         seer_repos_linked = False
-        if is_free_cohort:
-            seer_repos_linked = True
-        elif integration_check is None:
+        if integration_check is None:
             try:
                 seer_repos_linked = has_project_connected_repos(org, group.project)
             except Exception as e:

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -22,7 +22,6 @@ from sentry.seer.autofix.utils import (
     AutomationCodingAgent,
     CodingAgentProviderType,
     add_seer_project_repos,
-    build_repo_definition_from_project_repo_fallback,
     bulk_read_preferences_from_sentry_db,
     bulk_write_preferences_to_sentry_db,
     clear_preference_automation_handoff,
@@ -74,55 +73,6 @@ class TestGetRepoUrlPath(TestCase):
         # real GitLab repo — fail loudly instead of returning the display name.
         with pytest.raises(ValueError):
             get_repo_url_path(repo)
-
-
-class TestBuildRepoDefinitionFromProjectRepoFallback(TestCase):
-    """Test the fallback builder that creates SeerRepoDefinition from ProjectRepository."""
-
-    def setUp(self):
-        super().setUp()
-        self.organization = self.create_organization()
-        self.project = self.create_project(organization=self.organization)
-        self.integration = self.create_integration(
-            organization=self.organization, provider="github", external_id="gh_123"
-        )
-        self.repo = self.create_repo(
-            project=self.project,
-            provider="integrations:github",
-            external_id="ext123",
-            name="test-org/test-repo",
-            integration_id=self.integration.id,
-        )
-
-    def test_builds_definition_with_null_seer_fields(self):
-        pr = ProjectRepository.objects.create(project=self.project, repository=self.repo)
-
-        result = build_repo_definition_from_project_repo_fallback(pr)
-
-        assert result is not None
-        assert result.repository_id == self.repo.id
-        assert result.organization_id == self.repo.organization_id
-        assert result.integration_id == str(self.integration.id)
-        assert result.provider == "integrations:github"
-        assert result.owner == "test-org"
-        assert result.name == "test-repo"
-        assert result.external_id == "ext123"
-        assert result.branch_name is None
-        assert result.instructions is None
-        assert result.branch_overrides == []
-
-    def test_returns_none_for_invalid_repo_name(self):
-        bad_repo = self.create_repo(
-            project=self.project,
-            provider="integrations:github",
-            external_id="ext_bad",
-            name="no-slash-repo",
-        )
-        pr = ProjectRepository.objects.create(project=self.project, repository=bad_repo)
-
-        result = build_repo_definition_from_project_repo_fallback(pr)
-
-        assert result is None
 
 
 class TestAutofixStateParsing(TestCase):
@@ -1191,44 +1141,6 @@ class TestReadPreferenceFromSentryDb(TestCase):
         assert len(result.repositories) == 1
         assert result.repositories[0].name == "test-repo"
 
-    @patch("sentry.seer.autofix.utils.is_free_cohort_org", return_value=True)
-    def test_free_cohort_org_uses_project_repository_fallback(self, _mock_free_cohort):
-        """Free cohort org with ProjectRepository rows (but no SeerProjectRepository)
-        gets repo definitions via the fallback path."""
-        ProjectRepository.objects.create(project=self.project, repository=self.repo)
-        ProjectRepository.objects.create(project=self.project, repository=self.repo2)
-
-        result = read_preference_from_sentry_db(self.project)
-        assert len(result.repositories) == 2
-        repo_by_name = {r.name: r for r in result.repositories}
-        assert "test-repo" in repo_by_name
-        assert "other-repo" in repo_by_name
-        # Fallback sets Seer-specific fields to None/empty
-        assert repo_by_name["test-repo"].branch_name is None
-        assert repo_by_name["test-repo"].instructions is None
-        assert repo_by_name["test-repo"].branch_overrides == []
-
-    @patch("sentry.seer.autofix.utils.is_free_cohort_org", return_value=True)
-    def test_free_cohort_org_excludes_inactive_repos(self, _mock_free_cohort):
-        """Free cohort fallback path also excludes inactive repos."""
-        ProjectRepository.objects.create(project=self.project, repository=self.repo)
-        self.repo2.status = ObjectStatus.DISABLED
-        self.repo2.save()
-        ProjectRepository.objects.create(project=self.project, repository=self.repo2)
-
-        result = read_preference_from_sentry_db(self.project)
-        assert len(result.repositories) == 1
-        assert result.repositories[0].name == "test-repo"
-
-    @patch("sentry.seer.autofix.utils.is_free_cohort_org", return_value=False)
-    def test_paying_org_without_seer_project_repo_gets_empty_repos(self, _mock_free_cohort):
-        """Paying org (not free cohort) with only ProjectRepository rows (no
-        SeerProjectRepository) gets empty repos — the fallback does NOT apply."""
-        ProjectRepository.objects.create(project=self.project, repository=self.repo)
-
-        result = read_preference_from_sentry_db(self.project)
-        assert result.repositories == []
-
 
 class TestBulkReadPreferencesFromSentryDb(TestCase):
     def setUp(self):
@@ -1367,34 +1279,6 @@ class TestBulkReadPreferencesFromSentryDb(TestCase):
         assert len(result[self.project1.id].repositories) == 1
         assert result[self.project1.id].repositories[0].name == "test-repo"
         assert len(result[self.project2.id].repositories) == 0
-
-    @patch("sentry.seer.autofix.utils.is_free_cohort_org", return_value=True)
-    def test_free_cohort_org_uses_project_repository_fallback(self, _mock_free_cohort):
-        """Free cohort org bulk read uses ProjectRepository fallback."""
-        ProjectRepository.objects.create(project=self.project1, repository=self.repo)
-        repo_p2 = self.create_repo(
-            project=self.project2,
-            provider="integrations:github",
-            external_id="ext_p2",
-            name="test-org/p2-repo",
-        )
-        ProjectRepository.objects.create(project=self.project2, repository=repo_p2)
-
-        result = bulk_read_preferences_from_sentry_db(
-            self.organization.id, [self.project1.id, self.project2.id]
-        )
-        assert len(result[self.project1.id].repositories) == 1
-        assert result[self.project1.id].repositories[0].name == "test-repo"
-        assert len(result[self.project2.id].repositories) == 1
-        assert result[self.project2.id].repositories[0].name == "p2-repo"
-
-    @patch("sentry.seer.autofix.utils.is_free_cohort_org", return_value=False)
-    def test_paying_org_without_seer_project_repo_gets_empty_repos(self, _mock_free_cohort):
-        """Paying org bulk read with only ProjectRepository rows gets empty repos."""
-        ProjectRepository.objects.create(project=self.project1, repository=self.repo)
-
-        result = bulk_read_preferences_from_sentry_db(self.organization.id, [self.project1.id])
-        assert result[self.project1.id].repositories == []
 
 
 class TestGetOrgDefaultSeerAutomationHandoff(TestCase):

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -326,19 +326,3 @@ class GroupAIAutofixSetupFreeCohortTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200
         assert response.data["billing"]["hasAutofixQuota"] is False
-
-    @patch(
-        "sentry.seer.endpoints.group_autofix_setup_check.is_free_cohort_org",
-        return_value=True,
-    )
-    def test_free_cohort_org_has_seer_repos_linked(self, mock_is_free_cohort: MagicMock) -> None:
-        """Free cohort orgs always get seerReposLinked: True — night shift
-        handles repo resolution at runtime via the ProjectRepository fallback,
-        so the setup prompt is not relevant."""
-        group = self.create_group()
-        self.login_as(user=self.user)
-        url = f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/autofix/setup/"
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200
-        assert response.data["seerReposLinked"] is True


### PR DESCRIPTION
## Summary
- Post merging deploying and running the script for this [PR](https://github.com/getsentry/getsentry/pull/21596 ) free cohort orgs now have `SeerProjectRepository` rows created by the stamping script (getsentry PR), so the runtime fallback to `ProjectRepository` is no longer needed
- Removes `build_repo_definition_from_project_repo_fallback()` and the `is_free_cohort_org` branches in `read_preference_from_sentry_db`, `bulk_read_preferences_from_sentry_db`, `has_project_connected_repos`
- Removes `seerReposLinked = True` bypass in `group_autofix_setup_check.py` — normal `has_project_connected_repos()` works since `SeerProjectRepository` rows exist
