### PR TITLE
feat(auth): Gate React login behind a cookie

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -2,6 +2,7 @@
 
 {% load crispy_forms_tags %}
 {% load i18n %}
+{% load sentry_assets %}
 
 {% block title %}{% trans "Sign In" %} | {{ block.super }}{% endblock %}
 
@@ -145,4 +146,25 @@
       </div>
     </div>
   </div>
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+{% script %}
+<script>
+  // Console helper for opting into the cookie-gated React login experiment.
+  window.__sentryEnableReactLogin = function() {
+    const hostname = window.location.hostname;
+    const cookieDomain = hostname === 'sentry.io' || hostname.endsWith('.sentry.io')
+      ? '.sentry.io'
+      : hostname === 'dev.getsentry.net' || hostname.endsWith('.dev.getsentry.net')
+        ? '.dev.getsentry.net'
+        : null;
+    const domainAttribute = cookieDomain ? `; Domain=${cookieDomain}` : '';
+
+    document.cookie = `sentry_react_auth=1; Path=/auth/; SameSite=Lax${domainAttribute}`;
+    window.location.reload();
+  };
+</script>
+{% endscript %}
 {% endblock %}

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -36,6 +36,7 @@ logger = logging.getLogger("sentry.auth")
 _LOGIN_URL: str | None = None
 
 MFA_SESSION_KEY = "mfa"
+REACT_AUTH_COOKIE = "sentry_react_auth"
 
 SUSPENDED_USER_REJECTED_METRIC = "auth.suspended_user.rejected"
 
@@ -190,6 +191,8 @@ def _get_login_redirect(request: HttpRequest, default: str | None = None) -> str
     # If there is a pending 2fa authentication bound to the session then
     # we need to go to the 2fa dialog.
     if has_pending_2fa(request):
