### PR TITLE
feat(sentry-apps): Add deploy.created webhook

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -228,6 +228,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:pr-metrics-judge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod_artifact webhook subscription UI in Sentry App settings
     manager.add("organizations:preprod-artifact-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable deploy webhook subscription UI in Sentry App settings
+    manager.add("organizations:deploy-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod PR comments for build distribution
     manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry.hybridcloud.rpc import coerce_id_from
+from sentry.models.deploy import Deploy
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.releases.deploy_webhooks import send_deploy_created_webhook
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation, app_service
 from sentry.sentry_apps.tasks.sentry_apps import build_comment_webhook, workflow_notification
 from sentry.sentry_apps.utils.webhooks import is_subscribed
@@ -16,6 +18,7 @@ from sentry.signals import (
     comment_created,
     comment_deleted,
     comment_updated,
+    deploy_created,
     issue_assigned,
     issue_escalating,
     issue_ignored,
@@ -96,6 +99,13 @@ def send_issue_unresolved_webhook_helper(
         event="issue.unresolved",
         data=data,
     )
+
+
+@deploy_created.connect(weak=False)
+def send_deploy_created_webhook_receiver(
+    deploy: Deploy, projects: Sequence[Project] | None = None, **kwargs
+) -> None:
+    send_deploy_created_webhook(deploy, projects or [])
 
 
 @comment_created.connect(weak=False)

--- a/src/sentry/releases/deploy_webhooks.py
+++ b/src/sentry/releases/deploy_webhooks.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from sentry import features
+from sentry.api.serializers import serialize
+from sentry.models.deploy import Deploy
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
+from sentry.sentry_apps.utils.webhooks import DeployActionType, SentryAppResourceType
+
+logger = logging.getLogger(__name__)
+
+DEPLOY_WEBHOOKS_FEATURE = "organizations:deploy-webhooks"
+
+
+def build_deploy_webhook_payload(
+    deploy: Deploy, projects: Sequence[Project], organization: Organization
+) -> dict[str, dict[str, Any]]:
+    """
+    Build the ``deploy.created`` webhook payload for a given deploy.
+
+    Wraps the public Deploy API representation, adding the deployed release version,
+    the projects the deploy targeted, and a Sentry permalink to the release. Datetimes
+    are rendered as ISO 8601 strings because this payload is handed to a task and then
+    JSON-encoded for delivery.
+
+    Note the two distinct URLs: ``url`` is the user-supplied deploy link (often a CI
+    build, and frequently absent), while ``web_url`` always points back into Sentry.
+    """
+    deploy_data: dict[str, Any] = dict(serialize(deploy))
+
+    for date_field in ("dateStarted", "dateFinished"):
+        value = deploy_data.get(date_field)
+        if value is not None:
+            deploy_data[date_field] = value.isoformat()
+
+    deploy_data["release"] = {"version": deploy.release.version}
+    deploy_data["projects"] = [{"slug": project.slug} for project in projects]
+    deploy_data["web_url"] = _build_release_web_url(
+        organization, deploy.release.version, deploy_data.get("environment")
+    )
+
+    return {"deploy": deploy_data}
+
+
+def _build_release_web_url(
+    organization: Organization, version: str, environment: str | None
+) -> str:
+    """
+    Permalink to the deployed release in Sentry, scoped to the deploy's environment.
+
+    A deploy can span several projects, so this links to the release rather than to any
+    one project's view of it. ``absolute_url`` handles customer domains. The version is
+    quoted because ``?``, ``#`` and spaces are all legal in release versions (only
+    ``BAD_RELEASE_CHARS`` are rejected) and would otherwise corrupt the URL.
+    """
+    return organization.absolute_url(
+        f"/organizations/{organization.slug}/releases/{quote(version, safe='')}/",
+        query=urlencode({"environment": environment}) if environment else None,
+    )
+
+
+def send_deploy_created_webhook(deploy: Deploy, projects: Sequence[Project]) -> None:
+    """
+    Send the ``deploy.created`` webhook for a given deploy, if applicable.
+
+    Builds the payload and enqueues via the generic broadcaster.
+    Fully fire-and-forget: exceptions are logged but never propagated, so a failure
+    here can never fail the deploy that triggered it.
+    """
+    try:
+        organization = Organization.objects.get_from_cache(id=deploy.organization_id)
+        if not features.has(DEPLOY_WEBHOOKS_FEATURE, organization):
+            return
+
+        broadcast_webhooks_for_organization.delay(
+            resource_name=SentryAppResourceType.DEPLOY.value,
+            event_name=DeployActionType.CREATED.value,
+            organization_id=deploy.organization_id,
+            payload=build_deploy_webhook_payload(deploy, projects, organization),
+        )
+    except Exception:
+        logger.exception(
+            "releases.deploy.webhook.failed",
+            extra={
+                "deploy_id": deploy.id,
+                "organization_id": deploy.organization_id,
+            },
+        )

--- a/src/sentry/releases/endpoints/release_deploys.py
+++ b/src/sentry/releases/endpoints/release_deploys.py
@@ -116,7 +116,7 @@ def create_deploy(
         name=result.get("name"),
         url=result.get("url"),
     )
-    deploy_created.send_robust(deploy=deploy, sender=create_deploy)
+    deploy_created.send_robust(deploy=deploy, projects=projects, sender=create_deploy)
 
     # XXX(dcramer): this has a race for most recent deploy, but
     # should be unlikely to hit in the real world

--- a/src/sentry/sentry_apps/api/serializers/app_platform_event.py
+++ b/src/sentry/sentry_apps/api/serializers/app_platform_event.py
@@ -89,6 +89,7 @@ class AppPlatformEvent[T: Mapping[str, Any]]:
             get_path(self.data, "issue", "permalink")  # issue.*
             or get_path(self.data, "event", "web_url")  # event_alert.triggered
             or get_path(self.data, "error", "web_url")  # error.created
+            or get_path(self.data, "deploy", "web_url")  # deploy.created
             or get_path(self.data, "web_url")  # metric_alert.*
         )
         if url:

--- a/src/sentry/sentry_apps/event_types.py
+++ b/src/sentry/sentry_apps/event_types.py
@@ -24,6 +24,9 @@ class SentryAppEventType(StrEnum):
     METRIC_ALERT_CRITICAL = "metric_alert.critical"
     METRIC_ALERT_WARNING = "metric_alert.warning"
 
+    # deploy webhooks
+    DEPLOY_CREATED = "deploy.created"
+
     # comment webhooks
     COMMENT_CREATED = "comment.created"
     COMMENT_UPDATED = "comment.updated"

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -46,6 +46,7 @@ REQUIRED_EVENT_PERMISSIONS = {
     "team": "team:read",
     "comment": "event:read",
     "preprod_artifact": "project:read",
+    "deploy": "project:releases",
 }
 
 # The only events valid for Sentry Apps are the ones listed in the values of

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -26,6 +26,10 @@ class ErrorActionType(SentryAppActionType):
     CREATED = "created"
 
 
+class DeployActionType(SentryAppActionType):
+    CREATED = "created"
+
+
 class CommentActionType(SentryAppActionType):
     CREATED = "created"
     DELETED = "deleted"
@@ -73,6 +77,7 @@ class SentryAppResourceType(StrEnum):
     ISSUE = "issue"
     ERROR = "error"
     COMMENT = "comment"
+    DEPLOY = "deploy"
     INSTALLATION = "installation"
     METRIC_ALERT = "metric_alert"
     SEER = "seer"
@@ -100,6 +105,7 @@ EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[SentryAppEventType]]] = 
         SentryAppEventType.COMMENT_DELETED,
         SentryAppEventType.COMMENT_UPDATED,
     ],
