### PR TITLE
feat(seer): Execute autofix actions from overview cards

### DIFF
--- a/static/app/components/events/autofix/useAutofixCreatePrGate.ts
+++ b/static/app/components/events/autofix/useAutofixCreatePrGate.ts
@@ -1,0 +1,46 @@
+import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofixRepos';
+import type {Group} from 'sentry/types/group';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {useIntegrations} from 'sentry/utils/integrations/useIntegrations';
+import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepositories/getProviderConfigUrl';
+
+interface PermissionsTarget {
+  integration: OrganizationIntegration;
+  url: string;
+}
+
+/**
+ * Gate for creating a pull request from Autofix code changes. Resolves whether
+ * any connected repo lacks write access and, if so, where to grant it — so a
+ * caller can send the user to update permissions instead of firing a doomed
+ * create-PR request. Shared by the Seer drawer and the Autofix overview.
+ */
+export function useAutofixCreatePrGate({
+  group,
+  enabled = true,
+}: {
+  group: Pick<Group, 'id'>;
+  enabled?: boolean;
+}): {isPending: boolean; permissionsTarget: PermissionsTarget | null} {
+  const repos = useAutofixRepos({group, enabled});
+  const integrationIds =
+    repos.data?.repos
+      ?.filter(repo => !repo.has_write_access)
+      .map(repo => repo.integration_id) ?? [];
+  const {integrations, isPending: isIntegrationsPending} = useIntegrations({
+    integrationIds,
+  });
+
+  const permissionsTarget =
+    integrations
+      .map(integration => {
+        const url = getProviderPermissionsUrl(integration);
+        return url ? {integration, url} : null;
+      })
+      .find(Boolean) ?? null;
+
+  return {
+    permissionsTarget,
+    isPending: enabled && (repos.isPending || isIntegrationsPending),
+  };
+}

