### PR TITLE
feat(scraps): Add typed OTP input formats

### DIFF
--- a/static/app/components/core/input/otpInput.mdx
+++ b/static/app/components/core/input/otpInput.mdx
@@ -14,7 +14,7 @@ export const documentation = import('!!type-loader!@sentry/scraps/input');
 input for autofill, paste, keyboard navigation, and assistive technology.
 
 ```jsx
-<OTPInput length={6} onComplete={code => submit(code)} />
+<OTPInput format="000000" onComplete={code => submit(code)} />
 ```
 
 ## Sizes
@@ -22,45 +22,48 @@ input for autofill, paste, keyboard navigation, and assistive technology.
 Use the size that matches the surrounding form controls.
 
 <Storybook.Demo>
-  <OTPInput length={6} size="xs" onComplete={() => {}} />
-  <OTPInput length={6} size="sm" onComplete={() => {}} />
-  <OTPInput length={6} size="md" onComplete={() => {}} />
+  <OTPInput format="000000" size="xs" onComplete={() => {}} />
+  <OTPInput format="000000" size="sm" onComplete={() => {}} />
+  <OTPInput format="000000" size="md" onComplete={() => {}} />
 </Storybook.Demo>
 ```jsx
-<OTPInput length={6} size="xs" onComplete={handleComplete} />
-<OTPInput length={6} size="sm" onComplete={handleComplete} />
-<OTPInput length={6} size="md" onComplete={handleComplete} />
+<OTPInput format="000000" size="xs" onComplete={handleComplete} />
+<OTPInput format="000000" size="sm" onComplete={handleComplete} />
+<OTPInput format="000000" size="md" onComplete={handleComplete} />
 ```
 
 ## Disabled
 
 <Storybook.Demo>
-  <OTPInput disabled length={6} onComplete={() => {}} />
+  <OTPInput disabled format="000000" onComplete={() => {}} />
 </Storybook.Demo>
 ```jsx
-<OTPInput disabled length={6} onComplete={handleComplete} />
+<OTPInput disabled format="000000" onComplete={handleComplete} />
+```
+
+## Format
+
+Use `0` for numeric codes and `A` for alphanumeric codes. A format must use one token
+throughout. Add `-` between groups to render a visual separator; separators are omitted
+from the completed value.
+
+<Storybook.Demo>
+  <OTPInput format="000-000" onComplete={() => {}} />
+</Storybook.Demo>
+```jsx
+<OTPInput format="000-000" onComplete={handleComplete} />
 ```
 
 ## Alphanumeric Codes
 
-Use `characterSet="alphanumeric"` for codes containing letters and numbers. A `transform`
-can normalize input from typing, paste, and autofill before completion.
+Use an `A` format for codes containing letters and numbers. The `uppercase` prop
+normalizes input from typing, paste, and autofill before completion.
 
 <Storybook.Demo>
-  <OTPInput
-    characterSet="alphanumeric"
-    length={6}
-    onComplete={() => {}}
-    transform={value => value.toUpperCase()}
-  />
+  <OTPInput format="AAAAAA" onComplete={() => {}} uppercase />
 </Storybook.Demo>
 ```jsx
-<OTPInput
-  characterSet="alphanumeric"
-  length={6}
-  onComplete={handleComplete}
-  transform={value => value.toUpperCase()}
-/>
+<OTPInput format="AAAAAA" onComplete={handleComplete} uppercase />
 ```
 
 ## Accessibility
@@ -71,11 +74,10 @@ devices. The segmented slots are visual and hidden from the accessibility tree.
 
 ## Props
 
-| Prop           | Type                          | Default     | Description                                  |
-| -------------- | ----------------------------- | ----------- | -------------------------------------------- |
-| `length`       | `number`                      | —           | Number of characters in the code.            |
-| `onComplete`   | `(value: string) => void`     | —           | Called when every slot contains a character. |
-| `characterSet` | `'numeric' \| 'alphanumeric'` | `'numeric'` | Limits the characters accepted.              |
-| `transform`    | `(value: string) => string`   | —           | Normalizes the value as it changes.          |
-| `size`         | `'xs' \| 'sm' \| 'md'`        | `'md'`      | Size of each code slot.                      |
-| `disabled`     | `boolean`                     | `false`     | Disables code entry.                         |
+| Prop         | Type                      | Default | Description                                             |
+| ------------ | ------------------------- | ------- | ------------------------------------------------------- |
+| `format`     | `OTPFormat`               | —       | Defines the character set, length, and visual grouping. |
+| `onComplete` | `(value: string) => void` | —       | Called when every slot contains a character.            |
+| `uppercase`  | `boolean`                 | `false` | Converts alphanumeric input to uppercase.               |
+| `size`       | `'xs' \| 'sm' \| 'md'`    | `'md'`  | Size of each code slot.                                 |
+| `disabled`   | `boolean`                 | `false` | Disables code entry.                                    |

