### PR TITLE
fix(explore): populate avg_if argument options in the equation editor

### DIFF
--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -20,7 +20,7 @@ import {
 import {TokenGrid} from 'sentry/components/arithmeticBuilder/token/grid';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 
-const aggregations = ['avg', 'sum', 'epm', 'count', 'count_unique', 'count_if'];
+const aggregations = ['avg', 'avg_if', 'sum', 'epm', 'count', 'count_unique', 'count_if'];
 
 const functionArguments = [
   {name: 'span.duration', kind: FieldKind.MEASUREMENT},
@@ -123,7 +123,7 @@ describe('token', () => {
       // typing should reduce the options avilable in the autocomplete
       expect(screen.getAllByRole('option')).toHaveLength(aggregations.length + 1);
       await userEvent.type(input, 'avg');
-      expect(screen.getAllByRole('option')).toHaveLength(1);
+      expect(screen.getAllByRole('option')).toHaveLength(2);
 
       await userEvent.click(screen.getByRole('option', {name: 'avg'}));
 
@@ -146,7 +146,7 @@ describe('token', () => {
       // typing should reduce the options avilable in the autocomplete
       expect(screen.getAllByRole('option')).toHaveLength(aggregations.length + 1);
       await userEvent.type(input, 'avg');
-      expect(screen.getAllByRole('option')).toHaveLength(1);
+      expect(screen.getAllByRole('option')).toHaveLength(2);
 
       await userEvent.type(input, '{ArrowDown}{Enter}');
       expect(
@@ -158,6 +158,22 @@ describe('token', () => {
       await waitFor(() => {
         expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
       });
+    });
+
+    it('fills in every argument when selecting avg_if', async () => {
+      render(<Tokens expression="" />);
+
+      const input = screen.getByRole('combobox', {name: 'Add a term'});
+
+      await userEvent.click(input);
+      await userEvent.type(input, 'avg_if');
+      await userEvent.click(screen.getByRole('option', {name: 'avg_if'}));
+
+      expect(
+        await screen.findByRole('row', {
+          name: 'avg_if(span.duration,span.op,equals,db)',
+        })
+      ).toBeInTheDocument();
     });
 
     it('allows selecting function with no arguments using mouse', async () => {
@@ -840,6 +856,42 @@ describe('token', () => {
       });
       await userEvent.keyboard('db');
       expect(thirdArg).toHaveValue('db');
+    });
+
+    it('suggests attributes for each argument of avg_if', async () => {
+      render(<Tokens expression="avg_if(span.duration,span.op,equals,queue.process)" />);
+
+      const argumentsGrid = await screen.findByRole('grid', {name: 'Enter arguments'});
+
+      const [numberArg, stringArg] = within(argumentsGrid).getAllByRole('combobox', {
+        name: 'Select an attribute',
+      });
+      const conditionArg = within(argumentsGrid).getByRole('combobox', {
+        name: 'Select an option',
+      });
+      const valueArg = within(argumentsGrid).getByRole('textbox', {
+        name: 'Add a value',
+      });
+
+      await userEvent.click(numberArg!);
+      expect(screen.getAllByRole('option').map(option => option.textContent)).toEqual([
+        'span.duration',
+        'span.self_time',
+      ]);
+
+      await userEvent.click(stringArg!);
+      expect(screen.getAllByRole('option').map(option => option.textContent)).toEqual([
+        'span.op',
+        'span.description',
+      ]);
+
+      await userEvent.click(conditionArg);
+      expect(screen.getAllByRole('option').map(option => option.textContent)).toEqual([
+        'is equal to',
+        'is not equal to',
+      ]);
+
+      expect(valueArg).toHaveValue('queue.process');
     });
   });
 

--- a/static/app/components/tokenizedInput/token/comboBox.spec.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.spec.tsx
@@ -49,4 +49,42 @@ describe('ComboBox', () => {
       value: 'foo',
     });
   });
+
+  it('does not open the menu when there are no options', async () => {
+    const onOpenChange = jest.fn();
+    render(
+      <ComboBoxWrapper
+        filterValue=""
+        inputLabel="combobox"
+        inputValue=""
+        items={[]}
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('does not open the menu when every option is filtered out', async () => {
+    const onOpenChange = jest.fn();
+    render(
+      <ComboBoxWrapper
+        filterValue="nomatch"
+        inputLabel="combobox"
+        inputValue="nomatch"
+        items={['foo', 'bar', 'qux'].map(item => ({
+          key: item,
+          label: item,
+          value: item,
+        }))}
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(true);
+  });
 });

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -188,7 +188,13 @@ export function ComboBox({
     [onInputBlur, shouldCloseOnInteractOutside, state]
   );
 
-  const isOpen = state.isOpen;
+  const totalOptions = items.reduce(
+    (acc, item) => acc + (itemIsSectionWithKey(item) ? item.options.length : 1),
+    0
+  );
+
+  // Showing the overlay with nothing to select renders as an empty grey bar
+  const isOpen = state.isOpen && totalOptions > hiddenOptions.size;
 
   const handleComboBoxKeyDown = useCallback(
     (evt: KeyboardEvent) => {

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -122,6 +122,17 @@ export const CONDITIONS_ARGUMENTS: Array<{value: string; label?: string}> = [
   },
 ];
 
+export const EQUALITY_CONDITIONS_ARGUMENTS: Array<{value: string; label?: string}> = [
+  {
+    label: 'is equal to',
+    value: 'equals',
+  },
+  {
+    label: 'is not equal to',
+    value: 'notEquals',
+  },
+];
+
 export const WEB_VITALS_QUALITY: Array<{value: string; label?: string}> = [
   {
     label: 'good',

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1,7 +1,11 @@
 import {ATTRIBUTE_METADATA} from '@sentry/conventions';
 
 import {t, td} from 'sentry/locale';
-import {CONDITIONS_ARGUMENTS, WEB_VITALS_QUALITY} from 'sentry/utils/discover/types';
+import {
+  CONDITIONS_ARGUMENTS,
+  EQUALITY_CONDITIONS_ARGUMENTS,
+  WEB_VITALS_QUALITY,
+} from 'sentry/utils/discover/types';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {SpanFields} from 'sentry/views/insights/types';
 import {METRICS_ARTIFACT_TYPES} from 'sentry/views/settings/project/preprod/types';
@@ -397,6 +401,7 @@ export enum AggregationKey {
   P100 = 'p100',
   PERCENTILE = 'percentile',
   AVG = 'avg',
+  AVG_IF = 'avg_if',
   APDEX = 'apdex',
   USER_MISERY = 'user_misery',
   FAILURE_RATE = 'failure_rate',
@@ -1000,6 +1005,47 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
       },
     ],
   },
+  [AggregationKey.AVG_IF]: {
+    desc: t('Returns averages for a selected field, for events matching a condition'),
+    kind: FieldKind.FUNCTION,
+    valueType: null,
+    parameterDependentValueType: getDynamicFieldValueType,
+    parameters: [
+      {
+        name: 'column',
+        kind: 'column',
+        columnTypes: validateForNumericAggregate([
+          FieldValueType.DURATION,
+          FieldValueType.NUMBER,
+          FieldValueType.PERCENTAGE,
+        ]),
+        defaultValue: 'transaction.duration',
+        required: true,
+      },
+      {
+        name: 'condition_column',
+        kind: 'column',
+        columnTypes: [FieldValueType.STRING],
+        defaultValue: 'transaction',
+        required: true,
+      },
+      {
+        name: 'condition',
+        kind: 'value',
+        dataType: FieldValueType.STRING,
+        defaultValue: EQUALITY_CONDITIONS_ARGUMENTS[0]!.value,
+        options: EQUALITY_CONDITIONS_ARGUMENTS,
+        required: true,
+      },
+      {
+        name: 'value',
+        kind: 'value',
+        dataType: FieldValueType.STRING,
+        defaultValue: '/',
+        required: true,
+      },
+    ],
+  },
   [AggregationKey.APDEX]: {
     desc: t('Performance score based on a duration threshold'),
     kind: FieldKind.FUNCTION,
@@ -1109,6 +1155,7 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
 
 export const ALLOWED_EXPLORE_EQUATION_AGGREGATES: AggregationKey[] = [
   ...ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  AggregationKey.AVG_IF,
   AggregationKey.COUNT_IF,
   AggregationKey.APDEX,
   AggregationKey.USER_MISERY,
@@ -1424,6 +1471,46 @@ const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
           FieldValueType.CURRENCY,
         ]),
         defaultValue: 'span.duration',
+        required: true,
+      },
+    ],
+  },
+  [AggregationKey.AVG_IF]: {
+    ...AGGREGATION_FIELDS[AggregationKey.AVG_IF],
+    parameterDependentValueType: getSpanDynamicFieldValueType,
+    parameters: [
+      {
+        name: 'column',
+        kind: 'column',
+        columnTypes: validateForNumericAggregate([
+          FieldValueType.DURATION,
+          FieldValueType.NUMBER,
+          FieldValueType.PERCENTAGE,
+          FieldValueType.CURRENCY,
+        ]),
+        defaultValue: 'span.duration',
+        required: true,
+      },
+      {
+        name: 'condition_column',
+        kind: 'column',
+        columnTypes: [FieldValueType.STRING],
+        defaultValue: 'span.op',
+        required: true,
+      },
+      {
+        name: 'condition',
+        kind: 'value',
+        dataType: FieldValueType.STRING,
+        defaultValue: EQUALITY_CONDITIONS_ARGUMENTS[0]!.value,
+        options: EQUALITY_CONDITIONS_ARGUMENTS,
+        required: true,
+      },
+      {
+        name: 'value',
+        kind: 'value',
+        dataType: FieldValueType.STRING,
+        defaultValue: 'db',
         required: true,
       },
     ],


### PR DESCRIPTION
`avg_if` had no frontend field definition, so `ArithmeticTokenFunction` could not resolve a parameter definition for any of its arguments. Without one, the attribute filter collapses to `() => false` and every argument's option list is empty. 💩 

This adds `AggregationKey.AVG_IF` to the `AGGREGATION_FIELDS` object that describes how to render it.

Example from `/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&aggregateField=%7B%22yAxes%22%3A%5B%22equation%7Cavg_if%28span.duration%2C%20span.op%2C%20equals%2Cqueue.process%29%22%5D%7D&project=11276&statsPeriod=90d`:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/28ca7c71-cb1d-4cb5-aaa4-7728fe88b32e" alt="Empty grey bar where the argument options should be"></td>
<td><img src="https://github.com/user-attachments/assets/dcea967b-c07d-4baf-963e-e42c45f35caf" alt="Populated attribute list for the first avg_if argument"></td>
</tr>
</tbody>
</table>

Closes EXP-1141
