### PR TITLE
feat(seer): Poll live autofix run status on overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -82,6 +82,7 @@ describe('AutofixOverview', () => {
     seerRunId: 'run-1',
     lastTriggeredAt: '2026-07-14T09:00:00Z',
     pullRequests: [],
+    status: null,
     issue: issueFixture({count: '1200', userCount: 5}),
   };
 
@@ -96,6 +97,7 @@ describe('AutofixOverview', () => {
     seerRunId: 'run-2',
     lastTriggeredAt: '2026-07-14T10:00:00Z',
     pullRequests: [],
+    status: null,
     issue: issueFixture({project: {id: '3', slug: 'project-slug', platform: 'python'}}),
   };
 
@@ -114,7 +116,7 @@ describe('AutofixOverview', () => {
     enrichedStatusCode?: number;
     truncated?: AutofixOverviewResponse['truncatedMilestones'];
   }) {
-    const baseRequest = MockApiClient.addMockResponse({
+    const statusPollRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       statusCode: baseStatusCode,
       body: {
@@ -124,7 +126,7 @@ describe('AutofixOverview', () => {
     });
     const enrichedRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
-      match: [MockApiClient.matchQuery({expand: ['scmInfo', 'issueStats']})],
+      match: [MockApiClient.matchQuery({expand: ['scmInfo', 'issueStats', 'status']})],
       asyncDelay: enrichedAsyncDelay,
       statusCode: enrichedStatusCode,
       body: {
@@ -132,7 +134,7 @@ describe('AutofixOverview', () => {
         truncatedMilestones: truncated ?? [],
       },
     });
-    return {baseRequest, enrichedRequest};
+    return {statusPollRequest, enrichedRequest};
   }
 
   // The un-expanded call cannot reach Snuba, so it nulls out the issue stats.
@@ -195,7 +197,7 @@ describe('AutofixOverview', () => {
   }
 
   it('gates the page and issues no requests when the feature is disabled', async () => {
-    const {baseRequest, enrichedRequest} = mockOverview({
+    const {statusPollRequest, enrichedRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
@@ -208,7 +210,7 @@ describe('AutofixOverview', () => {
       await screen.findByText("You don't have access to this feature")
     ).toBeInTheDocument();
     expect(screen.queryByText('Autofix Overview')).not.toBeInTheDocument();
-    expect(baseRequest).not.toHaveBeenCalled();
+    expect(statusPollRequest).not.toHaveBeenCalled();
     expect(enrichedRequest).not.toHaveBeenCalled();
   });
 
@@ -336,7 +338,7 @@ describe('AutofixOverview', () => {
 
   it('scopes the request to the selected project', async () => {
     PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [2]}));
-    const {baseRequest} = mockOverview({
+    const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
@@ -345,7 +347,7 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(baseRequest).toHaveBeenCalledWith(
+    expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
         query: expect.objectContaining({project: [2]}),
@@ -354,7 +356,7 @@ describe('AutofixOverview', () => {
   });
 
   it('scopes the request to the selected time window', async () => {
-    const {baseRequest} = mockOverview({
+    const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
@@ -368,7 +370,7 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(baseRequest).toHaveBeenCalledWith(
+    expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
         query: expect.objectContaining({statsPeriod: '7d'}),
@@ -377,7 +379,7 @@ describe('AutofixOverview', () => {
   });
 
   it('issues a cheap request and an enriched expand request', async () => {
-    const {baseRequest, enrichedRequest} = mockOverview({
+    const {statusPollRequest, enrichedRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
     // Overview reads everything from the overview endpoint; the legacy
@@ -400,13 +402,13 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(baseRequest).toHaveBeenCalledWith(
+    expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
-        query: expect.not.objectContaining({expand: expect.anything()}),
+        query: expect.objectContaining({expand: ['status']}),
       })
     );
-    expect(baseRequest).toHaveBeenCalledWith(
+    expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
         query: expect.not.objectContaining({environment: expect.anything()}),
@@ -416,13 +418,23 @@ describe('AutofixOverview', () => {
       expect(enrichedRequest).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/seer/autofix-overview/`,
         expect.objectContaining({
-          query: expect.objectContaining({expand: ['scmInfo', 'issueStats']}),
+          query: expect.objectContaining({expand: ['scmInfo', 'issueStats', 'status']}),
         })
       )
     );
     expect(runsRequest).not.toHaveBeenCalled();
     expect(autofixRequest).not.toHaveBeenCalled();
     expect(issuesRequest).not.toHaveBeenCalled();
+  });
+
+  it('shows a working spinner for a run that is processing', async () => {
+    mockOverview({
+      base: {autofix_root_cause: [{...rootCauseRun, status: 'processing' as const}]},
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Working…')).toBeInTheDocument();
   });
 
   it('shimmers the enriched slots until the expand request resolves', async () => {
@@ -483,7 +495,9 @@ describe('AutofixOverview', () => {
   });
 
   it('keeps the list up with a spinner while a sort change reloads', async () => {
-    const {baseRequest} = mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
 
     // The events sort returns a different run; hold its enrichment open to keep
     // the reloading state on screen.
@@ -491,7 +505,10 @@ describe('AutofixOverview', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [
-        MockApiClient.matchQuery({sort: 'events', expand: ['scmInfo', 'issueStats']}),
+        MockApiClient.matchQuery({
+          sort: 'events',
+          expand: ['scmInfo', 'issueStats', 'status'],
+        }),
       ],
       asyncDelay: eventsEnriched.promise,
       body: {runsByMilestone: {...emptyMilestones, autofix_solution: [solutionRun]}},
@@ -502,18 +519,18 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(baseRequest).toHaveBeenCalledTimes(1);
+    expect(statusPollRequest).toHaveBeenCalledTimes(1);
 
     await userEvent.click(screen.getByRole('button', {name: /Sort/}));
     await userEvent.click(screen.getByRole('option', {name: 'Most events'}));
 
-    // Base does not refetch on a sort change; the old list stays up with a
-    // spinner while the single enriched request reloads.
+    // The status poll refetches for the new sort, but the old list stays up with
+    // a spinner (keepPreviousData) while the enriched request reloads.
     expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
     expect(
       screen.getByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(baseRequest).toHaveBeenCalledTimes(1);
+    expect(statusPollRequest).toHaveBeenCalledTimes(2);
 
     eventsEnriched.resolve();
 
@@ -1076,7 +1093,9 @@ describe('AutofixOverview', () => {
   });
 
   it('defaults to Recent Seer Activity and omits the sort param', async () => {
-    const {baseRequest} = mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
 
     renderPage();
 
@@ -1086,7 +1105,7 @@ describe('AutofixOverview', () => {
     expect(screen.getByRole('button', {name: /Sort/})).toHaveTextContent(
       'Recent Seer Activity'
     );
-    expect(baseRequest).toHaveBeenCalledWith(
+    expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
         query: expect.not.objectContaining({sort: expect.anything()}),
@@ -1270,7 +1289,7 @@ describe('AutofixOverview', () => {
   });
 
   it('replaces the overview content when the org is eligible for Seer but has not purchased it', () => {
-    const {baseRequest, enrichedRequest} = mockOverview({
+    const {statusPollRequest, enrichedRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
@@ -1284,7 +1303,7 @@ describe('AutofixOverview', () => {
     expect(screen.getByText('Autofix Overview')).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: /Sort/})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: /Create Plan/})).not.toBeInTheDocument();
-    expect(baseRequest).not.toHaveBeenCalled();
+    expect(statusPollRequest).not.toHaveBeenCalled();
     expect(enrichedRequest).not.toHaveBeenCalled();
   });
 

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -11,6 +11,7 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ErrorLevel} from 'sentry/components/events/errorLevel';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
 import {
@@ -115,7 +116,18 @@ function OverviewAction({
   run: OverviewRun;
   sectionKey: AutofixStateKey;
 }) {
-  const {pullRequests} = run;
+  const {pullRequests, status} = run;
+  if (status === 'processing') {
+    return (
+      <Flex align="center" gap="xs">
+        <LoadingIndicator mini />
+        <Text size="sm" variant="muted">
+          {t('Working…')}
+        </Text>
+      </Flex>
+    );
+  }
+
   if (sectionKey === 'merged') {
     if (pullRequests.length > 0) {
       return (

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -38,6 +38,7 @@ describe('OverviewCardAction', () => {
       seerRunId: 'run-1',
       lastTriggeredAt: '2026-07-14T09:00:00Z',
       pullRequests: [],
+      status: null,
       issue: issueFixture(),
       ...overrides,
     };

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -27,6 +27,7 @@ describe('OverviewIssueAssignee', () => {
           seerRunId: 'run-1',
           lastTriggeredAt: '2026-07-14T09:00:00Z',
           pullRequests: [],
+          status: null,
           issue: {
             assignedTo: null,
             count: '1',

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -19,6 +19,11 @@ import type {PlatformKey} from 'sentry/types/platform';
 // Shared staleTime for the overview's issue/run/state queries.
 export const QUERY_STALE_TIME = 30_000;
 
+// How often the `expand=status` poll refreshes live run status.
+export const POLL_INTERVAL = 10_000;
+
+export type RunStatus = 'processing' | 'completed' | 'error' | 'awaiting_user_input';
+
 // Runs filter: the explorer runs autofix creates. Combined with a
 // ``group:[...]`` filter so we only fetch runs for the issues on the page.
 export const RUNS_QUERY = 'type:explorer source:autofix';
@@ -193,6 +198,7 @@ export interface OverviewRun {
   rootCause: {oneLineDescription: string | null} | null;
   seerRunId: string;
   shortId: string;
+  status: RunStatus | null;
   title: string;
   codeChanges?: OverviewCodeChangeFile[];
 }

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
@@ -1,0 +1,102 @@
+import type {AutofixOverviewResponse, OverviewRun, RunStatus} from './types';
+import {
+  overlayStatus,
+  sectionSignature,
+  shouldRefetchEnriched,
+} from './useAutofixOverview';
+
+const emptyMilestones = {
+  autofix_root_cause: [],
+  autofix_solution: [],
+  autofix_code_changes: [],
+  has_pull_request: [],
+  pull_requests_merged: [],
+};
+
+// The helpers only read seerRunId and status, so a minimal cast is sufficient.
+const run = (seerRunId: string, status: RunStatus | null = null) =>
+  ({seerRunId, status}) as OverviewRun;
+
+function response(
+  partial: Partial<AutofixOverviewResponse['runsByMilestone']>
+): AutofixOverviewResponse {
+  return {
+    runsByMilestone: {...emptyMilestones, ...partial},
+    truncatedMilestones: [],
+  };
+}
+
+describe('sectionSignature', () => {
+  it('returns null when there is no data', () => {
+    expect(sectionSignature(undefined)).toBeNull();
+  });
+
+  it('changes when a run moves to a new section', () => {
+    const before = sectionSignature(response({autofix_root_cause: [run('r1')]}));
+    const after = sectionSignature(response({has_pull_request: [run('r1')]}));
+    expect(after).not.toEqual(before);
+  });
+
+  it('is stable when only a run status changes', () => {
+    const before = sectionSignature(response({autofix_root_cause: [run('r1', null)]}));
+    const after = sectionSignature(
+      response({autofix_root_cause: [run('r1', 'processing')]})
+    );
+    expect(after).toEqual(before);
+  });
+});
+
+describe('overlayStatus', () => {
+  it('applies the polled status onto the matching run', () => {
+    const base = response({autofix_root_cause: [run('r1', null)]});
+    const poll = response({autofix_root_cause: [run('r1', 'processing')]});
+    const merged = overlayStatus(base, poll);
+    expect(merged.runsByMilestone.autofix_root_cause[0]!.status).toBe('processing');
+  });
+
+  it('returns the base unchanged when the poll has no runs', () => {
+    const base = response({autofix_root_cause: [run('r1', 'completed')]});
+    expect(overlayStatus(base, undefined)).toBe(base);
+  });
+
+  it('keeps the existing status when the poll reports null', () => {
+    const base = response({autofix_root_cause: [run('r1', 'processing')]});
+    const poll = response({autofix_root_cause: [run('r1', null)]});
+    const merged = overlayStatus(base, poll);
+    expect(merged.runsByMilestone.autofix_root_cause[0]!.status).toBe('processing');
+  });
+
+  it('returns the base reference when no status changed', () => {
+    const base = response({autofix_root_cause: [run('r1', 'processing')]});
+    const poll = response({autofix_root_cause: [run('r1', 'processing')]});
+    expect(overlayStatus(base, poll)).toBe(base);
+  });
+});
+
+describe('shouldRefetchEnriched', () => {
+  it('is false when either side has no data', () => {
+    const data = response({autofix_root_cause: [run('r1')]});
+    expect(shouldRefetchEnriched(undefined, data)).toBe(false);
+    expect(shouldRefetchEnriched(data, undefined)).toBe(false);
+  });
+
+  it('is false when the sections match', () => {
+    const sections = {autofix_root_cause: [run('r1')]};
+    expect(shouldRefetchEnriched(response(sections), response(sections))).toBe(false);
+  });
+
+  it('is false when only a run status differs', () => {
+    expect(
+      shouldRefetchEnriched(
+        response({autofix_root_cause: [run('r1', 'processing')]}),
+        response({autofix_root_cause: [run('r1', 'completed')]})
+      )
+    ).toBe(false);
+  });
+
+  it('is true when the poll and enriched sections diverge', () => {
+    const poll = response({has_pull_request: [run('r1')]});
+    const enriched = response({autofix_root_cause: [run('r1')]});
+    expect(shouldRefetchEnriched(poll, enriched)).toBe(true);
+  });
+});

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -1,3 +1,4 @@
+import {useEffect, useMemo} from 'react';
 import {keepPreviousData, useQuery} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
@@ -5,10 +6,82 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 
-import {type AutofixOverviewResponse, type OverviewSort, QUERY_STALE_TIME} from './types';
+import {
+  type AutofixOverviewResponse,
+  type OverviewSort,
+  POLL_INTERVAL,
+  QUERY_STALE_TIME,
+  type RunStatus,
+} from './types';
 
-// Progressive load: the base request paints the cards fast, then the enriched
-// `expand` request fills in Snuba stats and SCM details.
+function statusByRunId(
+  data: AutofixOverviewResponse | undefined
+): Map<string, RunStatus | null> {
+  const map = new Map<string, RunStatus | null>();
+  for (const runs of Object.values(data?.runsByMilestone ?? {})) {
+    for (const run of runs) {
+      map.set(run.seerRunId, run.status);
+    }
+  }
+  return map;
+}
+
+// Fingerprint of which run sits in which section; a change cues an enrichment refetch.
+export function sectionSignature(
+  data: AutofixOverviewResponse | undefined
+): string | null {
+  if (!data) {
+    return null;
+  }
+  const pairs: string[] = [];
+  for (const [milestone, runs] of Object.entries(data.runsByMilestone)) {
+    for (const run of runs) {
+      pairs.push(`${run.seerRunId}:${milestone}`);
+    }
+  }
+  return pairs.sort().join(',');
+}
+
+export function shouldRefetchEnriched(
+  pollData: AutofixOverviewResponse | undefined,
+  enrichedData: AutofixOverviewResponse | undefined
+): boolean {
+  const pollSignature = sectionSignature(pollData);
+  const enrichedSignature = sectionSignature(enrichedData);
+  return (
+    pollSignature !== null &&
+    enrichedSignature !== null &&
+    pollSignature !== enrichedSignature
+  );
+}
+
+export function overlayStatus(
+  base: AutofixOverviewResponse,
+  poll: AutofixOverviewResponse | undefined
+): AutofixOverviewResponse {
+  const statuses = statusByRunId(poll);
+  if (statuses.size === 0) {
+    return base;
+  }
+  let changed = false;
+  const runsByMilestone = Object.fromEntries(
+    Object.entries(base.runsByMilestone).map(([milestone, runs]) => [
+      milestone,
+      runs.map(run => {
+        const next = statuses.get(run.seerRunId);
+        if (typeof next === 'string' && next !== run.status) {
+          changed = true;
+          return {...run, status: next};
+        }
+        return run;
+      }),
+    ])
+  ) as AutofixOverviewResponse['runsByMilestone'];
+  return changed ? {...base, runsByMilestone} : base;
+}
+
+// Progressive load: a light `status` poll paints cards fast and stays live every 10s;
+// the enriched `expand` request fills in Snuba/SCM detail and refetches on section change.
 export function useAutofixOverview({
   organization,
   selection,
@@ -20,7 +93,7 @@ export function useAutofixOverview({
   selection: PageFilters;
   sort: OverviewSort;
 }) {
-  const overviewQuery = (query: {expand?: Array<'scmInfo' | 'issueStats'>}) =>
+  const overviewQuery = (query: {expand?: Array<'scmInfo' | 'issueStats' | 'status'>}) =>
     apiOptions.as<AutofixOverviewResponse>()(
       '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
       {
@@ -37,34 +110,46 @@ export function useAutofixOverview({
     );
 
   const enrichedQuery = useQuery({
-    ...overviewQuery({expand: ['scmInfo', 'issueStats']}),
+    ...overviewQuery({expand: ['scmInfo', 'issueStats', 'status']}),
     enabled,
     placeholderData: keepPreviousData,
     // Enrichment is progressive polish: fail fast to empty slots rather than
     // shimmering through the default retry backoff.
     retry: 1,
   });
-  // Base is a one-time bootstrap: it stops fetching once enriched has data, so a
-  // filter/sort change makes a single enriched request rather than two.
-  const baseQuery = useQuery({
-    ...overviewQuery({}),
-    enabled: enabled && !enrichedQuery.data,
+
+  const statusPollQuery = useQuery({
+    ...overviewQuery({expand: ['status']}),
+    enabled,
     placeholderData: keepPreviousData,
+    refetchInterval: POLL_INTERVAL,
   });
 
-  const data = enrichedQuery.data ?? baseQuery.data;
+  const enrichedRefetch = enrichedQuery.refetch;
+  useEffect(() => {
+    if (shouldRefetchEnriched(statusPollQuery.data, enrichedQuery.data)) {
+      enrichedRefetch();
+    }
+  }, [statusPollQuery.data, enrichedQuery.data, enrichedRefetch]);
+
+  const source = enrichedQuery.data ?? statusPollQuery.data;
+  const data = useMemo(
+    () => (source ? overlayStatus(source, statusPollQuery.data) : undefined),
+    [source, statusPollQuery.data]
+  );
+
   return {
     data,
     isPending: !data,
-    // Error only once both fail with nothing to show; base alone may still be
+    // Error only once both fail with nothing to show; the poll alone may still be
     // recovered by an in-flight enriched call.
-    isError: baseQuery.isError && enrichedQuery.isError && !data,
-    // Cold-load shimmer only: base is painted but no enriched payload yet.
+    isError: statusPollQuery.isError && enrichedQuery.isError && !data,
+    // Cold-load shimmer only: the poll painted but no enriched payload yet.
     enrichmentPending: Boolean(data) && !enrichedQuery.data && !enrichedQuery.isError,
     // A later refetch keeps the list up; the caller shows a spinner meanwhile.
     isRefetching: enrichedQuery.isFetching && Boolean(enrichedQuery.data),
     refetch: () => {
-      baseQuery.refetch();
+      statusPollQuery.refetch();
       enrichedQuery.refetch();
     },
   };


### PR DESCRIPTION
Polls live Autofix run status on the overview page so cards show a "Working…" spinner while a run is actively processing, and so a card moves sections (e.g. a PR merged directly on GitHub → "Merged") within ~10s — even when no run is running.

## How
- The overview hook now runs a light `expand=status` poll every `POLL_INTERVAL` (10s), alongside the enriched (`scmInfo`/`issueStats`/`status`) request. The poll pauses when the tab is hidden.
- Each poll overlays the freshest per-run status onto the rendered cards (by `seerRunId`), so spinners update without re-fetching enrichment.
- A `(seerRunId, milestone)` **section signature** is computed from each poll; when it changes (a run moved section, or appeared/disappeared) the enriched request is silently refetched, so badges/counts and bucketing stay consistent.
- `OverviewAction` renders a `Working…` spinner when a run's status is `processing`.

## Notes
- **Stacked on the backend PR #122190** (`status` expand) and **blocked on that backend deploying** — the poll is a no-op (`status: null`) until the endpoint ships.
- **Out of scope:** live "checks passed"/"approved" badges — those are GitHub-sourced enrichment and need their own webhook mechanism, independent of this poll.
- Follow-up (v2): swap the poll transport for Conduit/SSE once it is production-ready, keeping polling as the fallback.
