### PR TITLE
fix(auth): Camelize auth config callback keys

### DIFF
--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -16,6 +16,7 @@ from sentry.api.serializers.models.auth import (
     AuthMfaRequiredSerializerResponse,
     serialize_auth_mfa_required,
 )
+from sentry.api.serializers.rest_framework import convert_dict_key_case, snake_to_camel_case
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
 from sentry.models.organization import Organization
@@ -36,7 +37,11 @@ class AuthConfigResponse(TypedDict):
     canRegister: bool
     hasNewsletter: bool
     pendingMfa: AuthMfaRequiredSerializerResponse | None
+    githubLoginLink: NotRequired[str]
+    googleLoginLink: NotRequired[str]
+    vstsLoginLink: NotRequired[str]
     warning: NotRequired[str]
+    loginBanner: NotRequired[str]
 
 
 @control_silo_endpoint
@@ -121,6 +126,9 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
         if "session_expired" in request.COOKIES:
             context["warning"] = str(WARN_SESSION_EXPIRED)
 
-        context.update(additional_context.run_callbacks(request))
+        additional_login_context = convert_dict_key_case(
+            additional_context.run_callbacks(request), snake_to_camel_case
+        )
+        context.update(additional_login_context)
 
         return cast(AuthConfigResponse, context)

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.conf import settings
 from django.test.utils import override_settings
@@ -9,6 +11,7 @@ from sentry.receivers import create_default_projects
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.web.frontend.auth_login import additional_context
 
 
 @control_silo_test
@@ -102,6 +105,38 @@ class AuthConfigEndpointTest(APITestCase):
             "mfaMethods": [{"id": "totp"}],
         }
 
+    def test_login_banner(self) -> None:
+        banner = 'Banner message <a href="https://example.com">Learn more</a>.'
+        with patch.object(
+            additional_context,
+            "_callbacks",
+            {lambda request: {"login_banner": banner}},
+        ):
+            response = self.client.get(self.path)
+
+        assert response.data["loginBanner"] == banner
+        assert "login_banner" not in response.data
+
+    def test_additional_context_keys_are_camelized(self) -> None:
+        with patch.object(
+            additional_context,
+            "_callbacks",
+            {
+                lambda request: {
+                    "github_login_link": "/identity/login/github/",
+                    "google_login_link": "/identity/login/google/",
+                    "vsts_login_link": "/identity/login/vsts/",
+                }
+            },
+        ):
+            response = self.client.get(self.path)
+
+        assert response.data["githubLoginLink"] == "/identity/login/github/"
+        assert response.data["googleLoginLink"] == "/identity/login/google/"
+        assert response.data["vstsLoginLink"] == "/identity/login/vsts/"
+        assert "github_login_link" not in response.data
+        assert "google_login_link" not in response.data
+        assert "vsts_login_link" not in response.data
     @pytest.mark.skipif(
         settings.SENTRY_NEWSLETTER != "sentry.newsletter.dummy.DummyNewsletter",
         reason="Requires DummyNewsletter.",

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -137,6 +137,7 @@ class AuthConfigEndpointTest(APITestCase):
         assert "github_login_link" not in response.data
         assert "google_login_link" not in response.data
         assert "vsts_login_link" not in response.data
+
     @pytest.mark.skipif(
         settings.SENTRY_NEWSLETTER != "sentry.newsletter.dummy.DummyNewsletter",
         reason="Requires DummyNewsletter.",


### PR DESCRIPTION
The auth config endpoint includes legacy login-template callback context whose snake_case keys were being returned unchanged, while API consumers expect camelCase response fields.

Convert the callback payload recursively before merging it into the response, and cover both provider login links and the login banner with endpoint tests.

>[!IMPORTANT]
> Nothing is using these at the moment, this was built for a very old SPA style login that isn't used anywhere.