### PR TITLE
feat(investigations): surface generated investigation summaries

### DIFF
--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -118,12 +118,12 @@ export function investigationCandidatesQueryOptions({
   );
 }
 
-function investigationCandidatesQueryKey(organizationSlug: string) {
+function investigationCandidatesUrl(organizationSlug: string) {
   const [url] = investigationCandidatesQueryOptions({
     organizationSlug,
     sources: [],
   }).queryKey;
-  return [url] as const;
+  return url;
 }
 
 type FavoriteVariables = {
@@ -187,7 +187,7 @@ function useInvestigationMutation<TData, TVariables>(
         }),
         invalidateCandidates
           ? queryClient.invalidateQueries({
-              queryKey: investigationCandidatesQueryKey(organizationSlug),
+              queryKey: [investigationCandidatesUrl(organizationSlug)],
             })
           : Promise.resolve(),
       ]);

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -14,6 +14,7 @@ import type {
   InvestigationDetail,
   InvestigationExecutionDetail,
   InvestigationListItem,
+  InvestigationTitleGeneration,
   MetricOpenPeriodInvestigationSource,
 } from 'sentry/views/investigations/types';
 
@@ -73,6 +74,22 @@ export function investigationExecutionDetailQueryOptions({
         investigationId,
         blockId,
         executionId,
+      },
+      staleTime: 0,
+    }
+  );
+}
+
+export function investigationTitleGenerationQueryOptions(
+  organizationSlug: string,
+  investigationId: string
+) {
+  return apiOptions.as<InvestigationTitleGeneration>()(
+    '/organizations/$organizationIdOrSlug/investigations/$investigationId/title-generation/',
+    {
+      path: {
+        organizationIdOrSlug: organizationSlug,
+        investigationId,
       },
       staleTime: 0,
     }

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -118,6 +118,14 @@ export function investigationCandidatesQueryOptions({
   );
 }
 
+function investigationCandidatesQueryKey(organizationSlug: string) {
+  const [url] = investigationCandidatesQueryOptions({
+    organizationSlug,
+    sources: [],
+  }).queryKey;
+  return [url] as const;
+}
+
 type FavoriteVariables = {
   investigation: InvestigationListItem;
   shouldFavorite: boolean;
@@ -179,7 +187,7 @@ function useInvestigationMutation<TData, TVariables>(
         }),
         invalidateCandidates
           ? queryClient.invalidateQueries({
-              queryKey: ['investigation-candidates', organizationSlug],
+              queryKey: investigationCandidatesQueryKey(organizationSlug),
             })
           : Promise.resolve(),
       ]);

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -164,7 +164,8 @@ type MutationOptions<TData, TVariables> = Omit<
 function useInvestigationMutation<TData, TVariables>(
   organizationSlug: string,
   mutationFn: (variables: TVariables) => Promise<TData>,
-  options?: MutationOptions<TData, TVariables>
+  options?: MutationOptions<TData, TVariables>,
+  {invalidateCandidates = false}: {invalidateCandidates?: boolean} = {}
 ) {
   const queryClient = useQueryClient();
 
@@ -172,9 +173,16 @@ function useInvestigationMutation<TData, TVariables>(
     ...options,
     mutationFn,
     onSuccess: async (data, variables, onMutateResult, context) => {
-      await queryClient.invalidateQueries({
-        queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: investigationListQueryOptions({organizationSlug}).queryKey,
+        }),
+        invalidateCandidates
+          ? queryClient.invalidateQueries({
+              queryKey: ['investigation-candidates', organizationSlug],
+            })
+          : Promise.resolve(),
+      ]);
       await options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });
@@ -212,7 +220,8 @@ export function useLaunchInvestigationMutation(
           source,
         },
       }),
-    options
+    options,
+    {invalidateCandidates: true}
   );
 }
 
@@ -587,6 +596,7 @@ export function useDeleteInvestigationMutation(
         method: 'DELETE',
         data: {investigationVersion: investigation.version},
       }),
