### PR TITLE
fix(investigations): run dependency-aware cell workflows

### DIFF
--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import html
+from datetime import datetime
 from enum import StrEnum
 from functools import partial
 from typing import Any
@@ -22,6 +23,7 @@ from sentry.investigations.models import (
     InvestigationStatus,
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
+from sentry.investigations.services.executions import mark_block_execution_dispatched
 from sentry.investigations.services.investigations import (
     DEFAULT_INVESTIGATION_TITLE,
     investigation_source,
@@ -130,6 +132,7 @@ def start_execution_run(
     organization: Organization,
     user: Any,
     client: SeerAgentClient | None = None,
+    dispatch_claimed_at: datetime | None = None,
 ) -> None:
     is_query = execution.block.kind == InvestigationBlockKind.QUERY
     if client is None:
@@ -151,15 +154,22 @@ def start_execution_run(
             "execution_id": str(execution.id),
         },
         record_in_history=False,
-        on_run_created=lambda run: _mark_dispatched(execution, run.id),
+        on_run_created=lambda run: _mark_dispatched(
+            execution, run.id, dispatch_claimed_at=dispatch_claimed_at
+        ),
     )
 
 
-def _mark_dispatched(execution: InvestigationBlockExecution, seer_run_id: int) -> None:
-    execution.update(
+def _mark_dispatched(
+    execution: InvestigationBlockExecution,
+    seer_run_id: int,
+    *,
+    dispatch_claimed_at: datetime | None = None,
+) -> None:
+    mark_block_execution_dispatched(
+        execution,
         seer_run_id=seer_run_id,
-        status=InvestigationBlockExecutionStatus.RUNNING,
-        started_at=timezone.now(),
+        dispatch_claimed_at=dispatch_claimed_at,
     )
 
 
@@ -695,8 +705,17 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
                 result["queryLinks"] = links
                 result = validate_query_result(result)
                 allowed_project_ids = set(execution.input_snapshot.get("projectIds", []))
-                if not {project.id for project in projects}.issubset(allowed_project_ids):
+                result_project_ids = {project.id for project in projects}.union(
+                    execution.input_snapshot.get("contextDataProjectIds", [])
+                )
+                if not result_project_ids.issubset(allowed_project_ids):
                     raise ValueError("The result queried outside the investigation project scope.")
+                projects = list(
+                    Project.objects.filter(
+                        organization=execution.block.investigation.organization,
+                        id__in=result_project_ids,
+                    ).order_by("id")
+                )
             else:
                 context_project_ids = execution.input_snapshot.get("contextDataProjectIds", [])
                 projects = list(

--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -73,11 +73,16 @@ loop variable, comprehension, or other expression; write separate calls when dif
 project lists are needed. Do not import sentry, sentry_sdk, or tool input types; use the provided
 sentry object directly. For a time-series chart, call sentry.render_chart with a title and series shaped like
 [{"label": "Errors", "data": [{"x": "2026-08-04T00:00:00+00:00", "y": 1}]}],
-for example title="Error volume", x_axis="time", y_axis_unit="number", and a supported
-visualization such as "line". Pass chart points and series as inline plain dictionaries; do not
+for example title="Error volume", subtitle="Last 24 hours | 1,240 total events",
+x_axis="time", y_axis_unit="number", and a supported visualization such as "line". Always give
+the chart a concise title and a subtitle containing the most useful result metadata, such as the
+time window, scope, and total count. Pass chart points and series as inline plain dictionaries; do not
 import type helpers. Time-axis
 x values must be offset-bearing ISO 8601 timestamps. If the question cannot be answered with telemetry, ask the user an
 inline clarification. Finish by returning exactly one raw JSON object in your final response.
+When notebookContext contains an item with currentBlock=true, it is the last successful result for
+the block being refined. Reuse its table and chart data for presentation-only requests such as
+changing line, area, or bar visualization; do not claim the data is unavailable or query it again.
 The first character must be { and the last character must be }.
 Do not wrap the object in a Markdown code fence or include prose before or after it. Do not call any function to
 write or save the result. tableMarkdown must be a complete Markdown table (or an empty table). When

--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -705,11 +705,12 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
                 result["queryLinks"] = links
                 result = validate_query_result(result)
                 allowed_project_ids = set(execution.input_snapshot.get("projectIds", []))
-                result_project_ids = {project.id for project in projects}.union(
+                queried_project_ids = {project.id for project in projects}
+                if not queried_project_ids.issubset(allowed_project_ids):
+                    raise ValueError("The result queried outside the investigation project scope.")
+                result_project_ids = queried_project_ids.union(
                     execution.input_snapshot.get("contextDataProjectIds", [])
                 )
-                if not result_project_ids.issubset(allowed_project_ids):
-                    raise ValueError("The result queried outside the investigation project scope.")
                 projects = list(
                     Project.objects.filter(
                         organization=execution.block.investigation.organization,

--- a/src/sentry/investigations/endpoints/organization_investigation_index.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_index.py
@@ -95,11 +95,11 @@ class OrganizationInvestigationsIndexEndpoint(OrganizationInvestigationsBaseEndp
                         accessible_project_ids=project_ids,
                         title=values.get("title"),
                     )
+                    schedule_eligible_auto_run_blocks(
+                        investigation_id=investigation.id,
+                        user_id=user_id(request),
+                    )
                     if created:
-                        schedule_eligible_auto_run_blocks(
-                            investigation_id=investigation.id,
-                            user_id=user_id(request),
-                        )
                         investigation.refresh_from_db()
                     else:
                         require_investigation_project_access(investigation, project_ids)

--- a/src/sentry/investigations/endpoints/organization_investigation_index.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_index.py
@@ -95,14 +95,12 @@ class OrganizationInvestigationsIndexEndpoint(OrganizationInvestigationsBaseEndp
                         accessible_project_ids=project_ids,
                         title=values.get("title"),
                     )
+                    if not created:
+                        require_investigation_project_access(investigation, project_ids)
                     schedule_eligible_auto_run_blocks(
                         investigation_id=investigation.id,
                         user_id=user_id(request),
                     )
-                    if created:
-                        investigation.refresh_from_db()
-                    else:
-                        require_investigation_project_access(investigation, project_ids)
             else:
                 created = True
                 requested_project_ids = values.get("project_ids", [])

--- a/src/sentry/investigations/services/auto_run.py
+++ b/src/sentry/investigations/services/auto_run.py
@@ -11,7 +11,10 @@ from sentry.investigations.models import (
     InvestigationBlockExecutionStatus,
     InvestigationBlockKind,
 )
-from sentry.investigations.services.executions import create_block_execution
+from sentry.investigations.services.executions import (
+    block_execution_needs_dispatch,
+    create_block_execution,
+)
 
 
 def _dependency_is_ready(block: InvestigationBlock) -> bool:
@@ -58,7 +61,7 @@ def schedule_eligible_auto_run_blocks(
         if not block.config.get("autoRun"):
             continue
         if block.current_execution is not None and block.stale_at is None:
-            if block.current_execution.status == InvestigationBlockExecutionStatus.PENDING:
+            if block_execution_needs_dispatch(block.current_execution):
                 _dispatch_after_commit(block.current_execution)
                 continue
             if not retry_failed or block.current_execution.status not in {

--- a/src/sentry/investigations/services/auto_run.py
+++ b/src/sentry/investigations/services/auto_run.py
@@ -27,6 +27,15 @@ def _dependency_is_ready(block: InvestigationBlock) -> bool:
     )
 
 
+def _dispatch_after_commit(execution: InvestigationBlockExecution) -> None:
+    from sentry.tasks.seer.investigation import dispatch_investigation_execution
+
+    transaction.on_commit(
+        partial(dispatch_investigation_execution, execution.id),
+        using=router.db_for_write(InvestigationBlockExecution),
+    )
+
+
 def schedule_eligible_auto_run_blocks(
     *, investigation_id: int, user_id: int, retry_failed: bool = False
 ) -> None:
@@ -49,6 +58,9 @@ def schedule_eligible_auto_run_blocks(
         if not block.config.get("autoRun"):
             continue
         if block.current_execution is not None and block.stale_at is None:
+            if block.current_execution.status == InvestigationBlockExecutionStatus.PENDING:
+                _dispatch_after_commit(block.current_execution)
+                continue
             if not retry_failed or block.current_execution.status not in {
                 InvestigationBlockExecutionStatus.FAILED,
                 InvestigationBlockExecutionStatus.CANCELLED,
@@ -66,9 +78,4 @@ def schedule_eligible_auto_run_blocks(
             accessible_project_ids=set(project_ids),
         )
         if created:
-            from sentry.tasks.seer.investigation import dispatch_investigation_execution
-
-            transaction.on_commit(
-                partial(dispatch_investigation_execution.delay, execution.id),
-                using=router.db_for_write(InvestigationBlockExecution),
-            )
+            _dispatch_after_commit(execution)

--- a/src/sentry/investigations/services/auto_run.py
+++ b/src/sentry/investigations/services/auto_run.py
@@ -31,7 +31,7 @@ def _dispatch_after_commit(execution: InvestigationBlockExecution) -> None:
     from sentry.tasks.seer.investigation import dispatch_investigation_execution
 
     transaction.on_commit(
-        partial(dispatch_investigation_execution, execution.id),
+        partial(dispatch_investigation_execution.delay, execution.id),
         using=router.db_for_write(InvestigationBlockExecution),
     )
 

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -459,11 +459,21 @@ def create_block_execution(
 
 
 def mark_block_execution_dispatched(
-    execution: InvestigationBlockExecution, *, seer_run_id: int
+    execution: InvestigationBlockExecution,
+    *,
+    seer_run_id: int,
+    dispatch_claimed_at: datetime | None = None,
 ) -> bool:
-    updated = InvestigationBlockExecution.objects.filter(
-        id=execution.id, status=InvestigationBlockExecutionStatus.PENDING
-    ).update(
+    candidates = InvestigationBlockExecution.objects.filter(id=execution.id)
+    if dispatch_claimed_at is None:
+        candidates = candidates.filter(status=InvestigationBlockExecutionStatus.PENDING)
+    else:
+        candidates = candidates.filter(
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            seer_run_id__isnull=True,
+            started_at=dispatch_claimed_at,
+        )
+    updated = candidates.update(
         seer_run_id=seer_run_id,
         status=InvestigationBlockExecutionStatus.RUNNING,
         started_at=timezone.now(),
@@ -471,8 +481,11 @@ def mark_block_execution_dispatched(
     return updated == 1
 
 
-def mark_block_execution_dispatch_started(execution: InvestigationBlockExecution) -> bool:
+def mark_block_execution_dispatch_started(
+    execution: InvestigationBlockExecution,
+) -> datetime | None:
     stale_before = timezone.now() - DISPATCH_CLAIM_TIMEOUT
+    claimed_at = timezone.now()
     updated = (
         InvestigationBlockExecution.objects.filter(id=execution.id)
         .filter(
@@ -490,10 +503,10 @@ def mark_block_execution_dispatch_started(execution: InvestigationBlockExecution
         )
         .update(
             status=InvestigationBlockExecutionStatus.RUNNING,
-            started_at=timezone.now(),
+            started_at=claimed_at,
         )
     )
-    return updated == 1
+    return claimed_at if updated == 1 else None
 
 
 def block_execution_needs_dispatch(execution: InvestigationBlockExecution) -> bool:
@@ -534,14 +547,24 @@ def mark_block_execution_cancelled(execution: InvestigationBlockExecution) -> bo
     return updated == 1
 
 
-def mark_block_execution_dispatch_failed(execution: InvestigationBlockExecution) -> bool:
-    updated = InvestigationBlockExecution.objects.filter(
-        id=execution.id,
-        status__in=[
-            InvestigationBlockExecutionStatus.PENDING,
-            InvestigationBlockExecutionStatus.RUNNING,
-        ],
-    ).update(
+def mark_block_execution_dispatch_failed(
+    execution: InvestigationBlockExecution, *, dispatch_claimed_at: datetime | None = None
+) -> bool:
+    candidates = InvestigationBlockExecution.objects.filter(id=execution.id)
+    if dispatch_claimed_at is None:
+        candidates = candidates.filter(
+            status__in=[
+                InvestigationBlockExecutionStatus.PENDING,
+                InvestigationBlockExecutionStatus.RUNNING,
+            ]
+        )
+    else:
+        candidates = candidates.filter(
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            seer_run_id__isnull=True,
+            started_at=dispatch_claimed_at,
+        )
+    updated = candidates.update(
         status=InvestigationBlockExecutionStatus.FAILED,
         error={
             "code": "dispatch_failed",

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import timedelta
 from typing import Any
 from uuid import UUID
 
 from django.db import router, transaction
+from django.db.models import Q
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
@@ -36,6 +38,7 @@ from sentry.utils import json
 MAX_CONTEXT_BLOCKS = 20
 MAX_CONTEXT_TEXT_CHARS = 50_000
 MAX_CONTEXT_BYTES = 512 * 1024
+DISPATCH_CLAIM_TIMEOUT = timedelta(minutes=5)
 
 
 def _fingerprint(snapshot: dict[str, Any]) -> str:
@@ -469,13 +472,41 @@ def mark_block_execution_dispatched(
 
 
 def mark_block_execution_dispatch_started(execution: InvestigationBlockExecution) -> bool:
-    updated = InvestigationBlockExecution.objects.filter(
-        id=execution.id, status=InvestigationBlockExecutionStatus.PENDING
-    ).update(
-        status=InvestigationBlockExecutionStatus.RUNNING,
-        started_at=timezone.now(),
+    stale_before = timezone.now() - DISPATCH_CLAIM_TIMEOUT
+    updated = (
+        InvestigationBlockExecution.objects.filter(id=execution.id)
+        .filter(
+            Q(status=InvestigationBlockExecutionStatus.PENDING)
+            | Q(
+                status=InvestigationBlockExecutionStatus.RUNNING,
+                seer_run_id__isnull=True,
+                started_at__lte=stale_before,
+            )
+            | Q(
+                status=InvestigationBlockExecutionStatus.RUNNING,
+                seer_run_id__isnull=True,
+                started_at__isnull=True,
+            )
+        )
+        .update(
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            started_at=timezone.now(),
+        )
     )
     return updated == 1
+
+
+def block_execution_needs_dispatch(execution: InvestigationBlockExecution) -> bool:
+    if execution.status == InvestigationBlockExecutionStatus.PENDING:
+        return True
+    return (
+        execution.status == InvestigationBlockExecutionStatus.RUNNING
+        and execution.seer_run_id is None
+        and (
+            execution.started_at is None
+            or execution.started_at <= timezone.now() - DISPATCH_CLAIM_TIMEOUT
+        )
+    )
 
 
 def mark_block_execution_resumed(execution: InvestigationBlockExecution) -> bool:

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -55,9 +55,39 @@ def _compact_query_context(
     return {
         "schemaVersion": validated["schemaVersion"],
         "tableMarkdown": validated["tableMarkdown"][:max_text_chars],
+        "chart": validated.get("chart"),
+        "preferredView": validated["preferredView"],
         "isEmpty": validated["isEmpty"],
+        "chartUnavailableReason": validated.get("chartUnavailableReason"),
         "queryLinks": validated["queryLinks"],
     }
+
+
+def _has_usable_query_data(result: Any) -> bool:
+    try:
+        validated = validate_query_result(result)
+    except ValidationError:
+        return False
+    return not validated["isEmpty"] and bool(
+        validated.get("chart") or validated["tableMarkdown"].strip()
+    )
+
+
+def _query_refinement_context_execution(
+    block: InvestigationBlock,
+) -> InvestigationBlockExecution | None:
+    current = block.result_execution
+    if current is not None and _has_usable_query_data(current.result):
+        return current
+
+    for execution in (
+        block.executions.filter(status=InvestigationBlockExecutionStatus.COMPLETED)
+        .exclude(id=current.id if current is not None else None)
+        .order_by("-date_added")[:20]
+    ):
+        if _has_usable_query_data(execution.result):
+            return execution
+    return current
 
 
 def _materialize_dependency_context(
@@ -263,6 +293,34 @@ def build_block_execution_snapshot(
         dependencies, context, context_project_ids = _materialize_dependency_context(
             block, accessible_project_ids=accessible_project_ids
         )
+        previous_execution = _query_refinement_context_execution(block)
+        if (
+            previous_execution is not None
+            and previous_execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        ):
+            previous_project_ids = set(
+                previous_execution.data_projects.values_list("id", flat=True)
+            )
+            if not previous_project_ids.issubset(accessible_project_ids):
+                raise InvestigationValidationError(
+                    {"context": "The previous query result uses inaccessible project data."}
+                )
+            context.insert(
+                0,
+                {
+                    "block_id": str(block.id),
+                    "kind": block.kind,
+                    "title": block.title,
+                    "currentBlock": True,
+                    "visibleExecutionId": str(previous_execution.id),
+                    "result": _compact_query_context(previous_execution.result),
+                },
+            )
+            context_project_ids = sorted(set(context_project_ids).union(previous_project_ids))
+            if len(json.dumps(context).encode()) > MAX_CONTEXT_BYTES:
+                raise InvestigationValidationError(
+                    {"context": "The query context is too large to send to the agent."}
+                )
     snapshot: dict[str, Any] = {
         "prompt": prompt,
         "source": investigation_source(block.investigation),

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -556,11 +556,13 @@ def mark_block_execution_dispatch_failed(
             status__in=[
                 InvestigationBlockExecutionStatus.PENDING,
                 InvestigationBlockExecutionStatus.RUNNING,
-            ]
+            ],
+            seer_run_id__isnull=True,
         )
     else:
         candidates = candidates.filter(
             status=InvestigationBlockExecutionStatus.RUNNING,
+            seer_run_id__isnull=True,
             started_at=dispatch_claimed_at,
         )
     updated = candidates.update(

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -468,6 +468,16 @@ def mark_block_execution_dispatched(
     return updated == 1
 
 
+def mark_block_execution_dispatch_started(execution: InvestigationBlockExecution) -> bool:
+    updated = InvestigationBlockExecution.objects.filter(
+        id=execution.id, status=InvestigationBlockExecutionStatus.PENDING
+    ).update(
+        status=InvestigationBlockExecutionStatus.RUNNING,
+        started_at=timezone.now(),
+    )
+    return updated == 1
+
+
 def mark_block_execution_resumed(execution: InvestigationBlockExecution) -> bool:
     updated = InvestigationBlockExecution.objects.filter(
         id=execution.id, status=InvestigationBlockExecutionStatus.AWAITING_INPUT

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -80,11 +80,11 @@ def _query_refinement_context_execution(
     if current is not None and _has_usable_query_data(current.result):
         return current
 
-    for execution in (
-        block.executions.filter(status=InvestigationBlockExecutionStatus.COMPLETED)
-        .exclude(id=current.id if current is not None else None)
-        .order_by("-date_added")[:20]
-    ):
+    completed = block.executions.filter(status=InvestigationBlockExecutionStatus.COMPLETED)
+    if current is not None:
+        assert current.id is not None
+        completed = completed.exclude(id=current.id)
+    for execution in completed.order_by("-date_added")[:20]:
         if _has_usable_query_data(execution.result):
             return execution
     return current

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -476,7 +476,7 @@ def mark_block_execution_dispatched(
     updated = candidates.update(
         seer_run_id=seer_run_id,
         status=InvestigationBlockExecutionStatus.RUNNING,
-        started_at=timezone.now(),
+        started_at=dispatch_claimed_at or timezone.now(),
     )
     return updated == 1
 
@@ -561,7 +561,6 @@ def mark_block_execution_dispatch_failed(
     else:
         candidates = candidates.filter(
             status=InvestigationBlockExecutionStatus.RUNNING,
-            seer_run_id__isnull=True,
             started_at=dispatch_claimed_at,
         )
     updated = candidates.update(

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import logging
 
 from sentry.investigations.agent import start_execution_run
-from sentry.investigations.models import (
-    InvestigationBlockExecution,
-    InvestigationBlockExecutionStatus,
-)
+from sentry.investigations.models import InvestigationBlockExecution
 from sentry.investigations.services import (
     mark_block_execution_dispatch_failed,
     mark_block_execution_dispatch_started,
@@ -25,7 +22,7 @@ logger = logging.getLogger(__name__)
 def dispatch_investigation_execution(execution_id: int) -> None:
     execution = (
         InvestigationBlockExecution.objects.select_related("block__investigation__organization")
-        .filter(id=execution_id, status=InvestigationBlockExecutionStatus.PENDING)
+        .filter(id=execution_id)
         .first()
     )
     if execution is None or not mark_block_execution_dispatch_started(execution):

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -25,7 +25,10 @@ def dispatch_investigation_execution(execution_id: int) -> None:
         .filter(id=execution_id)
         .first()
     )
-    if execution is None or not mark_block_execution_dispatch_started(execution):
+    if execution is None:
+        return
+    dispatch_claimed_at = mark_block_execution_dispatch_started(execution)
+    if dispatch_claimed_at is None:
         return
     user = (
         user_service.get_user(user_id=execution.triggered_by_id)
@@ -37,7 +40,8 @@ def dispatch_investigation_execution(execution_id: int) -> None:
             execution,
             execution.block.investigation.organization,
             user,
+            dispatch_claimed_at=dispatch_claimed_at,
         )
     except Exception:
         logger.exception("investigations.execution.dispatch_failed")
-        mark_block_execution_dispatch_failed(execution)
+        mark_block_execution_dispatch_failed(execution, dispatch_claimed_at=dispatch_claimed_at)

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -7,7 +7,10 @@ from sentry.investigations.models import (
     InvestigationBlockExecution,
     InvestigationBlockExecutionStatus,
 )
-from sentry.investigations.services import mark_block_execution_dispatch_failed
+from sentry.investigations.services import (
+    mark_block_execution_dispatch_failed,
+    mark_block_execution_dispatch_started,
+)
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.users.services.user.service import user_service
@@ -25,7 +28,7 @@ def dispatch_investigation_execution(execution_id: int) -> None:
         .filter(id=execution_id, status=InvestigationBlockExecutionStatus.PENDING)
         .first()
     )
-    if execution is None:
+    if execution is None or not mark_block_execution_dispatch_started(execution):
         return
     user = (
         user_service.get_user(user_id=execution.triggered_by_id)

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
@@ -123,7 +123,7 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         assert duplicate.status_code == 200
         assert duplicate.data["id"] == launched.data["id"]
         assert Investigation.objects.count() == 1
-        schedule_auto_run.assert_called_once()
+        assert schedule_auto_run.call_count == 2
 
         response = self.client.post(self.candidates_url, candidate_payload, format="json")
         assert response.data == {

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
@@ -256,8 +256,13 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         )
         self.login_as(viewer)
 
-        duplicate = self.client.post(self.collection_url, launch_payload, format="json")
+        with mock.patch(
+            "sentry.investigations.endpoints.organization_investigation_index."
+            "schedule_eligible_auto_run_blocks"
+        ) as schedule_auto_run:
+            duplicate = self.client.post(self.collection_url, launch_payload, format="json")
         assert duplicate.status_code == 403
+        schedule_auto_run.assert_not_called()
 
         candidate = self.client.post(
             self.candidates_url,

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from sentry.investigations.models import (
+    InvestigationBlockExecution,
+    InvestigationBlockExecutionStatus,
+    InvestigationBlockKind,
+)
+from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
+from sentry.testutils.cases import TestCase
+
+
+class InvestigationAutoRunTest(TestCase):
+    def setUp(self) -> None:
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.investigation = self.create_investigation(
+            organization=self.organization,
+            created_by=self.user,
+        )
+        self.create_investigation_project(investigation=self.investigation, project=self.project)
+        self.root = self.create_investigation_block(
+            investigation=self.investigation,
+            position=0,
+            kind=InvestigationBlockKind.QUERY,
+            prompt="Chart the breach",
+            config={"autoRun": True},
+        )
+        self.dependent = self.create_investigation_block(
+            investigation=self.investigation,
+            position=1,
+            kind=InvestigationBlockKind.TEXT,
+            prompt="Explain the chart",
+            config={"autoRun": True},
+        )
+        self.create_investigation_block_dependency(block=self.dependent, depends_on=self.root)
+
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_execution")
+    def test_dispatches_in_dependency_order(self, dispatch: mock.Mock) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+
+        self.root.refresh_from_db()
+        self.dependent.refresh_from_db()
+        assert self.root.current_execution is not None
+        assert self.root.current_execution.status == InvestigationBlockExecutionStatus.PENDING
+        assert self.dependent.current_execution is None
+        dispatch.assert_called_once_with(self.root.current_execution.id)
+
+        self.root.current_execution.update(
+            status=InvestigationBlockExecutionStatus.COMPLETED,
+            result={
+                "schemaVersion": 1,
+                "tableMarkdown": "| count |\n| --- |\n| 1 |",
+                "chart": None,
+                "preferredView": "table",
+                "isEmpty": False,
+                "chartUnavailableReason": None,
+                "queryLinks": [],
+            },
+        )
+        self.root.result_execution = self.root.current_execution
+        self.root.save(update_fields=["result_execution", "date_updated"])
+        self.root.refresh_from_db()
+        assert self.root.stale_at is None
+        assert self.root.result_execution is not None
+        assert self.root.result_execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        dispatch.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+
+        self.dependent.refresh_from_db()
+        assert self.dependent.current_execution is not None
+        assert self.dependent.current_execution.status == InvestigationBlockExecutionStatus.PENDING
+        dispatch.assert_called_once_with(self.dependent.current_execution.id)
+
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_execution")
+    def test_redispatches_an_existing_pending_execution(self, dispatch: mock.Mock) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+        self.root.refresh_from_db()
+        execution_id = self.root.current_execution_id
+        assert execution_id is not None
+        dispatch.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+
+        self.root.refresh_from_db()
+        assert self.root.current_execution_id == execution_id
+        assert InvestigationBlockExecution.objects.filter(block=self.root).count() == 1
+        dispatch.assert_called_once_with(execution_id)

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 from sentry.investigations.models import (
+    InvestigationBlock,
     InvestigationBlockExecution,
     InvestigationBlockExecutionStatus,
     InvestigationBlockKind,
@@ -49,7 +50,7 @@ class InvestigationAutoRunTest(TestCase):
         assert self.root.current_execution is not None
         assert self.root.current_execution.status == InvestigationBlockExecutionStatus.PENDING
         assert self.dependent.current_execution is None
-        dispatch.assert_called_once_with(self.root.current_execution.id)
+        dispatch.delay.assert_called_once_with(self.root.current_execution.id)
 
         self.root.current_execution.update(
             status=InvestigationBlockExecutionStatus.COMPLETED,
@@ -69,7 +70,7 @@ class InvestigationAutoRunTest(TestCase):
         assert self.root.stale_at is None
         assert self.root.result_execution is not None
         assert self.root.result_execution.status == InvestigationBlockExecutionStatus.COMPLETED
-        dispatch.reset_mock()
+        dispatch.delay.reset_mock()
 
         with self.captureOnCommitCallbacks(execute=True):
             schedule_eligible_auto_run_blocks(
@@ -77,10 +78,10 @@ class InvestigationAutoRunTest(TestCase):
                 user_id=self.user.id,
             )
 
-        self.dependent.refresh_from_db()
-        assert self.dependent.current_execution is not None
-        assert self.dependent.current_execution.status == InvestigationBlockExecutionStatus.PENDING
-        dispatch.assert_called_once_with(self.dependent.current_execution.id)
+        dependent = InvestigationBlock.objects.get(id=self.dependent.id)
+        assert dependent.current_execution is not None
+        assert dependent.current_execution.status == InvestigationBlockExecutionStatus.PENDING
+        dispatch.delay.assert_called_once_with(dependent.current_execution.id)
 
     @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_execution")
     def test_redispatches_an_existing_pending_execution(self, dispatch: mock.Mock) -> None:
@@ -92,7 +93,7 @@ class InvestigationAutoRunTest(TestCase):
         self.root.refresh_from_db()
         execution_id = self.root.current_execution_id
         assert execution_id is not None
-        dispatch.reset_mock()
+        dispatch.delay.reset_mock()
 
         with self.captureOnCommitCallbacks(execute=True):
             schedule_eligible_auto_run_blocks(
@@ -103,4 +104,4 @@ class InvestigationAutoRunTest(TestCase):
         self.root.refresh_from_db()
         assert self.root.current_execution_id == execution_id
         assert InvestigationBlockExecution.objects.filter(block=self.root).count() == 1
-        dispatch.assert_called_once_with(execution_id)
+        dispatch.delay.assert_called_once_with(execution_id)

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest import mock
+
+from django.utils import timezone
 
 from sentry.investigations.models import (
     InvestigationBlock,
@@ -122,3 +125,44 @@ class InvestigationAutoRunTest(TestCase):
         dispatch_investigation_execution(execution_id)
 
         start_execution_run.assert_called_once()
+
+    @mock.patch("sentry.tasks.seer.investigation.start_execution_run")
+    def test_stale_dispatch_claim_can_be_reclaimed(self, start_execution_run: mock.Mock) -> None:
+        with self.captureOnCommitCallbacks(execute=False):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+        self.root.refresh_from_db()
+        execution = self.root.current_execution
+        assert execution is not None
+
+        dispatch_investigation_execution(execution.id)
+        execution.update(started_at=timezone.now() - timedelta(minutes=6))
+        dispatch_investigation_execution(execution.id)
+
+        assert start_execution_run.call_count == 2
+
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_execution")
+    def test_redispatches_a_stale_dispatch_claim(self, dispatch: mock.Mock) -> None:
+        with self.captureOnCommitCallbacks(execute=False):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+        self.root.refresh_from_db()
+        execution = self.root.current_execution
+        assert execution is not None
+        execution.update(
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            started_at=timezone.now() - timedelta(minutes=6),
+        )
+        dispatch.delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+
+        dispatch.delay.assert_called_once_with(execution.id)

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -9,6 +9,7 @@ from sentry.investigations.models import (
     InvestigationBlockKind,
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
+from sentry.tasks.seer.investigation import dispatch_investigation_execution
 from sentry.testutils.cases import TestCase
 
 
@@ -105,3 +106,19 @@ class InvestigationAutoRunTest(TestCase):
         assert self.root.current_execution_id == execution_id
         assert InvestigationBlockExecution.objects.filter(block=self.root).count() == 1
         dispatch.delay.assert_called_once_with(execution_id)
+
+    @mock.patch("sentry.tasks.seer.investigation.start_execution_run")
+    def test_duplicate_dispatches_only_start_one_run(self, start_execution_run: mock.Mock) -> None:
+        with self.captureOnCommitCallbacks(execute=False):
+            schedule_eligible_auto_run_blocks(
+                investigation_id=self.investigation.id,
+                user_id=self.user.id,
+            )
+        self.root.refresh_from_db()
+        execution_id = self.root.current_execution_id
+        assert execution_id is not None
+
+        dispatch_investigation_execution(execution_id)
+        dispatch_investigation_execution(execution_id)
+
+        start_execution_run.assert_called_once()

--- a/tests/sentry/investigations/services/test_executions.py
+++ b/tests/sentry/investigations/services/test_executions.py
@@ -376,6 +376,7 @@ class InvestigationExecutionServiceTest(TestCase):
             seer_run_id=seer_run.id,
             dispatch_claimed_at=second_claim,
         )
+        assert mark_block_execution_dispatch_failed(execution, dispatch_claimed_at=second_claim)
 
     def test_notebook_context_query_count_is_constant(self) -> None:
         one_query_count = self._snapshot_query_count(1)

--- a/tests/sentry/investigations/services/test_executions.py
+++ b/tests/sentry/investigations/services/test_executions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 from uuid import uuid4
@@ -23,6 +24,7 @@ from sentry.investigations.services.executions import (
     build_block_execution_snapshot,
     create_block_execution,
     mark_block_execution_dispatch_failed,
+    mark_block_execution_dispatch_started,
     mark_block_execution_dispatched,
 )
 from sentry.investigations.services.investigations import (
@@ -352,6 +354,28 @@ class InvestigationExecutionServiceTest(TestCase):
         execution.refresh_from_db()
         assert execution.status == InvestigationBlockExecutionStatus.COMPLETED
         assert execution.error is None
+
+    def test_stale_dispatch_claim_fences_the_previous_worker(self) -> None:
+        block = self.create_block()
+        execution, _ = self.run_block(block)
+        first_claim = mark_block_execution_dispatch_started(execution)
+        assert first_claim is not None
+        execution.update(started_at=timezone.now() - timedelta(minutes=6))
+        second_claim = mark_block_execution_dispatch_started(execution)
+        assert second_claim is not None
+        seer_run = self.create_seer_run(organization=self.organization)
+
+        assert not mark_block_execution_dispatch_failed(execution, dispatch_claimed_at=first_claim)
+        assert not mark_block_execution_dispatched(
+            execution,
+            seer_run_id=seer_run.id,
+            dispatch_claimed_at=first_claim,
+        )
+        assert mark_block_execution_dispatched(
+            execution,
+            seer_run_id=seer_run.id,
+            dispatch_claimed_at=second_claim,
+        )
 
     def test_notebook_context_query_count_is_constant(self) -> None:
         one_query_count = self._snapshot_query_count(1)

--- a/tests/sentry/investigations/services/test_executions.py
+++ b/tests/sentry/investigations/services/test_executions.py
@@ -338,14 +338,15 @@ class InvestigationExecutionServiceTest(TestCase):
         assert execution.status == InvestigationBlockExecutionStatus.FAILED
         assert execution.seer_run_id is None
 
-    def test_dispatch_failure_accepts_running_but_not_terminal_execution(self) -> None:
+    def test_dispatch_failure_does_not_overwrite_dispatched_or_terminal_execution(self) -> None:
         block = self.create_block()
         execution, _ = self.run_block(block)
         seer_run = self.create_seer_run(organization=self.organization)
         assert mark_block_execution_dispatched(execution, seer_run_id=seer_run.id)
-        assert mark_block_execution_dispatch_failed(execution)
+        assert not mark_block_execution_dispatch_failed(execution)
         execution.refresh_from_db()
-        assert execution.status == InvestigationBlockExecutionStatus.FAILED
+        assert execution.status == InvestigationBlockExecutionStatus.RUNNING
+        assert execution.seer_run_id == seer_run.id
 
         execution.status = InvestigationBlockExecutionStatus.COMPLETED
         execution.error = None
@@ -376,7 +377,7 @@ class InvestigationExecutionServiceTest(TestCase):
             seer_run_id=seer_run.id,
             dispatch_claimed_at=second_claim,
         )
-        assert mark_block_execution_dispatch_failed(execution, dispatch_claimed_at=second_claim)
+        assert not mark_block_execution_dispatch_failed(execution, dispatch_claimed_at=second_claim)
 
     def test_notebook_context_query_count_is_constant(self) -> None:
         one_query_count = self._snapshot_query_count(1)

--- a/tests/sentry/investigations/services/test_executions.py
+++ b/tests/sentry/investigations/services/test_executions.py
@@ -130,6 +130,57 @@ class InvestigationExecutionServiceTest(TestCase):
         assert execution.input_snapshot["source"] == source
         assert execution.input_snapshot["filters"] == {"environment": ["production"]}
 
+    def test_query_refinement_snapshots_its_previous_chart(self) -> None:
+        block = self.create_block(title="Error volume")
+        previous = self.create_execution(
+            block,
+            result={
+                "schemaVersion": 1,
+                "tableMarkdown": "| day | errors |\n| --- | ---: |\n| Aug 11 | 17 |",
+                "chart": {
+                    "title": "Issue volume",
+                    "subtitle": "Last 7 days | 17 total errors",
+                    "visualization": "line",
+                    "x_axis": "time",
+                    "y_axis_unit": "number",
+                    "series": [
+                        {
+                            "name": "Errors",
+                            "data": [{"x": "2026-08-11T00:00:00+00:00", "y": 17}],
+                        }
+                    ],
+                },
+                "preferredView": "chart",
+                "isEmpty": False,
+                "chartUnavailableReason": None,
+                "queryLinks": [],
+            },
+        )
+        previous.data_projects.add(self.project)
+        empty_refinement = self.create_execution(
+            block,
+            result={
+                "schemaVersion": 1,
+                "tableMarkdown": "| Note |\n| --- |\n| No prior chart data found |",
+                "chart": None,
+                "preferredView": "table",
+                "isEmpty": True,
+                "chartUnavailableReason": "No prior chart data found.",
+                "queryLinks": [],
+            },
+        )
+        block.result_execution = empty_refinement
+        block.save(update_fields=["result_execution"])
+
+        execution, created = self.run_block(block)
+
+        assert created
+        current_context = execution.input_snapshot["context"][0]
+        assert current_context["currentBlock"] is True
+        assert current_context["visibleExecutionId"] == str(previous.id)
+        assert current_context["result"]["chart"]["visualization"] == "line"
+        assert execution.input_snapshot["contextDataProjectIds"] == [self.project.id]
+
     def test_rejects_invalid_query_dataset_hint(self) -> None:
         block = self.create_block(config={"datasetHint": "invalid"})
 

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -153,6 +153,32 @@ class InvestigationAgentTest(TestCase):
         assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
         assert list(self.execution.data_projects.all()) == [self.project]
 
+    def test_completed_query_keeps_reused_result_projects(self) -> None:
+        self.execution.input_snapshot["contextDataProjectIds"] = [self.project.id]
+        self.execution.save(update_fields=["input_snapshot"])
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content=(
+                            '{"tableMarkdown":"| Errors |\\n| ---: |\\n| 12 |",'
+                            '"chart":null,"preferredView":"table","isEmpty":false,'
+                            '"chartUnavailableReason":"Reused the previous result."}'
+                        ),
+                    ),
+                )
+            ]
+        )
+
+        synchronize_execution(self.execution, run_state)
+
+        self.execution.refresh_from_db()
+        assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
+        assert list(self.execution.data_projects.all()) == [self.project]
+
     def test_start_run_requests_a_final_response_without_an_artifact_writer(self) -> None:
         client = MagicMock()
         self.execution.input_snapshot["source"] = {

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -154,6 +154,7 @@ class InvestigationAgentTest(TestCase):
         assert list(self.execution.data_projects.all()) == [self.project]
 
     def test_completed_query_keeps_reused_result_projects(self) -> None:
+        self.execution.input_snapshot["projectIds"] = []
         self.execution.input_snapshot["contextDataProjectIds"] = [self.project.id]
         self.execution.save(update_fields=["input_snapshot"])
         run_state = state(


### PR DESCRIPTION
Template-based investigation launches now enqueue eligible cells after the launch transaction commits. Root cells run first, dependent cells are scheduled only after every parent has a completed, non-stale result, and repeating a launch safely recovers executions that never attached a Seer run. Existing investigations are access-checked before any work is scheduled.

Query refinements also receive the latest usable result for the block being refined, including its chart payload, table data, query links, and project provenance. Presentation-only requests such as converting a line chart to a bar chart can therefore reuse the existing telemetry instead of reporting that no data is available or issuing another query. If a technically successful refinement produced an empty result, execution history falls back to the most recent completed result with usable data.

Dispatch remains asynchronous through the taskworker so Seer latency, failure isolation, and task retries stay outside the web and completion processes. Recoverable dispatch claims are fenced so a stale worker cannot overwrite or fail a newer claim. The additional snapshot fields are additive for rolling-deployment compatibility.
