### PR TITLE
feat(auth): Add console SMS backend

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -182,6 +182,11 @@ register(
 
 # SMS
 register(
+    "sms.backend",
+    default="twilio",
+    flags=FLAG_NOSTORE,
+)
+register(
     "sms.twilio-account",
     default="",
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/utils/sms.py
+++ b/src/sentry/utils/sms.py
@@ -42,18 +42,26 @@ def phone_number_as_e164(num: str) -> str:
 
 
 def sms_available() -> bool:
-    return bool(options.get("sms.twilio-account"))
+    backend = options.get("sms.backend")
+    return backend == "console" or (backend == "twilio" and bool(options.get("sms.twilio-account")))
 
 
 def send_sms(body: str, to: str, from_: str | None = None) -> bool:
+    phone_number = phone_number_as_e164(to)
+    backend = options.get("sms.backend")
+
+    if backend == "console":
+        logger.info("sms.console", extra={"phone_number": phone_number, "body": body})
+        return True
+    if backend != "twilio":
+        raise RuntimeError(f"Unknown SMS backend: {backend}")
+
     account = options.get("sms.twilio-account")
     if not account:
         raise RuntimeError("SMS backend is not configured.")
     if account[:2] != "AC":
         account = "AC" + account
     url = "https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json" % quote(account)
-
-    phone_number = phone_number_as_e164(to)
 
     rv = requests.post(
         url,

--- a/tests/sentry/auth/authenticators/test_sms.py
+++ b/tests/sentry/auth/authenticators/test_sms.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
@@ -8,7 +9,7 @@ from sentry.auth.authenticators.sms import SmsInterface, SMSRateLimitExceeded
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
-from sentry.utils.sms import InvalidPhoneNumber, phone_number_as_e164
+from sentry.utils.sms import InvalidPhoneNumber, phone_number_as_e164, send_sms, sms_available
 
 
 @control_silo_test
@@ -120,3 +121,25 @@ class SmsInterfaceTest(TestCase):
     def test_valid_phone_number(self) -> None:
         formatted_number = phone_number_as_e164("2345678900")
         assert "+12345678900" == formatted_number
+
+    @patch("sentry.utils.sms.logger.info")
+    @patch("sentry.utils.sms.requests.post")
+    def test_console_backend(self, requests_post: MagicMock, logger_info: MagicMock) -> None:
+        with self.options({"sms.backend": "console", "sms.twilio-account": ""}):
+            assert sms_available()
+            assert send_sms("123456 is your Sentry authentication code.", "2125550199")
+
+        requests_post.assert_not_called()
+        logger_info.assert_called_once_with(
+            "sms.console",
+            extra={
+                "phone_number": "+12125550199",
+                "body": "123456 is your Sentry authentication code.",
+            },
+        )
+
+    def test_unknown_backend(self) -> None:
+        with self.options({"sms.backend": "unknown"}):
+            assert not sms_available()
+            with pytest.raises(RuntimeError, match="Unknown SMS backend: unknown"):
+                send_sms("message", "2125550199")


### PR DESCRIPTION
The new API-based 2FA flow needs local end-to-end coverage for SMS challenge activation and verification. Today, enabling SMS with placeholder Twilio configuration makes a real HTTP request and fails before the verification code can be used.

This adds an explicit console SMS backend that treats SMS as available, normalizes the destination number, and logs the complete message—including the verification code—without making a network request. Twilio remains the default for compatibility, and local development can opt by configuring their local `sentry.conf.py`.