### PR TITLE
feat(seer): Add collapse/expand all groups toggle to autofix overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
+import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {EmptyState} from '@sentry/scraps/emptyState';
@@ -135,6 +136,20 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     );
   };
 
+  const populatedKeys = populatedSections.map(section => section.key);
+  const allCollapsed =
+    populatedKeys.length > 0
+      ? populatedKeys.every(key => collapsedGroups.includes(key))
+      : collapsedGroups.length > 0;
+
+  const toggleAllGroups = () => {
+    setCollapsedGroups(previous =>
+      allCollapsed
+        ? previous.filter(key => !populatedKeys.includes(key))
+        : [...new Set([...previous, ...populatedKeys])]
+    );
+  };
+
   return (
     <Stack gap="lg" padding="lg xl">
       <Flex gap="md" align="center" wrap="wrap">
@@ -169,6 +184,11 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             )}
           </Text>
         )}
+        <Flex marginLeft="auto">
+          <Button onClick={toggleAllGroups} disabled={populatedSections.length === 0}>
+            {allCollapsed ? t('Expand All') : t('Collapse All')}
+          </Button>
+        </Flex>
       </Flex>
       {isError ? (
         <LoadingError onRetry={refetch} />


### PR DESCRIPTION
The Autofix Overview filter bar gains a right-aligned button that collapses or
expands every visible status group at once, so a reviewer with many sections
open no longer has to toggle them one by one. It shares the same
localStorage-backed collapse state the individual group disclosures use, so the
setting persists across reloads and stays in sync with per-group toggles.

The label reflects the current state: it reads "Collapse All" while any visible
group is expanded and "Expand All" once they're all collapsed. Collapsing folds
in only the groups currently on screen (preserving any collapsed-but-hidden
groups), and expanding clears just those. Before runs load — or when a filter
leaves no groups — the button is disabled, and it derives its initial label from
the persisted state to avoid flipping once data arrives.

<img width="2484" height="978" alt="CleanShot 2026-08-18 at 17 32 14@2x" src="https://github.com/user-attachments/assets/5f9be755-ddef-4ec9-979a-65fccf7df408" />

