### PR TITLE
feat(seer): Show project platform icon next to short ID on overview card

### DIFF
--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
@@ -470,9 +471,17 @@ export function OverviewCard({
                   <TitleLink to={issueUrl}>{run.title}</TitleLink>
                 </Text>
                 <Flex wrap="wrap" gap="md" align="center">
-                  <Text size="sm" monospace variant="muted">
-                    {run.shortId}
-                  </Text>
+                  <Flex gap="xs" align="center">
+                    <ProjectAvatar
+                      project={run.issue.project}
+                      size={12}
+                      hasTooltip
+                      tooltip={run.issue.project.slug}
+                    />
+                    <Text size="sm" monospace variant="muted">
+                      {run.shortId}
+                    </Text>
+                  </Flex>
                   <IssueVitals
                     run={run}
                     statsPeriod={statsPeriod}


### PR DESCRIPTION
Add a project platform icon (`ProjectAvatar`) beside the group short ID on the Seer autofix overview card.

The card rendered the short ID as bare monospace text, unlike nearly every other short-ID surface in the app — issue stream rows, the issue-detail header, and the event drawers all already show a project graphic next to the short ID. This brings the overview card in line so each card indicates at a glance which project/platform the issue belongs to.

The project (including `platform`) is already present on the card's run data, so no data threading or API changes were needed. The avatar falls back to a generic icon when `platform` is absent, and the project slug shows on hover.

Scope is intentionally limited to this card; the remaining bare short-ID sites (autofix markdown embed, Discover/dashboards field renderers) are left for a follow-up.