### PR TITLE
feat(seer): Include autofix_rca runs in autofix overview

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -471,7 +471,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         milestone_rows = (
             SeerRunMilestone.objects.filter(
                 seer_run__organization=organization,
-                seer_run__agent__source="autofix",
+                seer_run__agent__source__in=("autofix", "autofix_rca"),
                 seer_run__agent__group_id__isnull=False,
                 seer_run__agent__project_id__in=project_ids,
                 seer_run__last_triggered_at__range=(start, end),


### PR DESCRIPTION
## Summary

The autofix overview endpoint's milestone query filtered on `agent.source == "autofix"`, which excluded root-cause-analysis runs (`autofix_rca`). This widens the filter to match both `autofix` and `autofix_rca` so RCA runs are surfaced in the overview.

## Changes

- `_latest_run_per_group` in `organization_seer_autofix_overview.py` now filters `seer_run__agent__source__in=("autofix", "autofix_rca")` instead of a single `"autofix"` value.

Existing tests are unaffected — they exercise `autofix` runs, which the widened filter still matches.