--- a/static/app/components/events/autofix/useAutofixCreatePrGate.ts
+++ b/static/app/components/events/autofix/useAutofixCreatePrGate.ts
@@ -10,10 +10,8 @@ interface PermissionsTarget {
 }
 
 /**
- * Gate for creating a pull request from Autofix code changes. Resolves whether
- * any connected repo lacks write access and, if so, where to grant it — so a
- * caller can send the user to update permissions instead of firing a doomed
- * create-PR request. Shared by the Seer drawer and the Autofix overview.
+ * Gate for creating a PR from Autofix changes: resolves whether a connected repo
+ * lacks write access and where to grant it. Shared by the drawer and overview.
  */
 export function useAutofixCreatePrGate({
   group,

--- a/static/app/components/events/autofix/useAutofixRepos.tsx
+++ b/static/app/components/events/autofix/useAutofixRepos.tsx
@@ -5,7 +5,7 @@ import type {Group} from 'sentry/types/group';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-function autofixReposApiOptions(orgSlug: string, group: Group) {
+function autofixReposApiOptions(orgSlug: string, group: Pick<Group, 'id'>) {
   return apiOptions.as<AutofixReposResponse>()(
     '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/repos/',
     {
@@ -19,7 +19,7 @@ export function useAutofixRepos({
   group,
   enabled = true,
 }: {
-  group: Group;
+  group: Pick<Group, 'id'>;
   enabled?: boolean;
 }) {
   const organization = useOrganization();

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -574,9 +574,8 @@ interface UseExplorerAutofixOptions {
    */
   codingAgentAnalyticsSource?: 'explorer' | 'overview';
   /**
-   * Whether to fetch and poll run state. The action callbacks (startStep,
-   * createPR, triggerCodingAgentHandoff) stay live even when false — the
-   * Autofix overview relies on dispatching actions without polling.
+   * Whether to fetch and poll run state. Action callbacks (startStep, createPR,
+   * triggerCodingAgentHandoff) stay live even when false — used by the overview.
    */
   enabled?: boolean;
   /**

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -569,11 +569,21 @@ function isLastBlockOfSection(block?: Block): boolean {
 
 interface UseExplorerAutofixOptions {
   /**
+   * The `source` reported on coding agent handoff analytics.
+   * Defaults to 'explorer'.
+   */
+  codingAgentAnalyticsSource?: 'explorer' | 'overview';
+  /**
    * Whether to enable the hook and make API calls.
    * When false, the hook returns null state and no-op functions.
    * Defaults to true.
    */
   enabled?: boolean;
+  /**
+   * Called with coding agent launch failure messages. Defaults to
+   * accumulating them in `codingAgentErrors` for inline display.
+   */
+  onCodingAgentError?: (messages: string[]) => void;
   /**
    * Force fast polling while the drawer is mounted. Other observers can keep
    * their processing-aware intervals.
@@ -590,13 +600,18 @@ interface UseExplorerAutofixOptions {
  * - Creating pull requests from code changes
  */
 export function useExplorerAutofix(
-  group: Group,
+  group: Pick<Group, 'id' | 'shortId'>,
   options: UseExplorerAutofixOptions = {}
 ) {
   const groupId = group.id;
   const {openModal} = useModal();
 
-  const {enabled = true, pollPR = false} = options;
+  const {
+    enabled = true,
+    pollPR = false,
+    codingAgentAnalyticsSource = 'explorer',
+    onCodingAgentError,
+  } = options;
   const api = useApi();
   const queryClient = useQueryClient();
   const organization = useOrganization();
@@ -621,6 +636,7 @@ export function useExplorerAutofix(
       ...messages.map(message => ({id: nextCodingAgentErrorId.current++, message})),
     ]);
   }, []);
+  const reportCodingAgentErrors = onCodingAgentError ?? appendCodingAgentErrors;
 
   const {
     data: apiData,
@@ -830,7 +846,7 @@ export function useExplorerAutofix(
         organization,
         group_id: groupId,
         provider: integration.provider,
-        source: 'explorer',
+        source: codingAgentAnalyticsSource,
         user_id: user.id,
       });
 
@@ -908,7 +924,7 @@ export function useExplorerAutofix(
           }
 
           if (otherFailures.length > 0) {
-            appendCodingAgentErrors(
+            reportCodingAgentErrors(
               otherFailures.map(f => f.error_message ?? 'Failed to launch coding agent')
             );
           }
@@ -924,7 +940,7 @@ export function useExplorerAutofix(
           window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
           return;
         }
-        appendCodingAgentErrors([
+        reportCodingAgentErrors([
           e?.responseJSON?.detail ?? 'Failed to launch coding agent',
         ]);
         throw e;
@@ -940,7 +956,8 @@ export function useExplorerAutofix(
       queryClient,
       organization,
       user.id,
-      appendCodingAgentErrors,
+      codingAgentAnalyticsSource,
+      reportCodingAgentErrors,
       openModal,
     ]
   );

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -574,9 +574,9 @@ interface UseExplorerAutofixOptions {
    */
   codingAgentAnalyticsSource?: 'explorer' | 'overview';
   /**
-   * Whether to enable the hook and make API calls.
-   * When false, the hook returns null state and no-op functions.
-   * Defaults to true.
+   * Whether to fetch and poll run state. The action callbacks (startStep,
+   * createPR, triggerCodingAgentHandoff) stay live even when false — the
+   * Autofix overview relies on dispatching actions without polling.
    */
   enabled?: boolean;
   /**

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -11,7 +11,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
-import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofixRepos';
+import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
 import {
   getAutofixArtifactFromSection,
   isCodeChangesSection,
@@ -33,10 +33,8 @@ import type {Group} from 'sentry/types/group';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
-import {useIntegrations} from 'sentry/utils/integrations/useIntegrations';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
-import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepositories/getProviderConfigUrl';
 
 interface SeerDrawerNextStepProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -278,36 +276,20 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
 function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextStepProps) {
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
 
-  const repos = useAutofixRepos({group, enabled: defined(artifact)});
-  const integrationIds =
-    repos.data?.repos
-      ?.filter(repo => !repo.has_write_access)
-      .map(repo => repo.integration_id) ?? [];
-  const {integrations, isPending: isIntegrationsPending} = useIntegrations({
-    integrationIds,
+  const {permissionsTarget, isPending} = useAutofixCreatePrGate({
+    group,
+    enabled: defined(artifact),
   });
-  const permissionsUrls = integrations
-    .map(integration => {
-      const url = getProviderPermissionsUrl(integration);
-      if (!defined(url)) {
-        return null;
-      }
-      return {
-        integration,
-        url,
-      };
-    })
-    .filter(Boolean);
 
   if (!defined(artifact)) {
     return null;
   }
 
-  if (repos.isPending || isIntegrationsPending) {
+  if (isPending) {
     return null;
   }
 
-  if (permissionsUrls.length) {
+  if (permissionsTarget) {
     return (
       <CodeChangesNextStepWithoutWritePermissions
         group={group}
@@ -315,8 +297,8 @@ function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextSte
         runId={runId}
         section={section}
         referrer={referrer}
-        integration={permissionsUrls[0]!.integration}
-        permissionsUrl={permissionsUrls[0]!.url}
+        integration={permissionsTarget.integration}
+        permissionsUrl={permissionsTarget.url}
       />
     );
   }

--- a/static/app/components/events/autofix/v3/useCodingAgents.ts
+++ b/static/app/components/events/autofix/v3/useCodingAgents.ts
@@ -7,7 +7,7 @@ import {
 } from 'sentry/components/events/autofix/useAutofix';
 import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {t} from 'sentry/locale';
-import type {Group} from 'sentry/types/group';
+import type {AvatarProject} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {
@@ -18,11 +18,11 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 
 interface UseCodingAgentsOptions {
-  autofix: ReturnType<typeof useExplorerAutofix>;
-  group: Group;
+  autofix: Pick<ReturnType<typeof useExplorerAutofix>, 'triggerCodingAgentHandoff'>;
+  group: {id: string; project: AvatarProject};
   referrer: string | undefined;
   runId: SeerExplorerRunId;
-  step: 'root_cause' | 'solution';
+  step: 'root_cause' | 'solution' | 'code_changes';
   enabled?: boolean;
   onHandoff?: () => void;
 }

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -56,7 +56,7 @@ export type SeerAnalyticsEventsParameters = {
     group_id: string;
     organization: Organization;
     provider: string;
-    step: 'root_cause' | 'solution';
+    step: 'root_cause' | 'solution' | 'code_changes';
     mode?: 'explorer' | 'legacy';
     referrer?: string;
   };
@@ -71,6 +71,17 @@ export type SeerAnalyticsEventsParameters = {
     group_id: string;
     organization: Organization;
     tool_name: string;
+  };
+  'autofix.overview.action_clicked': {
+    action: 'create_plan' | 'generate_code' | 'draft_pr';
+    group_id: string;
+    organization: Organization;
+    run_id: string;
+  };
+  'autofix.overview.open_seer_clicked': {
+    group_id: string;
+    organization: Organization;
+    run_id: string;
   };
   'autofix.pr_iteration.feedback': {
     group_id: string;
@@ -117,7 +128,7 @@ export type SeerAnalyticsEventsParameters = {
     group_id: string;
     organization: Organization;
     provider: string;
-    source: 'autofix' | 'explorer';
+    source: 'autofix' | 'explorer' | 'overview';
     user_id: string;
   };
   'coding_integration.setup_handoff_clicked': {
@@ -189,6 +200,8 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.code_changes.re_run': 'Autofix: Code Changes Re-run',
   'autofix.create_pr_clicked': 'Autofix: Create PR Setup Clicked',
   'autofix.evidence.clicked': 'Autofix: Evidence Clicked',
+  'autofix.overview.action_clicked': 'Autofix Overview: Action Clicked',
+  'autofix.overview.open_seer_clicked': 'Autofix Overview: Open Seer Clicked',
   'autofix.pr_iteration.feedback': 'Autofix: PR Iteration Feedback',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.root_cause.re_run': 'Autofix: Root Cause Re-run',

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -233,6 +233,24 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText('No issues')).not.toBeInTheDocument();
   });
 
+  it('refetches the overview after a card action is dispatched', async () => {
+    const {enrichedRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {run_id: 1, sentry_run_id: 'run-1'},
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create Plan'}));
+
+    expect(await screen.findByRole('button', {name: /Creating Plan/})).toBeDisabled();
+    await waitFor(() => expect(enrichedRequest).toHaveBeenCalledTimes(2));
+  });
+
   it('shows the empty state while keeping the query controls visible', async () => {
     mockOverview({base: {}});
 

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -176,6 +176,11 @@ describe('AutofixOverview', () => {
       url: '/projects/org-slug/project-slug/seer/repos/',
       body: [{provider: 'github'}],
     });
+    // Draft-PR cards fetch write-access via the shared create-PR gate.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/repos/',
+      body: {repos: [{has_write_access: true, integration_id: 5}]},
+    });
   });
 
   function renderPage(query: Record<string, string> = {}) {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -167,7 +167,6 @@ describe('AutofixOverview', () => {
       url: `/organizations/${organization.slug}/users/`,
       body: [],
     });
-    // The card action dropdown self-fetches coding agents and Seer repos.
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/coding-agents/`,
       body: {integrations: []},
@@ -176,7 +175,6 @@ describe('AutofixOverview', () => {
       url: '/projects/org-slug/project-slug/seer/repos/',
       body: [{provider: 'github'}],
     });
-    // Draft-PR cards fetch write-access via the shared create-PR gate.
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/2/autofix/repos/',
       body: {repos: [{has_write_access: true, integration_id: 5}]},

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -167,6 +167,15 @@ describe('AutofixOverview', () => {
       url: `/organizations/${organization.slug}/users/`,
       body: [],
     });
+    // The card action dropdown self-fetches coding agents and Seer repos.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {integrations: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [{provider: 'github'}],
+    });
   });
 
   function renderPage(query: Record<string, string> = {}) {

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -18,18 +18,15 @@ import {
   IconCircle,
   IconClock,
   IconClose,
-  IconCode,
   IconCommit,
   IconGraph,
   IconMerge,
   IconOpen,
   IconPullRequest,
-  IconSearch,
   IconSeer,
   IconThumb,
   IconUser,
 } from 'sentry/icons';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tn} from 'sentry/locale';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import type {
@@ -39,6 +36,7 @@ import type {
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 
 import {CodeChanges} from './codeChanges';
+import {OverviewCardAction} from './overviewCardAction';
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
 import {
   OverviewIssuePriority,
@@ -59,35 +57,10 @@ function selectReviewPullRequest(
   return actionable.at(-1) ?? pullRequests.at(-1);
 }
 
-interface ActionMeta {
-  Icon: React.ComponentType<SVGIconProps>;
-  description: string;
-  label: string;
-}
-
-// Live status overlays (Running/Retry/Add context) are intentionally omitted here.
-// The merged section has no action button, so it is excluded from the map.
-const ACTION_META: Record<Exclude<AutofixStateKey, 'merged'>, ActionMeta> = {
-  review_pr: {
-    Icon: IconPullRequest,
-    label: t('Review PR'),
-    description: t('Autofix opened a pull request. Review and merge it.'),
-  },
-  code_changes_ready: {
-    Icon: IconCommit,
-    label: t('Draft PR'),
-    description: t('Autofix wrote a diff. Review it and open a pull request.'),
-  },
-  solution_ready: {
-    Icon: IconCode,
-    label: t('Generate code'),
-    description: t('Autofix proposed a fix. Continue the pipeline to generate code.'),
-  },
-  needs_investigation: {
-    Icon: IconSearch,
-    label: t('Create Plan'),
-    description: t('Seer stopped at a diagnosis. Review the root cause to continue.'),
-  },
+const REVIEW_PR_META = {
+  Icon: IconPullRequest,
+  label: t('Review PR'),
+  description: t('Autofix opened a pull request. Review and merge it.'),
 };
 
 interface PullRequestStatusTagMeta {
@@ -130,17 +103,18 @@ const REVIEW_STATUS_TAGS = {
 
 function OverviewAction({
   sectionKey,
-  pullRequests,
+  run,
   reviewPullRequest,
   issueUrl,
   enrichmentPending,
 }: {
   enrichmentPending: boolean;
   issueUrl: string;
-  pullRequests: OverviewPullRequest[];
   reviewPullRequest: OverviewPullRequest | undefined;
+  run: OverviewRun;
   sectionKey: AutofixStateKey;
 }) {
+  const {pullRequests} = run;
   if (sectionKey === 'merged') {
     if (pullRequests.length > 0) {
       return (
@@ -197,7 +171,7 @@ function OverviewAction({
 
     return (
       <Stack align="end" gap="xs">
-        <Tooltip title={ACTION_META.review_pr.description} skipWrapper>
+        <Tooltip title={REVIEW_PR_META.description} skipWrapper>
           <LinkButton size="sm" variant="primary" href={reviewPullRequest.url} external>
             <Flex as="span" gap="xs" align="center">
               {t('Review PR #%s', reviewPullRequest.number)}
@@ -248,14 +222,23 @@ function OverviewAction({
     );
   }
 
-  const meta = ACTION_META[sectionKey];
-  return (
-    <Tooltip title={meta.description} skipWrapper>
-      <LinkButton size="sm" variant="secondary" icon={<meta.Icon />} to={issueUrl}>
-        {meta.label}
-      </LinkButton>
-    </Tooltip>
-  );
+  // A review_pr card without a PR URL keeps the plain issue link fallback.
+  if (sectionKey === 'review_pr') {
+    return (
+      <Tooltip title={REVIEW_PR_META.description} skipWrapper>
+        <LinkButton
+          size="sm"
+          variant="secondary"
+          icon={<REVIEW_PR_META.Icon />}
+          to={issueUrl}
+        >
+          {REVIEW_PR_META.label}
+        </LinkButton>
+      </Tooltip>
+    );
+  }
+
+  return <OverviewCardAction run={run} sectionKey={sectionKey} issueUrl={issueUrl} />;
 }
 
 const TitleLink = styled(Link)`
@@ -497,7 +480,7 @@ export function OverviewCard({
           <Stack gap="lg" align="end" justify="between" flexShrink={0} minWidth="0">
             <OverviewAction
               sectionKey={sectionKey}
-              pullRequests={run.pullRequests}
+              run={run}
               reviewPullRequest={reviewPullRequest}
               issueUrl={issueUrl}
               enrichmentPending={enrichmentPending}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -222,7 +222,6 @@ function OverviewAction({
     );
   }
 
-  // A review_pr card without a PR URL keeps the plain issue link fallback.
   if (sectionKey === 'review_pr') {
     return (
       <Tooltip title={REVIEW_PR_META.description} skipWrapper>

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -1,0 +1,286 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {OverviewCardAction} from 'sentry/views/seerWorkflows/overview/overviewCardAction';
+import type {
+  OverviewRun,
+  OverviewRunIssue,
+} from 'sentry/views/seerWorkflows/overview/types';
+
+jest.mock('sentry/utils/analytics');
+
+describe('OverviewCardAction', () => {
+  const organization = OrganizationFixture();
+  const issueUrl = '/organizations/org-slug/issues/2/';
+
+  function issueFixture(): OverviewRunIssue {
+    return {
+      ...GroupFixture(),
+      count: '10',
+      userCount: 2,
+      owners: [],
+      substatus: 'ongoing',
+      project: {id: '2', slug: 'project-slug', platform: 'python'},
+    };
+  }
+
+  function runFixture(overrides: Partial<OverviewRun> = {}): OverviewRun {
+    return {
+      groupId: '2',
+      shortId: 'PROJ-1',
+      title: 'TypeError in checkout cart',
+      rootCause: {oneLineDescription: 'The cart total is read before it is set.'},
+      proposedFix: null,
+      seerRunId: 'run-1',
+      lastTriggeredAt: '2026-07-14T09:00:00Z',
+      pullRequests: [],
+      issue: issueFixture(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {
+        integrations: [{id: '123', name: 'Claude Agent', provider: 'claude_code'}],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [{provider: 'github'}],
+    });
+  });
+
+  it('triggers the plan step and shows a busy button', async () => {
+    const postRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {run_id: 1, sentry_run_id: 'run-1'},
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create Plan'}));
+
+    expect(postRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/2/autofix/',
+      expect.objectContaining({
+        method: 'POST',
+        query: {mode: 'explorer'},
+        data: expect.objectContaining({
+          step: 'solution',
+          sentry_run_id: 'run-1',
+          referrer: 'api.web',
+        }),
+      })
+    );
+
+    expect(await screen.findByRole('button', {name: /Creating Plan/})).toBeDisabled();
+    expect(
+      screen.queryByRole('button', {name: 'More Seer options'})
+    ).not.toBeInTheDocument();
+
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'autofix.overview.action_clicked',
+      expect.objectContaining({
+        organization,
+        group_id: '2',
+        run_id: 'run-1',
+        action: 'create_plan',
+      })
+    );
+  });
+
+  it('triggers the code changes step from a solution card', async () => {
+    const postRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {run_id: 1, sentry_run_id: 'run-1'},
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="solution_ready"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Generate code'}));
+
+    expect(postRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/2/autofix/',
+      expect.objectContaining({
+        data: expect.objectContaining({step: 'code_changes', sentry_run_id: 'run-1'}),
+      })
+    );
+    expect(await screen.findByRole('button', {name: /Generating Code/})).toBeDisabled();
+  });
+
+  it('drafts a PR from a code changes card', async () => {
+    const postRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {run_id: 1, sentry_run_id: 'run-1'},
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="code_changes_ready"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Draft PR'}));
+
+    expect(postRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/2/autofix/',
+      expect.objectContaining({
+        data: expect.objectContaining({step: 'open_pr', sentry_run_id: 'run-1'}),
+      })
+    );
+    expect(await screen.findByRole('button', {name: /Creating PR/})).toBeDisabled();
+  });
+
+  it('restores the action button when the trigger fails', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create Plan'}));
+
+    expect(await screen.findByRole('button', {name: 'Create Plan'})).toBeEnabled();
+  });
+
+  it('links to the issue with the Seer drawer open from the dropdown', async () => {
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    const openSeer = await screen.findByRole('menuitemradio', {name: 'Open Seer'});
+    expect(openSeer).toHaveAttribute(
+      'href',
+      expect.stringContaining('/organizations/org-slug/issues/2/?seerDrawer=true')
+    );
+
+    expect(trackAnalytics).not.toHaveBeenCalledWith(
+      'autofix.overview.action_clicked',
+      expect.anything()
+    );
+  });
+
+  it('hands off to a coding agent from the dropdown', async () => {
+    const postRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {failures: [], successes: [{}]},
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Send to Claude Agent'})
+    );
+
+    await waitFor(() => {
+      expect(postRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues/2/autofix/',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            step: 'coding_agent_handoff',
+            integration_id: 123,
+            sentry_run_id: 'run-1',
+          }),
+        })
+      );
+    });
+
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'coding_integration.send_to_agent_clicked',
+      expect.objectContaining({provider: 'claude_code', source: 'overview'})
+    );
+  });
+
+  it('shows the add integration link in the dropdown footer', async () => {
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    expect(await screen.findByRole('button', {name: 'Add Integration'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/integrations/?category=coding%20agent'
+    );
+  });
+
+  it('disables agent handoff without a connected GitHub repo', async () => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [{provider: 'bitbucket'}],
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    const agentItem = await screen.findByRole('menuitemradio', {
+      name: 'Send to Claude Agent',
+    });
+    expect(agentItem).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -1,3 +1,4 @@
+import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
@@ -53,6 +54,11 @@ describe('OverviewCardAction', () => {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/seer/repos/',
       body: [{provider: 'github'}],
+    });
+    // Draft-PR cards fetch write-access via the shared create-PR gate.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/repos/',
+      body: {repos: [{has_write_access: true, integration_id: 5}]},
     });
   });
 
@@ -155,6 +161,39 @@ describe('OverviewCardAction', () => {
       })
     );
     expect(await screen.findByRole('button', {name: /Creating PR/})).toBeDisabled();
+  });
+
+  it('routes a Draft PR card to grant permissions when write access is missing', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/repos/',
+      body: {repos: [{has_write_access: false, integration_id: 42}]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/42/',
+      body: GitHubIntegrationFixture({externalId: '654321', accountType: ''}),
+    });
+    const postRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {},
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="code_changes_ready"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    const permissionsLink = await screen.findByRole('button', {name: /permissions/i});
+    expect(permissionsLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('/permissions/update')
+    );
+    expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
+    expect(postRequest).not.toHaveBeenCalled();
   });
 
   it('restores the action button when the trigger fails', async () => {

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -161,6 +161,28 @@ describe('OverviewCardAction', () => {
     expect(postRequest).not.toHaveBeenCalled();
   });
 
+  it('disables the Draft PR button until the write-access gate resolves', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/repos/',
+      body: {repos: [{has_write_access: true, integration_id: 5}]},
+      asyncDelay: 20,
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="code_changes_ready"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    expect(screen.getByRole('button', {name: 'Draft PR'})).toBeDisabled();
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Draft PR'})).toBeEnabled()
+    );
+  });
+
   it('restores the action button when the trigger fails', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/2/autofix/',

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -261,6 +261,39 @@ describe('OverviewCardAction', () => {
     );
   });
 
+  it('defers coding agent fetches until the dropdown is opened', async () => {
+    const agentsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {
+        integrations: [{id: '123', name: 'Claude Agent', provider: 'claude_code'}],
+      },
+    });
+    const reposRequest = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [{provider: 'github'}],
+    });
+
+    render(
+      <OverviewCardAction
+        run={runFixture()}
+        sectionKey="needs_investigation"
+        issueUrl={issueUrl}
+      />,
+      {organization}
+    );
+
+    expect(agentsRequest).not.toHaveBeenCalled();
+    expect(reposRequest).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Send to Claude Agent'})
+    ).toBeInTheDocument();
+    expect(agentsRequest).toHaveBeenCalled();
+    expect(reposRequest).toHaveBeenCalled();
+  });
+
   it('disables agent handoff without a connected GitHub repo', async () => {
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/seer/repos/',

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -55,7 +55,6 @@ describe('OverviewCardAction', () => {
       url: '/projects/org-slug/project-slug/seer/repos/',
       body: [{provider: 'github'}],
     });
-    // Draft-PR cards fetch write-access via the shared create-PR gate.
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/2/autofix/repos/',
       body: {repos: [{has_write_access: true, integration_id: 5}]},

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -62,106 +62,71 @@ describe('OverviewCardAction', () => {
     });
   });
 
-  it('triggers the plan step and shows a busy button', async () => {
-    const postRequest = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/2/autofix/',
-      method: 'POST',
-      body: {run_id: 1, sentry_run_id: 'run-1'},
-    });
-
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Create Plan'}));
-
-    expect(postRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issues/2/autofix/',
-      expect.objectContaining({
+  it.each([
+    {
+      sectionKey: 'needs_investigation',
+      label: 'Create Plan',
+      busyLabel: /Creating Plan/,
+      step: 'solution',
+      action: 'create_plan',
+    },
+    {
+      sectionKey: 'solution_ready',
+      label: 'Generate code',
+      busyLabel: /Generating Code/,
+      step: 'code_changes',
+      action: 'generate_code',
+    },
+    {
+      sectionKey: 'code_changes_ready',
+      label: 'Draft PR',
+      busyLabel: /Creating PR/,
+      step: 'open_pr',
+      action: 'draft_pr',
+    },
+  ] as const)(
+    'dispatches the $action action and shows a busy button',
+    async ({sectionKey, label, busyLabel, step, action}) => {
+      const postRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/2/autofix/',
         method: 'POST',
-        query: {mode: 'explorer'},
-        data: expect.objectContaining({
-          step: 'solution',
-          sentry_run_id: 'run-1',
-          referrer: 'api.web',
-        }),
-      })
-    );
+        body: {run_id: 1, sentry_run_id: 'run-1'},
+      });
 
-    expect(await screen.findByRole('button', {name: /Creating Plan/})).toBeDisabled();
-    expect(
-      screen.queryByRole('button', {name: 'More Seer options'})
-    ).not.toBeInTheDocument();
+      render(
+        <OverviewCardAction
+          run={runFixture()}
+          sectionKey={sectionKey}
+          issueUrl={issueUrl}
+        />,
+        {organization}
+      );
 
-    expect(trackAnalytics).toHaveBeenCalledWith(
-      'autofix.overview.action_clicked',
-      expect.objectContaining({
-        organization,
-        group_id: '2',
-        run_id: 'run-1',
-        action: 'create_plan',
-      })
-    );
-  });
+      await userEvent.click(screen.getByRole('button', {name: label}));
 
-  it('triggers the code changes step from a solution card', async () => {
-    const postRequest = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/2/autofix/',
-      method: 'POST',
-      body: {run_id: 1, sentry_run_id: 'run-1'},
-    });
+      expect(postRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues/2/autofix/',
+        expect.objectContaining({
+          data: expect.objectContaining({step, sentry_run_id: 'run-1'}),
+        })
+      );
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="solution_ready"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+      expect(await screen.findByRole('button', {name: busyLabel})).toBeDisabled();
+      expect(
+        screen.queryByRole('button', {name: 'More Seer options'})
+      ).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Generate code'}));
-
-    expect(postRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issues/2/autofix/',
-      expect.objectContaining({
-        data: expect.objectContaining({step: 'code_changes', sentry_run_id: 'run-1'}),
-      })
-    );
-    expect(await screen.findByRole('button', {name: /Generating Code/})).toBeDisabled();
-  });
-
-  it('drafts a PR from a code changes card', async () => {
-    const postRequest = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/2/autofix/',
-      method: 'POST',
-      body: {run_id: 1, sentry_run_id: 'run-1'},
-    });
-
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="code_changes_ready"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Draft PR'}));
-
-    expect(postRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/issues/2/autofix/',
-      expect.objectContaining({
-        data: expect.objectContaining({step: 'open_pr', sentry_run_id: 'run-1'}),
-      })
-    );
-    expect(await screen.findByRole('button', {name: /Creating PR/})).toBeDisabled();
-  });
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'autofix.overview.action_clicked',
+        expect.objectContaining({
+          organization,
+          group_id: '2',
+          run_id: 'run-1',
+          action,
+        })
+      );
+    }
+  );
 
   it('routes a Draft PR card to grant permissions when write access is missing', async () => {
     MockApiClient.addMockResponse({
@@ -279,24 +244,6 @@ describe('OverviewCardAction', () => {
     expect(trackAnalytics).toHaveBeenCalledWith(
       'coding_integration.send_to_agent_clicked',
       expect.objectContaining({provider: 'claude_code', source: 'overview'})
-    );
-  });
-
-  it('shows the add integration link in the dropdown footer', async () => {
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
-
-    expect(await screen.findByRole('button', {name: 'Add Integration'})).toHaveAttribute(
-      'href',
-      '/settings/org-slug/integrations/?category=coding%20agent'
     );
   });
 

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -96,8 +96,7 @@ export function OverviewCardAction({
   const queryClient = useQueryClient();
   const config = ACTIONS[sectionKey];
   const [dispatched, setDispatched] = useState(false);
-  // Agent options are only needed once the dropdown opens; deferring the
-  // fetches avoids draining per-project repo pagination for every card.
+  // Defer agent-option fetches until the dropdown opens to avoid per-card repo pagination.
   const [menuOpened, setMenuOpened] = useState(false);
 
   const autofix = useExplorerAutofix(
@@ -120,8 +119,6 @@ export function OverviewCardAction({
       enabled: menuOpened,
     });
 
-  // Only Draft PR cards can create a PR; mirror the drawer's write-access gate
-  // so a missing-permissions repo sends the user to grant access.
   const isDraftPr = sectionKey === 'code_changes_ready';
   const {permissionsTarget, isPending: isCreatePrGatePending} = useAutofixCreatePrGate({
     group: {id: run.groupId},
@@ -197,8 +194,6 @@ export function OverviewCardAction({
     });
     try {
       await config.trigger(autofix, run.seerRunId);
-      // Mark the overview stale so mounted lists refetch and can re-bucket the
-      // card once the backend reflects the new milestone.
       queryClient.invalidateQueries({
         queryKey: [
           getApiUrl('/organizations/$organizationIdOrSlug/seer/autofix-overview/', {
@@ -211,8 +206,6 @@ export function OverviewCardAction({
         const detail = (error as RequestError)?.responseJSON?.detail;
         addErrorMessage(typeof detail === 'string' ? detail : config.errorFallback);
       }
-      // startStep writes an error into the shared explorer cache; drop it so a
-      // later drawer open doesn't briefly show this card's stale failure.
       queryClient.removeQueries({
         queryKey: [
           getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/', {

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -1,5 +1,6 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {useQueryClient} from '@tanstack/react-query';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
 import {MenuComponents} from '@sentry/scraps/compactSelect';
@@ -24,6 +25,7 @@ import {PluginIcon} from 'sentry/icons/pluginIcon';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -36,13 +38,14 @@ interface ActionConfig {
   action: 'create_plan' | 'generate_code' | 'draft_pr';
   busyLabel: string;
   description: string;
-  errorFallback: string;
   handoffStep: 'root_cause' | 'solution' | 'code_changes';
   label: string;
   trigger: (
-    autofix: ReturnType<typeof useExplorerAutofix>,
+    autofix: Pick<ReturnType<typeof useExplorerAutofix>, 'startStep' | 'createPR'>,
     runId: string
   ) => Promise<unknown>;
+  // Absent when the trigger surfaces its own error toast.
+  errorFallback?: string;
 }
 
 const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
@@ -71,8 +74,6 @@ const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
     action: 'draft_pr',
     busyLabel: t('Creating PR…'),
     description: t('Autofix wrote a diff. Review it and open a pull request.'),
-    // createPR surfaces its own error toast.
-    errorFallback: '',
     handoffStep: 'code_changes',
     label: t('Draft PR'),
     trigger: (autofix, runId) => autofix.createPR(runId),
@@ -89,8 +90,12 @@ export function OverviewCardAction({
   sectionKey: ActionableSectionKey;
 }) {
   const organization = useOrganization();
+  const queryClient = useQueryClient();
   const config = ACTIONS[sectionKey];
   const [dispatched, setDispatched] = useState(false);
+  // Agent options are only needed once the dropdown opens; deferring the
+  // fetches avoids draining per-project repo pagination for every card.
+  const [menuOpened, setMenuOpened] = useState(false);
 
   const autofix = useExplorerAutofix(
     {id: run.groupId, shortId: run.shortId},
@@ -109,6 +114,7 @@ export function OverviewCardAction({
       runId: run.seerRunId,
       step: config.handoffStep,
       referrer: 'autofix-overview',
+      enabled: menuOpened,
     });
 
   const menuItems = useMemo<MenuItemProps[]>(() => {
@@ -180,6 +186,15 @@ export function OverviewCardAction({
     });
     try {
       await config.trigger(autofix, run.seerRunId);
+      // Mark the overview stale so mounted lists refetch and can re-bucket the
+      // card once the backend reflects the new milestone.
+      queryClient.invalidateQueries({
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/seer/autofix-overview/', {
+            path: {organizationIdOrSlug: organization.slug},
+          }),
+        ],
+      });
     } catch (error: any) {
       if (config.errorFallback) {
         addErrorMessage(error?.responseJSON?.detail ?? config.errorFallback);
@@ -213,6 +228,7 @@ export function OverviewCardAction({
         )}
         position="bottom-end"
         shouldCloseOnBlur={false}
+        onOpenChange={isOpen => isOpen && setMenuOpened(true)}
         menuFooter={
           <DropdownMenuFooter>
             <MenuComponents.CTALinkButton

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
-import {Button, ButtonBar} from '@sentry/scraps/button';
+import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -10,6 +10,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
+import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
 import {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -18,6 +19,7 @@ import {
   IconChevron,
   IconCode,
   IconCommit,
+  IconOpen,
   IconSearch,
   IconSeer,
 } from 'sentry/icons';
@@ -27,6 +29,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {AutofixStateKey, OverviewRun} from './types';
@@ -117,6 +120,14 @@ export function OverviewCardAction({
       enabled: menuOpened,
     });
 
+  // Only Draft PR cards can create a PR; mirror the drawer's write-access gate
+  // so a missing-permissions repo sends the user to grant access.
+  const isDraftPr = sectionKey === 'code_changes_ready';
+  const {permissionsTarget} = useAutofixCreatePrGate({
+    group: {id: run.groupId},
+    enabled: isDraftPr,
+  });
+
   const menuItems = useMemo<MenuItemProps[]>(() => {
     const agentItems = (codingAgentIntegrations ?? []).map(integration => {
       const actionLabel =
@@ -195,26 +206,58 @@ export function OverviewCardAction({
           }),
         ],
       });
-    } catch (error: any) {
+    } catch (error) {
       if (config.errorFallback) {
-        addErrorMessage(error?.responseJSON?.detail ?? config.errorFallback);
+        const detail = (error as RequestError)?.responseJSON?.detail;
+        addErrorMessage(typeof detail === 'string' ? detail : config.errorFallback);
       }
+      // startStep writes an error into the shared explorer cache; drop it so a
+      // later drawer open doesn't briefly show this card's stale failure.
+      queryClient.removeQueries({
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/', {
+            path: {organizationIdOrSlug: organization.slug, issueId: run.groupId},
+          }),
+        ],
+      });
       setDispatched(false);
     }
   };
 
+  const permissionsButton = permissionsTarget ? (
+    <Tooltip
+      title={t(
+        'You need to grant write permissions for your %s integration',
+        permissionsTarget.integration.provider.name
+      )}
+      skipWrapper
+    >
+      <LinkButton
+        size="sm"
+        variant="secondary"
+        icon={<IconOpen />}
+        href={permissionsTarget.url}
+        external
+      >
+        {t('Update permissions')}
+      </LinkButton>
+    </Tooltip>
+  ) : null;
+
   return (
     <ButtonBar>
-      <Tooltip title={config.description} skipWrapper>
-        <Button
-          size="sm"
-          variant="secondary"
-          icon={<config.Icon />}
-          onClick={handleTrigger}
-        >
-          {config.label}
-        </Button>
-      </Tooltip>
+      {permissionsButton ?? (
+        <Tooltip title={config.description} skipWrapper>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon={<config.Icon />}
+            onClick={handleTrigger}
+          >
+            {config.label}
+          </Button>
+        </Tooltip>
+      )}
       <DropdownMenu
         items={menuItems}
         trigger={(triggerProps, isOpen) => (

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -123,7 +123,7 @@ export function OverviewCardAction({
   // Only Draft PR cards can create a PR; mirror the drawer's write-access gate
   // so a missing-permissions repo sends the user to grant access.
   const isDraftPr = sectionKey === 'code_changes_ready';
-  const {permissionsTarget} = useAutofixCreatePrGate({
+  const {permissionsTarget, isPending: isCreatePrGatePending} = useAutofixCreatePrGate({
     group: {id: run.groupId},
     enabled: isDraftPr,
   });
@@ -253,6 +253,7 @@ export function OverviewCardAction({
             variant="secondary"
             icon={<config.Icon />}
             onClick={handleTrigger}
+            disabled={isCreatePrGatePending}
           >
             {config.label}
           </Button>

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -1,0 +1,233 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button, ButtonBar} from '@sentry/scraps/button';
+import {MenuComponents} from '@sentry/scraps/compactSelect';
+import {Flex} from '@sentry/scraps/layout';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
+import {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {
+  IconAdd,
+  IconChevron,
+  IconCode,
+  IconCommit,
+  IconSearch,
+  IconSeer,
+} from 'sentry/icons';
+import {PluginIcon} from 'sentry/icons/pluginIcon';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {defined} from 'sentry/utils/defined';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {AutofixStateKey, OverviewRun} from './types';
+
+export type ActionableSectionKey = Exclude<AutofixStateKey, 'merged' | 'review_pr'>;
+
+interface ActionConfig {
+  Icon: React.ComponentType<SVGIconProps>;
+  action: 'create_plan' | 'generate_code' | 'draft_pr';
+  busyLabel: string;
+  description: string;
+  errorFallback: string;
+  handoffStep: 'root_cause' | 'solution' | 'code_changes';
+  label: string;
+  trigger: (
+    autofix: ReturnType<typeof useExplorerAutofix>,
+    runId: string
+  ) => Promise<unknown>;
+}
+
+const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
+  needs_investigation: {
+    Icon: IconSearch,
+    action: 'create_plan',
+    busyLabel: t('Creating Plan…'),
+    description: t('Seer stopped at a diagnosis. Review the root cause to continue.'),
+    errorFallback: t('Seer could not start creating a plan.'),
+    handoffStep: 'root_cause',
+    label: t('Create Plan'),
+    trigger: (autofix, runId) => autofix.startStep('solution', {runId}),
+  },
+  solution_ready: {
+    Icon: IconCode,
+    action: 'generate_code',
+    busyLabel: t('Generating Code…'),
+    description: t('Autofix proposed a fix. Continue the pipeline to generate code.'),
+    errorFallback: t('Seer could not start generating code.'),
+    handoffStep: 'solution',
+    label: t('Generate code'),
+    trigger: (autofix, runId) => autofix.startStep('code_changes', {runId}),
+  },
+  code_changes_ready: {
+    Icon: IconCommit,
+    action: 'draft_pr',
+    busyLabel: t('Creating PR…'),
+    description: t('Autofix wrote a diff. Review it and open a pull request.'),
+    // createPR surfaces its own error toast.
+    errorFallback: '',
+    handoffStep: 'code_changes',
+    label: t('Draft PR'),
+    trigger: (autofix, runId) => autofix.createPR(runId),
+  },
+};
+
+export function OverviewCardAction({
+  run,
+  sectionKey,
+  issueUrl,
+}: {
+  issueUrl: string;
+  run: OverviewRun;
+  sectionKey: ActionableSectionKey;
+}) {
+  const organization = useOrganization();
+  const config = ACTIONS[sectionKey];
+  const [dispatched, setDispatched] = useState(false);
+
+  const autofix = useExplorerAutofix(
+    {id: run.groupId, shortId: run.shortId},
+    {
+      enabled: false,
+      codingAgentAnalyticsSource: 'overview',
+      onCodingAgentError: messages =>
+        messages.forEach(message => addErrorMessage(message)),
+    }
+  );
+
+  const {codingAgentIntegrations, codingAgentDisabledReason, handleCodingAgentHandoff} =
+    useCodingAgents({
+      autofix,
+      group: {id: run.groupId, project: run.issue.project},
+      runId: run.seerRunId,
+      step: config.handoffStep,
+      referrer: 'autofix-overview',
+    });
+
+  const menuItems = useMemo<MenuItemProps[]>(() => {
+    const agentItems = (codingAgentIntegrations ?? []).map(integration => {
+      const actionLabel =
+        integration.requires_identity && !integration.has_identity
+          ? t('Setup %s', integration.name)
+          : t('Send to %s', integration.name);
+      return {
+        key: `agent:${integration.id ?? integration.provider}`,
+        textValue: actionLabel,
+        label: (
+          <Flex gap="md" align="center">
+            <PluginIcon pluginId={integration.provider} size={16} />
+            <span>{actionLabel}</span>
+          </Flex>
+        ),
+        disabled: defined(codingAgentDisabledReason),
+        tooltip: codingAgentDisabledReason,
+        onAction: () => handleCodingAgentHandoff(integration),
+      };
+    });
+
+    return [
+      {
+        key: 'open-seer',
+        textValue: t('Open Seer'),
+        label: (
+          <Flex gap="md" align="center">
+            <IconSeer size="sm" />
+            <span>{t('Open Seer')}</span>
+          </Flex>
+        ),
+        to: {pathname: issueUrl, query: {seerDrawer: 'true'}},
+        onAction: () =>
+          trackAnalytics('autofix.overview.open_seer_clicked', {
+            organization,
+            group_id: run.groupId,
+            run_id: run.seerRunId,
+          }),
+      },
+      ...agentItems,
+    ];
+  }, [
+    codingAgentIntegrations,
+    codingAgentDisabledReason,
+    handleCodingAgentHandoff,
+    issueUrl,
+    organization,
+    run.groupId,
+    run.seerRunId,
+  ]);
+
+  if (dispatched) {
+    return (
+      <Button size="sm" variant="secondary" disabled icon={<ButtonSpinner size={14} />}>
+        {config.busyLabel}
+      </Button>
+    );
+  }
+
+  const handleTrigger = async () => {
+    setDispatched(true);
+    trackAnalytics('autofix.overview.action_clicked', {
+      organization,
+      group_id: run.groupId,
+      run_id: run.seerRunId,
+      action: config.action,
+    });
+    try {
+      await config.trigger(autofix, run.seerRunId);
+    } catch (error: any) {
+      if (config.errorFallback) {
+        addErrorMessage(error?.responseJSON?.detail ?? config.errorFallback);
+      }
+      setDispatched(false);
+    }
+  };
+
+  return (
+    <ButtonBar>
+      <Tooltip title={config.description} skipWrapper>
+        <Button
+          size="sm"
+          variant="secondary"
+          icon={<config.Icon />}
+          onClick={handleTrigger}
+        >
+          {config.label}
+        </Button>
+      </Tooltip>
+      <DropdownMenu
+        items={menuItems}
+        trigger={(triggerProps, isOpen) => (
+          <Button
+            {...triggerProps}
+            size="sm"
+            variant="secondary"
+            icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
+            aria-label={t('More Seer options')}
+          />
+        )}
+        position="bottom-end"
+        shouldCloseOnBlur={false}
+        menuFooter={
+          <DropdownMenuFooter>
+            <MenuComponents.CTALinkButton
+              icon={<IconAdd />}
+              to={`/settings/${organization.slug}/integrations/?category=coding%20agent`}
+            >
+              {t('Add Integration')}
+            </MenuComponents.CTALinkButton>
+          </DropdownMenuFooter>
+        }
+      />
+    </ButtonBar>
+  );
+}
+
+const ButtonSpinner = styled(LoadingIndicator)`
+  margin: 0;
+`;


### PR DESCRIPTION
On the Autofix overview, the Create Plan / Generate code / Draft PR card buttons currently just link to the issue page. Per the design discussion for AIML-3323, clicking should trigger the action directly (one click), with a separate mechanism to open the Seer drawer for more detail.

## Changes

- **`OverviewCardAction` (new)**: the three actionable sections render a split button. The primary button POSTs the next autofix step directly (`solution`, `code_changes`, or `open_pr` with the run's `sentry_run_id`). After dispatch the button optimistically collapses to a disabled in-progress state ("Creating Plan…" / "Generating Code…" / "Creating PR…"); a failed request reverts it with an error toast. Wiring the button state to the run's live status is a follow-up.
- **Caret dropdown** next to the action: **Open Seer** (issue page with `?seerDrawer=true`, which auto-opens the drawer), **Send to {agent}** per connected coding-agent integration (disabled with a tooltip when no GitHub repo is connected, "Setup {name}" when identity is required), and an **Add Integration** footer.
- **Shared handoff path**: `useExplorerAutofix` now accepts a minimal `{id, shortId}` group plus options for the analytics source and error reporting, and `useCodingAgents` accepts minimal group data, so the overview reuses the drawer's handoff logic — including the GitHub-permissions / Copilot-license / Cursor-access modals and OAuth redirects — without a full `Group`/`Project` in hand.
- **Analytics**: new `autofix.overview.action_clicked` and `autofix.overview.open_seer_clicked` events, and coding-agent handoffs report `source: 'overview'`, so we can compare one-click actions against drawer usage.

Review PR and Merged cards are unchanged. Unlike the drawer (which only offers handoff after root cause and solution), the caret offers agent handoff on all three actionable sections, including Draft PR cards.

Refs AIML-3323