### PR TITLE
feat(seer): Default autofix overview to 7 day window

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -507,9 +507,7 @@ describe('AutofixOverview', () => {
       await screen.findByText('You don’t have any Autofix runs...yet.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'project-slug'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Autofix Activity 14D'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Autofix Activity 7D'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /Sort/})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: /Create Plan/})).not.toBeInTheDocument();
     expect(

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -64,7 +64,7 @@ export default function AutofixOverview() {
     >
       <PageFiltersContainer
         skipInitializeUrlParams
-        defaultSelection={{datetime: {period: '14d', start: null, end: null, utc: null}}}
+        defaultSelection={{datetime: {period: '7d', start: null, end: null, utc: null}}}
       >
         <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
           <Layout.Title>{t('Autofix Overview')}</Layout.Title>


### PR DESCRIPTION
## Summary

Changes the default activity time range on the Autofix Overview page from **14 days** to **7 days**, so the initial view focuses on more recent runs.

## Motivation

The 14-day default surfaced a lot of older runs on first load. A 7-day window keeps the overview centered on recent activity, which better matches how the page is used. Users can still widen (or narrow) the range via the existing page-filter picker — `7d` is already a valid picker option, so no other changes are needed.

## Changes

- `static/app/views/seerWorkflows/overview/index.tsx`: `PageFiltersContainer` `defaultSelection` period `14d` → `7d`.

## Notes

- Frontend-only change.
- The backend endpoint's 90-day fallback (`MAX_STATS_PERIOD`, only hit by param-less direct API calls) is unchanged.
- No existing tests assert the old default; the overview spec's time-window test passes `statsPeriod` explicitly and is unaffected.