### PR TITLE
fix(seer): Match sort and assignee filter sizes on autofix overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
+++ b/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
@@ -71,7 +71,7 @@ export function AssigneeFilter({
       value={value ?? undefined}
       onChange={selected => onChange(selected?.value ?? null)}
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} size="sm" prefix={t('Assignee')} />
+        <OverlayTrigger.Button {...triggerProps} prefix={t('Assignee')} />
       )}
     />
   );

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -147,7 +147,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value)
           }
           trigger={triggerProps => (
-            <OverlayTrigger.Button {...triggerProps} size="sm" prefix={t('Sort')} />
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
         />
         <AssigneeFilter


### PR DESCRIPTION
The Sort and Assignee dropdown triggers on the autofix overview page hard-coded `size="sm"`, making them render one step smaller than the Project and Date page filters (which use the default `md`). This drops the explicit size on both triggers so they inherit `md` and line up with the rest of the header controls.

The Assignee button is fixed alongside Sort since it shares the same control row and had the identical mismatch — otherwise the fix would just move the inconsistency over one slot.

The other notes on the ticket (adding assignees, splitting out the date selector since the date reflects Seer activity rather than issue activity) are explicitly deferred to a separate issue and are out of scope here.

Refs AIML-3340