### PR TITLE
feat(seer): Expose failed check names on Autofix overview PRs

### DIFF
--- a/src/sentry/integrations/github/pull_request_status.py
+++ b/src/sentry/integrations/github/pull_request_status.py
@@ -20,6 +20,19 @@ fragment PullRequestStatusFields on PullRequest {
       commit {
         statusCheckRollup {
           state
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun {
+                name
+                conclusion
+              }
+              ... on StatusContext {
+                context
+                state
+              }
+            }
+          }
         }
       }
     }
@@ -47,6 +60,12 @@ _CHECKS_STATUS_BY_STATE: dict[str, AggregateChecksStatus] = {
     "PENDING": AggregateChecksStatus.PENDING,
     "EXPECTED": AggregateChecksStatus.PENDING,
 }
+
+# CANCELLED is deliberately absent: like the rollup mapping above, it is neither pass nor fail.
+_FAILING_CHECK_RUN_CONCLUSIONS = frozenset(
+    ("FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED")
+)
+_FAILING_STATUS_CONTEXT_STATES = frozenset(("FAILURE", "ERROR"))
 
 _REVIEW_STATUS_BY_DECISION: dict[str, AggregateReviewStatus] = {
     "APPROVED": AggregateReviewStatus.APPROVED,
@@ -137,6 +156,37 @@ def _extract_files(pull_request: Any) -> tuple[PullRequestFileSummary, ...]:
     return tuple(files)
 
 
+def _extract_failed_checks(pull_request: Any) -> tuple[str, ...]:
+    nodes = (
+        get_path(
+            pull_request,
+            "commits",
+            "nodes",
+            0,
+            "commit",
+            "statusCheckRollup",
+            "contexts",
+            "nodes",
+        )
+        or []
+    )
+    failed: list[str] = []
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        if node.get("__typename") == "CheckRun":
+            name = node.get("name")
+            failing = node.get("conclusion") in _FAILING_CHECK_RUN_CONCLUSIONS
+        elif node.get("__typename") == "StatusContext":
+            name = node.get("context")
+            failing = node.get("state") in _FAILING_STATUS_CONTEXT_STATES
+        else:
+            continue
+        if failing and isinstance(name, str):
+            failed.append(name)
+    return tuple(failed)
+
+
 def _extract_pull_request_status(pull_request: Any) -> PullRequestStatusResult:
     state = get_path(pull_request, "commits", "nodes", 0, "commit", "statusCheckRollup", "state")
     decision = get_path(pull_request, "reviewDecision")
@@ -144,6 +194,7 @@ def _extract_pull_request_status(pull_request: Any) -> PullRequestStatusResult:
         checks=_CHECKS_STATUS_BY_STATE.get(state),
         review=_REVIEW_STATUS_BY_DECISION.get(decision),
         files=_extract_files(pull_request),
+        failed_checks=_extract_failed_checks(pull_request),
     )
 
 

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -71,6 +71,7 @@ class PullRequestStatusResult:
     checks: AggregateChecksStatus | None = None
     review: AggregateReviewStatus | None = None
     files: tuple[PullRequestFileSummary, ...] = ()
+    failed_checks: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -131,6 +131,7 @@ def _serialize_pull_request(
             }
             for file in checks_and_review.files
         ],
+        "failedChecks": list(checks_and_review.failed_checks),
     }
 
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -22,6 +22,7 @@ class PullRequestPayload(TypedDict):
     reviewStatus: str | None
     repoName: str | None
     files: list[PullRequestFilePayload]
+    failedChecks: list[str]
 
 
 class IssueProjectPayload(TypedDict):

--- a/tests/sentry/integrations/github/test_pull_request_status.py
+++ b/tests/sentry/integrations/github/test_pull_request_status.py
@@ -127,6 +127,89 @@ def test_extract_review(decision: str, expected: AggregateReviewStatus | None) -
     assert result.review == expected
 
 
