### PR TITLE
feat(seer): Add Autofix project suggestions endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -576,6 +576,9 @@ from sentry.seer.endpoints.organization_seer_autofix_overview import (
     OrganizationSeerAutofixOverviewEndpoint,
 )
 from sentry.seer.endpoints.organization_seer_onboarding_check import OrganizationSeerOnboardingCheck
+from sentry.seer.endpoints.organization_seer_project_suggestions import (
+    OrganizationSeerProjectSuggestionsEndpoint,
+)
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
 from sentry.seer.endpoints.organization_seer_runs import OrganizationSeerRunsEndpoint
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheckEndpoint
@@ -2570,6 +2573,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/autofix/automation-settings/$",
         OrganizationAutofixAutomationSettingsEndpoint.as_view(),
         name="sentry-api-0-organization-autofix-automation-settings",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/project-suggestions/$",
+        OrganizationSeerProjectSuggestionsEndpoint.as_view(),
+        name="sentry-api-0-organization-seer-project-suggestions",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/projects/$",

--- a/src/sentry/seer/endpoints/organization_seer_project_suggestions.py
+++ b/src/sentry/seer/endpoints/organization_seer_project_suggestions.py
@@ -115,25 +115,6 @@ class OrganizationSeerProjectSuggestionsEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationPermission,)
 
-    def get_per_page(
-        self,
-        request: Request,
-        default_per_page: int | None = None,
-        max_per_page: int | None = None,
-    ) -> int:
-        requested_per_page = request.GET.get("per_page")
-        if requested_per_page is not None:
-            try:
-                if int(requested_per_page) > SUGGESTIONS_PER_PAGE:
-                    return SUGGESTIONS_PER_PAGE
-            except ValueError:
-                pass
-        return super().get_per_page(
-            request,
-            default_per_page=SUGGESTIONS_PER_PAGE,
-            max_per_page=SUGGESTIONS_PER_PAGE,
-        )
-
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has(
             "organizations:seer-autofix-quick-add",
@@ -158,16 +139,13 @@ class OrganizationSeerProjectSuggestionsEndpoint(OrganizationEndpoint):
                 linked_repos_count=Count(
                     "projectrepository",
                     filter=eligible_repository_filter,
-                    distinct=True,
                 ),
                 seer_repos_count=Count(
                     "projectrepository__seerprojectrepository",
                     filter=Q(projectrepository__repository__status=ObjectStatus.ACTIVE),
-                    distinct=True,
                 ),
             )
             .filter(linked_repos_count__gt=0, seer_repos_count=0)
