### PR TITLE
feat(seer): Report truncated sections on the Autofix overview

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -317,6 +317,11 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         }
         for group_id, run in latest_run_per_group.items():
             capped_runs_by_milestone[run.furthest_milestone].append((group_id, run))
+        truncated_milestones = [
+            milestone
+            for milestone, pairs in capped_runs_by_milestone.items()
+            if len(pairs) > _MAX_RUNS_PER_MILESTONE
+        ]
         for pairs in capped_runs_by_milestone.values():
             del pairs[_MAX_RUNS_PER_MILESTONE:]
 
@@ -367,7 +372,10 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                     )
                 )
 
-        response: OverviewResponse = {"runsByMilestone": runs_by_milestone}
+        response: OverviewResponse = {
+            "runsByMilestone": runs_by_milestone,
+            "truncatedMilestones": truncated_milestones,
+        }
         return Response(response)
 
     def _latest_run_per_group(

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -73,3 +73,4 @@ class RunPayload(TypedDict):
 
 class OverviewResponse(TypedDict):
     runsByMilestone: dict[str, list[RunPayload]]
+    truncatedMilestones: list[str]

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -692,6 +692,24 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
 
         assert len(resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]) == 2
 
+    @mock.patch(
+        "sentry.seer.endpoints.organization_seer_autofix_overview._MAX_RUNS_PER_MILESTONE", 2
+    )
+    def test_truncated_milestones_reports_capped_sections(self):
+        for i in range(3):
+            self._run_for_group(self.create_group(), f"boom {i}")
+
+        resp = self.get_success_response(self.organization.slug)
+
+        assert resp.data["truncatedMilestones"] == [SeerRunMilestoneType.ROOT_CAUSE]
+
+    def test_truncated_milestones_empty_when_under_cap(self):
+        self._run_for_group(self.create_group(), "boom")
+
+        resp = self.get_success_response(self.organization.slug)
+
+        assert resp.data["truncatedMilestones"] == []
+
     @mock.patch(_INTEGRATION_SERVICE)
     def test_both_expands_enrich_pull_request_and_request_stats(self, mock_get_integration):
         group = self.create_group()


### PR DESCRIPTION
Each Autofix overview section is capped at `_MAX_RUNS_PER_MILESTONE` (100) runs, applied before serialization. Today that truncation is invisible to the client: an org with more than 100 runs in a section sees a silently incomplete list, and the upcoming client-side assignee filter ([AIML-3185](https://linear.app/getsentry/issue/AIML-3185)) would compound that by deriving filter options and counts from the capped payload.

This adds a `truncatedMilestones` field to the response — the list of milestone keys whose section hit the cap — so the frontend can disclose that the view is incomplete (e.g. a "showing the 100 most recent runs" hint). Disclosure only; no filtering behavior changes here. The frontend assignee-filter PR will follow and read this field.

Refs AIML-3185