### PR TITLE
feat(seer): Add Autofix quick-add suggestions

### DIFF
--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -467,10 +467,7 @@ describe('SeerProjectTable', () => {
       );
     });
 
-    it.each([
-      ['a non-GitHub provider', 'integrations:gitlab'],
-      ['a missing provider', ''],
-    ])('forces the Seer agent for %s', async (_label, provider) => {
+    it('forces the Seer agent for a non-GitHub provider', async () => {
       setupSuggestionTable({
         organizationOverrides: {defaultCodingAgentIntegrationId: 123},
         suggestions: [
@@ -479,7 +476,7 @@ describe('SeerProjectTable', () => {
               {
                 repositoryId: '11',
                 name: 'getsentry/suggested-repository',
-                provider,
+                provider: 'integrations:gitlab',
               },
             ],
           }),
@@ -516,33 +513,23 @@ describe('SeerProjectTable', () => {
       expect(await screen.findByRole('button', {name: 'Enable Autofix'})).toBeDisabled();
     });
 
-    it('opens Configure when the stopping point default is missing', async () => {
-      setupSuggestionTable({
-        organizationOverrides: {defaultAutomatedRunStoppingPoint: undefined},
-      });
-      const repositoriesPut = MockApiClient.addMockResponse({
-        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
-        method: 'PUT',
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/repos/`,
-        body: [],
-      });
-
-      renderTable();
-
-      await userEvent.click(await screen.findByRole('button', {name: 'Configure'}));
-
-      await waitFor(() => expect(mockOpenModal).toHaveBeenCalledTimes(1));
-      const modalElement = mockOpenModal.mock.calls[0]![0]({});
-      expect(modalElement.props.defaultProject).toBe(suggestedProject);
-      expect(repositoriesPut).not.toHaveBeenCalled();
-    });
-
-    it('opens Configure when the full repository count is greater than 10', async () => {
-      setupSuggestionTable({
-        suggestions: [makeSuggestion({linkedReposCount: 11})],
-      });
+    it.each<[string, () => void]>([
+      [
+        'the stopping point default is missing',
+        () =>
+          setupSuggestionTable({
+            organizationOverrides: {defaultAutomatedRunStoppingPoint: undefined},
+          }),
+      ],
+      [
+        'the full repository count is greater than 10',
+        () =>
+          setupSuggestionTable({
+            suggestions: [makeSuggestion({linkedReposCount: 11})],
+          }),
+      ],
+    ])('opens Configure when %s', async (_label, setup) => {
+      setup();
       const repositoriesPut = MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
         method: 'PUT',
@@ -597,10 +584,11 @@ describe('SeerProjectTable', () => {
       expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
     });
 
-    it('keeps a retry warning after a partial save and clears it after retry', async () => {
+    it('keeps a retry warning across filtering and clears it after retry', async () => {
       let repositoriesSaved = false;
       let settingsAttempts = 0;
       setupSuggestionTable({
+        projectSettings: [],
         suggestions: () => (repositoriesSaved ? [] : [makeSuggestion()]),
       });
       const repositoriesPut = MockApiClient.addMockResponse({
@@ -635,6 +623,14 @@ describe('SeerProjectTable', () => {
       await waitFor(() =>
         expect(screen.queryByText('Suggested Project')).not.toBeInTheDocument()
       );
+
+      await userEvent.click(await screen.findByText('All'));
+      await userEvent.click(await screen.findByRole('option', {name: 'Seer'}));
+      expect(
+        screen.getByText(
+          'Repositories were saved, but Autofix settings were not. Retry settings to finish setup.'
+        )
+      ).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', {name: 'Retry settings'}));
 

--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -5,8 +5,17 @@ import {SentryNuqsTestingAdapter} from 'sentry-test/nuqsTestingAdapter';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
+import {AutofixStoppingPoint} from 'sentry/components/events/autofix/types';
 import {SeerProjectTable} from 'sentry/components/seer/projectTable/seerProjectTable';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Organization} from 'sentry/types/organization';
+
+const mockOpenModal = jest.fn();
+
+jest.mock('@sentry/scraps/modal', () => ({
+  ...jest.requireActual('@sentry/scraps/modal'),
+  useModal: () => ({openModal: mockOpenModal}),
+}));
 
 // jsdom has no layout, so the virtualizer would render zero rows. Force it to
 // render a row per item so the table body is present.
@@ -29,31 +38,82 @@ jest.mock('@tanstack/react-virtual', () => ({
 }));
 
 describe('SeerProjectTable', () => {
-  const organization = OrganizationFixture({access: ['org:write']});
-  const project = ProjectFixture({id: '2', slug: 'project-slug'});
+  let organization = OrganizationFixture();
+  let project = ProjectFixture();
+  let suggestedProject = ProjectFixture();
 
-  function mockBaseEndpoints() {
+  function makeProjectSettings(overrides: Record<string, unknown> = {}) {
+    return {
+      projectId: project.id,
+      projectSlug: project.slug,
+      agent: 'seer',
+      integrationId: null,
+      stoppingPoint: 'root_cause',
+      autoCreatePr: null,
+      automationTuning: 'off',
+      scannerAutomation: false,
+      reposCount: 1,
+      ...overrides,
+    };
+  }
+
+  function makeSuggestion(overrides: Record<string, unknown> = {}) {
+    return {
+      projectId: suggestedProject.id,
+      projectSlug: suggestedProject.slug,
+      linkedReposCount: 1,
+      linkedRepositories: [
+        {
+          repositoryId: '11',
+          name: 'getsentry/suggested-repository',
+          provider: 'integrations:github',
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  function mockBaseEndpoints({
+    projectSettings = [makeProjectSettings()],
+    codingAgents,
+    codingAgentsDelay,
+  }: {
+    codingAgents?: () => unknown;
+    codingAgentsDelay?: number;
+    projectSettings?: unknown[];
+  } = {}) {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/coding-agents/`,
-      body: {
-        integrations: [{id: '123', provider: 'cursor', name: 'Cursor Cloud Agent'}],
-      },
+      body:
+        codingAgents ??
+        (() => ({
+          integrations: [{id: '123', provider: 'cursor', name: 'Cursor Cloud Agent'}],
+        })),
+      ...(codingAgentsDelay ? {asyncDelay: codingAgentsDelay} : {}),
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/projects/`,
-      body: [
-        {
-          projectId: '2',
-          projectSlug: 'project-slug',
-          agent: 'seer',
-          integrationId: null,
-          stoppingPoint: 'root_cause',
-          autoCreatePr: null,
-          automationTuning: 'off',
-          scannerAutomation: false,
-          reposCount: 1,
-        },
-      ],
+      body: projectSettings,
+    });
+  }
+
+  function mockSuggestions({
+    body = [makeSuggestion()],
+    headers,
+    match,
+    statusCode,
+  }: {
+    body?: unknown[] | (() => unknown[]);
+    headers?: Record<string, string>;
+    match?: Array<(url: string, options: Record<string, unknown>) => boolean>;
+    statusCode?: number;
+  } = {}) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/project-suggestions/`,
+      body,
+      ...(headers ? {headers} : {}),
+      ...(match ? {match} : {}),
+      ...(statusCode ? {statusCode} : {}),
     });
   }
 
@@ -81,23 +141,70 @@ describe('SeerProjectTable', () => {
   }
 
   beforeEach(() => {
-    ProjectsStore.loadInitialData([project]);
+    organization = OrganizationFixture({access: ['org:write']});
+    project = ProjectFixture({id: '2', slug: 'project-slug'});
+    suggestedProject = ProjectFixture({
+      id: '3',
+      slug: 'suggested-project',
+      name: 'Suggested Project',
+    });
+    ProjectsStore.loadInitialData([project, suggestedProject]);
     mockBaseEndpoints();
   });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
     ProjectsStore.reset();
+    mockOpenModal.mockReset();
     jest.restoreAllMocks();
   });
 
-  function renderTable() {
+  function renderTable(search = '') {
+    const query = Object.fromEntries(new URLSearchParams(search));
     render(
       <SentryNuqsTestingAdapter>
         <SeerProjectTable />
       </SentryNuqsTestingAdapter>,
-      {organization}
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/settings/${organization.slug}/seer/projects/`,
+            query,
+          },
+        },
+      }
     );
+  }
+
+  function setupSuggestionTable({
+    organizationOverrides,
+    projectSettings = [makeProjectSettings()],
+    suggestions = [makeSuggestion()],
+    codingAgents,
+    codingAgentsDelay,
+    statusCode,
+  }: {
+    codingAgents?: () => unknown;
+    codingAgentsDelay?: number;
+    organizationOverrides?: Partial<Organization>;
+    projectSettings?: unknown[];
+    statusCode?: number;
+    suggestions?: null | unknown[] | (() => unknown[]);
+  } = {}) {
+    organization = OrganizationFixture({
+      access: ['org:write'],
+      features: ['seer-autofix-quick-add'],
+      defaultAutomatedRunStoppingPoint: AutofixStoppingPoint.ROOT_CAUSE,
+      ...organizationOverrides,
+    });
+    MockApiClient.clearMockResponses();
+    ProjectsStore.reset();
+    ProjectsStore.loadInitialData([project, suggestedProject]);
+    mockBaseEndpoints({projectSettings, codingAgents, codingAgentsDelay});
+    return suggestions === null
+      ? undefined
+      : mockSuggestions({body: suggestions, statusCode});
   }
 
   it('blocks coding-agent handoff and warns for a project with a non-GitHub repo', async () => {
@@ -187,5 +294,399 @@ describe('SeerProjectTable', () => {
     // The check passes, so the selection is persisted and no warning is shown.
     await waitFor(() => expect(settingsPut).toHaveBeenCalled());
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  describe('suggested projects', () => {
+    const disabledSuggestionCases: Array<[string, Partial<Organization>]> = [
+      ['the feature is disabled', {features: []}],
+      ['the user cannot write settings', {access: ['org:read']}],
+    ];
+
+    it.each(disabledSuggestionCases)(
+      'does not request suggestions when %s',
+      async (_label, organizationOverrides) => {
+        const suggestionsRequest = setupSuggestionTable({
+          organizationOverrides,
+          projectSettings: [],
+        });
+
+        renderTable();
+
+        expect(
+          await screen.findByRole('heading', {name: 'Enable Autofix on a Project'})
+        ).toBeInTheDocument();
+        expect(suggestionsRequest).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(['?name=project', '?agent=seer'])(
+      'does not request or show suggestions with active filters: %s',
+      async search => {
+        const suggestionsRequest = setupSuggestionTable();
+
+        renderTable(search);
+
+        await screen.findByText(project.slug);
+        expect(suggestionsRequest).not.toHaveBeenCalled();
+        expect(
+          screen.queryByRole('heading', {name: 'Suggested Projects'})
+        ).not.toBeInTheDocument();
+      }
+    );
+
+    it('renders candidate metadata without requesting all organization repositories', async () => {
+      setupSuggestionTable();
+      const allRepositoriesRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/`,
+        body: [],
+      });
+
+      renderTable();
+
+      expect(
+        await screen.findByRole('heading', {name: 'Suggested Projects'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('getsentry/suggested-repository')
+      ).toBeInTheDocument();
+      expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
+      expect(screen.getByText('1 linked repository')).toBeInTheDocument();
+      expect(screen.getByText('Agent: Seer')).toBeInTheDocument();
+      expect(
+        screen.getByText('Stopping point: Stop after Root Cause')
+      ).toBeInTheDocument();
+      expect(allRepositoriesRequest).not.toHaveBeenCalled();
+    });
+
+    it('loads the next suggestion page only after Show more is selected', async () => {
+      const secondSuggestedProject = ProjectFixture({
+        id: '4',
+        slug: 'second-suggested-project',
+        name: 'Second Suggested Project',
+      });
+      setupSuggestionTable({suggestions: null});
+      ProjectsStore.loadInitialData([project, suggestedProject, secondSuggestedProject]);
+      const suggestionsUrl = `/organizations/${organization.slug}/seer/project-suggestions/`;
+      const firstPageRequest = MockApiClient.addMockResponse({
+        url: suggestionsUrl,
+        body: [makeSuggestion()],
+        headers: {
+          Link: `<${suggestionsUrl}?cursor=0:10:0>; rel="next"; results="true"; cursor="0:10:0"`,
+        },
+      });
+      const secondPageRequest = MockApiClient.addMockResponse({
+        url: suggestionsUrl,
+        body: [
+          makeSuggestion({
+            projectId: secondSuggestedProject.id,
+            projectSlug: secondSuggestedProject.slug,
+            linkedRepositories: [
+              {
+                repositoryId: '12',
+                name: 'getsentry/second-repository',
+                provider: 'integrations:github',
+              },
+            ],
+          }),
+        ],
+        headers: {
+          Link: `<${suggestionsUrl}?cursor=0:20:0>; rel="next"; results="false"; cursor="0:20:0"`,
+        },
+        match: [MockApiClient.matchQuery({cursor: '0:10:0'})],
+      });
+
+      renderTable();
+
+      expect(
+        await screen.findByText('getsentry/suggested-repository')
+      ).toBeInTheDocument();
+      expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
+      expect(secondPageRequest).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Show more'}));
+
+      expect(await screen.findByText('getsentry/second-repository')).toBeInTheDocument();
+      expect(screen.getByText(secondSuggestedProject.slug)).toBeInTheDocument();
+      expect(firstPageRequest).toHaveBeenCalledTimes(1);
+      expect(secondPageRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the resolved project, agent, and stopping point and refreshes both lists', async () => {
+      let repositoriesSaved = false;
+      setupSuggestionTable({
+        organizationOverrides: {defaultCodingAgentIntegrationId: 123},
+        suggestions: () => (repositoriesSaved ? [] : [makeSuggestion()]),
+      });
+      const repositoriesPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+        body: () => {
+          repositoriesSaved = true;
+          return {};
+        },
+      });
+      const settingsPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        method: 'PUT',
+        body: {},
+      });
+      const projectUpdate = jest.spyOn(ProjectsStore, 'onUpdateSuccess');
+
+      renderTable();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Enable Autofix'}));
+
+      await waitFor(() => expect(settingsPut).toHaveBeenCalled());
+      expect(repositoriesPut).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {repos: [{repositoryId: 11, branchName: null}]},
+        })
+      );
+      expect(settingsPut).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        expect.objectContaining({
+          method: 'PUT',
+          data: expect.objectContaining({
+            agent: 'cursor_background_agent',
+            integrationId: '123',
+            automationTuning: 'medium',
+            stoppingPoint: 'root_cause',
+          }),
+        })
+      );
+      expect(repositoriesPut.mock.invocationCallOrder[0]).toBeLessThan(
+        settingsPut.mock.invocationCallOrder[0]!
+      );
+      expect(projectUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({id: suggestedProject.id, slug: suggestedProject.slug})
+      );
+      await waitFor(() =>
+        expect(screen.queryByText(suggestedProject.slug)).not.toBeInTheDocument()
+      );
+    });
+
+    it.each([
+      ['a non-GitHub provider', 'integrations:gitlab'],
+      ['a missing provider', ''],
+    ])('forces the Seer agent for %s', async (_label, provider) => {
+      setupSuggestionTable({
+        organizationOverrides: {defaultCodingAgentIntegrationId: 123},
+        suggestions: [
+          makeSuggestion({
+            linkedRepositories: [
+              {
+                repositoryId: '11',
+                name: 'getsentry/suggested-repository',
+                provider,
+              },
+            ],
+          }),
+        ],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+        body: {},
+      });
+      const settingsPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        method: 'PUT',
+        body: {},
+      });
+
+      renderTable();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Enable Autofix'}));
+
+      await waitFor(() => expect(settingsPut).toHaveBeenCalled());
+      const settingsPayload = settingsPut.mock.calls[0]![1].data;
+      expect(settingsPayload.agent).toBe('seer');
+      expect(settingsPayload).not.toHaveProperty('integrationId');
+    });
+
+    it('disables Enable Autofix while the default agent is pending', async () => {
+      setupSuggestionTable({
+        codingAgentsDelay: 10_000,
+      });
+
+      renderTable();
+
+      expect(await screen.findByRole('button', {name: 'Enable Autofix'})).toBeDisabled();
+    });
+
+    it('opens Configure when the stopping point default is missing', async () => {
+      setupSuggestionTable({
+        organizationOverrides: {defaultAutomatedRunStoppingPoint: undefined},
+      });
+      const repositoriesPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/`,
+        body: [],
+      });
+
+      renderTable();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Configure'}));
+
+      await waitFor(() => expect(mockOpenModal).toHaveBeenCalledTimes(1));
+      const modalElement = mockOpenModal.mock.calls[0]![0]({});
+      expect(modalElement.props.defaultProject).toBe(suggestedProject);
+      expect(repositoriesPut).not.toHaveBeenCalled();
+    });
+
+    it('opens Configure when the full repository count is greater than 10', async () => {
+      setupSuggestionTable({
+        suggestions: [makeSuggestion({linkedReposCount: 11})],
+      });
+      const repositoriesPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/`,
+        body: [],
+      });
+
+      renderTable();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Configure'}));
+
+      await waitFor(() => expect(mockOpenModal).toHaveBeenCalledTimes(1));
+      const modalElement = mockOpenModal.mock.calls[0]![0]({});
+      expect(modalElement.props.defaultProject).toBe(suggestedProject);
+      expect(repositoriesPut).not.toHaveBeenCalled();
+    });
+
+    it('disables the action when the full project object is unavailable', async () => {
+      setupSuggestionTable();
+      ProjectsStore.loadInitialData([project]);
+
+      renderTable();
+
+      expect(await screen.findByRole('button', {name: 'Unavailable'})).toBeDisabled();
+    });
+
+    it('keeps the suggestion visible when the repository write fails', async () => {
+      setupSuggestionTable();
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+        body: () => {
+          throw new Error('repository write failed');
+        },
+      });
+      const settingsPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        method: 'PUT',
+      });
+      const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
+
+      renderTable();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Enable Autofix'}));
+
+      await waitFor(() =>
+        expect(errorSpy).toHaveBeenCalledWith('Could not enable Autofix. Try again.')
+      );
+      expect(settingsPut).not.toHaveBeenCalled();
+      expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
+    });
+
+    it('keeps a retry warning after a partial save and clears it after retry', async () => {
+      let repositoriesSaved = false;
+      let settingsAttempts = 0;
+      setupSuggestionTable({
+        suggestions: () => (repositoriesSaved ? [] : [makeSuggestion()]),
+      });
+      const repositoriesPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+        body: () => {
+          repositoriesSaved = true;
+          return {};
+        },
+      });
+      const settingsPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        method: 'PUT',
+        body: () => {
+          settingsAttempts += 1;
+          if (settingsAttempts === 1) {
+            throw new Error('settings write failed');
+          }
+          return {};
+        },
+      });
+
+      renderTable();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Enable Autofix'}));
+
+      expect(
+        await screen.findByText(
+          'Repositories were saved, but Autofix settings were not. Retry settings to finish setup.'
+        )
+      ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.queryByText('Suggested Project')).not.toBeInTheDocument()
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Retry settings'}));
+
+      await waitFor(() =>
+        expect(
+          screen.queryByText(
+            'Repositories were saved, but Autofix settings were not. Retry settings to finish setup.'
+          )
+        ).not.toBeInTheDocument()
+      );
+      expect(repositoriesPut).toHaveBeenCalledTimes(2);
+      expect(settingsPut).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the standard table layout when only suggestions exist', async () => {
+      setupSuggestionTable({projectSettings: []});
+
+      renderTable();
+
+      expect(
+        await screen.findByRole('heading', {name: 'Suggested Projects'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', {name: 'Enable Autofix on a Project'})
+      ).not.toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+      expect(await screen.findByText('All')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Add Project'})).toBeInTheDocument();
+      expect(await screen.findByText('No projects found')).toBeInTheDocument();
+    });
+
+    it('shows the large empty state when both configured projects and suggestions are empty', async () => {
+      setupSuggestionTable({projectSettings: [], suggestions: []});
+
+      renderTable();
+
+      expect(
+        await screen.findByRole('heading', {name: 'Enable Autofix on a Project'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', {name: 'Suggested Projects'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('keeps the configured table usable when the suggestion query fails', async () => {
+      setupSuggestionTable({statusCode: 500});
+
+      renderTable();
+
+      expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
+      expect(screen.getByText(project.slug)).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Add Project'})).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -2,7 +2,13 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {SentryNuqsTestingAdapter} from 'sentry-test/nuqsTestingAdapter';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import {AutofixStoppingPoint} from 'sentry/components/events/autofix/types';
@@ -328,9 +334,7 @@ describe('SeerProjectTable', () => {
 
         await screen.findByText(project.slug);
         expect(suggestionsRequest).not.toHaveBeenCalled();
-        expect(
-          screen.queryByRole('heading', {name: 'Suggested Projects'})
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
       }
     );
 
@@ -343,17 +347,20 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
+      expect(await screen.findByText('Suggested')).toBeInTheDocument();
+      const suggestionRow = (
+        await screen.findByText(suggestedProject.slug)
+      ).closest<HTMLElement>('[role="row"]')!;
+      // The effective agent and stopping point defaults, as plain text.
+      expect(await within(suggestionRow).findByText('Seer')).toBeInTheDocument();
       expect(
-        await screen.findByRole('heading', {name: 'Suggested Projects'})
+        within(suggestionRow).getByText('Stop after Root Cause')
       ).toBeInTheDocument();
+
+      // The repo names live in the tooltip on the linked repository count.
+      await userEvent.hover(within(suggestionRow).getByText('1'));
       expect(
         await screen.findByText('getsentry/suggested-repository')
-      ).toBeInTheDocument();
-      expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
-      expect(screen.getByText('1 linked repository')).toBeInTheDocument();
-      expect(screen.getByText('Agent: Seer')).toBeInTheDocument();
-      expect(
-        screen.getByText('Stopping point: Stop after Root Cause')
       ).toBeInTheDocument();
       expect(allRepositoriesRequest).not.toHaveBeenCalled();
     });
@@ -397,16 +404,14 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(
-        await screen.findByText('getsentry/suggested-repository')
-      ).toBeInTheDocument();
-      expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
+      expect(await screen.findByText(suggestedProject.slug)).toBeInTheDocument();
+      expect(screen.queryByText(secondSuggestedProject.slug)).not.toBeInTheDocument();
       expect(secondPageRequest).not.toHaveBeenCalled();
 
       await userEvent.click(screen.getByRole('button', {name: 'Show more'}));
 
-      expect(await screen.findByText('getsentry/second-repository')).toBeInTheDocument();
-      expect(screen.getByText(secondSuggestedProject.slug)).toBeInTheDocument();
+      expect(await screen.findByText(secondSuggestedProject.slug)).toBeInTheDocument();
+      expect(screen.getByText(suggestedProject.slug)).toBeInTheDocument();
       expect(firstPageRequest).toHaveBeenCalledTimes(1);
       expect(secondPageRequest).toHaveBeenCalledTimes(1);
     });
@@ -621,7 +626,7 @@ describe('SeerProjectTable', () => {
         )
       ).toBeInTheDocument();
       await waitFor(() =>
-        expect(screen.queryByText('Suggested Project')).not.toBeInTheDocument()
+        expect(screen.queryByText(suggestedProject.slug)).not.toBeInTheDocument()
       );
 
       await userEvent.click(await screen.findByText('All'));
@@ -650,9 +655,8 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(
-        await screen.findByRole('heading', {name: 'Suggested Projects'})
-      ).toBeInTheDocument();
+      expect(await screen.findByText('Suggested')).toBeInTheDocument();
+      expect(await screen.findByText(suggestedProject.slug)).toBeInTheDocument();
       expect(
         screen.queryByRole('heading', {name: 'Enable Autofix on a Project'})
       ).not.toBeInTheDocument();
@@ -670,9 +674,7 @@ describe('SeerProjectTable', () => {
       expect(
         await screen.findByRole('heading', {name: 'Enable Autofix on a Project'})
       ).toBeInTheDocument();
-      expect(
-        screen.queryByRole('heading', {name: 'Suggested Projects'})
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
     });
 
     it('keeps the configured table usable when the suggestion query fails', async () => {
@@ -680,7 +682,8 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
+      expect(await screen.findByText('Could not load suggestions.')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
       expect(screen.getByText(project.slug)).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Add Project'})).toBeInTheDocument();
     });

--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -18,9 +18,6 @@ import type {Organization} from 'sentry/types/organization';
 
 const mockOpenModal = jest.fn();
 
-const SUGGESTED_GROUP_TEXT =
-  'These projects have trusted repository links and are not yet configured for Autofix.';
-
 jest.mock('@sentry/scraps/modal', () => ({
   ...jest.requireActual('@sentry/scraps/modal'),
   useModal: () => ({openModal: mockOpenModal}),
@@ -337,7 +334,7 @@ describe('SeerProjectTable', () => {
 
         await screen.findByText(project.slug);
         expect(suggestionsRequest).not.toHaveBeenCalled();
-        expect(screen.queryByText(SUGGESTED_GROUP_TEXT)).not.toBeInTheDocument();
+        expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
       }
     );
 
@@ -350,10 +347,10 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(await screen.findByText(SUGGESTED_GROUP_TEXT)).toBeInTheDocument();
       const suggestionRow = (
         await screen.findByText(suggestedProject.slug)
       ).closest<HTMLElement>('[role="row"]')!;
+      expect(within(suggestionRow).getByText('Suggested')).toBeInTheDocument();
       // The row selects come preselected with the effective defaults.
       expect(await within(suggestionRow).findByText('Seer')).toBeInTheDocument();
       expect(
@@ -721,8 +718,8 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(await screen.findByText(SUGGESTED_GROUP_TEXT)).toBeInTheDocument();
       expect(await screen.findByText(suggestedProject.slug)).toBeInTheDocument();
+      expect(screen.getByText('Suggested')).toBeInTheDocument();
       expect(
         screen.queryByRole('heading', {name: 'Enable Autofix on a Project'})
       ).not.toBeInTheDocument();
@@ -740,7 +737,7 @@ describe('SeerProjectTable', () => {
       expect(
         await screen.findByRole('heading', {name: 'Enable Autofix on a Project'})
       ).toBeInTheDocument();
-      expect(screen.queryByText(SUGGESTED_GROUP_TEXT)).not.toBeInTheDocument();
+      expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
     });
 
     it('keeps the configured table usable when the suggestion query fails', async () => {

--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -18,6 +18,9 @@ import type {Organization} from 'sentry/types/organization';
 
 const mockOpenModal = jest.fn();
 
+const SUGGESTED_GROUP_TEXT =
+  'These projects have trusted repository links and are not yet configured for Autofix.';
+
 jest.mock('@sentry/scraps/modal', () => ({
   ...jest.requireActual('@sentry/scraps/modal'),
   useModal: () => ({openModal: mockOpenModal}),
@@ -334,7 +337,7 @@ describe('SeerProjectTable', () => {
 
         await screen.findByText(project.slug);
         expect(suggestionsRequest).not.toHaveBeenCalled();
-        expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
+        expect(screen.queryByText(SUGGESTED_GROUP_TEXT)).not.toBeInTheDocument();
       }
     );
 
@@ -347,11 +350,11 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(await screen.findByText('Suggested')).toBeInTheDocument();
+      expect(await screen.findByText(SUGGESTED_GROUP_TEXT)).toBeInTheDocument();
       const suggestionRow = (
         await screen.findByText(suggestedProject.slug)
       ).closest<HTMLElement>('[role="row"]')!;
-      // The effective agent and stopping point defaults, as plain text.
+      // The row selects come preselected with the effective defaults.
       expect(await within(suggestionRow).findByText('Seer')).toBeInTheDocument();
       expect(
         within(suggestionRow).getByText('Stop after Root Cause')
@@ -518,23 +521,10 @@ describe('SeerProjectTable', () => {
       expect(await screen.findByRole('button', {name: 'Enable Autofix'})).toBeDisabled();
     });
 
-    it.each<[string, () => void]>([
-      [
-        'the stopping point default is missing',
-        () =>
-          setupSuggestionTable({
-            organizationOverrides: {defaultAutomatedRunStoppingPoint: undefined},
-          }),
-      ],
-      [
-        'the full repository count is greater than 10',
-        () =>
-          setupSuggestionTable({
-            suggestions: [makeSuggestion({linkedReposCount: 11})],
-          }),
-      ],
-    ])('opens Configure when %s', async (_label, setup) => {
-      setup();
+    it('opens Configure when the full repository count is greater than 10', async () => {
+      setupSuggestionTable({
+        suggestions: [makeSuggestion({linkedReposCount: 11})],
+      });
       const repositoriesPut = MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
         method: 'PUT',
@@ -552,6 +542,82 @@ describe('SeerProjectTable', () => {
       const modalElement = mockOpenModal.mock.calls[0]![0]({});
       expect(modalElement.props.defaultProject).toBe(suggestedProject);
       expect(repositoriesPut).not.toHaveBeenCalled();
+    });
+
+    it('sends the row-selected agent and stopping point instead of the defaults', async () => {
+      setupSuggestionTable();
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+        body: {},
+      });
+      const settingsPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        method: 'PUT',
+        body: {},
+      });
+
+      renderTable();
+
+      const suggestionRow = (
+        await screen.findByText(suggestedProject.slug)
+      ).closest<HTMLElement>('[role="row"]')!;
+      await userEvent.click(await within(suggestionRow).findByText('Seer'));
+      await userEvent.click(
+        await screen.findByRole('menuitemradio', {name: 'Cursor Cloud Agent'})
+      );
+      await userEvent.click(within(suggestionRow).getByText('Stop after Root Cause'));
+      await userEvent.click(
+        await screen.findByRole('menuitemradio', {name: 'Stop after Plan'})
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Enable Autofix'}));
+
+      await waitFor(() => expect(settingsPut).toHaveBeenCalled());
+      expect(settingsPut).toHaveBeenCalledWith(
+        `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            agent: 'cursor_background_agent',
+            integrationId: '123',
+            stoppingPoint: 'code_changes',
+          }),
+        })
+      );
+    });
+
+    it('requires a stopping point choice when the org default is missing', async () => {
+      setupSuggestionTable({
+        organizationOverrides: {defaultAutomatedRunStoppingPoint: undefined},
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/repos/`,
+        method: 'PUT',
+        body: {},
+      });
+      const settingsPut = MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${suggestedProject.slug}/seer/settings/`,
+        method: 'PUT',
+        body: {},
+      });
+
+      renderTable();
+
+      const enableButton = await screen.findByRole('button', {name: 'Enable Autofix'});
+      expect(enableButton).toBeDisabled();
+
+      const suggestionRow = screen
+        .getByText(suggestedProject.slug)
+        .closest<HTMLElement>('[role="row"]')!;
+      await userEvent.click(within(suggestionRow).getByText('Select...'));
+      await userEvent.click(
+        await screen.findByRole('menuitemradio', {name: 'Stop after Root Cause'})
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Enable Autofix'}));
+
+      await waitFor(() => expect(settingsPut).toHaveBeenCalled());
+      expect(settingsPut.mock.calls[0]![1].data.stoppingPoint).toBe('root_cause');
     });
 
     it('disables the action when the full project object is unavailable', async () => {
@@ -655,7 +721,7 @@ describe('SeerProjectTable', () => {
 
       renderTable();
 
-      expect(await screen.findByText('Suggested')).toBeInTheDocument();
+      expect(await screen.findByText(SUGGESTED_GROUP_TEXT)).toBeInTheDocument();
       expect(await screen.findByText(suggestedProject.slug)).toBeInTheDocument();
       expect(
         screen.queryByRole('heading', {name: 'Enable Autofix on a Project'})
@@ -674,7 +740,7 @@ describe('SeerProjectTable', () => {
       expect(
         await screen.findByRole('heading', {name: 'Enable Autofix on a Project'})
       ).toBeInTheDocument();
-      expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
+      expect(screen.queryByText(SUGGESTED_GROUP_TEXT)).not.toBeInTheDocument();
     });
 
     it('keeps the configured table usable when the suggestion query fails', async () => {

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -16,12 +16,13 @@ import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {AutoSaveForm} from '@sentry/scraps/form';
 import {Image} from '@sentry/scraps/image';
-import {InfoText, InfoTip} from '@sentry/scraps/info';
+import {InfoText} from '@sentry/scraps/info';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Select} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -397,19 +398,13 @@ function SuggestedProjectRows({
   const {isLoadingModal, openProjectModal} = useProjectAddRepoModal();
 
   const suggestions = suggestionsEnabled ? (result.data ?? []) : [];
-  const stoppingPointLabel =
-    PROJECT_STOPPING_POINT_OPTIONS.find(option => option.value === stoppingPoint)
-      ?.label ?? t('Not configured');
 
   async function enableAutofix(
     suggestion: SeerProjectSuggestionResponse,
     project: Project,
-    agentOption: AutofixAgentSelectOption
+    agentOption: AutofixAgentSelectOption,
+    selectedStoppingPoint: UserFacingStoppingPoint
   ) {
-    if (stoppingPoint === undefined) {
-      return;
-    }
-
     const variables: AutofixProjectMutationVariables = {
       project,
       repoEntries: suggestion.linkedRepositories.map(repository => ({
@@ -417,7 +412,7 @@ function SuggestedProjectRows({
         branch: '',
       })),
       agentOption,
-      stoppingPoint,
+      stoppingPoint: selectedStoppingPoint,
     };
 
     try {
@@ -486,22 +481,11 @@ function SuggestedProjectRows({
 
       {showGroup ? (
         <Fragment>
-          <Flex
-            align="center"
-            gap="xs"
-            padding="sm xl"
-            background="secondary"
-            borderBottom="muted"
-          >
-            <Text size="sm" variant="muted" bold>
-              {t('Suggested')}
-            </Text>
-            <InfoTip
-              title={t(
-                'These projects have trusted repository links and are not yet configured for Autofix. Enable Autofix applies the defaults shown in the row.'
-              )}
-            />
-          </Flex>
+          <Alert variant="info" system>
+            {t(
+              'These projects have trusted repository links and are not yet configured for Autofix.'
+            )}
+          </Alert>
 
           {result.isError ? (
             <Flex
@@ -532,100 +516,35 @@ function SuggestedProjectRows({
           ) : (
             suggestions.map(suggestion => {
               const project = projectsById.get(suggestion.projectId);
-              const hasOnlyGithubRepositories =
-                suggestion.linkedRepositories.length > 0 &&
-                suggestion.linkedRepositories.every(repository =>
-                  isGitHubProvider(repository.provider)
-                );
-              const effectiveAgent = hasOnlyGithubRepositories ? defaultAgent : 'seer';
-              const agentLabel = defaultAgentQuery.isPending
-                ? t('Loading')
-                : (agentSelectOptions.find(option => option.value === effectiveAgent)
-                    ?.label ?? t('Seer'));
-              const shouldConfigure =
-                suggestion.linkedReposCount > 10 || stoppingPoint === undefined;
-              const isCurrentMutation =
-                saveMutation.isPending &&
-                saveMutation.variables?.project.id === project?.id;
-
               return (
-                <Grid
+                <SuggestedProjectRow
                   key={suggestion.projectId}
-                  columns={TABLE_COLUMNS}
-                  align="center"
-                  role="row"
-                  background="secondary"
-                  borderBottom="muted"
-                >
-                  <InfiniteTable.RowCell>
-                    {/* Sized to the sm checkbox box so this row's max-content
-                        first column matches the checkbox rows. */}
-                    <Container width="16px" />
-                  </InfiniteTable.RowCell>
-                  <InfiniteTable.RowCell>
-                    <ProjectBadge
-                      disableLink
-                      project={project ?? {slug: suggestion.projectSlug}}
-                      avatarSize={16}
-                    />
-                  </InfiniteTable.RowCell>
-                  <InfiniteTable.RowCell justify="end">
-                    <InfoText
-                      tabular
-                      title={
-                        suggestion.linkedRepositories.length > 0
-                          ? suggestion.linkedRepositories
-                              .map(repository => repository.name)
-                              .join(', ')
-                          : t('Repository details unavailable')
-                      }
-                    >
-                      {suggestion.linkedReposCount}
-                    </InfoText>
-                  </InfiniteTable.RowCell>
-                  <InfiniteTable.RowCell>
-                    <Text size="sm" variant="muted">
-                      {agentLabel}
-                    </Text>
-                  </InfiniteTable.RowCell>
-                  <InfiniteTable.RowCell justify="between" gap="md">
-                    <Text size="sm" variant="muted" ellipsis>
-                      {stoppingPointLabel}
-                    </Text>
-                    {project ? (
-                      shouldConfigure ? (
-                        <Button
-                          size="xs"
-                          busy={isLoadingModal}
-                          disabled={saveMutation.isPending || isLoadingModal}
-                          onClick={() => void openProjectModal(project)}
-                        >
-                          {t('Configure')}
-                        </Button>
-                      ) : (
-                        <Button
-                          variant="primary"
-                          size="xs"
-                          busy={isCurrentMutation}
-                          disabled={
-                            saveMutation.isPending ||
-                            defaultAgentQuery.isPending ||
-                            isLoadingModal
-                          }
-                          onClick={() =>
-                            void enableAutofix(suggestion, project, effectiveAgent)
-                          }
-                        >
-                          {t('Enable Autofix')}
-                        </Button>
-                      )
-                    ) : (
-                      <Button size="xs" disabled>
-                        {t('Unavailable')}
-                      </Button>
-                    )}
-                  </InfiniteTable.RowCell>
-                </Grid>
+                  suggestion={suggestion}
+                  project={project}
+                  agentSelectOptions={agentSelectOptions}
+                  defaultAgent={defaultAgent}
+                  defaultAgentPending={defaultAgentQuery.isPending}
+                  defaultStoppingPoint={stoppingPoint}
+                  disabled={saveMutation.isPending || isLoadingModal}
+                  isCurrentMutation={
+                    saveMutation.isPending &&
+                    saveMutation.variables?.project.id === project?.id
+                  }
+                  isLoadingModal={isLoadingModal}
+                  onConfigure={configureProject =>
+                    void openProjectModal(configureProject)
+                  }
+                  onEnable={(agentOption, selectedStoppingPoint) =>
+                    project
+                      ? void enableAutofix(
+                          suggestion,
+                          project,
+                          agentOption,
+                          selectedStoppingPoint
+                        )
+                      : undefined
+                  }
+                />
               );
             })
           )}
@@ -646,6 +565,160 @@ function SuggestedProjectRows({
         </Fragment>
       ) : null}
     </Fragment>
+  );
+}
+
+interface SuggestedProjectRowProps {
+  agentSelectOptions: Array<{label: string; value: AutofixAgentSelectOption}>;
+  defaultAgent: AutofixAgentSelectOption;
+  defaultAgentPending: boolean;
+  defaultStoppingPoint: UserFacingStoppingPoint | undefined;
+  disabled: boolean;
+  isCurrentMutation: boolean;
+  isLoadingModal: boolean;
+  onConfigure: (project: Project) => void;
+  onEnable: (
+    agentOption: AutofixAgentSelectOption,
+    stoppingPoint: UserFacingStoppingPoint
+  ) => void;
+  project: Project | undefined;
+  suggestion: SeerProjectSuggestionResponse;
+}
+
+function SuggestedProjectRow({
+  agentSelectOptions,
+  defaultAgent,
+  defaultAgentPending,
+  defaultStoppingPoint,
+  disabled,
+  isCurrentMutation,
+  isLoadingModal,
+  onConfigure,
+  onEnable,
+  project,
+  suggestion,
+}: SuggestedProjectRowProps) {
+  // The selects hold row-local choices that are only persisted by the Enable
+  // Autofix click, unlike the autosaving selects in the configured rows.
+  const [agentOverride, setAgentOverride] = useState<AutofixAgentSelectOption | null>(
+    null
+  );
+  const [stoppingPointOverride, setStoppingPointOverride] =
+    useState<UserFacingStoppingPoint | null>(null);
+
+  const hasOnlyGithubRepositories =
+    suggestion.linkedRepositories.length > 0 &&
+    suggestion.linkedRepositories.every(repository =>
+      isGitHubProvider(repository.provider)
+    );
+  const selectedAgent = hasOnlyGithubRepositories
+    ? (agentOverride ?? defaultAgent)
+    : 'seer';
+  const selectedStoppingPoint = stoppingPointOverride ?? defaultStoppingPoint;
+  const shouldConfigure = suggestion.linkedReposCount > 10;
+
+  return (
+    <Grid
+      columns={TABLE_COLUMNS}
+      align="center"
+      role="row"
+      background="secondary"
+      borderBottom="muted"
+    >
+      <InfiniteTable.RowCell>
+        {/* Sized to the sm checkbox box so this row's max-content first
+            column matches the checkbox rows. */}
+        <Container width="16px" />
+      </InfiniteTable.RowCell>
+      <InfiniteTable.RowCell>
+        <ProjectBadge
+          disableLink
+          project={project ?? {slug: suggestion.projectSlug}}
+          avatarSize={16}
+        />
+      </InfiniteTable.RowCell>
+      <InfiniteTable.RowCell justify="end">
+        <InfoText
+          tabular
+          title={
+            suggestion.linkedRepositories.length > 0
+              ? suggestion.linkedRepositories
+                  .map(repository => repository.name)
+                  .join(', ')
+              : t('Repository details unavailable')
+          }
+        >
+          {suggestion.linkedReposCount}
+        </InfoText>
+      </InfiniteTable.RowCell>
+      <InfiniteTable.RowCell overflow="visible">
+        <Stack align="stretch" flex="1">
+          <Select
+            size="xs"
+            menuPortalTarget={document.body}
+            searchable={false}
+            clearable={false}
+            disabled={
+              disabled ||
+              shouldConfigure ||
+              defaultAgentPending ||
+              !hasOnlyGithubRepositories
+            }
+            options={agentSelectOptions}
+            value={selectedAgent}
+            onChange={(option: {value: AutofixAgentSelectOption}) =>
+              setAgentOverride(option.value)
+            }
+          />
+        </Stack>
+      </InfiniteTable.RowCell>
+      <InfiniteTable.RowCell gap="md" overflow="visible">
+        <Stack align="stretch" flex="1">
+          <Select
+            size="xs"
+            menuPortalTarget={document.body}
+            searchable={false}
+            clearable={false}
+            disabled={disabled || shouldConfigure}
+            options={PROJECT_STOPPING_POINT_OPTIONS}
+            value={selectedStoppingPoint ?? null}
+            onChange={(option: {value: UserFacingStoppingPoint}) =>
+              setStoppingPointOverride(option.value)
+            }
+          />
+        </Stack>
+        {project ? (
+          shouldConfigure ? (
+            <Button
+              size="xs"
+              busy={isLoadingModal}
+              disabled={disabled}
+              onClick={() => onConfigure(project)}
+            >
+              {t('Configure')}
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="xs"
+              busy={isCurrentMutation}
+              disabled={disabled || defaultAgentPending || !selectedStoppingPoint}
+              onClick={() =>
+                selectedStoppingPoint
+                  ? onEnable(selectedAgent, selectedStoppingPoint)
+                  : undefined
+              }
+            >
+              {t('Enable Autofix')}
+            </Button>
+          )
+        ) : (
+          <Button size="xs" disabled>
+            {t('Unavailable')}
+          </Button>
+        )}
+      </InfiniteTable.RowCell>
+    </Grid>
   );
 }
 

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react';
 import {css} from '@emotion/react';
 import {
   infiniteQueryOptions,
+  type UseInfiniteQueryResult,
   useInfiniteQuery,
   useQuery,
   useQueryClient,
@@ -10,12 +11,13 @@ import {debounce, parseAsStringLiteral, parseAsString, useQueryState} from 'nuqs
 
 import SeerConfigConnect2 from 'sentry-images/spot/seer-config-connect-2.svg';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {AutoSaveForm} from '@sentry/scraps/form';
 import {Image} from '@sentry/scraps/image';
 import {InputGroup} from '@sentry/scraps/input';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
@@ -31,7 +33,8 @@ import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ProjectTableHeader} from 'sentry/components/seer/projectTable/seerProjectTableHeader';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconSearch} from 'sentry/icons/iconSearch';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {ListItemSelectCheckbox} from 'sentry/utils/list/listItemSelectCheckbox';
@@ -42,10 +45,12 @@ import {
   knownAgentIntegrationsQueryOptions,
   coalesePreferredAgent,
   NON_GITHUB_HANDOFF_WARNING,
+  orgDefaultAgentQueryOptions,
   seerAgentProviderNameSelectQueryOptions,
 } from 'sentry/utils/seer/preferredAgent';
 import {
   fetchProjectHasNonGithubRepo,
+  isGitHubProvider,
   prefetchAllSeerProjectRepos,
 } from 'sentry/utils/seer/seerProjectRepos';
 import {
@@ -53,12 +58,25 @@ import {
   getInfiniteSeerProjectsSettingsQueryOptions,
   seerProjectSettingsSchema,
 } from 'sentry/utils/seer/seerProjectSettings';
+import {getInfiniteSeerProjectSuggestionsQueryOptions} from 'sentry/utils/seer/seerProjectSuggestions';
 import {
   coaleseStoppingPoint,
+  PROJECT_STOPPING_POINT_OPTIONS,
+  useOrgDefaultStoppingPoint,
   useStoppingPointSelectOptions,
 } from 'sentry/utils/seer/stoppingPoint';
-import type {AgentIntegration, AutofixAgentSelectOption} from 'sentry/utils/seer/types';
+import type {
+  AgentIntegration,
+  AutofixAgentSelectOption,
+  SeerProjectSuggestionResponse,
+  UserFacingStoppingPoint,
+} from 'sentry/utils/seer/types';
 import {useCanWriteSettings} from 'sentry/utils/seer/useCanWriteSettings';
+import {
+  AutofixSettingsPartialSaveError,
+  type AutofixProjectMutationVariables,
+  useMutateAutofixProject,
+} from 'sentry/utils/seer/useMutateAutofixProject';
 import {parseAsSort} from 'sentry/utils/url/parseAsSort';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -123,13 +141,32 @@ export function SeerProjectTable() {
   useFetchAllPages({result});
   const {data, isPending, isError, error, hasNextPage} = result;
 
+  const suggestionsEnabled =
+    organization.features.includes('seer-autofix-quick-add') &&
+    canWrite &&
+    searchTerm === '' &&
+    agentFilter === 'all';
+  const suggestionsResult = useInfiniteQuery({
+    ...getInfiniteSeerProjectSuggestionsQueryOptions({
+      organization,
+      enabled: suggestionsEnabled,
+    }),
+    select: ({pages}) => pages.flatMap(page => page.json),
+  });
+  const suggestions = suggestionsEnabled ? (suggestionsResult.data ?? []) : [];
+  const suggestionsSettled = !suggestionsEnabled || !suggestionsResult.isPending;
+  const suggestionsFailed = suggestionsEnabled && suggestionsResult.isError;
+
   if (
     !isError &&
     !isPending &&
     data?.length === 0 &&
     !hasNextPage &&
     searchTerm === '' &&
-    agentFilter === 'all'
+    agentFilter === 'all' &&
+    suggestionsSettled &&
+    !suggestionsFailed &&
+    suggestions.length === 0
   ) {
     return (
       <Container display="flex" padding="2xl" border="primary" radius="md">
@@ -189,6 +226,12 @@ export function SeerProjectTable() {
           <AddProjectButton />
         </Flex>
       </Stack>
+      {suggestionsEnabled ? (
+        <SuggestedProjectsPanel
+          agentSelectOptions={agentSelectOptions}
+          result={suggestionsResult}
+        />
+      ) : null}
       <ListItemCheckboxProvider
         hits={data?.length ?? 0}
         knownIds={data?.map(item => String(item.projectId)) ?? []}
@@ -316,6 +359,262 @@ export function SeerProjectTable() {
   );
 }
 
+interface SuggestedProjectsPanelProps {
+  agentSelectOptions: Array<{label: string; value: AutofixAgentSelectOption}>;
+  result: UseInfiniteQueryResult<SeerProjectSuggestionResponse[]>;
+}
+
+function SuggestedProjectsPanel({
+  agentSelectOptions,
+  result,
+}: SuggestedProjectsPanelProps) {
+  const organization = useOrganization();
+  const projectsById = useProjectsById();
+  const defaultAgentQuery = useQuery(orgDefaultAgentQueryOptions({organization}));
+  const defaultAgent = defaultAgentQuery.data ?? 'seer';
+  const stoppingPoint: UserFacingStoppingPoint | undefined = useOrgDefaultStoppingPoint();
+  const saveMutation = useMutateAutofixProject();
+  const {isLoadingModal, openProjectModal} = useProjectAddRepoModal();
+  const [failedMutationVariables, setFailedMutationVariables] =
+    useState<AutofixProjectMutationVariables | null>(null);
+
+  const suggestions = result.data ?? [];
+  const stoppingPointLabel =
+    PROJECT_STOPPING_POINT_OPTIONS.find(option => option.value === stoppingPoint)
+      ?.label ?? t('Not configured');
+
+  async function enableAutofix(
+    suggestion: SeerProjectSuggestionResponse,
+    project: Project,
+    agentOption: AutofixAgentSelectOption
+  ) {
+    if (stoppingPoint === undefined) {
+      return;
+    }
+
+    const variables: AutofixProjectMutationVariables = {
+      project,
+      repoEntries: suggestion.linkedRepositories.map(repository => ({
+        repoId: repository.repositoryId,
+        branch: '',
+      })),
+      agentOption,
+      stoppingPoint,
+    };
+
+    try {
+      await saveMutation.mutateAsync(variables);
+    } catch (error) {
+      if (error instanceof AutofixSettingsPartialSaveError) {
+        setFailedMutationVariables(variables);
+        return;
+      }
+      addErrorMessage(t('Could not enable Autofix. Try again.'));
+    }
+  }
+
+  async function retrySettings() {
+    if (!failedMutationVariables) {
+      return;
+    }
+
+    try {
+      await saveMutation.mutateAsync(failedMutationVariables);
+      setFailedMutationVariables(null);
+    } catch (error) {
+      if (!(error instanceof AutofixSettingsPartialSaveError)) {
+        addErrorMessage(t('Could not retry Autofix settings. Try again.'));
+      }
+    }
+  }
+
+  const showPanel = result.isPending || result.isError || suggestions.length > 0;
+  if (!showPanel && !failedMutationVariables) {
+    return null;
+  }
+
+  return (
+    <Stack gap="md">
+      {failedMutationVariables ? (
+        <Alert.Container>
+          <Alert
+            variant="warning"
+            trailingItems={
+              <Flex gap="sm">
+                <Alert.Button
+                  variant="secondary"
+                  busy={saveMutation.isPending}
+                  disabled={saveMutation.isPending}
+                  onClick={() => void retrySettings()}
+                >
+                  {t('Retry settings')}
+                </Alert.Button>
+                <Alert.Button
+                  variant="secondary"
+                  disabled={saveMutation.isPending}
+                  onClick={() => setFailedMutationVariables(null)}
+                >
+                  {t('Dismiss')}
+                </Alert.Button>
+              </Flex>
+            }
+          >
+            {t(
+              'Repositories were saved, but Autofix settings were not. Retry settings to finish setup.'
+            )}
+          </Alert>
+        </Alert.Container>
+      ) : null}
+
+      {showPanel ? (
+        <Container border="primary" radius="md" padding="lg">
+          <Stack gap="lg">
+            <Stack gap="xs">
+              <Heading as="h3" size="md">
+                {t('Suggested Projects')}
+              </Heading>
+              <Text variant="muted">
+                {t(
+                  'These projects have trusted repository links and are not yet configured for Autofix.'
+                )}
+              </Text>
+            </Stack>
+
+            {result.isError ? (
+              <LoadingError
+                message={result.error?.message}
+                onRetry={() => void result.refetch()}
+              />
+            ) : null}
+
+            {result.isPending ? (
+              <Flex justify="center" align="center" padding="lg">
+                <LoadingIndicator />
+              </Flex>
+            ) : (
+              <Stack gap="sm">
+                {suggestions.map(suggestion => {
+                  const project = projectsById.get(suggestion.projectId);
+                  const hasOnlyGithubRepositories =
+                    suggestion.linkedRepositories.length > 0 &&
+                    suggestion.linkedRepositories.every(
+                      repository =>
+                        Boolean(repository.provider) &&
+                        isGitHubProvider(repository.provider)
+                    );
+                  const effectiveAgent = hasOnlyGithubRepositories
+                    ? defaultAgent
+                    : 'seer';
+                  const agentLabel = defaultAgentQuery.isPending
+                    ? t('Loading')
+                    : (agentSelectOptions.find(option => option.value === effectiveAgent)
+                        ?.label ?? t('Seer'));
+                  const shouldConfigure =
+                    suggestion.linkedReposCount > 10 || stoppingPoint === undefined;
+                  const isCurrentMutation =
+                    saveMutation.isPending &&
+                    saveMutation.variables?.project.id === project?.id;
+
+                  return (
+                    <Container
+                      key={suggestion.projectId}
+                      border="primary"
+                      radius="md"
+                      padding="md"
+                    >
+                      <Grid
+                        columns={{
+                          zero: '1fr',
+                          xl: 'minmax(160px, 1fr) minmax(220px, 2fr) minmax(180px, 1fr) max-content',
+                        }}
+                        gap="md"
+                        align="center"
+                      >
+                        <ProjectBadge
+                          disableLink
+                          project={project ?? {slug: suggestion.projectSlug}}
+                          avatarSize={20}
+                        />
+                        <Stack gap="2xs" minWidth={0}>
+                          <Text size="sm">
+                            {suggestion.linkedRepositories.length > 0
+                              ? suggestion.linkedRepositories
+                                  .map(repository => repository.name)
+                                  .join(', ')
+                              : t('Repository details unavailable')}
+                          </Text>
+                          <Text variant="muted" size="sm">
+                            {tn(
+                              '%s linked repository',
+                              '%s linked repositories',
+                              suggestion.linkedReposCount
+                            )}
+                          </Text>
+                        </Stack>
+                        <Stack gap="2xs">
+                          <Text size="sm">{t('Agent: %s', agentLabel)}</Text>
+                          <Text size="sm">
+                            {t('Stopping point: %s', stoppingPointLabel)}
+                          </Text>
+                        </Stack>
+                        {project ? (
+                          shouldConfigure ? (
+                            <Button
+                              size="sm"
+                              busy={isLoadingModal}
+                              disabled={saveMutation.isPending || isLoadingModal}
+                              onClick={() => void openProjectModal(project)}
+                            >
+                              {t('Configure')}
+                            </Button>
+                          ) : (
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              busy={isCurrentMutation}
+                              disabled={
+                                saveMutation.isPending ||
+                                defaultAgentQuery.isPending ||
+                                isLoadingModal
+                              }
+                              onClick={() =>
+                                void enableAutofix(suggestion, project, effectiveAgent)
+                              }
+                            >
+                              {t('Enable Autofix')}
+                            </Button>
+                          )
+                        ) : (
+                          <Button size="sm" disabled>
+                            {t('Unavailable')}
+                          </Button>
+                        )}
+                      </Grid>
+                    </Container>
+                  );
+                })}
+              </Stack>
+            )}
+
+            {result.hasNextPage ? (
+              <Flex justify="end">
+                <Button
+                  size="sm"
+                  busy={result.isFetchingNextPage}
+                  disabled={result.isFetchingNextPage}
+                  onClick={() => void result.fetchNextPage()}
+                >
+                  {t('Show more')}
+                </Button>
+              </Flex>
+            ) : null}
+          </Stack>
+        </Container>
+      ) : null}
+    </Stack>
+  );
+}
+
 interface AgentSelectCellProps {
   agentSelectOptions: Array<{label: string; value: AutofixAgentSelectOption}>;
   disabled: boolean;
@@ -394,33 +693,46 @@ function AgentSelectCell({
   );
 }
 
-function AddProjectButton() {
+function useProjectAddRepoModal() {
   const {openModal} = useModal();
-
   const [isLoadingModal, setIsLoadingModal] = useState(false);
+
+  async function openProjectModal(defaultProject?: Project) {
+    setIsLoadingModal(true);
+    try {
+      const {ProjectAddRepoModal} =
+        await import('sentry/components/seer/projectAddRepoModal/projectAddRepoModal');
+
+      openModal(
+        deps => (
+          <ProjectAddRepoModal
+            {...deps}
+            title={t('Add Project to Autofix')}
+            defaultProject={defaultProject}
+          />
+        ),
+        {
+          modalCss: css`
+            width: 700px;
+          `,
+        }
+      );
+    } finally {
+      setIsLoadingModal(false);
+    }
+  }
+
+  return {isLoadingModal, openProjectModal};
+}
+
+function AddProjectButton() {
+  const {isLoadingModal, openProjectModal} = useProjectAddRepoModal();
 
   return (
     <Button
       variant="primary"
       size="md"
-      onClick={async () => {
-        setIsLoadingModal(true);
-        try {
-          const {ProjectAddRepoModal} =
-            await import('sentry/components/seer/projectAddRepoModal/projectAddRepoModal');
-
-          openModal(
-            deps => <ProjectAddRepoModal {...deps} title={t('Add Project to Autofix')} />,
-            {
-              modalCss: css`
-                width: 700px;
-              `,
-            }
-          );
-        } finally {
-          setIsLoadingModal(false);
-        }
-      }}
+      onClick={() => void openProjectModal()}
       icon={<IconAdd />}
       busy={isLoadingModal}
       disabled={isLoadingModal}

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -16,6 +16,7 @@ import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {AutoSaveForm} from '@sentry/scraps/form';
 import {Image} from '@sentry/scraps/image';
+import {InfoText, InfoTip} from '@sentry/scraps/info';
 import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
@@ -33,7 +34,7 @@ import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {ProjectTableHeader} from 'sentry/components/seer/projectTable/seerProjectTableHeader';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconSearch} from 'sentry/icons/iconSearch';
-import {t, tct, tn} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
@@ -82,6 +83,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 const estimateSize = () => 41;
+
+// Header and body rows are separate grids that each apply this template, so
+// suggestion rows must use the identical string to stay column-aligned.
+const TABLE_COLUMNS = 'max-content 2fr 74px repeat(2, 1fr)';
 
 export function SeerProjectTable() {
   const queryClient = useQueryClient();
@@ -229,27 +234,28 @@ export function SeerProjectTable() {
           <AddProjectButton />
         </Flex>
       </Stack>
-      {suggestionsEnabled || failedSuggestionMutationVariables ? (
-        <SuggestedProjectsPanel
-          agentSelectOptions={agentSelectOptions}
-          failedMutationVariables={failedSuggestionMutationVariables}
-          result={suggestionsResult}
-          suggestionsEnabled={suggestionsEnabled}
-          onFailedMutationVariablesChange={setFailedSuggestionMutationVariables}
-        />
-      ) : null}
       <ListItemCheckboxProvider
         hits={data?.length ?? 0}
         knownIds={data?.map(item => String(item.projectId)) ?? []}
         endpointOptions={safeParseQueryKey(queryOptions.queryKey)?.options}
       >
-        <InfiniteTable.Table columns="max-content 2fr 74px repeat(2, 1fr)">
+        <InfiniteTable.Table columns={TABLE_COLUMNS}>
           <ProjectTableHeader
             settings={data ?? []}
             sort={sortBy}
             onSortClick={setSort}
             mutableSearch={mutableSearch}
           />
+
+          {suggestionsEnabled || failedSuggestionMutationVariables ? (
+            <SuggestedProjectRows
+              agentSelectOptions={agentSelectOptions}
+              failedMutationVariables={failedSuggestionMutationVariables}
+              result={suggestionsResult}
+              suggestionsEnabled={suggestionsEnabled}
+              onFailedMutationVariablesChange={setFailedSuggestionMutationVariables}
+            />
+          ) : null}
 
           <InfiniteTable.Scrollable>
             {isPending ? (
@@ -365,7 +371,7 @@ export function SeerProjectTable() {
   );
 }
 
-interface SuggestedProjectsPanelProps {
+interface SuggestedProjectRowsProps {
   agentSelectOptions: Array<{label: string; value: AutofixAgentSelectOption}>;
   failedMutationVariables: AutofixProjectMutationVariables | null;
   onFailedMutationVariablesChange: (
@@ -375,13 +381,13 @@ interface SuggestedProjectsPanelProps {
   suggestionsEnabled: boolean;
 }
 
-function SuggestedProjectsPanel({
+function SuggestedProjectRows({
   agentSelectOptions,
   failedMutationVariables,
   onFailedMutationVariablesChange,
   result,
   suggestionsEnabled,
-}: SuggestedProjectsPanelProps) {
+}: SuggestedProjectRowsProps) {
   const organization = useOrganization();
   const projectsById = useProjectsById();
   const defaultAgentQuery = useQuery(orgDefaultAgentQueryOptions({organization}));
@@ -440,189 +446,206 @@ function SuggestedProjectsPanel({
     }
   }
 
-  const showPanel =
+  const showGroup =
     suggestionsEnabled && (result.isPending || result.isError || suggestions.length > 0);
-  if (!showPanel && !failedMutationVariables) {
+  if (!showGroup && !failedMutationVariables) {
     return null;
   }
 
   return (
-    <Stack gap="md">
+    <Fragment>
       {failedMutationVariables ? (
-        <Alert.Container>
-          <Alert
-            variant="warning"
-            trailingItems={
-              <Flex gap="sm">
-                <Alert.Button
-                  variant="secondary"
-                  busy={saveMutation.isPending}
-                  disabled={saveMutation.isPending}
-                  onClick={() => void retrySettings()}
-                >
-                  {t('Retry settings')}
-                </Alert.Button>
-                <Alert.Button
-                  variant="secondary"
-                  disabled={saveMutation.isPending}
-                  onClick={() => onFailedMutationVariablesChange(null)}
-                >
-                  {t('Dismiss')}
-                </Alert.Button>
-              </Flex>
-            }
+        <Alert
+          variant="warning"
+          system
+          trailingItems={
+            <Flex gap="sm">
+              <Alert.Button
+                variant="secondary"
+                busy={saveMutation.isPending}
+                disabled={saveMutation.isPending}
+                onClick={() => void retrySettings()}
+              >
+                {t('Retry settings')}
+              </Alert.Button>
+              <Alert.Button
+                variant="secondary"
+                disabled={saveMutation.isPending}
+                onClick={() => onFailedMutationVariablesChange(null)}
+              >
+                {t('Dismiss')}
+              </Alert.Button>
+            </Flex>
+          }
+        >
+          {t(
+            'Repositories were saved, but Autofix settings were not. Retry settings to finish setup.'
+          )}
+        </Alert>
+      ) : null}
+
+      {showGroup ? (
+        <Fragment>
+          <Flex
+            align="center"
+            gap="xs"
+            padding="sm xl"
+            background="secondary"
+            borderBottom="muted"
           >
-            {t(
-              'Repositories were saved, but Autofix settings were not. Retry settings to finish setup.'
-            )}
-          </Alert>
-        </Alert.Container>
-      ) : null}
+            <Text size="sm" variant="muted" bold>
+              {t('Suggested')}
+            </Text>
+            <InfoTip
+              title={t(
+                'These projects have trusted repository links and are not yet configured for Autofix. Enable Autofix applies the defaults shown in the row.'
+              )}
+            />
+          </Flex>
 
-      {showPanel ? (
-        <Container border="primary" radius="md" padding="lg">
-          <Stack gap="lg">
-            <Stack gap="xs">
-              <Heading as="h3" size="md">
-                {t('Suggested Projects')}
-              </Heading>
-              <Text variant="muted">
-                {t(
-                  'These projects have trusted repository links and are not yet configured for Autofix.'
-                )}
+          {result.isError ? (
+            <Flex
+              align="center"
+              justify="center"
+              gap="md"
+              padding="md xl"
+              background="secondary"
+              borderBottom="muted"
+            >
+              <Text size="sm" variant="muted">
+                {t('Could not load suggestions.')}
               </Text>
-            </Stack>
+              <Button size="xs" onClick={() => void result.refetch()}>
+                {t('Retry')}
+              </Button>
+            </Flex>
+          ) : result.isPending ? (
+            <Flex
+              align="center"
+              justify="center"
+              padding="md xl"
+              background="secondary"
+              borderBottom="muted"
+            >
+              <LoadingIndicator mini />
+            </Flex>
+          ) : (
+            suggestions.map(suggestion => {
+              const project = projectsById.get(suggestion.projectId);
+              const hasOnlyGithubRepositories =
+                suggestion.linkedRepositories.length > 0 &&
+                suggestion.linkedRepositories.every(repository =>
+                  isGitHubProvider(repository.provider)
+                );
+              const effectiveAgent = hasOnlyGithubRepositories ? defaultAgent : 'seer';
+              const agentLabel = defaultAgentQuery.isPending
+                ? t('Loading')
+                : (agentSelectOptions.find(option => option.value === effectiveAgent)
+                    ?.label ?? t('Seer'));
+              const shouldConfigure =
+                suggestion.linkedReposCount > 10 || stoppingPoint === undefined;
+              const isCurrentMutation =
+                saveMutation.isPending &&
+                saveMutation.variables?.project.id === project?.id;
 
-            {result.isError ? (
-              <LoadingError
-                message={result.error?.message}
-                onRetry={() => void result.refetch()}
-              />
-            ) : null}
-
-            {result.isPending ? (
-              <Flex justify="center" align="center" padding="lg">
-                <LoadingIndicator />
-              </Flex>
-            ) : (
-              <Stack gap="sm">
-                {suggestions.map(suggestion => {
-                  const project = projectsById.get(suggestion.projectId);
-                  const hasOnlyGithubRepositories =
-                    suggestion.linkedRepositories.length > 0 &&
-                    suggestion.linkedRepositories.every(repository =>
-                      isGitHubProvider(repository.provider)
-                    );
-                  const effectiveAgent = hasOnlyGithubRepositories
-                    ? defaultAgent
-                    : 'seer';
-                  const agentLabel = defaultAgentQuery.isPending
-                    ? t('Loading')
-                    : (agentSelectOptions.find(option => option.value === effectiveAgent)
-                        ?.label ?? t('Seer'));
-                  const shouldConfigure =
-                    suggestion.linkedReposCount > 10 || stoppingPoint === undefined;
-                  const isCurrentMutation =
-                    saveMutation.isPending &&
-                    saveMutation.variables?.project.id === project?.id;
-
-                  return (
-                    <Container
-                      key={suggestion.projectId}
-                      border="primary"
-                      radius="md"
-                      padding="md"
-                    >
-                      <Grid
-                        columns={{
-                          zero: '1fr',
-                          xl: 'minmax(160px, 1fr) minmax(220px, 2fr) minmax(180px, 1fr) max-content',
-                        }}
-                        gap="md"
-                        align="center"
-                      >
-                        <ProjectBadge
-                          disableLink
-                          project={project ?? {slug: suggestion.projectSlug}}
-                          avatarSize={20}
-                        />
-                        <Stack gap="2xs" minWidth={0}>
-                          <Text size="sm">
-                            {suggestion.linkedRepositories.length > 0
-                              ? suggestion.linkedRepositories
-                                  .map(repository => repository.name)
-                                  .join(', ')
-                              : t('Repository details unavailable')}
-                          </Text>
-                          <Text variant="muted" size="sm">
-                            {tn(
-                              '%s linked repository',
-                              '%s linked repositories',
-                              suggestion.linkedReposCount
-                            )}
-                          </Text>
-                        </Stack>
-                        <Stack gap="2xs">
-                          <Text size="sm">{t('Agent: %s', agentLabel)}</Text>
-                          <Text size="sm">
-                            {t('Stopping point: %s', stoppingPointLabel)}
-                          </Text>
-                        </Stack>
-                        {project ? (
-                          shouldConfigure ? (
-                            <Button
-                              size="sm"
-                              busy={isLoadingModal}
-                              disabled={saveMutation.isPending || isLoadingModal}
-                              onClick={() => void openProjectModal(project)}
-                            >
-                              {t('Configure')}
-                            </Button>
-                          ) : (
-                            <Button
-                              variant="primary"
-                              size="sm"
-                              busy={isCurrentMutation}
-                              disabled={
-                                saveMutation.isPending ||
-                                defaultAgentQuery.isPending ||
-                                isLoadingModal
-                              }
-                              onClick={() =>
-                                void enableAutofix(suggestion, project, effectiveAgent)
-                              }
-                            >
-                              {t('Enable Autofix')}
-                            </Button>
-                          )
-                        ) : (
-                          <Button size="sm" disabled>
-                            {t('Unavailable')}
-                          </Button>
-                        )}
-                      </Grid>
-                    </Container>
-                  );
-                })}
-              </Stack>
-            )}
-
-            {result.hasNextPage ? (
-              <Flex justify="end">
-                <Button
-                  size="sm"
-                  busy={result.isFetchingNextPage}
-                  disabled={result.isFetchingNextPage}
-                  onClick={() => void result.fetchNextPage()}
+              return (
+                <Grid
+                  key={suggestion.projectId}
+                  columns={TABLE_COLUMNS}
+                  align="center"
+                  role="row"
+                  background="secondary"
+                  borderBottom="muted"
                 >
-                  {t('Show more')}
-                </Button>
-              </Flex>
-            ) : null}
-          </Stack>
-        </Container>
+                  <InfiniteTable.RowCell>
+                    {/* Sized to the sm checkbox box so this row's max-content
+                        first column matches the checkbox rows. */}
+                    <Container width="16px" />
+                  </InfiniteTable.RowCell>
+                  <InfiniteTable.RowCell>
+                    <ProjectBadge
+                      disableLink
+                      project={project ?? {slug: suggestion.projectSlug}}
+                      avatarSize={16}
+                    />
+                  </InfiniteTable.RowCell>
+                  <InfiniteTable.RowCell justify="end">
+                    <InfoText
+                      tabular
+                      title={
+                        suggestion.linkedRepositories.length > 0
+                          ? suggestion.linkedRepositories
+                              .map(repository => repository.name)
+                              .join(', ')
+                          : t('Repository details unavailable')
+                      }
+                    >
+                      {suggestion.linkedReposCount}
+                    </InfoText>
+                  </InfiniteTable.RowCell>
+                  <InfiniteTable.RowCell>
+                    <Text size="sm" variant="muted">
+                      {agentLabel}
+                    </Text>
+                  </InfiniteTable.RowCell>
+                  <InfiniteTable.RowCell justify="between" gap="md">
+                    <Text size="sm" variant="muted" ellipsis>
+                      {stoppingPointLabel}
+                    </Text>
+                    {project ? (
+                      shouldConfigure ? (
+                        <Button
+                          size="xs"
+                          busy={isLoadingModal}
+                          disabled={saveMutation.isPending || isLoadingModal}
+                          onClick={() => void openProjectModal(project)}
+                        >
+                          {t('Configure')}
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="primary"
+                          size="xs"
+                          busy={isCurrentMutation}
+                          disabled={
+                            saveMutation.isPending ||
+                            defaultAgentQuery.isPending ||
+                            isLoadingModal
+                          }
+                          onClick={() =>
+                            void enableAutofix(suggestion, project, effectiveAgent)
+                          }
+                        >
+                          {t('Enable Autofix')}
+                        </Button>
+                      )
+                    ) : (
+                      <Button size="xs" disabled>
+                        {t('Unavailable')}
+                      </Button>
+                    )}
+                  </InfiniteTable.RowCell>
+                </Grid>
+              );
+            })
+          )}
+
+          {result.hasNextPage ? (
+            <Flex justify="center" background="secondary" borderBottom="muted">
+              <Button
+                size="xs"
+                variant="transparent"
+                busy={result.isFetchingNextPage}
+                disabled={result.isFetchingNextPage}
+                onClick={() => void result.fetchNextPage()}
+              >
+                {t('Show more')}
+              </Button>
+            </Flex>
+          ) : null}
+        </Fragment>
       ) : null}
-    </Stack>
+    </Fragment>
   );
 }
 

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -12,6 +12,7 @@ import {debounce, parseAsStringLiteral, parseAsString, useQueryState} from 'nuqs
 import SeerConfigConnect2 from 'sentry-images/spot/seer-config-connect-2.svg';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {AutoSaveForm} from '@sentry/scraps/form';
@@ -24,6 +25,7 @@ import {useModal} from '@sentry/scraps/modal';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Select} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
@@ -86,8 +88,11 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 const estimateSize = () => 41;
 
 // Header and body rows are separate grids that each apply this template, so
-// suggestion rows must use the identical string to stay column-aligned.
-const TABLE_COLUMNS = 'max-content 2fr 74px repeat(2, 1fr)';
+// suggestion rows must use the identical string to stay column-aligned. The
+// trailing track is a fixed width (not max-content) for the same reason: it
+// holds the suggestion-row action button and stays empty in the other rows,
+// and a per-row max-content track would resolve to different widths.
+const TABLE_COLUMNS = 'max-content 2fr 74px repeat(2, 1fr) 132px';
 
 export function SeerProjectTable() {
   const queryClient = useQueryClient();
@@ -481,12 +486,6 @@ function SuggestedProjectRows({
 
       {showGroup ? (
         <Fragment>
-          <Alert variant="info" system>
-            {t(
-              'These projects have trusted repository links and are not yet configured for Autofix.'
-            )}
-          </Alert>
-
           {result.isError ? (
             <Flex
               align="center"
@@ -630,12 +629,19 @@ function SuggestedProjectRow({
             column matches the checkbox rows. */}
         <Container width="16px" />
       </InfiniteTable.RowCell>
-      <InfiniteTable.RowCell>
+      <InfiniteTable.RowCell gap="sm">
         <ProjectBadge
           disableLink
           project={project ?? {slug: suggestion.projectSlug}}
           avatarSize={16}
         />
+        <Tooltip
+          title={t(
+            'This project has trusted repository links and is not yet configured for Autofix.'
+          )}
+        >
+          <Tag variant="info">{t('Suggested')}</Tag>
+        </Tooltip>
       </InfiniteTable.RowCell>
       <InfiniteTable.RowCell justify="end">
         <InfoText
@@ -672,7 +678,7 @@ function SuggestedProjectRow({
           />
         </Stack>
       </InfiniteTable.RowCell>
-      <InfiniteTable.RowCell gap="md" overflow="visible">
+      <InfiniteTable.RowCell overflow="visible">
         <Stack align="stretch" flex="1">
           <Select
             size="xs"
@@ -687,6 +693,8 @@ function SuggestedProjectRow({
             }
           />
         </Stack>
+      </InfiniteTable.RowCell>
+      <InfiniteTable.RowCell justify="end">
         {project ? (
           shouldConfigure ? (
             <Button

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -88,6 +88,8 @@ export function SeerProjectTable() {
   const location = useLocation();
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
+  const [failedSuggestionMutationVariables, setFailedSuggestionMutationVariables] =
+    useState<AutofixProjectMutationVariables | null>(null);
 
   // Query Values
   const [agentFilter, setAgentFilter] = useQueryState(
@@ -158,6 +160,7 @@ export function SeerProjectTable() {
   const suggestionsFailed = suggestionsEnabled && suggestionsResult.isError;
 
   if (
+    !failedSuggestionMutationVariables &&
     !isError &&
     !isPending &&
     data?.length === 0 &&
@@ -226,10 +229,13 @@ export function SeerProjectTable() {
           <AddProjectButton />
         </Flex>
       </Stack>
-      {suggestionsEnabled ? (
+      {suggestionsEnabled || failedSuggestionMutationVariables ? (
         <SuggestedProjectsPanel
           agentSelectOptions={agentSelectOptions}
+          failedMutationVariables={failedSuggestionMutationVariables}
           result={suggestionsResult}
+          suggestionsEnabled={suggestionsEnabled}
+          onFailedMutationVariablesChange={setFailedSuggestionMutationVariables}
         />
       ) : null}
       <ListItemCheckboxProvider
@@ -361,12 +367,20 @@ export function SeerProjectTable() {
 
 interface SuggestedProjectsPanelProps {
   agentSelectOptions: Array<{label: string; value: AutofixAgentSelectOption}>;
+  failedMutationVariables: AutofixProjectMutationVariables | null;
+  onFailedMutationVariablesChange: (
+    variables: AutofixProjectMutationVariables | null
+  ) => void;
   result: UseInfiniteQueryResult<SeerProjectSuggestionResponse[]>;
+  suggestionsEnabled: boolean;
 }
 
 function SuggestedProjectsPanel({
   agentSelectOptions,
+  failedMutationVariables,
+  onFailedMutationVariablesChange,
   result,
+  suggestionsEnabled,
 }: SuggestedProjectsPanelProps) {
   const organization = useOrganization();
   const projectsById = useProjectsById();
@@ -375,10 +389,8 @@ function SuggestedProjectsPanel({
   const stoppingPoint: UserFacingStoppingPoint | undefined = useOrgDefaultStoppingPoint();
   const saveMutation = useMutateAutofixProject();
   const {isLoadingModal, openProjectModal} = useProjectAddRepoModal();
-  const [failedMutationVariables, setFailedMutationVariables] =
-    useState<AutofixProjectMutationVariables | null>(null);
 
-  const suggestions = result.data ?? [];
+  const suggestions = suggestionsEnabled ? (result.data ?? []) : [];
   const stoppingPointLabel =
     PROJECT_STOPPING_POINT_OPTIONS.find(option => option.value === stoppingPoint)
       ?.label ?? t('Not configured');
@@ -406,7 +418,7 @@ function SuggestedProjectsPanel({
       await saveMutation.mutateAsync(variables);
     } catch (error) {
       if (error instanceof AutofixSettingsPartialSaveError) {
-        setFailedMutationVariables(variables);
+        onFailedMutationVariablesChange(variables);
         return;
       }
       addErrorMessage(t('Could not enable Autofix. Try again.'));
@@ -420,7 +432,7 @@ function SuggestedProjectsPanel({
 
     try {
       await saveMutation.mutateAsync(failedMutationVariables);
-      setFailedMutationVariables(null);
+      onFailedMutationVariablesChange(null);
     } catch (error) {
       if (!(error instanceof AutofixSettingsPartialSaveError)) {
         addErrorMessage(t('Could not retry Autofix settings. Try again.'));
@@ -428,7 +440,8 @@ function SuggestedProjectsPanel({
     }
   }
 
-  const showPanel = result.isPending || result.isError || suggestions.length > 0;
+  const showPanel =
+    suggestionsEnabled && (result.isPending || result.isError || suggestions.length > 0);
   if (!showPanel && !failedMutationVariables) {
     return null;
   }
@@ -452,7 +465,7 @@ function SuggestedProjectsPanel({
                 <Alert.Button
                   variant="secondary"
                   disabled={saveMutation.isPending}
-                  onClick={() => setFailedMutationVariables(null)}
+                  onClick={() => onFailedMutationVariablesChange(null)}
                 >
                   {t('Dismiss')}
                 </Alert.Button>
@@ -497,10 +510,8 @@ function SuggestedProjectsPanel({
                   const project = projectsById.get(suggestion.projectId);
                   const hasOnlyGithubRepositories =
                     suggestion.linkedRepositories.length > 0 &&
-                    suggestion.linkedRepositories.every(
-                      repository =>
-                        Boolean(repository.provider) &&
-                        isGitHubProvider(repository.provider)
+                    suggestion.linkedRepositories.every(repository =>
+                      isGitHubProvider(repository.provider)
                     );
                   const effectiveAgent = hasOnlyGithubRepositories
                     ? defaultAgent

--- a/static/app/utils/seer/seerProjectSuggestions.ts
+++ b/static/app/utils/seer/seerProjectSuggestions.ts
@@ -1,0 +1,22 @@
+import {skipToken} from '@tanstack/react-query';
+
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {SeerProjectSuggestionResponse} from 'sentry/utils/seer/types';
+
+export function getInfiniteSeerProjectSuggestionsQueryOptions({
+  organization,
+  enabled,
+}: {
+  enabled: boolean;
+  organization: Organization;
+}) {
+  return apiOptions.asInfinite<SeerProjectSuggestionResponse[]>()(
+    '/organizations/$organizationIdOrSlug/seer/project-suggestions/',
+    {
+      path: enabled ? {organizationIdOrSlug: organization.slug} : skipToken,
+      query: {per_page: 10},
+      staleTime: 60_000,
+    }
+  );
+}

--- a/static/app/utils/seer/types.ts
+++ b/static/app/utils/seer/types.ts
@@ -62,6 +62,19 @@ export type SeerProjectSettingResponse = {
   stoppingPoint: SeerAutofixStoppingPoint;
 };
 
+export type SuggestedRepositoryResponse = {
+  name: string;
+  provider: string;
+  repositoryId: string;
+};
+
+export type SeerProjectSuggestionResponse = {
+  linkedReposCount: number;
+  linkedRepositories: SuggestedRepositoryResponse[];
+  projectId: string;
+  projectSlug: string;
+};
+
 type BranchOverrideInput = {
   branchName: string;
   tagName: string;

--- a/static/app/utils/seer/types.ts
+++ b/static/app/utils/seer/types.ts
@@ -62,7 +62,7 @@ export type SeerProjectSettingResponse = {
   stoppingPoint: SeerAutofixStoppingPoint;
 };
 
-export type SuggestedRepositoryResponse = {
+type SuggestedRepositoryResponse = {
   name: string;
   provider: string;
   repositoryId: string;

--- a/static/app/utils/seer/useMutateAutofixProject.ts
+++ b/static/app/utils/seer/useMutateAutofixProject.ts
@@ -15,6 +15,7 @@ import {
   getInfiniteSeerProjectsSettingsQueryOptions,
   getSeerProjectSettingsQueryOptions,
 } from 'sentry/utils/seer/seerProjectSettings';
+import {getInfiniteSeerProjectSuggestionsQueryOptions} from 'sentry/utils/seer/seerProjectSuggestions';
 import {
   getTuningFromStoppingPoint,
   resolveStoppingPoint,
@@ -26,7 +27,7 @@ import type {
 } from 'sentry/utils/seer/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-type TVariables = {
+export type AutofixProjectMutationVariables = {
   agentOption: AutofixAgentSelectOption;
   project: Project;
   repoEntries: Array<{
@@ -66,7 +67,7 @@ export function useMutateAutofixProject() {
       repoEntries,
       agentOption,
       stoppingPoint,
-    }: TVariables): Promise<void> => {
+    }: AutofixProjectMutationVariables): Promise<void> => {
       const tuning = getTuningFromStoppingPoint(stoppingPoint);
       const {agent, integrationId} = parseAgentOption(agentOption, knownAgents);
       const {stoppingPointValue} = resolveStoppingPoint(stoppingPoint, undefined);
@@ -169,6 +170,12 @@ export function useMutateAutofixProject() {
         getInfiniteSeerProjectsSettingsQueryOptions({organization, query: {}});
       queryClient.invalidateQueries({
         queryKey: [infiniteProjectsQueryKey[0]],
+        exact: false,
+      });
+      const {queryKey: infiniteSuggestionsQueryKey} =
+        getInfiniteSeerProjectSuggestionsQueryOptions({organization, enabled: true});
+      queryClient.invalidateQueries({
+        queryKey: [infiniteSuggestionsQueryKey[0]],
         exact: false,
       });
     },


### PR DESCRIPTION
## TLDR

Shows suggested projects as pinned rows at the top of the Autofix settings table, with the agent and stopping point selectable in the row and one click to enable Autofix. This replaces the six-click, two-search modal path with one action.

## Details

The suggestion query runs only for write-enabled, flag-enabled organizations with no active table filters, and loads 10 projects per page behind a Show more row. Each row carries a Suggested tag next to the project badge and renders the same selects as the configured rows, preselected with the org defaults from the same helpers as `ProjectAddRepoModal`, but the choices stay row-local until Enable Autofix writes them through `useMutateAutofixProject`, whose invalidations then refresh both lists. A missing org stopping-point default leaves that select empty and disables Enable until a choice is made; projects with more than 10 links fall back to Configure, which opens the modal prefilled. A partial settings failure keeps a retry warning, since the repositories persisted.

The rows render between the table header and the scrollable body, never inside the virtualized `InfiniteTable.Body`. `InfiniteTable` rows are independent grids that each apply the shared column template, so per-row `max-content` tracks resolve independently: the first cell holds a checkbox-width spacer, and the action button lives in a fixed-width trailing track that stays empty in the header and configured rows. The large empty state appears only when the configured list and the suggestion list are both empty.