+    SentryAppResourceType.DEPLOY: [SentryAppEventType.DEPLOY_CREATED],
     SentryAppResourceType.SEER: [
         SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
         SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -140,7 +140,7 @@ alert_rule_created = BetterSignal()
 alert_rule_edited = BetterSignal()  # ["project", "rule", "user", "rule_type", "is_api_token"]
 repo_linked = BetterSignal()  # ["repo", "user"]
 release_created = BetterSignal()  # ["release"]
-deploy_created = BetterSignal()  # ["deploy"]
+deploy_created = BetterSignal()  # ["deploy", "projects"]
 ownership_rule_created = BetterSignal()  # ["project"]
 
 # issues

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -113,6 +113,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetQuery,
 )
 from sentry.models.debugfile import ProjectDebugFile
+from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
 from sentry.models.files.control_file import ControlFile
 from sentry.models.files.file import File
@@ -652,6 +653,18 @@ class Factories:
         env = Environment.objects.create(organization_id=organization_id, name=name)
         env.add_project(project, is_hidden=kwargs.get("is_hidden"))
         return env
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_deploy(release, environment, **kwargs) -> Deploy:
+        organization_id = kwargs.pop("organization_id", release.organization_id)
+
+        return Deploy.objects.create(
+            organization_id=organization_id,
+            release=release,
+            environment_id=environment.id,
+            **kwargs,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -27,6 +27,7 @@ from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.custominboundfilter import CustomInboundFilter
+from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
@@ -246,6 +247,13 @@ class Fixtures:
         if project is None:
             project = self.project
         return Factories.create_environment(project=project, **kwargs)
+
+    def create_deploy(self, release=None, environment=None, **kwargs) -> Deploy:
+        if release is None:
+            release = self.release
+        if environment is None:
+            environment = self.environment
+        return Factories.create_deploy(release=release, environment=environment, **kwargs)
 
     def create_project(self, **kwargs) -> Project:
         if "teams" not in kwargs:

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -7,12 +7,14 @@ from sentry.issues.escalating.escalating import manage_issue_states
 from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
+from sentry.models.deploy import Deploy
 from sentry.models.group import GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupinbox import GroupInboxReason
 from sentry.models.grouplink import GroupLink
 from sentry.models.release import Release
 from sentry.models.repository import Repository
+from sentry.signals import deploy_created
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -397,3 +399,40 @@ class TestIssueWorkflowNotificationsForExactSubscription(APITestCase):
             user_id=self.user.id,
             data={},
         )
