### PR TITLE
feat(seer): Gate autofix overview handoff on precomputed repo eligibility

### DIFF
--- a/static/app/components/events/autofix/v3/useCodingAgents.ts
+++ b/static/app/components/events/autofix/v3/useCodingAgents.ts
@@ -17,6 +17,11 @@ import {
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 
+interface RepoEligibility {
+  hasNonGithubRepo: boolean;
+  hasReposConnected: boolean;
+}
+
 interface UseCodingAgentsOptions {
   autofix: Pick<ReturnType<typeof useExplorerAutofix>, 'triggerCodingAgentHandoff'>;
   group: {id: string; project: AvatarProject};
@@ -25,6 +30,7 @@ interface UseCodingAgentsOptions {
   step: 'root_cause' | 'solution' | 'code_changes';
   enabled?: boolean;
   onHandoff?: () => void;
+  repoEligibility?: RepoEligibility;
 }
 
 export function useCodingAgents({
@@ -35,33 +41,42 @@ export function useCodingAgents({
   referrer,
   enabled = true,
   onHandoff,
+  repoEligibility,
 }: UseCodingAgentsOptions) {
   const organization = useOrganization();
   const {triggerCodingAgentHandoff} = autofix;
 
-  const {data: codingAgentResponse} = useQuery({
+  const {data: codingAgentResponse, isLoading: isAgentsLoading} = useQuery({
     ...organizationIntegrationsCodingAgents(organization),
     enabled,
   });
 
+  const reposEnabled = enabled && repoEligibility === undefined;
   const reposQuery = useInfiniteQuery({
     ...getSeerProjectReposInfiniteQueryOptions({organization, project: group.project}),
-    enabled,
+    enabled: reposEnabled,
     select: ({pages}) => pages.flatMap(page => page.json),
   });
-  useFetchAllPages({result: reposQuery, enabled});
+  useFetchAllPages({result: reposQuery, enabled: reposEnabled});
   const repos = reposQuery.data ?? [];
 
   // Wait until pagination is fully drained so the gate is computed over every repo.
   const isReposLoading =
-    reposQuery.isPending || reposQuery.isFetchingNextPage || reposQuery.hasNextPage;
-  const hasNoRepos = repos.length === 0;
-  const hasNonGithubRepo = repos.some(repo => !isGitHubProvider(repo.provider));
+    repoEligibility === undefined &&
+    (reposQuery.isPending || reposQuery.isFetchingNextPage || reposQuery.hasNextPage);
+  const hasNoRepos = repoEligibility
+    ? !repoEligibility.hasReposConnected
+    : repos.length === 0;
+  const hasNonGithubRepo = repoEligibility
+    ? repoEligibility.hasNonGithubRepo
+    : repos.some(repo => !isGitHubProvider(repo.provider));
 
   const codingAgentIntegrations = useMemo(
     () => (isReposLoading ? undefined : codingAgentResponse?.integrations),
     [codingAgentResponse?.integrations, isReposLoading]
   );
+
+  const isLoading = enabled && (isAgentsLoading || isReposLoading);
 
   const codingAgentDisabledReason = hasNoRepos
     ? t('Connect a GitHub repository to hand off to a coding agent.')
@@ -91,5 +106,10 @@ export function useCodingAgents({
     [triggerCodingAgentHandoff, organization, runId, group, step, referrer, onHandoff]
   );
 
-  return {codingAgentIntegrations, codingAgentDisabledReason, handleCodingAgentHandoff};
+  return {
+    codingAgentIntegrations,
+    codingAgentDisabledReason,
+    handleCodingAgentHandoff,
+    isLoading,
+  };
 }

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -290,4 +290,96 @@ describe('OverviewCardAction', () => {
     });
     expect(agentItem).toHaveAttribute('aria-disabled', 'true');
   });
+
+  function runWithEligibility(hasReposConnected: boolean, hasNonGithubRepo: boolean) {
+    return runFixture({
+      issue: {
+        ...issueFixture(),
+        project: {
+          id: '2',
+          slug: 'project-slug',
+          platform: 'python',
+          hasReposConnected,
+          hasNonGithubRepo,
+        },
+      },
+    });
+  }
+
+  it('uses precomputed repo eligibility and skips the repos fetch', async () => {
+    const reposRequest = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [{provider: 'github'}],
+    });
+
+    render(
+      <OverviewCardAction
+        run={runWithEligibility(true, false)}
+        sectionKey="needs_investigation"
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    const agentItem = await screen.findByRole('menuitemradio', {
+      name: 'Send to Claude Agent',
+    });
+    expect(agentItem).not.toHaveAttribute('aria-disabled', 'true');
+    expect(reposRequest).not.toHaveBeenCalled();
+  });
+
+  it('disables handoff from precomputed eligibility without fetching repos', async () => {
+    const reposRequest = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [{provider: 'github'}],
+    });
+
+    render(
+      <OverviewCardAction
+        run={runWithEligibility(false, false)}
+        sectionKey="needs_investigation"
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    const agentItem = await screen.findByRole('menuitemradio', {
+      name: 'Send to Claude Agent',
+    });
+    expect(agentItem).toHaveAttribute('aria-disabled', 'true');
+    expect(reposRequest).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading state before revealing all options at once', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {
+        integrations: [{id: '123', name: 'Claude Agent', provider: 'claude_code'}],
+      },
+      asyncDelay: 50,
+    });
+
+    render(
+      <OverviewCardAction
+        run={runWithEligibility(true, false)}
+        sectionKey="needs_investigation"
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More Seer options'}));
+
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Open Seer'})
+    ).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: 'Open Seer'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Send to Claude Agent'})
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -109,15 +109,26 @@ export function OverviewCardAction({
     }
   );
 
-  const {codingAgentIntegrations, codingAgentDisabledReason, handleCodingAgentHandoff} =
-    useCodingAgents({
-      autofix,
-      group: {id: run.groupId, project: run.issue.project},
-      runId: run.seerRunId,
-      step: config.handoffStep,
-      referrer: 'autofix-overview',
-      enabled: menuOpened,
-    });
+  const {hasReposConnected, hasNonGithubRepo} = run.issue.project;
+  const repoEligibility =
+    hasReposConnected === undefined
+      ? undefined
+      : {hasReposConnected, hasNonGithubRepo: hasNonGithubRepo ?? false};
+
+  const {
+    codingAgentIntegrations,
+    codingAgentDisabledReason,
+    handleCodingAgentHandoff,
+    isLoading: isLoadingOptions,
+  } = useCodingAgents({
+    autofix,
+    group: {id: run.groupId, project: run.issue.project},
+    runId: run.seerRunId,
+    step: config.handoffStep,
+    referrer: 'autofix-overview',
+    enabled: menuOpened,
+    repoEligibility,
+  });
 
   const isDraftPr = sectionKey === 'code_changes_ready';
   const {permissionsTarget, isPending: isCreatePrGatePending} = useAutofixCreatePrGate({
@@ -126,6 +137,21 @@ export function OverviewCardAction({
   });
 
   const menuItems = useMemo<MenuItemProps[]>(() => {
+    if (isLoadingOptions) {
+      return [
+        {
+          key: 'loading',
+          textValue: t('Loading'),
+          disabled: true,
+          label: (
+            <Flex justify="center" padding="sm">
+              <LoadingIndicator mini size={20} />
+            </Flex>
+          ),
+        },
+      ];
+    }
+
     const agentItems = (codingAgentIntegrations ?? []).map(integration => {
       const actionLabel =
         integration.requires_identity && !integration.has_identity
@@ -170,6 +196,7 @@ export function OverviewCardAction({
       ...agentItems,
     ];
   }, [
+    isLoadingOptions,
     codingAgentIntegrations,
     codingAgentDisabledReason,
     handleCodingAgentHandoff,

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -184,7 +184,13 @@ export interface OverviewRunIssue {
   owners: SuggestedOwner[];
   priority: PriorityLevel | null;
   priorityLockedAt: string | null;
-  project: {id: string; slug: string; platform?: PlatformKey};
+  project: {
+    id: string;
+    slug: string;
+    hasNonGithubRepo?: boolean;
+    hasReposConnected?: boolean;
+    platform?: PlatformKey;
+  };
   substatus: string | null;
   userCount: number | null;
 }


### PR DESCRIPTION
## Summary

Fixes the autofix overview dropdown flash: on first open of a run's "More Seer options" menu, it briefly showed only "Open Seer" and then popped the coding-agent handoff options in a moment later, once a per-card, fully-paginated Seer repos fetch drained.

## Changes

- Read the new `hasReposConnected` / `hasNonGithubRepo` booleans off the overview payload (`issue.project`, present under `expand=scmInfo`) to gate handoff options, instead of fetching the project's Seer repos per card.
- `useCodingAgents` accepts an optional `repoEligibility`; when provided it skips the repos query entirely and derives the disabled-reason from the precomputed flags. When absent, it falls back to the repos query — so the change degrades gracefully before the backend fields exist.
- The dropdown now shows a single loading state until its options are ready and reveals them together, instead of rendering the static "Open Seer" item first and staggering the agents in after.

## Depends on

Backend PR #122226 (adds the `hasReposConnected` / `hasNonGithubRepo` fields). Frontend/backend are not atomically deployed; that PR should land first. This PR is safe to deploy independently because it falls back to the existing repos query when the fields are absent.
