### PR TITLE
fix: Move long running issue tasks to the long pool

### DIFF
--- a/src/sentry/tasks/auto_source_code_config.py
+++ b/src/sentry/tasks/auto_source_code_config.py
@@ -6,12 +6,13 @@ from taskbroker_client.retry import Retry
 
 from sentry.issues.auto_source_code_config.task import process_event
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import issues_long_tasks, issues_tasks
 
 
 @instrumented_task(
     name="sentry.tasks.auto_source_code_config",
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     processing_deadline_duration=15 * 60,
     retry=Retry(times=3, delay=60 * 10),
 )

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -29,7 +29,7 @@ from sentry.plugins.base import bindings
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationResourceNotFoundError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import issues_long_tasks, issues_tasks
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -330,7 +330,8 @@ def fetch_commits_for_ref_with_lifecycle(
 
 @instrumented_task(
     name="sentry.tasks.commits.fetch_commits",
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     processing_deadline_duration=60 * 15 + 5,
     retry=Retry(
         times=5,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -176,6 +176,11 @@ issues_reprocessing_tasks = app.taskregistry.create_namespace(
     app_feature="issueplatform",
 )
 
+issues_long_tasks = app.taskregistry.create_namespace(
+    "issues.long",
+    app_feature="issueplatform",
+)
+
 integrations_tasks = app.taskregistry.create_namespace(
     "integrations",
     app_feature="integrations",


### PR DESCRIPTION
These tasks have processing deadlines of 15 minutes. However the majority of issue tasks expect to
be completed much faster than that. These long running tasks can clog up the workers, particularly
when they are being produced multiple times per second.

Create a new namespace that runs on the long pool, and migrate these tasks onto that namespace.