### PR TITLE
feat(api): Return authentication state from login

### DIFF
--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -6,15 +7,23 @@ from sentry import ratelimits as ratelimiter
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.helpers.auth import get_auth_success_payload
 from sentry.api.serializers.base import serialize
+from sentry.api.serializers.models.auth import (
+    AuthMfaRequiredSerializer,
+    AuthSuccessSerializer,
+    serialize_auth_mfa_required,
+)
 from sentry.models.organization import Organization
 from sentry.users.api.serializers.user import DetailedSelfUserSerializer
+from sentry.users.models.authenticator import Authenticator
 from sentry.utils import auth, metrics
 from sentry.utils.hashlib import md5_text
 from sentry.web.forms.accounts import AuthenticationForm
 from sentry.web.frontend.base import OrganizationMixin, determine_active_organization
 
 
+@extend_schema(tags=["Users"])
 @control_silo_endpoint
 class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
@@ -28,6 +37,10 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
         self.active_organization = determine_active_organization(request)
         return super().dispatch(request, *args, **kwargs)
 
+    @extend_schema(
+        operation_id="Log in with a username and password",
+        responses={200: AuthSuccessSerializer, 202: AuthMfaRequiredSerializer},
+    )
     def post(
         self, request: Request, organization: Organization | None = None, *args, **kwargs
     ) -> Response:
@@ -65,7 +78,9 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
             auth.record_suspended_user_rejection("api_login")
             return self.respond_with_error({"__all__": ["Your account has been suspended."]})
 
-        auth.login(request, user, organization_id=organization.id if organization else None)
+        login_completed = auth.login(
+            request, user, organization_id=organization.id if organization else None
+        )
         metrics.incr("login.attempt", instance="success", skip_internal=True, sample_rate=1.0)
 
         if not user.is_active:
@@ -76,16 +91,17 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
                 }
             )
 
-        redirect_url = auth.get_org_redirect_url(
-            request, self.active_organization.organization if self.active_organization else None
-        )
+        if not login_completed:
+            interfaces = Authenticator.objects.all_interfaces_for_user(user)
 
-        return Response(
-            {
-                "nextUri": auth.get_login_redirect(request, redirect_url),
-                "user": serialize(user, user, DetailedSelfUserSerializer()),
-            }
-        )
+            return Response(
+                serialize_auth_mfa_required(
+                    user, [interface.interface_id for interface in interfaces]
+                ),
+                status=202,
+            )
+
+        return Response(get_auth_success_payload(request, user))
 
     def respond_with_error(self, errors):
         return Response({"detail": "Login attempt failed", "errors": errors}, status=400)

--- a/src/sentry/api/helpers/auth.py
+++ b/src/sentry/api/helpers/auth.py
@@ -1,0 +1,18 @@
+from django.http import HttpRequest
+
+from sentry.api.serializers.models.auth import (
+    AuthSuccessSerializerResponse,
+    serialize_auth_success,
+)
+from sentry.users.models.user import User
+from sentry.utils import auth
+from sentry.web.frontend.base import determine_active_organization
+
+
+def get_auth_success_payload(request: HttpRequest, user: User) -> AuthSuccessSerializerResponse:
+    active_organization = determine_active_organization(request)
+    default_redirect = auth.get_org_redirect_url(
+        request, active_organization.organization if active_organization else None
+    )
+
+    return serialize_auth_success(user, auth.get_login_redirect(request, default_redirect))

