### PR TITLE
feat(api): Support organization context during login

### DIFF
--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -1,6 +1,7 @@
 from typing import TypedDict
 
 from django.http import HttpRequest
+from django.urls import reverse
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -18,9 +19,14 @@ from sentry.api.serializers.models.auth import (
     serialize_auth_mfa_required,
 )
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
-from sentry.models.organization import Organization
+from sentry.auth.services.access.service import access_service
+from sentry.hybridcloud.services.organization_mapping.model import RpcOrganizationMapping
+from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.organizations.services.organization import RpcOrganizationMemberSummary
 from sentry.users.api.serializers.user import DetailedSelfUserSerializer
 from sentry.users.models.authenticator import Authenticator
+from sentry.users.models.user import User
+from sentry.users.services.user.service import user_service
 from sentry.utils import auth, metrics
 from sentry.utils.hashlib import md5_text
 from sentry.web.forms.accounts import AuthenticationForm
@@ -30,11 +36,13 @@ from sentry.web.frontend.base import OrganizationMixin, determine_active_organiz
 class AuthLoginRequest(TypedDict):
     username: str
     password: str
+    org_slug: str | None
 
 
 class AuthLoginRequestSerializer(CamelSnakeSerializer[AuthLoginRequest]):
     username = serializers.CharField(allow_blank=True)
     password = serializers.CharField(allow_blank=True, trim_whitespace=False)
+    org_slug = serializers.CharField(allow_null=True, default=None, required=False)
 
 
 @extend_schema(tags=["Users"])
@@ -47,6 +55,50 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     # Disable authentication and permission requirements.
     permission_classes = ()
 
+    def get_password_organization(
+        self,
+        user: User,
+        requested_slug: str | None,
+        organization_mappings: list[RpcOrganizationMapping],
+    ) -> RpcOrganizationMapping | None:
+        """Choose a destination that does not require an SSO-authenticated session.
+
+        The requested slug controls navigation only. Password authentication must never
+        satisfy an organization's SSO requirement.
+        """
+        ordered_mappings = sorted(
+            organization_mappings,
+            key=lambda mapping: mapping.slug != requested_slug,
+        )
+        member_mappings = {
+            mapping.organization_id: mapping
+            for mapping in OrganizationMemberMapping.objects.filter(
+                organization_id__in=[mapping.id for mapping in ordered_mappings],
+                user_id=user.id,
+            )
+        }
+
+        for mapping in ordered_mappings:
+            member_mapping = member_mappings.get(mapping.id)
+            if member_mapping is None or member_mapping.organizationmember_id is None:
+                continue
+
+            auth_state = access_service.get_user_auth_state(
+                user_id=user.id,
+                organization_id=mapping.id,
+                is_superuser=user.is_superuser,
+                is_staff=user.is_staff,
+                org_member=RpcOrganizationMemberSummary(
+                    id=member_mapping.organizationmember_id,
+                    organization_id=member_mapping.organization_id,
+                    user_id=member_mapping.user_id,
+                ),
+            )
+            if not auth_state.sso_state.is_required:
+                return mapping
+
+        return None
+
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> Response:
         self.active_organization = determine_active_organization(request)
         return super().dispatch(request, *args, **kwargs)
@@ -56,9 +108,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
         request=AuthLoginRequestSerializer,
         responses={200: AuthSuccessSerializer, 202: AuthMfaRequiredSerializer},
     )
-    def post(
-        self, request: Request, organization: Organization | None = None, *args, **kwargs
-    ) -> Response:
+    def post(self, request: Request, *args, **kwargs) -> Response:
         """
         Process a login request via username/password. SSO login is handled
         elsewhere.
@@ -97,9 +147,19 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
             auth.record_suspended_user_rejection("api_login")
             return self.respond_with_error({"__all__": ["Your account has been suspended."]})
 
-        login_completed = auth.login(
-            request, user, organization_id=organization.id if organization else None
-        )
+        org_slug = serializer.validated_data["org_slug"]
+        organizations = user_service.get_organizations(user_id=user.id, only_visible=True)
+        organization = self.get_password_organization(user, org_slug, organizations)
+        if organization:
+            auth.set_active_org(request, organization.slug)
+        else:
+            # An SSO-only membership still authenticates the user account. Keep the
+            # organization out of session context so it cannot be mistaken for SSO access.
+            auth.clear_active_org(request)
+            if organizations:
+                request.session["_next"] = reverse("sentry-account-settings")
+
+        login_completed = auth.login(request, user)
         metrics.incr("login.attempt", instance="success", skip_internal=True, sample_rate=1.0)
 
         if not user.is_active:
@@ -120,7 +180,13 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
                 status=202,
             )
 
-        return Response(get_auth_success_payload(request, user))
+        payload = get_auth_success_payload(request, user)
+        if organization is None and organizations:
+            # Payload generation resolves a default membership after login. Remove that
+            # fallback when every membership requires SSO.
+            auth.clear_active_org(request)
+
+        return Response(payload)
 
     def respond_with_error(self, errors):
         return Response({"detail": "Login attempt failed", "errors": errors}, status=400)

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -450,6 +450,11 @@ def set_active_org(request: HttpRequest, org_slug: str) -> None:
         request.session["activeorg"] = org_slug
 
 
+def clear_active_org(request: HttpRequest) -> None:
+    if hasattr(request, "session"):
+        request.session.pop("activeorg", None)
+
+
 class EmailAuthBackend(ModelBackend):
     """
     Authenticate against django.contrib.auth.models.User.

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.utils.auth import SsoSession
 
 
 @control_silo_test
