### PR TITLE
feat(scraps): Add OTP input primitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "gl-matrix": "3.4.4",
     "html-webpack-plugin": "5.6.3",
     "idb-keyval": "6.2.2",
+    "input-otp": "^1.5.0",
     "invariant": "^2.2.4",
     "jed": "^1.1.0",
     "jest-fetch-mock": "4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,9 @@ importers:
       idb-keyval:
         specifier: 6.2.2
         version: 6.2.2
+      input-otp:
+        specifier: ^1.5.0
+        version: 1.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
@@ -6238,6 +6241,12 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  input-otp@1.5.0:
+    resolution: {integrity: sha512-3AcfdW1sNG0FmSA5hHMBXG7jNW5CdcdKs8ln8JOmn6S2SRkoXoJx+2UwC+ZvjflfnOdHJx0SfQ9/YjlxVYLtGQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -15116,6 +15125,11 @@ snapshots:
   ini@4.1.3: {}
 
   inline-style-parser@0.2.7: {}
+
+  input-otp@1.5.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   internal-slot@1.1.0:
     dependencies:

--- a/static/app/components/core/input/index.tsx
+++ b/static/app/components/core/input/index.tsx
@@ -3,4 +3,6 @@ export {InputGroup} from './inputGroup';
 /** @public */
 export {NumberDragInput} from './numberDragInput';
 export {NumberInput} from './numberInput';
+/** @public */
+export {OTPInput} from './otpInput';
 export {useAutosizeInput} from './useAutosizeInput';

--- a/static/app/components/core/input/otpInput.mdx
+++ b/static/app/components/core/input/otpInput.mdx
@@ -1,0 +1,81 @@
+---
+title: OTPInput
+description: A segmented input for one-time authentication codes.
+category: forms
+source: '@sentry/scraps/input'
+---
+
+import {OTPInput} from '@sentry/scraps/input';
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/input');
+
+`OTPInput` presents a one-time code as individual slots while retaining a single native
+input for autofill, paste, keyboard navigation, and assistive technology.
+
+```jsx
+<OTPInput length={6} onComplete={code => submit(code)} />
+```
+
+## Sizes
+
+Use the size that matches the surrounding form controls.
+
+<Storybook.Demo>
+  <OTPInput length={6} size="xs" onComplete={() => {}} />
+  <OTPInput length={6} size="sm" onComplete={() => {}} />
+  <OTPInput length={6} size="md" onComplete={() => {}} />
+</Storybook.Demo>
+```jsx
+<OTPInput length={6} size="xs" onComplete={handleComplete} />
+<OTPInput length={6} size="sm" onComplete={handleComplete} />
+<OTPInput length={6} size="md" onComplete={handleComplete} />
+```
+
+## Disabled
+
+<Storybook.Demo>
+  <OTPInput disabled length={6} onComplete={() => {}} />
+</Storybook.Demo>
+```jsx
+<OTPInput disabled length={6} onComplete={handleComplete} />
+```
+
+## Alphanumeric Codes
+
+Use `characterSet="alphanumeric"` for codes containing letters and numbers. A `transform`
+can normalize input from typing, paste, and autofill before completion.
+
+<Storybook.Demo>
+  <OTPInput
+    characterSet="alphanumeric"
+    length={6}
+    onComplete={() => {}}
+    transform={value => value.toUpperCase()}
+  />
+</Storybook.Demo>
+```jsx
+<OTPInput
+  characterSet="alphanumeric"
+  length={6}
+  onComplete={handleComplete}
+  transform={value => value.toUpperCase()}
+/>
+```
+
+## Accessibility
+
+The component exposes one native input named “One-time password.” This preserves normal
+text input behavior for screen readers and enables `one-time-code` autofill on supported
+devices. The segmented slots are visual and hidden from the accessibility tree.
+
+## Props
+
+| Prop           | Type                          | Default     | Description                                  |
+| -------------- | ----------------------------- | ----------- | -------------------------------------------- |
+| `length`       | `number`                      | —           | Number of characters in the code.            |
+| `onComplete`   | `(value: string) => void`     | —           | Called when every slot contains a character. |
+| `characterSet` | `'numeric' \| 'alphanumeric'` | `'numeric'` | Limits the characters accepted.              |
+| `transform`    | `(value: string) => string`   | —           | Normalizes the value as it changes.          |
+| `size`         | `'xs' \| 'sm' \| 'md'`        | `'md'`      | Size of each code slot.                      |
+| `disabled`     | `boolean`                     | `false`     | Disables code entry.                         |

--- a/static/app/components/core/input/otpInput.spec.tsx
+++ b/static/app/components/core/input/otpInput.spec.tsx
@@ -1,0 +1,70 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {OTPInput} from '@sentry/scraps/input';
+
+describe('OTPInput', () => {
+  beforeAll(() => {
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: jest.fn(() => null),
+    });
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(document, 'elementFromPoint');
+  });
+
+  it('accepts characters and reports a filled code', async () => {
+    const onComplete = jest.fn();
+    render(<OTPInput length={4} onComplete={onComplete} />);
+
+    const input = screen.getByRole<HTMLInputElement>('textbox', {
+      name: 'One-time password',
+    });
+    await userEvent.type(input, '1234');
+
+    expect(input).toHaveValue('1234');
+    expect(onComplete).toHaveBeenCalledWith('1234');
+  });
+
+  it('supports one-time-code autofill', () => {
+    render(<OTPInput length={6} onComplete={jest.fn()} />);
+
+    expect(screen.getByRole('textbox', {name: 'One-time password'})).toHaveAttribute(
+      'autocomplete',
+      'one-time-code'
+    );
+  });
+
+  it('disables the native input', () => {
+    render(<OTPInput disabled length={6} onComplete={jest.fn()} />);
+
+    expect(screen.getByRole('textbox', {name: 'One-time password'})).toBeDisabled();
+  });
+
+  it('renders the requested number of visual slots', () => {
+    render(<OTPInput length={6} onComplete={jest.fn()} />);
+
+    expect(document.querySelectorAll('[data-input-otp-slot]')).toHaveLength(6);
+  });
+
+  it('supports alphanumeric codes and transforms their value', async () => {
+    const onComplete = jest.fn();
+    render(
+      <OTPInput
+        characterSet="alphanumeric"
+        length={4}
+        onComplete={onComplete}
+        transform={value => value.toUpperCase()}
+      />
+    );
+
+    const input = screen.getByRole<HTMLInputElement>('textbox', {
+      name: 'One-time password',
+    });
+    await userEvent.type(input, 'a1b2');
+
+    expect(input).toHaveValue('A1B2');
+    expect(onComplete).toHaveBeenCalledWith('A1B2');
+  });
+});

