### PR TITLE
ref(settings): Link the org permission alert to the members page

### DIFF
--- a/static/app/components/seer/projectDefaults/projectDefaultsForm.tsx
+++ b/static/app/components/seer/projectDefaults/projectDefaultsForm.tsx
@@ -11,6 +11,7 @@ import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useCanWriteSettings} from 'sentry/utils/seer/useCanWriteSettings';
+import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 const schema = z.object({
   defaultAutofixAutomationTuning: z.boolean(),
@@ -46,13 +47,7 @@ export function ProjectDefaultsForm({organization}: Props) {
 
   return (
     <Stack gap="lg">
-      {canWrite ? null : (
-        <Alert variant="warning">
-          {t(
-            'These settings can only be edited by users with the organization owner or manager role.'
-          )}
-        </Alert>
-      )}
+      {canWrite ? null : <OrganizationPermissionAlert />}
       <FieldGroup>
         <AutoSaveForm
           name="defaultAutofixAutomationTuning"

--- a/static/app/components/seer/repoDefaults/repoDefaultsForm.tsx
+++ b/static/app/components/seer/repoDefaults/repoDefaultsForm.tsx
@@ -1,7 +1,6 @@
 import {mutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
-import {Alert} from '@sentry/scraps/alert';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 import {Stack} from '@sentry/scraps/layout';
 
@@ -11,6 +10,7 @@ import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useCanWriteSettings} from 'sentry/utils/seer/useCanWriteSettings';
+import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 const schema = z.object({
   autoEnableCodeReview: z.boolean(),
@@ -33,13 +33,7 @@ export function RepoDefaultsForm({organization}: Props) {
 
   return (
     <Stack gap="lg">
-      {canWrite ? null : (
-        <Alert variant="warning">
-          {t(
-            'These settings can only be edited by users with the organization owner or manager role.'
-          )}
-        </Alert>
-      )}
+      {canWrite ? null : <OrganizationPermissionAlert />}
       <FieldGroup>
         <AutoSaveForm
           name="autoEnableCodeReview"

--- a/static/app/components/seer/repoDetails/repoDetailsForm.tsx
+++ b/static/app/components/seer/repoDetails/repoDetailsForm.tsx
@@ -2,7 +2,6 @@ import {mutationOptions} from '@tanstack/react-query';
 import {useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
 
-import {Alert} from '@sentry/scraps/alert';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 import {Container, Stack} from '@sentry/scraps/layout';
 
@@ -14,6 +13,7 @@ import type {CodeReviewTrigger} from 'sentry/types/seer';
 import {getSeerOnboardingCheckQueryOptions} from 'sentry/utils/getSeerOnboardingCheckQueryOptions';
 import {fetchMutation, getApiQueryData, setApiQueryData} from 'sentry/utils/queryClient';
 import {useCanWriteSettings} from 'sentry/utils/seer/useCanWriteSettings';
+import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 const schema = z.object({
   enabledCodeReview: z.boolean(),
@@ -84,13 +84,7 @@ export function RepoDetailsForm({organization, repoWithSettings}: Props) {
 
   return (
     <Stack gap="lg">
-      {canWrite ? null : (
-        <Alert data-test-id="org-permission-alert" variant="warning">
-          {t(
-            'These settings can only be edited by users with the organization owner or manager role.'
-          )}
-        </Alert>
-      )}
+      {canWrite ? null : <OrganizationPermissionAlert />}
       <FieldGroup>
         <AutoSaveForm
           name="enabledCodeReview"

--- a/static/app/views/settings/organization/organizationPermissionAlert.tsx
+++ b/static/app/views/settings/organization/organizationPermissionAlert.tsx
@@ -1,10 +1,12 @@
 import type {ReactNode} from 'react';
 
 import {Alert, type AlertProps} from '@sentry/scraps/alert';
+import {Link} from '@sentry/scraps/link';
 
 import {Access} from 'sentry/components/acl/access';
-import {t} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface OrganizationPermissionAlertProps extends Omit<AlertProps, 'variant'> {
   access?: Scope[];
@@ -13,18 +15,22 @@ interface OrganizationPermissionAlertProps extends Omit<AlertProps, 'variant'> {
 
 export function OrganizationPermissionAlert({
   access = ['org:write'],
-  message = t(
-    'These settings can only be edited by users with the organization owner or manager role.'
-  ),
+  message,
   ...props
 }: OrganizationPermissionAlertProps) {
+  const organization = useOrganization();
+
   return (
     <Access access={access}>
       {({hasAccess}) =>
         !hasAccess && (
           <Alert.Container>
             <Alert data-test-id="org-permission-alert" variant="warning" {...props}>
-              {message}
+              {message ??
+                tct(
+                  'These settings can only be edited by users with the organization owner or manager role. [link:View your organization members].',
+                  {link: <Link to={`/settings/${organization.slug}/members/`} />}
+                )}
             </Alert>
           </Alert.Container>
         )

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -160,11 +160,12 @@ describe('OrganizationGeneralSettings', () => {
       expect(isDisabled).toBe(true);
     }
 
+    expect(screen.getByTestId('org-permission-alert')).toHaveTextContent(
+      'These settings can only be edited by users with the organization owner or manager role.'
+    );
     expect(
-      screen.getByText(
-        'These settings can only be edited by users with the organization owner or manager role.'
-      )
-    ).toBeInTheDocument();
+      screen.getByRole('link', {name: 'View your organization members'})
+    ).toHaveAttribute('href', '/settings/org-slug/members/');
   });
 
   it('does not have remove organization button without org:admin permission', () => {

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageBanners.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageBanners.tsx
@@ -1,11 +1,9 @@
 import {Fragment} from 'react';
 
-import {Alert} from '@sentry/scraps/alert';
-
 import {NoActiveSeerSubscriptionBanner} from 'sentry/components/seer/noActiveSeerSubscriptionBanner';
-import {t} from 'sentry/locale';
 import {useCanWriteSettings} from 'sentry/utils/seer/useCanWriteSettings';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 import {useSubscription} from 'getsentry/hooks/useSubscription';
 
@@ -25,13 +23,7 @@ export function SeerSettingsPageBanners() {
     <Fragment>
       {showNoActiveSeerSubscriptionBanner ? <NoActiveSeerSubscriptionBanner /> : null}
 
-      {canWrite ? null : (
-        <Alert data-test-id="org-permission-alert" variant="warning">
-          {t(
-            'These settings can only be edited by users with the organization owner or manager role.'
-          )}
-        </Alert>
-      )}
+      {canWrite ? null : <OrganizationPermissionAlert />}
     </Fragment>
   );
 }


### PR DESCRIPTION
#Before

<img width="2500" height="510" alt="CleanShot 2026-08-18 at 15 38 43@2x" src="https://github.com/user-attachments/assets/98f9e299-ee50-46d6-a3be-4ac894d117f8" />

# After

<img width="2506" height="552" alt="CleanShot 2026-08-18 at 15 38 36@2x" src="https://github.com/user-attachments/assets/a64586b9-35d3-4a42-90f5-74a255315556" />