+
+
+@patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook.delay")
+class TestDeployCreatedWebhook(APITestCase):
+    def setUp(self) -> None:
+        self.sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            events=["deploy"],
+            scopes=["project:releases"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization, slug=self.sentry_app.slug
+        )
+        self.release = self.create_release(project=self.project, version="1.0.0")
+        self.environment = self.create_environment(project=self.project, name="production")
+        self.login_as(self.user)
+
+    def create_deploy_via_signal(self) -> Deploy:
+        deploy = self.create_deploy(release=self.release, environment=self.environment)
+        deploy_created.send_robust(deploy=deploy, projects=[self.project], sender=None)
+        return deploy
+
+    def test_notifies_subscribed_installation(self, delay: MagicMock) -> None:
+        with self.feature("organizations:deploy-webhooks"), self.tasks():
+            self.create_deploy_via_signal()
+
+        delay.assert_called_once()
+        assert delay.call_args[0][0] == self.install.id
+        assert delay.call_args[0][1] == "deploy.created"
+        assert delay.call_args[0][2]["deploy"]["release"] == {"version": "1.0.0"}
+        assert delay.call_args[0][2]["deploy"]["projects"] == [{"slug": self.project.slug}]
+
+    def test_skips_when_feature_disabled(self, delay: MagicMock) -> None:
+        with self.feature({"organizations:deploy-webhooks": False}), self.tasks():
+            self.create_deploy_via_signal()
+
+        assert not delay.called

--- a/tests/sentry/releases/endpoints/test_release_deploys.py
+++ b/tests/sentry/releases/endpoints/test_release_deploys.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
@@ -501,3 +502,44 @@ class ReleaseDeploysCreateTest(APITestCase):
         assert not ReleaseProjectEnvironment.objects.filter(
             project=self.project, release=release, environment=environment
         ).exists()
