### PR TITLE
feat(seer): Toast autofix milestone advances on overview

### DIFF
--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -78,6 +78,13 @@ export type SeerAnalyticsEventsParameters = {
     organization: Organization;
     run_id: string;
   };
+  'autofix.overview.milestone_advanced': {
+    from_milestone: string;
+    group_id: string;
+    organization: Organization;
+    run_id: string;
+    to_milestone: string;
+  };
   'autofix.overview.open_seer_clicked': {
     group_id: string;
     organization: Organization;
@@ -201,6 +208,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.create_pr_clicked': 'Autofix: Create PR Setup Clicked',
   'autofix.evidence.clicked': 'Autofix: Evidence Clicked',
   'autofix.overview.action_clicked': 'Autofix Overview: Action Clicked',
+  'autofix.overview.milestone_advanced': 'Autofix Overview: Milestone Advanced',
   'autofix.overview.open_seer_clicked': 'Autofix Overview: Open Seer Clicked',
   'autofix.pr_iteration.feedback': 'Autofix: PR Iteration Feedback',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -105,14 +105,21 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       {replace: true}
     );
 
-  const {data, isPending, isError, enrichmentPending, isRefetching, refetch} =
-    useAutofixOverview({
-      organization,
-      selection,
-      sort,
-      enabled: pageFiltersReady,
-    });
-  useMilestoneAdvanceToasts(data);
+  const {
+    data,
+    isPending,
+    isError,
+    enrichmentPending,
+    isRefetching,
+    refetch,
+    enrichedSettled,
+  } = useAutofixOverview({
+    organization,
+    selection,
+    sort,
+    enabled: pageFiltersReady,
+  });
+  useMilestoneAdvanceToasts(data, enrichedSettled);
   const allRuns = useMemo(
     () => Object.values(data?.runsByMilestone ?? {}).flat(),
     [data]

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -36,6 +36,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
+import {useMilestoneAdvanceToasts} from './milestoneToast';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
@@ -111,6 +112,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       sort,
       enabled: pageFiltersReady,
     });
