### PR TITLE
feat(seer): Add status expand for live autofix run status

### DIFF
--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import re
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
@@ -60,6 +60,10 @@ agent_connection_pool = connection_from_url(
 class AgentStateRequest(TypedDict):
     run_id: int
     organization_id: int
+
+
+class RunsByIdsRequest(TypedDict):
+    run_ids: list[int]
 
 
 class AgentChatRequest(TypedDict):
@@ -148,6 +152,19 @@ def make_agent_state_request(
         connection_pool or agent_connection_pool,
         "/v1/automation/explorer/state",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
+    )
+
+
+def make_runs_by_ids_request(
+    body: RunsByIdsRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or agent_connection_pool,
+        "/v1/automation/explorer/runs/by-ids",
+        body=orjson.dumps(body),
         viewer_context=viewer_context,
     )
 
@@ -500,6 +517,33 @@ def fetch_run_status(
         raise ValueError(f"No session found for run_id {run_id}")
 
     return SeerRunState(**session)
+
+
+def fetch_run_statuses(
+    run_state_ids: Sequence[int],
+    organization: Organization,
+    viewer_context: SeerViewerContext | None = None,
+) -> dict[int, str]:
+    """Batch-fetch live Explorer run statuses. Best-effort: returns {} on failure."""
+    if not run_state_ids:
+        return {}
+    try:
+        response = make_runs_by_ids_request(
+            {"run_ids": list(run_state_ids)},
+            viewer_context=viewer_context or SeerViewerContext(organization_id=organization.id),
+        )
+        if response.status >= 400:
+            logger.warning("seer.run_statuses.error", extra={"status": response.status})
+            return {}
+        data = response.json()
+        return {
+            int(run_id): run["status"]
+            for run_id, run in data.get("data", {}).items()
+            if run.get("status") is not None
+        }
+    except Exception:
+        logger.warning("seer.run_statuses.request_failed", exc_info=True)
+        return {}
 
 
 def poll_until_done(

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -39,6 +39,7 @@ from sentry.models.repository import Repository
 from sentry.plugins.base import bindings
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
 from sentry.seer.agent.client_models import AgentFilePatch, FilePatch
+from sentry.seer.agent.client_utils import fetch_run_statuses
 from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
     CodeChangeFilePayload,
     IssuePayload,
@@ -262,6 +263,7 @@ def _serialize_run(
     run: _RunMilestones,
     serialized_group: dict,
     pull_requests: list[PullRequestPayload],
+    status: str | None,
 ) -> RunPayload:
     root_cause_artifact = run.root_cause_artifact
     root_cause: RootCausePayload | None = (
@@ -290,6 +292,7 @@ def _serialize_run(
         "pullRequests": pull_requests,
         "codeChanges": code_changes,
         "issue": _serialize_issue(group, serialized_group),
+        "status": status,
     }
 
 
@@ -311,6 +314,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         expand = request.GET.getlist("expand")
         include_scm_info = "scmInfo" in expand
         include_issue_stats = "issueStats" in expand
+        include_status = "status" in expand
         environments = self.get_environments(request, organization)
 
         sort = request.GET.get("sort")
@@ -379,6 +383,15 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             [run.seer_run.id for _, run in capped], include_scm_info=include_scm_info
         )
 
+        status_by_state_id: dict[int, str] = {}
+        if include_status:
+            state_ids = [
+                run.seer_run.seer_run_state_id
+                for _, run in capped
+                if run.seer_run.seer_run_state_id is not None
+            ]
+            status_by_state_id = fetch_run_statuses(state_ids, organization)
+
         runs_by_milestone: dict[str, list[RunPayload]] = {milestone: [] for milestone in _PIPELINE}
         for milestone, pairs in capped_runs_by_milestone.items():
             for group_id, run in pairs:
@@ -391,6 +404,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                         run,
                         serialized_by_id[str(group_id)],
                         pull_requests_by_seer_run_id.get(run.seer_run.id, []),
+                        status_by_state_id.get(run.seer_run.seer_run_state_id),
                     )
                 )
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -70,6 +70,7 @@ class RunPayload(TypedDict):
     pullRequests: list[PullRequestPayload]
     codeChanges: list[CodeChangeFilePayload]
     issue: IssuePayload
+    status: str | None
 
 
 class OverviewResponse(TypedDict):

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -1,4 +1,8 @@
+from typing import Any
+from unittest import mock
+
 import jwt
+import orjson
 from django.test import override_settings
 
 from sentry.hybridcloud.models.outbox import CellOutbox
@@ -9,6 +13,7 @@ from sentry.seer.agent.client_utils import (
     _sanitize_json_strings,
     collect_user_org_context,
     enqueue_seer_run,
+    fetch_run_statuses,
     get_proxy_headers,
     has_seer_agent_access_with_detail,
     snapshot_to_markdown,
@@ -560,3 +565,51 @@ class EnqueueSeerRunSanitizeTest(TestCase):
         assert outbox.payload is not None
         title = outbox.payload["body"]["payload"]["candidates"][0]["title"]
         assert title == "System.FormatException: The input string '' was..."
+
+
+class FetchRunStatusesTest(TestCase):
+    _PATCH = "sentry.seer.agent.client_utils.make_signed_seer_api_request"
+
+    def _response(self, status: int, payload: dict) -> mock.Mock:
+        response = mock.Mock(status=status)
+        response.json.return_value = payload
+        return response
+
+    def test_empty_ids_makes_no_request(self) -> None:
+        with mock.patch(self._PATCH) as m:
+            assert fetch_run_statuses([], self.organization) == {}
+        assert m.call_count == 0
+
+    def test_maps_run_id_to_status_and_omits_null(self) -> None:
+        payload = {
+            "data": {
+                "7": {"status": "processing"},
+                "9": {"status": "completed"},
+                "11": {"status": None},
+            }
+        }
+        with mock.patch(self._PATCH, return_value=self._response(200, payload)) as m:
+            result = fetch_run_statuses([7, 9, 11], self.organization)
+
+        assert result == {7: "processing", 9: "completed"}
+        sent = orjson.loads(m.call_args.kwargs["body"])
+        assert sent == {"run_ids": [7, 9, 11]}
+        assert m.call_args.kwargs["viewer_context"] is not None
+
+    def test_seer_error_status_returns_empty(self) -> None:
+        with mock.patch(self._PATCH, return_value=self._response(500, {})):
+            assert fetch_run_statuses([7], self.organization) == {}
+
+    def test_request_exception_returns_empty(self) -> None:
+        with mock.patch(self._PATCH, side_effect=Exception("boom")):
+            assert fetch_run_statuses([7], self.organization) == {}
+
+    def test_malformed_payload_returns_empty(self) -> None:
+        payloads: list[dict[str, Any]] = [
+            {"data": None},
+            {"data": {"7": "not-a-dict"}},
+            {"data": {"x": {}}},
+        ]
+        for payload in payloads:
+            with mock.patch(self._PATCH, return_value=self._response(200, payload)):
+                assert fetch_run_statuses([7], self.organization) == {}

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -842,3 +842,48 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert client.requested_keys == ["123"]
         assert pull_requests[0]["checksStatus"] == "success"
         assert "stats" not in serializer.call_args.kwargs["collapse"]
+
+
+class OrganizationSeerAutofixOverviewStatusExpandTest(APITestCase, SnubaTestCase):
+    endpoint = "sentry-api-0-organization-seer-autofix-overview"
+    _FETCH = "sentry.seer.endpoints.organization_seer_autofix_overview.fetch_run_statuses"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+    def _run_for_group(self, group, description, state_id):
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", group=group, project=group.project)
+        reconcile_milestones(run, _root_cause_state(description))
+        run.update(seer_run_state_id=state_id)
+        return run
+
+    def _root_cause_runs(self, resp):
+        return resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE]
+
+    def test_status_absent_without_expand(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom", state_id=101)
+        with mock.patch(self._FETCH) as m:
+            resp = self.get_success_response(self.organization.slug)
+        assert m.call_count == 0
+        assert self._root_cause_runs(resp)[0]["status"] is None
+
+    def test_expand_status_attaches_status_by_state_id(self):
+        group = self.create_group()
+        run = self._run_for_group(group, "boom", state_id=101)
+        with mock.patch(self._FETCH, return_value={101: "processing"}) as m:
+            resp = self.get_success_response(self.organization.slug, qs_params={"expand": "status"})
+        assert m.call_args.args[0] == [101]
+        serialized = self._root_cause_runs(resp)[0]
+        assert serialized["seerRunId"] == str(run.uuid)
+        assert serialized["status"] == "processing"
+
+    def test_expand_status_run_without_state_id_gets_null(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom", state_id=None)
+        with mock.patch(self._FETCH, return_value={}) as m:
+            resp = self.get_success_response(self.organization.slug, qs_params={"expand": "status"})
+        assert m.call_args.args[0] == []
+        assert self._root_cause_runs(resp)[0]["status"] is None


### PR DESCRIPTION
Adds `status` as a new `expand` option to the autofix overview endpoint (`GET .../seer/autofix-overview/?expand=status`), attaching each run's live status from Seer so the overview page can show "in progress" spinners.

## What
- New batch client `fetch_run_statuses(state_ids, org)` (`client_utils.py`) calling Seer's Explorer batch endpoint `POST /v1/automation/explorer/runs/by-ids`, keyed on the integer `seer_run_state_id`. Org scoping is via the viewer-context JWT (no org id in the body).
- `expand=status` collects the state ids from the already-capped run set and attaches `status: str | None` per run.

## Best-effort by design
Status never breaks the page: if Seer errors or is unreachable, the client returns an empty map and runs come back with `status: null`, still `200`. Runs without a `seer_run_state_id` are skipped.

## Notes
- Default (no expand) is unchanged — no Seer call, `status` is `null`.
- Status enum (pass-through from Seer): `processing | completed | error | awaiting_user_input`.
- Depends on getsentry/seer #7732 (batch run-status endpoint).
- A stacked frontend PR will poll `expand=status` every ~10s to drive live spinners.
