### PR TITLE
feat(seer): Add coding-agent repo eligibility to autofix overview

### DIFF
--- a/src/sentry/seer/constants.py
+++ b/src/sentry/seer/constants.py
@@ -12,13 +12,15 @@ SeerSCMProvider = Literal[
     "gitlab",
 ]
 
-# Supported repository providers for Seer features
-SEER_SUPPORTED_SCM_PROVIDERS = [
+# GitHub providers (bare and `integrations:`-prefixed); mirrors frontend `isGitHubProvider`.
+SEER_GITHUB_SCM_PROVIDERS = [
     "integrations:github",
     "integrations:github_enterprise",
     IntegrationProviderSlug.GITHUB.value,
     IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
 ]
+
+SEER_SUPPORTED_SCM_PROVIDERS = [*SEER_GITHUB_SCM_PROVIDERS]
 
 SEER_GITLAB_SCM_PROVIDERS = [
     "integrations:gitlab",

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import cast
+from typing import NamedTuple, cast
 
 from django.db.models import Exists, OuterRef, Q
 from pydantic import ValidationError
@@ -40,15 +40,18 @@ from sentry.plugins.base import bindings
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
 from sentry.seer.agent.client_models import AgentFilePatch, FilePatch
 from sentry.seer.agent.client_utils import fetch_run_statuses
+from sentry.seer.constants import SEER_GITHUB_SCM_PROVIDERS
 from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
     CodeChangeFilePayload,
     IssuePayload,
+    IssueProjectPayload,
     OverviewResponse,
     ProposedFixPayload,
     PullRequestPayload,
     RootCausePayload,
     RunPayload,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.seer.models.run import (
     CodeChangesArtifactExtras,
     RootCauseArtifactExtras,
@@ -59,6 +62,7 @@ from sentry.seer.models.run import (
     SeerRunPullRequest,
     SolutionArtifactExtras,
 )
+from sentry.seer.seer_setup import get_supported_scm_providers
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +223,45 @@ def _pull_requests_by_seer_run_id(
     return by_run
 
 
-def _serialize_issue(group: Group, serialized_group: dict) -> IssuePayload:
+class _RepoEligibility(NamedTuple):
+    has_repos_connected: bool
+    has_non_github_repo: bool
+
+
+def _coding_agent_repo_eligibility(
+    organization: Organization, project_ids: Collection[int]
+) -> dict[int, _RepoEligibility]:
+    github_providers = set(SEER_GITHUB_SCM_PROVIDERS)
+    eligibility = {pid: _RepoEligibility(False, False) for pid in project_ids}
+    rows = (
+        SeerProjectRepository.objects.filter(
+            project_repository__project_id__in=project_ids,
+            project_repository__repository__status=ObjectStatus.ACTIVE,
+            project_repository__repository__provider__in=get_supported_scm_providers(organization),
+        )
+        .values_list("project_repository__project_id", "project_repository__repository__provider")
+        .distinct()
+    )
+    for project_id, provider in rows:
+        prev = eligibility[project_id]
+        eligibility[project_id] = _RepoEligibility(
+            True, prev.has_non_github_repo or provider not in github_providers
+        )
+    return eligibility
+
+
+def _serialize_issue(
+    group: Group, serialized_group: dict, repo_eligibility: dict[int, _RepoEligibility] | None
+) -> IssuePayload:
+    project: IssueProjectPayload = {
+        "id": str(group.project_id),
+        "slug": group.project.slug,
+        "platform": group.project.platform,
+    }
+    if repo_eligibility is not None:
+        flags = repo_eligibility[group.project_id]
+        project["hasReposConnected"] = flags.has_repos_connected
+        project["hasNonGithubRepo"] = flags.has_non_github_repo
     return {
         "count": serialized_group.get("count"),
         "userCount": serialized_group.get("userCount"),
@@ -232,11 +274,7 @@ def _serialize_issue(group: Group, serialized_group: dict) -> IssuePayload:
         "issueCategory": serialized_group.get("issueCategory"),
         "assignedTo": serialized_group.get("assignedTo"),
         "owners": serialized_group.get("owners") or [],
-        "project": {
-            "id": str(group.project_id),
-            "slug": group.project.slug,
-            "platform": group.project.platform,
-        },
+        "project": project,
     }
 
 
@@ -264,6 +302,7 @@ def _serialize_run(
     serialized_group: dict,
     pull_requests: list[PullRequestPayload],
     status: str | None,
+    repo_eligibility: dict[int, _RepoEligibility] | None,
 ) -> RunPayload:
     root_cause_artifact = run.root_cause_artifact
     root_cause: RootCausePayload | None = (
@@ -291,7 +330,7 @@ def _serialize_run(
         "lastTriggeredAt": run.seer_run.last_triggered_at,
         "pullRequests": pull_requests,
         "codeChanges": code_changes,
-        "issue": _serialize_issue(group, serialized_group),
+        "issue": _serialize_issue(group, serialized_group, repo_eligibility),
         "status": status,
     }
 
@@ -383,6 +422,12 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             [run.seer_run.id for _, run in capped], include_scm_info=include_scm_info
         )
 
+        repo_eligibility_by_project: dict[int, _RepoEligibility] | None = None
+        if include_scm_info:
+            repo_eligibility_by_project = _coding_agent_repo_eligibility(
+                organization, {group.project_id for group in groups.values()}
+            )
+
         status_by_state_id: dict[int, str] = {}
         if include_status:
             state_ids = [
@@ -405,6 +450,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                         serialized_by_id[str(group_id)],
                         pull_requests_by_seer_run_id.get(run.seer_run.id, []),
                         status_by_state_id.get(run.seer_run.seer_run_state_id),
+                        repo_eligibility_by_project,
                     )
                 )
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from sentry.seer.agent.client_models import FilePatch
 
@@ -29,6 +29,8 @@ class IssueProjectPayload(TypedDict):
     id: str
     slug: str
     platform: str | None
+    hasReposConnected: NotRequired[bool]
+    hasNonGithubRepo: NotRequired[bool]
 
 
 class IssuePayload(TypedDict):

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -1,6 +1,9 @@
 from collections.abc import Sequence
 from unittest import mock
 
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+
 from sentry import search
 from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnuba
 from sentry.constants import ObjectStatus
@@ -458,6 +461,148 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         resp = self.get_success_response(self.organization.slug, **kwargs)
         run_data = resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE][0]
         return run_data["pullRequests"]
+
+    def _issue_project(self, resp, milestone=SeerRunMilestoneType.ROOT_CAUSE):
+        return resp.data["runsByMilestone"][milestone][0]["issue"]["project"]
+
+    def _projects_by_id(self, resp, milestone=SeerRunMilestoneType.ROOT_CAUSE):
+        return {
+            r["issue"]["project"]["id"]: r["issue"]["project"]
+            for r in resp.data["runsByMilestone"][milestone]
+        }
+
+    def test_scm_info_marks_project_with_github_repo_eligible(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:github")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        project = self._issue_project(resp)
+        assert project.get("hasReposConnected") is True
+        assert project.get("hasNonGithubRepo") is False
+
+    def test_project_without_repos_is_not_eligible(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        project = self._issue_project(resp)
+        assert project["hasReposConnected"] is False
+        assert project["hasNonGithubRepo"] is False
+
+    def test_non_github_repo_flags_has_non_github(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:gitlab")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        with self.feature("organizations:seer-gitlab-support"):
+            resp = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "scmInfo"}
+            )
+
+        project = self._issue_project(resp)
+        assert project["hasReposConnected"] is True
+        assert project["hasNonGithubRepo"] is True
+
+    def test_eligibility_absent_without_scm_info_expand(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:github")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        resp = self.get_success_response(self.organization.slug)
+
+        project = self._issue_project(resp)
+        assert "hasReposConnected" not in project
+        assert "hasNonGithubRepo" not in project
+
+    def test_github_enterprise_repo_is_github(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:github_enterprise")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        project = self._issue_project(resp)
+        assert project["hasReposConnected"] is True
+        assert project["hasNonGithubRepo"] is False
+
+    def test_mixed_github_and_gitlab_repos(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        gh = self.create_repo(self.project, provider="integrations:github")
+        gl = self.create_repo(self.project, provider="integrations:gitlab")
+        self.create_seer_project_repository(project=self.project, repository=gh)
+        self.create_seer_project_repository(project=self.project, repository=gl)
+
+        with self.feature("organizations:seer-gitlab-support"):
+            resp = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "scmInfo"}
+            )
+
+        project = self._issue_project(resp)
+        assert project["hasReposConnected"] is True
+        assert project["hasNonGithubRepo"] is True
+
+    def test_gitlab_repo_without_flag_is_not_connected(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:gitlab")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        project = self._issue_project(resp)
+        assert project["hasReposConnected"] is False
+        assert project["hasNonGithubRepo"] is False
+
+    def test_inactive_repo_is_not_connected(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:github")
+        repo.update(status=ObjectStatus.DISABLED)
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        project = self._issue_project(resp)
+        assert project["hasReposConnected"] is False
+        assert project["hasNonGithubRepo"] is False
+
+    def test_eligibility_is_keyed_per_project(self):
+        eligible_group = self.create_group()
+        self._run_for_group(eligible_group, "eligible")
+        repo = self.create_repo(self.project, provider="integrations:github")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        other_project = self.create_project(organization=self.organization)
+        ineligible_group = self.create_group(project=other_project)
+        self._run_for_group(ineligible_group, "ineligible")
+
+        resp = self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        projects = self._projects_by_id(resp)
+        assert projects[str(self.project.id)]["hasReposConnected"] is True
+        assert projects[str(other_project.id)]["hasReposConnected"] is False
+
+    def test_repo_eligibility_is_one_query_regardless_of_project_count(self):
+        for i in range(3):
+            project = self.create_project(organization=self.organization)
+            group = self.create_group(project=project)
+            self._run_for_group(group, f"boom {i}")
+            repo = self.create_repo(project, provider="integrations:github")
+            self.create_seer_project_repository(project=project, repository=repo)
+
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            self.get_success_response(self.organization.slug, qs_params={"expand": "scmInfo"})
+
+        repo_queries = [q for q in ctx.captured_queries if "seer_projectrepository" in q["sql"]]
+        assert len(repo_queries) == 1
 
     @mock.patch(_INTEGRATION_SERVICE)
     def test_run_includes_pull_requests(self, mock_get_integration):


### PR DESCRIPTION
## Summary

The autofix overview dropdown greys out coding-agent handoff options ("Send to Claude Agent", etc.) based on whether a project has a connected GitHub repo. Today the frontend derives this from a per-card, fully-paginated Seer repos fetch that is gated on completion — so on first open the menu briefly shows only "Open Seer" and the handoff options pop in a moment later once that request drains.

This PR moves the eligibility signal onto the overview payload so the frontend can gate the options without a separate per-card request.

## Changes

- Expose two per-project booleans on `issue.project` — `hasReposConnected` and `hasNonGithubRepo` — on the autofix overview response, present only under `expand=scmInfo` (both `NotRequired`, so existing consumers and the lightweight `expand=status` poll are unaffected).
- Compute them in a single batched query across all shown projects (`_coding_agent_repo_eligibility`) — no N+1. `group.project` is already `select_related`, so the serialize loop only does dict lookups.
- GitHub detection uses a new explicit `SEER_GITHUB_SCM_PROVIDERS` constant that mirrors the frontend `isGitHubProvider` whitelist, rather than reusing the broader "supported providers" list.

The two booleans reconstruct the frontend gate exactly: `hasNoRepos == !hasReposConnected`, and `hasNonGithubRepo` maps directly — including the GitLab-behind-flag behavior.

## Follow-up

A separate frontend PR will consume these fields, drop the per-card repos query, and show a single dropdown loader (frontend/backend are not atomically deployed, so this backend PR lands first). The field is additive; the frontend falls back to its current behavior when the field is absent.
