### PR TITLE
fix(issues): Return 400 for invalid search queries on issues-stats

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index_stats.py
+++ b/src/sentry/issues/endpoints/organization_group_index_stats.py
@@ -8,6 +8,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEventPermission
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.group_index import build_query_params_from_request, calculate_stats_period
+from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_stats_period
@@ -109,9 +110,12 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
         )
 
         environments = self.get_environments(request, organization)
-        query_kwargs = build_query_params_from_request(
-            request, organization, projects, environments
-        )
+        try:
+            query_kwargs = build_query_params_from_request(
+                request, organization, projects, environments
+            )
+        except ValidationError as exc:
+            return Response({"detail": str(exc)}, status=400)
         context = serialize(
             groups,
             request.user,

--- a/src/sentry/issues/endpoints/organization_group_index_stats.py
+++ b/src/sentry/issues/endpoints/organization_group_index_stats.py
@@ -114,8 +114,8 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
             query_kwargs = build_query_params_from_request(
                 request, organization, projects, environments
             )
-        except ValidationError as exc:
-            return Response({"detail": str(exc)}, status=400)
+        except ValidationError:
+            return Response({"detail": "Invalid request parameters."}, status=400)
         context = serialize(
             groups,
             request.user,

--- a/tests/sentry/issues/endpoints/test_organization_group_index_stats.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index_stats.py
@@ -1,0 +1,18 @@
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationGroupIndexStatsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-group-index-stats"
+
+    def test_invalid_search_query(self) -> None:
+        group = self.create_group()
+        self.login_as(user=self.user)
+
+        response = self.get_error_response(
+            self.organization.slug,
+            query="title:hello OR title:goodbye",
+            groups=[group.id],
+            status_code=400,
+        )
+
+        assert response.data["detail"] == "Invalid request parameters."

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -301,18 +301,3 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert response.status_code == 200
         assert response.data[0]["filtered"]["count"] == "3"
         assert response.data[0]["count"] == "3"
-
-    def test_invalid_search_query(self) -> None:
-        group = self.store_event(
-            data={"timestamp": before_now(seconds=1).isoformat(), "fingerprint": ["group-a"]},
-            project_id=self.project.id,
-        ).group
-        self.login_as(user=self.user)
-
-        response = self.get_response(query="title:hello OR title:goodbye", groups=[group.id])
-
-        assert response.status_code == 400
-        assert (
-            response.data["detail"]
-            == 'Error parsing search query: Boolean statements containing "OR" or "AND" are not supported in this search'
-        )

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -301,3 +301,18 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert response.status_code == 200
         assert response.data[0]["filtered"]["count"] == "3"
         assert response.data[0]["count"] == "3"
+
+    def test_invalid_search_query(self) -> None:
+        group = self.store_event(
+            data={"timestamp": before_now(seconds=1).isoformat(), "fingerprint": ["group-a"]},
+            project_id=self.project.id,
+        ).group
+        self.login_as(user=self.user)
+
+        response = self.get_response(query="title:hello OR title:goodbye", groups=[group.id])
+
+        assert response.status_code == 400
+        assert (
+            response.data["detail"]
+            == 'Error parsing search query: Boolean statements containing "OR" or "AND" are not supported in this search'
+        )


### PR DESCRIPTION
build_query_params_from_request raises the group_index ValidationError, which is a plain Exception subclass rather than an APIException. The issues-stats endpoint called it unguarded, so DRF's exception handler did not recognize it and a malformed search query surfaced as an uncaught 500 instead of a client error.

Catch it the way the sibling group_index endpoints already do, which keeps the {"detail": ...} response body consistent across them.

Fixes SENTRY-5TBK