--- a/static/app/components/core/input/otpInput.tsx
+++ b/static/app/components/core/input/otpInput.tsx
@@ -1,0 +1,82 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import {
+  OTPInput as OTPInputPrimitive,
+  REGEXP_ONLY_DIGITS,
+  REGEXP_ONLY_DIGITS_AND_CHARS,
+} from 'input-otp';
+
+import {Flex} from '@sentry/scraps/layout';
+
+import {t} from 'sentry/locale';
+import type {FormSize} from 'sentry/utils/theme';
+
+import {inputStyles} from './inputStyles';
+
+export interface OTPInputProps {
+  length: number;
+  onComplete: (value: string) => void;
+  characterSet?: 'alphanumeric' | 'numeric';
+  disabled?: boolean;
+  size?: FormSize;
+  transform?: (value: string) => string;
+}
+
+/** @public */
+export function OTPInput({
+  length,
+  onComplete,
+  characterSet = 'numeric',
+  disabled = false,
+  size = 'md',
+  transform,
+}: OTPInputProps) {
+  const [value, setValue] = useState('');
+
+  return (
+    <OTPInputPrimitive
+      aria-label={t('One-time password')}
+      autoComplete="one-time-code"
+      disabled={disabled}
+      inputMode={characterSet === 'numeric' ? 'numeric' : 'text'}
+      maxLength={length}
+      onChange={newValue => setValue(transform?.(newValue) ?? newValue)}
+      onComplete={onComplete}
+      pattern={
+        characterSet === 'numeric' ? REGEXP_ONLY_DIGITS : REGEXP_ONLY_DIGITS_AND_CHARS
+      }
+      render={({slots}) => (
+        <Flex aria-hidden gap="xs">
+          {slots.map((slot, index) => (
+            <OTPInputSlot
+              key={index}
+              align="center"
+              aria-hidden
+              aria-disabled={disabled}
+              data-input-otp-slot
+              justify="center"
+              $isActive={slot.isActive}
+              $size={size}
+            >
+              {slot.char ?? slot.placeholderChar}
+            </OTPInputSlot>
+          ))}
+        </Flex>
+      )}
+      value={value}
+    />
+  );
+}
+
+const OTPInputSlot = styled(Flex)<{$isActive: boolean; $size: FormSize}>`
+  ${p => inputStyles({theme: p.theme, size: p.$size})};
+  min-width: ${p => p.theme.form[p.$size].height};
+  padding: 0;
+  width: ${p => p.theme.form[p.$size].height};
+
+  ${p =>
+    p.$isActive &&
+    p.theme.focusRing(
+      `0 1px 0 0 ${p.theme.tokens.interactive.chonky.debossed.neutral.chonk} inset`
+    )};
+`;

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -142,6 +142,7 @@ export const COMPONENT_SUBCATEGORY_CONFIG: Record<
           'inputgroup',
           'numberinput',
           'numberdraginput',
+          'otpinput',
           'checkbox',
           'radio',
           'switch',


### PR DESCRIPTION
Adds a shared `OTPInput` form primitive backed by `input-otp`. The wrapper keeps one native input for autofill and assistive technology while rendering Sentry-styled visual slots, with focused integration coverage and component documentation.

The current stable `input-otp` release does not map pointer clicks to earlier visual slots. The upstream implementation is still under review in https://github.com/guilhermerodz/input-otp/pull/132; the slots already include its proposed `data-input-otp-slot` marker so the behavior can be adopted when released.

## Testing

- `pnpm test-ci static/app/components/core/input/otpInput.spec.tsx`
- `pnpm run lint:js static/app/components/core/input/otpInput.tsx static/app/components/core/input/otpInput.spec.tsx static/app/components/core/input/index.tsx`
- `.venv/bin/prek run -q`