### PR TITLE
fix(autofix): Align changed file rows

### DIFF
--- a/static/app/views/seerWorkflows/overview/changedFileRow.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFileRow.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {TagVariant} from 'sentry/utils/theme';
@@ -31,22 +31,11 @@ export function ChangedFileRow({
   path: string;
 }) {
   return (
-    <FileRow>
+    <FileRow padding="0 xs">
       <Disclosure size="sm" expanded={expanded} onExpandedChange={onExpandedChange}>
         <Disclosure.Title
           trailingItems={
-            changeTag ? (
-              <Tag variant={changeTag.variant}>{changeTag.label}</Tag>
-            ) : undefined
-          }
-        >
-          <Grid
-            columns="minmax(60px, auto) minmax(0, 1fr)"
-            gap="xl"
-            align="center"
-            width="100%"
-          >
-            <Flex gap="md" align="center">
+            <Flex gap="xs" align="center">
               <Text size="sm" monospace variant="success">
                 +{additions}
               </Text>
@@ -54,10 +43,16 @@ export function ChangedFileRow({
                 -{deletions}
               </Text>
             </Flex>
-            <FilePath size="sm" monospace ellipsis title={path}>
-              {path}
-            </FilePath>
-          </Grid>
+          }
+        >
+          <Flex gap="md" align="center" minWidth="0" width="100%">
+            <Container minWidth="0" flexShrink={1}>
+              <FilePath size="sm" monospace ellipsis title={path}>
+                {path}
+              </FilePath>
+            </Container>
+            {changeTag ? <Tag variant={changeTag.variant}>{changeTag.label}</Tag> : null}
+          </Flex>
         </Disclosure.Title>
         <Disclosure.Content>{children}</Disclosure.Content>
       </Disclosure>
@@ -65,7 +60,7 @@ export function ChangedFileRow({
   );
 }
 
-const FileRow = styled('div')`
+const FileRow = styled(Container)`
   & + & {
     border-top: 1px solid ${p => p.theme.tokens.border.primary};
   }

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -47,7 +47,7 @@ export function ChangedFilesSection({
   onToggle: (key: string, expanded: boolean) => void;
 }) {
   return (
-    <Stack gap="sm">
+    <Stack gap="md">
       <Flex gap="xs" align="center">
         <IconCode size="xs" variant="secondary" aria-hidden />
         <Text size="xs" bold uppercase variant="secondary">
@@ -60,7 +60,7 @@ export function ChangedFilesSection({
             <Flex
               gap="md"
               align="center"
-              padding="md xl"
+              padding="md"
               borderBottom="primary"
               borderTop={groupIndex > 0 ? 'primary' : undefined}
             >

--- a/static/app/views/seerWorkflows/overview/codeChanges.tsx
+++ b/static/app/views/seerWorkflows/overview/codeChanges.tsx
@@ -10,9 +10,9 @@ import {
 } from './changedFilesSection';
 import type {OverviewCodeChangeFile} from './types';
 
-const DIFF_TYPE_TAG: Record<DiffFileType, FileChangeTag> = {
+const DIFF_TYPE_TAG: Record<DiffFileType, FileChangeTag | null> = {
   [DiffFileType.ADDED]: {label: t('Added'), variant: 'success'},
-  [DiffFileType.MODIFIED]: {label: t('Modified'), variant: 'muted'},
+  [DiffFileType.MODIFIED]: null,
   [DiffFileType.DELETED]: {label: t('Deleted'), variant: 'danger'},
 };
 

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -776,7 +776,7 @@ describe('AutofixOverview', () => {
     expect(screen.queryByRole('button', {name: /Review PR #1/})).not.toBeInTheDocument();
   });
 
-  it('labels each changed file with its change type', async () => {
+  it('labels non-modified files with their change type', async () => {
     mockOverview({
       base: {
         has_pull_request: [
@@ -829,19 +829,18 @@ describe('AutofixOverview', () => {
     expect(await screen.findByText('src/sentry/new.py')).toBeInTheDocument();
     expect(screen.getByText('Added')).toBeInTheDocument();
     expect(screen.getByText('Deleted')).toBeInTheDocument();
-    expect(screen.getByText('Modified')).toBeInTheDocument();
     expect(screen.getByText('Renamed')).toBeInTheDocument();
+    expect(screen.queryByText('Modified')).not.toBeInTheDocument();
     expect(screen.getByText('+12')).toBeInTheDocument();
     expect(screen.getByText('-30')).toBeInTheDocument();
 
-    // Added and deleted keep their own color, rather than all six collapsing
-    // into the muted label used for the rest.
+    // Added and deleted keep their own color, while other non-modified states
+    // use the muted label.
     const tagClassName = (label: string) =>
       screen.getByText(label).closest('[data-test-id="tag-background"]')?.className;
     expect(tagClassName('Added')).not.toEqual(tagClassName('Deleted'));
-    expect(tagClassName('Added')).not.toEqual(tagClassName('Modified'));
-    expect(tagClassName('Deleted')).not.toEqual(tagClassName('Modified'));
-    expect(tagClassName('Renamed')).toEqual(tagClassName('Modified'));
+    expect(tagClassName('Added')).not.toEqual(tagClassName('Renamed'));
+    expect(tagClassName('Deleted')).not.toEqual(tagClassName('Renamed'));
   });
 
   it('renders a file with an unknown change type without a tag', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -875,7 +875,10 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    const fileRow = (await screen.findByText('src/sentry/mystery.py')).closest('div')!;
+    const fileToggle = await screen.findByRole('button', {
+      name: /src\/sentry\/mystery\.py/,
+    });
+    const fileRow = fileToggle.closest<HTMLElement>('[data-disclosure]')!;
 
     expect(within(fileRow).getByText('+4')).toBeInTheDocument();
     expect(within(fileRow).queryByTestId('tag-background')).not.toBeInTheDocument();

--- a/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
@@ -20,12 +20,12 @@ import {
   QUERY_STALE_TIME,
 } from './types';
 
-const FILE_CHANGE_TAG: Record<PullRequestFileChangeType, FileChangeTag> = {
+const FILE_CHANGE_TAG: Record<PullRequestFileChangeType, FileChangeTag | null> = {
   ADDED: {label: t('Added'), variant: 'success'},
-  CHANGED: {label: t('Changed'), variant: 'muted'},
+  CHANGED: null,
   COPIED: {label: t('Copied'), variant: 'muted'},
   DELETED: {label: t('Deleted'), variant: 'danger'},
-  MODIFIED: {label: t('Modified'), variant: 'muted'},
+  MODIFIED: null,
   RENAMED: {label: t('Renamed'), variant: 'muted'},
 };
 


### PR DESCRIPTION
match figma mocks - move line counts to the trailing edge, normalize row spacing, and only show change-type tags for non-modified files.
<img width="2264" height="304" alt="CleanShot 2026-08-18 at 12 54 00@2x" src="https://github.com/user-attachments/assets/cf49e566-c5d3-4db4-bc68-5addd026096c" />

