### PR TITLE
ref(seer): Extract shared coding-agent handoff dropdown

### DIFF
--- a/static/app/components/events/autofix/v3/codingAgentMenu.spec.tsx
+++ b/static/app/components/events/autofix/v3/codingAgentMenu.spec.tsx
@@ -1,0 +1,86 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
+import {
+  CodingAgentMenuFooter,
+  useCodingAgentMenuItems,
+} from 'sentry/components/events/autofix/v3/codingAgentMenu';
+
+function integrationFixture(
+  overrides: Partial<CodingAgentIntegration> = {}
+): CodingAgentIntegration {
+  return {id: '7', name: 'Claude Agent', provider: 'claude_code', ...overrides};
+}
+
+describe('useCodingAgentMenuItems', () => {
+  it('builds one send-to item per integration', () => {
+    const onCodingAgentHandoff = jest.fn();
+    const {result} = renderHookWithProviders(() =>
+      useCodingAgentMenuItems({
+        codingAgentIntegrations: [integrationFixture()],
+        onCodingAgentHandoff,
+      })
+    );
+
+    expect(result.current).toHaveLength(1);
+    const [item] = result.current;
+    expect(item!.key).toBe('agent:7');
+    expect(item!.textValue).toBe('Send to Claude Agent');
+
+    item!.onAction?.();
+    expect(onCodingAgentHandoff).toHaveBeenCalledWith(integrationFixture());
+  });
+
+  it('labels items that require identity setup and keys by provider when id is null', () => {
+    const {result} = renderHookWithProviders(() =>
+      useCodingAgentMenuItems({
+        codingAgentIntegrations: [
+          integrationFixture({id: null, requires_identity: true, has_identity: false}),
+        ],
+        onCodingAgentHandoff: jest.fn(),
+      })
+    );
+
+    expect(result.current[0]!.key).toBe('agent:claude_code');
+    expect(result.current[0]!.textValue).toBe('Setup Claude Agent');
+  });
+
+  it('disables items with a tooltip when a disabled reason is provided', () => {
+    const {result} = renderHookWithProviders(() =>
+      useCodingAgentMenuItems({
+        codingAgentIntegrations: [integrationFixture()],
+        codingAgentDisabledReason: 'Connect a GitHub repository.',
+        onCodingAgentHandoff: jest.fn(),
+      })
+    );
+
+    expect(result.current[0]!.disabled).toBe(true);
+    expect(result.current[0]!.tooltip).toBe('Connect a GitHub repository.');
+  });
+
+  it('returns an empty list when integrations are undefined', () => {
+    const {result} = renderHookWithProviders(() =>
+      useCodingAgentMenuItems({
+        codingAgentIntegrations: undefined,
+        onCodingAgentHandoff: jest.fn(),
+      })
+    );
+
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe('CodingAgentMenuFooter', () => {
+  it('links to the coding-agent integrations settings', () => {
+    render(<CodingAgentMenuFooter />, {
+      organization: OrganizationFixture({slug: 'acme'}),
+    });
+
+    expect(screen.getByRole('button', {name: 'Add Integration'})).toHaveAttribute(
+      'href',
+      '/settings/acme/integrations/?category=coding%20agent'
+    );
+  });
+});

--- a/static/app/components/events/autofix/v3/codingAgentMenu.tsx
+++ b/static/app/components/events/autofix/v3/codingAgentMenu.tsx
@@ -1,0 +1,67 @@
+import {useMemo} from 'react';
+
+import {MenuComponents} from '@sentry/scraps/compactSelect';
+import {Flex} from '@sentry/scraps/layout';
+
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
+import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
+import {IconAdd} from 'sentry/icons';
+import {PluginIcon} from 'sentry/icons/pluginIcon';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils/defined';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+/**
+ * Menu items for handing an Autofix run off to a connected coding agent, shared
+ * by the Seer drawer, issue preview, and Autofix overview dropdowns. Items carry
+ * a per-item disabled/tooltip; callers that gate the whole trigger can ignore it.
+ */
+export function useCodingAgentMenuItems({
+  codingAgentIntegrations,
+  codingAgentDisabledReason,
+  onCodingAgentHandoff,
+}: {
+  codingAgentIntegrations: CodingAgentIntegration[] | undefined;
+  onCodingAgentHandoff: (integration: CodingAgentIntegration) => void;
+  codingAgentDisabledReason?: string;
+}): MenuItemProps[] {
+  return useMemo(
+    () =>
+      (codingAgentIntegrations ?? []).map(integration => {
+        const actionLabel =
+          integration.requires_identity && !integration.has_identity
+            ? t('Setup %s', integration.name)
+            : t('Send to %s', integration.name);
+
+        return {
+          key: `agent:${integration.id ?? integration.provider}`,
+          textValue: actionLabel,
+          label: (
+            <Flex gap="md" align="center">
+              <PluginIcon pluginId={integration.provider} size={16} />
+              <span>{actionLabel}</span>
+            </Flex>
+          ),
+          disabled: defined(codingAgentDisabledReason),
+          tooltip: codingAgentDisabledReason,
+          onAction: () => onCodingAgentHandoff(integration),
+        };
+      }),
+    [codingAgentIntegrations, codingAgentDisabledReason, onCodingAgentHandoff]
+  );
+}
+
+export function CodingAgentMenuFooter() {
+  const organization = useOrganization();
+  return (
+    <DropdownMenuFooter>
+      <MenuComponents.CTALinkButton
+        icon={<IconAdd />}
+        to={`/settings/${organization.slug}/integrations/?category=coding%20agent`}
+      >
+        {t('Add Integration')}
+      </MenuComponents.CTALinkButton>
+    </DropdownMenuFooter>
+  );
+}

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,14 +1,12 @@
 import {useCallback, useMemo, useState, type ReactNode} from 'react';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
-import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
@@ -22,12 +20,14 @@ import {
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {
+  CodingAgentMenuFooter,
+  useCodingAgentMenuItems,
+} from 'sentry/components/events/autofix/v3/codingAgentMenu';
 import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
 import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
-import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconOpen} from 'sentry/icons/iconOpen';
-import {PluginIcon} from 'sentry/icons/pluginIcon';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
@@ -480,28 +480,11 @@ function NextStepTemplate({
   codingAgentDisabledReason,
   onCodingAgentHandoff,
 }: NextStepTemplateProps) {
-  const organization = useOrganization();
-
-  const codingAgentOptions = useMemo(() => {
-    return (codingAgentIntegrations ?? []).map(integration => {
-      const actionLabel =
-        integration.requires_identity && !integration.has_identity
-          ? t('Setup %s', integration.name)
-          : t('Send to %s', integration.name);
-
-      return {
-        key: `agent:${integration.id ?? integration.provider}`,
-        textValue: actionLabel,
-        label: (
-          <Flex gap="md" align="center">
-            <PluginIcon pluginId={integration.provider} size={16} />
-            <span>{actionLabel}</span>
-          </Flex>
-        ),
-        onAction: () => onCodingAgentHandoff?.(integration),
-      };
-    });
-  }, [codingAgentIntegrations, onCodingAgentHandoff]);
+  const codingAgentOptions = useCodingAgentMenuItems({
+    codingAgentIntegrations,
+    codingAgentDisabledReason,
+    onCodingAgentHandoff: integration => onCodingAgentHandoff?.(integration),
+  });
 
   const [clickedNo, handleClickedNo] = useState(false);
   const [userContext, setUserContext] = useState('');
@@ -556,16 +539,7 @@ function NextStepTemplate({
               )}
               position="bottom-end"
               shouldCloseOnBlur={false}
-              menuFooter={
-                <DropdownMenuFooter>
-                  <MenuComponents.CTALinkButton
-                    icon={<IconAdd />}
-                    to={`/settings/${organization.slug}/integrations/?category=coding%20agent`}
-                  >
-                    {t('Add Integration')}
-                  </MenuComponents.CTALinkButton>
-                </DropdownMenuFooter>
-              }
+              menuFooter={<CodingAgentMenuFooter />}
             />
           )}
         </ButtonBar>

--- a/static/app/views/issueDetails/issuePreview/issuePreviewActions.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewActions.spec.tsx
@@ -1,0 +1,108 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+
+import {IssuePreviewActions} from './issuePreviewActions';
+
+// A completed root-cause run so the next step is "make a plan", which renders
+// the coding-agent handoff dropdown.
+function makeAutofix(
+  overrides: Partial<ReturnType<typeof useExplorerAutofix>> = {}
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    runState: {
+      run_id: 1,
+      status: 'completed',
+      updated_at: '2026-01-01T00:00:00Z',
+      blocks: [
+        {
+          id: 'b1',
+          message: {role: 'assistant', content: 'done', metadata: {step: 'root_cause'}},
+          timestamp: '2026-01-01T00:00:00Z',
+          loading: false,
+        },
+      ],
+    } as any,
+    autofixFormatted: null,
+    startStep: jest.fn(),
+    createPR: jest.fn(),
+    reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: jest.fn(),
+    warnings: [],
+    isLoading: false,
+    isWaitingForRun: false,
+    isPolling: false,
+    ...overrides,
+  };
+}
+
+describe('IssuePreviewActions', () => {
+  const organization = OrganizationFixture();
+  const group = GroupFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
+      body: {integrations: [{id: '9', name: 'Claude Agent', provider: 'claude_code'}]},
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${group.project.slug}/seer/repos/`,
+      body: [{provider: 'github'}],
+    });
+  });
+
+  it('hands off to a coding agent from the shared dropdown', async () => {
+    const autofix = makeAutofix();
+
+    render(
+      <IssuePreviewActions
+        autofix={autofix}
+        group={group}
+        onContinueInSeer={jest.fn()}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'More code fix options'})
+    );
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Send to Claude Agent'})
+    );
+
+    expect(autofix.triggerCodingAgentHandoff).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({provider: 'claude_code'})
+    );
+  });
+
+  it('shows the Add Integration footer in the dropdown', async () => {
+    render(
+      <IssuePreviewActions
+        autofix={makeAutofix()}
+        group={group}
+        onContinueInSeer={jest.fn()}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'More code fix options'})
+    );
+
+    expect(await screen.findByRole('button', {name: 'Add Integration'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/integrations/?category=coding%20agent`
+    );
+  });
+});