+
+
+class ReleaseDeploysCreateWebhookTest(APITestCase):
+    def setUp(self) -> None:
+        self.login_as(self.user)
+        self.release = self.create_release(project=self.project, version="1.0.0")
+        self.url = reverse(
+            "sentry-api-0-organization-release-deploys",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "version": self.release.version,
+            },
+        )
+
+    @patch("sentry.releases.deploy_webhooks.broadcast_webhooks_for_organization.delay")
+    def test_creating_a_deploy_enqueues_the_webhook(self, delay: MagicMock) -> None:
+        with self.feature("organizations:deploy-webhooks"):
+            response = self.client.post(self.url, data={"environment": "production"})
+
+        assert response.status_code == 201, response.content
+
+        delay.assert_called_once()
+        kwargs = delay.call_args.kwargs
+        assert kwargs["resource_name"] == "deploy"
+        assert kwargs["event_name"] == "created"
+        assert kwargs["organization_id"] == self.organization.id
+
+        deploy_payload = kwargs["payload"]["deploy"]
+        assert deploy_payload["environment"] == "production"
+        assert deploy_payload["release"] == {"version": "1.0.0"}
+        assert deploy_payload["projects"] == [{"slug": self.project.slug}]
+        # Datetimes must already be strings; the payload is JSON-encoded downstream.
+        assert isinstance(deploy_payload["dateFinished"], str)
+
+    @patch("sentry.releases.deploy_webhooks.broadcast_webhooks_for_organization.delay")
+    def test_no_webhook_without_the_feature(self, delay: MagicMock) -> None:
+        with self.feature({"organizations:deploy-webhooks": False}):
+            response = self.client.post(self.url, data={"environment": "production"})
+
+        assert response.status_code == 201, response.content
+        assert not delay.called

