### PR TITLE
fix(scraps): Prevent 1Password from covering OTP input

### DIFF
--- a/static/app/components/core/input/otpInput.tsx
+++ b/static/app/components/core/input/otpInput.tsx
@@ -46,7 +46,7 @@ export function OTPInput({
         characterSet === 'numeric' ? REGEXP_ONLY_DIGITS : REGEXP_ONLY_DIGITS_AND_CHARS
       }
       render={({slots}) => (
-        <Flex aria-hidden gap="xs">
+        <Flex aria-hidden gap="xs" paddingRight="md">
           {slots.map((slot, index) => (
             <OTPInputSlot
               key={index}


### PR DESCRIPTION
OTP inputs now reserve space beside the rendered slots so 1Password's injected badge does not overlap the final digit.