### PR TITLE
fix(attachments): decode UTF-16 previews from BOM

### DIFF
--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -105,4 +105,35 @@ describe('api', () => {
       )
     ).not.toThrow();
   });
+
+  it('parses JSON error bodies when responseType is arraybuffer', async () => {
+    fetchMock.mockResponse(
+      JSON.stringify({
+        detail: {code: 'sso-required', extra: {loginUrl: '/sso/'}},
+      }),
+      {status: 400, headers: {'Content-Type': 'application/json'}}
+    );
+
+    await expect(
+      new Client().requestPromise('/test/', {responseType: 'arraybuffer'})
+    ).rejects.toMatchObject({
+      status: 400,
+      responseJSON: {
+        detail: {code: 'sso-required', extra: {loginUrl: '/sso/'}},
+      },
+    });
+  });
+
+  it('returns ArrayBuffer for successful arraybuffer responses', async () => {
+    fetchMock.mockResponse('hello', {
+      status: 200,
+      headers: {'Content-Type': 'text/plain'},
+    });
+
+    const data = await new Client().requestPromise('/test/', {
+      responseType: 'arraybuffer',
+    });
+
+    expect(new TextDecoder().decode(data as ArrayBuffer)).toBe('hello');
+  });
 });

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -509,17 +509,20 @@ export class Client {
           let twoHundredErrorReason: string | undefined;
 
           const useArrayBuffer = options.responseType === 'arraybuffer';
+          // Error bodies are JSON (sso-required, sudo-required, …). Only decode
+          // successful responses as ArrayBuffer so global error handlers still work.
+          const decodeAsArrayBuffer = useArrayBuffer && response.ok;
 
           // Try to get the body out of the response no matter the status
           try {
-            if (useArrayBuffer) {
+            if (decodeAsArrayBuffer) {
               responseData = await response.arrayBuffer();
               responseText = '';
             } else {
               responseText = await response.text();
             }
           } catch (error: any) {
-            twoHundredErrorReason = useArrayBuffer
+            twoHundredErrorReason = decodeAsArrayBuffer
               ? 'Failed awaiting response.arrayBuffer()'
               : 'Failed awaiting response.text()';
             ok = false;
@@ -536,7 +539,7 @@ export class Client {
             requestHeaders.get('Accept') === Client.JSON_HEADERS.Accept;
 
           const isStatus3XX = status >= 300 && status < 400;
-          if (!useArrayBuffer && status !== 204 && !isStatus3XX) {
+          if (!decodeAsArrayBuffer && status !== 204 && !isStatus3XX) {
             try {
               responseJSON = JSON.parse(responseText);
             } catch (error: any) {
@@ -572,7 +575,7 @@ export class Client {
           };
 
           // Respect the response content-type header
-          if (!useArrayBuffer) {
+          if (!decodeAsArrayBuffer) {
             responseData = isResponseJSON ? responseJSON : responseText;
           }
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -242,6 +242,12 @@ export type RequestOptions = RequestCallbacks & {
    */
   query?: Record<string, any>;
   /**
+   * How to decode the response body. `arraybuffer` is required for binary
+   * payloads (for example UTF-16 attachments) because `response.text()` is
+   * always UTF-8 per the Fetch spec.
+   */
+  responseType?: 'arraybuffer';
+  /**
    * By default, requests will be aborted anytime api.clear() is called,
    * which is commonly used on unmounts. When skipAbort is true, the
    * request is opted out of this behavior. Useful for when you still
@@ -495,17 +501,27 @@ export class Client {
           // Response objects need to be cloned before its body can be used.
           let responseJSON: any;
           let responseText: any;
+          let responseData: any;
 
           const {status, statusText} = response;
           let {ok} = response;
           let errorReason = 'Request not OK'; // the default error reason
           let twoHundredErrorReason: string | undefined;
 
-          // Try to get text out of the response no matter the status
+          const useArrayBuffer = options.responseType === 'arraybuffer';
+
+          // Try to get the body out of the response no matter the status
           try {
-            responseText = await response.text();
+            if (useArrayBuffer) {
+              responseData = await response.arrayBuffer();
+              responseText = '';
+            } else {
+              responseText = await response.text();
+            }
           } catch (error: any) {
-            twoHundredErrorReason = 'Failed awaiting response.text()';
+            twoHundredErrorReason = useArrayBuffer
+              ? 'Failed awaiting response.arrayBuffer()'
+              : 'Failed awaiting response.text()';
             ok = false;
             if (error.name === 'AbortError') {
               errorReason = 'Request was aborted';
@@ -520,7 +536,7 @@ export class Client {
             requestHeaders.get('Accept') === Client.JSON_HEADERS.Accept;
 
           const isStatus3XX = status >= 300 && status < 400;
-          if (status !== 204 && !isStatus3XX) {
+          if (!useArrayBuffer && status !== 204 && !isStatus3XX) {
             try {
               responseJSON = JSON.parse(responseText);
             } catch (error: any) {
@@ -556,7 +572,9 @@ export class Client {
           };
 
           // Respect the response content-type header
-          const responseData = isResponseJSON ? responseJSON : responseText;
+          if (!useArrayBuffer) {
+            responseData = isResponseJSON ? responseJSON : responseText;
+          }
 
           if (ok) {
             successHandler(responseMeta, statusText, responseData);

--- a/static/app/components/events/attachmentViewers/decodeAttachmentText.spec.tsx
+++ b/static/app/components/events/attachmentViewers/decodeAttachmentText.spec.tsx
@@ -1,0 +1,40 @@
+import {
+  decodeAttachmentPreview,
+  decodeAttachmentText,
+} from 'sentry/components/events/attachmentViewers/decodeAttachmentText';
+
+describe('decodeAttachmentText', () => {
+  it('decodes UTF-16LE with BOM including Chinese', () => {
+    const text = '时间: UTF-16 附件';
+    const payload = new Uint8Array([0xff, 0xfe, ...utf16leBytes(text)]);
+
+    expect(decodeAttachmentText(payload)).toBe(text);
+  });
+
+  it('falls back to UTF-8 when BOM is missing', () => {
+    expect(decodeAttachmentText(new TextEncoder().encode('中文 hello'))).toBe(
+      '中文 hello'
+    );
+  });
+});
+
+describe('decodeAttachmentPreview', () => {
+  it('returns mocked string payloads unchanged', () => {
+    expect(decodeAttachmentPreview('file contents')).toBe('file contents');
+  });
+
+  it('decodes ArrayBuffer UTF-16LE payloads', () => {
+    const text = '时间: UTF-16 附件';
+    const bytes = new Uint8Array([0xff, 0xfe, ...utf16leBytes(text)]);
+    expect(decodeAttachmentPreview(bytes.buffer)).toBe(text);
+  });
+});
+
+function utf16leBytes(text: string): number[] {
+  const bytes: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    bytes.push(code & 0xff, code >> 8);
+  }
+  return bytes;
+}

--- a/static/app/components/events/attachmentViewers/decodeAttachmentText.ts
+++ b/static/app/components/events/attachmentViewers/decodeAttachmentText.ts
@@ -1,0 +1,63 @@
+const UTF16LE_BOM = [0xff, 0xfe] as const;
+const UTF16BE_BOM = [0xfe, 0xff] as const;
+const UTF8_BOM = [0xef, 0xbb, 0xbf] as const;
+
+function hasPrefix(bytes: Uint8Array, prefix: readonly number[]): boolean {
+  if (bytes.length < prefix.length) {
+    return false;
+  }
+  return prefix.every((value, index) => bytes[index] === value);
+}
+
+/**
+ * Detect a Unicode encoding from a leading BOM.
+ */
+export function encodingFromBom(bytes: Uint8Array): string | null {
+  if (hasPrefix(bytes, UTF16LE_BOM)) {
+    return 'utf-16le';
+  }
+  if (hasPrefix(bytes, UTF16BE_BOM)) {
+    return 'utf-16be';
+  }
+  if (hasPrefix(bytes, UTF8_BOM)) {
+    return 'utf-8';
+  }
+  return null;
+}
+
+function bomLength(encoding: string): number {
+  if (encoding === 'utf-16le' || encoding === 'utf-16be') {
+    return 2;
+  }
+  if (encoding === 'utf-8') {
+    return 3;
+  }
+  return 0;
+}
+
+export function decodeAttachmentText(bytes: Uint8Array): string {
+  const encoding = encodingFromBom(bytes);
+  if (!encoding) {
+    return new TextDecoder('utf-8').decode(bytes);
+  }
+  return new TextDecoder(encoding).decode(bytes.subarray(bomLength(encoding)));
+}
+
+/**
+ * Decode preview payload from the API client.
+ * Production fetches use ArrayBuffer (raw bytes). Tests often mock a UTF-8 string.
+ */
+export function decodeAttachmentPreview(data: unknown): string {
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return decodeAttachmentText(new Uint8Array(data));
+  }
+  if (ArrayBuffer.isView(data)) {
+    return decodeAttachmentText(
+      new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+    );
+  }
+  return '';
+}

--- a/static/app/components/events/attachmentViewers/decodeAttachmentText.ts
+++ b/static/app/components/events/attachmentViewers/decodeAttachmentText.ts
@@ -12,7 +12,7 @@ function hasPrefix(bytes: Uint8Array, prefix: readonly number[]): boolean {
 /**
  * Detect a Unicode encoding from a leading BOM.
  */
-export function encodingFromBom(bytes: Uint8Array): string | null {
+function encodingFromBom(bytes: Uint8Array): string | null {
   if (hasPrefix(bytes, UTF16LE_BOM)) {
     return 'utf-16le';
   }

--- a/static/app/components/events/attachmentViewers/logFileViewer.spec.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.spec.tsx
@@ -1,0 +1,54 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {EventAttachmentFixture} from 'sentry-fixture/eventAttachment';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LogFileViewer} from 'sentry/components/events/attachmentViewers/logFileViewer';
+
+describe('LogFileViewer', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({organization});
+  const event = EventFixture({project});
+  const attachment = EventAttachmentFixture({
+    event_id: event.id,
+    name: 'cpp_crash_report_utf16.txt',
+    mimetype: 'text/plain',
+    headers: {'Content-Type': 'text/plain'},
+  });
+
+  it('renders UTF-16LE Chinese text instead of mojibake', async () => {
+    const text = '时间: UTF-16 附件\n异常: std::runtime_error';
+    const body = new Uint8Array([0xff, 0xfe, ...utf16leBytes(text)]);
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.id}/${project.slug}/events/${event.id}/attachments/${attachment.id}/`,
+      body,
+      headers: {'Content-Type': 'text/plain'},
+      match: [MockApiClient.matchQuery({download: true})],
+    });
+
+    render(
+      <LogFileViewer
+        attachment={attachment}
+        eventId={event.id}
+        orgSlug={organization.id}
+        projectSlug={project.slug}
+      />
+    );
+
+    expect(await screen.findByText(/时间: UTF-16 附件/)).toBeInTheDocument();
+    expect(screen.getByText(/std::runtime_error/)).toBeInTheDocument();
+    expect(screen.queryByText(/æ/)).not.toBeInTheDocument();
+  });
+});
+
+function utf16leBytes(text: string): number[] {
+  const bytes: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    bytes.push(code & 0xff, code >> 8);
+  }
+  return bytes;
+}

--- a/static/app/components/events/attachmentViewers/logFileViewer.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.tsx
@@ -2,6 +2,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import Ansi from 'ansi-to-react';
 
+import {decodeAttachmentPreview} from 'sentry/components/events/attachmentViewers/decodeAttachmentText';
 import {PreviewPanelItem} from 'sentry/components/events/attachmentViewers/previewPanelItem';
 import type {ViewerProps} from 'sentry/components/events/attachmentViewers/utils';
 import {getAttachmentUrl} from 'sentry/components/events/attachmentViewers/utils';
@@ -11,15 +12,22 @@ import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 export function LogFileViewer(props: ViewerProps) {
-  const {data, isPending, isError} = useApiQuery<string>(
+  const {data, isPending, isError} = useApiQuery<ArrayBuffer | string>(
     [
       getAttachmentUrl(props),
-      {headers: {Accept: '*/*; charset=utf-8'}, query: {download: true}},
+      {
+        headers: {Accept: '*/*'},
+        query: {download: true},
+        responseType: 'arraybuffer',
+      },
     ],
     {
       staleTime: Infinity,
     }
   );
+
+  const previewText =
+    data === undefined || data === null ? null : decodeAttachmentPreview(data);
 
   if (isError) {
     return <LoadingError message={t('Failed to download attachment.')} />;
@@ -29,10 +37,10 @@ export function LogFileViewer(props: ViewerProps) {
     return <LoadingIndicator />;
   }
 
-  return data ? (
+  return previewText ? (
     <PreviewPanelItem>
       <CodeWrapper>
-        <SentryStyleAnsi useClasses>{data}</SentryStyleAnsi>
+        <SentryStyleAnsi useClasses>{previewText}</SentryStyleAnsi>
       </CodeWrapper>
     </PreviewPanelItem>
   ) : null;

--- a/static/app/utils/api/apiFetch.tsx
+++ b/static/app/utils/api/apiFetch.tsx
@@ -28,6 +28,7 @@ export async function apiFetch<TQueryFnData = unknown>(
     data: options?.data,
     query: options?.query,
     headers: options?.headers,
+    responseType: options?.responseType,
   });
 
   const hits = response?.getResponseHeader('X-Hits');

--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -14,6 +14,7 @@ export type QueryKeyEndpointOptions = {
   includeAllArgs?: boolean;
   method?: RequestMethod;
   query?: Record<string, unknown>;
+  responseType?: 'arraybuffer';
 };
 
 const apiUrlSchema = z.custom<ApiUrl>(val => typeof val === 'string');


### PR DESCRIPTION
## Summary
- Text attachment preview used `response.text()`, which the Fetch spec always decodes as UTF-8. UTF-16LE files (e.g. Chinese crash logs with a `FF FE` BOM) showed mojibake while ASCII still looked readable.
- Preview now fetches the attachment as an `ArrayBuffer` and decodes with `TextDecoder` based on BOM: UTF-16LE, UTF-16BE, UTF-8, otherwise UTF-8.

## Test plan
- [ ] Open an event with a UTF-16LE text attachment that starts with BOM `FF FE` and confirm Chinese (and other non-ASCII) text renders correctly in the preview.
- [ ] Open a normal UTF-8 / ASCII log attachment and confirm preview is unchanged.
- [ ] `pnpm` tests: `decodeAttachmentText.spec.tsx`, `logFileViewer.spec.tsx`, `eventAttachments.spec.tsx`
