### PR TITLE
fix(insights): Fix web vitals and screen load detection

### DIFF
--- a/src/sentry/insights/__init__.py
+++ b/src/sentry/insights/__init__.py
@@ -28,13 +28,18 @@ class FilterSpan(NamedTuple):
         )
 
     @classmethod
-    def from_span_attributes(cls, attributes: dict[str, Any]) -> "FilterSpan":
+    def from_span_attributes(
+        cls, attributes: dict[str, Any], is_segment: bool | None = None
+    ) -> "FilterSpan":
         """Get relevant fields from `span.attributes`."""
+        op = (attributes.get("sentry.op") or {}).get("value")
+        if is_segment is None:
+            is_segment = (attributes.get("sentry.is_segment") or {}).get("value")
         return cls(
-            op=(attributes.get("sentry.op") or {}).get("value"),
+            op=op,
             category=(attributes.get("sentry.category") or {}).get("value"),
             description=(attributes.get("sentry.description") or {}).get("value"),
-            transaction_op=(attributes.get("sentry.transaction_op") or {}).get("value"),
+            transaction_op=op if is_segment else None,
             gen_ai_op_name=(attributes.get("gen_ai.operation.name") or {}).get("value"),
         )
 

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -489,7 +489,12 @@ def _record_signals(
     )
 
     for module in insights_modules(
-        [FilterSpan.from_span_attributes(span.get("attributes") or {}) for span in spans]
+        [
+            FilterSpan.from_span_attributes(
+                span.get("attributes") or {}, is_segment=span.get("is_segment")
+            )
+            for span in spans
+        ]
     ):
         set_project_flag_and_signal(
             project,

--- a/tests/sentry/insights/test_filter_span.py
+++ b/tests/sentry/insights/test_filter_span.py
@@ -1,0 +1,55 @@
+from sentry.insights import FilterSpan
+
+
+def test_from_span_attributes_sets_transaction_op_when_is_transaction() -> None:
+    result = FilterSpan.from_span_attributes(
+        {
+            "sentry.op": {"type": "string", "value": "pageload"},
+            "sentry.category": {"type": "string", "value": "http"},
+            "sentry.description": {"type": "string", "value": "/checkout"},
+            "sentry.is_segment": {"type": "boolean", "value": True},
+            "gen_ai.operation.name": {"type": "string", "value": "chat"},
+        }
+    )
+
+    assert result == FilterSpan(
+        op="pageload",
+        category="http",
+        description="/checkout",
+        transaction_op="pageload",
+        gen_ai_op_name="chat",
+    )
+
+
+def test_from_span_attributes_sets_transaction_op_none_when_not_transaction() -> None:
+    result = FilterSpan.from_span_attributes(
+        {
+            "sentry.op": {"type": "string", "value": "http.client"},
+            "sentry.category": {"type": "string", "value": "http"},
+            "sentry.description": {"type": "string", "value": "GET /api"},
+            "sentry.is_segment": {"type": "boolean", "value": False},
+            "gen_ai.operation.name": {"type": "string", "value": "chat"},
+        }
+    )
+
+    assert result == FilterSpan(
+        op="http.client",
+        category="http",
+        description="GET /api",
+        transaction_op=None,
+        gen_ai_op_name="chat",
+    )
+
+
+def test_from_span_attributes_uses_explicit_is_segment_over_missing_attribute() -> None:
+    result = FilterSpan.from_span_attributes(
+        {
+            "sentry.op": {"type": "string", "value": "pageload"},
+            "sentry.category": {"type": "string", "value": "http"},
+            "sentry.description": {"type": "string", "value": "/checkout"},
+            "gen_ai.operation.name": {"type": "string", "value": "chat"},
+        },
+        is_segment=True,
+    )
+
+    assert result.transaction_op == "pageload"

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -443,6 +443,25 @@ class TestSpansTask(TestCase):
         assert "has_insights_agent_monitoring" not in signals
 
     @mock.patch("sentry.spans.consumers.process_segments.message.set_project_flag_and_signal")
+    def test_record_signals_vitals_from_top_level_is_segment(self, mock_track):
+        span = build_mock_span(
+            project_id=self.project.id,
+            is_segment=True,
+            span_op="pageload",
+            attributes={
+                "sentry.op": {"value": "pageload"},
+            },
+        )
+        assert "sentry.is_segment" not in (span.get("attributes") or {})
+
+        spans = process_segment([span])
+        assert len(spans) == 1
+        assert "sentry.is_segment" not in (spans[0].get("attributes") or {})
+
+        signals = [args[0][1] for args in mock_track.call_args_list]
+        assert "has_insights_vitals" in signals
+
+    @mock.patch("sentry.spans.consumers.process_segments.message.set_project_flag_and_signal")
     def test_record_signals_agents_via_gen_ai_op_name(self, mock_track):
         """Test that spans with gen_ai.operation.name attribute trigger agents insight."""
         span = build_mock_span(


### PR DESCRIPTION
The segments consumer contains code to record that various Insights modules have received data:

https://github.com/getsentry/sentry/blob/d9617f3af9c77dee8ac6fcc134cb8b160d03ac7f/src/sentry/spans/consumers/process_segments/message.py#L491-L499

The flags for receiving screen load and vitals data used an extracted `transaction_op`:

https://github.com/getsentry/sentry/blob/d9617f3af9c77dee8ac6fcc134cb8b160d03ac7f/src/sentry/insights/__init__.py#L58-L63

But, this relied on a non-existent attribute (`sentry.transaction_op` is not a real thing):

https://github.com/getsentry/sentry/blob/d9617f3af9c77dee8ac6fcc134cb8b160d03ac7f/src/sentry/insights/__init__.py#L37

There is no equivalent attribute for streaming spans. Instead, use the `sentry.op` when `sentry.is_segment` is true.

This fixes detection for both screen loads and web vitals.

Fixes DAIN-1839.