### PR TITLE
fix(seer): Break long tokens in autofix overview issue titles

### DIFF
--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -538,7 +538,13 @@ export function OverviewCard({
             <Grid columns="max-content minmax(0, 1fr)" gap="sm">
               <LevelBar level={run.issue.level ?? undefined} />
               <Stack minWidth="0" gap="xs">
-                <Text bold display="block" textWrap="pretty" size="lg">
+                <Text
+                  bold
+                  display="block"
+                  textWrap="pretty"
+                  wordBreak="break-word"
+                  size="lg"
+                >
                   <TitleLink to={issueUrl}>{run.title}</TitleLink>
                 </Text>
                 <Flex wrap="wrap" gap="md" align="center">


### PR DESCRIPTION
Long unbroken issue-title tokens — file paths, URLs, long error type names — had no break opportunity on the Seer Autofix overview cards. The wrapped title overflowed its grid cell and its second line ran full-width underneath the "Review PR" action button, breaking the card layout.

## Changes

- Add `wordBreak="break-word"` to the issue-title `Text` in `issueCard.tsx` so long unbroken tokens break within their column instead of overflowing.

The intended multi-line `textWrap="pretty"` wrapping and the level bar spanning all title lines are preserved. This matches the treatment the Root Cause and Plan narrative blocks on the same card already use.

Refs [AIML-3357](https://linear.app/getsentry/issue/AIML-3357/fix-wrapping-issues-on-issue-names)
