### PR TITLE
fix(scraps): Normalize completed OTP values

### DIFF
--- a/static/app/components/core/input/otpInput.tsx
+++ b/static/app/components/core/input/otpInput.tsx
@@ -32,6 +32,7 @@ export function OTPInput({
   transform,
 }: OTPInputProps) {
   const [value, setValue] = useState('');
+  const transformValue = (newValue: string) => transform?.(newValue) ?? newValue;
 
   return (
     <OTPInputPrimitive
@@ -40,8 +41,8 @@ export function OTPInput({
       disabled={disabled}
       inputMode={characterSet === 'numeric' ? 'numeric' : 'text'}
       maxLength={length}
-      onChange={newValue => setValue(transform?.(newValue) ?? newValue)}
-      onComplete={onComplete}
+      onChange={newValue => setValue(transformValue(newValue))}
+      onComplete={(newValue: string) => onComplete(transformValue(newValue))}
       pattern={
         characterSet === 'numeric' ? REGEXP_ONLY_DIGITS : REGEXP_ONLY_DIGITS_AND_CHARS
       }
@@ -70,6 +71,7 @@ export function OTPInput({
 
 const OTPInputSlot = styled(Flex)<{$isActive: boolean; $size: FormSize}>`
   ${p => inputStyles({theme: p.theme, size: p.$size})};
+  display: flex;
   min-width: ${p => p.theme.form[p.$size].height};
   padding: 0;
   width: ${p => p.theme.form[p.$size].height};


### PR DESCRIPTION
Follow up on #122211 by applying OTP transforms consistently when completion fires and preserving flex centering after shared input styles are applied.