### PR TITLE
fix(seer): Render overview summaries as Markdown

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -276,8 +276,32 @@ describe('AutofixOverview', () => {
 
     // The root-cause-only run has no plan, so only the solution card carries
     // the plan label.
-    expect(screen.getAllByText('Root cause')).toHaveLength(2);
+    expect(screen.getAllByText('Root Cause')).toHaveLength(2);
     expect(screen.getAllByText('Plan')).toHaveLength(1);
+  });
+
+  it('renders inline code in root cause and plan summaries', async () => {
+    mockOverview({
+      base: {
+        autofix_solution: [
+          {
+            ...solutionRun,
+            rootCause: {
+              oneLineDescription: 'The request is passed to `dateutil.parse()`.',
+            },
+            proposedFix: {
+              oneLineSummary: 'Wrap `parse_date()` in a try/catch.',
+            },
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    await screen.findByRole('link', {name: 'KeyError in proxy handler'});
+    expect(screen.getByText('dateutil.parse()').tagName).toBe('CODE');
+    expect(screen.getByText('parse_date()').tagName).toBe('CODE');
   });
 
   it('scopes the request to the selected project', async () => {

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -6,6 +6,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {Markdown, type MarkdownProps} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -273,6 +274,21 @@ const LevelBar = styled(ErrorLevel)`
   width: 4px;
 `;
 
+const NARRATIVE_MARKDOWN_COMPONENTS: MarkdownProps['components'] = {
+  Paragraph: ({children}) => (
+    <Text
+      as="p"
+      size="sm"
+      variant="secondary"
+      bold={false}
+      tabular
+      wordBreak="break-word"
+    >
+      {children}
+    </Text>
+  ),
+};
+
 function NarrativeBlock({
   icon,
   label,
@@ -286,13 +302,11 @@ function NarrativeBlock({
     <Stack gap="xs">
       <Flex gap="xs" align="center">
         {icon}
-        <Text size="xs" bold uppercase variant="secondary">
+        <Text size="sm" bold tabular variant="secondary">
           {label}
         </Text>
       </Flex>
-      <Text size={{xs: 'md', lg: 'lg'}} density="comfortable" wordBreak="break-word">
-        {children}
-      </Text>
+      <Markdown raw={children} components={NARRATIVE_MARKDOWN_COMPONENTS} />
     </Stack>
   );
 }
@@ -469,7 +483,7 @@ export function OverviewCard({
             {rootCause && (
               <NarrativeBlock
                 icon={<IconBug size="xs" variant="secondary" aria-hidden />}
-                label={t('Root cause')}
+                label={t('Root Cause')}
               >
                 {rootCause}
               </NarrativeBlock>

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -302,7 +302,7 @@ function NarrativeBlock({
     <Stack gap="xs">
       <Flex gap="xs" align="center">
         {icon}
-        <Text size="sm" bold tabular variant="secondary">
+        <Text size="xs" bold variant="secondary">
           {label}
         </Text>
       </Flex>


### PR DESCRIPTION
Use the Scraps Markdown renderer so inline code is formatted in root cause and plan summaries. Align the summary and label typography with the overview design.

see code formatting
<img width="1952" height="318" alt="CleanShot 2026-08-17 at 22 57 25@2x" src="https://github.com/user-attachments/assets/c2687475-abeb-4372-b8dc-d0b1c97542b9" />