--- a/tests/sentry/releases/test_deploy_webhooks.py
+++ b/tests/sentry/releases/test_deploy_webhooks.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone as dt_timezone
+from unittest.mock import MagicMock, patch
+
+from sentry.models.deploy import Deploy
+from sentry.releases.deploy_webhooks import (
+    build_deploy_webhook_payload,
+    send_deploy_created_webhook,
+)
+from sentry.testutils.cases import TestCase
+from sentry.utils import json
+
+DEPLOY_WEBHOOKS_FEATURE = "organizations:deploy-webhooks"
+
+
+class DeployWebhookTestBase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.environment = self.create_environment(project=self.project, name="production")
+        self.release = self.create_release(project=self.project, version="1.0.0")
+
+    def make_deploy(self, **kwargs) -> Deploy:
+        kwargs.setdefault("date_finished", datetime(2026, 8, 14, 12, 0, 0, tzinfo=dt_timezone.utc))
+        return self.create_deploy(release=self.release, environment=self.environment, **kwargs)
+
+
+class BuildDeployWebhookPayloadTest(DeployWebhookTestBase):
+    def test_payload_shape(self) -> None:
+        deploy = self.make_deploy(name="my-deploy", url="https://example.com/build/1")
+
+        payload = build_deploy_webhook_payload(deploy, [self.project], self.organization)
+
+        assert payload == {
+            "deploy": {
+                "id": str(deploy.id),
+                "environment": "production",
+                "dateStarted": None,
+                "dateFinished": "2026-08-14T12:00:00+00:00",
+                "name": "my-deploy",
+                "url": "https://example.com/build/1",
+                "release": {"version": "1.0.0"},
+                "projects": [{"slug": self.project.slug}],
+                "web_url": self.organization.absolute_url(
+                    f"/organizations/{self.organization.slug}/releases/1.0.0/",
+                    query="environment=production",
+                ),
+            }
+        }
+
+    def test_web_url_is_an_absolute_sentry_link(self) -> None:
+        payload = build_deploy_webhook_payload(
+            self.make_deploy(), [self.project], self.organization
+        )
+
+        web_url = payload["deploy"]["web_url"]
+        assert web_url.startswith("http")
+        assert "/releases/1.0.0/" in web_url
+        assert "environment=production" in web_url
+
+    def test_web_url_quotes_url_unsafe_release_versions(self) -> None:
+        """`?`, `#` and spaces are all legal in release versions (only BAD_RELEASE_CHARS
+        are rejected), so an unquoted version would corrupt the permalink."""
+        release = self.create_release(project=self.project, version="v1.0 rc#2?x=1")
+        deploy = self.create_deploy(release=release, environment=self.environment)
+
+        web_url = build_deploy_webhook_payload(deploy, [self.project], self.organization)["deploy"][
+            "web_url"
+        ]
+
+        assert "/releases/v1.0%20rc%232%3Fx%3D1/" in web_url
+        # The version must not leak out of its path segment into the query string.
+        assert web_url.endswith("?environment=production")
+
+    def test_web_url_omits_environment_query_when_unknown(self) -> None:
+        deploy = self.make_deploy()
+        # An environment row that no longer resolves serializes to environment=None.
+        deploy.update(environment_id=123456789)
+
+        web_url = build_deploy_webhook_payload(deploy, [self.project], self.organization)["deploy"][
+            "web_url"
+        ]
+
+        assert "environment=" not in web_url
+        assert web_url.endswith("/releases/1.0.0/")
+
+    def test_date_started_is_serialized_when_present(self) -> None:
+        deploy = self.make_deploy(
+            date_started=datetime(2026, 8, 14, 11, 30, 0, tzinfo=dt_timezone.utc)
+        )
+
+        payload = build_deploy_webhook_payload(deploy, [self.project], self.organization)
+
+        assert payload["deploy"]["dateStarted"] == "2026-08-14T11:30:00+00:00"
+
+    def test_payload_is_json_serializable(self) -> None:
+        """The payload is handed to a task and JSON-encoded for delivery, so it must
+        contain no datetime objects."""
+        deploy = self.make_deploy(
+            date_started=datetime(2026, 8, 14, 11, 30, 0, tzinfo=dt_timezone.utc)
+        )
+
+        payload = build_deploy_webhook_payload(deploy, [self.project], self.organization)
+
+        assert json.loads(json.dumps(payload)) == payload
+
+    def test_projects_reflects_the_deployed_subset_not_the_whole_release(self) -> None:
+        """A deploy may target a subset of the release's projects, so the payload must
+        report the projects passed in rather than everything on the release."""
+        other_project = self.create_project(organization=self.organization)
+        self.release.add_project(other_project)
+
+        payload = build_deploy_webhook_payload(
+            self.make_deploy(), [self.project], self.organization
+        )
+
+        assert payload["deploy"]["projects"] == [{"slug": self.project.slug}]
+
+
+@patch("sentry.releases.deploy_webhooks.broadcast_webhooks_for_organization.delay")
+class SendDeployCreatedWebhookTest(DeployWebhookTestBase):
+    def test_enqueues_when_feature_enabled(self, delay: MagicMock) -> None:
+        deploy = self.make_deploy()
+
+        with self.feature(DEPLOY_WEBHOOKS_FEATURE):
+            send_deploy_created_webhook(deploy, [self.project])
+
+        delay.assert_called_once_with(
+            resource_name="deploy",
+            event_name="created",
+            organization_id=self.organization.id,
+            payload=build_deploy_webhook_payload(deploy, [self.project], self.organization),
+        )
+
+    def test_does_not_enqueue_when_feature_disabled(self, delay: MagicMock) -> None:
+        deploy = self.make_deploy()
+
+        with self.feature({DEPLOY_WEBHOOKS_FEATURE: False}):
+            send_deploy_created_webhook(deploy, [self.project])
+
+        assert not delay.called
+
+    def test_swallows_and_logs_payload_failures(self, delay: MagicMock) -> None:
+        deploy = self.make_deploy()
+
+        with (
+            self.feature(DEPLOY_WEBHOOKS_FEATURE),
+            patch(
+                "sentry.releases.deploy_webhooks.build_deploy_webhook_payload",
+                side_effect=ValueError("boom"),
+            ),
+            patch("sentry.releases.deploy_webhooks.logger") as mock_logger,
+        ):
+            send_deploy_created_webhook(deploy, [self.project])
+
+        assert not delay.called
+        mock_logger.exception.assert_called_once()
+        assert mock_logger.exception.call_args[0][0] == "releases.deploy.webhook.failed"

