### PR TITLE
feat(seer): Add Seer button to overview PR and merged cards

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1084,6 +1084,30 @@ describe('AutofixOverview', () => {
     expect(screen.queryByRole('button', {name: /Review PR #1/})).not.toBeInTheDocument();
   });
 
+  it('renders a Seer button alongside a merged pull request', async () => {
+    mockOverview({
+      base: {
+        pull_requests_merged: [
+          {
+            ...rootCauseRun,
+            pullRequests: [pullRequestFixture({number: 8, status: 'merged'})],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('button', {name: /Merged #8/})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/pull/8'
+    );
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toHaveAttribute(
+      'href',
+      expect.stringContaining('seerDrawer=2')
+    );
+  });
+
   it('labels non-modified files with their change type', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -932,6 +932,10 @@ describe('AutofixOverview', () => {
       'https://github.com/getsentry/sentry/pull/2'
     );
     expect(screen.queryByRole('button', {name: /Review PR #1/})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toHaveAttribute(
+      'href',
+      expect.stringContaining('seerDrawer=2')
+    );
     const approvedTag = getTagForText('Approved');
     const checksPassingTag = getTagForText('Checks Passing');
     expect(

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -217,14 +217,35 @@ function OverviewAction({
 
     return (
       <Stack align="end" gap="xs">
-        <Tooltip title={REVIEW_PR_META.description} skipWrapper>
-          <LinkButton size="sm" variant="primary" href={reviewPullRequest.url} external>
-            <Flex as="span" gap="xs" align="center">
-              {t('Review PR #%s', reviewPullRequest.number)}
-              <IconOpen size="xs" />
-            </Flex>
-          </LinkButton>
-        </Tooltip>
+        <ButtonBar>
+          <Tooltip title={REVIEW_PR_META.description} skipWrapper>
+            <LinkButton size="sm" variant="primary" href={reviewPullRequest.url} external>
+              <Flex as="span" gap="xs" align="center">
+                {t('Review PR #%s', reviewPullRequest.number)}
+                <IconOpen size="xs" />
+              </Flex>
+            </LinkButton>
+          </Tooltip>
+          <Tooltip title={t('Open Seer')} skipWrapper>
+            <LinkButton
+              size="sm"
+              variant="primary"
+              aria-label={t('Open Seer')}
+              icon={<IconSeer size="sm" />}
+              to={{
+                pathname: location.pathname,
+                query: {...location.query, seerDrawer: run.groupId},
+              }}
+              onClick={() =>
+                trackAnalytics('autofix.overview.open_seer_clicked', {
+                  organization,
+                  group_id: run.groupId,
+                  run_id: run.seerRunId,
+                })
+              }
+            />
+          </Tooltip>
+        </ButtonBar>
         {enrichmentPending ? (
           // Two slots mirror the review + checks tags the enriched response
           // typically fills in, so the row height doesn't jump on resolve.

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -110,6 +110,38 @@ const REVIEW_STATUS_TAGS = {
   review_required: null,
 } satisfies Record<PullRequestReviewStatus, PullRequestStatusTagMeta | null>;
 
+function OpenSeerButton({
+  run,
+  variant,
+}: {
+  run: OverviewRun;
+  variant: 'primary' | 'secondary';
+}) {
+  const organization = useOrganization();
+  const location = useLocation();
+  return (
+    <Tooltip title={t('Open Seer')} skipWrapper>
+      <LinkButton
+        size="sm"
+        variant={variant}
+        aria-label={t('Open Seer')}
+        icon={<IconSeer size="sm" />}
+        to={{
+          pathname: location.pathname,
+          query: {...location.query, seerDrawer: run.groupId},
+        }}
+        onClick={() =>
+          trackAnalytics('autofix.overview.open_seer_clicked', {
+            organization,
+            group_id: run.groupId,
+            run_id: run.seerRunId,
+          })
+        }
+      />
+    </Tooltip>
+  );
+}
+
 function OverviewAction({
   sectionKey,
   run,
@@ -123,8 +155,6 @@ function OverviewAction({
   run: OverviewRun;
   sectionKey: AutofixStateKey;
 }) {
-  const organization = useOrganization();
-  const location = useLocation();
   const {pullRequests, status} = run;
   if (status === 'processing') {
     return (
@@ -138,25 +168,7 @@ function OverviewAction({
         >
           {getProcessingLabel(sectionKey)}
         </Button>
-        <Tooltip title={t('Open Seer')} skipWrapper>
-          <LinkButton
-            size="sm"
-            variant="secondary"
-            aria-label={t('Open Seer')}
-            icon={<IconSeer size="sm" />}
-            to={{
-              pathname: location.pathname,
-              query: {...location.query, seerDrawer: run.groupId},
-            }}
-            onClick={() =>
-              trackAnalytics('autofix.overview.open_seer_clicked', {
-                organization,
-                group_id: run.groupId,
-                run_id: run.seerRunId,
-              })
-            }
-          />
-        </Tooltip>
+        <OpenSeerButton run={run} variant="secondary" />
       </ButtonBar>
     );
   }
@@ -167,13 +179,19 @@ function OverviewAction({
         <Stack gap="xs" align="end">
           {pullRequests.map(pullRequest => {
             const label = t('Merged #%s', pullRequest.number);
+            const title = t('The pull request for this fix was merged.');
+            if (!pullRequest.url) {
+              return (
+                <Tooltip key={pullRequest.id} title={title} skipWrapper>
+                  <Tag variant="muted" icon={<IconMerge />}>
+                    {label}
+                  </Tag>
+                </Tooltip>
+              );
+            }
             return (
-              <Tooltip
-                key={pullRequest.id}
-                title={t('The pull request for this fix was merged.')}
-                skipWrapper
-              >
-                {pullRequest.url ? (
+              <ButtonBar key={pullRequest.id}>
+                <Tooltip title={title} skipWrapper>
                   <LinkButton
                     size="sm"
                     variant="secondary"
@@ -183,12 +201,9 @@ function OverviewAction({
                   >
                     {label}
                   </LinkButton>
-                ) : (
-                  <Tag variant="muted" icon={<IconMerge />}>
-                    {label}
-                  </Tag>
-                )}
-              </Tooltip>
+                </Tooltip>
+                <OpenSeerButton run={run} variant="secondary" />
+              </ButtonBar>
             );
           })}
         </Stack>
@@ -226,25 +241,7 @@ function OverviewAction({
               </Flex>
             </LinkButton>
           </Tooltip>
-          <Tooltip title={t('Open Seer')} skipWrapper>
-            <LinkButton
-              size="sm"
-              variant="primary"
-              aria-label={t('Open Seer')}
-              icon={<IconSeer size="sm" />}
-              to={{
-                pathname: location.pathname,
-                query: {...location.query, seerDrawer: run.groupId},
-              }}
-              onClick={() =>
-                trackAnalytics('autofix.overview.open_seer_clicked', {
-                  organization,
-                  group_id: run.groupId,
-                  run_id: run.seerRunId,
-                })
-              }
-            />
-          </Tooltip>
+          <OpenSeerButton run={run} variant="primary" />
         </ButtonBar>
         {enrichmentPending ? (
           // Two slots mirror the review + checks tags the enriched response


### PR DESCRIPTION
On the autofix overview, the **Review PR** and **Merged** actions were single buttons that only opened the pull request on GitHub — there was no way to jump into Seer from those states.

Both now use the same two-button split control the processing state already uses:

- **Review Open PRs card** — the purple `Review PR #N` link gains a purple Seer segment.
- **Merged card** — each linkable `Merged #N` button (grey) gains a grey Seer segment. Tag-only fallbacks (a merged PR with no URL, or the no-PR "Merged" status) stay as tags.

The Seer segment opens the Seer drawer in place (via the `seerDrawer` query param) and fires the existing `autofix.overview.open_seer_clicked` analytics event. The shared button is extracted into a single `OpenSeerButton` component, so the processing, review-PR, and merged states no longer duplicate it.

Note: a merged card can list multiple PRs, so it can render multiple stacked Seer buttons today. Tightening that layout is left as a follow-up.
