### PR TITLE
feat(sentry-apps): Add Deploys webhook subscription to the UI

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -551,7 +551,13 @@ export type IntegrationIssueConfig = {
 
 export type AppOrProviderOrPlugin = SentryApp | IntegrationProvider | DocIntegration;
 
-export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer' | 'preprod_artifact';
+export type WebhookEvent =
+  | 'issue'
+  | 'error'
+  | 'comment'
+  | 'deploy'
+  | 'seer'
+  | 'preprod_artifact';
 
 /**
  * Codeowners and repository path mappings.

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -5,6 +5,7 @@ export const EVENT_CHOICES = [
   'issue',
   'error',
   'comment',
+  'deploy',
   'seer',
   'preprod_artifact',
 ] as const satisfies readonly WebhookEvent[];
@@ -21,6 +22,7 @@ export const RESOURCE_EVENTS = {
   ],
   error: ['error.created'],
   comment: ['comment.created', 'comment.updated', 'comment.deleted'],
+  deploy: ['deploy.created'],
   seer: [
     'seer.root_cause_started',
     'seer.root_cause_completed',
@@ -44,6 +46,7 @@ export const WEBHOOK_SUBSCRIPTION_CHOICES = [
   ...RESOURCE_EVENTS.issue,
   ...RESOURCE_EVENTS.error,
   ...RESOURCE_EVENTS.comment,
+  ...RESOURCE_EVENTS.deploy,
   ...RESOURCE_EVENTS.seer,
   ...RESOURCE_EVENTS.preprod_artifact,
 ] as const;
@@ -84,6 +87,7 @@ const RESOURCE_LABELS: Record<WebhookEvent, string> = {
   issue: 'Issues',
   error: 'Errors',
   comment: 'Comments',
+  deploy: 'Deploys',
   seer: 'Seer',
   preprod_artifact: 'Preprod Artifacts',
 };
@@ -96,6 +100,7 @@ export const PERMISSIONS_MAP = {
   issue: 'Event',
   error: 'Event',
   comment: 'Event',
+  deploy: 'Release',
   seer: 'Event',
   preprod_artifact: 'Project',
 } as const;

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Form} from 'sentry/components/forms/form';
@@ -34,6 +36,47 @@ describe('Resource Subscriptions', () => {
       expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
       // preprod_artifact requires Project permission which is 'write' here, so it's enabled
       expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
+    });
+
+    it('disables deploy checkbox without Release permission', () => {
+      const org = OrganizationFixture({features: ['deploy-webhooks']});
+      render(
+        <Form>
+          <Subscriptions
+            events={[]}
+            permissions={{...basePermissions, Release: 'no-access'}}
+            onChange={jest.fn()}
+          />
+        </Form>,
+        {organization: org}
+      );
+
+      expect(screen.getByRole('checkbox', {name: 'deploy'})).toBeDisabled();
+    });
+
+    it('enables deploy checkbox with Release permission', () => {
+      const org = OrganizationFixture({features: ['deploy-webhooks']});
+      render(
+        <Form>
+          <Subscriptions events={[]} permissions={basePermissions} onChange={jest.fn()} />
+        </Form>,
+        {organization: org}
+      );
+
+      expect(screen.getByRole('checkbox', {name: 'deploy'})).toBeEnabled();
+    });
+
+    it('hides deploy checkbox without deploy-webhooks flag', () => {
+      render(
+        <Form>
+          <Subscriptions events={[]} permissions={basePermissions} onChange={jest.fn()} />
+        </Form>
+      );
+
+      expect(screen.queryByRole('checkbox', {name: 'deploy'})).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('checkbox', {name: 'deploy.created'})
+      ).not.toBeInTheDocument();
     });
 
     it('updates events state when new permissions props is passed', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -91,6 +91,24 @@ describe('SubscriptionBox', () => {
     });
   });
 
+  describe('deploy resource subscription', () => {
+    it('hidden without deploy-webhooks flag', () => {
+      renderComponent({resource: 'deploy'});
+
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('renders deploy checkbox enabled with deploy-webhooks flag', () => {
+      renderComponent(
+        {resource: 'deploy'},
+        {organization: OrganizationFixture({features: ['deploy-webhooks']})}
+      );
+
+      expect(screen.getByRole('checkbox', {name: 'deploy'})).toBeEnabled();
+      expect(screen.getByRole('checkbox', {name: 'deploy.created'})).toBeInTheDocument();
+    });
+  });
+
   describe('preprod_artifact resource subscription', () => {
     it('renders preprod_artifact checkbox enabled', () => {
       renderComponent({resource: 'preprod_artifact'});

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -42,6 +42,10 @@ export function SubscriptionBox({
 }: Props) {
   const {features} = useOrganization();
 
+  if (resource === 'deploy' && !features.includes('deploy-webhooks')) {
+    return null;
+  }
+
   let disabled = disabledFromPermissions;
   let message = t(
     "Must have at least 'Read' permissions enabled for %s",


### PR DESCRIPTION
Exposes the `deploy` webhook resource from #122205 as a subscription checkbox under Developer Settings → webhook subscriptions.

**Depends on #122205.** Until `deploy` is a valid subscription server-side, checking the box would fail validation. Split because `static/` and `src/` are not atomically deployed and CI rejects mixed PRs.

> Based on `feat/deploy-created-webhook` so the diff shows only `static/`. Retarget to `master` once #122205 merges.

## Changes

- `deploy` added to the `WebhookEvent` union and to `EVENT_CHOICES` / `RESOURCE_EVENTS` / `WEBHOOK_SUBSCRIPTION_CHOICES` / `RESOURCE_LABELS` in `constants.tsx`. That file is `satisfies`-constrained against `WebhookEvent`, so the compiler enforces every map stays complete.
- `PERMISSIONS_MAP.deploy = 'Release'`, mirroring the backend's `project:releases` scope.
- Gated on `organizations:deploy-webhooks` in `subscriptionBox.tsx`, following the `preprod-artifact-webhooks` precedent, so it stays hidden until the flag is on.

## Note for review

`subscriptionBox.tsx` renders a fixed tooltip — *"Must have at least 'Read' permissions enabled for %s"* — but the `Release` permission in `constants/index.tsx` only offers `no-access` and `admin`; there is no Read level. So the message reads slightly wrong for this resource. That is pre-existing generic copy shared by every resource, so I have not changed it here, but it is worth deciding whether to special-case.
