### PR TITLE
feat(api): Add two-factor authentication endpoints

### DIFF
--- a/src/sentry/api/endpoints/auth_2fa.py
+++ b/src/sentry/api/endpoints/auth_2fa.py
@@ -1,0 +1,255 @@
+from typing import NotRequired, TypedDict
+
+import sentry_sdk
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.helpers.auth import get_auth_success_payload
+from sentry.api.serializers.models.auth import (
+    AuthDetailSerializer,
+    AuthMfaChallengeSerializer,
+    AuthMfaRequiredSerializer,
+    AuthSuccessSerializer,
+    serialize_activation,
+    serialize_auth_mfa_required,
+)
+from sentry.api.serializers.rest_framework import CamelSnakeSerializer
+from sentry.auth.authenticators.base import (
+    ActivationChallengeResult,
+    ActivationMessageResult,
+    ActivationRateLimited,
+    AuthenticatorInterface,
+)
+from sentry.auth.twofactor import is_2fa_rate_limited, send_2fa_rate_limit_notification
+from sentry.users.models.authenticator import Authenticator
+from sentry.users.models.user import User
+from sentry.utils import auth
+
+
+class AuthWebAuthnResponse(TypedDict):
+    key_handle: str
+    client_data: str
+    authenticator_data: str
+    signature_data: str
+
+
+class AuthTwoFactorRequest(TypedDict):
+    method: str
+    otp: NotRequired[str]
+    response: NotRequired[AuthWebAuthnResponse]
+
+
+class AuthWebAuthnResponseSerializer(CamelSnakeSerializer[AuthWebAuthnResponse]):
+    key_handle = serializers.CharField()
+    client_data = serializers.CharField()
+    authenticator_data = serializers.CharField()
+    signature_data = serializers.CharField()
+
+
+class AuthTwoFactorRequestSerializer(CamelSnakeSerializer[AuthTwoFactorRequest]):
+    method = serializers.CharField(max_length=20)
+    otp = serializers.CharField(max_length=20, required=False, trim_whitespace=False)
+    response = AuthWebAuthnResponseSerializer(required=False)
+
+    def validate(self, attrs: AuthTwoFactorRequest) -> AuthTwoFactorRequest:
+        has_otp = "otp" in attrs
+        has_response = "response" in attrs
+        if has_otp == has_response:
+            raise serializers.ValidationError("Provide either an OTP or a challenge response.")
+        return attrs
+
+
+class AuthTwoFactorChallengeRequest(TypedDict):
+    method: str
+
+
+class AuthTwoFactorChallengeRequestSerializer(CamelSnakeSerializer[AuthTwoFactorChallengeRequest]):
+    method = serializers.CharField(max_length=20)
+
+
+def get_pending_interface(
+    request: Request, method: str
+) -> tuple[User | None, AuthenticatorInterface | None]:
+    user = auth.get_pending_2fa_user(request)
+    if user is None:
+        return None, None
+
+    interfaces = Authenticator.objects.all_interfaces_for_user(user)
+    interface = next(
+        (interface for interface in interfaces if interface.interface_id == method), None
+    )
+    return user, interface
+
+
+@extend_schema(tags=["Users"])
+@control_silo_endpoint
+class AuthTwoFactorEndpoint(Endpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.FOUNDATIONS
+    permission_classes = ()
+
+    @extend_schema(
+        operation_id="Get available methods for a pending two-factor authentication login",
+        responses={200: AuthMfaRequiredSerializer},
+    )
+    def get(self, request: Request) -> Response:
+        user = auth.get_pending_2fa_user(request)
+        if user is None:
+            return Response(
+                {"detail": "No two-factor authentication request is active"}, status=404
+            )
+
+        interfaces = Authenticator.objects.all_interfaces_for_user(user)
+        return Response(
+            serialize_auth_mfa_required(user, [interface.interface_id for interface in interfaces])
+        )
+
+    @extend_schema(
+        operation_id="Complete a pending two-factor authentication login",
+        request=AuthTwoFactorRequestSerializer,
+        responses={200: AuthSuccessSerializer, 403: AuthDetailSerializer},
+    )
+    def post(self, request: Request) -> Response:
+        serializer = AuthTwoFactorRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user, interface = get_pending_interface(request, serializer.validated_data["method"])
+        if user is None:
+            return Response({"detail": "No pending two-factor authentication"}, status=401)
+        if interface is None:
+            return Response({"detail": "Unsupported two-factor authentication method"}, status=400)
+
+        if is_2fa_rate_limited(user.id):
+            send_2fa_rate_limit_notification(
+                user_id=user.id,
+                email=user.username,
+                ip_address=request.META["REMOTE_ADDR"],
+            )
+            return Response(
+                {"detail": "Too many two-factor authentication attempts"},
+                status=429,
+            )
+
+        if "otp" in serializer.validated_data:
+            if not interface.can_validate_otp:
+                return Response(
+                    {"detail": "Unsupported two-factor authentication method"}, status=400
+                )
+            is_valid = interface.validate_otp(serializer.validated_data["otp"])
+        elif "response" in serializer.validated_data:
+            response = serializer.validated_data["response"]
+            try:
+                is_valid = interface.validate_response(
+                    request,
+                    None,
+                    {
+                        "keyHandle": response["key_handle"],
+                        "clientData": response["client_data"],
+                        "authenticatorData": response["authenticator_data"],
+                        "signatureData": response["signature_data"],
+                    },
+                )
+            except ValueError:
+                is_valid = False
+        else:
+            is_valid = False
+
+        if not is_valid:
+            return Response({"detail": "Invalid two-factor authentication credentials"}, status=400)
+
+        try:
+            is_authenticated = auth.login(request, user, passed_2fa=True)
+        except auth.AuthUserPasswordExpired:
+            request.session.pop(auth.MFA_SESSION_KEY, None)
+            return Response(
+                {"detail": "Cannot complete authentication because the password has expired"},
+                status=403,
+            )
+
+        if not is_authenticated:
+            return Response({"detail": "Unable to complete authentication"}, status=400)
+
+        assert interface.authenticator is not None
+        interface.authenticator.mark_used()
+
+        return Response(get_auth_success_payload(request, user))
+
+    @extend_schema(
+        operation_id="Cancel a pending two-factor authentication login",
+        responses={204: None},
+    )
+    def delete(self, request: Request) -> Response:
+        request.session.pop("_pending_2fa", None)
+        request.session.pop("_after_2fa", None)
+        request.session.pop("webauthn_authentication_state", None)
+        return Response(status=204)
+
+
+@extend_schema(tags=["Users"])
+@control_silo_endpoint
+class AuthTwoFactorChallengeEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.FOUNDATIONS
+    permission_classes = ()
+
+    @extend_schema(
+        operation_id="Activate a two-factor authentication challenge",
+        request=AuthTwoFactorChallengeRequestSerializer,
+        responses={200: AuthMfaChallengeSerializer},
+    )
+    def post(self, request: Request) -> Response:
+        serializer = AuthTwoFactorChallengeRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user, interface = get_pending_interface(request, serializer.validated_data["method"])
+        if user is None:
+            return Response({"detail": "No pending two-factor authentication"}, status=401)
+
+        if interface is None or not interface.requires_activation:
+            return Response(
+                {"detail": "Authentication method does not require a challenge"}, status=400
+            )
+
+        try:
+            activation = interface.activate(request)
+        except ActivationRateLimited:
+            return Response(
+                {"detail": "Too many authentication challenge attempts"},
+                status=429,
+            )
+
+        if isinstance(activation, ActivationMessageResult) and activation.type == "error":
+            sentry_sdk.capture_message(
+                "Two-factor authentication challenge activation failed",
+                level="error",
+                extras={"method": interface.interface_id},
+            )
+            return Response({"detail": "Unable to activate authentication challenge"}, status=503)
+        if not isinstance(activation, (ActivationChallengeResult, ActivationMessageResult)):
+            sentry_sdk.capture_message(
+                "Unexpected two-factor authentication challenge activation result",
+                level="error",
+                extras={
+                    "activation_type": type(activation).__name__,
+                    "method": interface.interface_id,
+                },
+            )
+            return Response({"detail": "Unable to activate authentication challenge"}, status=500)
+
+        try:
+            response = serialize_activation(interface.interface_id, activation, user)
+        except ValueError as error:
+            sentry_sdk.capture_exception(error)
+            return Response({"detail": "Unable to activate authentication challenge"}, status=500)
+        return Response(response)

--- a/src/sentry/api/serializers/models/auth.py
+++ b/src/sentry/api/serializers/models/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from base64 import b64encode
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
@@ -7,6 +8,7 @@ from typing import Any, Literal, TypedDict
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, serialize
+from sentry.auth.authenticators.base import ActivationChallengeResult, ActivationMessageResult
 from sentry.users.api.serializers.user import (
     DetailedSelfUserSerializer,
     DetailedSelfUserSerializerResponse,
@@ -42,6 +44,26 @@ class AuthSuccessSerializer(Serializer[AuthSuccessSerializerResponse]):
 
 def serialize_auth_success(user: User, next_uri: str) -> AuthSuccessSerializerResponse:
     return serialize(AuthSuccess(user=user, next_uri=next_uri), user, AuthSuccessSerializer())
+
+
+@dataclass(frozen=True)
+class AuthDetail:
+    detail: str
+
+
+class AuthDetailSerializerResponse(TypedDict):
+    detail: str
+
+
+class AuthDetailSerializer(Serializer[AuthDetailSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthDetail,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthDetailSerializerResponse:
+        return {"detail": obj.detail}
 
 
 @dataclass(frozen=True)
@@ -134,3 +156,87 @@ def serialize_auth_mfa_required(
 ) -> AuthMfaRequiredSerializerResponse:
     methods = tuple(AuthMfaMethod(method_id) for method_id in method_ids)
     return serialize(AuthMfaRequired(methods), user, AuthMfaRequiredSerializer())
+
+
+@dataclass(frozen=True)
+class AuthMfaWebAuthnChallenge:
+    challenge: str
+
+
+@dataclass(frozen=True)
+class AuthMfaSmsChallenge:
+    expires_in: int
+
+
+class AuthMfaWebAuthnChallengeData(TypedDict):
+    webAuthnAuthenticationData: str
+
+
+class AuthMfaWebAuthnChallengeSerializerResponse(TypedDict):
+    method: Literal["u2f"]
+    challenge: AuthMfaWebAuthnChallengeData
+
+
+class AuthMfaSmsChallengeSerializerResponse(TypedDict):
+    method: Literal["sms"]
+    expiresIn: int
+
+
+AuthMfaChallengeSerializerResponse = (
+    AuthMfaWebAuthnChallengeSerializerResponse | AuthMfaSmsChallengeSerializerResponse
+)
+
+
+class AuthMfaWebAuthnChallengeSerializer(Serializer[AuthMfaWebAuthnChallengeSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaWebAuthnChallenge,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaWebAuthnChallengeSerializerResponse:
+        return {
+            "method": "u2f",
+            "challenge": {"webAuthnAuthenticationData": obj.challenge},
+        }
+
+
+class AuthMfaSmsChallengeSerializer(Serializer[AuthMfaSmsChallengeSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaSmsChallenge,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaSmsChallengeSerializerResponse:
+        return {"method": "sms", "expiresIn": obj.expires_in}
+
+
+class AuthMfaChallengeSerializer(Serializer[AuthMfaChallengeSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthMfaWebAuthnChallenge | AuthMfaSmsChallenge,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthMfaChallengeSerializerResponse:
+        if isinstance(obj, AuthMfaWebAuthnChallenge):
+            return AuthMfaWebAuthnChallengeSerializer().serialize(obj, attrs, user)
+        return AuthMfaSmsChallengeSerializer().serialize(obj, attrs, user)
+
+
+def serialize_activation(
+    method: str,
+    activation: ActivationChallengeResult | ActivationMessageResult,
+    user: User,
+) -> AuthMfaChallengeSerializerResponse:
+    challenge: AuthMfaWebAuthnChallenge | AuthMfaSmsChallenge
+
+    if isinstance(activation, ActivationChallengeResult):
+        challenge = AuthMfaWebAuthnChallenge(b64encode(activation.challenge).decode("ascii"))
+    elif method == "sms" and activation.expires_in is not None:
+        challenge = AuthMfaSmsChallenge(activation.expires_in)
+    else:
+        raise ValueError(f"Unsupported activation result for method: {method}")
+
+    return serialize(challenge, user, AuthMfaChallengeSerializer())

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -723,6 +723,7 @@ from .endpoints.api_tokens import ApiTokensEndpoint
 from .endpoints.artifact_bundles import ArtifactBundlesEndpoint
 from .endpoints.artifact_lookup import ProjectArtifactLookupEndpoint
 from .endpoints.assistant import AssistantEndpoint
+from .endpoints.auth_2fa import AuthTwoFactorChallengeEndpoint, AuthTwoFactorEndpoint
 from .endpoints.auth_config import AuthConfigEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.auth_login import AuthLoginEndpoint
@@ -1078,6 +1079,16 @@ AUTH_URLS = [
         r"^login/$",
         AuthLoginEndpoint.as_view(),
         name="sentry-api-0-auth-login",
+    ),
+    re_path(
+        r"^2fa/$",
+        AuthTwoFactorEndpoint.as_view(),
+        name="sentry-api-0-auth-2fa",
+    ),
+    re_path(
+        r"^2fa/challenge/$",
+        AuthTwoFactorChallengeEndpoint.as_view(),
+        name="sentry-api-0-auth-2fa-challenge",
     ),
     re_path(
         r"^validate/$",

--- a/src/sentry/auth/authenticators/base.py
+++ b/src/sentry/auth/authenticators/base.py
@@ -23,15 +23,21 @@ class ActivationResult:
     type: str
 
 
+class ActivationRateLimited(Exception):
+    pass
+
+
 class ActivationMessageResult(ActivationResult):
     def __init__(
         self,
         message: str | _StrPromise,
         type: Literal["error", "warning", "info"] = "info",
+        expires_in: int | None = None,
     ) -> None:
         assert type in ("error", "warning", "info")
         self.type = type
         self.message = message
+        self.expires_in = expires_in
 
     def __str__(self) -> str:
         return str(self.message)

--- a/src/sentry/auth/authenticators/sms.py
+++ b/src/sentry/auth/authenticators/sms.py
@@ -12,7 +12,7 @@ from sentry.ratelimits import backend as ratelimiter
 from sentry.utils.otp import TOTP
 from sentry.utils.sms import phone_number_as_e164, send_sms, sms_available
 
-from .base import ActivationMessageResult, OtpMixin
+from .base import ActivationMessageResult, ActivationRateLimited, OtpMixin
 
 if TYPE_CHECKING:
     from django.utils.functional import _StrPromise
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("sentry.auth")
 
 
-class SMSRateLimitExceeded(Exception):
+class SMSRateLimitExceeded(ActivationRateLimited):
     def __init__(self, phone_number: str, user_id: int | None, remote_ip: str | None) -> None:
         super().__init__()
         self.phone_number = phone_number
@@ -75,7 +75,8 @@ class SmsInterface(OtpMixin):
                     "A confirmation code was sent to %(phone_mask)s. "
                     "It is valid for %(ttl)d seconds."
                 )
-                % {"phone_mask": "<strong>%s</strong>" % mask, "ttl": self.code_ttl}
+                % {"phone_mask": "<strong>%s</strong>" % mask, "ttl": self.code_ttl},
+                expires_in=self.code_ttl,
             )
         return ActivationMessageResult(
             _(

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -155,6 +155,8 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/auth/$'),
   new RegExp('^api/0/auth/config/$'),
   new RegExp('^api/0/auth/login/$'),
+  new RegExp('^api/0/auth/2fa/$'),
+  new RegExp('^api/0/auth/2fa/challenge/$'),
   new RegExp('^api/0/auth/validate/$'),
   new RegExp('^api/0/auth-v2/flag/$'),
   new RegExp('^api/0/auth-v2/csrf/$'),

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -24,6 +24,8 @@ export type KnownSentryApiUrls =
   | '/auth-v2/merge-accounts/'
   | '/auth-v2/user-merge-verification-codes/'
   | '/auth/'
+  | '/auth/2fa/'
+  | '/auth/2fa/challenge/'
   | '/auth/config/'
   | '/auth/login/'
   | '/auth/validate/'

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -1,8 +1,12 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
+from django.conf import settings
 from django.urls import reverse
 
+from sentry.auth.authenticators.base import ActivationChallengeResult, ActivationMessageResult
+from sentry.auth.authenticators.sms import SmsInterface
 from sentry.auth.authenticators.totp import TotpInterface
+from sentry.auth.authenticators.u2f import U2fInterface
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.auth import SsoSession
@@ -139,6 +143,347 @@ class AuthLoginEndpointTest(APITestCase):
         }
         assert "_auth_user_id" not in self.client.session
         assert self.client.session["_pending_2fa"][0] == self.user.id
+
+    def test_get_mfa_methods(self) -> None:
+        TotpInterface().enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.get(reverse("sentry-api-0-auth-2fa"))
+
+        assert response.status_code == 200
+        assert response.data == {
+            "mfaRequired": True,
+            "mfaMethods": [{"id": "totp"}],
+        }
+
+    def test_get_mfa_methods_requires_pending_login(self) -> None:
+        response = self.client.get(reverse("sentry-api-0-auth-2fa"))
+
+        assert response.status_code == 404
+        assert response.data == {"detail": "No two-factor authentication request is active"}
+
+    def test_complete_mfa_login(self) -> None:
+        interface = TotpInterface()
+        interface.enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        with patch.object(interface.__class__, "validate_otp", return_value=True):
+            response = self.client.post(
+                reverse("sentry-api-0-auth-2fa"),
+                data={"method": "totp", "otp": "123456"},
+            )
+
+        assert response.status_code == 200
+        assert response.data["nextUri"] == "/organizations/new/"
+        assert response.data["user"]["id"] == str(self.user.id)
+        assert self.client.session["_auth_user_id"] == str(self.user.id)
+        assert "_pending_2fa" not in self.client.session
+
+    def test_complete_mfa_login_requires_pending_login(self) -> None:
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa"),
+            data={"method": "totp", "otp": "123456"},
+        )
+
+        assert response.status_code == 401
+        assert response.data == {"detail": "No pending two-factor authentication"}
+
+    def test_complete_mfa_login_rejects_invalid_code(self) -> None:
+        interface = TotpInterface()
+        interface.enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        with patch.object(interface.__class__, "validate_otp", return_value=False):
+            response = self.client.post(
+                reverse("sentry-api-0-auth-2fa"),
+                data={"method": "totp", "otp": "invalid"},
+            )
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid two-factor authentication credentials"}
+        assert "_auth_user_id" not in self.client.session
+
+    @patch("sentry.api.endpoints.auth_2fa.send_2fa_rate_limit_notification")
+    @patch("sentry.api.endpoints.auth_2fa.is_2fa_rate_limited", return_value=True)
+    def test_complete_mfa_login_rate_limited(
+        self, is_rate_limited: MagicMock, send_notification: MagicMock
+    ) -> None:
+        TotpInterface().enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa"),
+            data={"method": "totp", "otp": "123456"},
+        )
+
+        assert response.status_code == 429
+        assert response.data == {"detail": "Too many two-factor authentication attempts"}
+        is_rate_limited.assert_called_once_with(self.user.id)
+        send_notification.assert_called_once_with(
+            user_id=self.user.id,
+            email=self.user.username,
+            ip_address="127.0.0.1",
+        )
+
+    def test_complete_mfa_login_rejects_expired_password(self) -> None:
+        interface = TotpInterface()
+        interface.enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+        self.user.update(is_password_expired=True)
+
+        with patch.object(interface.__class__, "validate_otp", return_value=True):
+            response = self.client.post(
+                reverse("sentry-api-0-auth-2fa"),
+                data={"method": "totp", "otp": "123456"},
+            )
+
+        assert response.status_code == 403
+        assert response.data == {
+            "detail": "Cannot complete authentication because the password has expired"
+        }
+        assert "_pending_2fa" not in self.client.session
+        assert "_auth_user_id" not in self.client.session
+        assert "mfa" not in self.client.session
+
+        self.user.refresh_from_db()
+        self.user.set_password("new-password")
+        self.user.save()
+
+        response = self.get_response(username=self.user.username, password="new-password")
+
+        assert response.status_code == 202
+        assert self.client.session["_pending_2fa"][0] == self.user.id
+
+    def test_cancel_mfa_login(self) -> None:
+        TotpInterface().enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+        session = self.client.session
+        session["_after_2fa"] = "/after-2fa/"
+        session["_next"] = "/settings/account/"
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key or ""
+        assert self.client.session["_next"] == "/settings/account/"
+
+        response = self.client.delete(reverse("sentry-api-0-auth-2fa"))
+
+        assert response.status_code == 204
+        assert "_pending_2fa" not in self.client.session
+        assert "_after_2fa" not in self.client.session
+        assert self.client.session["_next"] == "/settings/account/"
+
+    def test_cancel_mfa_login_is_idempotent(self) -> None:
+        response = self.client.delete(reverse("sentry-api-0-auth-2fa"))
+
+        assert response.status_code == 204
+
+    def test_cancel_mfa_login_clears_webauthn_challenge(self) -> None:
+        session = self.client.session
+        session["webauthn_authentication_state"] = "state"
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key or ""
+        assert self.client.session["webauthn_authentication_state"] == "state"
+
+        response = self.client.delete(reverse("sentry-api-0-auth-2fa"))
+
+        assert response.status_code == 204
+        assert "webauthn_authentication_state" not in self.client.session
+
+    @patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
+    @patch(
+        "sentry.auth.authenticators.U2fInterface.activate",
+        return_value=ActivationChallengeResult(b"challenge"),
+    )
+    def test_activate_webauthn_challenge(self, activate, is_available) -> None:
+        U2fInterface().enroll(self.user)
+        login_response = self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa-challenge"),
+            data={"method": "u2f"},
+        )
+
+        assert login_response.data["mfaMethods"] == [{"id": "u2f"}]
+        assert response.status_code == 200
+        assert response.data == {
+            "method": "u2f",
+            # Base64-encoded form of the mocked b"challenge" activation payload.
+            "challenge": {"webAuthnAuthenticationData": "Y2hhbGxlbmdl"},
+        }
+        activate.assert_called_once()
+
+    @patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
+    @patch("sentry.auth.authenticators.U2fInterface.validate_response", return_value=True)
+    def test_complete_webauthn_login(self, validate_response, is_available) -> None:
+        U2fInterface().enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+        webauthn_response = {
+            "keyHandle": "key-handle",
+            "clientData": "client-data",
+            "authenticatorData": "authenticator-data",
+            "signatureData": "signature-data",
+        }
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa"),
+            data={"method": "u2f", "response": webauthn_response},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["user"]["id"] == str(self.user.id)
+        assert self.client.session["_auth_user_id"] == str(self.user.id)
+        validate_response.assert_called_once_with(
+            ANY,
+            None,
+            {
+                "keyHandle": "key-handle",
+                "clientData": "client-data",
+                "authenticatorData": "authenticator-data",
+                "signatureData": "signature-data",
+            },
+        )
+
+    @patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
+    def test_complete_webauthn_login_rejects_malformed_response(self, is_available) -> None:
+        U2fInterface().enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+        session = self.client.session
+        session["webauthn_authentication_state"] = "state"
+        session.save()
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa"),
+            data={
+                "method": "u2f",
+                "response": {
+                    "keyHandle": "a",
+                    "clientData": "a",
+                    "authenticatorData": "a",
+                    "signatureData": "a",
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid two-factor authentication credentials"}
+        assert "_auth_user_id" not in self.client.session
+
+    @patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
+    def test_complete_webauthn_login_uses_camel_case_validation_errors(self, is_available) -> None:
+        U2fInterface().enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa"),
+            data={
+                "method": "u2f",
+                "response": {
+                    "keyHandle": "key-handle",
+                    "clientData": "client-data",
+                    "authenticatorData": "authenticator-data",
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "signatureData" in response.data["response"]
+
+    @patch("sentry.auth.authenticators.SmsInterface.is_available", return_value=True)
+    @patch(
+        "sentry.auth.authenticators.SmsInterface.activate",
+        return_value=ActivationMessageResult("Code sent", expires_in=45),
+    )
+    def test_activate_sms_challenge(self, activate, is_available) -> None:
+        interface = SmsInterface()
+        interface.phone_number = "5555551212"
+        interface.enroll(self.user)
+        login_response = self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa-challenge"),
+            data={"method": "sms"},
+        )
+
+        assert login_response.data["mfaMethods"] == [{"id": "sms"}]
+        assert response.status_code == 200
+        assert response.data == {"method": "sms", "expiresIn": 45}
+        activate.assert_called_once()
+
+    @patch("sentry.api.endpoints.auth_2fa.sentry_sdk.capture_message")
+    @patch("sentry.auth.authenticators.SmsInterface.is_available", return_value=True)
+    @patch(
+        "sentry.auth.authenticators.SmsInterface.activate",
+        return_value=ActivationMessageResult("Unable to send code", type="error"),
+    )
+    def test_activate_challenge_captures_provider_error(
+        self, activate, is_available, capture_message
+    ) -> None:
+        interface = SmsInterface()
+        interface.phone_number = "5555551212"
+        interface.enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa-challenge"),
+            data={"method": "sms"},
+        )
+
+        assert response.status_code == 503
+        assert response.data == {"detail": "Unable to activate authentication challenge"}
+        capture_message.assert_called_once_with(
+            "Two-factor authentication challenge activation failed",
+            level="error",
+            extras={"method": "sms"},
+        )
+
+    @patch("sentry.api.endpoints.auth_2fa.sentry_sdk.capture_message")
+    @patch("sentry.auth.authenticators.SmsInterface.is_available", return_value=True)
+    @patch("sentry.auth.authenticators.SmsInterface.activate", return_value=None)
+    def test_activate_challenge_captures_unexpected_result(
+        self, activate, is_available, capture_message
+    ) -> None:
+        interface = SmsInterface()
+        interface.phone_number = "5555551212"
+        interface.enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa-challenge"),
+            data={"method": "sms"},
+        )
+
+        assert response.status_code == 500
+        assert response.data == {"detail": "Unable to activate authentication challenge"}
+        capture_message.assert_called_once_with(
+            "Unexpected two-factor authentication challenge activation result",
+            level="error",
+            extras={"activation_type": "NoneType", "method": "sms"},
+        )
+
+    @patch("sentry.api.endpoints.auth_2fa.sentry_sdk.capture_exception")
+    @patch("sentry.auth.authenticators.SmsInterface.is_available", return_value=True)
+    @patch(
+        "sentry.auth.authenticators.SmsInterface.activate",
+        return_value=ActivationMessageResult("Code sent"),
+    )
+    def test_activate_challenge_captures_unsupported_result(
+        self, activate, is_available, capture_exception
+    ) -> None:
+        interface = SmsInterface()
+        interface.phone_number = "5555551212"
+        interface.enroll(self.user)
+        self.get_response(username=self.user.username, password="admin")
+
+        response = self.client.post(
+            reverse("sentry-api-0-auth-2fa-challenge"),
+            data={"method": "sms"},
+        )
+
+        assert response.status_code == 500
+        assert response.data == {"detail": "Unable to activate authentication challenge"}
+        capture_exception.assert_called_once()
 
     def test_must_reactivate(self) -> None:
         self.user.update(is_active=False)


### PR DESCRIPTION
Adds private API endpoints for listing, completing, and canceling a pending two-factor login, plus activating SMS or WebAuthn challenges. TOTP, recovery codes, SMS, and WebAuthn reuse the existing authenticator implementations, attempt limits, backend-selected redirect, and shared successful-login payload; password-expired accounts receive a 403 instead of completing authentication.

Pending user and WebAuthn state remain session-bound. Cancellation idempotently clears the pending login, post-MFA override, and WebAuthn challenge while preserving the original login redirect. Invalid credentials use the normal authentication error response, while provider and internal challenge failures return service/server errors and are captured for diagnosis.
