### PR TITLE
feat(seer): Add an assignee filter to the Autofix overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
+++ b/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
@@ -20,8 +20,6 @@ export function matchesAssignee(run: OverviewRun, selected: string): boolean {
   return assigneeValue(run.issue.assignedTo) === selected;
 }
 
-// Options are derived from the loaded results: only assignees with at least one
-// run appear, each with its matching issue count.
 export function AssigneeFilter({
   runs,
   value,

--- a/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
+++ b/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
@@ -1,0 +1,80 @@
+import {useMemo} from 'react';
+
+import {ActorAvatar} from '@sentry/scraps/avatar';
+import {Badge} from '@sentry/scraps/badge';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+
+import {t} from 'sentry/locale';
+import type {Actor} from 'sentry/types/core';
+
+import type {OverviewRun} from './types';
+
+const UNASSIGNED = 'unassigned';
+
+function assigneeValue(assignedTo: Actor | null): string {
+  return assignedTo ? `${assignedTo.type}:${assignedTo.id}` : UNASSIGNED;
+}
+
+export function matchesAssignee(run: OverviewRun, selected: string): boolean {
+  return assigneeValue(run.issue.assignedTo) === selected;
+}
+
+// Options are derived from the loaded results: only assignees with at least one
+// run appear, each with its matching issue count.
+export function AssigneeFilter({
+  runs,
+  value,
+  onChange,
+}: {
+  onChange: (value: string | null) => void;
+  runs: OverviewRun[];
+  value: string | null;
+}) {
+  const options = useMemo(() => {
+    const byValue = new Map<string, {actor: Actor | null; count: number}>();
+    for (const run of runs) {
+      const key = assigneeValue(run.issue.assignedTo);
+      const entry = byValue.get(key) ?? {actor: run.issue.assignedTo, count: 0};
+      entry.count += 1;
+      byValue.set(key, entry);
+    }
+
+    const actorOptions = [...byValue.entries()]
+      .filter((entry): entry is [string, {actor: Actor; count: number}] =>
+        Boolean(entry[1].actor)
+      )
+      .map(([key, {actor, count}]) => ({
+        value: key,
+        label: actor.type === 'team' ? `#${actor.name}` : actor.name,
+        leadingItems: <ActorAvatar actor={actor} size={18} />,
+        trailingItems: <Badge variant="muted">{count}</Badge>,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    const unassigned = byValue.get(UNASSIGNED);
+    return unassigned
+      ? [
+          ...actorOptions,
+          {
+            value: UNASSIGNED,
+            label: t('Unassigned'),
+            trailingItems: <Badge variant="muted">{unassigned.count}</Badge>,
+          },
+        ]
+      : actorOptions;
+  }, [runs]);
+
+  return (
+    <CompactSelect
+      clearable
+      search
+      options={options}
+      value={value ?? undefined}
+      onChange={selected => onChange(selected?.value ?? null)}
+      trigger={triggerProps => (
+        <OverlayTrigger.Button {...triggerProps} size="sm" prefix={t('Assignee')} />
+      )}
+    />
+  );
+}

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1052,8 +1052,49 @@ describe('AutofixOverview', () => {
       renderPage();
 
       expect(
-        await screen.findByText('Some sections show only their most recent runs.')
+        await screen.findByText(
+          'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
+        )
       ).toBeInTheDocument();
+    });
+
+    it('formats team assignees with a # prefix', async () => {
+      const squad: Actor = {type: 'team', id: '9', name: 'squad'};
+      mockOverview({
+        base: {
+          autofix_root_cause: [
+            {...rootCauseRun, issue: issueFixture({assignedTo: squad})},
+          ],
+        },
+      });
+
+      renderPage();
+      await screen.findByRole('button', {name: 'Create Plan 1'});
+
+      await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
+
+      const option = await screen.findByRole('option', {name: /#squad/});
+      expect(within(option).getByText('1')).toBeInTheDocument();
+    });
+
+    it('clears the filter and restores all sections', async () => {
+      mockOverview({
+        base: {autofix_root_cause: [assignedRun], autofix_solution: [solutionRun]},
+      });
+
+      const {router} = renderPage({assignee: 'user:7'});
+      await screen.findByRole('button', {name: 'Create Plan 1'});
+      expect(
+        screen.queryByRole('button', {name: /Generate code changes/})
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Clear'}));
+
+      expect(
+        await screen.findByRole('button', {name: 'Generate code changes 1'})
+      ).toBeInTheDocument();
+      expect(router.location.query.assignee).toBeUndefined();
     });
 
     it('adds a newly assigned user to the filter options', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1086,19 +1086,41 @@ describe('AutofixOverview', () => {
       expect(router.location.query.assignee).toBeUndefined();
     });
 
-    it('adds a newly assigned user to the filter options', async () => {
+    it('reflects a reassignment in the filter options after refetch', async () => {
       const nextAssignee = UserFixture({id: '42', name: 'Next Assignee'});
+      const nextActor: Actor = {
+        id: nextAssignee.id,
+        name: nextAssignee.name,
+        type: 'user',
+        email: '',
+      };
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/users/`,
         body: [MemberFixture({user: nextAssignee})],
       });
-      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      // The overview endpoint returns the new assignee only once the issue has
+      // been reassigned, mirroring the refetch that invalidation triggers.
+      let reassigned = false;
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+        body: () => ({
+          runsByMilestone: {
+            ...emptyMilestones,
+            autofix_root_cause: [
+              reassigned
+                ? {...rootCauseRun, issue: issueFixture({assignedTo: nextActor})}
+                : rootCauseRun,
+            ],
+          },
+          truncatedMilestones: [],
+        }),
+      });
       const assignRequest = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/issues/${rootCauseRun.groupId}/`,
         method: 'PUT',
-        body: {
-          ...GroupFixture({id: rootCauseRun.groupId}),
-          assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
+        body: () => {
+          reassigned = true;
+          return {...GroupFixture({id: rootCauseRun.groupId}), assignedTo: nextActor};
         },
       });
 

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -993,23 +993,7 @@ describe('AutofixOverview', () => {
       issue: issueFixture({assignedTo: jane, count: '1200', userCount: 5}),
     };
 
-    it('derives options and issue counts from the loaded results', async () => {
-      mockOverview({
-        base: {autofix_root_cause: [assignedRun], autofix_solution: [solutionRun]},
-      });
-
-      renderPage();
-      await screen.findByRole('button', {name: 'Create Plan 1'});
-
-      await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
-
-      const janeOption = await screen.findByRole('option', {name: /Jane Doe/});
-      expect(within(janeOption).getByText('1')).toBeInTheDocument();
-      const unassignedOption = screen.getByRole('option', {name: /Unassigned/});
-      expect(within(unassignedOption).getByText('1')).toBeInTheDocument();
-    });
-
-    it('filters sections client-side and records the selection in the URL', async () => {
+    it('derives options with counts and filters sections via the URL', async () => {
       const {enrichedRequest} = mockOverview({
         base: {autofix_root_cause: [assignedRun], autofix_solution: [solutionRun]},
       });
@@ -1018,7 +1002,13 @@ describe('AutofixOverview', () => {
       await screen.findByRole('button', {name: 'Generate code changes 1'});
 
       await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
-      await userEvent.click(await screen.findByRole('option', {name: /Jane Doe/}));
+
+      const janeOption = await screen.findByRole('option', {name: /Jane Doe/});
+      expect(within(janeOption).getByText('1')).toBeInTheDocument();
+      const unassignedOption = screen.getByRole('option', {name: /Unassigned/});
+      expect(within(unassignedOption).getByText('1')).toBeInTheDocument();
+
+      await userEvent.click(janeOption);
 
       expect(
         await screen.findByRole('button', {name: 'Create Plan 1'})
@@ -1073,8 +1063,7 @@ describe('AutofixOverview', () => {
 
       await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
 
-      const option = await screen.findByRole('option', {name: /#squad/});
-      expect(within(option).getByText('1')).toBeInTheDocument();
+      expect(await screen.findByRole('option', {name: /#squad/})).toBeInTheDocument();
     });
 
     it('clears the filter and restores all sections', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1,7 +1,9 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {
   render,
@@ -15,6 +17,7 @@ import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Actor} from 'sentry/types/core';
 import type {PullRequestStatus} from 'sentry/types/integrations';
 import AutofixOverview from 'sentry/views/seerWorkflows/overview';
 import type {
@@ -101,24 +104,32 @@ describe('AutofixOverview', () => {
     enrichedAsyncDelay,
     enrichedStatusCode,
     baseStatusCode,
+    truncated,
   }: {
     base: Partial<AutofixOverviewResponse['runsByMilestone']>;
     baseStatusCode?: number;
     enriched?: Partial<AutofixOverviewResponse['runsByMilestone']>;
     enrichedAsyncDelay?: number | Promise<void>;
     enrichedStatusCode?: number;
+    truncated?: AutofixOverviewResponse['truncatedMilestones'];
   }) {
     const baseRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       statusCode: baseStatusCode,
-      body: {runsByMilestone: {...emptyMilestones, ...base}},
+      body: {
+        runsByMilestone: {...emptyMilestones, ...base},
+        truncatedMilestones: truncated ?? [],
+      },
     });
     const enrichedRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({expand: ['scmInfo', 'issueStats']})],
       asyncDelay: enrichedAsyncDelay,
       statusCode: enrichedStatusCode,
-      body: {runsByMilestone: {...emptyMilestones, ...(enriched ?? base)}},
+      body: {
+        runsByMilestone: {...emptyMilestones, ...(enriched ?? base)},
+        truncatedMilestones: truncated ?? [],
+      },
     });
     return {baseRequest, enrichedRequest};
   }
@@ -157,10 +168,10 @@ describe('AutofixOverview', () => {
     });
   });
 
-  function renderPage() {
+  function renderPage(query: Record<string, string> = {}) {
     return render(<AutofixOverview />, {
       organization,
-      initialRouterConfig: {location: {pathname: basePath}},
+      initialRouterConfig: {location: {pathname: basePath, query}},
     });
   }
 
@@ -973,6 +984,106 @@ describe('AutofixOverview', () => {
       )
     );
     expect(router.location.query.sort).toBe(sort);
+  });
+
+  describe('assignee filter', () => {
+    const jane: Actor = {type: 'user', id: '7', name: 'Jane Doe', email: ''};
+    const assignedRun = {
+      ...rootCauseRun,
+      issue: issueFixture({assignedTo: jane, count: '1200', userCount: 5}),
+    };
+
+    it('derives options and issue counts from the loaded results', async () => {
+      mockOverview({
+        base: {autofix_root_cause: [assignedRun], autofix_solution: [solutionRun]},
+      });
+
+      renderPage();
+      await screen.findByRole('button', {name: 'Create Plan 1'});
+
+      await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
+
+      const janeOption = await screen.findByRole('option', {name: /Jane Doe/});
+      expect(within(janeOption).getByText('1')).toBeInTheDocument();
+      const unassignedOption = screen.getByRole('option', {name: /Unassigned/});
+      expect(within(unassignedOption).getByText('1')).toBeInTheDocument();
+    });
+
+    it('filters sections client-side and records the selection in the URL', async () => {
+      const {enrichedRequest} = mockOverview({
+        base: {autofix_root_cause: [assignedRun], autofix_solution: [solutionRun]},
+      });
+
+      const {router} = renderPage();
+      await screen.findByRole('button', {name: 'Generate code changes 1'});
+
+      await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
+      await userEvent.click(await screen.findByRole('option', {name: /Jane Doe/}));
+
+      expect(
+        await screen.findByRole('button', {name: 'Create Plan 1'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /Generate code changes/})
+      ).not.toBeInTheDocument();
+      expect(router.location.query.assignee).toBe('user:7');
+      expect(enrichedRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a filtered empty state when no runs match the assignee', async () => {
+      mockOverview({base: {autofix_root_cause: [assignedRun]}});
+
+      renderPage({assignee: 'user:999'});
+
+      expect(
+        await screen.findByText('No Autofix runs match the selected assignee.')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('You don’t have any Autofix runs...yet.')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows a truncation notice when the backend caps a section', async () => {
+      mockOverview({
+        base: {autofix_root_cause: [assignedRun]},
+        truncated: ['autofix_root_cause'],
+      });
+
+      renderPage();
+
+      expect(
+        await screen.findByText('Some sections show only their most recent runs.')
+      ).toBeInTheDocument();
+    });
+
+    it('adds a newly assigned user to the filter options', async () => {
+      const nextAssignee = UserFixture({id: '42', name: 'Next Assignee'});
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/users/`,
+        body: [MemberFixture({user: nextAssignee})],
+      });
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      const assignRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${rootCauseRun.groupId}/`,
+        method: 'PUT',
+        body: {
+          ...GroupFixture({id: rootCauseRun.groupId}),
+          assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
+        },
+      });
+
+      renderPage();
+      await screen.findByRole('button', {name: 'Create Plan 1'});
+
+      await userEvent.click(screen.getByRole('button', {name: 'Modify issue assignee'}));
+      await userEvent.click(await screen.findByRole('option', {name: /Next Assignee/}));
+      await waitFor(() => expect(assignRequest).toHaveBeenCalled());
+
+      await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
+      const newOption = await screen.findByRole('option', {name: /Next Assignee/});
+      expect(within(newOption).getByText('1')).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: /Unassigned/})).not.toBeInTheDocument();
+    });
   });
 
   it('shows an error state when the request fails', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1086,41 +1086,19 @@ describe('AutofixOverview', () => {
       expect(router.location.query.assignee).toBeUndefined();
     });
 
-    it('reflects a reassignment in the filter options after refetch', async () => {
+    it('adds a newly assigned user to the filter options', async () => {
       const nextAssignee = UserFixture({id: '42', name: 'Next Assignee'});
-      const nextActor: Actor = {
-        id: nextAssignee.id,
-        name: nextAssignee.name,
-        type: 'user',
-        email: '',
-      };
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/users/`,
         body: [MemberFixture({user: nextAssignee})],
       });
-      // The overview endpoint returns the new assignee only once the issue has
-      // been reassigned, mirroring the refetch that invalidation triggers.
-      let reassigned = false;
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/seer/autofix-overview/`,
-        body: () => ({
-          runsByMilestone: {
-            ...emptyMilestones,
-            autofix_root_cause: [
-              reassigned
-                ? {...rootCauseRun, issue: issueFixture({assignedTo: nextActor})}
-                : rootCauseRun,
-            ],
-          },
-          truncatedMilestones: [],
-        }),
-      });
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
       const assignRequest = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/issues/${rootCauseRun.groupId}/`,
         method: 'PUT',
-        body: () => {
-          reassigned = true;
-          return {...GroupFixture({id: rootCauseRun.groupId}), assignedTo: nextActor};
+        body: {
+          ...GroupFixture({id: rootCauseRun.groupId}),
+          assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
         },
       });
 

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -86,7 +87,10 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       sort,
       enabled: pageFiltersReady,
     });
-  const allRuns = Object.values(data?.runsByMilestone ?? {}).flat();
+  const allRuns = useMemo(
+    () => Object.values(data?.runsByMilestone ?? {}).flat(),
+    [data]
+  );
   const populatedSections = OVERVIEW_SECTIONS.map(section => ({
     ...section,
     runs: (data?.runsByMilestone[section.milestone] ?? []).filter(
@@ -144,7 +148,9 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
         {isRefetching && <LoadingIndicator mini />}
         {(data?.truncatedMilestones?.length ?? 0) > 0 && (
           <Text size="sm" variant="muted">
-            {t('Some sections show only their most recent runs.')}
+            {t(
+              'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
+            )}
           </Text>
         )}
       </Flex>

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -29,6 +29,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewSort} from './types';
@@ -76,6 +77,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   const sort: OverviewSort =
     SORT_OPTIONS.find(option => option.value === decodeScalar(location.query.sort))
       ?.value ?? 'seer';
+  const assignee = decodeScalar(location.query.assignee) ?? null;
 
   const {data, isPending, isError, enrichmentPending, isRefetching, refetch} =
     useAutofixOverview({
@@ -84,9 +86,12 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       sort,
       enabled: pageFiltersReady,
     });
+  const allRuns = Object.values(data?.runsByMilestone ?? {}).flat();
   const populatedSections = OVERVIEW_SECTIONS.map(section => ({
     ...section,
-    runs: data?.runsByMilestone[section.milestone] ?? [],
+    runs: (data?.runsByMilestone[section.milestone] ?? []).filter(
+      run => assignee === null || matchesAssignee(run, assignee)
+    ),
   })).filter(section => section.runs.length > 0);
 
   const toggleGroup = (groupKey: StatusGroupKey, expanded: boolean) => {
@@ -123,14 +128,39 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             <OverlayTrigger.Button {...triggerProps} size="sm" prefix={t('Sort')} />
           )}
         />
+        <AssigneeFilter
+          runs={allRuns}
+          value={assignee}
+          onChange={next =>
+            navigate(
+              {
+                pathname: location.pathname,
+                query: {...location.query, assignee: next ?? undefined},
+              },
+              {replace: true}
+            )
+          }
+        />
         {isRefetching && <LoadingIndicator mini />}
+        {(data?.truncatedMilestones?.length ?? 0) > 0 && (
+          <Text size="sm" variant="muted">
+            {t('Some sections show only their most recent runs.')}
+          </Text>
+        )}
       </Flex>
       {isError ? (
         <LoadingError onRetry={refetch} />
       ) : isPending ? (
         <LoadingIndicator />
       ) : populatedSections.length === 0 ? (
-        <EmptyState padding="3xl" title={t('You don’t have any Autofix runs...yet.')} />
+        assignee === null ? (
+          <EmptyState padding="3xl" title={t('You don’t have any Autofix runs...yet.')} />
+        ) : (
+          <EmptyState
+            padding="3xl"
+            title={t('No Autofix runs match the selected assignee.')}
+          />
+        )
       ) : (
         <Stack gap="lg">
           {populatedSections.map(({key, runs}) => {

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -6,13 +6,51 @@ import {UserFixture} from 'sentry-fixture/user';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
+import type {AutofixOverviewResponse} from './types';
 
 describe('OverviewIssueAssignee', () => {
   const organization = OrganizationFixture();
   const group = GroupFixture();
 
-  it('invalidates the overview query after mutation', async () => {
+  const overviewResponse: AutofixOverviewResponse = {
+    runsByMilestone: {
+      autofix_root_cause: [
+        {
+          groupId: group.id,
+          shortId: group.shortId,
+          title: group.title,
+          rootCause: null,
+          proposedFix: null,
+          seerRunId: 'run-1',
+          lastTriggeredAt: '2026-07-14T09:00:00Z',
+          pullRequests: [],
+          issue: {
+            assignedTo: null,
+            count: '1',
+            issueCategory: null,
+            issueType: null,
+            lastSeen: null,
+            level: null,
+            owners: [],
+            priority: null,
+            priorityLockedAt: null,
+            project: {id: group.project.id, slug: group.project.slug},
+            substatus: null,
+            userCount: 1,
+          },
+        },
+      ],
+      autofix_solution: [],
+      autofix_code_changes: [],
+      has_pull_request: [],
+      pull_requests_merged: [],
+    },
+  };
+
+  it('patches the cached overview payload after mutation', async () => {
     const assignee = UserFixture({
       id: '42',
       name: 'Next Assignee',
@@ -28,7 +66,14 @@ describe('OverviewIssueAssignee', () => {
     });
 
     const queryClient = makeTestQueryClient();
-    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const overviewOptions = apiOptions.as<AutofixOverviewResponse>()(
+      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
+      {path: {organizationIdOrSlug: organization.slug}, staleTime: 0}
+    );
+    queryClient.setQueryData(overviewOptions.queryKey, {
+      json: overviewResponse,
+      headers: {},
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -48,8 +93,9 @@ describe('OverviewIssueAssignee', () => {
     );
 
     await waitFor(() => expect(assignRequest).toHaveBeenCalled());
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: [`/organizations/${organization.slug}/seer/autofix-overview/`],
-    });
+    const patched = queryClient.getQueryData(overviewOptions.queryKey);
+    expect(patched?.json.runsByMilestone.autofix_root_cause[0]?.issue.assignedTo).toEqual(
+      {id: assignee.id, name: assignee.name, type: 'user'}
+    );
   });
 });

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -50,27 +50,39 @@ describe('OverviewIssueAssignee', () => {
     },
   };
 
-  it('patches the cached overview payload after mutation', async () => {
+  it('patches the cache and survives a stale in-flight overview response', async () => {
     const assignee = UserFixture({
       id: '42',
       name: 'Next Assignee',
       email: 'next.assignee@example.com',
     });
+    const assignedTo = {id: assignee.id, name: assignee.name, type: 'user'};
     const assignRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/`,
       method: 'PUT',
-      body: {
-        ...group,
-        assignedTo: {id: assignee.id, name: assignee.name, type: 'user'},
-      },
+      body: {...group, assignedTo},
     });
 
     const queryClient = makeTestQueryClient();
-    const {queryKey: overviewKey} = apiOptions.as<AutofixOverviewResponse>()(
+    const overviewOptions = apiOptions.as<AutofixOverviewResponse>()(
       '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
       {path: {organizationIdOrSlug: organization.slug}, staleTime: 0}
     );
+    const overviewKey = overviewOptions.queryKey;
     queryClient.setQueryData(overviewKey, {json: overviewResponse, headers: {}});
+
+    // A background refetch that is still in flight when the reassign lands, and
+    // whose response carries the pre-assign assignee.
+    let releaseStale!: () => void;
+    const stale = new Promise<void>(resolve => {
+      releaseStale = resolve;
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      asyncDelay: stale,
+      body: overviewResponse,
+    });
+    const inFlight = queryClient.fetchQuery(overviewOptions);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -88,11 +100,15 @@ describe('OverviewIssueAssignee', () => {
     await userEvent.click(
       await screen.findByRole('option', {name: new RegExp(assignee.name)})
     );
-
     await waitFor(() => expect(assignRequest).toHaveBeenCalled());
+
+    // Let the stale response resolve; the reassign must have cancelled it.
+    releaseStale();
+    await inFlight.catch(() => {});
+
     const patched = queryClient.getQueryData(overviewKey);
     expect(patched?.json.runsByMilestone.autofix_root_cause[0]?.issue.assignedTo).toEqual(
-      {id: assignee.id, name: assignee.name, type: 'user'}
+      assignedTo
     );
   });
 });

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -6,83 +6,29 @@ import {UserFixture} from 'sentry-fixture/user';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {apiOptions} from 'sentry/utils/api/apiOptions';
-
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
-import type {AutofixOverviewResponse} from './types';
 
 describe('OverviewIssueAssignee', () => {
   const organization = OrganizationFixture();
   const group = GroupFixture();
 
-  const overviewResponse: AutofixOverviewResponse = {
-    runsByMilestone: {
-      autofix_root_cause: [
-        {
-          groupId: group.id,
-          shortId: group.shortId,
-          title: group.title,
-          rootCause: null,
-          proposedFix: null,
-          seerRunId: 'run-1',
-          lastTriggeredAt: '2026-07-14T09:00:00Z',
-          pullRequests: [],
-          issue: {
-            assignedTo: null,
-            count: '1',
-            issueCategory: null,
-            issueType: null,
-            lastSeen: null,
-            level: null,
-            owners: [],
-            priority: null,
-            priorityLockedAt: null,
-            project: {id: group.project.id, slug: group.project.slug},
-            substatus: null,
-            userCount: 1,
-          },
-        },
-      ],
-      autofix_solution: [],
-      autofix_code_changes: [],
-      has_pull_request: [],
-      pull_requests_merged: [],
-    },
-  };
-
-  it('patches the cache and survives a stale in-flight overview response', async () => {
+  it('invalidates the overview query after mutation', async () => {
     const assignee = UserFixture({
       id: '42',
       name: 'Next Assignee',
       email: 'next.assignee@example.com',
     });
-    const assignedTo = {id: assignee.id, name: assignee.name, type: 'user'};
     const assignRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/`,
       method: 'PUT',
-      body: {...group, assignedTo},
+      body: {
+        ...group,
+        assignedTo: {id: assignee.id, name: assignee.name, type: 'user'},
+      },
     });
 
     const queryClient = makeTestQueryClient();
-    const overviewOptions = apiOptions.as<AutofixOverviewResponse>()(
-      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
-      {path: {organizationIdOrSlug: organization.slug}, staleTime: 0}
-    );
-    const overviewKey = overviewOptions.queryKey;
-    queryClient.setQueryData(overviewKey, {json: overviewResponse, headers: {}});
-
-    // A background refetch that is still in flight when the reassign lands, and
-    // whose response carries the pre-assign assignee.
-    let releaseStale!: () => void;
-    const stale = new Promise<void>(resolve => {
-      releaseStale = resolve;
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
-      asyncDelay: stale,
-      body: overviewResponse,
-    });
-    const inFlight = queryClient.fetchQuery(overviewOptions);
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -100,15 +46,10 @@ describe('OverviewIssueAssignee', () => {
     await userEvent.click(
       await screen.findByRole('option', {name: new RegExp(assignee.name)})
     );
+
     await waitFor(() => expect(assignRequest).toHaveBeenCalled());
-
-    // Let the stale response resolve; the reassign must have cancelled it.
-    releaseStale();
-    await inFlight.catch(() => {});
-
-    const patched = queryClient.getQueryData(overviewKey);
-    expect(patched?.json.runsByMilestone.autofix_root_cause[0]?.issue.assignedTo).toEqual(
-      assignedTo
-    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: [`/organizations/${organization.slug}/seer/autofix-overview/`],
+    });
   });
 });

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -1,16 +1,56 @@
+import {QueryClientProvider} from '@tanstack/react-query';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
+import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
+import type {AutofixOverviewResponse} from './types';
 
 describe('OverviewIssueAssignee', () => {
   const organization = OrganizationFixture();
   const group = GroupFixture();
 
-  it('updates the local assignment after mutation', async () => {
+  const overviewResponse: AutofixOverviewResponse = {
+    runsByMilestone: {
+      autofix_root_cause: [
+        {
+          groupId: group.id,
+          shortId: group.shortId,
+          title: group.title,
+          rootCause: null,
+          proposedFix: null,
+          seerRunId: 'run-1',
+          lastTriggeredAt: '2026-07-14T09:00:00Z',
+          pullRequests: [],
+          issue: {
+            assignedTo: null,
+            count: '1',
+            issueCategory: null,
+            issueType: null,
+            lastSeen: null,
+            level: null,
+            owners: [],
+            priority: null,
+            priorityLockedAt: null,
+            project: {id: group.project.id, slug: group.project.slug},
+            substatus: null,
+            userCount: 1,
+          },
+        },
+      ],
+      autofix_solution: [],
+      autofix_code_changes: [],
+      has_pull_request: [],
+      pull_requests_merged: [],
+    },
+  };
+
+  it('patches the cached overview payload after mutation', async () => {
     const assignee = UserFixture({
       id: '42',
       name: 'Next Assignee',
@@ -25,13 +65,22 @@ describe('OverviewIssueAssignee', () => {
       },
     });
 
+    const queryClient = makeTestQueryClient();
+    const {queryKey: overviewKey} = apiOptions.as<AutofixOverviewResponse>()(
+      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
+      {path: {organizationIdOrSlug: organization.slug}, staleTime: 0}
+    );
+    queryClient.setQueryData(overviewKey, {json: overviewResponse, headers: {}});
+
     render(
-      <OverviewIssueAssignee
-        groupId={group.id}
-        projectId={group.project.id}
-        projectSlug={group.project.slug}
-        memberList={[assignee]}
-      />,
+      <QueryClientProvider client={queryClient}>
+        <OverviewIssueAssignee
+          groupId={group.id}
+          projectId={group.project.id}
+          projectSlug={group.project.slug}
+          memberList={[assignee]}
+        />
+      </QueryClientProvider>,
       {organization}
     );
 
@@ -41,9 +90,9 @@ describe('OverviewIssueAssignee', () => {
     );
 
     await waitFor(() => expect(assignRequest).toHaveBeenCalled());
-    expect(await screen.findByTestId('assigned-avatar')).toHaveAttribute(
-      'title',
-      assignee.name
+    const patched = queryClient.getQueryData(overviewKey);
+    expect(patched?.json.runsByMilestone.autofix_root_cause[0]?.issue.assignedTo).toEqual(
+      {id: assignee.id, name: assignee.name, type: 'user'}
     );
   });
 });

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -76,7 +76,10 @@ export function OverviewIssueAssignee({
   );
 
   const handleSuccess = useCallback(
-    (nextAssignedTo: Group['assignedTo']) => {
+    async (nextAssignedTo: Group['assignedTo']) => {
+      // Cancel in-flight overview fetches first so a stale response can't land
+      // after the patch and revert the assignee.
+      await queryClient.cancelQueries({queryKey: [overviewUrl]});
       queryClient.setQueriesData<ApiResponse<AutofixOverviewResponse>>(
         {queryKey: [overviewUrl]},
         previous =>

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -8,8 +8,11 @@ import {
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {AutofixOverviewResponse} from './types';
 
 interface OverviewIssueAssigneeProps {
   groupId: string;
@@ -19,6 +22,24 @@ interface OverviewIssueAssigneeProps {
   memberList?: User[];
   memberListLoading?: boolean;
   owners?: Group['owners'];
+}
+
+function withRunAssignee(
+  response: AutofixOverviewResponse,
+  groupId: string,
+  assignedTo: Group['assignedTo']
+): AutofixOverviewResponse {
+  return {
+    ...response,
+    runsByMilestone: Object.fromEntries(
+      Object.entries(response.runsByMilestone).map(([milestone, runs]) => [
+        milestone,
+        runs.map(run =>
+          run.groupId === groupId ? {...run, issue: {...run.issue, assignedTo}} : run
+        ),
+      ])
+    ) as AutofixOverviewResponse['runsByMilestone'],
+  };
 }
 
 // Intentionally duplicates static/app/utils/dashboards/issueAssignee.tsx for the Autofix Overview POC.
@@ -54,12 +75,22 @@ export function OverviewIssueAssignee({
     [assignedTo, groupId, owners, projectId, projectSlug]
   );
 
-  const handleSuccess = useCallback(() => {
-    // Refetch the overview so the assignee filter's options and counts pick up
-    // the reassignment from the server.
-    void queryClient.invalidateQueries({queryKey: [overviewUrl]});
-    void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
-  }, [issueIndexUrl, overviewUrl, queryClient]);
+  const handleSuccess = useCallback(
+    (nextAssignedTo: Group['assignedTo']) => {
+      // Patch the assignee straight into the cached overview so the card and the
+      // filter's options/counts update without a full (Snuba-heavy) refetch.
+      queryClient.setQueriesData<ApiResponse<AutofixOverviewResponse>>(
+        {queryKey: [overviewUrl]},
+        previous =>
+          previous && {
+            ...previous,
+            json: withRunAssignee(previous.json, groupId, nextAssignedTo),
+          }
+      );
+      void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
+    },
+    [groupId, issueIndexUrl, overviewUrl, queryClient]
+  );
 
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
     group,

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {
@@ -24,6 +24,26 @@ interface OverviewIssueAssigneeProps {
   owners?: Group['owners'];
 }
 
+// Object.fromEntries widens the key type, so the milestone Record is restored
+// with a cast; the map itself never adds or drops keys.
+function withRunAssignee(
+  response: AutofixOverviewResponse,
+  groupId: string,
+  assignedTo: Group['assignedTo']
+): AutofixOverviewResponse {
+  return {
+    ...response,
+    runsByMilestone: Object.fromEntries(
+      Object.entries(response.runsByMilestone).map(([milestone, runs]) => [
+        milestone,
+        runs.map(run =>
+          run.groupId === groupId ? {...run, issue: {...run.issue, assignedTo}} : run
+        ),
+      ])
+    ) as AutofixOverviewResponse['runsByMilestone'],
+  };
+}
+
 // Intentionally duplicates static/app/utils/dashboards/issueAssignee.tsx for the Autofix Overview POC.
 export function OverviewIssueAssignee({
   groupId,
@@ -43,52 +63,30 @@ export function OverviewIssueAssignee({
     '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
     {path: {organizationIdOrSlug: organization.slug}}
   );
-  const [assignedToOverride, setAssignedToOverride] = useState<{
-    assignedTo: Group['assignedTo'];
-    groupId: OverviewIssueAssigneeProps['groupId'];
-  } | null>(null);
-
-  const currentAssignedTo =
-    assignedToOverride?.groupId === groupId
-      ? assignedToOverride.assignedTo
-      : (assignedTo ?? null);
 
   const group = useMemo(
     () => ({
       id: groupId,
-      assignedTo: currentAssignedTo,
+      assignedTo: assignedTo ?? null,
       owners,
       project: {
         id: projectId,
         slug: projectSlug,
       },
     }),
-    [currentAssignedTo, groupId, owners, projectId, projectSlug]
+    [assignedTo, groupId, owners, projectId, projectSlug]
   );
 
   const handleSuccess = useCallback(
     (nextAssignedTo: Group['assignedTo']) => {
-      setAssignedToOverride({groupId, assignedTo: nextAssignedTo});
-      // Patch the cached overview payloads so payload-derived UI (the assignee
-      // filter options and counts) reflects the reassignment without a refetch.
+      // The cached overview payload is the single source of truth: patching it
+      // re-renders this card and the payload-derived assignee filter alike.
       queryClient.setQueriesData<ApiResponse<AutofixOverviewResponse>>(
         {queryKey: [overviewUrl]},
         previous =>
           previous && {
             ...previous,
-            json: {
-              ...previous.json,
-              runsByMilestone: Object.fromEntries(
-                Object.entries(previous.json.runsByMilestone).map(([milestone, runs]) => [
-                  milestone,
-                  runs.map(run =>
-                    run.groupId === groupId
-                      ? {...run, issue: {...run.issue, assignedTo: nextAssignedTo}}
-                      : run
-                  ),
-                ])
-              ) as AutofixOverviewResponse['runsByMilestone'],
-            },
+            json: withRunAssignee(previous.json, groupId, nextAssignedTo),
           }
       );
       void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -24,8 +24,6 @@ interface OverviewIssueAssigneeProps {
   owners?: Group['owners'];
 }
 
-// Object.fromEntries widens the key type, so the milestone Record is restored
-// with a cast; the map itself never adds or drops keys.
 function withRunAssignee(
   response: AutofixOverviewResponse,
   groupId: string,
@@ -79,8 +77,6 @@ export function OverviewIssueAssignee({
 
   const handleSuccess = useCallback(
     (nextAssignedTo: Group['assignedTo']) => {
-      // The cached overview payload is the single source of truth: patching it
-      // re-renders this card and the payload-derived assignee filter alike.
       queryClient.setQueriesData<ApiResponse<AutofixOverviewResponse>>(
         {queryKey: [overviewUrl]},
         previous =>

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -8,8 +8,11 @@ import {
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {AutofixOverviewResponse} from './types';
 
 interface OverviewIssueAssigneeProps {
   groupId: string;
@@ -36,6 +39,10 @@ export function OverviewIssueAssignee({
   const issueIndexUrl = getApiUrl('/organizations/$organizationIdOrSlug/issues/', {
     path: {organizationIdOrSlug: organization.slug},
   });
+  const overviewUrl = getApiUrl(
+    '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
+    {path: {organizationIdOrSlug: organization.slug}}
+  );
   const [assignedToOverride, setAssignedToOverride] = useState<{
     assignedTo: Group['assignedTo'];
     groupId: OverviewIssueAssigneeProps['groupId'];
@@ -62,9 +69,31 @@ export function OverviewIssueAssignee({
   const handleSuccess = useCallback(
     (nextAssignedTo: Group['assignedTo']) => {
       setAssignedToOverride({groupId, assignedTo: nextAssignedTo});
+      // Patch the cached overview payloads so payload-derived UI (the assignee
+      // filter options and counts) reflects the reassignment without a refetch.
+      queryClient.setQueriesData<ApiResponse<AutofixOverviewResponse>>(
+        {queryKey: [overviewUrl]},
+        previous =>
+          previous && {
+            ...previous,
+            json: {
+              ...previous.json,
+              runsByMilestone: Object.fromEntries(
+                Object.entries(previous.json.runsByMilestone).map(([milestone, runs]) => [
+                  milestone,
+                  runs.map(run =>
+                    run.groupId === groupId
+                      ? {...run, issue: {...run.issue, assignedTo: nextAssignedTo}}
+                      : run
+                  ),
+                ])
+              ) as AutofixOverviewResponse['runsByMilestone'],
+            },
+          }
+      );
       void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
     },
-    [groupId, issueIndexUrl, queryClient]
+    [groupId, issueIndexUrl, overviewUrl, queryClient]
   );
 
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -8,11 +8,8 @@ import {
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
-
-import type {AutofixOverviewResponse} from './types';
 
 interface OverviewIssueAssigneeProps {
   groupId: string;
@@ -22,24 +19,6 @@ interface OverviewIssueAssigneeProps {
   memberList?: User[];
   memberListLoading?: boolean;
   owners?: Group['owners'];
-}
-
-function withRunAssignee(
-  response: AutofixOverviewResponse,
-  groupId: string,
-  assignedTo: Group['assignedTo']
-): AutofixOverviewResponse {
-  return {
-    ...response,
-    runsByMilestone: Object.fromEntries(
-      Object.entries(response.runsByMilestone).map(([milestone, runs]) => [
-        milestone,
-        runs.map(run =>
-          run.groupId === groupId ? {...run, issue: {...run.issue, assignedTo}} : run
-        ),
-      ])
-    ) as AutofixOverviewResponse['runsByMilestone'],
-  };
 }
 
 // Intentionally duplicates static/app/utils/dashboards/issueAssignee.tsx for the Autofix Overview POC.
@@ -75,23 +54,12 @@ export function OverviewIssueAssignee({
     [assignedTo, groupId, owners, projectId, projectSlug]
   );
 
-  const handleSuccess = useCallback(
-    async (nextAssignedTo: Group['assignedTo']) => {
-      // Cancel in-flight overview fetches first so a stale response can't land
-      // after the patch and revert the assignee.
-      await queryClient.cancelQueries({queryKey: [overviewUrl]});
-      queryClient.setQueriesData<ApiResponse<AutofixOverviewResponse>>(
-        {queryKey: [overviewUrl]},
-        previous =>
-          previous && {
-            ...previous,
-            json: withRunAssignee(previous.json, groupId, nextAssignedTo),
-          }
-      );
-      void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
-    },
-    [groupId, issueIndexUrl, overviewUrl, queryClient]
-  );
+  const handleSuccess = useCallback(() => {
+    // Refetch the overview so the assignee filter's options and counts pick up
+    // the reassignment from the server.
+    void queryClient.invalidateQueries({queryKey: [overviewUrl]});
+    void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
+  }, [issueIndexUrl, overviewUrl, queryClient]);
 
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
     group,

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -197,6 +197,5 @@ export interface OverviewRun {
 
 export interface AutofixOverviewResponse {
   runsByMilestone: Record<MilestoneKey, OverviewRun[]>;
-  // Sections the backend capped; optional until the backend change is deployed.
   truncatedMilestones?: MilestoneKey[];
 }

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -197,4 +197,6 @@ export interface OverviewRun {
 
 export interface AutofixOverviewResponse {
   runsByMilestone: Record<MilestoneKey, OverviewRun[]>;
+  // Sections the backend capped; optional until the backend change is deployed.
+  truncatedMilestones?: MilestoneKey[];
 }


### PR DESCRIPTION
Restores the assignee filter that was lost when the legacy overview page was replaced (#122177/#122178), implementing [AIML-3185](https://linear.app/getsentry/issue/AIML-3185).

Unlike the old filter (which listed every org member/team and re-queried the issues endpoint), this one follows the ticket's spec: options are limited to assignees and teams actually represented in the page's results, each showing its matching issue count, plus an "Unassigned" entry. Filtering happens client-side over the already-loaded payload — the response includes each issue's `assignedTo`, so no extra requests are made — and the selection is kept in the `assignee` URL param alongside `sort`.

Reassigning an issue from a card now also patches the cached overview responses (previously only the issues-index query was invalidated), so the filter's options and counts update immediately; assigning to someone not yet represented adds them as an option, per the ticket.

Since each section is capped at 100 runs server-side, a client-side filter over a capped payload can be incomplete. #122181 adds a `truncatedMilestones` field to the response; when present, the page shows a "some sections show only their most recent runs" notice so the capped case is disclosed rather than silent. The field is treated as optional, so this PR is safe to land before or after the backend one.

Refs AIML-3185