-    options
+    options,
+    {invalidateCandidates: true}
   );
 }

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -71,6 +71,21 @@ export function InvestigationCell({
   const progressState = getCellProgressState(block, investigation.blocks ?? []);
   const waitingForDependencies =
     progressState === 'waiting' || progressState === 'blocked';
+  const executionId = block.currentExecution?.id;
+  const streamedTextQuery = useQuery({
+    ...investigationExecutionDetailQueryOptions({
+      organizationSlug,
+      investigationId: investigation.id,
+      blockId: block.id,
+      executionId: executionId ?? 'disabled',
+    }),
+    enabled:
+      block.kind === 'text' &&
+      Boolean(executionId) &&
+      isExecutionActive(block.currentExecution?.status),
+    refetchInterval: query =>
+      isExecutionActive(query.state.data?.json.status) ? 500 : false,
+  });
 
   const chartTitle =
     block.kind === 'query'
@@ -218,6 +233,7 @@ export function InvestigationCell({
             block={block}
             progressState={progressState}
             refinementButton={refinementButton}
+            streamedMarkdown={streamedTextQuery.data?.partialMarkdown}
           />
           {panel}
         </Fragment>
@@ -230,12 +246,15 @@ function CellResult({
   block,
   progressState,
   refinementButton,
+  streamedMarkdown,
 }: {
   block: InvestigationBlock;
   progressState: CellProgressState;
   refinementButton: React.ReactNode;
+  streamedMarkdown?: string | null;
 }) {
-  const markdown = getTextOutput(block.output) ?? (block.content.trim() || null);
+  const markdown =
+    streamedMarkdown ?? getTextOutput(block.output) ?? (block.content.trim() || null);
   return (
     <Stack
       position="relative"

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -70,7 +70,9 @@ export function InvestigationCell({
   );
   const progressState = getCellProgressState(block, investigation.blocks ?? []);
   const waitingForDependencies =
-    progressState === 'waiting' || progressState === 'blocked';
+    progressState === 'waiting' ||
+    progressState === 'blockedByFailure' ||
+    progressState === 'blockedByCancellation';
   const executionId = block.currentExecution?.id;
   const streamedTextQuery = useQuery({
     ...investigationExecutionDetailQueryOptions({
@@ -233,7 +235,11 @@ export function InvestigationCell({
             block={block}
             progressState={progressState}
             refinementButton={refinementButton}
-            streamedMarkdown={streamedTextQuery.data?.partialMarkdown}
+            streamedMarkdown={
+              isExecutionActive(block.currentExecution?.status)
+                ? streamedTextQuery.data?.partialMarkdown
+                : null
+            }
           />
           {panel}
         </Fragment>
@@ -267,6 +273,7 @@ function CellResult({
       <Container position="absolute" top={0} right={0}>
         {refinementButton}
       </Container>
+      <CellExecutionAlert block={block} />
       {markdown ? (
         <SeerMarkdown raw={markdown} />
       ) : (
@@ -344,6 +351,7 @@ function QueryResult({
             {actions}
           </Flex>
           <Container width="100%" overflow="hidden" padding={chart ? 'md lg' : '0'}>
+            <CellExecutionAlert block={block} />
             {chart ? (
               <ChartContent data={chart} showHeader={false} />
             ) : output?.tableMarkdown ? (
@@ -363,16 +371,33 @@ function QueryResult({
 type CellProgressState =
   | 'running'
   | 'waiting'
-  | 'blocked'
   | 'failed'
   | 'cancelled'
+  | 'blockedByFailure'
+  | 'blockedByCancellation'
   | null;
+
+function CellExecutionAlert({block}: {block: InvestigationBlock}) {
+  const execution = block.currentExecution;
+  if (execution?.status !== 'failed' && execution?.status !== 'cancelled') {
+    return null;
+  }
+  const failed = execution.status === 'failed';
+  return (
+    <Alert.Container data-test-id={`cell-execution-${execution.status}`}>
+      <Alert variant={failed ? 'danger' : 'warning'}>
+        {execution.error?.message ||
+          (failed ? t('This Seer run failed.') : t('This Seer run was cancelled.'))}
+      </Alert>
+    </Alert.Container>
+  );
+}
 
 function CellProgress({state}: {state: CellProgressState}) {
   if (!state) {
     return <Text variant="muted">{t('This cell has no output yet.')}</Text>;
   }
-  let message = t('Waiting for a successful result from previous cells.');
+  let message = t('Cancelled because a previous cell failed.');
   if (state === 'running') {
     message = t('Seer is working on this cell…');
   } else if (state === 'waiting') {
@@ -381,6 +406,8 @@ function CellProgress({state}: {state: CellProgressState}) {
     message = t('This cell failed to run.');
   } else if (state === 'cancelled') {
     message = t('This cell run was cancelled.');
+  } else if (state === 'blockedByCancellation') {
+    message = t('Waiting because a previous cell was cancelled.');
   }
   return (
     <Flex align="center" gap="xs" data-test-id={`cell-progress-${state}`}>
@@ -413,16 +440,13 @@ function getCellProgressState(
   ) {
     return null;
   }
-  const dependencies = block.dependencies.flatMap(dependencyId => {
-    const dependency = blocks.find(candidate => candidate.id === dependencyId);
-    return dependency ? [dependency] : [];
-  });
   if (
-    dependencies.some(dependency =>
-      ['failed', 'cancelled'].includes(dependency.currentExecution?.status ?? '')
-    )
+    blocks.some(candidate => isInvestigationFailureExecution(candidate.currentExecution))
   ) {
-    return 'blocked';
+    return 'blockedByFailure';
+  }
+  if (hasCancelledDependency(block, blocks)) {
+    return 'blockedByCancellation';
   }
   return 'waiting';
 }
@@ -435,6 +459,39 @@ export function shouldPollInvestigationBlocks(blocks: InvestigationBlock[]) {
   );
 }
 
+function isInvestigationFailureExecution(
+  execution: InvestigationBlock['currentExecution']
+) {
+  return (
+    execution?.status === 'failed' ||
+    (execution?.status === 'cancelled' &&
+      execution.error?.code === 'investigation_execution_failed')
+  );
+}
+
+function hasCancelledDependency(
+  block: InvestigationBlock,
+  blocks: InvestigationBlock[],
+  visited = new Set<string>()
+): boolean {
+  for (const dependencyId of block.dependencies) {
+    if (visited.has(dependencyId)) {
+      continue;
+    }
+    visited.add(dependencyId);
+    const dependency = blocks.find(candidate => candidate.id === dependencyId);
+    if (!dependency) {
+      continue;
+    }
+    if (dependency.currentExecution?.status === 'cancelled') {
+      return true;
+    }
+    if (hasCancelledDependency(dependency, blocks, visited)) {
+      return true;
+    }
+  }
+  return false;
+}
 function FlushTable({children}: {children: React.ReactNode}) {
   return (
     <Container overflowX="auto">

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -440,9 +440,7 @@ function getCellProgressState(
   ) {
     return null;
   }
-  if (
-    blocks.some(candidate => isInvestigationFailureExecution(candidate.currentExecution))
-  ) {
+  if (hasFailedDependency(block, blocks)) {
     return 'blockedByFailure';
   }
   if (hasCancelledDependency(block, blocks)) {
@@ -467,6 +465,30 @@ function isInvestigationFailureExecution(
     (execution?.status === 'cancelled' &&
       execution.error?.code === 'investigation_execution_failed')
   );
+}
+
+function hasFailedDependency(
+  block: InvestigationBlock,
+  blocks: InvestigationBlock[],
+  visited = new Set<string>()
+): boolean {
+  for (const dependencyId of block.dependencies) {
+    if (visited.has(dependencyId)) {
+      continue;
+    }
+    visited.add(dependencyId);
+    const dependency = blocks.find(candidate => candidate.id === dependencyId);
+    if (!dependency) {
+      continue;
+    }
+    if (isInvestigationFailureExecution(dependency.currentExecution)) {
+      return true;
+    }
+    if (hasFailedDependency(dependency, blocks, visited)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function hasCancelledDependency(

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -271,6 +271,31 @@ describe('Investigation detail', () => {
     );
   });
 
+  it('restores the generated preview after abandoning an empty title edit', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        title: 'Untitled investigation',
+        titleGeneration: {status: 'running'},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'running', preview: 'Checkout error rate spike'},
+    });
+
+    renderView();
+
+    const titleInput = await screen.findByRole('textbox', {
+      name: 'Investigation title',
+    });
+    await waitFor(() => expect(titleInput).toHaveValue('Checkout error rate spike'));
+    await userEvent.clear(titleInput);
+    fireEvent.blur(titleInput);
+
+    await waitFor(() => expect(titleInput).toHaveValue('Checkout error rate spike'));
+  });
+
   it('does not replace an investigation title that was renamed before mount', async () => {
     MockApiClient.addMockResponse({
       url: detailUrl,

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -14,7 +14,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
-import {getInvestigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {
+  getInvestigationDetailQueryOptions,
+  investigationListQueryOptions,
+} from 'sentry/views/investigations/api';
 import InvestigationDetailView from 'sentry/views/investigations/detail';
 import type {
   InvestigationBlock,
@@ -144,6 +147,30 @@ describe('Investigation detail', () => {
     expect(screen.queryByText('Ask Seer')).not.toBeInTheDocument();
     expect(screen.queryByText(/"blocks":/)).not.toBeInTheDocument();
     expect(request).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('investigation-summary')).not.toBeInTheDocument();
+  });
+
+  it('renders completed investigation metadata above the first block', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        summary: 'Errors rose across releases',
+        summaryDescription:
+          'All active releases increased together.\nCheck shared infrastructure and dependencies.',
+      }),
+    });
+
+    renderView();
+
+    const summary = await screen.findByTestId('investigation-summary');
+    expect(within(summary).getByText('Current understanding')).toBeInTheDocument();
+    expect(within(summary).getByText('Errors rose across releases')).toBeInTheDocument();
+    expect(
+      within(summary).getByText(/All active releases increased together/)
+    ).toBeInTheDocument();
+    expect(
+      summary.compareDocumentPosition(screen.getByTestId('investigation-cell-block-1'))
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('renders partial text while an agent-written text cell is running', async () => {
@@ -199,6 +226,34 @@ describe('Investigation detail', () => {
       expect(screen.getByRole('textbox', {name: 'Investigation title'})).toHaveValue(
         'Checkout error rate spike'
       )
+    );
+  });
+
+  it('invalidates the investigations list when metadata generation settles', async () => {
+    const queryClient = makeTestQueryClient();
+    const listOptions = investigationListQueryOptions({
+      organizationSlug: 'org-slug',
+    });
+    queryClient.setQueryData(listOptions.queryKey, {
+      headers: {},
+      json: [],
+    });
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        title: 'Untitled investigation',
+        titleGeneration: {status: 'running'},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'completed', preview: 'Checkout error rate spike'},
+    });
+
+    renderView(organization, queryClient);
+
+    await waitFor(() =>
+      expect(queryClient.getQueryState(listOptions.queryKey)?.isInvalidated).toBe(true)
     );
   });
 

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -229,6 +229,46 @@ describe('Investigation detail', () => {
     );
   });
 
+  it('renders the persisted title when completion has no preview', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        title: 'Untitled investigation',
+        titleGeneration: {status: 'running'},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'running', preview: null},
+    });
+
+    renderView();
+    expect(await screen.findByDisplayValue('Untitled investigation')).toBeInTheDocument();
+
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        title: 'Mobile API Monitor False Alert',
+        summary: 'Comparison logic triggered breach',
+        summaryDescription: 'One event appeared against a zero-event baseline.',
+        titleGeneration: {status: 'completed'},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'completed', preview: null},
+    });
+
+    await waitFor(
+      () =>
+        expect(screen.getByRole('textbox', {name: 'Investigation title'})).toHaveValue(
+          'Mobile API Monitor False Alert'
+        ),
+      {timeout: 2000}
+    );
+    expect(screen.getByText('Comparison logic triggered breach')).toBeInTheDocument();
+  });
+
   it('invalidates the investigations list when metadata generation settles', async () => {
     const queryClient = makeTestQueryClient();
     const listOptions = investigationListQueryOptions({

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -28,6 +28,8 @@ const organization = OrganizationFixture({
   openMembership: true,
 });
 const detailUrl = '/organizations/org-slug/investigations/investigation-1/';
+const titleGenerationUrl =
+  '/organizations/org-slug/investigations/investigation-1/title-generation/';
 
 function InvestigationDetailFixture(
   overrides: Partial<InvestigationDetail> = {}
@@ -43,6 +45,8 @@ function InvestigationDetailFixture(
     version: 1,
     blockCount: 2,
     isFavorited: false,
+    summary: null,
+    summaryDescription: null,
     blocks: [
       {
         id: 'block-1',
@@ -142,6 +146,62 @@ describe('Investigation detail', () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
+  it('renders partial text while an agent-written text cell is running', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks[0] = {
+      ...investigation.blocks[0]!,
+      outputStatus: 'running',
+      currentExecution: {
+        id: 'execution-1',
+        status: 'running',
+        startedAt: '2026-08-18T20:00:00Z',
+        completedAt: null,
+        error: null,
+      },
+    };
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/block-1/executions/execution-1/`,
+      body: {
+        id: 'execution-1',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: 'Errors are concentrated in checkout.',
+        error: null,
+      },
+    });
+
+    renderView();
+
+    expect(
+      await screen.findByText('Errors are concentrated in checkout.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the streamed investigation title preview', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        title: 'Untitled investigation',
+        titleGeneration: {status: 'running'},
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'running', preview: 'Checkout error rate spike'},
+    });
+
+    renderView();
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Investigation title'})).toHaveValue(
+        'Checkout error rate spike'
+      )
+    );
+  });
+
   it('shows running and dependency-waiting states for auto-run cells', async () => {
     const investigation = InvestigationDetailFixture({
       template: {key: 'breached_metric', version: 1},
@@ -185,6 +245,18 @@ describe('Investigation detail', () => {
       },
     ];
     MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/block-1/executions/execution-1/`,
+      body: {
+        id: 'execution-1',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
 
     renderView();
 
@@ -598,7 +670,9 @@ describe('Investigation detail', () => {
       )
     );
     expect(
-      await screen.findByRole('button', {name: 'Ask Seer about Working theory'})
+      await screen.findByRole('button', {
+        name: 'Ask Seer about Working theory',
+      })
     ).toBeInTheDocument();
     expect(screen.queryByDisplayValue('Working theory')).not.toBeInTheDocument();
 

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -1248,6 +1248,18 @@ describe('Investigation detail', () => {
     const investigation = InvestigationDetailFixture();
     MockApiClient.addMockResponse({url: detailUrl, body: investigation});
     MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/block-1/executions/execution-running/`,
+      body: {
+        id: 'execution-running',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
+    MockApiClient.addMockResponse({
       url: detailUrl,
       method: 'PUT',
       body: () => {
@@ -1329,6 +1341,10 @@ describe('Investigation detail', () => {
 
   it('polls for and displays a generated title after block execution finishes', async () => {
     let requestCount = 0;
+    MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'completed', preview: null},
+    });
     MockApiClient.addMockResponse({
       url: detailUrl,
       body: () => {

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -271,6 +271,28 @@ describe('Investigation detail', () => {
     );
   });
 
+  it('does not replace an investigation title that was renamed before mount', async () => {
+    MockApiClient.addMockResponse({
+      url: detailUrl,
+      body: InvestigationDetailFixture({
+        title: 'Manually renamed investigation',
+        titleGeneration: {status: 'running'},
+      }),
+    });
+    const titleRequest = MockApiClient.addMockResponse({
+      url: titleGenerationUrl,
+      body: {status: 'running', preview: 'Generated title preview'},
+    });
+
+    renderView();
+
+    await waitFor(() => expect(titleRequest).toHaveBeenCalled());
+    expect(screen.getByRole('textbox', {name: 'Investigation title'})).toHaveValue(
+      'Manually renamed investigation'
+    );
+    expect(screen.queryByDisplayValue('Generated title preview')).not.toBeInTheDocument();
+  });
+
   it('renders the persisted title when completion has no preview', async () => {
     MockApiClient.addMockResponse({
       url: detailUrl,
@@ -454,6 +476,63 @@ describe('Investigation detail', () => {
     expect(await screen.findByTestId('cell-execution-failed')).toHaveTextContent(
       'Query failed'
     );
+  });
+
+  it('only blocks cells that depend on a failed branch', async () => {
+    const investigation = InvestigationDetailFixture();
+    const textBlock = investigation.blocks[0]!;
+    const queryBlock = investigation.blocks[1]!;
+    investigation.blocks = [
+      {
+        ...textBlock,
+        outputStatus: 'failed',
+        currentExecution: {
+          id: 'execution-failed',
+          status: 'failed',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: '2026-08-17T10:00:10Z',
+          error: {message: 'Summary failed'},
+        },
+      },
+      {
+        ...queryBlock,
+        config: {autoRun: true},
+        dependencies: ['block-1'],
+      },
+      {
+        ...textBlock,
+        id: 'block-3',
+        position: 2,
+        title: 'Independent analysis',
+        outputStatus: 'completed',
+        currentExecution: {
+          id: 'execution-completed',
+          status: 'completed',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: '2026-08-17T10:00:10Z',
+          error: null,
+        },
+      },
+      {
+        ...queryBlock,
+        id: 'block-4',
+        position: 3,
+        title: 'Independent follow-up',
+        config: {autoRun: true},
+        dependencies: ['block-3'],
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    expect(
+      await screen.findByText('Cancelled because a previous cell failed.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Waiting for previous cells…')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('investigation-execution-failed')
+    ).not.toBeInTheDocument();
   });
 
   it('keeps the refinement composer expanded while editing', async () => {

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -16,6 +16,7 @@ import {
 import * as indicators from 'sentry/actionCreators/indicator';
 import {
   getInvestigationDetailQueryOptions,
+  investigationExecutionDetailQueryOptions,
   investigationListQueryOptions,
 } from 'sentry/views/investigations/api';
 import InvestigationDetailView from 'sentry/views/investigations/detail';
@@ -205,6 +206,47 @@ describe('Investigation detail', () => {
     expect(
       await screen.findByText('Errors are concentrated in checkout.')
     ).toBeInTheDocument();
+  });
+
+  it('does not render stale streamed text after a text cell completes', async () => {
+    const queryClient = makeTestQueryClient();
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks[0] = {
+      ...investigation.blocks[0]!,
+      outputStatus: 'available',
+      output: {schemaVersion: 1, markdown: 'Final persisted analysis'},
+      currentExecution: {
+        id: 'execution-1',
+        status: 'completed',
+        startedAt: '2026-08-18T20:00:00Z',
+        completedAt: '2026-08-18T20:01:00Z',
+        error: null,
+      },
+    };
+    const executionOptions = investigationExecutionDetailQueryOptions({
+      organizationSlug: organization.slug,
+      investigationId: investigation.id,
+      blockId: 'block-1',
+      executionId: 'execution-1',
+    });
+    queryClient.setQueryData(executionOptions.queryKey, {
+      headers: {},
+      json: {
+        id: 'execution-1',
+        status: 'running',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: 'Thinking…',
+        error: null,
+      },
+    });
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView(organization, queryClient);
+
+    expect(await screen.findByText('Final persisted analysis')).toBeInTheDocument();
+    expect(screen.queryByText('Thinking…')).not.toBeInTheDocument();
   });
 
   it('renders the streamed investigation title preview', async () => {
@@ -409,7 +451,9 @@ describe('Investigation detail', () => {
 
     renderView();
 
-    expect(await screen.findByText('This cell failed to run.')).toBeInTheDocument();
+    expect(await screen.findByTestId('cell-execution-failed')).toHaveTextContent(
+      'Query failed'
+    );
   });
 
   it('keeps the refinement composer expanded while editing', async () => {

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -250,7 +250,13 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
       }
       return;
     }
-    handleTitleChange(persistedTitle.current);
+    setDraftTitle(null);
+    updateInvestigationCache(
+      queryClient,
+      organization.slug,
+      investigation.id,
+      current => ({...current, title: persistedTitle.current})
+    );
   }
 
   const blocks = investigation.blocks ?? [];

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -31,6 +31,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {
   getInvestigationDetailQueryOptions,
+  investigationListQueryOptions,
   investigationTitleGenerationQueryOptions,
   useAddInvestigationBlockMutation,
   useDeleteInvestigationMutation,
@@ -42,6 +43,7 @@ import {
   shouldPollInvestigationBlocks,
 } from 'sentry/views/investigations/detail/cell';
 import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
+import {InvestigationSummaryCard} from 'sentry/views/investigations/investigationSummaryCard';
 import type {
   InvestigationBlockKind,
   InvestigationDetail,
@@ -164,9 +166,21 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
       !titleGenerationSettled.current
     ) {
       titleGenerationSettled.current = true;
-      void queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      void Promise.all([
+        queryClient.invalidateQueries({queryKey: detailOptions.queryKey}),
+        queryClient.invalidateQueries({
+          queryKey: investigationListQueryOptions({
+            organizationSlug: organization.slug,
+          }).queryKey,
+        }),
+      ]);
     }
-  }, [detailOptions.queryKey, queryClient, titleGenerationQuery.data?.status]);
+  }, [
+    detailOptions.queryKey,
+    organization.slug,
+    queryClient,
+    titleGenerationQuery.data?.status,
+  ]);
 
   const renameMutation = useRenameInvestigationMutation(
     organization.slug,
@@ -375,6 +389,11 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
         <Layout.Body>
           <Layout.Main width="full">
             <InvestigationCanvas>
+              <NotebookSummaryCard
+                summary={investigation.summary}
+                summaryDescription={investigation.summaryDescription}
+              />
+
               {summaryBlock ? (
                 <InvestigationCell
                   block={summaryBlock}
@@ -538,6 +557,10 @@ function getStatusVariant(status: string): 'success' | 'warning' | 'muted' {
 const InvestigationCanvas = styled(Stack)`
   width: min(100%, 884px);
   margin: 0 auto;
+`;
+
+const NotebookSummaryCard = styled(InvestigationSummaryCard)`
+  margin-bottom: ${p => p.theme.space.xl};
 `;
 
 const HeaderBreadcrumbs = styled(Flex)`

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -50,6 +50,8 @@ import type {
 } from 'sentry/views/investigations/types';
 import {RouteError} from 'sentry/views/routeError';
 
+const DEFAULT_INVESTIGATION_TITLE = 'Untitled investigation';
+
 function FeatureDisabledPage() {
   return (
     <Stack flex={1} padding="2xl 3xl">
@@ -118,9 +120,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   const queryClient = useQueryClient();
   const {copy} = useCopyToClipboard();
   const [draftTitle, setDraftTitle] = useState<string | null>(null);
-  const displayedTitle = draftTitle ?? investigation.title;
   const persistedTitle = useRef(investigation.title);
-  const titleEditedByUser = useRef(false);
   const titleGenerationSettled = useRef(false);
   const detailOptions = getInvestigationDetailQueryOptions(
     organization.slug,
@@ -132,29 +132,13 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
     refetchInterval: query =>
       isTitleGenerationActive(query.state.data?.json.status) ? 500 : false,
   });
-
-  useEffect(() => {
-    const generatedTitle = titleGenerationQuery.data?.preview;
-    if (!generatedTitle || titleEditedByUser.current) {
-      return;
-    }
-    setDraftTitle(generatedTitle);
-    updateInvestigationCache(
-      queryClient,
-      organization.slug,
-      investigation.id,
-      current => ({...current, title: generatedTitle})
-    );
-    if (titleGenerationQuery.data?.status === 'completed') {
-      persistedTitle.current = generatedTitle;
-    }
-  }, [
-    investigation.id,
-    organization.slug,
-    queryClient,
-    titleGenerationQuery.data?.preview,
-    titleGenerationQuery.data?.status,
-  ]);
+  const generatedTitlePreview =
+    draftTitle === null &&
+    investigation.title === DEFAULT_INVESTIGATION_TITLE &&
+    isTitleGenerationActive(titleGenerationQuery.data?.status)
+      ? titleGenerationQuery.data?.preview
+      : null;
+  const displayedTitle = draftTitle ?? generatedTitlePreview ?? investigation.title;
 
   useEffect(() => {
     const status = titleGenerationQuery.data?.status;
@@ -167,14 +151,12 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
       !titleGenerationSettled.current
     ) {
       titleGenerationSettled.current = true;
-      void Promise.all([
-        queryClient.invalidateQueries({queryKey: detailOptions.queryKey}),
-        queryClient.invalidateQueries({
-          queryKey: investigationListQueryOptions({
-            organizationSlug: organization.slug,
-          }).queryKey,
-        }),
-      ]);
+      void queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+      void queryClient.invalidateQueries({
+        queryKey: investigationListQueryOptions({
+          organizationSlug: organization.slug,
+        }).queryKey,
+      });
     }
   }, [
     detailOptions.queryKey,
@@ -204,14 +186,8 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   );
 
   useEffect(() => {
-    if (
-      draftTitle === persistedTitle.current &&
-      investigation.title !== persistedTitle.current
-    ) {
+    if (draftTitle === null) {
       persistedTitle.current = investigation.title;
-      // Keep an in-progress user edit, but adopt a generated title while the draft is clean.
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
-      setDraftTitle(investigation.title);
     }
   }, [draftTitle, investigation.title]);
   const duplicateMutation = useDuplicateInvestigationMutation(organization.slug, {
@@ -240,7 +216,6 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   );
 
   function handleTitleChange(nextTitle: string) {
-    titleEditedByUser.current = true;
     setDraftTitle(nextTitle);
     updateInvestigationCache(
       queryClient,
@@ -253,9 +228,12 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
 
   function handleTitleBlur() {
     renameDebouncer.cancel();
-    const title = displayedTitle.trim();
+    if (draftTitle === null) {
+      return;
+    }
+    const title = draftTitle.trim();
     if (title) {
-      if (title !== displayedTitle) {
+      if (title !== draftTitle) {
         setDraftTitle(title);
         updateInvestigationCache(
           queryClient,
@@ -273,13 +251,6 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   }
 
   const blocks = investigation.blocks ?? [];
-  const failedBlock = blocks.find(block => block.currentExecution?.status === 'failed');
-  const hasFailureCancellation = blocks.some(
-    block =>
-      block.currentExecution?.status === 'cancelled' &&
-      block.currentExecution.error?.code === 'investigation_execution_failed'
-  );
-  const investigationExecutionFailed = Boolean(failedBlock || hasFailureCancellation);
   const summaryBlock = investigation.template ? blocks[0] : undefined;
   const notebookCells = summaryBlock ? blocks.slice(1) : blocks;
 
@@ -397,22 +368,6 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
         <Layout.Body>
           <Layout.Main width="full">
             <InvestigationCanvas>
-              {investigationExecutionFailed ? (
-                <InvestigationFailureAlert data-test-id="investigation-execution-failed">
-                  <Alert variant="danger">
-                    <strong>
-                      {failedBlock
-                        ? t('%s failed.', failedBlock.title || t('A cell'))
-                        : t('The investigation failed.')}
-                    </strong>{' '}
-                    {failedBlock?.currentExecution?.error?.message ||
-                      t('The agent run failed.')}{' '}
-                    {t(
-                      'The investigation was stopped and remaining cells were cancelled.'
-                    )}
-                  </Alert>
-                </InvestigationFailureAlert>
-              ) : null}
               <NotebookSummaryCard
                 summary={investigation.summary}
                 summaryDescription={investigation.summaryDescription}
@@ -584,10 +539,6 @@ const InvestigationCanvas = styled(Stack)`
 `;
 
 const NotebookSummaryCard = styled(InvestigationSummaryCard)`
-  margin-bottom: ${p => p.theme.space.xl};
-`;
-
-const InvestigationFailureAlert = styled(Alert.Container)`
   margin-bottom: ${p => p.theme.space.xl};
 `;
 

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -273,6 +273,13 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   }
 
   const blocks = investigation.blocks ?? [];
+  const failedBlock = blocks.find(block => block.currentExecution?.status === 'failed');
+  const hasFailureCancellation = blocks.some(
+    block =>
+      block.currentExecution?.status === 'cancelled' &&
+      block.currentExecution.error?.code === 'investigation_execution_failed'
+  );
+  const investigationExecutionFailed = Boolean(failedBlock || hasFailureCancellation);
   const summaryBlock = investigation.template ? blocks[0] : undefined;
   const notebookCells = summaryBlock ? blocks.slice(1) : blocks;
 
@@ -390,6 +397,22 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
         <Layout.Body>
           <Layout.Main width="full">
             <InvestigationCanvas>
+              {investigationExecutionFailed ? (
+                <InvestigationFailureAlert data-test-id="investigation-execution-failed">
+                  <Alert variant="danger">
+                    <strong>
+                      {failedBlock
+                        ? t('%s failed.', failedBlock.title || t('A cell'))
+                        : t('The investigation failed.')}
+                    </strong>{' '}
+                    {failedBlock?.currentExecution?.error?.message ||
+                      t('The agent run failed.')}{' '}
+                    {t(
+                      'The investigation was stopped and remaining cells were cancelled.'
+                    )}
+                  </Alert>
+                </InvestigationFailureAlert>
+              ) : null}
               <NotebookSummaryCard
                 summary={investigation.summary}
                 summaryDescription={investigation.summaryDescription}
@@ -561,6 +584,10 @@ const InvestigationCanvas = styled(Stack)`
 `;
 
 const NotebookSummaryCard = styled(InvestigationSummaryCard)`
+  margin-bottom: ${p => p.theme.space.xl};
+`;
+
+const InvestigationFailureAlert = styled(Alert.Container)`
   margin-bottom: ${p => p.theme.space.xl};
 `;
 

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -31,6 +31,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {
   getInvestigationDetailQueryOptions,
+  investigationTitleGenerationQueryOptions,
   useAddInvestigationBlockMutation,
   useDeleteInvestigationMutation,
   useDuplicateInvestigationMutation,
@@ -116,10 +117,56 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   const {copy} = useCopyToClipboard();
   const [draftTitle, setDraftTitle] = useState(investigation.title);
   const persistedTitle = useRef(investigation.title);
+  const titleEditedByUser = useRef(false);
+  const titleGenerationSettled = useRef(false);
   const detailOptions = getInvestigationDetailQueryOptions(
     organization.slug,
     investigation.id
   );
+  const titleGenerationQuery = useQuery({
+    ...investigationTitleGenerationQueryOptions(organization.slug, investigation.id),
+    enabled: isTitleGenerationActive(investigation.titleGeneration?.status),
+    refetchInterval: query =>
+      isTitleGenerationActive(query.state.data?.json.status) ? 500 : false,
+  });
+
+  useEffect(() => {
+    const generatedTitle = titleGenerationQuery.data?.preview;
+    if (!generatedTitle || titleEditedByUser.current) {
+      return;
+    }
+    setDraftTitle(generatedTitle);
+    updateInvestigationCache(
+      queryClient,
+      organization.slug,
+      investigation.id,
+      current => ({...current, title: generatedTitle})
+    );
+    if (titleGenerationQuery.data?.status === 'completed') {
+      persistedTitle.current = generatedTitle;
+    }
+  }, [
+    investigation.id,
+    organization.slug,
+    queryClient,
+    titleGenerationQuery.data?.preview,
+    titleGenerationQuery.data?.status,
+  ]);
+
+  useEffect(() => {
+    const status = titleGenerationQuery.data?.status;
+    if (isTitleGenerationActive(status)) {
+      titleGenerationSettled.current = false;
+      return;
+    }
+    if (
+      (status === 'completed' || status === 'failed') &&
+      !titleGenerationSettled.current
+    ) {
+      titleGenerationSettled.current = true;
+      void queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
+    }
+  }, [detailOptions.queryKey, queryClient, titleGenerationQuery.data?.status]);
 
   const renameMutation = useRenameInvestigationMutation(
     organization.slug,
@@ -178,6 +225,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   );
 
   function handleTitleChange(nextTitle: string) {
+    titleEditedByUser.current = true;
     setDraftTitle(nextTitle);
     updateInvestigationCache(
       queryClient,

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -121,7 +121,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   const {copy} = useCopyToClipboard();
   const [draftTitle, setDraftTitle] = useState<string | null>(null);
   const persistedTitle = useRef(investigation.title);
-  const titleGenerationSettled = useRef(false);
+  const titleGenerationSettledFor = useRef<string | null>(null);
   const detailOptions = getInvestigationDetailQueryOptions(
     organization.slug,
     investigation.id
@@ -143,14 +143,16 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   useEffect(() => {
     const status = titleGenerationQuery.data?.status;
     if (isTitleGenerationActive(status)) {
-      titleGenerationSettled.current = false;
+      if (titleGenerationSettledFor.current === investigation.id) {
+        titleGenerationSettledFor.current = null;
+      }
       return;
     }
     if (
       (status === 'completed' || status === 'failed') &&
-      !titleGenerationSettled.current
+      titleGenerationSettledFor.current !== investigation.id
     ) {
-      titleGenerationSettled.current = true;
+      titleGenerationSettledFor.current = investigation.id;
       void queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
       void queryClient.invalidateQueries({
         queryKey: investigationListQueryOptions({
@@ -160,6 +162,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
     }
   }, [
     detailOptions.queryKey,
+    investigation.id,
     organization.slug,
     queryClient,
     titleGenerationQuery.data?.status,

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -117,7 +117,8 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const {copy} = useCopyToClipboard();
-  const [draftTitle, setDraftTitle] = useState(investigation.title);
+  const [draftTitle, setDraftTitle] = useState<string | null>(null);
+  const displayedTitle = draftTitle ?? investigation.title;
   const persistedTitle = useRef(investigation.title);
   const titleEditedByUser = useRef(false);
   const titleGenerationSettled = useRef(false);
@@ -252,9 +253,9 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
 
   function handleTitleBlur() {
     renameDebouncer.cancel();
-    const title = draftTitle.trim();
+    const title = displayedTitle.trim();
     if (title) {
-      if (title !== draftTitle) {
+      if (title !== displayedTitle) {
         setDraftTitle(title);
         updateInvestigationCache(
           queryClient,
@@ -288,7 +289,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   }
 
   return (
-    <SentryDocumentTitle title={draftTitle} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={displayedTitle} orgSlug={organization.slug}>
       <Stack flex={1}>
         <Layout.Title>
           <HeaderBreadcrumbs
@@ -305,7 +306,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
               {t('Investigations')}
             </HeaderBreadcrumbLink>
             <HeaderDivider>/</HeaderDivider>
-            <HeaderInvestigationTitle>{draftTitle}</HeaderInvestigationTitle>
+            <HeaderInvestigationTitle>{displayedTitle}</HeaderInvestigationTitle>
             <DropdownMenu
               items={[
                 {
@@ -362,7 +363,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
             <Stack gap="xs" minWidth={0}>
               <NotebookTitleInput
                 aria-label={t('Investigation title')}
-                value={draftTitle}
+                value={displayedTitle}
                 onChange={event => handleTitleChange(event.target.value)}
                 onBlur={handleTitleBlur}
                 maxLength={200}

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -519,7 +519,8 @@ describe('Explore Investigations', () => {
       ],
     });
     queryClient.setQueryData(candidateOptions.queryKey, {
-      items: [{status: 'view', investigationId: '1'}],
+      json: {items: [{status: 'view', investigationId: '1'}]},
+      headers: {},
     });
     await userEvent.click(
       await screen.findByLabelText('More options for Database latency investigation')

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -61,6 +61,8 @@ function InvestigationFixture(
     version: 3,
     blockCount: 4,
     isFavorited: false,
+    summary: null,
+    summaryDescription: null,
     ...overrides,
   };
 }

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -13,7 +13,11 @@ import {
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {Organization} from 'sentry/types/organization';
 import InvestigationsView from 'sentry/views/investigations';
-import {getInvestigationDetailQueryOptions} from 'sentry/views/investigations/api';
+import {
+  investigationCandidatesQueryOptions,
+  getInvestigationDetailQueryOptions,
+  investigationListQueryOptions,
+} from 'sentry/views/investigations/api';
 import type {
   InvestigationDetail,
   InvestigationListItem,
@@ -63,6 +67,7 @@ function InvestigationFixture(
     isFavorited: false,
     summary: null,
     summaryDescription: null,
+    titleGeneration: {status: null},
     ...overrides,
   };
 }
@@ -253,6 +258,47 @@ describe('Explore Investigations', () => {
       unrelatedDetail
     );
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Investigation created.');
+  });
+
+  it('refreshes running title and summary generation in the list', async () => {
+    MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [
+        InvestigationFixture({
+          title: 'Untitled investigation',
+          titleGeneration: {status: 'running'},
+        }),
+      ],
+    });
+
+    const {queryClient} = renderView();
+    await screen.findByText('Untitled investigation');
+    const completedRequest = MockApiClient.addMockResponse({
+      url: listUrl,
+      body: [
+        InvestigationFixture({
+          title: 'Checkout errors across releases',
+          summary: 'Errors rose across releases',
+          summaryDescription: 'All active releases increased together.',
+          titleGeneration: {status: 'completed'},
+        }),
+      ],
+    });
+
+    expect(
+      await screen.findByText('Checkout errors across releases', {}, {timeout: 3000})
+    ).toBeInTheDocument();
+    expect(completedRequest).toHaveBeenCalled();
+    expect(
+      queryClient.getQueryData(
+        investigationListQueryOptions({organizationSlug: 'org-slug'}).queryKey
+      )?.json[0]
+    ).toEqual(
+      expect.objectContaining({
+        summary: 'Errors rose across releases',
+        summaryDescription: 'All active releases increased together.',
+      })
+    );
   });
 
   it('toggles an investigation favorite and refreshes the list', async () => {
@@ -451,6 +497,41 @@ describe('Explore Investigations', () => {
 
     await waitFor(() =>
       expect(queryClient.getQueryData(detailOptions.queryKey)).toBeUndefined()
+    );
+  });
+
+  it('invalidates breached-metric entry points after deletion', async () => {
+    const investigation = InvestigationFixture();
+    MockApiClient.addMockResponse({url: listUrl, body: [investigation]});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/1/',
+      method: 'DELETE',
+    });
+
+    const {queryClient} = renderView();
+    const candidateOptions = investigationCandidatesQueryOptions({
+      organizationSlug: 'org-slug',
+      sources: [
+        {
+          type: 'metric_open_period',
+          ref: {groupId: '123', openPeriodId: '456'},
+        },
+      ],
+    });
+    queryClient.setQueryData(candidateOptions.queryKey, {
+      items: [{status: 'view', investigationId: '1'}],
+    });
+    await userEvent.click(
+      await screen.findByLabelText('More options for Database latency investigation')
+    );
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(queryClient.getQueryState(candidateOptions.queryKey)?.isInvalidated).toBe(
+        true
+      )
     );
   });
 

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -117,6 +117,12 @@ function InvestigationsPage() {
   const {data, isPending, isError, error} = useQuery({
     ...listOptions,
     select: selectJsonWithHeaders,
+    refetchInterval: queryState =>
+      queryState.state.data?.json.some(item =>
+        ['pending', 'running'].includes(item.titleGeneration?.status ?? '')
+      )
+        ? 2000
+        : false,
   });
 
   const createMutation = useCreateInvestigationMutation(organization.slug, {

--- a/static/app/views/investigations/investigationCache.spec.ts
+++ b/static/app/views/investigations/investigationCache.spec.ts
@@ -13,6 +13,8 @@ const investigation: InvestigationDetail = {
   isFavorited: false,
   sourceType: 'manual',
   status: 'active',
+  summary: null,
+  summaryDescription: null,
   title: 'Investigate database latency',
   version: 1,
 };

--- a/static/app/views/investigations/investigationSummaryCard.tsx
+++ b/static/app/views/investigations/investigationSummaryCard.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+type InvestigationSummaryCardProps = {
+  summary: string | null;
+  summaryDescription: string | null;
+  className?: string;
+};
+
+export function InvestigationSummaryCard({
+  className,
+  summary,
+  summaryDescription,
+}: InvestigationSummaryCardProps) {
+  if (!summary || !summaryDescription) {
+    return null;
+  }
+
+  return (
+    <SummaryCard className={className} gap="xs" data-test-id="investigation-summary">
+      <Text size="md" variant="muted">
+        {t('Current understanding')}
+      </Text>
+      <Text size="lg" bold>
+        {summary}
+      </Text>
+      <SummaryDescription size="md">{summaryDescription}</SummaryDescription>
+    </SummaryCard>
+  );
+}
+
+const SummaryCard = styled(Stack)`
+  position: relative;
+  overflow: hidden;
+  padding: ${p => p.theme.space.lg};
+  border: 1px solid ${p => p.theme.tokens.border.accent.muted};
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: ${p => p.theme.shadow.low};
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 4px;
+    background: ${p => p.theme.tokens.background.accent.vibrant};
+  }
+`;
+
+const SummaryDescription = styled(Text)`
+  white-space: pre-line;
+`;

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -9,6 +9,8 @@ export type InvestigationListItem = {
   isFavorited: boolean;
   sourceType: string;
   status: string;
+  summary: string | null;
+  summaryDescription: string | null;
   title: string;
   version: number;
 };
@@ -130,7 +132,14 @@ export type InvestigationDetail = InvestigationListItem & {
   projectIds?: number[];
   source?: Record<string, unknown>;
   template?: {key: string; version: number} | null;
-  titleGeneration?: {status: string | null};
+  titleGeneration?: {
+    status: 'pending' | 'running' | 'completed' | 'failed' | null;
+  };
+};
+
+export type InvestigationTitleGeneration = {
+  preview: string | null;
+  status: 'pending' | 'running' | 'completed' | 'failed' | null;
 };
 
 export type MetricOpenPeriodInvestigationSource = {

--- a/static/app/views/investigations/types.ts
+++ b/static/app/views/investigations/types.ts
@@ -13,6 +13,9 @@ export type InvestigationListItem = {
   summaryDescription: string | null;
   title: string;
   version: number;
+  titleGeneration?: {
+    status: 'pending' | 'running' | 'completed' | 'failed' | null;
+  };
 };
 
 // Expand this response type as the detail UI begins consuming additional fields.
@@ -132,9 +135,6 @@ export type InvestigationDetail = InvestigationListItem & {
   projectIds?: number[];
   source?: Record<string, unknown>;
   template?: {key: string; version: number} | null;
-  titleGeneration?: {
-    status: 'pending' | 'running' | 'completed' | 'failed' | null;
-  };
 };
 
 export type InvestigationTitleGeneration = {

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -100,6 +100,15 @@ describe('MetricDetectorTriggeredSection', () => {
       method: 'POST',
       body: {items: [{status: 'view', investigationId: '4567'}]},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/4567/',
+      body: {
+        id: '4567',
+        summary: 'Errors rose across releases',
+        summaryDescription: 'All active releases increased together.',
+        titleGeneration: {status: 'completed'},
+      },
+    });
     render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
       organization,
     });
@@ -107,11 +116,43 @@ describe('MetricDetectorTriggeredSection', () => {
     await screen.findByRole('region', {
       name: 'Seer Investigation',
     });
-    expect(await screen.findByText('Different investigation title')).toBeInTheDocument();
-    expect(screen.getByText('Different investigation summary text')).toBeInTheDocument();
+    expect(await screen.findByText('Errors rose across releases')).toBeInTheDocument();
+    expect(
+      screen.getByText('All active releases increased together.')
+    ).toBeInTheDocument();
     expect(
       await screen.findByRole('button', {name: 'View Investigation'})
     ).toHaveAttribute('href', '/organizations/org-slug/seer/investigation/4567/');
+  });
+
+  it('hides an existing investigation summary until all summary fields are ready', async () => {
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'view', investigationId: '4567'}]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/4567/',
+      body: {
+        id: '4567',
+        summary: 'Errors rose across releases',
+        summaryDescription: null,
+        titleGeneration: {status: 'failed'},
+      },
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'View Investigation'})
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('investigation-summary')).not.toBeInTheDocument();
   });
 
   it('launches an investigation for the selected open period', async () => {
@@ -133,6 +174,13 @@ describe('MetricDetectorTriggeredSection', () => {
     render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
       organization,
     });
+
+    expect(
+      await screen.findByText(
+        'Launch a Seer investigation to understand what happened, identify what drove the breach, and get evidence-backed next steps.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('investigation-summary')).not.toBeInTheDocument();
 
     await userEvent.click(
       await screen.findByRole('button', {name: 'Launch Investigation'})

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -4,7 +4,7 @@ import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import {
@@ -153,6 +153,48 @@ describe('MetricDetectorTriggeredSection', () => {
       await screen.findByRole('button', {name: 'View Investigation'})
     ).toBeInTheDocument();
     expect(screen.queryByTestId('investigation-summary')).not.toBeInTheDocument();
+  });
+
+  it('keeps polling briefly while metadata generation is starting', async () => {
+    jest.useFakeTimers();
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'view', investigationId: '4567'}]},
+    });
+    const detailRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/4567/',
+      body: {
+        id: '4567',
+        summary: null,
+        summaryDescription: null,
+        titleGeneration: {status: null},
+        blocks: [
+          {
+            id: 'block-1',
+            config: {autoRun: true},
+            dependencies: [],
+            outputStatus: 'completed',
+            currentExecution: {status: 'completed'},
+          },
+        ],
+      },
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'View Investigation'})
+    ).toBeInTheDocument();
+    act(() => jest.advanceTimersByTime(2000));
+    await waitFor(() => expect(detailRequest).toHaveBeenCalledTimes(2));
+    jest.useRealTimers();
   });
 
   it('launches an investigation for the selected open period', async () => {

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -197,6 +197,55 @@ describe('MetricDetectorTriggeredSection', () => {
     jest.useRealTimers();
   });
 
+  it('keeps polling while a parallel branch is active after another branch fails', async () => {
+    jest.useFakeTimers();
+    const organization = OrganizationFixture({
+      slug: 'org-slug',
+      features: ['investigations'],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/candidates/',
+      method: 'POST',
+      body: {items: [{status: 'view', investigationId: '4567'}]},
+    });
+    const detailRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/investigations/4567/',
+      body: {
+        id: '4567',
+        summary: null,
+        summaryDescription: null,
+        titleGeneration: {status: null},
+        blocks: [
+          {
+            id: 'block-1',
+            config: {autoRun: true},
+            dependencies: [],
+            outputStatus: 'failed',
+            currentExecution: {status: 'failed'},
+          },
+          {
+            id: 'block-2',
+            config: {autoRun: true},
+            dependencies: [],
+            outputStatus: 'running',
+            currentExecution: {status: 'running'},
+          },
+        ],
+      },
+    });
+
+    render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'View Investigation'})
+    ).toBeInTheDocument();
+    act(() => jest.advanceTimersByTime(2000));
+    await waitFor(() => expect(detailRequest).toHaveBeenCalledTimes(2));
+    jest.useRealTimers();
+  });
+
   it('launches an investigation for the selected open period', async () => {
     const organization = OrganizationFixture({
       slug: 'org-slug',

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useEffectEvent, useMemo, useState} from 'react';
+import {Fragment, useEffect, useEffectEvent, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import type {LocationDescriptor} from 'history';
@@ -66,6 +66,9 @@ import {FoldSection} from 'sentry/views/issueDetails/foldSection';
 
 import {AttributeComparisonSection} from './attributeComparisonSection';
 import {OpenPeriodTimelineSection} from './openPeriodTimelineSection';
+
+const INVESTIGATION_POLL_INTERVAL = 2000;
+const INVESTIGATION_METADATA_GRACE_PERIOD = 10_000;
 
 interface MetricDetectorEvidenceData {
   /**
@@ -573,6 +576,7 @@ function SeerInvestigationSection({
   const organization = useOrganization();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const metadataIdleSince = useRef<{id: string; timestamp: number} | null>(null);
   const eventOpenPeriodQuery = useEventOpenPeriod({groupId, eventId});
   const shouldLoadLatest =
     eventOpenPeriodQuery.isSuccess && eventOpenPeriodQuery.data === null;
@@ -627,9 +631,32 @@ function SeerInvestigationSection({
         ) {
           return false;
         }
-        return shouldPollInvestigationBlocks(investigation.blocks ?? []) ||
+        const blocks = investigation.blocks ?? [];
+        if (
+          investigation.titleGeneration?.status === 'failed' ||
+          blocks.some(
+            block =>
+              block.config.autoRun === true &&
+              (block.currentExecution?.status === 'failed' ||
+                block.currentExecution?.status === 'cancelled')
+          )
+        ) {
+          return false;
+        }
+        if (
+          shouldPollInvestigationBlocks(blocks) ||
           isTitleGenerationActive(investigation.titleGeneration?.status)
-          ? 2000
+        ) {
+          metadataIdleSince.current = null;
+          return INVESTIGATION_POLL_INTERVAL;
+        }
+        const idleSince =
+          metadataIdleSince.current?.id === investigation.id
+            ? metadataIdleSince.current.timestamp
+            : Date.now();
+        metadataIdleSince.current = {id: investigation.id, timestamp: idleSince};
+        return Date.now() - idleSince < INVESTIGATION_METADATA_GRACE_PERIOD
+          ? INVESTIGATION_POLL_INTERVAL
           : false;
       },
     });

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -59,6 +59,7 @@ import {
   getInvestigationDetailQueryOptions,
   useLaunchInvestigationMutation,
 } from 'sentry/views/investigations/api';
+import {InvestigationSummaryCard} from 'sentry/views/investigations/investigationSummaryCard';
 import type {MetricOpenPeriodInvestigationSource} from 'sentry/views/investigations/types';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
 
@@ -561,19 +562,6 @@ const GroupListWrapper = styled('div')`
   margin-top: ${p => p.theme.space.md};
 `;
 
-const InvestigationSummaryCard = styled(Stack)`
-  padding: 14px 16px;
-  box-shadow: ${p => p.theme.shadow.low};
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 4px;
-    background: ${p => p.theme.tokens.background.accent.vibrant};
-  }
-`;
-
 function SeerInvestigationSection({
   eventId,
   groupId,
@@ -620,6 +608,28 @@ function SeerInvestigationSection({
     enabled: source !== null,
     select: response => response.json.items[0],
   });
+  const existingInvestigationId =
+    candidate?.status === 'view' ? candidate.investigationId : null;
+  const {data: existingInvestigation, isPending: isExistingInvestigationPending} =
+    useQuery({
+      ...getInvestigationDetailQueryOptions(
+        organization.slug,
+        existingInvestigationId ?? 'disabled'
+      ),
+      enabled: existingInvestigationId !== null,
+      select: response => response.json,
+      refetchInterval: query => {
+        const investigation = query.state.data?.json;
+        if (
+          !investigation ||
+          (investigation.summary && investigation.summaryDescription) ||
+          investigation.titleGeneration?.status === 'failed'
+        ) {
+          return false;
+        }
+        return 2000;
+      },
+    });
   const launchMutation = useLaunchInvestigationMutation(organization.slug, {
     onSuccess: launchedInvestigation => {
       queryClient.setQueryData(candidateOptions.queryKey, {
@@ -658,7 +668,9 @@ function SeerInvestigationSection({
       titleLabel={t('Seer Investigation')}
       sectionKey="seer_investigation"
     >
-      {isOpenPeriodPending || (source !== null && isCandidatePending) ? (
+      {isOpenPeriodPending ||
+      (source !== null && isCandidatePending) ||
+      (existingInvestigationId !== null && isExistingInvestigationPending) ? (
         <Placeholder height="40px" width="160px" />
       ) : isOpenPeriodError || isCandidateError ? (
         <Alert.Container>
@@ -668,18 +680,18 @@ function SeerInvestigationSection({
         </Alert.Container>
       ) : (
         <Stack gap="md">
-          <InvestigationSummaryCard
-            position="relative"
-            overflow="hidden"
-            border="primary"
-            radius="md"
-            gap="xs"
-          >
-            <Text size="lg" bold>
-              {t('Different investigation title')}
+          {existingInvestigation?.summary && existingInvestigation.summaryDescription ? (
+            <InvestigationSummaryCard
+              summary={existingInvestigation.summary}
+              summaryDescription={existingInvestigation.summaryDescription}
+            />
+          ) : investigationPath ? null : (
+            <Text size="md" variant="muted">
+              {t(
+                'Launch a Seer investigation to understand what happened, identify what drove the breach, and get evidence-backed next steps.'
+              )}
             </Text>
-            <Text size="md">{t('Different investigation summary text')}</Text>
-          </InvestigationSummaryCard>
+          )}
           <Flex>
             {investigationPath ? (
               <LinkButton size="md" variant="primary" to={investigationPath}>

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -633,6 +633,13 @@ function SeerInvestigationSection({
         }
         const blocks = investigation.blocks ?? [];
         if (
+          shouldPollInvestigationBlocks(blocks) ||
+          isTitleGenerationActive(investigation.titleGeneration?.status)
+        ) {
+          metadataIdleSince.current = null;
+          return INVESTIGATION_POLL_INTERVAL;
+        }
+        if (
           investigation.titleGeneration?.status === 'failed' ||
           blocks.some(
             block =>
@@ -642,13 +649,6 @@ function SeerInvestigationSection({
           )
         ) {
           return false;
-        }
-        if (
-          shouldPollInvestigationBlocks(blocks) ||
-          isTitleGenerationActive(investigation.titleGeneration?.status)
-        ) {
-          metadataIdleSince.current = null;
-          return INVESTIGATION_POLL_INTERVAL;
         }
         const idleSince =
           metadataIdleSince.current?.id === investigation.id

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -59,6 +59,7 @@ import {
   getInvestigationDetailQueryOptions,
   useLaunchInvestigationMutation,
 } from 'sentry/views/investigations/api';
+import {shouldPollInvestigationBlocks} from 'sentry/views/investigations/detail/cell';
 import {InvestigationSummaryCard} from 'sentry/views/investigations/investigationSummaryCard';
 import type {MetricOpenPeriodInvestigationSource} from 'sentry/views/investigations/types';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
@@ -622,12 +623,14 @@ function SeerInvestigationSection({
         const investigation = query.state.data?.json;
         if (
           !investigation ||
-          (investigation.summary && investigation.summaryDescription) ||
-          investigation.titleGeneration?.status === 'failed'
+          (investigation.summary && investigation.summaryDescription)
         ) {
           return false;
         }
-        return 2000;
+        return shouldPollInvestigationBlocks(investigation.blocks ?? []) ||
+          isTitleGenerationActive(investigation.titleGeneration?.status)
+          ? 2000
+          : false;
       },
     });
   const launchMutation = useLaunchInvestigationMutation(organization.slug, {
@@ -713,6 +716,10 @@ function SeerInvestigationSection({
       )}
     </FoldSection>
   );
+}
+
+function isTitleGenerationActive(status: string | null | undefined) {
+  return status === 'pending' || status === 'running';
 }
 
 export function MetricIssueSeerInvestigationSection({


### PR DESCRIPTION
Investigation text and title previews now appear as their existing polling endpoints return partial
content, while manual title edits continue to take precedence. Once completion metadata is ready,
the notebook and breached-metric detail view share a "Current understanding" card containing the
generated summary and actionable description; the card stays hidden until both fields exist.

Investigation list, detail, and breached-metric candidate caches now stay synchronized across
metadata completion, launch, rename, and deletion. Lists already on screen poll only while metadata
generation is pending or running, and deleting an investigation invalidates its breached-metric
entry point instead of leaving a stale link.
