### PR TITLE
feat(seer): Show failed check details on Autofix overview PR tags

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -674,6 +674,25 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText(/^\d+ Checks? Failing$/)).not.toBeInTheDocument();
   });
 
+  it('does not crash when a failing PR omits failedChecks entirely', async () => {
+    // Pre-backend-deploy the field is absent from the payload; the failing tag
+    // must fall back to the plain label rather than reading .length of undefined.
+    const {failedChecks: _omitted, ...withoutFailedChecks} = {
+      ...pullRequestFixture({number: 3, status: 'open'}),
+      checksStatus: 'failure' as const,
+    };
+    mockOverview({
+      base: {
+        has_pull_request: [{...rootCauseRun, pullRequests: [withoutFailedChecks]}],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Checks Failing')).toBeInTheDocument();
+    expect(screen.queryByText(/^\d+ Checks? Failing$/)).not.toBeInTheDocument();
+  });
+
   it('renders a draft pull request as the actionable one', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -651,6 +651,29 @@ describe('AutofixOverview', () => {
     expect(screen.getByText('mypy')).toBeInTheDocument();
   });
 
+  it('uses the singular label for a single failed check', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                ...pullRequestFixture({number: 3, status: 'open'}),
+                checksStatus: 'failure',
+                failedChecks: ['mypy'],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('1 Check Failing')).toBeInTheDocument();
+  });
+
   it('falls back to the plain failing label when no check names are known', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -674,32 +674,9 @@ describe('AutofixOverview', () => {
     expect(await screen.findByText('1 Check Failing')).toBeInTheDocument();
   });
 
-  it('falls back to the plain failing label when no check names are known', async () => {
-    mockOverview({
-      base: {
-        has_pull_request: [
-          {
-            ...rootCauseRun,
-            pullRequests: [
-              {
-                ...pullRequestFixture({number: 3, status: 'open'}),
-                checksStatus: 'failure',
-              },
-            ],
-          },
-        ],
-      },
-    });
-
-    renderPage();
-
-    expect(await screen.findByText('Checks Failing')).toBeInTheDocument();
-    expect(screen.queryByText(/^\d+ Checks? Failing$/)).not.toBeInTheDocument();
-  });
-
-  it('does not crash when a failing PR omits failedChecks entirely', async () => {
-    // Pre-backend-deploy the field is absent from the payload; the failing tag
-    // must fall back to the plain label rather than reading .length of undefined.
+  it('falls back to the plain failing label when a failing PR omits failedChecks', async () => {
+    // The field is absent until the backend deploys; the failing tag must fall
+    // back to the plain label rather than reading .length of undefined.
     const {failedChecks: _omitted, ...withoutFailedChecks} = {
       ...pullRequestFixture({number: 3, status: 'open'}),
       checksStatus: 'failure' as const,

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -64,6 +64,7 @@ describe('AutofixOverview', () => {
       checksStatus: null,
       reviewStatus: null,
       files: [],
+      failedChecks: [],
     };
   }
 
@@ -471,6 +472,7 @@ describe('AutofixOverview', () => {
       reviewStatus: null,
       repoName: 'getsentry/sentry',
       files: [],
+      failedChecks: [],
     };
 
     const enriched = deferEnriched();
@@ -529,6 +531,7 @@ describe('AutofixOverview', () => {
       checksStatus: null,
       reviewStatus: null,
       repoName: null,
+      failedChecks: [],
       files: [
         {path: 'src/sentry/foo.py', additions: 1, deletions: 1, changeType: 'MODIFIED'},
         {path: 'src/sentry/bar.py', additions: 2, deletions: 0, changeType: 'ADDED'},
@@ -554,6 +557,7 @@ describe('AutofixOverview', () => {
       checksStatus: null,
       reviewStatus: null,
       files: [],
+      failedChecks: [],
     };
     // The endpoint enriches open/draft links only, so the actionable PR is the
     // one carrying badges and files.
@@ -572,6 +576,7 @@ describe('AutofixOverview', () => {
           changeType: 'MODIFIED',
         },
       ],
+      failedChecks: [],
     };
     mockOverview({
       base: {
@@ -603,6 +608,7 @@ describe('AutofixOverview', () => {
       ...pullRequestFixture({number: 3, status: 'open'}),
       checksStatus: 'failure',
       reviewStatus: 'changes_requested',
+      failedChecks: ['build (3.12)', 'mypy'],
     };
     const pendingPullRequest: OverviewPullRequest = {
       ...pullRequestFixture({number: 4, status: 'open'}),
@@ -629,7 +635,7 @@ describe('AutofixOverview', () => {
 
     expect(await screen.findByText('Changes Requested')).toBeInTheDocument();
     const changesRequestedTag = getTagForText('Changes Requested');
-    const checksFailingTag = getTagForText('Checks Failing');
+    const checksFailingTag = getTagForText('2 Checks Failing');
     const checksRunningTag = getTagForText('Checks Running');
     expect(
       changesRequestedTag.compareDocumentPosition(checksFailingTag) &
@@ -637,8 +643,35 @@ describe('AutofixOverview', () => {
     ).toBeTruthy();
     expect(changesRequestedTag.className).toEqual(checksRunningTag.className);
     expect(checksFailingTag.className).not.toEqual(changesRequestedTag.className);
-    expect(screen.queryByText(/^\d+ Checks Failing$/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Checks Failing')).not.toBeInTheDocument();
     expect(screen.queryByText('Review Required')).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('2 Checks Failing'));
+    expect(await screen.findByText('build (3.12)')).toBeInTheDocument();
+    expect(screen.getByText('mypy')).toBeInTheDocument();
+  });
+
+  it('falls back to the plain failing label when no check names are known', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                ...pullRequestFixture({number: 3, status: 'open'}),
+                checksStatus: 'failure',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Checks Failing')).toBeInTheDocument();
+    expect(screen.queryByText(/^\d+ Checks? Failing$/)).not.toBeInTheDocument();
   });
 
   it('renders a draft pull request as the actionable one', async () => {
@@ -703,6 +736,7 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
+                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/new.py',
@@ -770,6 +804,7 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
+                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/mystery.py',
@@ -807,6 +842,7 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
+                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/foo.py',
@@ -862,6 +898,7 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
+                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/gone.py',

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -30,7 +30,7 @@ import {
   IconUser,
 } from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
-import {t} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import type {
   PullRequestChecksStatus,
@@ -190,6 +190,8 @@ function OverviewAction({
     const reviewStatusTag = reviewPullRequest.reviewStatus
       ? REVIEW_STATUS_TAGS[reviewPullRequest.reviewStatus]
       : null;
+    const failedChecks =
+      reviewPullRequest.checksStatus === 'failure' ? reviewPullRequest.failedChecks : [];
 
     return (
       <Stack align="end" gap="xs">
@@ -216,9 +218,27 @@ function OverviewAction({
               </Tag>
             )}
             {checksStatusTag && (
-              <Tag variant={checksStatusTag.variant} icon={checksStatusTag.icon}>
-                {checksStatusTag.label}
-              </Tag>
+              <Tooltip
+                disabled={failedChecks.length === 0}
+                title={
+                  <Stack gap="xs" align="start">
+                    <Text size="sm" bold>
+                      {t('Failing checks:')}
+                    </Text>
+                    {failedChecks.map((name, index) => (
+                      <Text key={`${name}-${index}`} size="sm">
+                        {name}
+                      </Text>
+                    ))}
+                  </Stack>
+                }
+              >
+                <Tag variant={checksStatusTag.variant} icon={checksStatusTag.icon}>
+                  {failedChecks.length > 0
+                    ? tn('%s Check Failing', '%s Checks Failing', failedChecks.length)
+                    : checksStatusTag.label}
+                </Tag>
+              </Tooltip>
             )}
           </Fragment>
         )}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -190,8 +190,12 @@ function OverviewAction({
     const reviewStatusTag = reviewPullRequest.reviewStatus
       ? REVIEW_STATUS_TAGS[reviewPullRequest.reviewStatus]
       : null;
+    // failedChecks is absent until the backend that populates it deploys, so
+    // guard the transition window where checksStatus is 'failure' without it.
     const failedChecks =
-      reviewPullRequest.checksStatus === 'failure' ? reviewPullRequest.failedChecks : [];
+      reviewPullRequest.checksStatus === 'failure'
+        ? (reviewPullRequest.failedChecks ?? [])
+        : [];
 
     return (
       <Stack align="end" gap="xs">

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -190,8 +190,6 @@ function OverviewAction({
     const reviewStatusTag = reviewPullRequest.reviewStatus
       ? REVIEW_STATUS_TAGS[reviewPullRequest.reviewStatus]
       : null;
-    // failedChecks is absent until the backend that populates it deploys, so
-    // guard the transition window where checksStatus is 'failure' without it.
     const failedChecks =
       reviewPullRequest.checksStatus === 'failure'
         ? (reviewPullRequest.failedChecks ?? [])

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -149,7 +149,6 @@ export interface OverviewPullRequest {
   reviewStatus: PullRequestReviewStatus | null;
   status: PullRequestStatus | null;
   url: string | null;
-  // Absent from the payload until the backend that populates it deploys.
   failedChecks?: string[];
   repoName?: string | null;
 }

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -143,13 +143,14 @@ export interface OverviewPullRequestFile {
 
 export interface OverviewPullRequest {
   checksStatus: PullRequestChecksStatus | null;
-  failedChecks: string[];
   files: OverviewPullRequestFile[];
   id: string;
   number: number;
   reviewStatus: PullRequestReviewStatus | null;
   status: PullRequestStatus | null;
   url: string | null;
+  // Absent from the payload until the backend that populates it deploys.
+  failedChecks?: string[];
   repoName?: string | null;
 }
 

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -143,6 +143,7 @@ export interface OverviewPullRequestFile {
 
 export interface OverviewPullRequest {
   checksStatus: PullRequestChecksStatus | null;
+  failedChecks: string[];
   files: OverviewPullRequestFile[];
   id: string;
   number: number;


### PR DESCRIPTION
Failing PRs on the Autofix overview currently render a generic red **✕ Checks Failing** tag with no detail. This consumes the new `failedChecks` field from the overview endpoint (#122183) to show how many checks failed and which ones:

- The failing tag label becomes a count, e.g. **✕ 2 Checks Failing** (pluralized via `tn`), falling back to the plain **Checks Failing** label when the list is empty (e.g. the field is missing or the individual contexts could not be fetched).
- Hovering the tag shows a tooltip listing the failed check names.
- Passing and pending tags are unchanged.

Depends on the backend PR #122183 — do not merge until that is deployed; until then the field is absent from the payload and the UI falls back to today's behavior.

Refs [AIML-3319](https://linear.app/getsentry/issue/AIML-3319/show-failed-status-check-details-in-autofix-overview)