### PR TITLE
feat(seer): Open autofix overview Seer drawer in place

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -315,11 +315,11 @@ describe('AutofixOverview', () => {
       expect(groupRequest).toHaveBeenCalled();
     });
 
-    it('stays closed when the org lacks gen-ai access', async () => {
+    it('stays closed and clears the param when the org lacks gen-ai access', async () => {
       mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
       mockDrawerFor('2');
 
-      render(<AutofixOverview />, {
+      const {router} = render(<AutofixOverview />, {
         organization: OrganizationFixture({features: ['seer-night-shift-ui']}),
         initialRouterConfig: {
           location: {pathname: basePath, query: {seerDrawer: '2'}},
@@ -330,6 +330,7 @@ describe('AutofixOverview', () => {
         await screen.findByRole('link', {name: 'TypeError in checkout cart'})
       ).toBeInTheDocument();
       expect(seerDrawer()).not.toBeInTheDocument();
+      await waitFor(() => expect(router.location.query.seerDrawer).toBeUndefined());
     });
 
     it('clears the param and closes when the drawer is dismissed', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -28,7 +28,7 @@ import type {
 
 describe('AutofixOverview', () => {
   const organization = OrganizationFixture({
-    features: ['seer-night-shift-ui'],
+    features: ['seer-night-shift-ui', 'gen-ai-features'],
   });
   const basePath = `/organizations/${organization.slug}/issues/autofix/overview/`;
 
@@ -256,34 +256,121 @@ describe('AutofixOverview', () => {
     await waitFor(() => expect(enrichedRequest).toHaveBeenCalledTimes(2));
   });
 
-  it('opens the Seer drawer in place when the URL carries a group id', async () => {
-    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
-    const groupRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/2/`,
-      body: GroupFixture({id: '2'}),
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/2/autofix/`,
-      body: {autofix: null},
-    });
-    // Hold setup open so the drawer sits in its loading state and fires no
+  describe('Seer drawer', () => {
+    // Holds setup open so the drawer sits in its loading state and fires no
     // downstream content requests.
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/2/autofix/setup/`,
-      asyncDelay: new Promise<void>(() => {}),
-      body: {},
+    function mockDrawerFor(groupId: string) {
+      const groupRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${groupId}/`,
+        body: GroupFixture({id: groupId}),
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${groupId}/autofix/`,
+        body: {autofix: null},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${groupId}/autofix/setup/`,
+        asyncDelay: new Promise<void>(() => {}),
+        body: {},
+      });
+      return groupRequest;
+    }
+
+    function seerDrawer() {
+      return screen.queryByRole('complementary', {name: 'Seer drawer'});
+    }
+
+    it('opens in place when the URL carries a group id', async () => {
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      const groupRequest = mockDrawerFor('2');
+
+      renderPage({seerDrawer: '2'});
+
+      // The overview list stays mounted behind the drawer.
+      expect(
+        await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('complementary', {name: 'Seer drawer'})
+      ).toBeInTheDocument();
+      expect(groupRequest).toHaveBeenCalled();
     });
 
-    renderPage({seerDrawer: '2'});
+    it('stays closed when the org lacks gen-ai access', async () => {
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      mockDrawerFor('2');
 
-    // The overview list stays mounted behind the drawer.
-    expect(
-      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole('complementary', {name: 'Seer drawer'})
-    ).toBeInTheDocument();
-    expect(groupRequest).toHaveBeenCalled();
+      render(<AutofixOverview />, {
+        organization: OrganizationFixture({features: ['seer-night-shift-ui']}),
+        initialRouterConfig: {
+          location: {pathname: basePath, query: {seerDrawer: '2'}},
+        },
+      });
+
+      expect(
+        await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+      ).toBeInTheDocument();
+      expect(seerDrawer()).not.toBeInTheDocument();
+    });
+
+    it('clears the param and closes when the drawer is dismissed', async () => {
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      mockDrawerFor('2');
+
+      const {router} = renderPage({seerDrawer: '2'});
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Close Drawer'}));
+
+      await waitFor(() => expect(seerDrawer()).not.toBeInTheDocument());
+      expect(router.location.query.seerDrawer).toBeUndefined();
+    });
+
+    it('closes when the group id leaves the URL (back navigation)', async () => {
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      mockDrawerFor('2');
+
+      const {router} = renderPage({seerDrawer: '2'});
+
+      expect(
+        await screen.findByRole('complementary', {name: 'Seer drawer'})
+      ).toBeInTheDocument();
+
+      router.navigate(basePath);
+
+      await waitFor(() => expect(seerDrawer()).not.toBeInTheDocument());
+    });
+
+    it('switches to another run when the URL group id changes', async () => {
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      mockDrawerFor('2');
+      const group3Request = mockDrawerFor('3');
+
+      const {router} = renderPage({seerDrawer: '2'});
+
+      expect(
+        await screen.findByRole('complementary', {name: 'Seer drawer'})
+      ).toBeInTheDocument();
+      expect(group3Request).not.toHaveBeenCalled();
+
+      router.navigate(`${basePath}?seerDrawer=3`);
+
+      await waitFor(() => expect(group3Request).toHaveBeenCalled());
+      expect(seerDrawer()).toBeInTheDocument();
+    });
+
+    it('shows an error state when the group fails to load', async () => {
+      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/2/`,
+        statusCode: 500,
+      });
+
+      renderPage({seerDrawer: '2'});
+
+      expect(
+        await screen.findByText('There was an error loading data.')
+      ).toBeInTheDocument();
+    });
   });
 
   it('renders All Runs and In Progress tabs with counts', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -357,20 +357,6 @@ describe('AutofixOverview', () => {
       await waitFor(() => expect(group3Request).toHaveBeenCalled());
       expect(seerDrawer()).toBeInTheDocument();
     });
-
-    it('shows an error state when the group fails to load', async () => {
-      mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/2/`,
-        statusCode: 500,
-      });
-
-      renderPage({seerDrawer: '2'});
-
-      expect(
-        await screen.findByText('There was an error loading data.')
-      ).toBeInTheDocument();
-    });
   });
 
   it('renders All Runs and In Progress tabs with counts', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -13,6 +13,8 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {useDrawer} from '@sentry/scraps/drawer';
+
 import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
@@ -25,6 +27,7 @@ import type {
   OverviewPullRequest,
   OverviewRunIssue,
 } from 'sentry/views/seerWorkflows/overview/types';
+import {useOverviewSeerDrawer} from 'sentry/views/seerWorkflows/overview/useOverviewSeerDrawer';
 
 describe('AutofixOverview', () => {
   const organization = OrganizationFixture({
@@ -280,6 +283,22 @@ describe('AutofixOverview', () => {
       return screen.queryByRole('complementary', {name: 'Seer drawer'});
     }
 
+    // Drives the hook alongside a button that opens a second drawer, so a test
+    // can replace and dismiss the Seer drawer the way Seer Agent would.
+    function DrawerHarness() {
+      useOverviewSeerDrawer();
+      const {openDrawer} = useDrawer();
+      return (
+        <button
+          onClick={() =>
+            openDrawer(() => <div>Other drawer body</div>, {ariaLabel: 'Other drawer'})
+          }
+        >
+          open other
+        </button>
+      );
+    }
+
     it('opens in place when the URL carries a group id', async () => {
       mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
       const groupRequest = mockDrawerFor('2');
@@ -356,6 +375,31 @@ describe('AutofixOverview', () => {
 
       await waitFor(() => expect(group3Request).toHaveBeenCalled());
       expect(seerDrawer()).toBeInTheDocument();
+    });
+
+    it('reopens after another drawer replaces and then closes it', async () => {
+      mockDrawerFor('2');
+
+      render(<DrawerHarness />, {
+        organization,
+        initialRouterConfig: {location: {pathname: basePath, query: {seerDrawer: '2'}}},
+      });
+
+      expect(
+        await screen.findByRole('complementary', {name: 'Seer drawer'})
+      ).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'open other'}));
+      expect(
+        await screen.findByRole('complementary', {name: 'Other drawer'})
+      ).toBeInTheDocument();
+      expect(seerDrawer()).not.toBeInTheDocument();
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(
+        await screen.findByRole('complementary', {name: 'Seer drawer'})
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -256,6 +256,36 @@ describe('AutofixOverview', () => {
     await waitFor(() => expect(enrichedRequest).toHaveBeenCalledTimes(2));
   });
 
+  it('opens the Seer drawer in place when the URL carries a group id', async () => {
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+    const groupRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/`,
+      body: GroupFixture({id: '2'}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/`,
+      body: {autofix: null},
+    });
+    // Hold setup open so the drawer sits in its loading state and fires no
+    // downstream content requests.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/setup/`,
+      asyncDelay: new Promise<void>(() => {}),
+      body: {},
+    });
+
+    renderPage({seerDrawer: '2'});
+
+    // The overview list stays mounted behind the drawer.
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('complementary', {name: 'Seer drawer'})
+    ).toBeInTheDocument();
+    expect(groupRequest).toHaveBeenCalled();
+  });
+
   it('renders All Runs and In Progress tabs with counts', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -38,6 +38,7 @@ import {OverviewCard} from './issueCard';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
+import {useOverviewSeerDrawer} from './useOverviewSeerDrawer';
 
 const SeerTrialCTA = OverrideOrDefault({
   overrideName: 'component:seer-trial-cta',
@@ -83,6 +84,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   const {selection, isReady: pageFiltersReady} = usePageFilters();
   const location = useLocation();
   const navigate = useNavigate();
+  useOverviewSeerDrawer();
   const [collapsedGroups, setCollapsedGroups] = useLocalStorageState<StatusGroupKey[]>(
     'seer-autofix-overview:collapsed-groups',
     []

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -257,7 +257,7 @@ function OverviewAction({
     );
   }
 
-  return <OverviewCardAction run={run} sectionKey={sectionKey} issueUrl={issueUrl} />;
+  return <OverviewCardAction run={run} sectionKey={sectionKey} />;
 }
 
 const TitleLink = styled(Link)`

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -15,7 +15,6 @@ jest.mock('sentry/utils/analytics');
 
 describe('OverviewCardAction', () => {
   const organization = OrganizationFixture();
-  const issueUrl = '/organizations/org-slug/issues/2/';
 
   function issueFixture(): OverviewRunIssue {
     return {
@@ -93,14 +92,9 @@ describe('OverviewCardAction', () => {
         body: {run_id: 1, sentry_run_id: 'run-1'},
       });
 
-      render(
-        <OverviewCardAction
-          run={runFixture()}
-          sectionKey={sectionKey}
-          issueUrl={issueUrl}
-        />,
-        {organization}
-      );
+      render(<OverviewCardAction run={runFixture()} sectionKey={sectionKey} />, {
+        organization,
+      });
 
       await userEvent.click(screen.getByRole('button', {name: label}));
 
@@ -143,14 +137,9 @@ describe('OverviewCardAction', () => {
       body: {},
     });
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="code_changes_ready"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+    render(<OverviewCardAction run={runFixture()} sectionKey="code_changes_ready" />, {
+      organization,
+    });
 
     const permissionsLink = await screen.findByRole('button', {name: /permissions/i});
     expect(permissionsLink).toHaveAttribute(
@@ -168,14 +157,9 @@ describe('OverviewCardAction', () => {
       asyncDelay: 20,
     });
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="code_changes_ready"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+    render(<OverviewCardAction run={runFixture()} sectionKey="code_changes_ready" />, {
+      organization,
+    });
 
     expect(screen.getByRole('button', {name: 'Draft PR'})).toBeDisabled();
     await waitFor(() =>
@@ -191,37 +175,34 @@ describe('OverviewCardAction', () => {
       body: {detail: 'Internal Error'},
     });
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+    render(<OverviewCardAction run={runFixture()} sectionKey="needs_investigation" />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'Create Plan'}));
 
     expect(await screen.findByRole('button', {name: 'Create Plan'})).toBeEnabled();
   });
 
-  it('links to the issue with the Seer drawer open from the dropdown', async () => {
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+  it('opens the Seer drawer in place from the dropdown without leaving the overview', async () => {
+    render(<OverviewCardAction run={runFixture()} sectionKey="needs_investigation" />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/issues/autofix/overview/',
+          query: {statsPeriod: '24h'},
+        },
+      },
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
 
     const openSeer = await screen.findByRole('menuitemradio', {name: 'Open Seer'});
-    expect(openSeer).toHaveAttribute(
-      'href',
-      expect.stringContaining('/organizations/org-slug/issues/2/?seerDrawer=true')
-    );
+    const href = openSeer.getAttribute('href') ?? '';
+    expect(href).toContain('/organizations/org-slug/issues/autofix/overview/');
+    expect(href).toContain('seerDrawer=2');
+    expect(href).toContain('statsPeriod=24h');
+    expect(href).not.toContain('/issues/2/');
 
     expect(trackAnalytics).not.toHaveBeenCalledWith(
       'autofix.overview.action_clicked',
@@ -236,14 +217,9 @@ describe('OverviewCardAction', () => {
       body: {failures: [], successes: [{}]},
     });
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+    render(<OverviewCardAction run={runFixture()} sectionKey="needs_investigation" />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
     await userEvent.click(
@@ -281,14 +257,9 @@ describe('OverviewCardAction', () => {
       body: [{provider: 'github'}],
     });
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+    render(<OverviewCardAction run={runFixture()} sectionKey="needs_investigation" />, {
+      organization,
+    });
 
     expect(agentsRequest).not.toHaveBeenCalled();
     expect(reposRequest).not.toHaveBeenCalled();
@@ -308,14 +279,9 @@ describe('OverviewCardAction', () => {
       body: [{provider: 'bitbucket'}],
     });
 
-    render(
-      <OverviewCardAction
-        run={runFixture()}
-        sectionKey="needs_investigation"
-        issueUrl={issueUrl}
-      />,
-      {organization}
-    );
+    render(<OverviewCardAction run={runFixture()} sectionKey="needs_investigation" />, {
+      organization,
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
 

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -30,6 +30,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {AutofixStateKey, OverviewRun} from './types';
@@ -86,13 +87,12 @@ const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
 export function OverviewCardAction({
   run,
   sectionKey,
-  issueUrl,
 }: {
-  issueUrl: string;
   run: OverviewRun;
   sectionKey: ActionableSectionKey;
 }) {
   const organization = useOrganization();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const config = ACTIONS[sectionKey];
   const [dispatched, setDispatched] = useState(false);
@@ -156,7 +156,12 @@ export function OverviewCardAction({
             <span>{t('Open Seer')}</span>
           </Flex>
         ),
-        to: {pathname: issueUrl, query: {seerDrawer: 'true'}},
+        // Stay on the overview and open the drawer in place; the group id lets
+        // a reload reopen the drawer for the same run.
+        to: {
+          pathname: location.pathname,
+          query: {...location.query, seerDrawer: run.groupId},
+        },
         onAction: () =>
           trackAnalytics('autofix.overview.open_seer_clicked', {
             organization,
@@ -170,7 +175,8 @@ export function OverviewCardAction({
     codingAgentIntegrations,
     codingAgentDisabledReason,
     handleCodingAgentHandoff,
-    issueUrl,
+    location.pathname,
+    location.query,
     organization,
     run.groupId,
     run.seerRunId,

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -156,8 +156,6 @@ export function OverviewCardAction({
             <span>{t('Open Seer')}</span>
           </Flex>
         ),
-        // Stay on the overview and open the drawer in place; the group id lets
-        // a reload reopen the drawer for the same run.
         to: {
           pathname: location.pathname,
           query: {...location.query, seerDrawer: run.groupId},

--- a/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
@@ -24,10 +24,8 @@ function SeerDrawerLoader({groupId}: {groupId: string}) {
   return <SeerDrawer group={group} project={group.project} />;
 }
 
-// Opens the Seer drawer in place when ?seerDrawer=<groupId> is set, so the
-// overview stays put instead of navigating to the issue page.
 export function useOverviewSeerDrawer() {
-  const {openDrawer} = useDrawer();
+  const {openDrawer, isAnyDrawerOpen} = useDrawer();
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
@@ -35,33 +33,36 @@ export function useOverviewSeerDrawer() {
   useEffect(() => {
     locationRef.current = location;
   });
+  const openGroupIdRef = useRef<string | undefined>(undefined);
 
   const hasSeerAccess =
     organization.features.includes('gen-ai-features') && !organization.hideAiFeatures;
   const groupId = decodeScalar(location.query.seerDrawer);
 
-  // The group id lives in the URL so a reload or a second card reopens the
-  // drawer for that run.
   useEffect(() => {
     if (!groupId || !hasSeerAccess) {
       return;
     }
+    if (isAnyDrawerOpen && openGroupIdRef.current === groupId) {
+      return;
+    }
     const pathname = locationRef.current.pathname;
+    openGroupIdRef.current = groupId;
     openDrawer(() => <SeerDrawerLoader groupId={groupId} />, {
       ariaLabel: t('Seer drawer'),
       drawerKey: 'seer-autofix-drawer',
       resizable: true,
       mode: 'passive',
-      // Close when leaving the overview or when the param stops pointing here, so
-      // browser back/forward can't orphan the drawer.
       shouldCloseOnLocationChange: nextLocation =>
         nextLocation.pathname !== pathname ||
         decodeScalar(nextLocation.query.seerDrawer) !== groupId,
-      onClose: () =>
+      onClose: () => {
+        openGroupIdRef.current = undefined;
         navigate(
           {pathname, query: {...locationRef.current.query, seerDrawer: undefined}},
           {replace: true, preventScrollReset: true}
-        ),
+        );
+      },
     });
-  }, [groupId, hasSeerAccess, openDrawer, navigate]);
+  }, [groupId, hasSeerAccess, isAnyDrawerOpen, openDrawer, navigate]);
 }

--- a/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
@@ -25,8 +25,7 @@ function SeerDrawerLoader({groupId}: {groupId: string}) {
 }
 
 // Opens the Seer drawer in place when ?seerDrawer=<groupId> is set, so the
-// overview stays put instead of navigating to the issue page. The group id lets
-// a reload reopen the drawer for the same run.
+// overview stays put instead of navigating to the issue page.
 export function useOverviewSeerDrawer() {
   const {openDrawer} = useDrawer();
   const organization = useOrganization();

--- a/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
@@ -1,0 +1,63 @@
+import {useEffect, useRef} from 'react';
+
+import {useDrawer} from '@sentry/scraps/drawer';
+
+import {SeerDrawer} from 'sentry/components/events/autofix/v3/drawer';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+
+function SeerDrawerLoader({groupId}: {groupId: string}) {
+  const {data: group, isPending, isError} = useGroup({groupId});
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+  if (isError || !group) {
+    return <LoadingError />;
+  }
+  return <SeerDrawer group={group} project={group.project} />;
+}
+
+// Opens the Seer drawer in place when ?seerDrawer=<groupId> is set, so the
+// overview stays put instead of navigating to the issue page. The group id lets
+// a reload reopen the drawer for the same run.
+export function useOverviewSeerDrawer() {
+  const {openDrawer} = useDrawer();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const locationRef = useRef(location);
+  useEffect(() => {
+    locationRef.current = location;
+  });
+
+  const groupId = decodeScalar(location.query.seerDrawer);
+
+  // Keyed on groupId so a fresh id (a reload, or a second card) reopens the
+  // drawer for that run; openDrawer replaces any drawer already open.
+  useEffect(() => {
+    if (!groupId) {
+      return;
+    }
+    const pathname = locationRef.current.pathname;
+    openDrawer(() => <SeerDrawerLoader groupId={groupId} />, {
+      ariaLabel: t('Seer drawer'),
+      drawerKey: 'seer-autofix-drawer',
+      resizable: true,
+      mode: 'passive',
+      shouldCloseOnLocationChange: nextLocation => nextLocation.pathname !== pathname,
+      onClose: () =>
+        navigate(
+          {
+            pathname,
+            query: {...locationRef.current.query, seerDrawer: undefined},
+          },
+          {replace: true, preventScrollReset: true}
+        ),
+    });
+  }, [groupId, openDrawer, navigate]);
+}

--- a/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
 function SeerDrawerLoader({groupId}: {groupId: string}) {
@@ -28,6 +29,7 @@ function SeerDrawerLoader({groupId}: {groupId: string}) {
 // a reload reopen the drawer for the same run.
 export function useOverviewSeerDrawer() {
   const {openDrawer} = useDrawer();
+  const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
   const locationRef = useRef(location);
@@ -35,12 +37,14 @@ export function useOverviewSeerDrawer() {
     locationRef.current = location;
   });
 
+  const hasSeerAccess =
+    organization.features.includes('gen-ai-features') && !organization.hideAiFeatures;
   const groupId = decodeScalar(location.query.seerDrawer);
 
-  // Keyed on groupId so a fresh id (a reload, or a second card) reopens the
-  // drawer for that run; openDrawer replaces any drawer already open.
+  // The group id lives in the URL so a reload or a second card reopens the
+  // drawer for that run.
   useEffect(() => {
-    if (!groupId) {
+    if (!groupId || !hasSeerAccess) {
       return;
     }
     const pathname = locationRef.current.pathname;
@@ -49,15 +53,16 @@ export function useOverviewSeerDrawer() {
       drawerKey: 'seer-autofix-drawer',
       resizable: true,
       mode: 'passive',
-      shouldCloseOnLocationChange: nextLocation => nextLocation.pathname !== pathname,
+      // Close when leaving the overview or when the param stops pointing here, so
+      // browser back/forward can't orphan the drawer.
+      shouldCloseOnLocationChange: nextLocation =>
+        nextLocation.pathname !== pathname ||
+        decodeScalar(nextLocation.query.seerDrawer) !== groupId,
       onClose: () =>
         navigate(
-          {
-            pathname,
-            query: {...locationRef.current.query, seerDrawer: undefined},
-          },
+          {pathname, query: {...locationRef.current.query, seerDrawer: undefined}},
           {replace: true, preventScrollReset: true}
         ),
     });
-  }, [groupId, openDrawer, navigate]);
+  }, [groupId, hasSeerAccess, openDrawer, navigate]);
 }

--- a/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
@@ -40,13 +40,23 @@ export function useOverviewSeerDrawer() {
   const groupId = decodeScalar(location.query.seerDrawer);
 
   useEffect(() => {
-    if (!groupId || !hasSeerAccess) {
+    if (!groupId) {
+      return;
+    }
+    const pathname = locationRef.current.pathname;
+    const clearSeerDrawer = () =>
+      navigate(
+        {pathname, query: {...locationRef.current.query, seerDrawer: undefined}},
+        {replace: true, preventScrollReset: true}
+      );
+
+    if (!hasSeerAccess) {
+      clearSeerDrawer();
       return;
     }
     if (isAnyDrawerOpen && openGroupIdRef.current === groupId) {
       return;
     }
-    const pathname = locationRef.current.pathname;
     openGroupIdRef.current = groupId;
     openDrawer(() => <SeerDrawerLoader groupId={groupId} />, {
       ariaLabel: t('Seer drawer'),
@@ -58,10 +68,7 @@ export function useOverviewSeerDrawer() {
         decodeScalar(nextLocation.query.seerDrawer) !== groupId,
       onClose: () => {
         openGroupIdRef.current = undefined;
-        navigate(
-          {pathname, query: {...locationRef.current.query, seerDrawer: undefined}},
-          {replace: true, preventScrollReset: true}
-        );
+        clearSeerDrawer();
       },
     });
   }, [groupId, hasSeerAccess, isAnyDrawerOpen, openDrawer, navigate]);


### PR DESCRIPTION
## Summary

Clicking **Open Seer** on an Autofix Overview card used to navigate to the issue details page and open the Seer sidebar there, pulling the user off the overview. This opens the same Seer drawer **in place** on the overview instead.

The drawer state is encoded in the overview URL as `?seerDrawer=<groupId>`, so:
- a reload reopens the drawer for the same run,
- the view is shareable, and
- opening Seer on another card switches the drawer to that run.

## Changes

- **`overviewCardAction.tsx`** — the "Open Seer" menu item now links to the current overview URL with `?seerDrawer=<groupId>` (preserving existing filters) instead of navigating to `/issues/<id>/?seerDrawer=true`. Removed the now-unused `issueUrl` prop (and stopped passing it from `issueCard.tsx`).
- **`useOverviewSeerDrawer.tsx`** (new) — a hook that watches `?seerDrawer=<groupId>` and opens the existing `SeerDrawer` in a passive drawer, via a small `SeerDrawerLoader` that fetches the full `Group` on demand. The drawer closes when the param clears/changes or when leaving the overview (so browser back/forward can't orphan it), and opening is gated on `gen-ai-features` / `hideAiFeatures` to match the canonical `useOpenSeerDrawer`.
- **`index.tsx`** — calls `useOverviewSeerDrawer()`.

Frontend-only.