@@ -35,6 +36,96 @@ class AuthLoginEndpointTest(APITestCase):
 
         assert response.data["nextUri"] == f"/organizations/{organization.slug}/issues/"
         assert self.client.session["activeorg"] == organization.slug
+
+    def test_login_valid_credentials_with_requested_organization(self) -> None:
+        self.create_organization(owner=self.user, slug="org-a")
+        requested_organization = self.create_organization(owner=self.user, slug="org-b")
+
+        response = self.get_success_response(
+            username=self.user.username,
+            password="admin",
+            orgSlug=requested_organization.slug,
+        )
+
+        assert response.data["nextUri"] == f"/organizations/{requested_organization.slug}/issues/"
+        assert self.client.session["activeorg"] == requested_organization.slug
+
+    def test_login_valid_credentials_with_snake_case_organization(self) -> None:
+        self.create_organization(owner=self.user, slug="org-a")
+        requested_organization = self.create_organization(owner=self.user, slug="org-b")
+
+        response = self.get_success_response(
+            username=self.user.username,
+            password="admin",
+            org_slug=requested_organization.slug,
+        )
+
+        assert response.data["nextUri"] == f"/organizations/{requested_organization.slug}/issues/"
+        assert self.client.session["activeorg"] == requested_organization.slug
+
+    def test_login_with_unknown_requested_organization_uses_default(self) -> None:
+        default_organization = self.create_organization(owner=self.user, slug="org-a")
+
+        response = self.get_success_response(
+            username=self.user.username,
+            password="admin",
+            orgSlug="missing-org",
+        )
+
+        assert response.data["nextUri"] == f"/organizations/{default_organization.slug}/issues/"
+        assert self.client.session["activeorg"] == default_organization.slug
+
+    def test_login_with_unauthorized_requested_organization_uses_default(self) -> None:
+        self.user.update(is_superuser=False)
+        default_organization = self.create_organization(owner=self.user, slug="org-a")
+        other_user = self.create_user("other@example.com")
+        self.create_organization(owner=other_user, slug="org-b")
+
+        response = self.get_success_response(
+            username=self.user.username,
+            password="admin",
+            orgSlug="org-b",
+        )
+
+        assert response.data["nextUri"] == f"/organizations/{default_organization.slug}/issues/"
+        assert self.client.session["activeorg"] == default_organization.slug
+
+    def test_password_login_cannot_select_sso_required_organization(self) -> None:
+        user = self.create_user(email="member@example.com")
+        user.set_password("password")
+        user.save()
+        organization = self.create_organization(slug="sso-org")
+        self.create_member(organization=organization, user=user)
+        self.create_auth_provider(organization_id=organization.id, provider="dummy")
+
+        response = self.get_success_response(
+            username=user.username,
+            password="password",
+            orgSlug=organization.slug,
+        )
+
+        assert response.data["nextUri"] == reverse("sentry-account-settings")
+        assert "activeorg" not in self.client.session
+        assert SsoSession.django_session_key(organization.id) not in self.client.session
+
+    def test_password_login_falls_back_from_sso_required_organization(self) -> None:
+        user = self.create_user(email="member@example.com")
+        user.set_password("password")
+        user.save()
+        sso_organization = self.create_organization(slug="sso-org")
+        self.create_member(organization=sso_organization, user=user)
+        self.create_auth_provider(organization_id=sso_organization.id, provider="dummy")
+        password_organization = self.create_organization(owner=user, slug="password-org")
+
+        response = self.get_success_response(
+            username=user.username,
+            password="password",
+            orgSlug=sso_organization.slug,
+        )
+
+        assert response.data["nextUri"] == (f"/organizations/{password_organization.slug}/issues/")
+        assert self.client.session["activeorg"] == password_organization.slug
+        assert SsoSession.django_session_key(sso_organization.id) not in self.client.session
 
     def test_login_requires_mfa(self) -> None:
         TotpInterface().enroll(self.user)

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -206,6 +206,31 @@ class LoginTest(TestCase):
         mock_metric.assert_called_once_with("session_login")
 
 
+@control_silo_test
+class ActiveOrganizationTest(TestCase):
+    def test_clear_active_org(self) -> None:
+        request = HttpRequest()
+        request.session = SessionBase()
+        request.session["activeorg"] = "acme"
+
+        sentry.utils.auth.clear_active_org(request)
+
+        assert "activeorg" not in request.session
+
+    def test_clear_active_org_without_active_org(self) -> None:
+        request = HttpRequest()
+        request.session = SessionBase()
+
+        sentry.utils.auth.clear_active_org(request)
+
+        assert "activeorg" not in request.session
+
+    def test_clear_active_org_without_session(self) -> None:
+        request = HttpRequest()
+
+        sentry.utils.auth.clear_active_org(request)
+
+
 def test_sso_expiry_default() -> None:
     value = sentry.utils.auth._sso_expiry_from_env(None)
     # make sure no accidental changes affect sso timeout


### PR DESCRIPTION
Password login now accepts an optional `orgSlug` and uses visible memberships to select the active organization and final redirect. Unknown or unauthorized organizations fall back to another eligible membership.

The requested slug controls navigation only: password authentication never satisfies an organization’s SSO requirement. If the requested organization requires SSO, login falls back to another password-capable organization; when every visible membership requires SSO, the account is authenticated without organization context and redirected to account settings.