-            .order_by("slug")
         )
 
         return self.paginate(

--- a/src/sentry/seer/endpoints/organization_seer_project_suggestions.py
+++ b/src/sentry/seer/endpoints/organization_seer_project_suggestions.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from functools import partial
+from typing import TypedDict
+
+from django.db.models import Count, F, Q, Window
+from django.db.models.functions import RowNumber
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.paginator import OffsetPaginator
+from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.seer.seer_setup import get_supported_scm_providers
+
+MAX_REPOSITORIES_PER_PROJECT = 10
+SUGGESTIONS_PER_PAGE = 10
+ELIGIBLE_REPOSITORY_SOURCES = (
+    ProjectRepositorySource.MANUAL,
+    ProjectRepositorySource.SCM_ONBOARDING,
+)
+
+
+class SuggestedRepositoryResponse(TypedDict):
+    repositoryId: str
+    name: str
+    provider: str
+
+
+class SeerProjectSuggestionResponse(TypedDict):
+    projectId: str
+    projectSlug: str
+    linkedReposCount: int
+    linkedRepositories: list[SuggestedRepositoryResponse]
+
+
+def _eligible_repository_filters(
+    *, relationship_prefix: str, organization_id: int, supported_providers: list[str]
+) -> dict[str, object]:
+    return {
+        f"{relationship_prefix}repository__organization_id": organization_id,
+        f"{relationship_prefix}repository__status": ObjectStatus.ACTIVE,
+        f"{relationship_prefix}repository__provider__in": supported_providers,
+        f"{relationship_prefix}source__in": ELIGIBLE_REPOSITORY_SOURCES,
+    }
+
+
+def _serialize_suggestions(
+    projects: list[Project], *, organization_id: int, supported_providers: list[str]
+) -> list[SeerProjectSuggestionResponse]:
+    project_ids = [project.id for project in projects]
+    repositories_by_project_id: defaultdict[int, list[SuggestedRepositoryResponse]] = defaultdict(
+        list
+    )
+
+    if project_ids:
+        project_repositories = (
+            ProjectRepository.objects.filter(
+                project_id__in=project_ids,
+                **_eligible_repository_filters(
+                    relationship_prefix="",
+                    organization_id=organization_id,
+                    supported_providers=supported_providers,
+                ),
+            )
+            .select_related("repository")
+            .annotate(
+                repository_row=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("project_id")],
+                    order_by=[F("repository_id").asc()],
+                )
+            )
+            .filter(repository_row__lte=MAX_REPOSITORIES_PER_PROJECT)
+            .order_by("project_id", "repository_id")
+        )
+
+        for project_repository in project_repositories:
+            provider = project_repository.repository.provider
+            if provider is None:
+                continue
+            repositories_by_project_id[project_repository.project_id].append(
+                SuggestedRepositoryResponse(
+                    repositoryId=str(project_repository.repository_id),
+                    name=project_repository.repository.name,
+                    provider=provider,
+                )
+            )
+
+    return [
+        SeerProjectSuggestionResponse(
+            projectId=str(project.id),
+            projectSlug=project.slug,
+            linkedReposCount=int(getattr(project, "linked_repos_count")),
+            linkedRepositories=repositories_by_project_id[project.id],
+        )
+        for project in projects
+    ]
+
+
+@cell_silo_endpoint
+class OrganizationSeerProjectSuggestionsEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.ML_AI
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (OrganizationPermission,)
+
+    def get_per_page(
+        self,
+        request: Request,
+        default_per_page: int | None = None,
+        max_per_page: int | None = None,
+    ) -> int:
+        requested_per_page = request.GET.get("per_page")
+        if requested_per_page is not None:
+            try:
+                if int(requested_per_page) > SUGGESTIONS_PER_PAGE:
+                    return SUGGESTIONS_PER_PAGE
+            except ValueError:
+                pass
+        return super().get_per_page(
+            request,
+            default_per_page=SUGGESTIONS_PER_PAGE,
+            max_per_page=SUGGESTIONS_PER_PAGE,
+        )
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has(
+            "organizations:seer-autofix-quick-add",
+            organization,
+            actor=request.user,
+        ):
+            raise NotFound
+
+        accessible_projects = self.get_projects(request, organization, include_all_accessible=True)
+        supported_providers = get_supported_scm_providers(organization)
+        eligible_repository_filter = Q(
+            **_eligible_repository_filters(
+                relationship_prefix="projectrepository__",
+                organization_id=organization.id,
+                supported_providers=supported_providers,
+            )
+        )
+
+        queryset = (
+            Project.objects.filter(id__in={project.id for project in accessible_projects})
+            .annotate(
+                linked_repos_count=Count(
+                    "projectrepository",
+                    filter=eligible_repository_filter,
+                    distinct=True,
+                ),
+                seer_repos_count=Count(
+                    "projectrepository__seerprojectrepository",
+                    filter=Q(projectrepository__repository__status=ObjectStatus.ACTIVE),
+                    distinct=True,
+                ),
+            )
+            .filter(linked_repos_count__gt=0, seer_repos_count=0)
+            .order_by("slug")
+        )
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="slug",
+            on_results=partial(
+                _serialize_suggestions,
+                organization_id=organization.id,
+                supported_providers=supported_providers,
+            ),
+            paginator_cls=OffsetPaginator,
+            default_per_page=SUGGESTIONS_PER_PAGE,
+            max_per_page=SUGGESTIONS_PER_PAGE,
+        )

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -370,6 +370,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/seer/explorer-pr-groups/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-update/$runId/'
   | '/organizations/$organizationIdOrSlug/seer/onboarding-check/'
+  | '/organizations/$organizationIdOrSlug/seer/project-suggestions/'
   | '/organizations/$organizationIdOrSlug/seer/projects/'
   | '/organizations/$organizationIdOrSlug/seer/runs/'
   | '/organizations/$organizationIdOrSlug/seer/setup-check/'

--- a/tests/sentry/seer/endpoints/test_organization_seer_project_suggestions.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_project_suggestions.py
@@ -33,7 +33,7 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
         project: Project | None = None,
         source: ProjectRepositorySource = ProjectRepositorySource.MANUAL,
         provider: str | None = GITHUB_PROVIDER,