--- a/src/sentry/api/serializers/models/auth.py
+++ b/src/sentry/api/serializers/models/auth.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
+
+from django.contrib.auth.models import AnonymousUser
+
+from sentry.api.serializers import Serializer, serialize
+from sentry.users.api.serializers.user import (
+    DetailedSelfUserSerializer,
+    DetailedSelfUserSerializerResponse,
+)
+from sentry.users.models.user import User
+from sentry.users.services.user import RpcUser
+
+
+@dataclass(frozen=True)
+class AuthSuccess:
+    user: User
+    next_uri: str
+
+
+class AuthSuccessSerializerResponse(TypedDict):
+    nextUri: str
+    user: DetailedSelfUserSerializerResponse
+
+
+class AuthSuccessSerializer(Serializer[AuthSuccessSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthSuccess,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthSuccessSerializerResponse:
+        return {
+            "nextUri": obj.next_uri,
+            "user": serialize(obj.user, user, DetailedSelfUserSerializer()),
+        }
+
+
+def serialize_auth_success(user: User, next_uri: str) -> AuthSuccessSerializerResponse:
+    return serialize(AuthSuccess(user=user, next_uri=next_uri), user, AuthSuccessSerializer())
+
+
+@dataclass(frozen=True)
+class AuthMfaMethod:
+    id: str
+
+
+class AuthMfaOtpMethodSerializerResponse(TypedDict):
+    id: Literal["totp", "sms", "recovery"]
+
+
+class AuthMfaWebAuthnMethodSerializerResponse(TypedDict):
+    id: Literal["u2f"]
+
+
+AuthMfaMethodSerializerResponse = (
+    AuthMfaOtpMethodSerializerResponse | AuthMfaWebAuthnMethodSerializerResponse
+)
+
+
+class AuthMfaOtpMethodSerializer(Serializer[AuthMfaOtpMethodSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaMethod,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaOtpMethodSerializerResponse:
+        if obj.id == "totp":
+            return {"id": "totp"}
+        if obj.id == "sms":
+            return {"id": "sms"}
+        if obj.id == "recovery":
+            return {"id": "recovery"}
+        raise ValueError(f"Unsupported OTP method: {obj.id}")
+
+
+class AuthMfaWebAuthnMethodSerializer(Serializer[AuthMfaWebAuthnMethodSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaMethod,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaWebAuthnMethodSerializerResponse:
+        if obj.id != "u2f":
+            raise ValueError(f"Unsupported WebAuthn method: {obj.id}")
+        return {"id": "u2f"}
+
+
+class AuthMfaMethodSerializer(Serializer[AuthMfaMethodSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaMethod,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaMethodSerializerResponse:
+        if obj.id == "u2f":
+            return AuthMfaWebAuthnMethodSerializer().serialize(obj, attrs, user)
+        return AuthMfaOtpMethodSerializer().serialize(obj, attrs, user)
+
+
+@dataclass(frozen=True)
+class AuthMfaRequired:
+    methods: tuple[AuthMfaMethod, ...]
+
+
+class AuthMfaRequiredSerializerResponse(TypedDict):
+    mfaRequired: bool
+    mfaMethods: list[AuthMfaMethodSerializerResponse]
+
+
+class AuthMfaRequiredSerializer(Serializer[AuthMfaRequiredSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaRequired,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaRequiredSerializerResponse:
+        return {
+            "mfaRequired": True,
+            "mfaMethods": serialize(list(obj.methods), user, AuthMfaMethodSerializer()),
+        }
+
+
+def serialize_auth_mfa_required(
+    user: User, method_ids: Sequence[str]
+) -> AuthMfaRequiredSerializerResponse:
+    methods = tuple(AuthMfaMethod(method_id) for method_id in method_ids)
+    return serialize(AuthMfaRequired(methods), user, AuthMfaRequiredSerializer())

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
+from sentry.auth.authenticators.totp import TotpInterface
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -26,6 +27,27 @@ class AuthLoginEndpointTest(APITestCase):
     def test_login_valid_credentials(self) -> None:
         response = self.get_success_response(username=self.user.username, password="admin")
         assert response.data["nextUri"] == "/organizations/new/"
+
+    def test_login_valid_credentials_with_organization(self) -> None:
+        organization = self.create_organization(owner=self.user)
+
+        response = self.get_success_response(username=self.user.username, password="admin")
+
+        assert response.data["nextUri"] == f"/organizations/{organization.slug}/issues/"
+        assert self.client.session["activeorg"] == organization.slug
+
+    def test_login_requires_mfa(self) -> None:
+        TotpInterface().enroll(self.user)
+
+        response = self.get_response(username=self.user.username, password="admin")
+
+        assert response.status_code == 202
+        assert response.data == {
+            "mfaRequired": True,
+            "mfaMethods": [{"id": "totp"}],
+        }
+        assert "_auth_user_id" not in self.client.session
+        assert self.client.session["_pending_2fa"][0] == self.user.id
 
     def test_must_reactivate(self) -> None:
         self.user.update(is_active=False)


### PR DESCRIPTION
The password login API now returns a consistent authentication-state response for both completed and MFA-gated logins. Successful authentication uses a shared payload helper to establish the active organization and return the backend-selected redirect alongside the serialized user.

This establishes the success contract that the two-factor completion endpoint can reuse while keeping redirect and organization selection authoritative on the backend.