### PR TITLE
feat(seer): Add projectConfig expand to autofix overview endpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -424,9 +424,19 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             [run.seer_run.id for _, run in capped], include_scm_info=include_scm_info
         )
 
+        # projectConfig covers every selected project; per-issue scmInfo only needs the
+        # projects with runs. Scan the smallest set that satisfies the requested expands.
         repo_eligibility_by_project: dict[int, _RepoEligibility] = {}
-        if include_scm_info or include_project_config:
-            repo_eligibility_by_project = _coding_agent_repo_eligibility(organization, project_ids)
+        if include_project_config:
+            eligibility_project_ids: Collection[int] = project_ids
+        elif include_scm_info:
+            eligibility_project_ids = {group.project_id for group in groups.values()}
+        else:
+            eligibility_project_ids = ()
+        if eligibility_project_ids:
+            repo_eligibility_by_project = _coding_agent_repo_eligibility(
+                organization, eligibility_project_ids
+            )
         issue_repo_eligibility = repo_eligibility_by_project if include_scm_info else None
 
         project_config: list[ProjectConfigPayload] = []

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -46,6 +46,7 @@ from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
     IssuePayload,
     IssueProjectPayload,
     OverviewResponse,
+    ProjectConfigPayload,
     ProposedFixPayload,
     PullRequestPayload,
     RootCausePayload,
@@ -354,6 +355,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         include_scm_info = "scmInfo" in expand
         include_issue_stats = "issueStats" in expand
         include_status = "status" in expand
+        include_project_config = "projectConfig" in expand
         environments = self.get_environments(request, organization)
 
         sort = request.GET.get("sort")
@@ -422,11 +424,23 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             [run.seer_run.id for _, run in capped], include_scm_info=include_scm_info
         )
 
-        repo_eligibility_by_project: dict[int, _RepoEligibility] | None = None
-        if include_scm_info:
-            repo_eligibility_by_project = _coding_agent_repo_eligibility(
-                organization, {group.project_id for group in groups.values()}
-            )
+        repo_eligibility_by_project: dict[int, _RepoEligibility] = {}
+        if include_scm_info or include_project_config:
+            repo_eligibility_by_project = _coding_agent_repo_eligibility(organization, project_ids)
+        issue_repo_eligibility = repo_eligibility_by_project if include_scm_info else None
+
+        project_config: list[ProjectConfigPayload] = []
+        if include_project_config:
+            project_config = [
+                {
+                    "id": str(project.id),
+                    "slug": project.slug,
+                    "hasReposConnected": repo_eligibility_by_project[
+                        project.id
+                    ].has_repos_connected,
+                }
+                for project in projects
+            ]
 
         status_by_state_id: dict[int, str] = {}
         if include_status:
@@ -450,7 +464,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                         serialized_by_id[str(group_id)],
                         pull_requests_by_seer_run_id.get(run.seer_run.id, []),
                         status_by_state_id.get(run.seer_run.seer_run_state_id),
-                        repo_eligibility_by_project,
+                        issue_repo_eligibility,
                     )
                 )
 
@@ -458,6 +472,8 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             "runsByMilestone": runs_by_milestone,
             "truncatedMilestones": truncated_milestones,
         }
+        if include_project_config:
+            response["projectConfig"] = project_config
         return Response(response)
 
     def _latest_run_per_group(

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -424,8 +424,6 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             [run.seer_run.id for _, run in capped], include_scm_info=include_scm_info
         )
 
-        # projectConfig covers every selected project; per-issue scmInfo only needs the
-        # projects with runs. Scan the smallest set that satisfies the requested expands.
         repo_eligibility_by_project: dict[int, _RepoEligibility] = {}
         if include_project_config:
             eligibility_project_ids: Collection[int] = project_ids

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -48,6 +48,12 @@ class IssuePayload(TypedDict):
     project: IssueProjectPayload
 
 
+class ProjectConfigPayload(TypedDict):
+    id: str
+    slug: str
+    hasReposConnected: bool
+
+
 class CodeChangeFilePayload(TypedDict):
     repoName: str
     patch: FilePatch
@@ -78,3 +84,4 @@ class RunPayload(TypedDict):
 class OverviewResponse(TypedDict):
     runsByMilestone: dict[str, list[RunPayload]]
     truncatedMilestones: list[str]
+    projectConfig: NotRequired[list[ProjectConfigPayload]]

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -604,6 +604,83 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         repo_queries = [q for q in ctx.captured_queries if "seer_projectrepository" in q["sql"]]
         assert len(repo_queries) == 1
 