-        status: ObjectStatus = ObjectStatus.ACTIVE,
+        status: int = ObjectStatus.ACTIVE,
         repository_organization_id: int | None = None,
         name: str | None = None,
     ) -> tuple[Repository, ProjectRepository]:

--- a/tests/sentry/seer/endpoints/test_organization_seer_project_suggestions.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_project_suggestions.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.repository import Repository
+from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import parse_link_header
+
+QUICK_ADD_FEATURE = "organizations:seer-autofix-quick-add"
+GITLAB_FEATURE = "organizations:seer-gitlab-support"
+GITHUB_PROVIDER = "integrations:github"
+
+
+class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.url = reverse(
+            "sentry-api-0-organization-seer-project-suggestions",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        self.repository_index = 0
+
+    def create_project_repository(
+        self,
+        *,
+        project: Project | None = None,
+        source: ProjectRepositorySource = ProjectRepositorySource.MANUAL,
+        provider: str | None = GITHUB_PROVIDER,
+        status: ObjectStatus = ObjectStatus.ACTIVE,
+        repository_organization_id: int | None = None,
+        name: str | None = None,
+    ) -> tuple[Repository, ProjectRepository]:
+        project = project or self.project
+        self.repository_index += 1
+        repository = Repository.objects.create(
+            organization_id=repository_organization_id or project.organization_id,
+            name=name or f"owner/repository-{self.repository_index}",
+            provider=provider,
+            status=status,
+        )
+        project_repository = ProjectRepository.objects.create(
+            project=project,
+            repository=repository,
+            source=source,
+        )
+        return repository, project_repository
+
+    def get_suggestions(self, query: dict[str, str] | None = None):
+        with self.feature(QUICK_ADD_FEATURE):
+            return self.client.get(self.url, query or {})
+
+    def test_feature_disabled_returns_404(self) -> None:
+        self.create_project_repository()
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == 404
+
+    def test_manual_and_scm_onboarding_links_are_eligible(self) -> None:
+        manual_project = self.create_project(organization=self.organization, slug="manual-project")
+        onboarding_project = self.create_project(
+            organization=self.organization, slug="onboarding-project"
+        )
+        self.create_project_repository(
+            project=manual_project, source=ProjectRepositorySource.MANUAL
+        )
+        self.create_project_repository(
+            project=onboarding_project, source=ProjectRepositorySource.SCM_ONBOARDING
+        )
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert {suggestion["projectSlug"] for suggestion in response.data} == {
+            "manual-project",
+            "onboarding-project",
+        }
+
+    def test_automatic_and_seer_preference_links_are_not_eligible(self) -> None:
+        sources = (
+            ProjectRepositorySource.AUTO_NAME_MATCH,
+            ProjectRepositorySource.AUTO_EVENT,
+            ProjectRepositorySource.SEER_PREFERENCE,
+        )
+        for index, source in enumerate(sources):
+            project = self.create_project(
+                organization=self.organization, slug=f"ineligible-project-{index}"
+            )
+            self.create_project_repository(project=project, source=source)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_repository_from_another_organization_is_not_eligible(self) -> None:
+        other_organization = self.create_organization()
+        self.create_project_repository(repository_organization_id=other_organization.id)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_inactive_repository_is_not_eligible(self) -> None:
+        self.create_project_repository(status=ObjectStatus.DISABLED)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_github_and_github_enterprise_repositories_are_eligible(self) -> None:
+        providers = ("integrations:github", "integrations:github_enterprise")
+        projects = []
+        for index, provider in enumerate(providers):
+            project = self.create_project(
+                organization=self.organization, slug=f"supported-provider-{index}"
+            )
+            self.create_project_repository(project=project, provider=provider)
+            projects.append(project)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert {suggestion["projectId"] for suggestion in response.data} == {
+            str(project.id) for project in projects
+        }
+
+    def test_gitlab_requires_support_feature(self) -> None:
+        self.create_project_repository(provider="integrations:gitlab")
+
+        response = self.get_suggestions()
+        assert response.status_code == 200
+        assert response.data == []
+
+        with self.feature([QUICK_ADD_FEATURE, GITLAB_FEATURE]):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert [suggestion["projectId"] for suggestion in response.data] == [str(self.project.id)]
+
+    def test_unsupported_provider_is_not_eligible(self) -> None:
+        self.create_project_repository(provider="integrations:bitbucket")
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_project_with_active_seer_repository_is_not_returned(self) -> None:
+        _, project_repository = self.create_project_repository()
+        SeerProjectRepository.objects.create(project_repository=project_repository)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_active_seer_preference_link_excludes_project_with_eligible_link(self) -> None:
+        self.create_project_repository(source=ProjectRepositorySource.MANUAL)
+        _, preference_link = self.create_project_repository(
+            source=ProjectRepositorySource.SEER_PREFERENCE
+        )
+        SeerProjectRepository.objects.create(project_repository=preference_link)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_inactive_seer_link_does_not_exclude_project(self) -> None:
+        self.create_project_repository(source=ProjectRepositorySource.MANUAL)
+        _, inactive_preference_link = self.create_project_repository(
+            source=ProjectRepositorySource.SEER_PREFERENCE,
+            status=ObjectStatus.DISABLED,
+        )
+        SeerProjectRepository.objects.create(project_repository=inactive_preference_link)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert [suggestion["projectId"] for suggestion in response.data] == [str(self.project.id)]
+
+    def test_project_without_eligible_repository_is_not_returned(self) -> None:
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_response_contains_repository_metadata_in_stable_order(self) -> None:
+        first_repository, _ = self.create_project_repository(name="owner/z-repository")
+        second_repository, _ = self.create_project_repository(name="owner/a-repository")
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == [
+            {
+                "projectId": str(self.project.id),
+                "projectSlug": self.project.slug,
+                "linkedReposCount": 2,
+                "linkedRepositories": [
+                    {
+                        "repositoryId": str(first_repository.id),
+                        "name": first_repository.name,
+                        "provider": GITHUB_PROVIDER,
+                    },
+                    {
+                        "repositoryId": str(second_repository.id),
+                        "name": second_repository.name,
+                        "provider": GITHUB_PROVIDER,
+                    },
+                ],
+            }
+        ]
+
+    def test_repository_list_is_capped_but_count_is_not(self) -> None:
+        repositories = [self.create_project_repository()[0] for _ in range(12)]
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        suggestion = response.data[0]
+        assert suggestion["linkedReposCount"] == 12
+        assert [repository["repositoryId"] for repository in suggestion["linkedRepositories"]] == [
+            str(repository.id) for repository in repositories[:10]
+        ]
+
+    def test_pagination_caps_page_size_and_returns_link_headers(self) -> None:
+        projects = []
+        for index in range(12):
+            project = self.create_project(
+                organization=self.organization, slug=f"candidate-{index:02d}"
+            )
+            self.create_project_repository(project=project)
+            projects.append(project)
+
+        response = self.get_suggestions({"per_page": "100"})
+
+        assert response.status_code == 200
+        assert [suggestion["projectSlug"] for suggestion in response.data] == [
+            project.slug for project in projects[:10]
+        ]
+        links = parse_link_header(response.headers["Link"])
+        next_url, next_link = next(
+            (url, link) for url, link in links.items() if link["rel"] == "next"
+        )
+        assert next_link["results"] == "true"
+
+        with self.feature(QUICK_ADD_FEATURE):
+            next_response = self.client.get(next_url)
+
+        assert next_response.status_code == 200
+        assert [suggestion["projectSlug"] for suggestion in next_response.data] == [
+            project.slug for project in projects[10:]
+        ]
+
+    def test_only_returns_projects_the_user_can_access(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+        accessible_team = self.create_team(organization=self.organization)
+        inaccessible_team = self.create_team(organization=self.organization)
+        accessible_project = self.create_project(
+            organization=self.organization,
+            teams=[accessible_team],
+            slug="accessible-project",
+        )
+        inaccessible_project = self.create_project(
+            organization=self.organization,
+            teams=[inaccessible_team],
+            slug="inaccessible-project",
+        )
+        self.create_project_repository(project=accessible_project)
+        self.create_project_repository(project=inaccessible_project)
+        restricted_user = self.create_user(is_superuser=False)
+        self.create_member(
+            organization=self.organization,
+            user=restricted_user,
+            role="member",
+            teams=[accessible_team],
+        )
+        self.login_as(restricted_user)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert [suggestion["projectSlug"] for suggestion in response.data] == [
+            accessible_project.slug
+        ]
+
+    def test_query_count_does_not_increase_per_project(self) -> None:
+        self.create_project_repository()
+
+        with self.feature(QUICK_ADD_FEATURE):
+            self.client.get(self.url)
+            with CaptureQueriesContext(connection) as single_project_queries:
+                single_project_response = self.client.get(self.url)
+
+            for index in range(4):
+                project = self.create_project(
+                    organization=self.organization, slug=f"query-count-project-{index}"
+                )
+                self.create_project_repository(project=project)
+
+            with CaptureQueriesContext(connection) as multiple_project_queries:
+                multiple_project_response = self.client.get(self.url)
+
+        assert single_project_response.status_code == 200
+        assert multiple_project_response.status_code == 200
+        assert len(multiple_project_queries) == len(single_project_queries)
+
+    def test_multiple_links_and_active_seer_link_do_not_multiply_counts(self) -> None:
+        _, first_link = self.create_project_repository()
+        self.create_project_repository()
+        SeerProjectRepository.objects.create(project_repository=first_link)
+
+        response = self.get_suggestions()
+
+        assert response.status_code == 200
+        assert response.data == []

--- a/tests/sentry/seer/endpoints/test_organization_seer_project_suggestions.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_project_suggestions.py
@@ -8,7 +8,6 @@ from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
 from sentry.models.repository import Repository
-from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import parse_link_header
 
@@ -156,8 +155,8 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
         assert response.data == []
 
     def test_project_with_active_seer_repository_is_not_returned(self) -> None:
-        _, project_repository = self.create_project_repository()
-        SeerProjectRepository.objects.create(project_repository=project_repository)
+        repository, _ = self.create_project_repository()
+        self.create_seer_project_repository(repository=repository)
 
         response = self.get_suggestions()
 
@@ -166,10 +165,10 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
 
     def test_active_seer_preference_link_excludes_project_with_eligible_link(self) -> None:
         self.create_project_repository(source=ProjectRepositorySource.MANUAL)
-        _, preference_link = self.create_project_repository(
+        preference_repository, _ = self.create_project_repository(
             source=ProjectRepositorySource.SEER_PREFERENCE
         )
-        SeerProjectRepository.objects.create(project_repository=preference_link)
+        self.create_seer_project_repository(repository=preference_repository)
 
         response = self.get_suggestions()
 
@@ -178,11 +177,11 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
 
     def test_inactive_seer_link_does_not_exclude_project(self) -> None:
         self.create_project_repository(source=ProjectRepositorySource.MANUAL)
-        _, inactive_preference_link = self.create_project_repository(
+        inactive_preference_repository, _ = self.create_project_repository(
             source=ProjectRepositorySource.SEER_PREFERENCE,
             status=ObjectStatus.DISABLED,
         )
-        SeerProjectRepository.objects.create(project_repository=inactive_preference_link)
+        self.create_seer_project_repository(repository=inactive_preference_repository)
 
         response = self.get_suggestions()
 
@@ -234,7 +233,7 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
             str(repository.id) for repository in repositories[:10]
         ]
 
-    def test_pagination_caps_page_size_and_returns_link_headers(self) -> None:
+    def test_paginates_suggestions_ten_at_a_time(self) -> None:
         projects = []
         for index in range(12):
             project = self.create_project(
@@ -243,7 +242,7 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
             self.create_project_repository(project=project)
             projects.append(project)
 
-        response = self.get_suggestions({"per_page": "100"})
+        response = self.get_suggestions()
 
         assert response.status_code == 200
         assert [suggestion["projectSlug"] for suggestion in response.data] == [
@@ -316,13 +315,3 @@ class OrganizationSeerProjectSuggestionsEndpointTest(APITestCase):
         assert single_project_response.status_code == 200
         assert multiple_project_response.status_code == 200
         assert len(multiple_project_queries) == len(single_project_queries)
-
-    def test_multiple_links_and_active_seer_link_do_not_multiply_counts(self) -> None:
-        _, first_link = self.create_project_repository()
-        self.create_project_repository()
-        SeerProjectRepository.objects.create(project_repository=first_link)
-
-        response = self.get_suggestions()
-
-        assert response.status_code == 200
-        assert response.data == []


### PR DESCRIPTION
## TLDR

Adds a feature-gated organization endpoint that returns up to 10 accessible Autofix project suggestions per page, with at most 10 trusted repository records per project.

## Details

This stays separate from `/seer/projects/` so flag-off organizations do not pay extra repository-query cost and the configured-project response remains unchanged. `OrganizationSeerProjectSuggestionsEndpoint` accepts only active, same-organization repositories from supported SCM providers and trusted manual or SCM onboarding sources. It excludes projects with any active Seer repository and returns the full eligible repository count so the frontend can require configuration when more than 10 links exist.

Repository metadata is fetched once per page with a windowed cap.