--- a/static/app/views/issueDetails/issuePreview/issuePreviewActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewActions.tsx
@@ -1,11 +1,9 @@
 import {Fragment, useState, type ReactNode} from 'react';
 
 import {Button, ButtonBar, LinkButton, type ButtonProps} from '@sentry/scraps/button';
-import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixNextStep} from 'sentry/components/events/autofix/getAutofixNextStep';
 import {findCodingAgentResultLink} from 'sentry/components/events/autofix/pullRequests';
 import {getCodingAgentName} from 'sentry/components/events/autofix/types';
@@ -13,22 +11,17 @@ import {
   getOrderedAutofixSections,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {
+  CodingAgentMenuFooter,
+  useCodingAgentMenuItems,
+} from 'sentry/components/events/autofix/v3/codingAgentMenu';
 import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
 import {useLinkedPullRequests} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {Placeholder} from 'sentry/components/placeholder';
-import {
-  IconAdd,
-  IconChevron,
-  IconGithub,
-  IconOpen,
-  IconRefresh,
-  IconSeer,
-} from 'sentry/icons';
-import {PluginIcon} from 'sentry/icons/pluginIcon';
+import {IconChevron, IconGithub, IconOpen, IconRefresh, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils/defined';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 type ExplorerAutofix = ReturnType<typeof useExplorerAutofix>;
 
@@ -105,7 +98,6 @@ function StartAutofixAction({
   variant?: 'primary' | 'secondary';
   waiting?: boolean;
 }) {
-  const organization = useOrganization();
   const [isStartingAction, setIsStartingAction] = useState(false);
   const runId = autofix.runState?.run_id;
   const isProcessing = autofix.isPolling || isStartingAction;
@@ -131,23 +123,10 @@ function StartAutofixAction({
     }
   };
 
-  const codingAgentOptions = (codingAgentIntegrations ?? []).map(integration => {
-    const actionLabel =
-      integration.requires_identity && !integration.has_identity
-        ? t('Setup %s', integration.name)
-        : t('Send to %s', integration.name);
-
-    return {
-      key: `agent:${integration.id ?? integration.provider}`,
-      textValue: actionLabel,
-      label: (
-        <Flex gap="md" align="center">
-          <PluginIcon pluginId={integration.provider} size={16} />
-          <span>{actionLabel}</span>
-        </Flex>
-      ),
-      onAction: () => handleCodingAgentHandoff(integration),
-    };
+  const codingAgentOptions = useCodingAgentMenuItems({
+    codingAgentIntegrations,
+    codingAgentDisabledReason,
+    onCodingAgentHandoff: handleCodingAgentHandoff,
   });
 
   const primaryButton = (
@@ -193,16 +172,7 @@ function StartAutofixAction({
         )}
         position="bottom-end"
         shouldCloseOnBlur={false}
-        menuFooter={
-          <DropdownMenuFooter>
-            <MenuComponents.CTALinkButton
-              icon={<IconAdd />}
-              to={`/settings/${organization.slug}/integrations/?category=coding%20agent`}
-            >
-              {t('Add Integration')}
-            </MenuComponents.CTALinkButton>
-          </DropdownMenuFooter>
-        }
+        menuFooter={<CodingAgentMenuFooter />}
       />
     </ButtonBar>
   );

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -2,20 +2,19 @@ import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
-import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
+import {
+  CodingAgentMenuFooter,
+  useCodingAgentMenuItems,
+} from 'sentry/components/events/autofix/v3/codingAgentMenu';
 import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {IconAdd, IconChevron, IconOpen, IconSeer} from 'sentry/icons';
-import {PluginIcon} from 'sentry/icons/pluginIcon';
+import {IconChevron, IconOpen, IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {defined} from 'sentry/utils/defined';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {useOpenSeerLink} from './openSeerButton';
 import {type ActionableSectionKey, useNextAction} from './overviewActions';
@@ -28,7 +27,6 @@ export function OverviewCardAction({
   run: OverviewRun;
   sectionKey: ActionableSectionKey;
 }) {
-  const organization = useOrganization();
   // Defer agent-option fetches until the dropdown opens to avoid per-card repo pagination.
   const [menuOpened, setMenuOpened] = useState(false);
 
@@ -62,6 +60,12 @@ export function OverviewCardAction({
     enabled: isDraftPr,
   });
 
+  const agentItems = useCodingAgentMenuItems({
+    codingAgentIntegrations,
+    codingAgentDisabledReason,
+    onCodingAgentHandoff: handleCodingAgentHandoff,
+  });
+
   const menuItems = useMemo<MenuItemProps[]>(() => {
     if (isLoadingOptions) {
       return [
@@ -78,26 +82,6 @@ export function OverviewCardAction({
       ];
     }
 
-    const agentItems = (codingAgentIntegrations ?? []).map(integration => {
-      const actionLabel =
-        integration.requires_identity && !integration.has_identity
-          ? t('Setup %s', integration.name)
-          : t('Send to %s', integration.name);
-      return {
-        key: `agent:${integration.id ?? integration.provider}`,
-        textValue: actionLabel,
-        label: (
-          <Flex gap="md" align="center">
-            <PluginIcon pluginId={integration.provider} size={16} />
-            <span>{actionLabel}</span>
-          </Flex>
-        ),
-        disabled: defined(codingAgentDisabledReason),
-        tooltip: codingAgentDisabledReason,
-        onAction: () => handleCodingAgentHandoff(integration),
-      };
-    });
-
     return [
       {
         key: 'open-seer',
@@ -113,14 +97,7 @@ export function OverviewCardAction({
       },
       ...agentItems,
     ];
-  }, [
-    isLoadingOptions,
-    codingAgentIntegrations,
-    codingAgentDisabledReason,
-    handleCodingAgentHandoff,
-    openSeerTo,
-    trackOpen,
-  ]);
+  }, [isLoadingOptions, agentItems, openSeerTo, trackOpen]);
 
   if (isDispatched) {
     return (
@@ -179,16 +156,7 @@ export function OverviewCardAction({
         position="bottom-end"
         shouldCloseOnBlur={false}
         onOpenChange={isOpen => isOpen && setMenuOpened(true)}
-        menuFooter={
-          <DropdownMenuFooter>
-            <MenuComponents.CTALinkButton
-              icon={<IconAdd />}
-              to={`/settings/${organization.slug}/integrations/?category=coding%20agent`}
-            >
-              {t('Add Integration')}
-            </MenuComponents.CTALinkButton>
-          </DropdownMenuFooter>
-        }
+        menuFooter={<CodingAgentMenuFooter />}
       />
     </ButtonBar>
   );


### PR DESCRIPTION
> Stacked on #122186 — base is `feat/autofix-overview-card-actions`. Review/merge that first; this targets it so the diff stays scoped to the refactor.

The coding-agent handoff dropdown — the `Setup %s` / `Send to %s` menu items with a plugin icon, plus the "Add Integration" footer — was hand-rolled identically in three places. This PR extracts it once and has all three consume it.

## Changes

- **New shared module** `codingAgentMenu.tsx`:
  - `useCodingAgentMenuItems({codingAgentIntegrations, codingAgentDisabledReason, onCodingAgentHandoff})` → `MenuItemProps[]` — the per-agent label/key/icon mapping, with per-item disabled + tooltip.
  - `<CodingAgentMenuFooter />` — the "Add Integration" CTA linking to the coding-agent integrations settings.
- **Consumed by all three dropdowns**: the Seer drawer (`nextStep.tsx`), issue preview (`issuePreviewActions.tsx`), and Autofix overview (`overviewCardAction.tsx`). Each drops ~30 lines of duplicated markup. No behavior change — the drawer/issue-preview keep gating their whole trigger; the overview keeps its per-item disable and extra "Open Seer" item.
- **Characterization test** added for the previously-untested issue-preview action dropdown, so the refactor there is guarded.

## Out of scope

`seerCommandPaletteActions.tsx` renders command-palette (`CMDKAction`) entries with search keywords and no footer — structurally incompatible with the `MenuItemProps[]` dropdown shape — so it's intentionally left alone.

Refs AIML-3323