+  useMilestoneAdvanceToasts(data);
   const allRuns = useMemo(
     () => Object.values(data?.runsByMilestone ?? {}).flat(),
     [data]

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -35,17 +35,12 @@ import type {
   PullRequestChecksStatus,
   PullRequestReviewStatus,
 } from 'sentry/types/integrations';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {CodeChanges} from './codeChanges';
-import {
-  ButtonSpinner,
-  getProcessingLabel,
-  OverviewCardAction,
-} from './overviewCardAction';
+import {OpenSeerButton} from './openSeerButton';
+import {getProcessingLabel} from './overviewActions';
+import {ButtonSpinner, OverviewCardAction} from './overviewCardAction';
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
 import {
   OverviewIssuePriority,
@@ -131,38 +126,6 @@ const REVIEW_STATUS_TAGS = {
   review_required: null,
 } satisfies Record<PullRequestReviewStatus, PullRequestStatusTagMeta | null>;
 
-function OpenSeerButton({
-  run,
-  variant,
-}: {
-  run: OverviewRun;
-  variant: 'primary' | 'secondary';
-}) {
-  const organization = useOrganization();
-  const location = useLocation();
-  return (
-    <Tooltip title={t('Open Seer')} skipWrapper>
-      <LinkButton
-        size="sm"
-        variant={variant}
-        aria-label={t('Open Seer')}
-        icon={<IconSeer size="sm" />}
-        to={{
-          pathname: location.pathname,
-          query: {...location.query, seerDrawer: run.groupId},
-        }}
-        onClick={() =>
-          trackAnalytics('autofix.overview.open_seer_clicked', {
-            organization,
-            group_id: run.groupId,
-            run_id: run.seerRunId,
-          })
-        }
-      />
-    </Tooltip>
-  );
-}
-
 function OverviewAction({
   sectionKey,
   run,
@@ -189,7 +152,7 @@ function OverviewAction({
         >
           {getProcessingLabel(sectionKey)}
         </Button>
-        <OpenSeerButton run={run} variant="secondary" />
+        <OpenSeerButton run={run} size="sm" variant="secondary" />
       </ButtonBar>
     );
   }
@@ -223,7 +186,7 @@ function OverviewAction({
                     {label}
                   </LinkButton>
                 </Tooltip>
-                <OpenSeerButton run={run} variant="secondary" />
+                <OpenSeerButton run={run} size="sm" variant="secondary" />
               </ButtonBar>
             );
           })}
@@ -262,7 +225,7 @@ function OverviewAction({
               </Flex>
             </LinkButton>
           </Tooltip>
-          <OpenSeerButton run={run} variant="primary" />
+          <OpenSeerButton run={run} size="sm" variant="primary" />
         </ButtonBar>
         {enrichmentPending ? (
           // Two slots mirror the review + checks tags the enriched response

--- a/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
@@ -60,6 +60,20 @@ describe('MilestoneToast', () => {
     expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
   });
 
+  it('hides the next-action button while the run is processing', () => {
+    render(
+      <MilestoneToast
+        run={run({status: 'processing'})}
+        toMilestone="autofix_code_changes"
+      />,
+      {organization}
+    );
+
+    expect(screen.getByText('SEER-1 reached Code Changes')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
+  });
+
   it('triggers the next action when its button is clicked', async () => {
     const postRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/2/autofix/',

--- a/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
@@ -1,0 +1,160 @@
+import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as indicators from 'sentry/actionCreators/indicator';
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+import {MilestoneToast, useMilestoneAdvanceToasts} from './milestoneToast';
+import type {AutofixOverviewResponse, OverviewRun} from './types';
+
+jest.mock('sentry/utils/analytics');
+
+const organization = OrganizationFixture();
+
+const run = (overrides: Partial<OverviewRun> = {}): OverviewRun =>
+  ({groupId: '2', shortId: 'SEER-1', seerRunId: 'run-1', ...overrides}) as OverviewRun;
+
+const emptyMilestones = {
+  autofix_root_cause: [],
+  autofix_solution: [],
+  autofix_code_changes: [],
+  has_pull_request: [],
+  pull_requests_merged: [],
+};
+
+const response = (
+  partial: Partial<AutofixOverviewResponse['runsByMilestone']>
+): AutofixOverviewResponse => ({
+  runsByMilestone: {...emptyMilestones, ...partial},
+  truncatedMilestones: [],
+});
+
+describe('MilestoneToast', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/repos/',
+      body: {repos: [{has_write_access: true, integration_id: 5}]},
+    });
+  });
+
+  it('shows the milestone and the next-action button plus Open Seer', async () => {
+    render(<MilestoneToast run={run()} toMilestone="autofix_code_changes" />, {
+      organization,
+    });
+
+    expect(screen.getByText('SEER-1 reached Code Changes')).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Draft PR'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+  });
+
+  it('omits the action button when the milestone has no next step', () => {
+    render(<MilestoneToast run={run()} toMilestone="pull_requests_merged" />, {
+      organization,
+    });
+
+    expect(screen.getByText('SEER-1 reached Merged')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
+  });
+
+  it('triggers the next action when its button is clicked', async () => {
+    const postRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/',
+      method: 'POST',
+      body: {},
+    });
+
+    render(<MilestoneToast run={run()} toMilestone="autofix_code_changes" />, {
+      organization,
+    });
+
+    const button = await screen.findByRole('button', {name: 'Draft PR'});
+    await waitFor(() => expect(button).toBeEnabled());
+    await userEvent.click(button);
+
+    await waitFor(() =>
+      expect(postRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues/2/autofix/',
+        expect.objectContaining({
+          data: expect.objectContaining({step: 'open_pr', sentry_run_id: 'run-1'}),
+        })
+      )
+    );
+  });
+
+  it('routes Draft PR to grant permissions when write access is missing', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/2/autofix/repos/',
+      body: {repos: [{has_write_access: false, integration_id: 42}]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/42/',
+      body: GitHubIntegrationFixture({externalId: '654321', accountType: ''}),
+    });
+
+    render(<MilestoneToast run={run()} toMilestone="autofix_code_changes" />, {
+      organization,
+    });
+
+    const permissionsLink = await screen.findByRole('button', {name: /permissions/i});
+    expect(permissionsLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('/permissions/update')
+    );
+    expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
+  });
+});
+
+describe('useMilestoneAdvanceToasts', () => {
+  function Harness({data}: {data: AutofixOverviewResponse | undefined}) {
+    useMilestoneAdvanceToasts(data);
+    return null;
+  }
+
+  it('does not toast on the first payload', () => {
+    const addSuccessMessage = jest.spyOn(indicators, 'addSuccessMessage');
+
+    render(<Harness data={response({autofix_root_cause: [run()]})} />, {organization});
+
+    expect(addSuccessMessage).not.toHaveBeenCalled();
+  });
+
+  it('toasts once and records analytics when a run advances', () => {
+    const addSuccessMessage = jest.spyOn(indicators, 'addSuccessMessage');
+
+    const {rerender} = render(
+      <Harness data={response({autofix_root_cause: [run()]})} />,
+      {organization}
+    );
+    rerender(<Harness data={response({autofix_code_changes: [run()]})} />);
+
+    expect(addSuccessMessage).toHaveBeenCalledTimes(1);
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'autofix.overview.milestone_advanced',
+      expect.objectContaining({
+        organization,
+        group_id: '2',
+        run_id: 'run-1',
+        from_milestone: 'autofix_root_cause',
+        to_milestone: 'autofix_code_changes',
+      })
+    );
+  });
+
+  it('does not toast when only the status changes', () => {
+    const addSuccessMessage = jest.spyOn(indicators, 'addSuccessMessage');
+
+    const {rerender} = render(
+      <Harness data={response({autofix_root_cause: [run({status: 'processing'})]})} />,
+      {organization}
+    );
+    rerender(
+      <Harness data={response({autofix_root_cause: [run({status: 'completed'})]})} />
+    );
+
+    expect(addSuccessMessage).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
@@ -109,8 +109,14 @@ describe('MilestoneToast', () => {
 });
 
 describe('useMilestoneAdvanceToasts', () => {
-  function Harness({data}: {data: AutofixOverviewResponse | undefined}) {
-    useMilestoneAdvanceToasts(data);
+  function Harness({
+    data,
+    dataSettled = true,
+  }: {
+    data: AutofixOverviewResponse | undefined;
+    dataSettled?: boolean;
+  }) {
+    useMilestoneAdvanceToasts(data, dataSettled);
     return null;
   }
 
@@ -142,6 +148,22 @@ describe('useMilestoneAdvanceToasts', () => {
         to_milestone: 'autofix_code_changes',
       })
     );
+  });
+
+  it('stays quiet for advances that happened while unmounted', () => {
+    const addSuccessMessage = jest.spyOn(indicators, 'addSuccessMessage');
+
+    const {rerender} = render(
+      <Harness data={response({autofix_root_cause: [run()]})} dataSettled={false} />,
+      {organization}
+    );
+    rerender(<Harness data={response({autofix_code_changes: [run()]})} dataSettled />);
+
+    expect(addSuccessMessage).not.toHaveBeenCalled();
+
+    rerender(<Harness data={response({has_pull_request: [run()]})} dataSettled />);
+
+    expect(addSuccessMessage).toHaveBeenCalledTimes(1);
   });
 
   it('does not toast when only the status changes', () => {

--- a/static/app/views/seerWorkflows/overview/milestoneToast.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.tsx
@@ -116,12 +116,18 @@ function showMilestoneAdvanceToast(
   });
 }
 
-export function useMilestoneAdvanceToasts(data: AutofixOverviewResponse | undefined) {
+export function useMilestoneAdvanceToasts(
+  data: AutofixOverviewResponse | undefined,
+  dataSettled: boolean
+) {
   const organization = useOrganization();
   const previousRef = useRef<AutofixOverviewResponse | undefined>(undefined);
 
   useEffect(() => {
-    if (!data) {
+    // Only diff once the source query has settled, so a stale-cache remount
+    // baselines off the refetch instead of toasting advances that landed while
+    // unmounted.
+    if (!data || !dataSettled) {
       return;
     }
     const previous = previousRef.current;
@@ -132,5 +138,5 @@ export function useMilestoneAdvanceToasts(data: AutofixOverviewResponse | undefi
     for (const advance of detectMilestoneAdvances(previous, data)) {
       showMilestoneAdvanceToast(advance, organization);
     }
-  }, [data, organization]);
+  }, [data, dataSettled, organization]);
 }

--- a/static/app/views/seerWorkflows/overview/milestoneToast.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.tsx
@@ -91,7 +91,7 @@ export function MilestoneToast({
   return (
     <Flex align="center" gap="md">
       <Text>{t('%s reached %s', run.shortId, MILESTONE_LABELS[toMilestone])}</Text>
-      {isActionableSection(sectionKey) && (
+      {isActionableSection(sectionKey) && run.status !== 'processing' && (
         <NextActionButton run={run} sectionKey={sectionKey} />
       )}
       <OpenSeerButton run={run} size="xs" />

--- a/static/app/views/seerWorkflows/overview/milestoneToast.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.tsx
@@ -1,0 +1,136 @@
+import {useEffect, useRef} from 'react';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {OpenSeerButton} from './openSeerButton';
+import {
+  type ActionableSectionKey,
+  isActionableSection,
+  sectionKeyForMilestone,
+  useNextAction,
+} from './overviewActions';
+import type {AutofixOverviewResponse, MilestoneKey, OverviewRun} from './types';
+import {detectMilestoneAdvances, type MilestoneAdvance} from './useAutofixOverview';
+
+const MILESTONE_LABELS: Record<MilestoneKey, string> = {
+  autofix_root_cause: t('Root Cause'),
+  autofix_solution: t('Solution'),
+  autofix_code_changes: t('Code Changes'),
+  has_pull_request: t('Pull Request'),
+  pull_requests_merged: t('Merged'),
+};
+
+function NextActionButton({
+  run,
+  sectionKey,
+}: {
+  run: OverviewRun;
+  sectionKey: ActionableSectionKey;
+}) {
+  const {config, isDispatched, trigger} = useNextAction({run, sectionKey});
+  const {permissionsTarget, isPending: isCreatePrGatePending} = useAutofixCreatePrGate({
+    group: {id: run.groupId},
+    enabled: sectionKey === 'code_changes_ready',
+  });
+
+  if (permissionsTarget) {
+    return (
+      <Tooltip
+        title={t(
+          'You need to grant write permissions for your %s integration',
+          permissionsTarget.integration.provider.name
+        )}
+        skipWrapper
+      >
+        <LinkButton
+          size="xs"
+          variant="primary"
+          icon={<IconOpen />}
+          href={permissionsTarget.url}
+          external
+        >
+          {t('Update permissions')}
+        </LinkButton>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Button
+      size="xs"
+      variant="primary"
+      busy={isDispatched}
+      disabled={isDispatched || isCreatePrGatePending}
+      icon={<config.Icon />}
+      onClick={trigger}
+    >
+      {config.label}
+    </Button>
+  );
+}
+
+export function MilestoneToast({
+  run,
+  toMilestone,
+}: {
+  run: OverviewRun;
+  toMilestone: MilestoneKey;
+}) {
+  const sectionKey = sectionKeyForMilestone(toMilestone);
+  return (
+    <Flex align="center" gap="md">
+      <Text>{t('%s reached %s', run.shortId, MILESTONE_LABELS[toMilestone])}</Text>
+      {isActionableSection(sectionKey) && (
+        <NextActionButton run={run} sectionKey={sectionKey} />
+      )}
+      <OpenSeerButton run={run} size="xs" />
+    </Flex>
+  );
+}
+
+function showMilestoneAdvanceToast(
+  advance: MilestoneAdvance,
+  organization: Organization
+) {
+  addSuccessMessage(
+    <MilestoneToast run={advance.run} toMilestone={advance.toMilestone} />,
+    {disableDismiss: true}
+  );
+  trackAnalytics('autofix.overview.milestone_advanced', {
+    organization,
+    group_id: advance.run.groupId,
+    run_id: advance.run.seerRunId,
+    from_milestone: advance.fromMilestone,
+    to_milestone: advance.toMilestone,
+  });
+}
+
+export function useMilestoneAdvanceToasts(data: AutofixOverviewResponse | undefined) {
+  const organization = useOrganization();
+  const previousRef = useRef<AutofixOverviewResponse | undefined>(undefined);
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+    const previous = previousRef.current;
+    previousRef.current = data;
+    if (!previous) {
+      return;
+    }
+    for (const advance of detectMilestoneAdvances(previous, data)) {
+      showMilestoneAdvanceToast(advance, organization);
+    }
+  }, [data, organization]);
+}

--- a/static/app/views/seerWorkflows/overview/openSeerButton.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/openSeerButton.spec.tsx
@@ -1,0 +1,32 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+import {OpenSeerButton} from './openSeerButton';
+import type {OverviewRun} from './types';
+
+jest.mock('sentry/utils/analytics');
+
+const organization = OrganizationFixture();
+
+const run = (overrides: Partial<OverviewRun> = {}): OverviewRun =>
+  ({groupId: '2', shortId: 'SEER-1', seerRunId: 'run-1', ...overrides}) as OverviewRun;
+
+describe('OpenSeerButton', () => {
+  it('opens the seer drawer for the run and tracks the click', async () => {
+    const {router} = render(<OpenSeerButton run={run()} size="xs" />, {
+      organization,
+      initialRouterConfig: {location: {pathname: '/seer/overview/'}},
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Open Seer'}));
+
+    expect(router.location.query.seerDrawer).toBe('2');
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'autofix.overview.open_seer_clicked',
+      expect.objectContaining({organization, group_id: '2', run_id: 'run-1'})
+    );
+  });
+});

--- a/static/app/views/seerWorkflows/overview/openSeerButton.tsx
+++ b/static/app/views/seerWorkflows/overview/openSeerButton.tsx
@@ -1,0 +1,58 @@
+import {useCallback, useMemo} from 'react';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconSeer} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {OverviewRun} from './types';
+
+export function useOpenSeerLink(run: OverviewRun) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const to = useMemo(
+    () => ({
+      pathname: location.pathname,
+      query: {...location.query, seerDrawer: run.groupId},
+    }),
+    [location.pathname, location.query, run.groupId]
+  );
+  const trackOpen = useCallback(
+    () =>
+      trackAnalytics('autofix.overview.open_seer_clicked', {
+        organization,
+        group_id: run.groupId,
+        run_id: run.seerRunId,
+      }),
+    [organization, run.groupId, run.seerRunId]
+  );
+  return {to, trackOpen};
+}
+
+export function OpenSeerButton({
+  run,
+  size,
+  variant = 'secondary',
+}: {
+  run: OverviewRun;
+  size: 'xs' | 'sm';
+  variant?: 'primary' | 'secondary';
+}) {
+  const {to, trackOpen} = useOpenSeerLink(run);
+  return (
+    <Tooltip title={t('Open Seer')} skipWrapper>
+      <LinkButton
+        size={size}
+        variant={variant}
+        aria-label={t('Open Seer')}
+        icon={<IconSeer size="sm" />}
+        to={to}
+        onClick={trackOpen}
+      />
+    </Tooltip>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/overviewActions.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewActions.tsx
@@ -30,7 +30,7 @@ interface ActionConfig {
   errorFallback?: string;
 }
 
-export const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
+const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
   needs_investigation: {
     Icon: IconSearch,
     action: 'create_plan',

--- a/static/app/views/seerWorkflows/overview/overviewActions.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewActions.tsx
@@ -1,0 +1,139 @@
+import {useCallback, useState} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {IconCode, IconCommit, IconSearch} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {AutofixStateKey, MilestoneKey, OverviewRun} from './types';
+import {OVERVIEW_SECTIONS} from './types';
+
+export type ActionableSectionKey = Exclude<AutofixStateKey, 'merged' | 'review_pr'>;
+
+interface ActionConfig {
+  Icon: React.ComponentType<SVGIconProps>;
+  action: 'create_plan' | 'generate_code' | 'draft_pr';
+  busyLabel: string;
+  description: string;
+  handoffStep: 'root_cause' | 'solution' | 'code_changes';
+  label: string;
+  trigger: (
+    autofix: Pick<ReturnType<typeof useExplorerAutofix>, 'startStep' | 'createPR'>,
+    runId: string
+  ) => Promise<unknown>;
+  errorFallback?: string;
+}
+
+export const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
+  needs_investigation: {
+    Icon: IconSearch,
+    action: 'create_plan',
+    busyLabel: t('Creating Plan…'),
+    description: t('Seer stopped at a diagnosis. Review the root cause to continue.'),
+    errorFallback: t('Seer could not start creating a plan.'),
+    handoffStep: 'root_cause',
+    label: t('Create Plan'),
+    trigger: (autofix, runId) => autofix.startStep('solution', {runId}),
+  },
+  solution_ready: {
+    Icon: IconCode,
+    action: 'generate_code',
+    busyLabel: t('Generating Code…'),
+    description: t('Autofix proposed a fix. Continue the pipeline to generate code.'),
+    errorFallback: t('Seer could not start generating code.'),
+    handoffStep: 'solution',
+    label: t('Generate code'),
+    trigger: (autofix, runId) => autofix.startStep('code_changes', {runId}),
+  },
+  code_changes_ready: {
+    Icon: IconCommit,
+    action: 'draft_pr',
+    busyLabel: t('Creating PR…'),
+    description: t('Autofix wrote a diff. Review it and open a pull request.'),
+    handoffStep: 'code_changes',
+    label: t('Draft PR'),
+    trigger: (autofix, runId) => autofix.createPR(runId),
+  },
+};
+
+const SECTION_BY_MILESTONE = Object.fromEntries(
+  OVERVIEW_SECTIONS.map(section => [section.milestone, section.key])
+) as Record<MilestoneKey, AutofixStateKey>;
+
+export function sectionKeyForMilestone(milestone: MilestoneKey): AutofixStateKey {
+  return SECTION_BY_MILESTONE[milestone];
+}
+
+export function isActionableSection(
+  sectionKey: AutofixStateKey
+): sectionKey is ActionableSectionKey {
+  return sectionKey in ACTIONS;
+}
+
+export function getProcessingLabel(sectionKey: AutofixStateKey): string {
+  return isActionableSection(sectionKey) ? ACTIONS[sectionKey].busyLabel : t('Working…');
+}
+
+export function useNextAction({
+  run,
+  sectionKey,
+}: {
+  run: OverviewRun;
+  sectionKey: ActionableSectionKey;
+}) {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const config = ACTIONS[sectionKey];
+  const [isDispatched, setIsDispatched] = useState(false);
+
+  const autofix = useExplorerAutofix(
+    {id: run.groupId, shortId: run.shortId},
+    {
+      enabled: false,
+      codingAgentAnalyticsSource: 'overview',
+      onCodingAgentError: messages =>
+        messages.forEach(message => addErrorMessage(message)),
+    }
+  );
+
+  const trigger = useCallback(async () => {
+    setIsDispatched(true);
+    trackAnalytics('autofix.overview.action_clicked', {
+      organization,
+      group_id: run.groupId,
+      run_id: run.seerRunId,
+      action: config.action,
+    });
+    try {
+      await config.trigger(autofix, run.seerRunId);
+      queryClient.invalidateQueries({
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/seer/autofix-overview/', {
+            path: {organizationIdOrSlug: organization.slug},
+          }),
+        ],
+      });
+    } catch (error) {
+      if (config.errorFallback) {
+        const detail = (error as RequestError)?.responseJSON?.detail;
+        addErrorMessage(typeof detail === 'string' ? detail : config.errorFallback);
+      }
+      queryClient.removeQueries({
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/', {
+            path: {organizationIdOrSlug: organization.slug, issueId: run.groupId},
+          }),
+        ],
+      });
+      setIsDispatched(false);
+    }
+  }, [autofix, config, organization, queryClient, run.groupId, run.seerRunId]);
+
+  return {autofix, config, isDispatched, trigger};
+}

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -1,94 +1,25 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import {useQueryClient} from '@tanstack/react-query';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
-import {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {
-  IconAdd,
-  IconChevron,
-  IconCode,
-  IconCommit,
-  IconOpen,
-  IconSearch,
-  IconSeer,
-} from 'sentry/icons';
+import {IconAdd, IconChevron, IconOpen, IconSeer} from 'sentry/icons';
 import {PluginIcon} from 'sentry/icons/pluginIcon';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import type {AutofixStateKey, OverviewRun} from './types';
-
-export type ActionableSectionKey = Exclude<AutofixStateKey, 'merged' | 'review_pr'>;
-
-interface ActionConfig {
-  Icon: React.ComponentType<SVGIconProps>;
-  action: 'create_plan' | 'generate_code' | 'draft_pr';
-  busyLabel: string;
-  description: string;
-  handoffStep: 'root_cause' | 'solution' | 'code_changes';
-  label: string;
-  trigger: (
-    autofix: Pick<ReturnType<typeof useExplorerAutofix>, 'startStep' | 'createPR'>,
-    runId: string
-  ) => Promise<unknown>;
-  // Absent when the trigger surfaces its own error toast.
-  errorFallback?: string;
-}
-
-const ACTIONS: Record<ActionableSectionKey, ActionConfig> = {
-  needs_investigation: {
-    Icon: IconSearch,
-    action: 'create_plan',
-    busyLabel: t('Creating Plan…'),
-    description: t('Seer stopped at a diagnosis. Review the root cause to continue.'),
-    errorFallback: t('Seer could not start creating a plan.'),
-    handoffStep: 'root_cause',
-    label: t('Create Plan'),
-    trigger: (autofix, runId) => autofix.startStep('solution', {runId}),
-  },
-  solution_ready: {
-    Icon: IconCode,
-    action: 'generate_code',
-    busyLabel: t('Generating Code…'),
-    description: t('Autofix proposed a fix. Continue the pipeline to generate code.'),
-    errorFallback: t('Seer could not start generating code.'),
-    handoffStep: 'solution',
-    label: t('Generate code'),
-    trigger: (autofix, runId) => autofix.startStep('code_changes', {runId}),
-  },
-  code_changes_ready: {
-    Icon: IconCommit,
-    action: 'draft_pr',
-    busyLabel: t('Creating PR…'),
-    description: t('Autofix wrote a diff. Review it and open a pull request.'),
-    handoffStep: 'code_changes',
-    label: t('Draft PR'),
-    trigger: (autofix, runId) => autofix.createPR(runId),
-  },
-};
-
-export function getProcessingLabel(sectionKey: AutofixStateKey): string {
-  return sectionKey in ACTIONS
-    ? ACTIONS[sectionKey as ActionableSectionKey].busyLabel
-    : t('Working…');
-}
+import {useOpenSeerLink} from './openSeerButton';
+import {type ActionableSectionKey, useNextAction} from './overviewActions';
+import type {OverviewRun} from './types';
 
 export function OverviewCardAction({
   run,
@@ -98,22 +29,11 @@ export function OverviewCardAction({
   sectionKey: ActionableSectionKey;
 }) {
   const organization = useOrganization();
-  const location = useLocation();
-  const queryClient = useQueryClient();
-  const config = ACTIONS[sectionKey];
-  const [dispatched, setDispatched] = useState(false);
   // Defer agent-option fetches until the dropdown opens to avoid per-card repo pagination.
   const [menuOpened, setMenuOpened] = useState(false);
 
-  const autofix = useExplorerAutofix(
-    {id: run.groupId, shortId: run.shortId},
-    {
-      enabled: false,
-      codingAgentAnalyticsSource: 'overview',
-      onCodingAgentError: messages =>
-        messages.forEach(message => addErrorMessage(message)),
-    }
-  );
+  const {autofix, config, isDispatched, trigger} = useNextAction({run, sectionKey});
+  const {to: openSeerTo, trackOpen} = useOpenSeerLink(run);
 
   const {hasReposConnected, hasNonGithubRepo} = run.issue.project;
   const repoEligibility =
@@ -188,16 +108,8 @@ export function OverviewCardAction({
             <span>{t('Open Seer')}</span>
           </Flex>
         ),
-        to: {
-          pathname: location.pathname,
-          query: {...location.query, seerDrawer: run.groupId},
-        },
-        onAction: () =>
-          trackAnalytics('autofix.overview.open_seer_clicked', {
-            organization,
-            group_id: run.groupId,
-            run_id: run.seerRunId,
-          }),
+        to: openSeerTo,
+        onAction: trackOpen,
       },
       ...agentItems,
     ];
@@ -206,53 +118,17 @@ export function OverviewCardAction({
     codingAgentIntegrations,
     codingAgentDisabledReason,
     handleCodingAgentHandoff,
-    location.pathname,
-    location.query,
-    organization,
-    run.groupId,
-    run.seerRunId,
+    openSeerTo,
+    trackOpen,
   ]);
 
-  if (dispatched) {
+  if (isDispatched) {
     return (
       <Button size="sm" variant="secondary" disabled icon={<ButtonSpinner size={14} />}>
         {config.busyLabel}
       </Button>
     );
   }
-
-  const handleTrigger = async () => {
-    setDispatched(true);
-    trackAnalytics('autofix.overview.action_clicked', {
-      organization,
-      group_id: run.groupId,
-      run_id: run.seerRunId,
-      action: config.action,
-    });
-    try {
-      await config.trigger(autofix, run.seerRunId);
-      queryClient.invalidateQueries({
-        queryKey: [
-          getApiUrl('/organizations/$organizationIdOrSlug/seer/autofix-overview/', {
-            path: {organizationIdOrSlug: organization.slug},
-          }),
-        ],
-      });
-    } catch (error) {
-      if (config.errorFallback) {
-        const detail = (error as RequestError)?.responseJSON?.detail;
-        addErrorMessage(typeof detail === 'string' ? detail : config.errorFallback);
-      }
-      queryClient.removeQueries({
-        queryKey: [
-          getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/', {
-            path: {organizationIdOrSlug: organization.slug, issueId: run.groupId},
-          }),
-        ],
-      });
-      setDispatched(false);
-    }
-  };
 
   const permissionsButton = permissionsTarget ? (
     <Tooltip
@@ -282,7 +158,7 @@ export function OverviewCardAction({
             size="sm"
             variant="secondary"
             icon={<config.Icon />}
-            onClick={handleTrigger}
+            onClick={trigger}
             disabled={isCreatePrGatePending}
           >
             {config.label}

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -114,7 +114,7 @@ export interface OverviewIssue {
 export type OverviewSort = 'seer' | 'issue' | 'events' | 'users';
 
 // The milestone a run reached, as keyed in the endpoint's `runsByMilestone`.
-type MilestoneKey =
+export type MilestoneKey =
   | 'autofix_root_cause'
   | 'autofix_solution'
   | 'autofix_code_changes'

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
@@ -1,5 +1,6 @@
 import type {AutofixOverviewResponse, OverviewRun, RunStatus} from './types';
 import {
+  detectMilestoneAdvances,
   overlayStatus,
   sectionSignature,
   shouldRefetchEnriched,
@@ -70,6 +71,66 @@ describe('overlayStatus', () => {
     const base = response({autofix_root_cause: [run('r1', 'processing')]});
     const poll = response({autofix_root_cause: [run('r1', 'processing')]});
     expect(overlayStatus(base, poll)).toBe(base);
+  });
+});
+
+describe('detectMilestoneAdvances', () => {
+  it('returns nothing when either poll is missing', () => {
+    const data = response({autofix_root_cause: [run('r1')]});
+    expect(detectMilestoneAdvances(undefined, data)).toEqual([]);
+    expect(detectMilestoneAdvances(data, undefined)).toEqual([]);
+  });
+
+  it('reports a run that moved up to a later milestone', () => {
+    const prev = response({autofix_root_cause: [run('r1')]});
+    const next = response({autofix_code_changes: [run('r1')]});
+
+    const advances = detectMilestoneAdvances(prev, next);
+
+    expect(advances).toEqual([
+      {
+        run: expect.objectContaining({seerRunId: 'r1'}),
+        fromMilestone: 'autofix_root_cause',
+        toMilestone: 'autofix_code_changes',
+      },
+    ]);
+  });
+
+  it('ignores a status-only change within the same milestone', () => {
+    const prev = response({autofix_root_cause: [run('r1', 'processing')]});
+    const next = response({autofix_root_cause: [run('r1', 'completed')]});
+    expect(detectMilestoneAdvances(prev, next)).toEqual([]);
+  });
+
+  it('ignores a run that is new this poll', () => {
+    const prev = response({autofix_root_cause: [run('r1')]});
+    const next = response({
+      autofix_root_cause: [run('r1')],
+      autofix_solution: [run('r2')],
+    });
+    expect(detectMilestoneAdvances(prev, next)).toEqual([]);
+  });
+
+  it('does not report a run that moved to an earlier milestone', () => {
+    const prev = response({autofix_code_changes: [run('r1')]});
+    const next = response({autofix_root_cause: [run('r1')]});
+    expect(detectMilestoneAdvances(prev, next)).toEqual([]);
+  });
+
+  it('reports each advanced run when several move at once', () => {
+    const prev = response({
+      autofix_root_cause: [run('r1')],
+      autofix_solution: [run('r2')],
+    });
+    const next = response({
+      autofix_solution: [run('r1')],
+      autofix_code_changes: [run('r2')],
+    });
+
+    const advanced = detectMilestoneAdvances(prev, next).map(a => a.run.seerRunId);
+
+    expect(advanced).toEqual(expect.arrayContaining(['r1', 'r2']));
+    expect(advanced).toHaveLength(2);
   });
 });
 

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -200,6 +200,7 @@ export function useAutofixOverview({
     enrichmentPending: Boolean(data) && !enrichedQuery.data && !enrichedQuery.isError,
     // A later refetch keeps the list up; the caller shows a spinner meanwhile.
     isRefetching: enrichedQuery.isFetching && Boolean(enrichedQuery.data),
+    enrichedSettled: !enrichedQuery.isFetching && Boolean(enrichedQuery.data),
     refetch: () => {
       statusPollQuery.refetch();
       enrichedQuery.refetch();

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -8,11 +8,63 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 
 import {
   type AutofixOverviewResponse,
+  type MilestoneKey,
+  type OverviewRun,
+  OVERVIEW_SECTIONS,
   type OverviewSort,
+  PIPELINE,
   POLL_INTERVAL,
   QUERY_STALE_TIME,
   type RunStatus,
 } from './types';
+
+export interface MilestoneAdvance {
+  fromMilestone: MilestoneKey;
+  run: OverviewRun;
+  toMilestone: MilestoneKey;
+}
+
+const FILL_BY_SECTION = new Map(PIPELINE.map(stage => [stage.key, stage.fill]));
+const MILESTONE_RANK = new Map<MilestoneKey, number>(
+  OVERVIEW_SECTIONS.map(section => [
+    section.milestone,
+    FILL_BY_SECTION.get(section.key) ?? 0,
+  ])
+);
+
+function milestoneByRun(data: AutofixOverviewResponse): Map<string, MilestoneKey> {
+  const map = new Map<string, MilestoneKey>();
+  for (const [milestone, runs] of Object.entries(data.runsByMilestone)) {
+    for (const run of runs) {
+      map.set(run.seerRunId, milestone as MilestoneKey);
+    }
+  }
+  return map;
+}
+
+export function detectMilestoneAdvances(
+  prev: AutofixOverviewResponse | undefined,
+  next: AutofixOverviewResponse | undefined
+): MilestoneAdvance[] {
+  if (!prev || !next) {
+    return [];
+  }
+  const prevMilestones = milestoneByRun(prev);
+  const advances: MilestoneAdvance[] = [];
+  for (const [milestone, runs] of Object.entries(next.runsByMilestone)) {
+    const toMilestone = milestone as MilestoneKey;
+    for (const run of runs) {
+      const fromMilestone = prevMilestones.get(run.seerRunId);
+      if (
+        fromMilestone !== undefined &&
+        (MILESTONE_RANK.get(toMilestone) ?? 0) > (MILESTONE_RANK.get(fromMilestone) ?? 0)
+      ) {
+        advances.push({run, fromMilestone, toMilestone});
+      }
+    }
+  }
+  return advances;
+}
 
 function statusByRunId(
   data: AutofixOverviewResponse | undefined


### PR DESCRIPTION
## Summary

Adds a success toast on the **Autofix Overview** page when a live run advances to a new milestone. This gives users immediate, actionable feedback as their runs progress, without watching the page.

The toast reads "SEER-123 reached Code Changes" and carries that run's **next-action button** (Create Plan / Generate code / Draft PR) plus an **Open Seer** button — the same control pairing used on in-progress run cards, so acting on a completed step is one click from the toast.

## How it works

- Detection compares successive overview polls by `seerRunId` and fires only on **forward** milestone moves. Status-only refreshes, brand-new runs, and backward moves stay quiet, and the first payload seeds a silent baseline so a fresh page load never toasts.
- Toasts are emitted via the standard `addSuccessMessage` indicator (they replace rather than stack), auto-clear after 10s, and stay reachable while showing interactive buttons.

## Refactors (shared with the overview card)

- **`useNextAction`** — extracted the next-action trigger + analytics + query invalidation so the card and the toast share one implementation.
- **`useOpenSeerLink` / `OpenSeerButton`** — one owner for the `seerDrawer` link target and the `open_seer_clicked` analytics, replacing three duplicated copies (card, its dropdown item, and the toast).
- The toast's **Draft PR** now honors the same write-access gate as the card, offering **Update permissions** when the connected repo lacks write access instead of silently failing.

## Tests

- New `openSeerButton.spec.tsx` and `milestoneToast.spec.tsx` (advance detection, one-toast-per-run, status-only no-op, next-action dispatch, and the write-access permission gate).
- Full overview suite green (106 tests); typecheck and lint clean.