+        if request.COOKIES.get(REACT_AUTH_COOKIE) == "1":
+            return reverse("sentry-login")
         return reverse("sentry-2fa-dialog")
 
     # If we have a different URL to go after the 2fa flow we want to go to

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -34,6 +34,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
 from sentry.utils import auth, json, metrics
 from sentry.utils.auth import (
+    REACT_AUTH_COOKIE,
     construct_link_with_query,
     get_login_redirect,
     has_user_registration,
@@ -47,8 +48,10 @@ from sentry.utils.urls import add_params_to_url
 from sentry.web.client_config import get_client_config
 from sentry.web.forms.accounts import AuthenticationForm, RegistrationForm
 from sentry.web.frontend.base import BaseView, control_silo_view, determine_active_organization
+from sentry.web.frontend.react_page import ReactMixin
 
 ERR_NO_SSO = _("The organization does not exist or does not have Single Sign-On enabled.")
+REACT_AUTH_URL_NAMES = frozenset({"sentry-login", "sentry-auth-organization"})
 
 logger = logging.getLogger("sentry.auth")
 
@@ -81,8 +84,17 @@ class AdditionalContext:
 additional_context = AdditionalContext()
 
 
+def should_render_react_auth(request: HttpRequest) -> bool:
+    return bool(
+        request.method == "GET"
+        and request.resolver_match
+        and request.resolver_match.url_name in REACT_AUTH_URL_NAMES
+        and request.COOKIES.get(REACT_AUTH_COOKIE) == "1"
+    )
+
+
 @control_silo_view
-class AuthLoginView(BaseView):
+class AuthLoginView(BaseView, ReactMixin):
     auth_required = False
 
     enforce_rate_limit = True
@@ -105,6 +117,9 @@ class AuthLoginView(BaseView):
         return super().handle(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, **kwargs) -> HttpResponseBase:
+        if should_render_react_auth(request):
+            return self.handle_react(request)
+
         next_uri = self.get_next_uri(request=request)
         if request.user.is_authenticated:
             return self.redirect_authenticated_user(request=request, next_uri=next_uri)

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -14,7 +14,7 @@ from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.models.authprovider import AuthProvider
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.utils.auth import initiate_login
-from sentry.web.frontend.auth_login import AuthLoginView
+from sentry.web.frontend.auth_login import AuthLoginView, should_render_react_auth
 
 logger = logging.getLogger("sentry.saml_setup_error")
 
@@ -59,6 +59,9 @@ class AuthOrganizationLoginView(AuthLoginView):
 
     @method_decorator(never_cache)
     def handle(self, request: HttpRequest, organization_slug) -> HttpResponseBase:
+        if should_render_react_auth(request):
+            return self.handle_react(request)
+
         org_context = organization_service.get_organization_by_slug(
             slug=organization_slug, only_visible=True
         )

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -196,11 +196,3 @@ class ReactPageView(ControlSiloOrganizationView, ReactMixin):
 class GenericReactPageView(BaseView, ReactMixin):
     def handle(self, request: HttpRequest, **kwargs) -> HttpResponse:
         return self.handle_react(request, **kwargs)
-
-
-@control_silo_view
-class AuthV2ReactPageView(GenericReactPageView):
-    auth_required = False
-
-    def handle_auth_required(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        raise Exception("This should not be called")

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -47,7 +47,7 @@ from sentry.web.frontend.organization_avatar import OrganizationAvatarPhotoView
 from sentry.web.frontend.out import OutView
 from sentry.web.frontend.pipeline_advancer import PipelineAdvancerView
 from sentry.web.frontend.project_event import ProjectEventRedirect
-from sentry.web.frontend.react_page import AuthV2ReactPageView, GenericReactPageView, ReactPageView
+from sentry.web.frontend.react_page import GenericReactPageView, ReactPageView
 from sentry.web.frontend.reactivate_account import ReactivateAccountView
 from sentry.web.frontend.release_webhook import ReleaseWebhookView
 from sentry.web.frontend.setup_wizard import SetupWizardView
@@ -65,7 +65,6 @@ from social_auth.views import complete
 # Only create one instance of the ReactPageView since it's duplicated everywhere
 generic_react_page_view = GenericReactPageView.as_view()
 react_page_view = ReactPageView.as_view()
-auth_v2_react_page_view = AuthV2ReactPageView.as_view()
 
 urlpatterns: list[URLResolver | URLPattern] = [
     re_path(
@@ -197,12 +196,6 @@ urlpatterns += [
         r"^api/embed/error-page/$",
         ErrorPageEmbedView.as_view(),
         name="sentry-error-page-embed",
-    ),
-    # Auth V2
-    re_path(
-        r"^auth-v2/",
-        auth_v2_react_page_view,
-        name="sentry-auth-v2",
     ),
     # OAuth
     re_path(

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -12,6 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.user import User
 from sentry.utils.auth import (
+    REACT_AUTH_COOKIE,
     EmailAuthBackend,
     SsoSession,
     construct_link_with_query,
@@ -142,6 +143,15 @@ class GetLoginRedirectTest(TestCase):
         request.session["_pending_2fa"] = [1234, 1234, 1234]
         result = get_login_redirect(request)
         assert result == f"http://orgslug.testserver{reverse('sentry-2fa-dialog')}"
+
+    def test_pending_2fa_with_react_auth(self) -> None:
+        request = self._make_request()
+        request.session["_pending_2fa"] = [1234, 1234, 1234]
+        request.COOKIES[REACT_AUTH_COOKIE] = "1"
+
+        result = get_login_redirect(request)
+
+        assert result == reverse("sentry-login")
 
     def test_login_uses_default(self) -> None:
         result = get_login_redirect(self._make_request(reverse("sentry-login")))

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -50,6 +50,15 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert resp.status_code == 200
         self.assertTemplateUsed("sentry/login.html")
 
+    def test_renders_react_template_with_cookie(self) -> None:
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        resp = self.client.get(self.path)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/base-react.html")
+        self.assertTemplateNotUsed(resp, "sentry/login.html")
+
     def test_cannot_request_access(self) -> None:
         resp = self.client.get(self.path)
 
@@ -349,6 +358,17 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
             assert resp.status_code == 200
             assert resp.context["op"] == "register"
             self.assertTemplateUsed("sentry/login.html")
+
+    def test_register_renders_django_template_with_react_auth_cookie(self) -> None:
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        with self.allow_registration():
+            resp = self.client.get(reverse("sentry-register"))
+
+        assert resp.status_code == 200
+        assert resp.context["op"] == "register"
+        self.assertTemplateUsed(resp, "sentry/login.html")
+        self.assertTemplateNotUsed(resp, "sentry/base-react.html")
 
     def test_register_prefills_invite_email(self) -> None:
         self.session["invite_email"] = "foo@example.com"

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -50,6 +50,15 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert "provider_key" not in resp.context
         assert resp.context["join_request_link"]
 
+    def test_renders_react_template_with_cookie(self) -> None:
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "sentry/base-react.html")
+        self.assertTemplateNotUsed(response, "sentry/organization-login.html")
+
     def test_cannot_get_request_join_link_with_setting_disabled(self) -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             OrganizationOption.objects.create(


### PR DESCRIPTION
Canonical global and organization login GET requests can now render the React shell when the `sentry_react_auth=1` opt-in cookie is present. Registration and requests without the cookie continue through the existing Django templates, preserving an immediate fallback during rollout.

The cookie only selects the presentation layer and grants no authentication or API access. A console helper enables the experiment on supported Sentry and development domains, and the temporary `/auth-v2/` server route is removed in favor of the canonical login URLs.