### PR TITLE
feat(api): Resume pending MFA from auth config

### DIFF
--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -1,3 +1,5 @@
+from typing import NotRequired, TypedDict, cast
+
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http.request import HttpRequest
@@ -10,17 +12,31 @@ from sentry import newsletter
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.serializers.models.auth import (
+    AuthMfaRequiredSerializerResponse,
+    serialize_auth_mfa_required,
+)
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
 from sentry.models.organization import Organization
+from sentry.users.models.authenticator import Authenticator
 from sentry.utils.auth import (
     get_org_redirect_url,
+    get_pending_2fa_user,
     has_user_registration,
     initiate_login,
     is_valid_redirect,
 )
 from sentry.web.frontend.auth_login import additional_context
 from sentry.web.frontend.base import OrganizationMixin, determine_active_organization
+
+
+class AuthConfigResponse(TypedDict):
+    serverHostname: str
+    canRegister: bool
+    hasNewsletter: bool
+    pendingMfa: AuthMfaRequiredSerializerResponse | None
+    warning: NotRequired[str]
 
 
 @control_silo_endpoint
@@ -43,6 +59,17 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
         if request.user.is_authenticated:
             return self.respond_authenticated(request)
 
+        user_pending_2fa = get_pending_2fa_user(request)
+        if user_pending_2fa is not None:
+            interfaces = Authenticator.objects.all_interfaces_for_user(user_pending_2fa)
+            payload = self.prepare_login_context(request, *args, **kwargs)
+            pending_mfa = serialize_auth_mfa_required(
+                user_pending_2fa, [interface.interface_id for interface in interfaces]
+            )
+            payload["pendingMfa"] = pending_mfa
+            # Preserve the pending MFA and redirect state that initiate_login clears below.
+            return self.respond_with_login_context(request, payload)
+
         next_uri = self.get_next_uri(request)
 
         # we always reset the state on GET so you don't end up at an odd location
@@ -56,11 +83,13 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
             org = Organization.get_default()
             return Response({"nextUri": reverse("sentry-auth-organization", args=[org.slug])})
 
-        session_expired = "session_expired" in request.COOKIES
         payload = self.prepare_login_context(request, *args, **kwargs)
+        return self.respond_with_login_context(request, payload)
+
+    def respond_with_login_context(self, request: Request, payload: AuthConfigResponse) -> Response:
         response = Response(payload)
 
-        if session_expired:
+        if "session_expired" in request.COOKIES:
             response.delete_cookie("session_expired")
 
         return response
@@ -79,18 +108,19 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
         next_uri_fallback = request.session.pop("_next", None)
         return request.GET.get(REDIRECT_FIELD_NAME, next_uri_fallback)
 
-    def prepare_login_context(self, request: Request, *args, **kwargs):
+    def prepare_login_context(self, request: Request, *args, **kwargs) -> AuthConfigResponse:
         can_register = bool(has_user_registration() or request.session.get("can_register"))
 
-        context = {
+        context: dict[str, object] = {
             "serverHostname": get_server_hostname(),
             "canRegister": can_register,
             "hasNewsletter": newsletter.backend.is_enabled(),
+            "pendingMfa": None,
         }
 
         if "session_expired" in request.COOKIES:
-            context["warning"] = WARN_SESSION_EXPIRED
+            context["warning"] = str(WARN_SESSION_EXPIRED)
 
         context.update(additional_context.run_callbacks(request))
 
-        return context
+        return cast(AuthConfigResponse, context)

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -101,6 +101,7 @@ class AuthConfigEndpointTest(APITestCase):
             "mfaRequired": True,
             "mfaMethods": [{"id": "totp"}],
         }
+
     @pytest.mark.skipif(
         settings.SENTRY_NEWSLETTER != "sentry.newsletter.dummy.DummyNewsletter",
         reason="Requires DummyNewsletter.",

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 from sentry import newsletter
+from sentry.auth.authenticators.totp import TotpInterface
 from sentry.newsletter.dummy import DummyNewsletter
 from sentry.receivers import create_default_projects
 from sentry.silo.base import SiloMode
@@ -52,10 +53,54 @@ class AuthConfigEndpointTest(APITestCase):
         response = self.client.get(self.path)
 
         assert response.status_code == 200
-        assert not response.data["canRegister"]
-        assert not response.data["hasNewsletter"]
-        assert response.data["serverHostname"] == "testserver"
+        assert response.data == {
+            "canRegister": False,
+            "hasNewsletter": False,
+            "pendingMfa": None,
+            "serverHostname": "testserver",
+        }
 
+    def test_pending_mfa_login(self) -> None:
+        TotpInterface().enroll(self.user)
+        self.client.get(self.path, {"next": "/settings/account/"})
+        login_response = self.client.post(
+            "/api/0/auth/login/",
+            data={"username": self.user.username, "password": "admin"},
+        )
+
+        response = self.client.get(self.path)
+
+        assert login_response.status_code == 202
+        assert response.status_code == 200
+        assert response.data == {
+            "canRegister": False,
+            "hasNewsletter": False,
+            "pendingMfa": {
+                "mfaRequired": True,
+                "mfaMethods": [{"id": "totp"}],
+            },
+            "serverHostname": "testserver",
+        }
+        assert self.client.session["_pending_2fa"][0] == self.user.id
+        assert self.client.session["_next"] == "/settings/account/"
+
+    def test_pending_mfa_consumes_session_expired_warning(self) -> None:
+        TotpInterface().enroll(self.user)
+        self.client.get(self.path)
+        self.client.post(
+            "/api/0/auth/login/",
+            data={"username": self.user.username, "password": "admin"},
+        )
+        self.client.cookies["session_expired"] = "1"
+
+        response = self.client.get(self.path)
+
+        assert response.data["warning"] == "Your session has expired."
+        assert response.cookies["session_expired"]["max-age"] == 0
+        assert response.data["pendingMfa"] == {
+            "mfaRequired": True,
+            "mfaMethods": [{"id": "totp"}],
+        }
     @pytest.mark.skipif(
         settings.SENTRY_NEWSLETTER != "sentry.newsletter.dummy.DummyNewsletter",
         reason="Requires DummyNewsletter.",


### PR DESCRIPTION
The auth-config endpoint now returns a typed login-page configuration with an always-present nullable `pendingMfa`. When a session has a pending two-factor login, the response includes the available methods without resetting the saved redirect, allowing the React login route to resume after a reload.

During rollout, pending responses also retain the legacy top-level `mfaRequired` and `mfaMethods` fields for the deployed frontend; ordinary responses contain `pendingMfa: null` and no flat MFA fields.