### PR TITLE
feat(seer): Hide closed pull requests on Autofix overview

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import cast
 
+from django.db.models import Exists, OuterRef
 from pydantic import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -33,7 +34,7 @@ from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.repository import Repository
 from sentry.plugins.base import bindings
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
@@ -72,6 +73,8 @@ _PIPELINE: tuple[str, ...] = (
 
 _MAX_RUNS_PER_MILESTONE = 100
 
+_HIDDEN_PULL_REQUEST_STATES = (PullRequestLifecycleState.CLOSED,)
+
 # The three issue-based sort params, mapped to their search-backend names.
 # Any other value (seer default, empty, unknown) keeps the default order.
 _ISSUE_SORT_TO_SEARCH = {"issue": "date", "events": "freq", "users": "user"}
@@ -81,7 +84,13 @@ _ISSUE_SORT_TO_SEARCH = {"issue": "date", "events": "freq", "users": "user"}
 class _RunMilestones:
     seer_run: SeerRun
     group_id: int
+    has_pull_request_link: bool = False
+    has_unclosed_pull_request: bool = False
     extras_by_milestone: dict[str, SeerRunMilestoneExtras] = field(default_factory=dict)
+
+    @property
+    def has_only_closed_pull_requests(self) -> bool:
+        return self.has_pull_request_link and not self.has_unclosed_pull_request
 
     @property
     def furthest_milestone(self) -> str:
@@ -140,6 +149,7 @@ def _pull_requests_by_seer_run_id(
     by_run: dict[int, list[PullRequestPayload]] = defaultdict(list)
     links = list(
         SeerRunPullRequest.objects.filter(seer_run_id__in=seer_run_ids)
+        .exclude(pull_request__state__in=_HIDDEN_PULL_REQUEST_STATES)
         .select_related("pull_request")
         .order_by("date_added")
     )
@@ -316,7 +326,13 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             milestone: [] for milestone in _PIPELINE
         }
         for group_id, run in latest_run_per_group.items():
-            capped_runs_by_milestone[run.furthest_milestone].append((group_id, run))
+            milestone = run.furthest_milestone
+            if (
+                milestone == SeerRunMilestoneType.HAS_PULL_REQUEST
+                and run.has_only_closed_pull_requests
+            ):
+                continue
+            capped_runs_by_milestone[milestone].append((group_id, run))
         truncated_milestones = [
             milestone
             for milestone, pairs in capped_runs_by_milestone.items()
@@ -385,6 +401,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         start: datetime,
         end: datetime,
     ) -> dict[int, _RunMilestones]:
+        pr_links = SeerRunPullRequest.objects.filter(seer_run_id=OuterRef("seer_run_id"))
         milestone_rows = (
             SeerRunMilestone.objects.filter(
                 seer_run__organization=organization,
@@ -394,6 +411,12 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                 seer_run__last_triggered_at__range=(start, end),
             )
             .select_related("seer_run", "seer_run__agent")
+            .annotate(
+                has_pull_request_link=Exists(pr_links),
+                has_unclosed_pull_request=Exists(
+                    pr_links.exclude(pull_request__state__in=_HIDDEN_PULL_REQUEST_STATES)
+                ),
+            )
             .order_by("-seer_run__last_triggered_at")
         )
 
@@ -403,6 +426,8 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                 runs_by_id[row.seer_run_id] = _RunMilestones(
                     seer_run=row.seer_run,
                     group_id=row.seer_run.agent.group_id,
+                    has_pull_request_link=row.has_pull_request_link,
+                    has_unclosed_pull_request=row.has_unclosed_pull_request,
                 )
             runs_by_id[row.seer_run_id].extras_by_milestone[row.milestone] = row.extras
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import cast
 
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 from pydantic import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -74,6 +74,11 @@ _PIPELINE: tuple[str, ...] = (
 _MAX_RUNS_PER_MILESTONE = 100
 
 _HIDDEN_PULL_REQUEST_STATES = (PullRequestLifecycleState.CLOSED,)
+
+# `.exclude(state__in=...)` drops NULL states via SQL three-valued logic; NULL means unenriched (open), so keep it.
+_VISIBLE_PULL_REQUEST_FILTER = Q(pull_request__state__isnull=True) | ~Q(
+    pull_request__state__in=_HIDDEN_PULL_REQUEST_STATES
+)
 
 # The three issue-based sort params, mapped to their search-backend names.
 # Any other value (seer default, empty, unknown) keeps the default order.
@@ -149,7 +154,7 @@ def _pull_requests_by_seer_run_id(
     by_run: dict[int, list[PullRequestPayload]] = defaultdict(list)
     links = list(
         SeerRunPullRequest.objects.filter(seer_run_id__in=seer_run_ids)
-        .exclude(pull_request__state__in=_HIDDEN_PULL_REQUEST_STATES)
+        .filter(_VISIBLE_PULL_REQUEST_FILTER)
         .select_related("pull_request")
         .order_by("date_added")
     )
@@ -413,9 +418,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             .select_related("seer_run", "seer_run__agent")
             .annotate(
                 has_pull_request_link=Exists(pr_links),
-                has_unclosed_pull_request=Exists(
-                    pr_links.exclude(pull_request__state__in=_HIDDEN_PULL_REQUEST_STATES)
-                ),
+                has_unclosed_pull_request=Exists(pr_links.filter(_VISIBLE_PULL_REQUEST_FILTER)),
             )
             .order_by("-seer_run__last_triggered_at")
         )

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -687,12 +687,28 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
         assert run_data["pullRequests"] == []
 
+    def test_unenriched_pull_request_is_kept_in_the_list(self):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        pull_request = self._pull_request_for_run(group, run, state=None)
+        resp = self.get_success_response(self.organization.slug)
+        run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
+        assert [pr["id"] for pr in run_data["pullRequests"]] == [str(pull_request.id)]
+
     def test_run_with_only_closed_pull_request_is_hidden(self):
         group = self.create_group()
         run = self._run_with_pull_request_milestone(group)
         self._pull_request_for_run(group, run, state=PullRequestLifecycleState.CLOSED)
         resp = self.get_success_response(self.organization.slug)
         assert resp.data["runsByMilestone"][SeerRunMilestoneType.HAS_PULL_REQUEST] == []
+
+    def test_run_with_only_unenriched_pull_request_is_shown(self):
+        group = self.create_group()
+        run = self._run_with_pull_request_milestone(group)
+        self._pull_request_for_run(group, run, state=None)
+        resp = self.get_success_response(self.organization.slug)
+        runs = resp.data["runsByMilestone"][SeerRunMilestoneType.HAS_PULL_REQUEST]
+        assert len(runs) == 1
 
     def test_run_with_open_and_closed_pull_requests_shows_only_open(self):
         group = self.create_group()

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -420,13 +420,15 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
             self.get_success_response(self.organization.slug, qs_params={"expand": "issueStats"})
         assert "stats" not in serializer.call_args.kwargs["collapse"]
 
-    def _pull_request_for_run(self, group, run, *, key="123", **updates):
+    def _pull_request_for_run(
+        self, group, run, *, key="123", name="getsentry/sentry", integration_id=123, **updates
+    ):
         repo = self.create_repo(
             project=group.project,
-            name="getsentry/sentry",
+            name=name,
             provider="integrations:github",
-            integration_id=123,
-            url="https://github.com/getsentry/sentry",
+            integration_id=integration_id,
+            url=f"https://github.com/{name}",
         )
         pull_request = self.create_pull_request(
             repository_id=repo.id, organization_id=self.organization.id, key=key
@@ -434,6 +436,14 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         pull_request.update(**updates)
         self.create_seer_run_pull_request(run=run, pull_request=pull_request)
         return pull_request
+
+    def _run_with_pull_request_milestone(self, group):
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", group=group, project=group.project)
+        state = self._code_changes_state("rc text")
+        state.blocks[0].pr_commit_shas = {"getsentry/sentry": "abc123"}
+        reconcile_milestones(run, state)
+        return run
 
     def _set_provider_client(self, mock_get_integration, client):
         installation = mock.Mock()
@@ -668,6 +678,69 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         resp = self.get_success_response(self.organization.slug)
         run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
         assert run_data["pullRequests"] == []
+
+    def test_closed_pull_request_is_excluded_from_the_list(self):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.CLOSED)
+        resp = self.get_success_response(self.organization.slug)
+        run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
+        assert run_data["pullRequests"] == []
+
+    def test_run_with_only_closed_pull_request_is_hidden(self):
+        group = self.create_group()
+        run = self._run_with_pull_request_milestone(group)
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.CLOSED)
+        resp = self.get_success_response(self.organization.slug)
+        assert resp.data["runsByMilestone"][SeerRunMilestoneType.HAS_PULL_REQUEST] == []
+
+    def test_run_with_open_and_closed_pull_requests_shows_only_open(self):
+        group = self.create_group()
+        run = self._run_with_pull_request_milestone(group)
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.CLOSED)
+        open_pr = self._pull_request_for_run(
+            group,
+            run,
+            key="456",
+            name="getsentry/other",
+            integration_id=456,
+            state=PullRequestLifecycleState.OPEN,
+            draft=False,
+        )
+        resp = self.get_success_response(self.organization.slug)
+        runs = resp.data["runsByMilestone"][SeerRunMilestoneType.HAS_PULL_REQUEST]
+        assert len(runs) == 1
+        assert [pr["id"] for pr in runs[0]["pullRequests"]] == [str(open_pr.id)]
+
+    @mock.patch(
+        "sentry.seer.endpoints.organization_seer_autofix_overview._MAX_RUNS_PER_MILESTONE", 1
+    )
+    def test_closed_pull_request_run_is_dropped_before_the_cap(self):
+        open_group = self.create_group()
+        open_run = self._run_with_pull_request_milestone(open_group)
+        open_run.update(last_triggered_at=before_now(minutes=5))
+        open_pr = self._pull_request_for_run(
+            open_group, open_run, state=PullRequestLifecycleState.OPEN, draft=False
+        )
+
+        closed_group = self.create_group()
+        closed_run = self._run_with_pull_request_milestone(closed_group)
+        closed_run.update(last_triggered_at=before_now(minutes=1))
+        self._pull_request_for_run(
+            closed_group,
+            closed_run,
+            key="456",
+            name="getsentry/other",
+            integration_id=456,
+            state=PullRequestLifecycleState.CLOSED,
+        )
+
+        resp = self.get_success_response(self.organization.slug)
+        runs = resp.data["runsByMilestone"][SeerRunMilestoneType.HAS_PULL_REQUEST]
+        # Cap is 1 and the closed-PR run is newest; dropping it before the cap
+        # keeps the older open-PR run instead of yielding an empty section.
+        assert len(runs) == 1
+        assert [pr["id"] for pr in runs[0]["pullRequests"]] == [str(open_pr.id)]
 
     def test_runs_outside_stats_period_are_excluded(self):
         recent = self.create_group()