+    def _project_config_by_id(self, resp):
+        return {entry["id"]: entry for entry in resp.data["projectConfig"]}
+
+    def test_project_config_absent_without_expand(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+
+        resp = self.get_success_response(self.organization.slug)
+
+        assert "projectConfig" not in resp.data
+
+    def test_project_config_returned_with_expand(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+
+        resp = self.get_success_response(
+            self.organization.slug, qs_params={"expand": "projectConfig"}
+        )
+
+        config = self._project_config_by_id(resp)
+        assert config[str(self.project.id)] == {
+            "id": str(self.project.id),
+            "slug": self.project.slug,
+            "hasReposConnected": False,
+        }
+
+    def test_project_config_includes_project_without_runs(self):
+        repo = self.create_repo(self.project, provider="integrations:github")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        resp = self.get_success_response(
+            self.organization.slug, qs_params={"expand": "projectConfig"}
+        )
+
+        assert resp.data["runsByMilestone"][SeerRunMilestoneType.ROOT_CAUSE] == []
+        config = self._project_config_by_id(resp)
+        assert config[str(self.project.id)]["hasReposConnected"] is True
+
+    def test_project_config_reflects_repo_connection_per_project(self):
+        connected = self.create_project(organization=self.organization)
+        repo = self.create_repo(connected, provider="integrations:github")
+        self.create_seer_project_repository(project=connected, repository=repo)
+        unconnected = self.create_project(organization=self.organization)
+
+        resp = self.get_success_response(
+            self.organization.slug, qs_params={"expand": "projectConfig"}
+        )
+
+        config = self._project_config_by_id(resp)
+        assert config[str(connected.id)]["hasReposConnected"] is True
+        assert config[str(unconnected.id)]["hasReposConnected"] is False
+
+    def test_project_config_respects_project_filter(self):
+        selected = self.create_project(organization=self.organization)
+        other = self.create_project(organization=self.organization)
+
+        resp = self.get_success_response(
+            self.organization.slug,
+            qs_params={"expand": "projectConfig", "project": selected.id},
+        )
+
+        config = self._project_config_by_id(resp)
+        assert set(config) == {str(selected.id)}
+        assert str(other.id) not in config
+
+    def test_project_config_eligibility_is_one_query(self):
+        for _ in range(3):
+            project = self.create_project(organization=self.organization)
+            repo = self.create_repo(project, provider="integrations:github")
+            self.create_seer_project_repository(project=project, repository=repo)
+
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            self.get_success_response(self.organization.slug, qs_params={"expand": "projectConfig"})
+
+        repo_queries = [q for q in ctx.captured_queries if "seer_projectrepository" in q["sql"]]
+        assert len(repo_queries) == 1
+
     @mock.patch(_INTEGRATION_SERVICE)
     def test_run_includes_pull_requests(self, mock_get_integration):
         group = self.create_group()

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -681,6 +681,22 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         repo_queries = [q for q in ctx.captured_queries if "seer_projectrepository" in q["sql"]]
         assert len(repo_queries) == 1
 
+    def test_scm_info_and_project_config_share_one_eligibility_query(self):
+        group = self.create_group()
+        self._run_for_group(group, "boom")
+        repo = self.create_repo(self.project, provider="integrations:github")
+        self.create_seer_project_repository(project=self.project, repository=repo)
+
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            resp = self.get_success_response(
+                self.organization.slug, qs_params={"expand": ["scmInfo", "projectConfig"]}
+            )
+
+        repo_queries = [q for q in ctx.captured_queries if "seer_projectrepository" in q["sql"]]
+        assert len(repo_queries) == 1
+        assert self._issue_project(resp)["hasReposConnected"] is True
+        assert self._project_config_by_id(resp)[str(self.project.id)]["hasReposConnected"] is True
+
     @mock.patch(_INTEGRATION_SERVICE)
     def test_run_includes_pull_requests(self, mock_get_integration):
         group = self.create_group()


### PR DESCRIPTION
Adds a per-selected-project setup summary to the autofix overview endpoint so the overview page can warn when selected projects can't run Autofix. Autofix requires a Seer repository mapping for a project; without one, a selected project produces no runs and is currently invisible in the response, so the frontend can't tell the user it needs setup.

The new `projectConfig` expand returns `[{id, slug, hasReposConnected}]` for every selected project (not just those with runs), which lets the frontend drive both wanted states: a full empty state when all selected projects are unconfigured, and a "Seer is only set up on X, Y but not Z" banner when a subset is. `hasReposConnected` reuses the endpoint's existing `_coding_agent_repo_eligibility` helper (active `SeerProjectRepository` rows with a supported provider), matching the per-card eligibility already on this page.

It's gated behind its own expand rather than computed unconditionally so the 10s status poll (`expand=status`) never carries it — the follow-up frontend can fetch it in a query keyed only on project selection. Eligibility is computed once when either `scmInfo` or `projectConfig` is requested, so asking for both doesn't double-query. The per-issue `hasReposConnected` stays `scmInfo`-gated and unchanged.

Backend only, per the repo's frontend/backend split. The overview banner/empty-state, `types.ts`, and the per-project `/settings/{org}/projects/{project}/seer/` links land in a follow-up frontend PR.

Refs AIML-3329