### PR TITLE
fix(seer): Render failing checks as a bulleted list

### DIFF
--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -228,11 +228,16 @@ function OverviewAction({
                     <Text size="sm" bold>
                       {t('Failing checks:')}
                     </Text>
-                    {failedChecks.map((name, index) => (
-                      <Text key={`${name}-${index}`} size="sm">
-                        {name}
-                      </Text>
-                    ))}
+                    <Stack gap="2xs" align="start">
+                      {failedChecks.map((name, index) => (
+                        <Flex key={`${name}-${index}`} gap="xs" align="start">
+                          <Text size="sm" variant="muted">
+                            •
+                          </Text>
+                          <Text size="sm">{name}</Text>
+                        </Flex>
+                      ))}
+                    </Stack>
                   </Stack>
                 }
               >

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -225,7 +225,7 @@ function OverviewAction({
                 disabled={failedChecks.length === 0}
                 title={
                   <Stack gap="xs" align="start">
-                    <Text size="sm" bold>
+                    <Text size="sm" bold align="left">
                       {t('Failing checks:')}
                     </Text>
                     <Stack gap="2xs" align="start">
@@ -234,7 +234,9 @@ function OverviewAction({
                           <Text size="sm" variant="muted">
                             •
                           </Text>
-                          <Text size="sm">{name}</Text>
+                          <Text size="sm" align="left">
+                            {name}
+                          </Text>
                         </Flex>
                       ))}
                     </Stack>


### PR DESCRIPTION
The failing-checks tooltip on the Autofix overview cards stacked bare text lines with a subtle gap, so long check names wrapped and blended into the next check — the list read as one run-on block.

Render each check as a bulleted item with a hanging indent, so wrapped lines align under the check name (not the bullet) and each item is visually distinct.

Before: `getsentry dispatch` / `(Optional) Shows the difference between the prod and dev schema` ran together.
After:

```
Failing checks:
• getsentry dispatch
• (Optional) Shows the difference
  between the prod and dev schema
```

Existing overview tests already assert each check name renders in the tooltip and continue to pass unchanged.