### PR TITLE
fix(seer): Clear free cohort repos on paid activation

### DIFF
--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -75,11 +75,13 @@ def should_increment_contributor_seat(
     and potentially assign a new seat.
 
     Require repo integration, code review OR autofix enabled for the repo,
-    seat-based Seer enabled for the organization, and contributor is not a bot.
+    seat-based Seer enabled for the organization, contributor is not a bot,
+    and the organization is not transitioning from the free cohort.
     """
     if (
         repo.integration_id is None
         or contributor.is_bot
+        or organization.get_option("agentic-triage-free-cohort", False)
         or not _has_code_review_or_autofix_enabled(organization, repo.id)
         or not features.has("organizations:seat-based-seer-enabled", organization)
     ):

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -205,7 +205,14 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     - Org-level: enable_seer_coding
     """
 
-    organization = Organization.objects.get(id=organization_id)
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.warning(
+            "configure_seer_for_existing_org.organization_not_found",
+            extra={"organization_id": organization_id},
+        )
+        return
 
     sentry_sdk.set_tag("organization_id", organization.id)
     sentry_sdk.set_attribute("organization_id", organization.id)

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -34,17 +34,16 @@ from sentry.utils import metrics
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
-FREE_AUTOFIX_COHORT_OPTION = "agentic-triage-free-cohort"
 
 
 def _clear_free_autofix_cohort_configuration(organization: Organization) -> None:
-    if not organization.get_option(FREE_AUTOFIX_COHORT_OPTION, False):
+    if not organization.get_option("agentic-triage-free-cohort", False):
         return
 
     SeerProjectRepository.objects.filter(
         project_repository__project__organization_id=organization.id
     ).delete()
-    organization.delete_option(FREE_AUTOFIX_COHORT_OPTION)
+    organization.delete_option("agentic-triage-free-cohort")
 
 
 def _get_group_or_log(group_id: int, task_name: str) -> Group | None:

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -27,12 +27,24 @@ from sentry.seer.autofix.utils import (
     get_seer_seat_based_tier_cache_key,
     update_seer_project_settings,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ingest_errors_tasks, issues_tasks
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
+FREE_AUTOFIX_COHORT_OPTION = "agentic-triage-free-cohort"
+
+
+def _clear_free_autofix_cohort_configuration(organization: Organization) -> None:
+    if not organization.get_option(FREE_AUTOFIX_COHORT_OPTION, False):
+        return
+
+    SeerProjectRepository.objects.filter(
+        project_repository__project__organization_id=organization.id
+    ).delete()
+    organization.delete_option(FREE_AUTOFIX_COHORT_OPTION)
 
 
 def _get_group_or_log(group_id: int, task_name: str) -> Group | None:
@@ -200,6 +212,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     sentry_sdk.set_attribute("organization_id", organization.id)
     sentry_sdk.set_tag("organization_slug", organization.slug)
     sentry_sdk.set_attribute("organization_slug", organization.slug)
+    _clear_free_autofix_cohort_configuration(organization)
 
     # Set org-level options
     organization.update_option(

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -164,6 +164,22 @@ class ShouldIncrementContributorSeatTest(TestCase):
         "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
         return_value=True,
     )
+    def test_returns_false_for_free_cohort_organization(self, mock_quota: MagicMock) -> None:
+        self.create_seer_project_repository(project=self.project, repository=self.repo)
+        self.organization.update_option("agentic-triage-free-cohort", True)
+
+        with self.feature("organizations:seat-based-seer-enabled"):
+            result = should_increment_contributor_seat(
+                self.organization, self.repo, self.contributor
+            )
+
+        assert result is False
+        mock_quota.assert_not_called()
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
+        return_value=True,
+    )
     def test_returns_true_when_code_review_enabled_and_quota_available(
         self, mock_quota: MagicMock
     ) -> None:

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -57,6 +57,15 @@ class TestGenerateIssueSummaryOnly(SentryTestCase):
 
 
 class TestConfigureSeerForExistingOrg(SentryTestCase):
+    @patch("sentry.tasks.seer.autofix.logger")
+    def test_missing_organization_returns_without_retry(self, mock_logger: MagicMock) -> None:
+        configure_seer_for_existing_org(organization_id=0)
+
+        mock_logger.warning.assert_called_once_with(
+            "configure_seer_for_existing_org.organization_not_found",
+            extra={"organization_id": 0},
+        )
+
     def test_configures_org_and_project_settings(self) -> None:
         """Test that org and project settings are configured correctly."""
         project1 = self.create_project(organization=self.organization)

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -8,6 +8,7 @@ from sentry.seer.models import (
     SummarizeIssueResponse,
     SummarizeIssueScores,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.autofix import (
     configure_seer_for_existing_org,
     generate_issue_summary_only,
@@ -79,6 +80,36 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         assert project1.get_option("sentry:seer_automation_handoff_target") is None
         assert project2.get_option("sentry:seer_automation_handoff_point") is None
         assert project2.get_option("sentry:seer_automation_handoff_target") is None
+
+    def test_clears_free_cohort_repository_configuration(self) -> None:
+        repository = self.create_repo(project=self.project)
+        self.create_seer_project_repository(project=self.project, repository=repository)
+
+        other_organization = self.create_organization()
+        other_project = self.create_project(organization=other_organization)
+        other_repository = self.create_repo(project=other_project)
+        other_seer_repository = self.create_seer_project_repository(
+            project=other_project, repository=other_repository
+        )
+        self.organization.update_option("agentic-triage-free-cohort", True)
+
+        configure_seer_for_existing_org(organization_id=self.organization.id)
+
+        assert not SeerProjectRepository.objects.filter(
+            project_repository__project__organization=self.organization
+        ).exists()
+        assert SeerProjectRepository.objects.filter(id=other_seer_repository.id).exists()
+        assert self.organization.get_option("agentic-triage-free-cohort", False) is False
+
+    def test_preserves_non_cohort_repository_configuration(self) -> None:
+        repository = self.create_repo(project=self.project)
+        seer_repository = self.create_seer_project_repository(
+            project=self.project, repository=repository
+        )
+
+        configure_seer_for_existing_org(organization_id=self.organization.id)
+
+        assert SeerProjectRepository.objects.filter(id=seer_repository.id).exists()
 
     @pytest.mark.skip("DO NOT override autofix automation tuning off")
     def test_overrides_autofix_off_to_medium(self) -> None:


### PR DESCRIPTION
Organizations transitioning from free Autofix access to seat-based Seer now have their promotional `SeerProjectRepository` selections removed before paid project defaults are applied. The transition also removes the `agentic-triage-free-cohort` option, so repositories must be selected again through normal paid onboarding. Organizations outside the free cohort keep their existing repository configuration.

Seat tracking now treats the raw cohort option as a transition guard. Contributor activity remains ineligible after billing activation until the asynchronous configuration task deletes the promotional repositories and removes the option. The option lookup runs only in PR and merge-request webhook seat processing and uses the existing organization-option cache.