--- a/static/app/components/core/input/otpInput.spec.tsx
+++ b/static/app/components/core/input/otpInput.spec.tsx
@@ -16,7 +16,7 @@ describe('OTPInput', () => {
 
   it('accepts characters and reports a filled code', async () => {
     const onComplete = jest.fn();
-    render(<OTPInput length={4} onComplete={onComplete} />);
+    render(<OTPInput format="0000" onComplete={onComplete} />);
 
     const input = screen.getByRole<HTMLInputElement>('textbox', {
       name: 'One-time password',
@@ -28,7 +28,7 @@ describe('OTPInput', () => {
   });
 
   it('supports one-time-code autofill', () => {
-    render(<OTPInput length={6} onComplete={jest.fn()} />);
+    render(<OTPInput format="000000" onComplete={jest.fn()} />);
 
     expect(screen.getByRole('textbox', {name: 'One-time password'})).toHaveAttribute(
       'autocomplete',
@@ -37,27 +37,35 @@ describe('OTPInput', () => {
   });
 
   it('disables the native input', () => {
-    render(<OTPInput disabled length={6} onComplete={jest.fn()} />);
+    render(<OTPInput disabled format="000000" onComplete={jest.fn()} />);
 
     expect(screen.getByRole('textbox', {name: 'One-time password'})).toBeDisabled();
   });
 
   it('renders the requested number of visual slots', () => {
-    render(<OTPInput length={6} onComplete={jest.fn()} />);
+    render(<OTPInput format="000000" onComplete={jest.fn()} />);
 
     expect(document.querySelectorAll('[data-input-otp-slot]')).toHaveLength(6);
   });
 
-  it('supports alphanumeric codes and transforms their value', async () => {
+  it('renders format separators without including them in the value', async () => {
     const onComplete = jest.fn();
-    render(
-      <OTPInput
-        characterSet="alphanumeric"
-        length={4}
-        onComplete={onComplete}
-        transform={value => value.toUpperCase()}
-      />
-    );
+    render(<OTPInput format="000-000" onComplete={onComplete} />);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+
+    const input = screen.getByRole<HTMLInputElement>('textbox', {
+      name: 'One-time password',
+    });
+    await userEvent.type(input, '123456');
+
+    expect(input).toHaveValue('123456');
+    expect(onComplete).toHaveBeenCalledWith('123456');
+  });
+
+  it('supports alphanumeric codes and uppercases their value', async () => {
+    const onComplete = jest.fn();
+    render(<OTPInput format="AAAA" onComplete={onComplete} uppercase />);
 
     const input = screen.getByRole<HTMLInputElement>('textbox', {
       name: 'One-time password',

--- a/static/app/components/core/input/otpInput.tsx
+++ b/static/app/components/core/input/otpInput.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import {
   OTPInput as OTPInputPrimitive,
@@ -7,61 +7,128 @@ import {
 } from 'input-otp';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import type {FormSize} from 'sentry/utils/theme';
 
 import {inputStyles} from './inputStyles';
 
-export interface OTPInputProps {
-  length: number;
+type FormatToken = '0' | 'A';
+type FormatParserState = 'start' | 'token' | 'separator';
+
+/**
+ * Type-level parsing machinery for OTP formats. It walks the format one character at
+ * a time, remembers whether the first input token was `0` or `A`, and rejects formats
+ * that mix the two token types. The parser state also prevents leading, trailing, or
+ * consecutive separators. This type has no runtime behavior; it exists solely to
+ * provide useful TypeScript errors at OTPInput call sites.
+ */
+type IsValidOTPFormat<
+  Format extends string,
+  SelectedToken extends FormatToken | null = null,
+  State extends FormatParserState = 'start',
+> = Format extends ''
+  ? State extends 'token'
+    ? true
+    : false
+  : Format extends `${infer Character}${infer Rest}`
+    ? Character extends FormatToken
+      ? SelectedToken extends null
+        ? IsValidOTPFormat<Rest, Character, 'token'>
+        : Character extends SelectedToken
+          ? IsValidOTPFormat<Rest, SelectedToken, 'token'>
+          : false
+      : Character extends '-'
+        ? State extends 'token'
+          ? IsValidOTPFormat<Rest, SelectedToken, 'separator'>
+          : false
+        : false
+    : false;
+
+type OTPFormat<Format extends string> =
+  IsValidOTPFormat<Format> extends true ? Format : never;
+
+export interface OTPInputProps<Format extends string> {
+  /**
+   * Describes the accepted characters and visual grouping. Use `0` for numeric
+   * inputs, `A` for alphanumeric inputs, and `-` for visual separators. A format
+   * must use either `0` or `A` throughout. Separators are not included in the value.
+   */
+  format: OTPFormat<Format>;
   onComplete: (value: string) => void;
-  characterSet?: 'alphanumeric' | 'numeric';
   disabled?: boolean;
   size?: FormSize;
-  transform?: (value: string) => string;
+  /** Converts alphanumeric input to uppercase as it is entered. */
+  uppercase?: boolean;
 }
 
 /** @public */
-export function OTPInput({
-  length,
+export function OTPInput<const Format extends string>({
+  format,
   onComplete,
-  characterSet = 'numeric',
   disabled = false,
   size = 'md',
-  transform,
-}: OTPInputProps) {
+  uppercase = false,
+}: OTPInputProps<Format>) {
   const [value, setValue] = useState('');
-  const transformValue = (newValue: string) => transform?.(newValue) ?? newValue;
+  const normalizeValue = (newValue: string) =>
+    uppercase ? newValue.toUpperCase() : newValue;
+  const formatCharacters = [...format];
+  const isAlphanumeric = format.includes('A');
+  const length = formatCharacters.filter(character => character !== '-').length;
 
   return (
     <OTPInputPrimitive
       aria-label={t('One-time password')}
       autoComplete="one-time-code"
       disabled={disabled}
-      inputMode={characterSet === 'numeric' ? 'numeric' : 'text'}
+      inputMode={isAlphanumeric ? 'text' : 'numeric'}
       maxLength={length}
-      onChange={newValue => setValue(transformValue(newValue))}
-      onComplete={(newValue: string) => onComplete(transformValue(newValue))}
-      pattern={
-        characterSet === 'numeric' ? REGEXP_ONLY_DIGITS : REGEXP_ONLY_DIGITS_AND_CHARS
-      }
+      onChange={newValue => setValue(normalizeValue(newValue))}
+      onComplete={(newValue: string) => onComplete(normalizeValue(newValue))}
+      pattern={isAlphanumeric ? REGEXP_ONLY_DIGITS_AND_CHARS : REGEXP_ONLY_DIGITS}
       render={({slots}) => (
-        <Flex aria-hidden gap="xs" paddingRight="md">
-          {slots.map((slot, index) => (
-            <OTPInputSlot
-              key={index}
-              align="center"
-              aria-hidden
-              aria-disabled={disabled}
-              data-input-otp-slot
-              justify="center"
-              $isActive={slot.isActive}
-              $size={size}
-            >
-              {slot.char ?? slot.placeholderChar}
-            </OTPInputSlot>
-          ))}
+        <Flex align="center" aria-hidden gap="xs" paddingRight="md">
+          {formatCharacters.map((character, formatIndex) => {
+            if (character === '-') {
+              return (
+                <Fragment key={formatIndex}>
+                  <Flex align="center" paddingLeft="xs" paddingRight="xs">
+                    {flexProps => (
+                      <Text {...flexProps} as="span" size="lg">
+                        -
+                      </Text>
+                    )}
+                  </Flex>
+                </Fragment>
+              );
+            }
+
+            const slotIndex = formatCharacters
+              .slice(0, formatIndex)
+              .filter(formatCharacter => formatCharacter !== '-').length;
+            const slot = slots[slotIndex];
+
+            if (!slot) {
+              return null;
+            }
+
+            return (
+              <OTPInputSlot
+                key={formatIndex}
+                align="center"
+                aria-hidden
+                aria-disabled={disabled}
+                data-input-otp-slot
+                justify="center"
+                $isActive={slot.isActive}
+                $size={size}
+              >
+                {slot.char ?? slot.placeholderChar}
+              </OTPInputSlot>
+            );
+          })}
         </Flex>
       )}
       value={value}


### PR DESCRIPTION
OTPInput callers now describe the code with a typed format such as `000-000` or `AAAA-AAAA`. The format determines the character set, input length, and visual grouping; TypeScript rejects mixed tokens and malformed separators. Alphanumeric inputs can opt into normalization with the focused `uppercase` prop.

Separators remain presentation-only, so typing or pasting a formatted code still passes the raw value to `onComplete`. The component documentation and interaction tests cover numeric formats, uppercase alphanumeric formats, and separator behavior.