### PR TITLE
[hackweek] feat(seer): Make Autofix session-aware for root-cause analysis

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1378,6 +1378,18 @@ class _EventTroubleshootingContext(TypedDict):
     troubleshootingHint: str | None
 
 
+# The SDK tags every event in a user session with this key. A session groups the user's telemetry
+# (spans, logs, errors) across multiple traces and page loads, so surfacing it lets Seer pull the
+# whole session as investigation context instead of only the error's own trace.
+_SESSION_ID_TAG = "session.id"
+
+
+def _get_event_session_id(event: Event | GroupEvent) -> str | None:
+    # `sentry.session.id` is the same attribute under the SDK's namespaced convention; accept both
+    # so this keeps working whichever form lands on the event as a tag.
+    return event.get_tag(_SESSION_ID_TAG) or event.get_tag(f"sentry.{_SESSION_ID_TAG}")
+
+
 def _get_event_troubleshooting_context(
     event: Event | GroupEvent,
 ) -> _EventTroubleshootingContext:
@@ -2013,8 +2025,10 @@ def get_event_details(
         include_breadcrumbs: Drop the breadcrumbs section from the rendered output when False.
 
     Returns:
-        Dict with serialized event, event_id, event_trace_id, project_id, project_slug, and
-        formatted (rendered text when a ``format`` is requested, else None), or None if not found.
+        Dict with serialized event, event_id, event_trace_id, session_id (the user session this
+        event belongs to, if tagged — query telemetry with ``session.id:<value>`` to pull the whole
+        session across traces), project_id, project_slug, and formatted (rendered text when a
+        ``format`` is requested, else None), or None if not found.
     """
     if bool(event_id) == bool(issue_id):
         raise BadRequest("Either event_id or issue_id must be provided, but not both.")
@@ -2123,6 +2137,7 @@ def get_event_details(
         event=serialized_event,
         event_id=event.event_id,
         event_trace_id=event.trace_id,
+        session_id=_get_event_session_id(event),
         project_id=event.project_id,
         project_slug=event.project.slug,
         formatted=formatted,

--- a/src/sentry/seer/autofix/prompts.py
+++ b/src/sentry/seer/autofix/prompts.py
@@ -48,9 +48,10 @@ def root_cause_prompt(
         Guidelines:
         1. Use your tools to fetch the issue details and examine the evidence
         2. Investigate the trace, replay, logs, other issues, trends, and other telemetry when available to gain a deeper understanding of the issue
-        3. Investigate the relevant code in the codebase
-        4. Ask "why" repeatedly to find the TRUE root cause (not just symptoms)
-        5. Use your todo list to track multiple hypotheses for complex bugs
+        3. If the event has a `session.id` (surfaced as `session_id` on the event details), it belongs to a user session that groups the user's telemetry — spans, logs, and errors across multiple traces and page loads. Query that telemetry with `session.id:<value>` to reconstruct what the user did before the error; the root cause often lives in an earlier trace in the same session, not in the error's own trace.
+        4. Investigate the relevant code in the codebase
+        5. Ask "why" repeatedly to find the TRUE root cause (not just symptoms)
+        6. Use your todo list to track multiple hypotheses for complex bugs
 
         If you have previously generated this artifact, disregard the prior attempt and produce a completely new one from scratch.
 

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -469,6 +469,9 @@ class EventDetailsResponse(_DictProxyMixin):
     event: dict[str, Any]
     event_id: str
     event_trace_id: str | None
+    # the user session this event belongs to, if the SDK tagged it; lets Seer pull the whole
+    # session's telemetry (across traces) as context, not just the error's own trace
+    session_id: str | None = None
     project_id: int
     project_slug: str
     # shared-formatter text; populated when the RPC is called with a `format`, else None

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2363,6 +2363,38 @@ class TestGetEventDetails(
         assert event_dict["detectionContext"] is None
         assert event_dict["troubleshootingHint"] is None
 
+    # --- session id (lets Seer pull the whole session's telemetry as context) ---
+
+    def test_session_id_surfaced_from_tag(self) -> None:
+        """An event tagged with session.id surfaces it so Seer can query the whole session."""
+        session_id = uuid.uuid4().hex
+        data = load_data("python", timestamp=before_now(minutes=5))
+        data["exception"] = {"values": [{"type": "Exception", "value": "Test exception"}]}
+        data["tags"] = {"session.id": session_id}
+        event = self.store_event(data=data, project_id=self.project.id)
+
+        result = get_event_details(
+            organization_id=self.organization.id,
+            event_id=event.event_id,
+            project_slug=self.project.slug,
+        )
+
+        assert result is not None
+        assert result["session_id"] == session_id
+
+    def test_session_id_is_none_when_untagged(self) -> None:
+        """Events without a session tag report session_id as None."""
+        event = self._make_error_event()
+
+        result = get_event_details(
+            organization_id=self.organization.id,
+            event_id=event.event_id,
+            project_slug=self.project.slug,
+        )
+
+        assert result is not None
+        assert result["session_id"] is None
+
 
 class TestGetIssueEventTimeseries(APITransactionTestCase, SnubaTestCase):
     """Tests for _get_issue_event_timeseries — resolution selection and API call params."""

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -237,6 +237,15 @@ class TestBuildStepPrompt(TestCase):
         assert "ROOT CAUSE" in prompt
         assert "root_cause artifact" in prompt
 
+    def test_root_cause_prompt_steers_to_session_telemetry(self) -> None:
+        prompt = build_step_prompt(AutofixStep.ROOT_CAUSE, self.group)
+
+        # The root-cause step should tell the agent to pivot on session.id when present, so it
+        # investigates the whole user session rather than just the error's own trace.
+        assert "session.id" in prompt
+        # The session hint is specific to root-cause investigation, not the later steps.
+        assert "session.id" not in build_step_prompt(AutofixStep.SOLUTION, self.group)
+
     def test_solution_prompt_contains_issue_details(self) -> None:
         prompt = build_step_prompt(AutofixStep.SOLUTION, self.group)
 


### PR DESCRIPTION
## What

Part of the **Sessions** hackweek project ([Persona 4 — Agent/Seer](https://app.notion.com/p/sentry/Personas-3c08b10e4b5d80cc88b5f6c935fe4079), the "Reader" step). Makes Seer's Autofix use `session.id` on its own so it investigates the *whole user session*, not just the error's own trace.

Two small, backend-only changes on the live (Sentry-driven) Autofix path:

1. **`get_event_details`** now surfaces the event's `session_id` as a first-class field on the response, mirroring the existing `event_trace_id`. The agent no longer has to dig it out of a long tags list.
2. **The root-cause prompt** (`build_step_prompt` → `root_cause_prompt`, sent to the agent via `SeerAgentClient.start_run`) now tells the agent: if the event has a `session.id`, it belongs to a user session that groups telemetry across many traces/page loads — query it with `session.id:<value>` to reconstruct what the user did before the error.

## Why

Frontend devs think in sessions, not single traces — an error on page D is often caused by something on page A, in an earlier trace. The project tags all of a user's telemetry with a shared `session.id`. But when [Lukas tested Autofix](https://sentry.slack.com/archives/C0BQRPYBYGL/p1787144189638449), it *"needed some serious hinting to look up telemetry via `session.id`."* This closes that gap so it happens automatically. (`session.id` is already indexed in ClickHouse, so no query-layer work was needed.)

Autofix is driven from Sentry (verified: the public `POST` autofix endpoint → `trigger_autofix_agent` → `build_step_prompt` → `root_cause_prompt`), so the whole change lives here rather than in the `seer` repo.

## Test plan

- `TestBuildStepPrompt::test_root_cause_prompt_steers_to_session_telemetry` — root-cause prompt carries the session guidance; the solution step does not.
- `TestGetEventDetails::test_session_id_surfaced_from_tag` / `test_session_id_is_none_when_untagged` — `session_id` is surfaced from the tag, `None` when absent.
- Full `TestBuildStepPrompt` + `TestGetEventDetails` classes: **32 passed**, no regressions. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)