--- a/tests/sentry/sentry_apps/api/serializers/test_app_platform_event.py
+++ b/tests/sentry/sentry_apps/api/serializers/test_app_platform_event.py
@@ -6,6 +6,7 @@ import orjson
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.models.sentry_app import MASKED_VALUE, SentryApp
 from sentry.sentry_apps.utils.webhooks import (
+    DeployActionType,
     ErrorActionType,
     InstallationActionType,
     IssueActionType,
@@ -244,6 +245,26 @@ class AppPlatformEventSerializerTest(TestCase):
             )
             == f"Sentry metric_alert.open: {url}"
         )
+        release_url = "https://org.sentry.io/organizations/org/releases/1.0.0/"
+        assert (
+            self._text_summary(
+                SentryAppResourceType.DEPLOY,
+                DeployActionType.CREATED,
+                {"deploy": {"web_url": release_url, "url": "https://ci.example.com/build/42"}},
+            )
+            == f"Sentry deploy.created: {release_url}"
+        )
+
+    def test_text_summary_prefers_sentry_permalink_over_user_supplied_deploy_url(self) -> None:
+        """`deploy.url` is an arbitrary user-supplied CI link, so it must never be the URL
+        surfaced in the summary."""
+        summary = self._text_summary(
+            SentryAppResourceType.DEPLOY,
+            DeployActionType.CREATED,
+            {"deploy": {"url": "https://evil.example.com/phish"}},
+        )
+
+        assert summary == "Sentry deploy.created"
 
     def test_text_summary_without_issue_data(self) -> None:
         result = AppPlatformEvent[dict[str, Any]](


### PR DESCRIPTION
Adds `deploy` as a subscribable Sentry App webhook resource with a single event, `deploy.created`, fired when a deploy is registered through the release-deploys API. Gated behind `organizations:deploy-webhooks`.

Integration platform consumers currently have no way to be notified of a deploy and have to poll the releases API.

## Registration

`EVENT_EXPANSION` in `sentry_apps/utils/webhooks.py` is the single source of truth for subscribable events — it already drives subscription validation, ServiceHook expansion (`expand_events`), and delivery matching (`is_subscribed`). Adding one entry there is what makes `VALID_EVENTS`, `EVENT_TO_RESOURCE`, `resource_of`, and `consolidate_events` pick up the new resource, so none of them changed.

`deploy` maps to `project:releases` in `REQUIRED_EVENT_PERMISSIONS`.

## Delivery

Reuses `broadcast_webhooks_for_organization`, the existing generic org-level broadcaster already used by the `seer` and `preprod_artifact` resources. New module `releases/deploy_webhooks.py` builds the payload and enqueues fire-and-forget — exceptions are logged and never propagated, so a webhook failure can't fail the deploy that triggered it.

A `deploy_created` signal already existed and already fired at the one deploy-creation site, so the receiver hangs off that, alongside the existing `issue.*` and `comment.*` receivers.

## Payload

Wraps the public Deploy representation and adds the release version, target project slugs, and `web_url` — a Sentry permalink to the release scoped to the deploy's environment.

Two details worth review:

- **`projects` is threaded through the signal** rather than derived from `release.projects`. `create_deploy` accepts a `projects` argument that may be a *subset* of the release's projects, so deriving them would report the wrong set. Test pins this.
- **Dates are rendered as ISO 8601 strings.** `DeploySerializer` returns `datetime` objects, and this payload is handed to a task and JSON-encoded for delivery. Test pins this too.

`web_url` URL-quotes the version: `BAD_RELEASE_CHARS` only rejects `\r\n\f\t/\`, so `?`, `#`, `%` and spaces are all legal in a release version and would otherwise corrupt the link.

## Text summary

`get_text_summary` learns about `deploy.web_url`, so webhooks delivered to Claude Code routine fire URLs carry a Sentry link rather than a bare `Sentry deploy.created`.

It deliberately prefers that permalink over the user-supplied `deploy.url`. That field is arbitrary text from whoever created the deploy, and the summary is read by a model — a test asserts a hostile `deploy.url` can never reach it, mirroring the existing `test_text_summary_excludes_user_controlled_title` guard.

## Testing

Adds a `create_deploy` factory + fixture to testutils; none existed, and `tests/AGENTS.md` prohibits calling `Model.objects.create` directly in tests.

Frontend is a separate PR since `static/` and `src/` are not atomically deployed and CI rejects mixed PRs. This lands first.
