### PR TITLE
ci(snapshots): Retry Playwright install with per-attempt timeout

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -48,7 +48,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium --with-deps
+        timeout-minutes: 20
+        run: |
+          for i in 1 2 3; do
+            echo "::group::playwright install (attempt $i)"
+            timeout -k 30 4m pnpm exec playwright install chromium --with-deps && exit 0
+            echo "::endgroup::"
+            echo "Attempt $i failed or timed out; retrying in 15s..."
+            sleep 15
+          done
+          echo "playwright install failed after 3 attempts"
+          exit 1
 
       - name: Run snapshot tests
         env:


### PR DESCRIPTION
## Summary

The `Install Playwright browsers` step in the snapshot-tests workflow runs `pnpm exec playwright install chromium --with-deps`. The `--with-deps` phase occasionally hangs while downloading apt dependencies from Ubuntu/Azure mirrors. With no per-attempt timeout, a hung install runs until the **20-minute job cap** is reached — failing the PR and holding a runner slot the whole time (recent runs show this step sitting at ~18m before the job times out).

For reference, healthy runs of this step complete in ~0.5–2.3 min.

## Changes

- Wrap the Playwright install in a bash retry loop:
  - Each attempt is hard-capped at **4 minutes** via `timeout` (~1.7x the slowest observed healthy run, so a slow-but-real install isn't killed).
  - Up to **3 attempts** with a 15s wait between them.
  - Retained a step-level `timeout-minutes: 20` as a backstop.
- A transient mirror hiccup now self-heals on retry instead of failing the run. A genuinely stuck attempt is killed in minutes, and the worst case (all 3 attempts hang) is ~12.5 min instead of eating the full 20-minute job budget.
- No new action dependency — pure shell (`timeout` + loop).
