### PR TITLE
fix(seer): Record merged milestone despite abandoned sibling PRs

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -49,6 +49,13 @@ def is_open_pull_request_state(state: str | None) -> bool:
     )
 
 
+def is_abandoned_pull_request_state(state: str | None) -> bool:
+    return state in (
+        PullRequestLifecycleState.CLOSED,
+        PullRequestLifecycleState.SUPERSEDED,
+    )
+
+
 class PullRequestAttributionSignalType(models.TextChoices):
     SENTRY_APP = "sentry_app"
     SEER_DELEGATED_CURSOR = "seer_delegated:cursor"

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -180,11 +180,13 @@ def handle_pull_requests_merged_milestone(
     integration: RpcIntegration | None = None,
     **kwargs: Any,
 ) -> None:
-    """Reconcile the run's PULL_REQUESTS_MERGED milestone when one of its PRs merges,
-    resolving the run via the SeerRunPullRequest link (covers coding-agent PRs too).
+    """Reconcile the run's PULL_REQUESTS_MERGED milestone whenever one of its PRs closes,
+    merges, or reopens, resolving the run via the SeerRunPullRequest link (covers
+    coding-agent PRs too). A close can be the event that leaves every remaining PR
+    merged; a reopen can revoke a milestone that a since-abandoned PR let through.
     """
     pull_request = event.get("pull_request")
-    if not pull_request or event.get("action") != "closed" or not pull_request.get("merged"):
+    if not pull_request or event.get("action") not in ("closed", "reopened"):
         return
 
     number = pull_request.get("number")

--- a/src/sentry/seer/milestones.py
+++ b/src/sentry/seer/milestones.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING
 
 from django.db import router, transaction
 
-from sentry.models.pullrequest import PullRequestLifecycleState
+from sentry.models.pullrequest import (
+    PullRequestLifecycleState,
+    is_abandoned_pull_request_state,
+)
 from sentry.seer.models.run import (
     SeerRun,
     SeerRunMilestone,
@@ -128,8 +131,11 @@ def reconcile_pull_requests_merged_milestone(seer_run: SeerRun) -> bool:
             milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED,
         )
 
-        all_prs_merged = bool(states) and all(
-            state == PullRequestLifecycleState.MERGED for state in states
+        # An abandoned PR (closed/superseded) doesn't count against "all merged"; a run
+        # counts as merged when every PR Seer still has in play merged.
+        relevant_states = [s for s in states if not is_abandoned_pull_request_state(s)]
+        all_prs_merged = bool(relevant_states) and all(
+            state == PullRequestLifecycleState.MERGED for state in relevant_states
         )
         if not all_prs_merged:
             milestone.delete()

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -2040,6 +2040,62 @@ class PullRequestEventWebhookTest(APITestCase):
 
         assert not SeerRunMilestone.objects.filter(seer_run=seer_run).exists()
 
+    def test_closing_last_pull_request_records_milestone_when_sibling_merged(self) -> None:
+        repo = self._repo_for_pull_request_events()
+        seer_run = self.create_seer_run(organization=self.organization)
+        merged_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="1"
+        )
+        merged_pr.update(state=PullRequestLifecycleState.MERGED)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=merged_pr)
+        closing_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="2"
+        )
+        self.create_seer_run_pull_request(run=seer_run, pull_request=closing_pr)
+
+        closed = json.loads(PULL_REQUEST_CLOSED_EVENT_EXAMPLE)
+        closed["pull_request"]["number"] = 2
+        closed["pull_request"]["state"] = "closed"
+        closed["pull_request"]["merged"] = False
+        self._post_pull_request_event(json.dumps(closed).encode())
+
+        assert SeerRunMilestone.objects.filter(
+            seer_run=seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        ).exists()
+
+    def test_reopening_a_pull_request_removes_a_stale_merged_milestone(self) -> None:
+        repo = self._repo_for_pull_request_events()
+        seer_run = self.create_seer_run(organization=self.organization)
+        merged_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="1"
+        )
+        merged_pr.update(state=PullRequestLifecycleState.MERGED)
+        self.create_seer_run_pull_request(run=seer_run, pull_request=merged_pr)
+        other_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.project.organization.id, key="2"
+        )
+        self.create_seer_run_pull_request(run=seer_run, pull_request=other_pr)
+
+        closed = json.loads(PULL_REQUEST_CLOSED_EVENT_EXAMPLE)
+        closed["pull_request"]["number"] = 2
+        closed["pull_request"]["state"] = "closed"
+        closed["pull_request"]["merged"] = False
+        self._post_pull_request_event(json.dumps(closed).encode())
+        assert SeerRunMilestone.objects.filter(
+            seer_run=seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        ).exists()
+
+        reopened = json.loads(PULL_REQUEST_CLOSED_EVENT_EXAMPLE)
+        reopened["action"] = "reopened"
+        reopened["pull_request"]["number"] = 2
+        reopened["pull_request"]["state"] = "open"
+        reopened["pull_request"]["merged"] = False
+        self._post_pull_request_event(json.dumps(reopened).encode())
+
+        assert not SeerRunMilestone.objects.filter(
+            seer_run=seer_run, milestone=SeerRunMilestoneType.PULL_REQUESTS_MERGED
+        ).exists()
+
     @patch("sentry.integrations.github.webhook.track_contributor_seat")
     def test_pr_lifecycle_activities_are_attributed_to_acting_user(
         self, _mock_track_contributor_seat: MagicMock

--- a/tests/sentry/seer/test_milestones.py
+++ b/tests/sentry/seer/test_milestones.py
@@ -423,6 +423,27 @@ class ReconcilePullRequestsMergedMilestoneTest(TestCase):
         assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
         assert self._recorded() == {SeerRunMilestoneType.PULL_REQUESTS_MERGED}
 
+    def test_records_when_a_closed_pull_request_is_ignored_and_others_merged(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.CLOSED)
+        self._linked_pull_request("2", PullRequestLifecycleState.MERGED)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+        assert self._recorded() == {SeerRunMilestoneType.PULL_REQUESTS_MERGED}
+
+    def test_records_when_a_superseded_pull_request_is_ignored_and_others_merged(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.SUPERSEDED)
+        self._linked_pull_request("2", PullRequestLifecycleState.MERGED)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is True
+        assert self._recorded() == {SeerRunMilestoneType.PULL_REQUESTS_MERGED}
+
+    def test_not_recorded_when_a_closed_and_an_open_pull_request(self) -> None:
+        self._linked_pull_request("1", PullRequestLifecycleState.CLOSED)
+        self._linked_pull_request("2", PullRequestLifecycleState.OPEN)
+
+        assert reconcile_pull_requests_merged_milestone(self.seer_run) is False
+        assert self._recorded() == set()
+
     def test_not_recorded_when_a_linked_pull_request_is_open(self) -> None:
         self._linked_pull_request("1", PullRequestLifecycleState.MERGED)
         self._linked_pull_request("2", PullRequestLifecycleState.OPEN)


### PR DESCRIPTION
## Summary

A Seer run can open multiple PRs on its behalf — an abandoned one gets closed (or superseded) while another merges. The `PULL_REQUESTS_MERGED` milestone required **every** linked PR to be exactly `merged`, so an abandoned+merged pair never counted as merged and the run never reached the merged milestone.

## Changes

- **Ignore abandoned PRs when deciding "all merged".** `reconcile_pull_requests_merged_milestone` now records the milestone when a run has at least one non-abandoned PR and every non-abandoned PR is merged. Abandoned states (`closed`, `superseded`) no longer block it; a run whose PRs are all abandoned stays unmerged.
- **New `is_abandoned_pull_request_state` helper** in `models/pullrequest.py`, beside `is_open_pull_request_state`, so the "will never merge" concept has a single home rather than a hardcoded state literal.
- **Reconcile on close and reopen, not just merge.** Previously the milestone was only re-evaluated on a merge webhook, so closing the last open PR after a sibling had already merged never marked the run merged. Reconciling on `closed` fixes that; reconciling on `reopened` revokes a milestone that a since-reopened PR should no longer satisfy.

## Motivation

Runs with a closed + merged PR pair were silently stuck short of the merged milestone, so they rendered in the wrong section of the autofix overview. The overview endpoint's closed-PR filter already handles the multi-PR case correctly (a run is hidden only when *all* its PRs are closed), so no endpoint change is needed.
