### PR TITLE
feat(seer): Break out Autofix Activity selector on overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -507,7 +507,9 @@ describe('AutofixOverview', () => {
       await screen.findByText('You don’t have any Autofix runs...yet.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'project-slug'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: '14D'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Autofix Activity 14D'})
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /Sort/})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: /Create Plan/})).not.toBeInTheDocument();
     expect(

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -140,8 +140,17 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       <Flex gap="md" align="center" wrap="wrap">
         <PageFilterBar condensed>
           <ProjectPageFilter />
-          <DatePageFilter />
         </PageFilterBar>
+        <DatePageFilter
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
+          )}
+        />
+        <AssigneeFilter
+          runs={allRuns}
+          value={assignee}
+          onChange={next => setQueryParam('assignee', next ?? undefined)}
+        />
         <CompactSelect
           value={sort}
           options={SORT_OPTIONS}
@@ -151,11 +160,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
-        />
-        <AssigneeFilter
-          runs={allRuns}
-          value={assignee}
-          onChange={next => setQueryParam('assignee', next ?? undefined)}
         />
         {isRefetching && <LoadingIndicator mini />}
         {(data?.truncatedMilestones?.length ?? 0) > 0 && (


### PR DESCRIPTION
The Autofix overview filter row previously combined the project and time-window
filters in one segmented `PageFilterBar`. This splits the time window out into
its own standalone control labeled **Autofix Activity**, since the window
reflects Autofix activity and reads as its own filter rather than a generic
date picker.

The underlying picker is unchanged — same `DatePageFilter`/`TimeRangeSelector`,
still URL-synced to page-filter datetime state — so `statsPeriod` continues to
flow to the cards and their "in the last …" labels exactly as before. Relative
and absolute ranges both remain available; only the default `14d` window and
the trigger label are unaffected by design.

Filter order is now: **Project → Autofix Activity → Assignee → Sort**.

<img width="1456" height="202" alt="CleanShot 2026-08-18 at 16 05 11@2x" src="https://github.com/user-attachments/assets/735d3e57-e34a-4c3f-8916-e93e1060cc8f" />


Refs AIML-3350
