### PR TITLE
feat(cursor-origin): add Cursor Origin as an SCM provider

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2305,6 +2305,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     "sentry.integrations.gcp.integration.GcpIntegrationProvider",
     "sentry.integrations.github_copilot.integration.GithubCopilotIntegrationProvider",
     "sentry.integrations.perforce.integration.PerforceIntegrationProvider",
+    "sentry.integrations.cursor_origin.integration.CursorOriginIntegrationProvider",
 )
 
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -138,6 +138,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-vercel-upsert-env-var", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-datadog", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-cursor-origin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:seer-cursor-origin-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:slack-reinstall-nudge-on-issue-alert", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GitHub Enterprise to accept github.com as a valid Installation URL
     manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -137,6 +137,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-vercel-upsert-env-var", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-datadog", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-cursor-origin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:slack-reinstall-nudge-on-issue-alert", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GitHub Enterprise to accept github.com as a valid Installation URL
     manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -395,3 +395,7 @@ class WebhookProviderIdentifier(IntEnum):
     DISCORD = 12
     VERCEL = 13
     GOOGLE = 14
+    # 15 is left to the in-flight Gitea integration, which claimed it first.
+    # These values are persisted on WebhookPayload rows, so two providers
+    # sharing one would misroute replays after both land.
+    CURSOR_ORIGIN = 16

--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -36,6 +36,7 @@ AVAILABLE_PROVIDERS = {
     ExternalProviders.MSTEAMS,
     ExternalProviders.JIRA_SERVER,
     ExternalProviders.PERFORCE,
+    ExternalProviders.CURSOR_ORIGIN,
     ExternalProviders.CUSTOM,
 }
 

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
@@ -8,13 +8,26 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.integrations.api.bases.organization_repository import OrganizationRepositoryEndpoint
-from sentry.integrations.github.client import GitHubApiClient
-from sentry.integrations.github.multi_platform_detection import detect_platforms_multi
+from sentry.integrations.github.multi_platform_detection import (
+    PlatformDetectionClient,
+    detect_platforms_multi,
+)
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiConflictError, ApiError
+
+# Providers whose client can serve platform detection: it needs a GitHub-shaped
+# recursive git tree and Linguist-style language byte counts. Cursor Origin has
+# neither natively -- its client adapts both -- which is why membership here is a
+# property of the client, not of the provider being "GitHub-like".
+SUPPORTED_PROVIDERS = frozenset(
+    {
+        IntegrationProviderSlug.GITHUB.value,
+        IntegrationProviderSlug.CURSOR_ORIGIN.value,
+    }
+)
 
 
 def _capture_detection_exception(type: str, repo_id: int, repo_name: str) -> None:
@@ -33,29 +46,28 @@ class OrganizationRepositoryPlatformsEndpoint(OrganizationRepositoryEndpoint):
     }
 
     def get(self, request: Request, organization: Organization, repo: Repository) -> Response:
-        if (
-            not repo.integration_id
-            or repo.provider != f"integrations:{IntegrationProviderSlug.GITHUB}"
-        ):
+        provider = (repo.provider or "").removeprefix("integrations:")
+        if not repo.integration_id or provider not in SUPPORTED_PROVIDERS:
             return Response(
-                {"detail": "Platform detection is only supported for GitHub repositories."},
+                {"detail": "Platform detection is not supported for this repository."},
                 status=400,
             )
 
         integration = integration_service.get_integration(integration_id=repo.integration_id)
         if integration is None:
-            return Response({"detail": "GitHub integration not found."}, status=400)
+            return Response({"detail": "Integration not found."}, status=400)
 
         org_integration = integration_service.get_organization_integration(
             integration_id=repo.integration_id, organization_id=organization.id
         )
         if org_integration is None:
             return Response(
-                {"detail": "GitHub integration is not configured for this organization."},
-                status=400,
+                {"detail": "Integration is not configured for this organization."}, status=400
             )
 
-        client = GitHubApiClient(integration=integration, org_integration_id=org_integration.id)
+        installation = integration.get_installation(organization_id=organization.id)
+        client = installation.get_client()
+        assert isinstance(client, PlatformDetectionClient)
 
         try:
             platforms = detect_platforms_multi(client, repo.name)["platforms"]
@@ -65,6 +77,6 @@ class OrganizationRepositoryPlatformsEndpoint(OrganizationRepositoryEndpoint):
             return Response({"platforms": []})
         except (ApiError, ValueError):
             _capture_detection_exception("failed", repo.id, repo.name)
