### PR TITLE
feat(seer): Turn autofix overview working status into a Seer button

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -669,9 +669,22 @@ describe('AutofixOverview', () => {
     expect(issuesRequest).not.toHaveBeenCalled();
   });
 
-  it('shows a working spinner for a run that is processing', async () => {
+  it('shows a step-specific working button that opens Seer for a processing run', async () => {
     mockOverview({
       base: {autofix_root_cause: [{...rootCauseRun, status: 'processing' as const}]},
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Creating Plan…')).toBeInTheDocument();
+
+    const openSeer = screen.getByRole('button', {name: 'Open Seer'});
+    expect(openSeer).toHaveAttribute('href', expect.stringContaining('seerDrawer=2'));
+  });
+
+  it('falls back to a generic working label for a processing run past code changes', async () => {
+    mockOverview({
+      base: {has_pull_request: [{...rootCauseRun, status: 'processing' as const}]},
     });
 
     renderPage();

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Tag, type TagProps} from '@sentry/scraps/badge';
-import {LinkButton} from '@sentry/scraps/button';
+import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
@@ -11,7 +11,6 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ErrorLevel} from 'sentry/components/events/errorLevel';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
 import {
@@ -35,10 +34,17 @@ import type {
   PullRequestChecksStatus,
   PullRequestReviewStatus,
 } from 'sentry/types/integrations';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {CodeChanges} from './codeChanges';
-import {OverviewCardAction} from './overviewCardAction';
+import {
+  ButtonSpinner,
+  getProcessingLabel,
+  OverviewCardAction,
+} from './overviewCardAction';
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
 import {
   OverviewIssuePriority,
@@ -116,15 +122,41 @@ function OverviewAction({
   run: OverviewRun;
   sectionKey: AutofixStateKey;
 }) {
+  const organization = useOrganization();
+  const location = useLocation();
   const {pullRequests, status} = run;
   if (status === 'processing') {
     return (
-      <Flex align="center" gap="xs">
-        <LoadingIndicator mini />
-        <Text size="sm" variant="muted">
-          {t('Working…')}
-        </Text>
-      </Flex>
+      <ButtonBar>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled
+          aria-busy
+          icon={<ButtonSpinner size={14} />}
+        >
+          {getProcessingLabel(sectionKey)}
+        </Button>
+        <Tooltip title={t('Open Seer')} skipWrapper>
+          <LinkButton
+            size="sm"
+            variant="secondary"
+            aria-label={t('Open Seer')}
+            icon={<IconSeer size="sm" />}
+            to={{
+              pathname: location.pathname,
+              query: {...location.query, seerDrawer: run.groupId},
+            }}
+            onClick={() =>
+              trackAnalytics('autofix.overview.open_seer_clicked', {
+                organization,
+                group_id: run.groupId,
+                run_id: run.seerRunId,
+              })
+            }
+          />
+        </Tooltip>
+      </ButtonBar>
     );
   }
 

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -84,6 +84,12 @@ const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
   },
 };
 
+export function getProcessingLabel(sectionKey: AutofixStateKey): string {
+  return sectionKey in ACTIONS
+    ? ACTIONS[sectionKey as ActionableSectionKey].busyLabel
+    : t('Working…');
+}
+
 export function OverviewCardAction({
   run,
   sectionKey,
@@ -285,6 +291,6 @@ export function OverviewCardAction({
   );
 }
 
-const ButtonSpinner = styled(LoadingIndicator)`
+export const ButtonSpinner = styled(LoadingIndicator)`
   margin: 0;
 `;


### PR DESCRIPTION
On the autofix overview, a run that is actively processing showed a plain spinner with "Working…" — a status the user could look at but not act on.

This replaces it with a split button matching the overview's action controls:

- **Left segment** — a disabled button with the step-specific busy label for the run's stage (e.g. "Creating Plan…", "Generating Code…", "Creating PR…"), reusing the existing action `busyLabel`s via a new `getProcessingLabel` helper, with a "Working…" fallback for later stages. Carries `aria-busy` to keep the in-progress cue for assistive tech.
- **Right segment** — a Seer-icon button that opens the Seer drawer in place via the `seerDrawer` query param and fires the existing `autofix.overview.open_seer_clicked` analytics event.

The shared `ButtonSpinner` styled component is now exported from `overviewCardAction` and reused instead of duplicated.

Builds on #122223 (Open autofix overview Seer drawer in place), now merged.