### PR DESCRIPTION
## Summary

On the Autofix overview page, an issue lands in the **Review PRs** section by having *ever* opened a PR (the `has_pull_request` milestone is a historical aggregate), not by whether a live PR still exists. So when a run's PR was later closed, the card kept showing — often linking to a dead, already-closed PR.

This filters closed PRs out of the overview at the Postgres level:

- **Hide the closed PR** — `_pull_requests_by_seer_run_id` now excludes PRs whose stored state is `closed`, so a surviving run (e.g. one closed + one open PR) shows only the open one.
- **Hide the whole run** — a `has_pull_request` run whose PRs are *all* closed has nothing left to review, so it's dropped from the response entirely. The live-PR check rides on the existing milestone query as an `Exists` annotation (no extra query) and runs **before** the per-milestone cap, so the section still fills to its limit from runs that actually have an open PR — no under-fill.

Both filter sites share a single `_HIDDEN_PULL_REQUEST_STATES` constant so they can't drift.

## Why closed-only

`closed` is the only reliably-populated "nothing to review" state. `merged` runs graduate to the merged section; `locked` is still an open PR; and `superseded` is a defined-but-never-written enum value, so filtering it would be dead code. NULL-state (unenriched) PRs are treated as open and kept, matching Sentry's existing `is_open_pull_request_state` convention.

## Scope

- A run whose milestone fired but has **no** linked PR row is **kept** (unchanged behavior — that's a separate missing-PR case).
- All-closed runs are removed from the overview entirely rather than demoted to an earlier section.

## Tests

- Closed PR excluded from a surviving run's list
- Run with only a closed PR is hidden entirely
- Run with one closed + one open PR shows only the open one
- Closed-PR run is dropped **before** the cap (proves no under-fill)