+def test_query_reads_individual_check_contexts() -> None:
+    assert "contexts(first: 100)" in PULL_REQUEST_STATUS_FRAGMENT
+
+
+def test_extract_failed_checks() -> None:
+    result = extract_pull_request_status_from_response(
+        response(
+            {
+                "state": "FAILURE",
+                "contexts": {
+                    "nodes": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "build (3.12)",
+                            "conclusion": "FAILURE",
+                        },
+                        {"__typename": "CheckRun", "name": "lint", "conclusion": "SUCCESS"},
+                        {"__typename": "CheckRun", "name": "deploy", "conclusion": "TIMED_OUT"},
+                        {
+                            "__typename": "CheckRun",
+                            "name": "setup",
+                            "conclusion": "STARTUP_FAILURE",
+                        },
+                        {
+                            "__typename": "CheckRun",
+                            "name": "approval",
+                            "conclusion": "ACTION_REQUIRED",
+                        },
+                        # CANCELLED maps to neither pass nor fail, matching the rollup mapping.
+                        {"__typename": "CheckRun", "name": "optional", "conclusion": "CANCELLED"},
+                        {"__typename": "CheckRun", "name": "running", "conclusion": None},
+                        {"__typename": "StatusContext", "context": "ci/legacy", "state": "FAILURE"},
+                        {"__typename": "StatusContext", "context": "ci/error", "state": "ERROR"},
+                        {"__typename": "StatusContext", "context": "ci/ok", "state": "SUCCESS"},
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result.failed_checks == (
+        "build (3.12)",
+        "deploy",
+        "setup",
+        "approval",
+        "ci/legacy",
+        "ci/error",
+    )
+
+
+def test_extract_failed_checks_skips_partial_nodes() -> None:
+    result = extract_pull_request_status_from_response(
+        response(
+            {
+                "state": "FAILURE",
+                "contexts": {
+                    "nodes": [
+                        None,
+                        {"__typename": "CheckRun", "conclusion": "FAILURE"},
+                        {"__typename": "StatusContext", "state": "ERROR"},
+                        {"__typename": "SomethingNew", "name": "mystery"},
+                        {"__typename": "CheckRun", "name": "mypy", "conclusion": "FAILURE"},
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result.failed_checks == ("mypy",)
+
+
+@pytest.mark.parametrize(
+    "contexts",
+    (None, {"nodes": None}, {"nodes": []}),
+    ids=("no_contexts", "no_nodes", "empty_nodes"),
+)
+def test_extract_failed_checks_without_nodes(contexts: dict[str, Any] | None) -> None:
+    result = extract_pull_request_status_from_response(
+        response({"state": "FAILURE", "contexts": contexts})
+    )
+    assert result.failed_checks == ()
+
+
 def test_extract_reads_checks_and_review_from_one_response() -> None:
     # Failing checks alongside an approving review: neither field masks the other.
     assert extract_pull_request_status_from_response(

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -476,6 +476,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
                 "reviewStatus": None,
                 "repoName": "getsentry/sentry",
                 "files": [],
+                "failedChecks": [],
             }
         ]
 
@@ -542,7 +543,30 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
 
         assert pull_requests[0]["checksStatus"] == "success"
         assert pull_requests[0]["reviewStatus"] == "approved"
+        assert pull_requests[0]["failedChecks"] == []
         assert client.requested_keys == ["123"]
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_failing_pull_request_lists_failed_checks(self, mock_get_integration):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom")
+        self._pull_request_for_run(group, run, state=PullRequestLifecycleState.OPEN, draft=False)
+        self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {
+                    "123": PullRequestStatusResult(
+                        checks=AggregateChecksStatus.FAILURE,
+                        failed_checks=("build (3.12)", "mypy"),
+                    )
+                }
+            ),
+        )
+
+        pull_requests = self._pull_requests(expand="scmInfo")
+
+        assert pull_requests[0]["checksStatus"] == "failure"
+        assert pull_requests[0]["failedChecks"] == ["build (3.12)", "mypy"]
 
     @mock.patch(_INTEGRATION_SERVICE)
     def test_merged_pull_request_skips_provider_fetch(self, mock_get_integration):


### PR DESCRIPTION
The Autofix overview PR cards show a single aggregate **Checks Failing** / **Checks Passing** tag driven by `checksStatus`, with no detail about what actually failed. This adds the data needed to show how many checks failed and which ones.

There is no cheap count-only path: the GraphQL query previously fetched only the pre-aggregated `statusCheckRollup.state`, and producing a count requires fetching the individual contexts — at which point the names come for free. So the payload exposes one field, `failedChecks: string[]`, and the count is derived from its length.

## Changes

- Extend `PULL_REQUEST_STATUS_FRAGMENT` to fetch `statusCheckRollup.contexts(first: 100)` with `CheckRun` and `StatusContext` inline fragments.
- Add `_extract_failed_checks`, collecting names of failing contexts: `CheckRun` conclusions `FAILURE`, `TIMED_OUT`, `STARTUP_FAILURE`, `ACTION_REQUIRED`; `StatusContext` states `FAILURE`, `ERROR`. `CANCELLED` is deliberately not counted as failing, consistent with the rollup state mapping.
- Add `failed_checks: tuple[str, ...] = ()` to `PullRequestStatusResult` (defaulted, so the cached result shape stays compatible) and surface it as `failedChecks` on the overview endpoint's PR payload.

The frontend change consuming this (count in the tag label + tooltip listing the failed checks) will follow in a separate PR once this is deployed.

Refs [AIML-3319](https://linear.app/getsentry/issue/AIML-3319/show-failed-status-check-details-in-autofix-overview)