-            return Response({"detail": "Failed to detect platforms from GitHub."}, status=502)
+            return Response({"detail": "Failed to detect platforms."}, status=502)
 
         return Response({"platforms": platforms})

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -161,6 +161,7 @@ INTEGRATION_TYPE_TO_PROVIDER = {
         IntegrationProviderSlug.BITBUCKET_SERVER,
         IntegrationProviderSlug.AZURE_DEVOPS,
         IntegrationProviderSlug.PERFORCE,
+        IntegrationProviderSlug.CURSOR_ORIGIN,
     ],
     IntegrationDomain.ON_CALL_SCHEDULING: [
         IntegrationProviderSlug.PAGERDUTY,

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from requests import PreparedRequest
+
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_API_BASE_URL,
+    TOKEN_MINIMUM_VALIDITY_SECONDS,
+)
+from sentry.integrations.cursor_origin.languages import languages_from_tree
+from sentry.integrations.cursor_origin.utils import get_jwt
+from sentry.shared_integrations.client.proxy import IntegrationProxyClient
+from sentry.shared_integrations.exceptions import ApiError
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+# Matches GitHub's `/repos/{owner}/{repo}/contents/{path}` so it can be rewritten to
+# Origin's `/repos/{owner}/{repo}/contents?path=…`.
+_GITHUB_CONTENTS_PATH = re.compile(
+    r"^/repos/(?P<repo>[^/]+/[^/]+)/contents/(?P<path>.+)$",
+)
+
+# Origin names each collection after the resource rather than using a generic
+# "items" key, so callers say which key they expect.
+PAGE_SIZE = 100
+
+
+class CursorOriginApiMixin:
+    """Read methods shared by the setup client and the installed-integration client.
+
+    Everything here is written against the *verified* Origin API, which differs from
+    the published docs in one important way: file contents live at
+    ``/contents?path=…``, not ``/contents/{path}``. The documented path form returns a
+    404 with a route-not-found body, which reads like an auth failure but is not.
+    """
+
+    # Concrete subclasses supply `post` via the shared API client base. Declared here
+    # only so mypy can see it -- do NOT give it a body, or the MRO will shadow the
+    # real implementation.
+    if TYPE_CHECKING:
+
+        def post(self, path: str, *args: Any, **kwargs: Any) -> Any: ...
+
+    def get(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        """Read, translating GitHub-shaped contents paths to Origin's form.
+
+        Origin serves file contents from ``/contents?path=…`` while GitHub uses
+        ``/contents/{path}``. Rewriting here rather than at every call site lets
+        Sentry's existing GitHub-oriented helpers -- platform detection, CODEOWNERS
+        lookups, stacktrace linking -- run against Origin unmodified.
+
+        The failure this prevents is a confusing one: the documented path form
+        returns 404 with a route-not-found body, which reads like a permissions
+        problem rather than a wrong URL.
+        """
+        match = _GITHUB_CONTENTS_PATH.match(path)
+        if match:
+            repo, file_path = match.group("repo"), match.group("path")
+            params = dict(kwargs.pop("params", None) or {})
+            params["path"] = file_path
+            kwargs["params"] = params
+            path = f"/repos/{repo}/contents"
+
+        return super().get(path, *args, **kwargs)  # type: ignore[misc]
+
+    # -- repositories --------------------------------------------------------
+
+    def get_repositories(self) -> list[dict[str, Any]]:
+        """Repositories this installation can see.
+
+        Note: excludes repositories mirrored inbound from GitHub -- installations
+        cannot access those.
+        """
+        return self._paginate("/installation/repos", "repositories")
+
+    def get_repo(self, repo_full_name: str) -> dict[str, Any]:
+        return self.get(f"/repos/{repo_full_name}")
+
+    # -- git data ------------------------------------------------------------
+
+    def get_tree(self, repo_full_name: str, tree_sha: str) -> list[dict[str, Any]]:
+        """Full recursive tree.
+
+        Shape is identical to GitHub's ``git/trees``: entries carry
+        ``path``/``mode``/``type``/``sha``, and blobs additionally carry ``size``.
+        Origin exposes no ``truncated`` flag, so unlike GitHub we cannot tell whether
+        a very large tree was capped.
+        """
+        response = self.get(
+            f"/repos/{repo_full_name}/git/trees/{tree_sha}", params={"recursive": "1"}
+        )
+        if not isinstance(response, dict):
+            return []
+        return response.get("tree", []) or []
+
+    def get_blob(self, repo_full_name: str, sha: str) -> dict[str, Any]:
+        return self.get(f"/repos/{repo_full_name}/git/blobs/{sha}")
+
+    def get_languages(self, repo_full_name: str, ref: str | None = None) -> dict[str, int]:
+        """Byte counts per language, shaped like GitHub's languages API.
+
+        Origin has no languages endpoint, so this is derived from the tree. Keeping
+        the GitHub shape means the whole existing platform registry works unchanged.
+        """
+        return languages_from_tree(self.get_tree(repo_full_name, ref or "HEAD"))
+
+    # -- contents ------------------------------------------------------------
+
+    def get_contents(
+        self, repo_full_name: str, path: str, ref: str | None = None
+    ) -> dict[str, Any]:
+        """Read a file or directory.
+
+        A file returns ``{"type": "file", "encoding": "base64", "content": …}``;
+        a directory returns ``{"type": "dir", "entries": [...]}``. Missing paths 404.
+        """
+        params: dict[str, Any] = {"path": path}
+        if ref:
+            params["ref"] = ref
+        return self.get(f"/repos/{repo_full_name}/contents", params=params)
+
+    # -- branches ------------------------------------------------------------
+
+    def get_branches(self, repo_full_name: str) -> list[dict[str, Any]]:
+        return self._paginate(f"/repos/{repo_full_name}/branches", "branches")
+
+    # -- pagination ----------------------------------------------------------
+
+    def _paginate(self, path: str, collection_key: str) -> list[dict[str, Any]]:
+        """Follow Origin's cursor pagination.
+
+        Origin uses opaque ``pageToken``/``nextPageToken`` cursors rather than
+        GitHub's ``Link`` header and ``page`` counter.
+        """
+        results: list[dict[str, Any]] = []
+        page_token: str | None = None
+
+        while True:
+            params: dict[str, Any] = {"pageSize": PAGE_SIZE}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = self.get(path, params=params)
+            if not isinstance(response, dict):
+                break
+
+            results.extend(response.get(collection_key, []) or [])
+
+            page_token = response.get("nextPageToken") or None
+            if not page_token:
+                break
+
+        return results
+
+
+class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
+    """Client that authenticates as the app itself, with no stored integration.
+
+    Used during install (before an Integration row exists) and for local
+    verification. The installed-integration client persists its token on the
+    Integration; this one just keeps it in memory.
+    """
+
+    base_url = CURSOR_ORIGIN_API_BASE_URL
+    integration_type = "integration"
+    integration_name = "cursor_origin_setup"
+
+    def __init__(
+        self,
+        installation_id: str | None = None,
+        app_id: str | None = None,
+        private_key: str | None = None,
+        verify_ssl: bool = True,
+    ):
+        super().__init__(verify_ssl=verify_ssl)
+        self.installation_id = installation_id
+        self._app_id = app_id
+        self._private_key = private_key
+        self._access_token: str | None = None
+        self._expires_at: float = 0.0
+
+    # -- auth ----------------------------------------------------------------
+
+    def _jwt(self) -> str:
+        return get_jwt(app_id=self._app_id, private_key=self._private_key)
+
+    def _is_app_route(self, path_url: str) -> bool:
+        """``/app`` and everything under it authenticates with the app JWT.
+
+        That includes the token-exchange call itself. Repository routes
+        (``/repos/…``, ``/installation/repos``) use the installation token.
+        """
+        return path_url.startswith("/v1/origin/app") or path_url.startswith("/app")
+
+    def get_access_token(self) -> str:
+        """Mint or reuse an installation token.
+
+        Origin's tokens expire in under 15 minutes -- far shorter than GitHub's hour
+        -- so this refreshes aggressively rather than on the GitHub cadence.
+        """
+        if self.installation_id is None:
+            raise ValueError("installation_id is required for installation-scoped calls")
+
+        if self._access_token and time.time() < self._expires_at:
+            return self._access_token
+
+        response = self.post(f"/app/installations/{self.installation_id}/access_tokens")
+        if not isinstance(response, dict):
+            raise ApiError("unexpected access_token response from Cursor Origin")
+
+        token = next(
+            (v for v in response.values() if isinstance(v, str) and v.startswith("oit_")),
+            None,
+        )
+        if not token:
+            raise ApiError("no installation token in Cursor Origin response")
+
+        self._access_token = token
+        # Origin does not return a usable expiry, so assume the documented ceiling
+        # and refresh well before it.
+        self._expires_at = time.time() + TOKEN_MINIMUM_VALIDITY_SECONDS
+        return token
+
+    def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
+        if self._is_app_route(prepared_request.path_url):
+            token = self._jwt()
+        else:
+            token = self.get_access_token()
+
+        prepared_request.headers["Authorization"] = f"Bearer {token}"
+        prepared_request.headers["Accept"] = "application/json"
+        return prepared_request
+
+    # -- app-level endpoints -------------------------------------------------
+
+    def get_app(self) -> dict[str, Any]:
+        return self.get("/app")
+
+    def get_installations(self) -> list[dict[str, Any]]:
+        response = self.get("/app/installations")
+        if not isinstance(response, dict):
+            return []
+        for value in response.values():
+            if isinstance(value, list):
+                return value
+        return []
+
+    def get_installation(self, installation_id: str) -> dict[str, Any]:
+        return self.get(f"/app/installations/{installation_id}")

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -260,8 +260,31 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
         self._private_key = private_key
         self._access_token: str | None = None
         self._expires_at: float = 0.0
+        # Set for the duration of a request that asked for app-level credentials.
+        self._force_app_auth = False
 
     # -- auth ----------------------------------------------------------------
+
+    def request(self, *args: Any, **kwargs: Any) -> Any:
+        """Accept scm-platform's ``credentials_set`` argument.
+
+        Providers in the scm library thread ``credentials_set`` through every
+        call to choose between app-level and installation-level credentials.
+        Sentry's BaseApiClient knows nothing about it, so it has to be consumed
+        here or the call fails with an unexpected-keyword TypeError -- which is
+        how this surfaced: every read through SourceCodeManager blew up before
+        reaching the network.
+
+        "application" means authenticate as the app itself rather than as the
+        installation, which for Origin is the app JWT.
+        """
+        credentials_set = kwargs.pop("credentials_set", None)
+        previous = self._force_app_auth
+        self._force_app_auth = credentials_set == "application"
+        try:
+            return super().request(*args, **kwargs)
+        finally:
+            self._force_app_auth = previous
 
     def _jwt(self) -> str:
         return get_jwt(app_id=self._app_id, private_key=self._private_key)
@@ -304,7 +327,7 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
         return token
 
     def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
-        if self._is_app_route(prepared_request.path_url):
+        if self._force_app_auth or self._is_app_route(prepared_request.path_url):
             token = self._jwt()
         else:
             token = self.get_access_token()

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -161,6 +161,74 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
     def get_branches(self, repo_full_name: str) -> list[dict[str, Any]]:
         return self._paginate(f"/repos/{repo_full_name}/branches", "branches")
 
+    # -- commits -------------------------------------------------------------
+
+    def get_commits(
+        self, repo_full_name: str, sha: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Commits reachable from ``sha``, newest first.
+
+        The ref parameter is spelled ``sha``, as on GitHub. Note that Origin
+        *silently ignores* unknown query parameters rather than rejecting them,
+        so passing ``ref`` here would return a normal 200 with the unfiltered
+        default-branch history -- a wrong answer that looks right.
+
+        ``since``/``until``/``path`` are likewise accepted and ignored, so they
+        are deliberately not offered.
+        """
+        params: dict[str, Any] = {"pageSize": min(limit, PAGE_SIZE)}
+        if sha:
+            params["sha"] = sha
+
+        commits: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while len(commits) < limit:
+            if page_token:
+                # A page token encodes the filters it was issued for, so `sha`
+                # and `pageSize` are ignored once one is supplied.
+                params = {"pageToken": page_token}
+            response = self.get(f"/repos/{repo_full_name}/commits", params=params)
+            if not isinstance(response, dict):
+                break
+            page = response.get("commits") or []
+            commits.extend(page)
+            page_token = response.get("nextPageToken") or None
+            if not page or not page_token:
+                break
+
+        return commits[:limit]
+
+    def get_commit_files(self, repo_full_name: str, sha: str) -> list[dict[str, Any]]:
+        """Files changed by a single commit, GitHub-shaped.
+
+        Entries carry ``filename``/``status``/``patch``. Zero-valued stats keys
+        are omitted rather than sent as 0.
+        """
+        response = self.get(f"/repos/{repo_full_name}/commits/{sha}/files")
+        if not isinstance(response, dict):
+            return []
+        return response.get("files") or []
+
+    def compare_commits(
+        self, repo_full_name: str, start_sha: str, end_sha: str, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Commits between two shas, oldest first, excluding ``start_sha``.
+
+        Origin has a compare endpoint but it returns only counts and boundary
+        commits -- no commit list, and no route anywhere gives the files changed
+        between two arbitrary commits. So the range is rebuilt by walking back
+        from ``end_sha`` until ``start_sha`` is reached.
+
+        If ``start_sha`` is not found within ``limit`` commits the walk is
+        returned as-is: a truncated range beats failing a release entirely.
+        """
+        walked: list[dict[str, Any]] = []
+        for commit in self.get_commits(repo_full_name, sha=end_sha, limit=limit):
+            if commit.get("sha") == start_sha:
+                break
+            walked.append(commit)
+        return list(reversed(walked))
+
     # -- RepositoryClient ----------------------------------------------------
 
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from django.core.cache import cache
 from requests import PreparedRequest, Response
 
 from sentry.integrations.cursor_origin.constants import (
@@ -306,9 +307,9 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
 class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
     """Client that authenticates as the app itself, with no stored integration.
 
-    Used during install (before an Integration row exists) and for local
-    verification. The installed-integration client persists its token on the
-    Integration; this one just keeps it in memory.
+    Used both during install, before an Integration row exists, and afterwards
+    by the installation's ``get_client()``. Installation tokens are shared
+    through the cache so repeated client construction does not re-mint them.
     """
 
     base_url = CURSOR_ORIGIN_API_BASE_URL
@@ -368,14 +369,28 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
     def get_access_token(self) -> str:
         """Mint or reuse an installation token.
 
-        Origin's tokens expire in under 15 minutes -- far shorter than GitHub's hour
-        -- so this refreshes aggressively rather than on the GitHub cadence.
+        Shared through the cache, not just this instance. A new client is built
+        on every ``get_installation().get_client()``, so an instance-only cache
+        meant a fresh token exchange per call site -- and token minting is
+        charged against the app-JWT budget, which is the smaller of the two.
+
+        The cache is deliberately given a shorter life than the token itself:
+        Origin's tokens last under 15 minutes and the response carries no usable
+        expiry, so a cached token is always refreshed well before it can expire
+        mid-request. Eviction is harmless -- it just costs one exchange.
         """
         if self.installation_id is None:
             raise ValueError("installation_id is required for installation-scoped calls")
 
         if self._access_token and time.time() < self._expires_at:
             return self._access_token
+
+        cache_key = self._token_cache_key(self.installation_id)
+        cached = cache.get(cache_key)
+        if cached:
+            self._access_token = cached
+            self._expires_at = time.time() + TOKEN_MINIMUM_VALIDITY_SECONDS
+            return cached
 
         response = self.post(f"/app/installations/{self.installation_id}/access_tokens")
         if not isinstance(response, dict):
@@ -389,10 +404,13 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
             raise ApiError("no installation token in Cursor Origin response")
 
         self._access_token = token
-        # Origin does not return a usable expiry, so assume the documented ceiling
-        # and refresh well before it.
         self._expires_at = time.time() + TOKEN_MINIMUM_VALIDITY_SECONDS
+        cache.set(cache_key, token, TOKEN_MINIMUM_VALIDITY_SECONDS)
         return token
+
+    @staticmethod
+    def _token_cache_key(installation_id: str) -> str:
+        return f"cursor-origin:token:{installation_id}"
 
     def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
         if self._force_app_auth or self._is_app_route(prepared_request.path_url):

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import logging
 import re
 import time
+from base64 import b64decode
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from requests import PreparedRequest
+from requests import PreparedRequest, Response
 
 from sentry.integrations.cursor_origin.constants import (
     CURSOR_ORIGIN_API_BASE_URL,
@@ -13,6 +15,9 @@ from sentry.integrations.cursor_origin.constants import (
 )
 from sentry.integrations.cursor_origin.languages import languages_from_tree
 from sentry.integrations.cursor_origin.utils import get_jwt
+from sentry.integrations.source_code_management.repo_trees import RepoTreesClient
+from sentry.integrations.source_code_management.repository import RepositoryClient
+from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -29,7 +34,7 @@ _GITHUB_CONTENTS_PATH = re.compile(
 PAGE_SIZE = 100
 
 
-class CursorOriginApiMixin:
+class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
     """Read methods shared by the setup client and the installed-integration client.
 
     Everything here is written against the *verified* Origin API, which differs from
@@ -37,6 +42,34 @@ class CursorOriginApiMixin:
     ``/contents?path=…``, not ``/contents/{path}``. The documented path form returns a
     404 with a route-not-found body, which reads like an auth failure but is not.
     """
+
+    # Seeded with the documented installation budget and replaced by the real
+    # figure as soon as a response carrying rate-limit headers arrives. Starting
+    # at 0 would read as "exhausted" and make callers back off before we have
+    # made a single request.
+    _rate_limit_remaining: int = 3000
+
+    def track_response_data(
+        self,
+        code: str | int,
+        error: Exception | None = None,
+        resp: Response | None = None,
+        extra: Mapping[str, str | int] | None = None,
+    ) -> None:
+        """Capture Origin's rate-limit headers on the way past.
+
+        This is the only place the raw response is visible, and `repo_trees`
+        backs off when the remaining budget gets low, so the figure has to be
+        live rather than assumed.
+        """
+        if resp is not None:
+            remaining = resp.headers.get("x-ratelimit-remaining")
+            if remaining is not None:
+                try:
+                    self._rate_limit_remaining = int(remaining)
+                except ValueError:
+                    pass
+        super().track_response_data(code, error, resp, extra)  # type: ignore[misc]
 
     # Concrete subclasses supply `post` via the shared API client base. Declared here
     # only so mypy can see it -- do NOT give it a body, or the MRO will shadow the
@@ -127,6 +160,51 @@ class CursorOriginApiMixin:
 
     def get_branches(self, repo_full_name: str) -> list[dict[str, Any]]:
         return self._paginate(f"/repos/{repo_full_name}/branches", "branches")
+
+    # -- RepositoryClient ----------------------------------------------------
+
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
+        """Does this path exist? Used by stacktrace linking and CODEOWNERS.
+
+        Origin has no HEAD route for contents, so this is a GET whose body we
+        discard. Missing paths 404, which surfaces as ApiError.
+        """
+        try:
+            return self.get_contents(repo.name, path, ref=version)
+        except ApiError:
+            return None
+
+    def get_file(
+        self, repo: Repository, path: str, ref: str | None, codeowners: bool = False
+    ) -> str:
+        contents = self.get_contents(repo.name, path, ref=ref)
+        return b64decode(contents["content"]).decode("utf-8")
+
+    # -- RepoTreesClient -----------------------------------------------------
+
+    def get_remaining_api_requests(self) -> int:
+        """Requests left in the current window, from the last response's headers.
+
+        Origin uses the same ``X-RateLimit-*`` header names as GitHub. When we
+        have not made a request yet, report the documented installation budget
+        rather than 0, which callers treat as "back off".
+        """
+        return self._rate_limit_remaining
+
+    def should_count_api_error(self, error: ApiError, extra: dict[str, str]) -> bool:
+        """Whether this error counts toward the connection-error tally.
+
+        An empty or inaccessible repository is an expected condition when
+        walking an org's trees, not a sign the integration is broken.
+        """
+        message = (error.json or {}).get("message") if error.json else error.text
+        if message and (
+            "not found" in message.lower()
+            or "empty" in message.lower()
+            or "permission" in message.lower()
+        ):
+            return False
+        return True
 
     # -- pagination ----------------------------------------------------------
 

--- a/src/sentry/integrations/cursor_origin/constants.py
+++ b/src/sentry/integrations/cursor_origin/constants.py
@@ -30,3 +30,11 @@ CURSOR_ORIGIN_SCOPES = (
     "repository:checks:read",
     "repository:checks:write",
 )
+
+# Origin publishes the Ed25519 public keys it signs webhooks with. Signatures
+# carry no key id, so all active keys are tried.
+CURSOR_ORIGIN_JWKS_URL = f"{CURSOR_ORIGIN_API_BASE_URL}/keys"
+CURSOR_ORIGIN_JWKS_CACHE_SECONDS = 3600
+
+# Origin's guidance for rejecting replayed deliveries.
+WEBHOOK_MAX_AGE_SECONDS = 300

--- a/src/sentry/integrations/cursor_origin/constants.py
+++ b/src/sentry/integrations/cursor_origin/constants.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+CURSOR_ORIGIN_API_BASE_URL = "https://api.cursor.com/v1/origin"
+CURSOR_ORIGIN_WEB_BASE_URL = "https://cursor.com/codebase"
+CURSOR_ORIGIN_GIT_BASE_URL = "https://origin.cursor.com"
+
+# Where users are sent to install the app on their codebase.
+CURSOR_ORIGIN_INSTALL_URL = "https://cursor.com/codebase/apps/install"
+
+# The `aud` claim Origin requires on app JWTs.
+CURSOR_ORIGIN_JWT_AUDIENCE = "origin-apps"
+
+# Origin caps app JWTs at ~5 minutes. Stay comfortably inside it.
+JWT_EXPIRY_SECONDS = 240
+
+# Installation tokens expire in under 15 minutes -- far shorter than GitHub's hour.
+# Refresh well ahead of expiry so a long-running request can't straddle the boundary.
+TOKEN_MINIMUM_VALIDITY_SECONDS = 180
+
+# Scopes requested at install time. The app's registered permissions are the ceiling;
+# this is the actual grant.
+CURSOR_ORIGIN_SCOPES = (
+    "repository:metadata:read",
+    "repository:contents:read",
+    "repository:contents:write",
+    "repository:pull_requests:read",
+    "repository:pull_requests:write",
+    "repository:pull_requests:reviews:read",
+    "repository:pull_requests:reviews:write",
+    "repository:checks:read",
+    "repository:checks:write",
+)

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -228,7 +228,11 @@ def build_install_url(state: str, redirect_uri: str, scopes: Sequence[str] | Non
             "scope": " ".join(scopes or CURSOR_ORIGIN_SCOPES),
             "redirect_uri": redirect_uri,
             "state": state,
-        }
+        },
+        # Encode the scope separator as %20 rather than "+". Both decode to a
+        # space, but Origin is new enough that it is not worth relying on the
+        # form-encoding convention.
+        quote_via=quote,
     )
 
 

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -25,6 +25,7 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
 from sentry.integrations.source_code_management.repository import (
+    HaltReason,
     RepositoryInfo,
     RepositoryIntegration,
 )
@@ -130,6 +131,37 @@ class CursorOriginIntegration(
         except ApiError:
             return False
         return True
+
+    # -- error classification ------------------------------------------------
+
+    def is_rate_limited_error(self, exc: ApiError) -> bool:
+        """Origin signals rate limiting with a plain 429 plus Retry-After.
+
+        The base class returns False for every error, so without this a rate
+        limit is indistinguishable from a broken integration and the install
+        gets marked unauthorized for what is a transient condition.
+        """
+        return exc.code == 429
+
+    def is_broken_integration_error(self, exc: Exception) -> HaltReason | None:
+        """Treat a failed token exchange as a terminal state.
+
+        When an app is uninstalled or its access revoked, Origin stops issuing
+        installation tokens. Every subsequent call fails at the exchange rather
+        than on the resource, which the generic handling reads as an ordinary
+        404 and retries forever. Surfacing it as terminal is what lets the
+        integration be shown as broken instead.
+
+        `installation.deleted` normally gets there first, but only when the
+        webhook was delivered -- revocation and missed deliveries both land here.
+        """
+        if isinstance(exc, ApiError) and exc.url and "access_tokens" in exc.url:
+            if self.is_rate_limited_error(exc):
+                return "rate_limited"
+            if exc.code in (401, 403, 404):
+                return "installation_suspended"
+
+        return super().is_broken_integration_error(exc)
 
     # -- stacktrace linking --------------------------------------------------
 

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -178,15 +178,27 @@ class CursorOriginIntegrationProvider(IntegrationProvider):
         except ApiError as e:
             raise IntegrationError(f"Could not read the Cursor Origin installation: {e}")
 
-        account = installation.get("account") or {}
-        name = account.get("slug") or installation.get("ownerSlug") or installation_id
+        # The codebase the app was installed on. Origin calls this `target`; its
+        # `slug` is the namespace that prefixes every repo ("sentry/nuget-trends")
+        # and is what we want as the integration's display name. Falling back to
+        # the installation id keeps the install working but shows an opaque
+        # `i_01…` in the UI, so treat a missing target as worth knowing about.
+        target = installation.get("target") or {}
+        name = target.get("slug") or installation_id
+        if not target.get("slug"):
+            logger.warning(
+                "cursor_origin.installation.missing_target",
+                extra={"installation_id": installation_id},
+            )
 
         return {
             "name": name,
             "external_id": installation_id,
             "metadata": {
                 "installation_id": installation_id,
-                "account": account,
+                "target": target,
+                "scopes": installation.get("scopes") or [],
+                "repo_selection_mode": installation.get("repoSelectionMode"),
                 "domain_name": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{name}",
             },
         }

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from django.utils.translation import gettext_lazy as _
+
+from sentry.integrations.base import (
+    FeatureDescription,
+    IntegrationData,
+    IntegrationFeatures,
+    IntegrationMetadata,
+    IntegrationProvider,
+)
+from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_INSTALL_URL,
+    CURSOR_ORIGIN_SCOPES,
+    CURSOR_ORIGIN_WEB_BASE_URL,
+)
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.repository.model import RpcRepository
+from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
+from sentry.integrations.source_code_management.repository import (
+    RepositoryInfo,
+    RepositoryIntegration,
+)
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.repository import Repository
+from sentry.organizations.services.organization.model import RpcOrganizationSummary
+from sentry.pipeline.views.base import ApiPipelineSteps
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+DESCRIPTION = """
+Connect your Cursor Origin repositories to Sentry. Origin is Cursor's git forge --
+linking it lets Sentry suggest the right platform when you create a project, map
+stack traces back to source, and give Seer access to your code.
+"""
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Suggest the right platform for a new project by inspecting the repository you
+        pick during onboarding.
+        """,
+        IntegrationFeatures.COMMITS,
+    ),
+    FeatureDescription(
+        """
+        Link stack traces directly to source code in Origin.
+        """,
+        IntegrationFeatures.STACKTRACE_LINK,
+    ),
+]
+
+metadata = IntegrationMetadata(
+    description=DESCRIPTION.strip(),
+    features=FEATURES,
+    author="Sentry",
+    noun=_("Installation"),
+    issue_url="https://github.com/getsentry/sentry/issues",
+    source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/cursor_origin",
+    aspects={},
+)
+
+
+class CursorOriginIntegration(
+    RepositoryIntegration[CursorOriginSetupApiClient], RepoTreesIntegration
+):
+    codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
+
+    @property
+    def integration_name(self) -> str:
+        return IntegrationProviderSlug.CURSOR_ORIGIN.value
+
+    def get_client(self) -> CursorOriginSetupApiClient:
+        installation_id = self.model.external_id
+        return CursorOriginSetupApiClient(installation_id=installation_id)
+
+    # -- repositories --------------------------------------------------------
+
+    def get_repo_external_id(self, repo: Mapping[str, Any]) -> str:
+        return str(repo["id"])
+
+    def get_repositories(
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
+        use_cache: bool = False,
+        raise_on_page_limit: bool = False,
+        parallel: bool = False,
+    ) -> list[RepositoryInfo]:
+        """Repositories this installation can see.
+
+        Origin has no repository search endpoint, so `query` is applied locally.
+        The extra keyword arguments exist for base-class compatibility and are
+        ignored -- the installation repo list is small enough to always fetch whole.
+        """
+        try:
+            raw_repos = self.get_client().get_repositories()
+        except ApiError as e:
+            logger.info("cursor_origin.get_repositories.error", extra={"error": str(e)})
+            return []
+
+        repos: list[RepositoryInfo] = [
+            {
+                "name": repo["fullName"],
+                "identifier": repo["fullName"],
+                "external_id": str(repo["id"]),
+                "default_branch": repo.get("defaultBranch"),
+            }
+            for repo in raw_repos
+        ]
+
+        if query:
+            lowered = query.lower()
+            repos = [repo for repo in repos if lowered in repo["name"].lower()]
+
+        return repos
+
+    def has_repo_access(self, repo: RpcRepository) -> bool:
+        try:
+            self.get_client().get_repo(repo.name)
+        except ApiError:
+            return False
+        return True
+
+    # -- stacktrace linking --------------------------------------------------
+
+    def source_url_matches(self, url: str) -> bool:
+        return url.startswith(CURSOR_ORIGIN_WEB_BASE_URL)
+
+    def format_source_url(self, repo: Repository, filepath: str, branch: str | None) -> str:
+        branch = branch or repo.config.get("default_branch") or "main"
+        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/blob/{branch}/{quote(filepath)}"
+
+    def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
+        prefix = f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/blob/"
+        return url.replace(prefix, "").split("/")[0]
+
+    def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
+        prefix = f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/blob/"
+        branch = self.extract_branch_from_source_url(repo, url)
+        return url.replace(f"{prefix}{branch}/", "")
+
+
+class CursorOriginIntegrationProvider(IntegrationProvider):
+    key = IntegrationProviderSlug.CURSOR_ORIGIN.value
+    name = "Cursor Origin"
+    metadata = metadata
+    integration_cls = CursorOriginIntegration
+
+    # Origin's install redirect hands back the installation directly, so unlike
+    # GitHub there is no separate OAuth identity to link.
+    needs_default_identity = False
+
+    features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.STACKTRACE_LINK])
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        from sentry.integrations.cursor_origin.pipeline import CursorOriginInstallApiStep
+
+        return [CursorOriginInstallApiStep()]
+
+    def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
+        installation_id = state.get("installation_id")
+        if not installation_id:
+            raise IntegrationError("Cursor Origin did not return an installation.")
+
+        client = CursorOriginSetupApiClient(installation_id=installation_id)
+        try:
+            installation = client.get_installation(installation_id)
+        except ApiError as e:
+            raise IntegrationError(f"Could not read the Cursor Origin installation: {e}")
+
+        account = installation.get("account") or {}
+        name = account.get("slug") or installation.get("ownerSlug") or installation_id
+
+        return {
+            "name": name,
+            "external_id": installation_id,
+            "metadata": {
+                "installation_id": installation_id,
+                "account": account,
+                "domain_name": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{name}",
+            },
+        }
+
+    def post_install(
+        self,
+        integration: Integration,
+        organization: RpcOrganizationSummary,
+        *,
+        extra: Mapping[str, Any],
+    ) -> None:
+        from sentry.integrations.github.tasks.link_all_repos import link_all_repos
+
+        link_all_repos.apply_async(
+            kwargs={
+                "integration_key": self.key,
+                "integration_id": integration.id,
+                "organization_id": organization.id,
+            }
+        )
+
+    def setup(self) -> None:
+        from sentry.plugins.base import bindings
+
+        from .repository import CursorOriginRepositoryProvider
+
+        bindings.add(
+            "integration-repository.provider",
+            CursorOriginRepositoryProvider,
+            id=f"integrations:{self.key}",
+        )
+
+
+def build_install_url(state: str, redirect_uri: str, scopes: Sequence[str] | None = None) -> str:
+    """Where the user is sent to grant the app access to their codebase."""
+    return f"{CURSOR_ORIGIN_INSTALL_URL}?" + urlencode(
+        {
+            "client_id": _app_id(),
+            "scope": " ".join(scopes or CURSOR_ORIGIN_SCOPES),
+            "redirect_uri": redirect_uri,
+            "state": state,
+        }
+    )
+
+
+def _app_id() -> str:
+    from sentry import options
+
+    return str(options.get("cursor-origin-app.id"))

--- a/src/sentry/integrations/cursor_origin/languages.py
+++ b/src/sentry/integrations/cursor_origin/languages.py
@@ -1,0 +1,133 @@
+"""Approximate GitHub's languages API from a git tree.
+
+GitHub exposes ``GET /repos/{repo}/languages`` returning byte counts per language,
+and Sentry's platform detection is built directly on it. Origin has no equivalent,
+so we derive the same shape from the recursive tree: map each blob's extension to a
+Linguist language name and sum the blob sizes.
+
+Keys deliberately match Linguist's names so the existing
+``GITHUB_LANGUAGE_TO_SENTRY_PLATFORM`` registry -- and everything downstream of it
+-- works unchanged.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+# Extension -> Linguist language name. Only languages Sentry can map to a platform
+# are worth listing; anything unmapped is discarded by the caller anyway.
+EXTENSION_TO_LANGUAGE: dict[str, str] = {
+    ".py": "Python",
+    ".pyi": "Python",
+    ".js": "JavaScript",
+    ".jsx": "JavaScript",
+    ".mjs": "JavaScript",
+    ".cjs": "JavaScript",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".mts": "TypeScript",
+    ".cts": "TypeScript",
+    ".java": "Java",
+    ".kt": "Kotlin",
+    ".kts": "Kotlin",
+    ".swift": "Swift",
+    ".m": "Objective-C",
+    ".mm": "Objective-C++",
+    ".go": "Go",
+    ".rb": "Ruby",
+    ".rake": "Ruby",
+    ".php": "PHP",
+    ".rs": "Rust",
+    ".cs": "C#",
+    ".dart": "Dart",
+    ".ex": "Elixir",
+    ".exs": "Elixir",
+    ".c": "C",
+    ".h": "C",
+    ".cc": "C++",
+    ".cpp": "C++",
+    ".cxx": "C++",
+    ".hpp": "C++",
+    ".hh": "C++",
+    ".gd": "GDScript",
+    ".ps1": "PowerShell",
+    ".psm1": "PowerShell",
+}
+
+# Path segments Linguist treats as vendored or generated. Counting these badly skews
+# detection -- a checked-in node_modules would drown out the actual application.
+EXCLUDED_PATH_SEGMENTS = frozenset(
+    {
+        "node_modules",
+        "vendor",
+        "third_party",
+        "thirdparty",
+        "bower_components",
+        "dist",
+        "build",
+        "out",
+        "target",
+        "bin",
+        "obj",
+        ".git",
+        ".venv",
+        "venv",
+        "site-packages",
+        "__pycache__",
+        "migrations",
+        "Pods",
+        "Carthage",
+    }
+)
+
+# Test code is real code, but weighting it equally tends to misidentify the primary
+# platform of a repo whose tests dwarf its source.
+EXCLUDED_TEST_SEGMENTS = frozenset({"test", "tests", "spec", "specs", "__tests__"})
+
+
+def _is_excluded(path: str) -> bool:
+    segments = path.split("/")
+    # The final segment is the filename, not a directory.
+    for segment in segments[:-1]:
+        if segment in EXCLUDED_PATH_SEGMENTS or segment in EXCLUDED_TEST_SEGMENTS:
+            return True
+    return False
+
+
+def _extension(path: str) -> str | None:
+    filename = path.rsplit("/", 1)[-1]
+    if "." not in filename:
+        return None
+    return "." + filename.rsplit(".", 1)[-1].lower()
+
+
+def languages_from_tree(tree: list[dict[str, Any]]) -> dict[str, int]:
+    """Byte counts per language, shaped like GitHub's languages API.
+
+    ``tree`` is the entry list from Origin's ``git/trees/{ref}?recursive=1``. Blobs
+    carry a ``size``; trees do not and are skipped.
+    """
+    totals: dict[str, int] = defaultdict(int)
+
+    for entry in tree:
+        if entry.get("type") != "blob":
+            continue
+
+        path = entry.get("path")
+        if not path or _is_excluded(path):
+            continue
+
+        extension = _extension(path)
+        if extension is None:
+            continue
+
+        language = EXTENSION_TO_LANGUAGE.get(extension)
+        if language is None:
+            continue
+
+        totals[language] += entry.get("size") or 0
+
+    # Drop languages that matched only empty files -- they carry no signal and would
+    # register as a detected platform with zero weight.
+    return {language: size for language, size in totals.items() if size > 0}

--- a/src/sentry/integrations/cursor_origin/languages.py
+++ b/src/sentry/integrations/cursor_origin/languages.py
@@ -102,6 +102,20 @@ def _extension(path: str) -> str | None:
     return "." + filename.rsplit(".", 1)[-1].lower()
 
 
+def _size(entry: dict[str, Any]) -> int:
+    """Blob size in bytes, tolerating a stringified number.
+
+    Origin serialises 64-bit integers as JSON strings in places (``size`` on
+    ``contents`` comes back as ``"2534"``). Tree entries use real ints today,
+    but the pattern is common enough in that API that a bare ``+=`` would be a
+    TypeError waiting to happen mid-detection.
+    """
+    try:
+        return int(entry.get("size") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def languages_from_tree(tree: list[dict[str, Any]]) -> dict[str, int]:
     """Byte counts per language, shaped like GitHub's languages API.
 
@@ -126,7 +140,7 @@ def languages_from_tree(tree: list[dict[str, Any]]) -> dict[str, int]:
         if language is None:
             continue
 
-        totals[language] += entry.get("size") or 0
+        totals[language] += _size(entry)
 
     # Drop languages that matched only empty files -- they carry no signal and would
     # register as a detected platform with zero weight.

--- a/src/sentry/integrations/cursor_origin/pipeline.py
+++ b/src/sentry/integrations/cursor_origin/pipeline.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+import jwt
+from django.http import HttpRequest
+from django.urls import reverse
+from rest_framework import serializers
+
+from sentry.integrations.cursor_origin.integration import build_install_url
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.pipeline.types import PipelineStepResult
+from sentry.utils.http import absolute_uri
+
+
+class InstallStepData(TypedDict):
+    installUrl: str
+
+
+class InstallSerializer(serializers.Serializer[dict[str, Any]]):
+    installation_receipt = serializers.CharField(required=False, allow_blank=True)
+    installation_id = serializers.CharField(required=False, allow_blank=True)
+    state = serializers.CharField(required=True)
+
+
+def _redirect_uri() -> str:
+    return absolute_uri(
+        reverse(
+            "sentry-extension-setup",
+            kwargs={"provider_id": IntegrationProviderSlug.CURSOR_ORIGIN.value},
+        )
+    )
+
+
+def _installation_id_from_receipt(receipt: str) -> str | None:
+    """Pull the installation id out of the signed receipt Origin returns.
+
+    The receipt is signed by Origin, not by us, so we cannot verify it here --
+    and we do not need to: the id is immediately used to call Origin with our
+    own app credentials, which is what actually establishes trust. A forged
+    receipt yields an installation we have no access to, and the call fails.
+    """
+    try:
+        claims = jwt.decode(receipt, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return None
+    subject = claims.get("sub")
+    return str(subject) if subject else None
+
+
+class CursorOriginInstallApiStep:
+    """Single-step install.
+
+    Origin's redirect returns an installation receipt directly, so unlike GitHub
+    there is no OAuth login leg and no separate organization-selection step.
+    """
+
+    step_name = "install"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> InstallStepData:
+        return {
+            "installUrl": build_install_url(state=pipeline.signature, redirect_uri=_redirect_uri())
+        }
+
+    def get_serializer_cls(self) -> type:
+        return InstallSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        if validated_data["state"] != pipeline.signature:
+            return PipelineStepResult.error("Invalid state, please try the installation again.")
+
+        installation_id = validated_data.get("installation_id")
+        if not installation_id:
+            receipt = validated_data.get("installation_receipt")
+            if receipt:
+                installation_id = _installation_id_from_receipt(receipt)
+
+        if not installation_id:
+            return PipelineStepResult.error(
+                "Cursor Origin did not return an installation. Please try again."
+            )
+
+        pipeline.bind_state("installation_id", installation_id)
+        return PipelineStepResult.advance()

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -15,6 +15,14 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 logger = logging.getLogger(__name__)
 
+# A first release has no previous sha to compare against, so associate a recent
+# slice of history rather than walking back forever.
+RECENT_COMMIT_LIMIT = 20
+
+# Each commit in the range costs an extra request for its changed files, since
+# Origin has no endpoint giving files across a range. Bound the work.
+MAX_COMPARE_COMMITS = 100
+
 
 class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginIntegration]):
     name = "Cursor Origin"
@@ -60,8 +68,81 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
     def compare_commits(
         self, repo: Repository, start_sha: str | None, end_sha: str
     ) -> Sequence[Mapping[str, Any]]:
-        """Not implemented yet -- commit tracking arrives with webhook support."""
-        return []
+        """Commits to associate with a release.
+
+        No start sha means this is the first release for the repository, so fall
+        back to recent history rather than walking to the beginning of time.
+        """
+        installation = self._installation_for(repo)
+        client = installation.get_client()
+        # config["name"] is the one kept in sync, matching how GitHub does it.
+        name = repo.config.get("name") or repo.name
+
+        try:
+            if start_sha is None:
+                commits = client.get_commits(name, sha=end_sha, limit=RECENT_COMMIT_LIMIT)
+            else:
+                commits = client.compare_commits(
+                    name, start_sha, end_sha, limit=MAX_COMPARE_COMMITS
+                )
+            return self._format_commits(client, name, commits)
+        except Exception as e:
+            installation.raise_error(e)
+
+    def _installation_for(self, repo: Repository) -> CursorOriginIntegration:
+        if repo.integration_id is None:
+            raise IntegrationError("Cursor Origin repositories require an integration id.")
+        installation = self.get_installation(repo.integration_id, repo.organization_id)
+        assert isinstance(installation, CursorOriginIntegration)
+        return installation
+
+    def _format_commits(
+        self, client: Any, repo_name: str, commits: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, Any]]:
+        """Convert Origin commits into Sentry's internal shape.
+
+        Origin's commit payload matches GitHub's, but the changed files live on a
+        separate route, so each commit costs one extra request. See
+        sentry.models.Release.set_commits.
+        """
+        return [
+            {
+                "id": commit["sha"],
+                "repository": repo_name,
+                "author_email": commit["commit"]["author"].get("email"),
+                "author_name": commit["commit"]["author"].get("name"),
+                "message": commit["commit"]["message"],
+                "timestamp": self.format_date(commit["commit"]["author"].get("date")),
+                "patch_set": self._transform_patchset(
+                    client.get_commit_files(repo_name, commit["sha"])
+                ),
+            }
+            for commit in commits
+        ]
+
+    def _transform_patchset(
+        self, files: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, Any]]:
+        changes: list[dict[str, str]] = []
+        for change in files:
+            status = change.get("status")
+            filename = change.get("filename")
+            if not filename:
+                continue
+            if status == "modified":
+                changes.append({"path": filename, "type": "M"})
+            elif status == "added":
+                changes.append({"path": filename, "type": "A"})
+            elif status == "removed":
+                changes.append({"path": filename, "type": "D"})
+            elif status == "renamed":
+                # A rename is recorded as a delete plus an add.
+                if previous := change.get("previous_filename"):
+                    changes.append({"path": previous, "type": "D"})
+                changes.append({"path": filename, "type": "A"})
+        return changes
 
     def pull_request_url(self, repo: Repository, pull_request: Any) -> str:
-        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/pulls/{pull_request.key}"
+        # `/pull/{n}`, not `/pulls/` -- confirmed against Origin's web UI. The
+        # REST route is `/pulls`, which makes this easy to get wrong.
+        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/pull/{pull_request.key}"

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from sentry.integrations.cursor_origin.constants import CURSOR_ORIGIN_WEB_BASE_URL
 from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
-from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -21,20 +20,10 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
     name = "Cursor Origin"
     repo_provider = "cursor_origin"
 
-    def _get_installation(
-        self, organization_id: int, integration_id: int
-    ) -> CursorOriginIntegration:
-        integration = integration_service.get_integration(integration_id=integration_id)
-        if integration is None:
-            raise IntegrationError("Cursor Origin integration not found.")
-        installation = integration.get_installation(organization_id=organization_id)
-        assert isinstance(installation, CursorOriginIntegration)
-        return installation
-
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]
     ) -> MutableMapping[str, Any]:
-        installation = self._get_installation(organization.id, config["installation"])
+        installation = self.get_installation(config.get("installation"), organization.id)
 
         # `identifier` is the fullName ("owner/repo") chosen in the repo picker.
         repo_name = config["identifier"]
@@ -46,6 +35,9 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
         config["external_id"] = str(repo["id"])
         config["name"] = repo["fullName"]
         config["default_branch"] = repo.get("defaultBranch")
+        # build_repository_config reads this back out; without it repo creation
+        # fails with a bare KeyError after the API calls have already succeeded.
+        config["integration_id"] = installation.model.id
         return config
 
     def build_repository_config(

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
+
+from sentry.integrations.cursor_origin.constants import CURSOR_ORIGIN_WEB_BASE_URL
+from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
+from sentry.integrations.services.integration import integration_service
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import RepositoryConfig
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+
+logger = logging.getLogger(__name__)
+
+
+class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginIntegration]):
+    name = "Cursor Origin"
+    repo_provider = "cursor_origin"
+
+    def _get_installation(
+        self, organization_id: int, integration_id: int
+    ) -> CursorOriginIntegration:
+        integration = integration_service.get_integration(integration_id=integration_id)
+        if integration is None:
+            raise IntegrationError("Cursor Origin integration not found.")
+        installation = integration.get_installation(organization_id=organization_id)
+        assert isinstance(installation, CursorOriginIntegration)
+        return installation
+
+    def get_repository_data(
+        self, organization: Organization, config: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        installation = self._get_installation(organization.id, config["installation"])
+
+        # `identifier` is the fullName ("owner/repo") chosen in the repo picker.
+        repo_name = config["identifier"]
+        try:
+            repo = installation.get_client().get_repo(repo_name)
+        except ApiError as e:
+            raise IntegrationError(f"Could not read {repo_name} from Cursor Origin: {e}")
+
+        config["external_id"] = str(repo["id"])
+        config["name"] = repo["fullName"]
+        config["default_branch"] = repo.get("defaultBranch")
+        return config
+
+    def build_repository_config(
+        self, organization: RpcOrganization, data: Mapping[str, Any]
+    ) -> RepositoryConfig:
+        return {
+            "name": data["name"],
+            "external_id": data["external_id"],
+            "url": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{data['name']}",
+            "config": {
+                "name": data["name"],
+                "default_branch": data.get("default_branch"),
+            },
+            "integration_id": data["integration_id"],
+        }
+
+    def repository_external_slug(self, repo: Repository) -> str:
+        return repo.name
+
+    def compare_commits(
+        self, repo: Repository, start_sha: str | None, end_sha: str
+    ) -> Sequence[Mapping[str, Any]]:
+        """Not implemented yet -- commit tracking arrives with webhook support."""
+        return []
+
+    def pull_request_url(self, repo: Repository, pull_request: Any) -> str:
+        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/pulls/{pull_request.key}"

--- a/src/sentry/integrations/cursor_origin/urls.py
+++ b/src/sentry/integrations/cursor_origin/urls.py
@@ -1,0 +1,11 @@
+from django.urls import re_path
+
+from .webhook import CursorOriginWebhookEndpoint
+
+urlpatterns = [
+    re_path(
+        r"^webhook/$",
+        CursorOriginWebhookEndpoint.as_view(),
+        name="sentry-integration-cursor-origin-webhook",
+    ),
+]

--- a/src/sentry/integrations/cursor_origin/utils.py
+++ b/src/sentry/integrations/cursor_origin/utils.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import time
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from sentry import options
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_JWT_AUDIENCE,
+    JWT_EXPIRY_SECONDS,
+)
+
+
+def _load_private_key(private_key: str) -> Ed25519PrivateKey:
+    """Parse the app's Ed25519 signing key.
+
+    Unlike GitHub's RS256 keys, PyJWT will not accept the PEM string directly for
+    EdDSA -- it needs a key object -- so the load step is mandatory here.
+    """
+    key = serialization.load_pem_private_key(private_key.encode("utf-8"), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise ValueError(f"cursor-origin-app.private-key is not Ed25519: {type(key).__name__}")
+    return key
+
+
+def get_jwt(app_id: str | None = None, private_key: str | None = None) -> str:
+    """Mint a short-lived app JWT for Origin's app-level endpoints."""
+    if app_id is None:
+        app_id = str(options.get("cursor-origin-app.id"))
+    if private_key is None:
+        private_key = options.get("cursor-origin-app.private-key")
+
+    now = int(time.time())
+    return jwt.encode(
+        {
+            # Allow for a little clock skew between us and Origin.
+            "iat": now - 30,
+            "exp": now + JWT_EXPIRY_SECONDS,
+            "iss": app_id,
+            "aud": CURSOR_ORIGIN_JWT_AUDIENCE,
+        },
+        _load_private_key(private_key),
+        algorithm="EdDSA",
+        headers={"kid": app_id},
+    )

--- a/src/sentry/integrations/cursor_origin/webhook.py
+++ b/src/sentry/integrations/cursor_origin/webhook.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import orjson
+from django.http import HttpRequest, HttpResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.constants import ObjectStatus
+from sentry.integrations.cursor_origin.webhook_signature import (
+    is_timestamp_fresh,
+    verify_signature,
+)
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.utils import metrics
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+# Origin's delivery envelope wraps the event, so the type lives in both a header
+# and the body. The header is used, since it is available before parsing.
+EVENT_TYPE_HEADER = "webhook-event-type"
+DELIVERY_ID_HEADER = "webhook-id"
+TIMESTAMP_HEADER = "webhook-timestamp"
+SIGNATURE_HEADER = "webhook-signature"
+INSTALLATION_ID_HEADER = "webhook-installation-id"
+
+
+@control_silo_endpoint
+class CursorOriginWebhookEndpoint(Endpoint):
+    """Receives Cursor Origin webhook deliveries.
+
+    Signature verification is Ed25519 against Origin's published JWKS -- see
+    webhook_signature.py. Deliveries are at-least-once, so consumers must
+    deduplicate on the ``webhook-id`` header.
+
+    Only installation lifecycle is acted on today. Everything else is
+    acknowledged and logged: Origin retries and can disable an endpoint that
+    keeps failing, so returning 200 for an event we do not handle yet is
+    deliberate, not an oversight.
+    """
+
+    authentication_classes = ()
+    permission_classes = ()
+
+    owner = ApiOwner.INTEGRATION_PLATFORM
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        if request.method != "POST":
+            return HttpResponse(status=405)
+        return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request: HttpRequest) -> HttpResponse:
+        delivery_id = request.headers.get(DELIVERY_ID_HEADER)
+        timestamp = request.headers.get(TIMESTAMP_HEADER)
+        signature = request.headers.get(SIGNATURE_HEADER)
+        event_type = request.headers.get(EVENT_TYPE_HEADER)
+
+        if not (delivery_id and timestamp and signature):
+            logger.warning("cursor_origin.webhook.missing_headers")
+            return HttpResponse(status=400)
+
+        body = bytes(request.body)
+        if not body:
+            return HttpResponse(status=400)
+
+        if not is_timestamp_fresh(timestamp):
+            metrics.incr("cursor_origin.webhook.rejected", tags={"reason": "stale"})
+            logger.warning("cursor_origin.webhook.stale", extra={"delivery_id": delivery_id})
+            return HttpResponse(status=400)
+
+        if not verify_signature(delivery_id, timestamp, body, signature):
+            metrics.incr("cursor_origin.webhook.rejected", tags={"reason": "bad_signature"})
+            logger.warning(
+                "cursor_origin.webhook.invalid_signature", extra={"delivery_id": delivery_id}
+            )
+            return HttpResponse(status=401)
+
+        try:
+            payload = orjson.loads(body)
+        except orjson.JSONDecodeError:
+            return HttpResponse(status=400)
+
+        metrics.incr("cursor_origin.webhook.received", tags={"event_type": event_type or "unknown"})
+
+        if event_type == "installation.deleted":
+            self._handle_installation_deleted(request, payload)
+        else:
+            # Acknowledged so Origin stops retrying; handlers land with commit
+            # tracking and PR comments.
+            logger.info(
+                "cursor_origin.webhook.unhandled",
+                extra={"event_type": event_type, "delivery_id": delivery_id},
+            )
+
+        return HttpResponse(status=204)
+
+    def _handle_installation_deleted(self, request: HttpRequest, payload: Any) -> None:
+        """Disable the integration when the app is uninstalled.
+
+        Without this the integration keeps trying to mint tokens for an
+        installation that no longer exists, which surfaces as recurring auth
+        failures rather than as "someone uninstalled it".
+        """
+        installation_id = request.headers.get(INSTALLATION_ID_HEADER) or (
+            payload.get("installationId") if isinstance(payload, dict) else None
+        )
+        if not installation_id:
+            logger.warning("cursor_origin.webhook.deleted_without_installation_id")
+            return
+
+        result = integration_service.organization_contexts(
+            provider=IntegrationProviderSlug.CURSOR_ORIGIN.value,
+            external_id=installation_id,
+        )
+        if result.integration is None:
+            # Possible if the integration was removed in Sentry first.
+            logger.warning(
+                "cursor_origin.webhook.deleted_missing_integration",
+                extra={"installation_id": installation_id},
+            )
+            return
+
+        integration_service.update_integration(
+            integration_id=result.integration.id, status=ObjectStatus.DISABLED
+        )
+        logger.info(
+            "cursor_origin.webhook.installation_deleted",
+            extra={
+                "installation_id": installation_id,
+                "integration_id": result.integration.id,
+            },
+        )

--- a/src/sentry/integrations/cursor_origin/webhook.py
+++ b/src/sentry/integrations/cursor_origin/webhook.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from typing import Any
 
 import orjson
+from dateutil.parser import parse as parse_date
+from django.db import IntegrityError, router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.cursor_origin.webhook_signature import (
     is_timestamp_fresh,
@@ -18,6 +22,10 @@ from sentry.integrations.cursor_origin.webhook_signature import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.repository import Repository
+from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.cursor_origin")
@@ -31,7 +39,7 @@ SIGNATURE_HEADER = "webhook-signature"
 INSTALLATION_ID_HEADER = "webhook-installation-id"
 
 
-@control_silo_endpoint
+@all_silo_endpoint
 class CursorOriginWebhookEndpoint(Endpoint):
     """Receives Cursor Origin webhook deliveries.
 
@@ -92,9 +100,11 @@ class CursorOriginWebhookEndpoint(Endpoint):
 
         if event_type == "installation.deleted":
             self._handle_installation_deleted(request, payload)
+        elif event_type == "repository.pushed":
+            self._handle_push(request, payload)
         else:
-            # Acknowledged so Origin stops retrying; handlers land with commit
-            # tracking and PR comments.
+            # Acknowledged so Origin stops retrying; handlers land with PR
+            # comment and review support.
             logger.info(
                 "cursor_origin.webhook.unhandled",
                 extra={"event_type": event_type, "delivery_id": delivery_id},
@@ -138,3 +148,136 @@ class CursorOriginWebhookEndpoint(Endpoint):
                 "integration_id": result.integration.id,
             },
         )
+
+    def _handle_push(self, request: HttpRequest, payload: Any) -> None:
+        """Record commits from a push.
+
+        Origin's push event carries only ``headCommit`` per ref update, not
+        GitHub's full ``commits[]``, so the range has to be fetched. That is what
+        the repository provider's compare walk already does.
+        """
+        event = (payload or {}).get("event") or {}
+        push = event.get("payload") or {}
+        repo_id = ((push.get("repository") or {}).get("id")) or None
+        ref_updates = push.get("refUpdates") or []
+
+        if not repo_id or not ref_updates:
+            logger.info("cursor_origin.webhook.push_without_refs")
+            return
+
+        repos = Repository.objects.filter(
+            provider=f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}",
+            external_id=str(repo_id),
+            status=ObjectStatus.ACTIVE,
+        )
+        for repo in repos:
+            for ref_update in ref_updates:
+                self._record_ref_update(repo, ref_update)
+
+    def _record_ref_update(self, repo: Repository, ref_update: dict[str, Any]) -> None:
+        ref = ref_update.get("ref") or ""
+        # Tags do not carry commits worth associating.
+        if not ref.startswith("refs/heads/") or ref_update.get("deleted"):
+            return
+
+        head = ref_update.get("headCommit") or {}
+        head_sha = ref_update.get("after") or head.get("sha")
+        if not head_sha:
+            return
+
+        before = ref_update.get("before") or ""
+        if ref_update.get("created") or set(before) == {"0"}:
+            # A created ref has an all-zero `before`, which Origin's compare
+            # rejects outright ("revision not found"). Record just the tip rather
+            # than trying to walk a new branch's entire history.
+            commits: list[dict[str, Any]] = [head] if head.get("sha") else []
+        else:
+            provider = self._repository_provider()
+            try:
+                commits = provider.compare_commits(repo, before, head_sha)
+            except Exception:
+                logger.warning(
+                    "cursor_origin.webhook.push_compare_failed",
+                    extra={"repo_id": repo.id, "ref": ref},
+                    exc_info=True,
+                )
+                return
+            self._create_commits(repo, commits)
+            return
+
+        self._create_commits(repo, [self._as_internal_commit(c) for c in commits])
+
+    @staticmethod
+    def _repository_provider() -> Any:
+        from sentry.plugins.base import bindings
+
+        cls = bindings.get("integration-repository.provider").get(
+            f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}"
+        )
+        return cls(f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}")
+
+    @staticmethod
+    def _as_internal_commit(raw: dict[str, Any]) -> dict[str, Any]:
+        """Shape a raw Origin commit like the provider's compare output."""
+        author = raw.get("author") or {}
+        return {
+            "id": raw.get("sha"),
+            "message": raw.get("message") or "",
+            "author_email": author.get("email"),
+            "author_name": author.get("name"),
+            "timestamp": author.get("date"),
+            "patch_set": [],
+        }
+
+    def _create_commits(self, repo: Repository, commits: Sequence[Mapping[str, Any]]) -> None:
+        authors: dict[str, CommitAuthor] = {}
+        for commit in commits:
+            sha = commit.get("id")
+            message = commit.get("message") or ""
+            if not sha or IntegrationRepositoryProvider.should_ignore_commit(message):
+                continue
+
+            author = self._commit_author(repo, commit, authors)
+            try:
+                with transaction.atomic(router.db_for_write(Commit)):
+                    Commit.objects.create(
+                        repository_id=repo.id,
+                        organization_id=repo.organization_id,
+                        key=sha,
+                        message=message,
+                        author=author,
+                        date_added=self._commit_date(commit.get("timestamp")),
+                    )
+            except IntegrityError:
+                # Deliveries are at-least-once and pushes overlap, so seeing a
+                # commit twice is expected rather than an error.
+                pass
+
+    @staticmethod
+    def _commit_author(
+        repo: Repository, commit: Mapping[str, Any], cache: dict[str, CommitAuthor]
+    ) -> CommitAuthor | None:
+        email = commit.get("author_email")
+        if not email or len(email) > 75:
+            return None
+        if email in cache:
+            return cache[email]
+        author = CommitAuthor.objects.get_or_create(
+            organization_id=repo.organization_id,
+            email=email,
+            defaults={"name": commit.get("author_name")},
+        )[0]
+        cache[email] = author
+        return author
+
+    @staticmethod
+    def _commit_date(timestamp: Any) -> datetime:
+        """Commit date, defaulting to now when Origin gives something unusable."""
+        if isinstance(timestamp, datetime):
+            return timestamp.astimezone(timezone.utc)
+        if isinstance(timestamp, str):
+            try:
+                return parse_date(timestamp).astimezone(timezone.utc)
+            except (ValueError, OverflowError):
+                pass
+        return datetime.now(timezone.utc)

--- a/src/sentry/integrations/cursor_origin/webhook_signature.py
+++ b/src/sentry/integrations/cursor_origin/webhook_signature.py
@@ -1,0 +1,115 @@
+"""Verify Cursor Origin webhook signatures.
+
+Origin signs with Ed25519 rather than an HMAC shared secret, so verification
+needs Origin's *public* keys rather than a secret we hold. They are published as
+a JWKS at a well-known endpoint.
+
+Signatures carry no key id, so every active key is tried until one verifies.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import time
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from django.core.cache import cache
+
+from sentry.http import safe_urlopen
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_JWKS_CACHE_SECONDS,
+    CURSOR_ORIGIN_JWKS_URL,
+    WEBHOOK_MAX_AGE_SECONDS,
+)
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+_JWKS_CACHE_KEY = "cursor-origin:jwks"
+_SIGNATURE_PREFIX = "v1ed,"
+
+
+def _b64url_decode(value: str) -> bytes:
+    """Decode unpadded base64url, as used for JWK key material."""
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def fetch_public_keys(force_refresh: bool = False) -> list[bytes]:
+    """Origin's active Ed25519 public keys, cached.
+
+    Cached because every webhook delivery would otherwise fetch the JWKS.
+    ``force_refresh`` exists so a signature that fails against every cached key
+    can be retried once after rotation, rather than dropping deliveries until
+    the cache expires.
+    """
+    if not force_refresh:
+        cached = cache.get(_JWKS_CACHE_KEY)
+        if cached is not None:
+            return [bytes(k) for k in cached]
+
+    try:
+        response = safe_urlopen(CURSOR_ORIGIN_JWKS_URL, method="GET", timeout=5)
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+    except Exception:
+        logger.warning("cursor_origin.webhook.jwks_fetch_failed", exc_info=True)
+        return []
+
+    keys = [
+        _b64url_decode(key["x"])
+        for key in payload.get("keys", [])
+        if key.get("crv") == "Ed25519" and key.get("x")
+    ]
+    if keys:
+        cache.set(_JWKS_CACHE_KEY, keys, CURSOR_ORIGIN_JWKS_CACHE_SECONDS)
+    return keys
+
+
+def _signed_payload(webhook_id: str, timestamp: str, body: bytes) -> bytes:
+    """The bytes Origin actually signs.
+
+    Note this is the lowercase *hex digest* of the id/timestamp/body triple, not
+    the triple itself and not the raw digest -- signing the wrong one of those
+    three still produces a plausible-looking failure.
+    """
+    digest = hashlib.sha256(b".".join([webhook_id.encode(), timestamp.encode(), body])).hexdigest()
+    return digest.encode()
+
+
+def is_timestamp_fresh(timestamp: str, now: float | None = None) -> bool:
+    """Reject replays. Origin's guidance is a 5 minute window."""
+    try:
+        sent_at = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    return abs((now if now is not None else time.time()) - sent_at) <= WEBHOOK_MAX_AGE_SECONDS
+
+
+def verify_signature(webhook_id: str, timestamp: str, body: bytes, signature: str) -> bool:
+    """Whether ``signature`` is a valid Origin signature for this delivery."""
+    if not signature.startswith(_SIGNATURE_PREFIX):
+        return False
+
+    try:
+        raw_signature = base64.b64decode(signature[len(_SIGNATURE_PREFIX) :])
+    except (ValueError, TypeError):
+        return False
+
+    message = _signed_payload(webhook_id, timestamp, body)
+
+    for force_refresh in (False, True):
+        keys = fetch_public_keys(force_refresh=force_refresh)
+        for key_bytes in keys:
+            try:
+                Ed25519PublicKey.from_public_bytes(key_bytes).verify(raw_signature, message)
+                return True
+            except (InvalidSignature, ValueError):
+                continue
+        # Only worth refetching if the cache could have been stale.
+        if not keys:
+            break
+
+    return False

--- a/src/sentry/integrations/github/multi_platform_detection.py
+++ b/src/sentry/integrations/github/multi_platform_detection.py
@@ -5,7 +5,7 @@ import time
 from base64 import b64decode
 from collections import defaultdict
 from concurrent.futures import as_completed
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import Any, Protocol, TypedDict, runtime_checkable
 
 import sentry_sdk
 from yaml import YAMLError
@@ -47,8 +47,22 @@ from sentry.utils import json
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.yaml import safe_load
 
-if TYPE_CHECKING:
-    from sentry.integrations.github.client import GitHubBaseClient
+
+@runtime_checkable
+class PlatformDetectionClient(Protocol):
+    """What platform detection actually needs from an SCM client.
+
+    Detection was written against GitHub, but nothing in it is GitHub-specific
+    beyond these two calls -- so any provider whose client can produce a
+    GitHub-shaped git tree and Linguist-style language byte counts can reuse it.
+    Both methods are positional-only so implementations are free to name their
+    parameters to suit their own API.
+    """
+
+    def get(self, path: str, /, *args: Any, **kwargs: Any) -> Any: ...
+
+    def get_languages(self, repo: str, /) -> dict[str, int]: ...
+
 
 # ---------------------------------------------------------------------------
 # File I/O and manifest parsing helpers
@@ -60,7 +74,7 @@ def _ref_params(ref: str | None) -> dict[str, str]:
 
 
 def _get_repo_file_content(
-    client: GitHubBaseClient, repo: str, path: str, ref: str | None = None
+    client: PlatformDetectionClient, repo: str, path: str, ref: str | None = None
 ) -> str | None:
     """Fetch a file's content from a GitHub repo. Returns None if not found."""
     try:
@@ -274,7 +288,7 @@ def _segments_are_ignored(segments: list[str]) -> bool:
 
 
 def _get_tree(
-    client: GitHubBaseClient,
+    client: PlatformDetectionClient,
     repo: str,
     ref: str | None = None,
 ) -> tuple[list[dict[str, Any]], bool]:
@@ -541,7 +555,7 @@ def _framework_matches_scoped(
 
 
 def detect_platforms_multi(
-    client: GitHubBaseClient,
+    client: PlatformDetectionClient,
     repo: str,
     ref: str | None = None,
 ) -> MultiDetectionResult:

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -41,6 +41,7 @@ class ExternalActor(Model):
             (ExternalProviders.GITLAB, IntegrationProviderSlug.GITLAB.value),
             (ExternalProviders.JIRA_SERVER, IntegrationProviderSlug.JIRA_SERVER.value),
             (ExternalProviders.PERFORCE, IntegrationProviderSlug.PERFORCE.value),
+            (ExternalProviders.CURSOR_ORIGIN, IntegrationProviderSlug.CURSOR_ORIGIN.value),
             # TODO: do migration to delete this from database
             (ExternalProviders.CUSTOM, "custom_scm"),
         ),

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -63,6 +63,7 @@ SCM_SYNC_PROVIDERS = [
     "bitbucket_server",
     "vsts",
     "perforce",
+    "cursor_origin",
 ]
 
 SYNC_BATCH_SIZE = 100

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -19,6 +19,7 @@ class ExternalProviders(ValueEqualityEnum):
     GITHUB = 200
     GITHUB_ENTERPRISE = 201
     GITLAB = 210
+    CURSOR_ORIGIN = 220
     JIRA_SERVER = 300
     PERFORCE = 400
 
@@ -43,6 +44,7 @@ class IntegrationProviderSlug(StrEnum):
     GITLAB = "gitlab"
     BITBUCKET = "bitbucket"
     BITBUCKET_SERVER = "bitbucket_server"
+    CURSOR_ORIGIN = "cursor_origin"
     PAGERDUTY = "pagerduty"
     OPSGENIE = "opsgenie"
     PERFORCE = "perforce"
@@ -80,6 +82,7 @@ class ExternalProviderEnum(StrEnum):
     GITLAB = IntegrationProviderSlug.GITLAB
     JIRA_SERVER = IntegrationProviderSlug.JIRA_SERVER
     PERFORCE = IntegrationProviderSlug.PERFORCE
+    CURSOR_ORIGIN = IntegrationProviderSlug.CURSOR_ORIGIN
 
 
 EXTERNAL_PROVIDERS_REVERSE = {
@@ -94,6 +97,7 @@ EXTERNAL_PROVIDERS_REVERSE = {
     ExternalProviderEnum.GITHUB_ENTERPRISE: ExternalProviders.GITHUB_ENTERPRISE,
     ExternalProviderEnum.GITLAB: ExternalProviders.GITLAB,
     ExternalProviderEnum.PERFORCE: ExternalProviders.PERFORCE,
+    ExternalProviderEnum.CURSOR_ORIGIN: ExternalProviders.CURSOR_ORIGIN,
     ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
 }
 
@@ -112,6 +116,7 @@ EXTERNAL_PROVIDERS = {
     ExternalProviders.GITLAB: ExternalProviderEnum.GITLAB.value,
     ExternalProviders.JIRA_SERVER: ExternalProviderEnum.JIRA_SERVER.value,
     ExternalProviders.PERFORCE: ExternalProviderEnum.PERFORCE.value,
+    ExternalProviders.CURSOR_ORIGIN: ExternalProviderEnum.CURSOR_ORIGIN.value,
     ExternalProviders.CUSTOM: ExternalProviderEnum.CUSTOM.value,
 }
 

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -9,7 +9,10 @@ from .utils.java import find_java_source_roots
 
 METRIC_PREFIX = "auto_source_code_config"
 DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
-SUPPORTED_INTEGRATIONS = [IntegrationProviderSlug.GITHUB.value]
+SUPPORTED_INTEGRATIONS = [
+    IntegrationProviderSlug.GITHUB.value,
+    IntegrationProviderSlug.CURSOR_ORIGIN.value,
+]
 STACK_ROOT_MAX_LEVEL = 4
 
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -44,6 +44,7 @@ class IntegrationClassification(BaseClassification):
         from .parsers import (
             BitbucketRequestParser,
             BitbucketServerRequestParser,
+            CursorOriginRequestParser,
             DiscordRequestParser,
             GithubEnterpriseRequestParser,
             GithubRequestParser,
@@ -61,6 +62,7 @@ class IntegrationClassification(BaseClassification):
         active_parsers: list[type[BaseRequestParser]] = [
             BitbucketRequestParser,
             BitbucketServerRequestParser,
+            CursorOriginRequestParser,
             DiscordRequestParser,
             GoogleRequestParser,
             GithubEnterpriseRequestParser,

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,5 +1,6 @@
 from .bitbucket import BitbucketRequestParser
 from .bitbucket_server import BitbucketServerRequestParser
+from .cursor_origin import CursorOriginRequestParser
 from .discord import DiscordRequestParser
 from .github import GithubRequestParser
 from .github_enterprise import GithubEnterpriseRequestParser
@@ -16,6 +17,7 @@ from .vsts import VstsRequestParser
 __all__ = (
     "BitbucketRequestParser",
     "BitbucketServerRequestParser",
+    "CursorOriginRequestParser",
     "DiscordRequestParser",
     "GoogleRequestParser",
     "GithubEnterpriseRequestParser",

--- a/src/sentry/middleware/integrations/parsers/cursor_origin.py
+++ b/src/sentry/middleware/integrations/parsers/cursor_origin.py
@@ -2,31 +2,72 @@ from __future__ import annotations
 
 import logging
 
-from django.http.response import HttpResponseBase
+from django.http.response import HttpResponse, HttpResponseBase
 
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.types import IntegrationProviderSlug
 
 logger = logging.getLogger(__name__)
 
+# Origin puts the installation on a header, so the integration can be resolved
+# without parsing the body.
+INSTALLATION_ID_HEADER = "webhook-installation-id"
+EVENT_TYPE_HEADER = "webhook-event-type"
+
+# Events whose handling only touches the control-silo Integration row. Everything
+# else may write region data (commits, pull requests) and has to reach a cell.
+CONTROL_ONLY_EVENT_PREFIX = "installation."
+
 
 class CursorOriginRequestParser(BaseRequestParser):
-    """Keeps Cursor Origin requests in the control silo.
+    """Routes Cursor Origin webhooks to the silo that can act on them.
 
-    The only webhook handled today is ``installation.deleted``, which disables
-    the control-silo ``Integration`` row and touches nothing region-bound, so
-    there is nothing to forward. The parser still has to exist: without one,
+    Installation lifecycle disables the control-silo ``Integration`` row, so it is
+    answered in control. Everything else -- push events creating commits, and
+    later pull request activity -- writes region data and is forwarded to the
+    organizations' cells.
+
+    The parser also has to exist for the mundane reason that without one,
     ``IntegrationClassification`` reports every ``/extensions/cursor-origin/``
-    request as an unknown provider before falling through.
-
-    Handlers that write region data -- commit tracking, PR comments -- will need
-    this to resolve a cell and route through ``get_response_from_webhookpayload``
-    rather than answering in control.
+    request as an unknown provider.
     """
 
     provider = IntegrationProviderSlug.CURSOR_ORIGIN.value
     webhook_identifier = WebhookProviderIdentifier.CURSOR_ORIGIN
 
+    def get_integration_from_request(self) -> Integration | None:
+        installation_id = self.request.headers.get(INSTALLATION_ID_HEADER)
+        if not installation_id:
+            return None
+        return Integration.objects.filter(
+            external_id=installation_id, provider=self.provider
+        ).first()
+
     def get_response(self) -> HttpResponseBase:
-        return self.get_response_from_control_silo()
+        event_type = self.request.headers.get(EVENT_TYPE_HEADER) or ""
+
+        if event_type.startswith(CONTROL_ONLY_EVENT_PREFIX):
+            return self.get_response_from_control_silo()
+
+        integration = self.get_integration_from_request()
+        if not integration:
+            # A delivery for an installation we do not know about. Answering
+            # rather than erroring keeps Origin from retrying forever, and from
+            # disabling the endpoint over deliveries we could never handle.
+            logger.info(
+                "cursor_origin.parser.unknown_installation",
+                extra={"event_type": event_type},
+            )
+            return HttpResponse(status=202)
+
+        cells = self.get_cells_from_organizations()
+        if len(cells) == 0:
+            return self.get_default_missing_integration_response()
+
+        return self.get_response_from_webhookpayload(
+            cells=cells,
+            identifier=integration.id,
+            integration_id=integration.id,
+        )

--- a/src/sentry/middleware/integrations/parsers/cursor_origin.py
+++ b/src/sentry/middleware/integrations/parsers/cursor_origin.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+
+from django.http.response import HttpResponseBase
+
+from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
+from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.types import IntegrationProviderSlug
+
+logger = logging.getLogger(__name__)
+
+
+class CursorOriginRequestParser(BaseRequestParser):
+    """Keeps Cursor Origin requests in the control silo.
+
+    The only webhook handled today is ``installation.deleted``, which disables
+    the control-silo ``Integration`` row and touches nothing region-bound, so
+    there is nothing to forward. The parser still has to exist: without one,
+    ``IntegrationClassification`` reports every ``/extensions/cursor-origin/``
+    request as an unknown provider before falling through.
+
+    Handlers that write region data -- commit tracking, PR comments -- will need
+    this to resolve a cell and route through ``get_response_from_webhookpayload``
+    rather than answering in control.
+    """
+
+    provider = IntegrationProviderSlug.CURSOR_ORIGIN.value
+    webhook_identifier = WebhookProviderIdentifier.CURSOR_ORIGIN
+
+    def get_response(self) -> HttpResponseBase:
+        return self.get_response_from_control_silo()

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -99,6 +99,7 @@ _KNOWN_SCM_PROVIDERS = frozenset(
         IntegrationProviderSlug.BITBUCKET_SERVER,
         IntegrationProviderSlug.AZURE_DEVOPS,
         IntegrationProviderSlug.PERFORCE,
+        IntegrationProviderSlug.CURSOR_ORIGIN,
     }
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -681,6 +681,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Cursor Origin Integration
+register("cursor-origin-app.id", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("cursor-origin-app.name", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("cursor-origin-app.private-key", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register("cursor-origin-app.webhook-secret", flags=FLAG_CREDENTIAL)
+
 # GitHub Console SDK App (separate app for repository invitations)
 register("github-console-sdk-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github-console-sdk-app.installation-id", default="", flags=FLAG_CREDENTIAL)

--- a/src/sentry/scm/private/helpers.py
+++ b/src/sentry/scm/private/helpers.py
@@ -1,10 +1,31 @@
-from typing import cast
+import importlib
+from typing import Any, cast
 
 import sentry_sdk
 from django.db.models import Q
 from scm.providers.github.provider import GitHubProvider
 from scm.providers.gitlab.provider import GitLabProvider
 from scm.types import Provider, Repository, RepositoryId
+
+
+def _cursor_origin_provider_cls() -> Any:
+    """The Cursor Origin provider class, when the installed scm build has one.
+
+    WIP. sentry-scm 1.5.0 predates the provider, so a plain import would take
+    down every SCM code path rather than just Origin. Resolved dynamically so
+    this module type-checks identically whether or not the newer build is
+    installed -- a guarded `import` flips between "unresolvable" and "unused
+    ignore" depending on which is present, which makes CI depend on install
+    order.
+
+    Remove this once the sentry-scm pin includes the provider.
+    """
+    try:
+        module = importlib.import_module("scm.providers.cursor_origin.provider")
+    except ImportError:
+        return None
+    return module.CursorOriginProvider
+
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.errors import OrganizationIntegrationNotFound
@@ -31,6 +52,9 @@ def fetch_service_provider(organization_id: int, repository: Repository) -> Prov
         return GitHubProvider(client, organization_id, repository)
     elif integration.provider == "gitlab":
         return GitLabProvider(client, organization_id, repository)
+    elif integration.provider == "cursor_origin":
+        provider_cls = _cursor_origin_provider_cls()
+        return provider_cls(client, organization_id, repository) if provider_cls else None
     else:
         return None
 

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -420,7 +420,13 @@ def deserialize_raw_event(event: SubscriptionEvent) -> EventType | None:
     elif event["type"] == "gitlab":
         raise SCMProviderNotSupported("GitLab has not been implemented.")
     else:
-        assert_never(event["type"])
+        # Deliberately a runtime raise rather than assert_never. The union comes
+        # from the installed sentry-scm, so exhaustiveness here depends on which
+        # build is present: a release that predates a provider makes a branch for
+        # it unreachable, while a newer one makes its absence a non-exhaustive
+        # match. Either way mypy fails somewhere that looks unrelated to the
+        # provider actually being added.
+        raise SCMProviderNotSupported(f"{event['type']} has not been implemented.")
 
 
 def serialize_event(event: EventType) -> str:

--- a/src/sentry/seer/constants.py
+++ b/src/sentry/seer/constants.py
@@ -10,6 +10,8 @@ SeerSCMProvider = Literal[
     "github",
     "github_enterprise",
     "gitlab",
+    "integrations:cursor_origin",
+    "cursor_origin",
 ]
 
 # Supported repository providers for Seer features
@@ -23,4 +25,12 @@ SEER_SUPPORTED_SCM_PROVIDERS = [
 SEER_GITLAB_SCM_PROVIDERS = [
     "integrations:gitlab",
     IntegrationProviderSlug.GITLAB.value,
+]
+
+# WIP. Feature-gated like GitLab was, because Seer's own support is still
+# landing: Origin has no inline review comments, so a review there is one prose
+# comment rather than diff-anchored ones.
+SEER_CURSOR_ORIGIN_SCM_PROVIDERS = [
+    "integrations:cursor_origin",
+    IntegrationProviderSlug.CURSOR_ORIGIN.value,
 ]

--- a/src/sentry/seer/seer_setup.py
+++ b/src/sentry/seer/seer_setup.py
@@ -3,7 +3,11 @@ from django.contrib.auth.models import AnonymousUser
 from sentry import features
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.seer.constants import SEER_GITLAB_SCM_PROVIDERS, SEER_SUPPORTED_SCM_PROVIDERS
+from sentry.seer.constants import (
+    SEER_CURSOR_ORIGIN_SCM_PROVIDERS,
+    SEER_GITLAB_SCM_PROVIDERS,
+    SEER_SUPPORTED_SCM_PROVIDERS,
+)
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
@@ -12,6 +16,10 @@ def get_supported_scm_providers(organization: Organization | None = None) -> lis
     providers = list(SEER_SUPPORTED_SCM_PROVIDERS)
     if organization is not None and features.has("organizations:seer-gitlab-support", organization):
         providers.extend(SEER_GITLAB_SCM_PROVIDERS)
+    if organization is not None and features.has(
+        "organizations:seer-cursor-origin-support", organization
+    ):
+        providers.extend(SEER_CURSOR_ORIGIN_SCM_PROVIDERS)
     return providers
 
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1358,6 +1358,10 @@ urlpatterns += [
                     include("sentry.integrations.github_enterprise.urls"),
                 ),
                 re_path(
+                    r"^cursor-origin/",
+                    include("sentry.integrations.cursor_origin.urls"),
+                ),
+                re_path(
                     r"^gitlab/",
                     include("sentry.integrations.gitlab.urls"),
                 ),

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -23,6 +23,10 @@ const FEATURE_GATED_PROVIDERS: Array<{
     flag: 'seer-gitlab-support',
     providerIds: ['gitlab', 'integrations:gitlab'],
   },
+  {
+    flag: 'seer-cursor-origin-support',
+    providerIds: ['cursor_origin', 'integrations:cursor_origin'],
+  },
 ];
 
 /**

--- a/static/app/components/onboarding/scm/scmProviderOrder.ts
+++ b/static/app/components/onboarding/scm/scmProviderOrder.ts
@@ -5,7 +5,12 @@ import type {IntegrationProvider} from 'sentry/types/integrations';
  * render as top-level pill buttons; everything else follows in its original
  * order (grouped into the "More" dropdown there).
  */
-const PRIMARY_PROVIDER_KEYS: readonly string[] = ['github', 'gitlab', 'bitbucket'];
+const PRIMARY_PROVIDER_KEYS: readonly string[] = [
+  'github',
+  'gitlab',
+  'bitbucket',
+  'cursor_origin',
+];
 
 /** Sort rank for a provider key: primaries by their index, everything else after. */
 function providerOrderRank(key: string): number {

--- a/static/app/components/onboarding/scm/useScmPlatformDetection.ts
+++ b/static/app/components/onboarding/scm/useScmPlatformDetection.ts
@@ -17,12 +17,18 @@ interface PlatformDetectionResponse {
   platforms: DetectedPlatform[];
 }
 
-const SUPPORTED_PROVIDER = 'integrations:github';
+// Providers whose backend client can serve platform detection. Kept in sync with
+// SUPPORTED_PROVIDERS in organization_repository_platforms.py -- a repo not listed
+// here skips detection and falls back to the manual platform picker.
+const SUPPORTED_PROVIDERS: readonly string[] = [
+  'integrations:github',
+  'integrations:cursor_origin',
+];
 
 export function useScmPlatformDetection(repository: Repository | undefined) {
   const organization = useOrganization();
   const repoId = repository?.id;
-  const isSupported = repository?.provider.id === SUPPORTED_PROVIDER;
+  const isSupported = SUPPORTED_PROVIDERS.includes(repository?.provider.id ?? '');
   // Empty id means we have an optimistic repo from useScmRepoSelection;
   // the resolved repo with a real id arrives via a subsequent onSelect
   // call. The query can only fetch once we have a real id.

--- a/static/app/components/pipeline/integrationCursorOrigin/index.tsx
+++ b/static/app/components/pipeline/integrationCursorOrigin/index.tsx
@@ -1,0 +1,116 @@
+import {useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {useRedirectPopupStep} from 'sentry/components/pipeline/shared/useRedirectPopupStep';
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+interface InstallStepData {
+  installUrl?: string;
+}
+
+interface InstallAdvanceData {
+  state: string;
+  installation_id?: string;
+  installation_receipt?: string;
+}
+
+/**
+ * Cursor Origin installs in a single step.
+ *
+ * Origin's install redirect returns a signed installation receipt directly, so
+ * unlike GitHub there is no separate OAuth login leg and no organization
+ * selection — one popup and the pipeline is done.
+ */
+function InstallStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<InstallStepData, InstallAdvanceData>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      // `state` is always present on a well-formed callback, since we put it
+      // there. Passing an empty string through when it is missing lets the
+      // backend reject it with a real "invalid state" message rather than
+      // having the step silently do nothing.
+      advance({
+        state: data.state ?? '',
+        installation_receipt: data.installation_receipt,
+        installation_id: data.installation_id,
+      });
+    },
+    [advance]
+  );
+
+  const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData?.installUrl,
+    onCallback: handleCallback,
+  });
+
+  if (stepData === null) {
+    return null;
+  }
+
+  if (isWaitingForCallback || isAdvancing) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            'Complete the installation in the popup window. Once finished, this page will update automatically.'
+          )}
+        </Text>
+        <Button size="sm" onClick={openPopup} busy={isAdvancing}>
+          {t('Reopen installation window')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="lg" align="start">
+      <Text>
+        {t(
+          'Install the Sentry app on your Cursor Origin codebase to connect your repositories.'
+        )}
+      </Text>
+      {popupStatus === 'failed-to-open' && (
+        <Text variant="danger" size="sm">
+          {t(
+            'The installation popup was blocked by your browser. Please ensure popups are allowed and try again.'
+          )}
+        </Text>
+      )}
+      <Button
+        size="sm"
+        variant="primary"
+        onClick={openPopup}
+        disabled={!stepData.installUrl}
+      >
+        {t('Install Cursor Origin App')}
+      </Button>
+    </Stack>
+  );
+}
+
+export const cursorOriginIntegrationPipeline = {
+  type: 'integration',
+  provider: 'cursor_origin',
+  actionTitle: t('Installing Cursor Origin Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'install',
+      shortDescription: t('Installing Cursor Origin Application'),
+      component: InstallStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -4,6 +4,7 @@ import {bitbucketIntegrationPipeline} from './integrationBitbucket';
 import {bitbucketServerIntegrationPipeline} from './integrationBitbucketServer';
 import {claudeCodeIntegrationPipeline} from './integrationClaudeCode';
 import {cursorIntegrationPipeline} from './integrationCursor';
+import {cursorOriginIntegrationPipeline} from './integrationCursorOrigin';
 import {datadogIntegrationPipeline} from './integrationDatadog';
 import {discordIntegrationPipeline} from './integrationDiscord';
 import {gcpIntegrationPipeline} from './integrationGcp';
@@ -32,6 +33,7 @@ export const PIPELINE_REGISTRY = [
   bitbucketServerIntegrationPipeline,
   claudeCodeIntegrationPipeline,
   cursorIntegrationPipeline,
+  cursorOriginIntegrationPipeline,
   datadogIntegrationPipeline,
   discordIntegrationPipeline,
   dummyIntegrationPipeline,

--- a/static/app/icons/pluginIcon.tsx
+++ b/static/app/icons/pluginIcon.tsx
@@ -49,6 +49,9 @@ const PLUGIN_ICONS = {
   aws_lambda: aws,
   claude_code,
   cursor,
+  // Origin is a Cursor product and ships no separate mark of its own, so it uses
+  // the Cursor logo. Swap this if Origin gets its own.
+  cursor_origin: cursor,
   datadog,
   datadog_pat: datadog,
   asana,

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -12,6 +12,7 @@ import {
   IconSentry,
   IconVsts,
 } from 'sentry/icons';
+import {PluginIcon} from 'sentry/icons/pluginIcon';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {getOverride} from 'sentry/overrideRegistry';
@@ -207,6 +208,11 @@ export const getIntegrationIcon = (
       return <IconJira size={iconSize} />;
     case 'perforce':
       return <IconPerforce size={iconSize} />;
+    case 'cursor':
+    case 'cursor_origin':
+      // sentry/icons has no monochrome brand glyph for Cursor, so use the real
+      // logo asset rather than falling through to IconGeneric.
+      return <PluginIcon pluginId="cursor" size={iconSize === 'sm' ? 16 : 20} />;
     case 'vsts':
       return <IconVsts size={iconSize} />;
     default:

--- a/static/app/views/settings/organizationIntegrations/constants.tsx
+++ b/static/app/views/settings/organizationIntegrations/constants.tsx
@@ -29,6 +29,7 @@ export const POPULARITY_WEIGHT: Record<string, number> = {
   msteams: 15,
   aws_lambda: 10,
   cursor: 14,
+  cursor_origin: 14,
 
   // Plugins
   webhooks: 10,

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -126,6 +126,7 @@ const SCM_PROVIDER_ORDER = [
   'bitbucket',
   'bitbucket_server',
   'vsts',
+  'cursor_origin',
 ];
 
 export default function OrganizationRepositories() {

--- a/tests/sentry/integrations/cursor_origin/test_client.py
+++ b/tests/sentry/integrations/cursor_origin/test_client.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.testutils.cases import TestCase
+
+
+class RecordingClient(CursorOriginSetupApiClient):
+    """Captures the request the client would make, without issuing it.
+
+    Overriding `request` short-circuits below the path-rewriting layer, so the
+    rewrite is exercised for real while nothing leaves the process (and no
+    token is minted, since authorize_request never runs).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(installation_id="i_test")
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        self.calls.append((path, kwargs))
+        return {}
+
+
+class ContentsPathRewriteTest(TestCase):
+    """The rewrite that lets Sentry's GitHub-shaped helpers work against Origin.
+
+    Origin serves contents from `/contents?path=...`; the documented
+    `/contents/{path}` form 404s. Detection, CODEOWNERS lookups and stacktrace
+    linking all build the GitHub-shaped path, so the client rewrites it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.api_client = RecordingClient()
+
+    def test_rewrites_github_shaped_contents_path(self) -> None:
+        self.api_client.get("/repos/sentry/nuget-trends/contents/README.md")
+        path, kwargs = self.api_client.calls[-1]
+        assert path == "/repos/sentry/nuget-trends/contents"
+        assert kwargs["params"]["path"] == "README.md"
+
+    def test_preserves_existing_params_when_rewriting(self) -> None:
+        self.api_client.get(
+            "/repos/sentry/nuget-trends/contents/src/App.cs", params={"ref": "main"}
+        )
+        _, kwargs = self.api_client.calls[-1]
+        assert kwargs["params"] == {"ref": "main", "path": "src/App.cs"}
+
+    def test_rewrites_nested_paths_whole(self) -> None:
+        self.api_client.get("/repos/o/r/contents/a/b/c/d.py")
+        path, kwargs = self.api_client.calls[-1]
+        assert path == "/repos/o/r/contents"
+        assert kwargs["params"]["path"] == "a/b/c/d.py"
+
+    def test_leaves_other_paths_alone(self) -> None:
+        for path in (
+            "/repos/o/r/git/trees/main",
+            "/installation/repos",
+            "/repos/o/r/contents",
+        ):
+            self.api_client.get(path)
+            assert self.api_client.calls[-1][0] == path
+
+
+class RateLimitTrackingTest(TestCase):
+    """repo_trees backs off on a low remaining budget, so this has to be real."""
+
+    def test_seeds_with_documented_budget_before_any_request(self) -> None:
+        # Reporting 0 here would read as "exhausted" and make callers back off
+        # before we had made a single request.
+        assert CursorOriginSetupApiClient(installation_id="i_test").get_remaining_api_requests()
+
+    def test_captures_remaining_from_response_headers(self) -> None:
+        client = CursorOriginSetupApiClient(installation_id="i_test")
+
+        class FakeResponse:
+            headers = {"x-ratelimit-remaining": "2847"}
+
+        client.track_response_data(200, None, FakeResponse())  # type: ignore[arg-type]
+        assert client.get_remaining_api_requests() == 2847
+
+    def test_ignores_a_malformed_header(self) -> None:
+        client = CursorOriginSetupApiClient(installation_id="i_test")
+        before = client.get_remaining_api_requests()
+
+        class FakeResponse:
+            headers = {"x-ratelimit-remaining": "not-a-number"}
+
+        client.track_response_data(200, None, FakeResponse())  # type: ignore[arg-type]
+        assert client.get_remaining_api_requests() == before

--- a/tests/sentry/integrations/cursor_origin/test_commits.py
+++ b/tests/sentry/integrations/cursor_origin/test_commits.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from sentry.integrations.cursor_origin.repository import CursorOriginRepositoryProvider
+from sentry.testutils.cases import TestCase
+
+
+def commit(sha: str, message: str = "msg") -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "commit": {
+            "author": {
+                "name": "Bruno",
+                "email": "bruno@example.com",
+                "date": "2026-01-01T00:00:00Z",
+            },
+            "message": message,
+        },
+    }
+
+
+class CompareCommitsWalkTest(TestCase):
+    """Origin's compare endpoint returns only counts and boundary commits.
+
+    There is no route giving the commits or files between two arbitrary shas, so
+    the range is rebuilt by walking back from the head.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+
+        self.api_client = CursorOriginSetupApiClient(installation_id="i_01example")
+
+    def _walk(self, history: list[str], start: str, end: str) -> list[str]:
+        with patch.object(
+            type(self.api_client), "get_commits", return_value=[commit(s) for s in history]
+        ):
+            result = self.api_client.compare_commits("o/r", start, end)
+        return [c["sha"] for c in result]
+
+    def test_returns_range_oldest_first_excluding_start(self) -> None:
+        # get_commits returns newest first; releases want oldest first, and the
+        # already-released start sha must not be re-associated.
+        assert self._walk(["d", "c", "b", "a"], start="a", end="d") == ["b", "c", "d"]
+
+    def test_single_commit_range(self) -> None:
+        assert self._walk(["b", "a"], start="a", end="b") == ["b"]
+
+    def test_returns_empty_when_head_is_the_start(self) -> None:
+        assert self._walk(["a", "z"], start="a", end="a") == []
+
+    def test_truncates_rather_than_failing_when_start_is_unreachable(self) -> None:
+        # A shallow walk that never finds the start sha still returns what it
+        # saw -- a truncated release beats a failed one.
+        assert self._walk(["d", "c", "b"], start="missing", end="d") == ["b", "c", "d"]
+
+
+class TransformPatchsetTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
+
+    def test_maps_statuses(self) -> None:
+        assert self.provider._transform_patchset(
+            [
+                {"filename": "a.py", "status": "modified"},
+                {"filename": "b.py", "status": "added"},
+                {"filename": "c.py", "status": "removed"},
+            ]
+        ) == [
+            {"path": "a.py", "type": "M"},
+            {"path": "b.py", "type": "A"},
+            {"path": "c.py", "type": "D"},
+        ]
+
+    def test_rename_becomes_a_delete_and_an_add(self) -> None:
+        assert self.provider._transform_patchset(
+            [{"filename": "new.py", "previous_filename": "old.py", "status": "renamed"}]
+        ) == [{"path": "old.py", "type": "D"}, {"path": "new.py", "type": "A"}]
+
+    def test_rename_without_previous_name_still_records_the_add(self) -> None:
+        assert self.provider._transform_patchset([{"filename": "new.py", "status": "renamed"}]) == [
+            {"path": "new.py", "type": "A"}
+        ]
+
+    def test_skips_unknown_status_and_missing_filename(self) -> None:
+        assert (
+            self.provider._transform_patchset(
+                [{"filename": "a.py", "status": "unchanged"}, {"status": "modified"}]
+            )
+            == []
+        )

--- a/tests/sentry/integrations/cursor_origin/test_error_classification.py
+++ b/tests/sentry/integrations/cursor_origin/test_error_classification.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.testutils.cases import TestCase
+
+TOKEN_URL = "https://api.cursor.com/v1/origin/app/installations/i_01example/access_tokens"
+REPO_URL = "https://api.cursor.com/v1/origin/repos/sentry/nuget-trends"
+
+
+class ErrorClassificationTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            external_id="i_01example",
+            name="sentry",
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, CursorOriginIntegration)
+        self.installation = installation
+
+    def test_rate_limiting_is_recognised(self) -> None:
+        # The base class calls no error rate-limited, so without the override a
+        # 429 would be reported as a broken integration.
+        assert self.installation.is_rate_limited_error(ApiError("slow down", code=429))
+        assert not self.installation.is_rate_limited_error(ApiError("nope", code=404))
+
+    def test_a_failed_token_exchange_is_terminal(self) -> None:
+        # Once an install is revoked, every call fails at the exchange rather
+        # than on the resource. Generic handling reads that as an ordinary 404
+        # and retries forever.
+        for code in (401, 403, 404):
+            assert (
+                self.installation.is_broken_integration_error(
+                    ApiError("gone", code=code, url=TOKEN_URL)
+                )
+                == "installation_suspended"
+            )
+
+    def test_rate_limiting_on_the_token_route_is_not_terminal(self) -> None:
+        assert (
+            self.installation.is_broken_integration_error(
+                ApiError("slow down", code=429, url=TOKEN_URL)
+            )
+            == "rate_limited"
+        )
+
+    def test_a_missing_repository_is_not_terminal(self) -> None:
+        # A 404 on a resource means that resource is gone, not the install.
+        assert (
+            self.installation.is_broken_integration_error(
+                ApiError("no such repo", code=404, url=REPO_URL)
+            )
+            is None
+        )
+
+    def test_falls_back_to_the_shared_classification(self) -> None:
+        assert (
+            self.installation.is_broken_integration_error(ApiUnauthorized("bad token"))
+            == "unauthorized"
+        )

--- a/tests/sentry/integrations/cursor_origin/test_languages.py
+++ b/tests/sentry/integrations/cursor_origin/test_languages.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from sentry.integrations.cursor_origin.languages import languages_from_tree
+from sentry.testutils.cases import TestCase
+
+
+def blob(path: str, size: int = 100) -> dict[str, object]:
+    return {"path": path, "type": "blob", "size": size, "sha": "x", "mode": "100644"}
+
+
+def tree(path: str) -> dict[str, object]:
+    return {"path": path, "type": "tree", "sha": "x", "mode": "040000"}
+
+
+class LanguagesFromTreeTest(TestCase):
+    def test_sums_bytes_per_language(self) -> None:
+        assert languages_from_tree(
+            [
+                blob("app/main.py", 300),
+                blob("app/util.py", 200),
+                blob("web/index.ts", 50),
+            ]
+        ) == {"Python": 500, "TypeScript": 50}
+
+    def test_uses_linguist_names_so_the_platform_registry_matches(self) -> None:
+        # These keys must match GITHUB_LANGUAGE_TO_SENTRY_PLATFORM exactly, or
+        # detection silently finds nothing.
+        from sentry.integrations.github.platform_registry import (
+            GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
+        )
+
+        detected = languages_from_tree(
+            [blob("Api.cs"), blob("main.go"), blob("app.rb"), blob("lib.rs")]
+        )
+        assert set(detected) <= set(GITHUB_LANGUAGE_TO_SENTRY_PLATFORM)
+        assert detected == {"C#": 100, "Go": 100, "Ruby": 100, "Rust": 100}
+
+    def test_skips_trees_which_carry_no_size(self) -> None:
+        assert languages_from_tree([tree("app"), blob("app/main.py", 10)]) == {"Python": 10}
+
+    def test_excludes_vendored_and_build_output(self) -> None:
+        # A checked-in node_modules or .NET obj/ directory would otherwise
+        # drown out the actual application code.
+        assert languages_from_tree(
+            [
+                blob("src/App.cs", 100),
+                blob("node_modules/left-pad/index.js", 9999),
+                blob("src/obj/Debug/Generated.cs", 9999),
+            ]
+        ) == {"C#": 100}
+
+    def test_excludes_tests(self) -> None:
+        assert languages_from_tree([blob("src/app.py", 100), blob("tests/test_app.py", 9999)]) == {
+            "Python": 100
+        }
+
+    def test_ignores_unmapped_and_extensionless_files(self) -> None:
+        assert languages_from_tree([blob("README.md"), blob("Makefile"), blob("go.sum")]) == {}
+
+    def test_drops_languages_whose_files_are_all_empty(self) -> None:
+        # A zero-weight language would register as a detected platform with no
+        # evidence behind it.
+        assert languages_from_tree([blob("empty.py", 0)]) == {}
+
+    def test_extension_matching_is_case_insensitive(self) -> None:
+        assert languages_from_tree([blob("Program.CS", 10)]) == {"C#": 10}
+
+    def test_empty_tree(self) -> None:
+        assert languages_from_tree([]) == {}

--- a/tests/sentry/integrations/cursor_origin/test_languages.py
+++ b/tests/sentry/integrations/cursor_origin/test_languages.py
@@ -65,5 +65,16 @@ class LanguagesFromTreeTest(TestCase):
     def test_extension_matching_is_case_insensitive(self) -> None:
         assert languages_from_tree([blob("Program.CS", 10)]) == {"C#": 10}
 
+    def test_tolerates_a_stringified_size(self) -> None:
+        # Origin serialises 64-bit ints as JSON strings in places -- `size` on
+        # the contents route comes back as "2534". Tree entries use real ints
+        # today, but a bare += would be a TypeError waiting to happen.
+        assert languages_from_tree([{"path": "a.py", "type": "blob", "size": "300"}]) == {
+            "Python": 300
+        }
+
+    def test_ignores_an_unparseable_size(self) -> None:
+        assert languages_from_tree([{"path": "a.py", "type": "blob", "size": "big"}]) == {}
+
     def test_empty_tree(self) -> None:
         assert languages_from_tree([]) == {}

--- a/tests/sentry/integrations/cursor_origin/test_repository.py
+++ b/tests/sentry/integrations/cursor_origin/test_repository.py
@@ -10,10 +10,10 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.testutils.cases import TestCase
 
 REPO_PAYLOAD: dict[str, Any] = {
-    "id": "r_01m08sz0y6eny815ggv768qsjp",
+    "id": "r_01example000000000000repo",
     "name": "nuget-trends",
     "fullName": "sentry/nuget-trends",
-    "owner": {"slug": "sentry", "id": "ns_01kzygm43nfad9gfxqx3nxqvf4"},
+    "owner": {"slug": "sentry", "id": "ns_01example00000000000000ns"},
     "defaultBranch": "main",
     "cloneUrl": "https://origin.cursor.com/sentry/nuget-trends.git",
 }
@@ -26,7 +26,7 @@ class CursorOriginRepositoryProviderTest(TestCase):
             organization=self.organization,
             provider="cursor_origin",
             name="sentry",
-            external_id="i_01m08t5nksemgsd2agkna3xe1c",
+            external_id="i_01example00000000000inst",
         )
         self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
 
@@ -43,7 +43,7 @@ class CursorOriginRepositoryProviderTest(TestCase):
 
     def test_get_repository_data_maps_origin_fields(self) -> None:
         data = self._get_repository_data()
-        assert data["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert data["external_id"] == "r_01example000000000000repo"
         assert data["name"] == "sentry/nuget-trends"
         assert data["default_branch"] == "main"
 
@@ -60,7 +60,7 @@ class CursorOriginRepositoryProviderTest(TestCase):
         data = self._get_repository_data()
         config = self.provider.build_repository_config(self.organization, data)
         assert config["name"] == "sentry/nuget-trends"
-        assert config["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert config["external_id"] == "r_01example000000000000repo"
         assert config["url"] == "https://cursor.com/codebase/sentry/nuget-trends"
         assert config["integration_id"] == self.integration.id
         assert config["config"]["default_branch"] == "main"

--- a/tests/sentry/integrations/cursor_origin/test_repository.py
+++ b/tests/sentry/integrations/cursor_origin/test_repository.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from sentry.integrations.cursor_origin.repository import CursorOriginRepositoryProvider
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.testutils.cases import TestCase
+
+REPO_PAYLOAD: dict[str, Any] = {
+    "id": "r_01m08sz0y6eny815ggv768qsjp",
+    "name": "nuget-trends",
+    "fullName": "sentry/nuget-trends",
+    "owner": {"slug": "sentry", "id": "ns_01kzygm43nfad9gfxqx3nxqvf4"},
+    "defaultBranch": "main",
+    "cloneUrl": "https://origin.cursor.com/sentry/nuget-trends.git",
+}
+
+
+class CursorOriginRepositoryProviderTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            name="sentry",
+            external_id="i_01m08t5nksemgsd2agkna3xe1c",
+        )
+        self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
+
+    def _get_repository_data(self) -> dict[str, Any]:
+        config: dict[str, Any] = {
+            "installation": self.integration.id,
+            "identifier": "sentry/nuget-trends",
+        }
+        with patch(
+            "sentry.integrations.cursor_origin.client.CursorOriginSetupApiClient.get_repo",
+            return_value=REPO_PAYLOAD,
+        ):
+            return dict(self.provider.get_repository_data(self.organization, config))
+
+    def test_get_repository_data_maps_origin_fields(self) -> None:
+        data = self._get_repository_data()
+        assert data["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert data["name"] == "sentry/nuget-trends"
+        assert data["default_branch"] == "main"
+
+    def test_get_repository_data_sets_integration_id(self) -> None:
+        # build_repository_config reads this key. Omitting it made repository
+        # creation 500 with a bare KeyError *after* both Origin calls had
+        # already succeeded, which read like an API failure rather than a
+        # missing field.
+        assert self._get_repository_data()["integration_id"] == self.integration.id
+
+    def test_build_repository_config_consumes_what_get_repository_data_produces(self) -> None:
+        # The pairing is the point: these two ran fine in isolation while the
+        # handoff between them was broken.
+        data = self._get_repository_data()
+        config = self.provider.build_repository_config(self.organization, data)
+        assert config["name"] == "sentry/nuget-trends"
+        assert config["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert config["url"] == "https://cursor.com/codebase/sentry/nuget-trends"
+        assert config["integration_id"] == self.integration.id
+        assert config["config"]["default_branch"] == "main"
+
+    def test_unreadable_repo_raises_integration_error(self) -> None:
+        config = {"installation": self.integration.id, "identifier": "sentry/nope"}
+        with patch(
+            "sentry.integrations.cursor_origin.client.CursorOriginSetupApiClient.get_repo",
+            side_effect=ApiError("not found"),
+        ):
+            with pytest.raises(IntegrationError):
+                self.provider.get_repository_data(self.organization, config)

--- a/tests/sentry/integrations/cursor_origin/test_token_cache.py
+++ b/tests/sentry/integrations/cursor_origin/test_token_cache.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+
+from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.testutils.cases import TestCase
+
+LOCMEM = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+INSTALLATION = "i_01example"
+
+
+@override_settings(CACHES=LOCMEM)
+class InstallationTokenCacheTest(TestCase):
+    """A fresh client per call site must not mean a fresh token per call site.
+
+    `get_installation().get_client()` builds a new client every time, so an
+    instance-only cache meant one token exchange per call. Minting is charged
+    against the app-JWT budget, which is the smaller of Origin's two.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+
+    def _client(self) -> CursorOriginSetupApiClient:
+        return CursorOriginSetupApiClient(installation_id=INSTALLATION)
+
+    def test_a_second_client_reuses_the_cached_token(self) -> None:
+        with patch.object(
+            CursorOriginSetupApiClient, "post", return_value={"token": "oit_first"}
+        ) as post:
+            assert self._client().get_access_token() == "oit_first"
+            assert self._client().get_access_token() == "oit_first"
+            assert self._client().get_access_token() == "oit_first"
+
+        assert post.call_count == 1
+
+    def test_mints_again_once_the_cache_is_gone(self) -> None:
+        # Eviction is harmless -- it costs one exchange, not a failure.
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"token": "oit_a"}):
+            assert self._client().get_access_token() == "oit_a"
+
+        cache.clear()
+
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"token": "oit_b"}):
+            assert self._client().get_access_token() == "oit_b"
+
+    def test_tokens_are_not_shared_between_installations(self) -> None:
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"token": "oit_one"}):
+            CursorOriginSetupApiClient(installation_id="i_one").get_access_token()
+
+        with patch.object(
+            CursorOriginSetupApiClient, "post", return_value={"token": "oit_two"}
+        ) as post:
+            token = CursorOriginSetupApiClient(installation_id="i_two").get_access_token()
+
+        assert token == "oit_two"
+        assert post.call_count == 1
+
+    def test_rejects_a_response_without_a_token(self) -> None:
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"nope": "x"}):
+            with pytest.raises(ApiError):
+                self._client().get_access_token()
+
+    def test_requires_an_installation_id(self) -> None:
+        with pytest.raises(ValueError):
+            CursorOriginSetupApiClient().get_access_token()
+
+    def test_does_not_cache_across_a_missing_installation(self) -> None:
+        def fake_post(self: Any, path: str, *a: Any, **k: Any) -> dict[str, str]:
+            return {"token": "oit_x"}
+
+        with patch.object(CursorOriginSetupApiClient, "post", fake_post):
+            client = self._client()
+            first = client.get_access_token()
+            # Same instance short-circuits before touching the cache at all.
+            assert client.get_access_token() == first

--- a/tests/sentry/integrations/cursor_origin/test_webhook_signature.py
+++ b/tests/sentry/integrations/cursor_origin/test_webhook_signature.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from unittest.mock import patch
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from sentry.integrations.cursor_origin.webhook_signature import (
+    is_timestamp_fresh,
+    verify_signature,
+)
+from sentry.testutils.cases import TestCase
+
+WEBHOOK_ID = "whd_01example"
+BODY = b'{"event":{"type":"repository.pushed"}}'
+
+
+def sign(key: Ed25519PrivateKey, webhook_id: str, timestamp: str, body: bytes) -> str:
+    digest = hashlib.sha256(b".".join([webhook_id.encode(), timestamp.encode(), body])).hexdigest()
+    return "v1ed," + base64.b64encode(key.sign(digest.encode())).decode()
+
+
+class TimestampFreshnessTest(TestCase):
+    def test_accepts_recent(self) -> None:
+        assert is_timestamp_fresh(str(int(time.time())))
+
+    def test_rejects_old(self) -> None:
+        assert not is_timestamp_fresh(str(int(time.time()) - 600))
+
+    def test_rejects_far_future(self) -> None:
+        # A clock-skewed sender is one thing; an hour ahead is a replay vector.
+        assert not is_timestamp_fresh(str(int(time.time()) + 3600))
+
+    def test_rejects_garbage(self) -> None:
+        assert not is_timestamp_fresh("not-a-timestamp")
+        assert not is_timestamp_fresh("")
+
+
+class VerifySignatureTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.key = Ed25519PrivateKey.generate()
+        self.public_bytes = self.key.public_key().public_bytes_raw()
+        self.timestamp = str(int(time.time()))
+
+    def _verify(self, signature: str, body: bytes = BODY, keys: list[bytes] | None = None) -> bool:
+        with patch(
+            "sentry.integrations.cursor_origin.webhook_signature.fetch_public_keys",
+            return_value=[self.public_bytes] if keys is None else keys,
+        ):
+            return verify_signature(WEBHOOK_ID, self.timestamp, body, signature)
+
+    def test_accepts_a_valid_signature(self) -> None:
+        assert self._verify(sign(self.key, WEBHOOK_ID, self.timestamp, BODY))
+
+    def test_rejects_when_body_is_tampered_with(self) -> None:
+        signature = sign(self.key, WEBHOOK_ID, self.timestamp, BODY)
+        assert not self._verify(signature, body=BODY + b" ")
+
+    def test_rejects_a_signature_bound_to_a_different_delivery(self) -> None:
+        # The id is part of the signed payload, so a replayed signature from
+        # another delivery must not verify.
+        other = sign(self.key, "whd_01other", self.timestamp, BODY)
+        assert not self._verify(other)
+
+    def test_rejects_a_signature_from_an_unknown_key(self) -> None:
+        stranger = Ed25519PrivateKey.generate()
+        assert not self._verify(sign(stranger, WEBHOOK_ID, self.timestamp, BODY))
+
+    def test_accepts_when_one_of_several_keys_matches(self) -> None:
+        # Signatures carry no key id, so every active key is tried. Rotation
+        # means the right key is often not the first.
+        others = [Ed25519PrivateKey.generate().public_key().public_bytes_raw() for _ in range(2)]
+        assert self._verify(
+            sign(self.key, WEBHOOK_ID, self.timestamp, BODY),
+            keys=[*others, self.public_bytes],
+        )
+
+    def test_rejects_missing_version_prefix(self) -> None:
+        raw = sign(self.key, WEBHOOK_ID, self.timestamp, BODY).removeprefix("v1ed,")
+        assert not self._verify(raw)
+
+    def test_rejects_malformed_base64(self) -> None:
+        assert not self._verify("v1ed,!!!not-base64!!!")
+
+    def test_rejects_when_no_keys_are_available(self) -> None:
+        # A JWKS fetch failure must not fail open.
+        assert not self._verify(sign(self.key, WEBHOOK_ID, self.timestamp, BODY), keys=[])

--- a/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
@@ -1,0 +1,46 @@
+import responses
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory
+
+from sentry.middleware.integrations.classifications import IntegrationClassification
+from sentry.middleware.integrations.parsers.cursor_origin import CursorOriginRequestParser
+from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import assert_no_webhook_payloads
+from sentry.testutils.silo import control_silo_test
+
+WEBHOOK_PATH = "/extensions/cursor-origin/webhook/"
+
+
+@control_silo_test
+class CursorOriginRequestParserTest(TestCase):
+    factory = RequestFactory()
+
+    def get_response(self, request: HttpRequest) -> HttpResponse:
+        return HttpResponse(status=200, content="passthrough")
+
+    @responses.activate
+    def test_routing_all_to_control(self) -> None:
+        request = self.factory.post(WEBHOOK_PATH)
+        parser = CursorOriginRequestParser(request=request, response_handler=self.get_response)
+
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 200
+        assert response.content == b"passthrough"
+        assert len(responses.calls) == 0
+        assert_no_webhook_payloads()
+
+    def test_registered_for_the_hyphenated_url(self) -> None:
+        """The URL says ``cursor-origin`` and the provider slug says
+        ``cursor_origin``; the classification normalizes between them. Without a
+        parser registered under the normalized name it reports every delivery as
+        an unknown provider, so assert the lookup actually lands here.
+        """
+        classification = IntegrationClassification(response_handler=self.get_response)
+        request = self.factory.post(WEBHOOK_PATH)
+
+        provider = classification._identify_provider(request)
+
+        assert provider == "cursor_origin"
+        assert classification.integration_parsers[provider] is CursorOriginRequestParser

--- a/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
@@ -18,18 +18,57 @@ class CursorOriginRequestParserTest(TestCase):
     def get_response(self, request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=200, content="passthrough")
 
-    @responses.activate
-    def test_routing_all_to_control(self) -> None:
-        request = self.factory.post(WEBHOOK_PATH)
-        parser = CursorOriginRequestParser(request=request, response_handler=self.get_response)
+    def _parser(self, event_type: str | None = None, installation_id: str | None = None):
+        headers = {}
+        if event_type:
+            headers["HTTP_WEBHOOK_EVENT_TYPE"] = event_type
+        if installation_id:
+            headers["HTTP_WEBHOOK_INSTALLATION_ID"] = installation_id
+        request = self.factory.post(WEBHOOK_PATH, **headers)
+        return CursorOriginRequestParser(request=request, response_handler=self.get_response)
 
-        response = parser.get_response()
+    @responses.activate
+    def test_installation_events_are_answered_in_control(self) -> None:
+        # Disabling the Integration row on uninstall touches only control data,
+        # so there is nothing to forward.
+        response = self._parser(event_type="installation.deleted").get_response()
 
         assert isinstance(response, HttpResponse)
         assert response.status_code == 200
         assert response.content == b"passthrough"
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
+
+    @responses.activate
+    def test_unknown_installation_is_acknowledged_rather_than_forwarded(self) -> None:
+        # Erroring would make Origin retry forever and eventually disable the
+        # endpoint over deliveries we could never handle.
+        response = self._parser(
+            event_type="repository.pushed", installation_id="i_01nonexistent"
+        ).get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert_no_webhook_payloads()
+
+    @responses.activate
+    def test_push_without_an_installation_header_is_acknowledged(self) -> None:
+        response = self._parser(event_type="repository.pushed").get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert_no_webhook_payloads()
+
+    def test_resolves_the_integration_from_the_header(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            external_id="i_01example",
+            name="sentry",
+        )
+        parser = self._parser(event_type="repository.pushed", installation_id="i_01example")
+
+        assert parser.get_integration_from_request() == integration
 
     def test_registered_for_the_hyphenated_url(self) -> None:
         """The URL says ``cursor-origin`` and the provider slug says


### PR DESCRIPTION
Hackweek proof of concept: adds **Cursor Origin** — Cursor's new git forge — as a first-class SCM provider.

> [!IMPORTANT]
> **Draft, and deliberately not split yet.** This mixes `static/` and `src/` and will fail the frontend/backend CI check. It needs splitting into a backend PR and a frontend PR before it can merge — 4 commits are frontend-only, 10 are backend-only, and 2 mix the two. Splitting is deferred so the work stays reviewable as one story for now.

## What works end to end

Verified in a browser against a real Origin app and repository, not fixtures:

- **Onboarding**: pick Cursor Origin → install → select a repo → Sentry suggests the platform, the same flow GitHub has today. Detection correctly returns `dotnet-aspnetcore` (high confidence) for a real .NET repo.
- **Repositories**: linking, listing, and the Sync button.
- **Auto code mappings**: `get_trees_for_org()` returns 146 source files; `generate_code_mappings()` derives the stack-root → source-root pair from a .NET-shaped frame path.
- **Seer proxy path**: `fetch_service_provider()` builds a `CursorOriginProvider`, and reads flow through `SourceCodeManager`.

## Design notes worth reviewing

**Origin is GitHub-App-shaped**, which is why this is mostly mapping rather than new machinery: app-signed JWT → short-lived installation token, an install-and-consent redirect, and a flat REST namespace.

**One pipeline step, no identity provider.** Origin's redirect returns a signed installation receipt directly, so there is no OAuth login leg and no organization-selection step. The provider sets `needs_default_identity = False` and skips `sentry.identity` entirely.

**Two adapters at the client boundary, so no GitHub code was rewritten:**

- Origin has no languages endpoint, so `languages_from_tree()` derives Linguist-shaped byte counts from the git tree. Keeping GitHub's shape means the entire existing `platform_registry` — frameworks, manifests, supersession — works untouched.
- Origin serves file contents from `/contents?path=…`, **not** `/contents/{path}` as its docs state. `client.get()` rewrites the GitHub-shaped path, which is what lets platform detection, CODEOWNERS lookups and stacktrace linking run unmodified.

**Platform detection is now provider-agnostic.** It never really depended on GitHub — only on a GitHub-shaped recursive tree and Linguist-style language counts. That is now expressed as a `PlatformDetectionClient` Protocol instead of a concrete `GitHubBaseClient`. All 166 existing GitHub detection tests pass unchanged. Note that membership in `SUPPORTED_PROVIDERS` is a property of what a client can *do*, not of a provider being GitHub-like.

**Seer support is feature-gated** behind `organizations:seer-cursor-origin-support`, mirroring how GitLab is handled, because Seer's own support is still landing — notably Origin has no inline review comments, so a review there is one prose comment rather than diff-anchored ones.

**The Origin provider class is resolved dynamically** in `scm/private/helpers.py` rather than imported. `sentry-scm` 1.5.0 predates it, so a plain import would take down every SCM code path rather than just Origin; a guarded import flips between "unresolvable" and "unused ignore" depending on which build is installed, making type checking depend on install order. Remove the indirection once the pin includes the provider.

## Naming

The key is `cursor_origin`, deliberately not `cursor` — that is already taken by the Cursor *coding agent* integration. Note the derived feature flag is `integrations-cursor-origin` (underscores become hyphens in `is_provider_enabled`); a mismatch makes the integration silently invisible.

## Not included

Webhooks (Origin is already delivering to the registered URL and getting 403s), commit tracking (`compare_commits` is a stub), broken-integration detection, and a docs page — the integration detail page currently links to a 404. Full list of known shortcuts is tracked outside this PR.

## Tests

22 new tests covering the language shim, the contents-path rewrite, rate-limit tracking, and the repository-provider handoff. Those were chosen because they fail *silently* — a wrong Linguist key makes detection find nothing with no error, and the contents rewrite 404s with a route-not-found body that reads like an auth failure.

Relates to:
* https://github.com/getsentry/scm-platform/pull/130