### PR TITLE
feat(api): Add password recovery endpoints

### DIFF
--- a/src/sentry/api/endpoints/auth_recovery.py
+++ b/src/sentry/api/endpoints/auth_recovery.py
@@ -1,0 +1,177 @@
+from typing import TypedDict
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import router, transaction
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import ratelimits as ratelimiter
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.serializers.base import serialize
+from sentry.api.serializers.models.auth import (
+    AuthRecoveryAccepted,
+    AuthRecoveryAcceptedSerializer,
+)
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.auth import password_validation
+from sentry.auth.twofactor import reset_2fa_rate_limits
+from sentry.security.utils import capture_security_activity
+from sentry.users.models.lostpasswordhash import LostPasswordHash
+from sentry.users.models.user import User
+from sentry.users.services.user.service import user_service
+from sentry.utils.auth import find_users
+
+
+class AuthRecoveryRequest(TypedDict):
+    user: str
+
+
+class AuthRecoveryRequestSerializer(CamelSnakeSerializer[AuthRecoveryRequest]):
+    user = serializers.CharField(max_length=128)
+
+
+class AuthRecoveryConfirmRequest(TypedDict):
+    user_id: int
+    token: str
+    password: str
+
+
+class AuthRecoveryConfirmRequestSerializer(CamelSnakeSerializer[AuthRecoveryConfirmRequest]):
+    user_id = serializers.IntegerField(min_value=1)
+    token = serializers.CharField(max_length=64)
+    password = serializers.CharField(max_length=256, trim_whitespace=False)
+
+
+def is_rate_limited(request: Request, action: str) -> bool:
+    return ratelimiter.backend.is_limited(
+        f"auth:recovery:{action}:{request.META['REMOTE_ADDR']}",
+        limit=5,
+        window=60,
+    )
+
+
+@extend_schema(tags=["Users"])
+@control_silo_endpoint
+class AuthRecoveryEndpoint(Endpoint):
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.FOUNDATIONS
+    permission_classes = ()
+
+    @extend_schema(
+        operation_id="Request account password recovery",
+        request=AuthRecoveryRequestSerializer,
+        responses={202: AuthRecoveryAcceptedSerializer},
+    )
+    def post(self, request: Request) -> Response:
+        if is_rate_limited(request, "request"):
+            return Response({"detail": "Too many password recovery attempts"}, status=429)
+
+        serializer = AuthRecoveryRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        users = find_users(serializer.validated_data["user"].strip(), with_valid_password=False)
+        if (
+            len(users) == 1
+            and not users[0].is_managed
+            and not getattr(users[0], "is_suspended", False)
+        ):
+            user = users[0]
+            password_hash = LostPasswordHash.for_user(user)
+            LostPasswordHash.send_recover_password_email(
+                user, password_hash.hash, request.META["REMOTE_ADDR"]
+            )
+
+        return Response(
+            serialize(AuthRecoveryAccepted(), request.user, AuthRecoveryAcceptedSerializer()),
+            status=202,
+        )
+
+
+@extend_schema(tags=["Users"])
+@control_silo_endpoint
+class AuthRecoveryConfirmEndpoint(Endpoint):
+    # TODO(epurkhiser): Support password recovery during self-hosted relocation.
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.FOUNDATIONS
+    permission_classes = ()
+
+    @extend_schema(
+        operation_id="Complete account password recovery",
+        request=AuthRecoveryConfirmRequestSerializer,
+        responses={204: None},
+    )
+    def post(self, request: Request) -> Response:
+        if is_rate_limited(request, "confirm"):
+            return Response({"detail": "Too many password recovery attempts"}, status=429)
+
+        serializer = AuthRecoveryConfirmRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user_id = serializer.validated_data["user_id"]
+        token = serializer.validated_data["token"]
+        password = serializer.validated_data["password"]
+
+        password_hash = (
+            LostPasswordHash.objects.select_related("user")
+            .filter(user_id=user_id, hash=token)
+            .first()
+        )
+        if password_hash is None:
+            return Response({"detail": "Invalid or expired recovery token"}, status=400)
+        if not password_hash.is_valid():
+            password_hash.delete()
+            return Response({"detail": "Invalid or expired recovery token"}, status=400)
+
+        user = password_hash.user
+        if getattr(user, "is_suspended", False) or user.is_managed:
+            password_hash.delete()
+            return Response({"detail": "Invalid or expired recovery token"}, status=400)
+
+        try:
+            password_validation.validate_password(password, user=user)
+        except DjangoValidationError as error:
+            raise serializers.ValidationError({"password": error.messages}) from error
+
+        database = router.db_for_write(User)
+        with transaction.atomic(database):
+            password_hash = (
+                LostPasswordHash.objects.select_for_update()
+                .select_related("user")
+                .filter(user_id=user_id, hash=token)
+                .first()
+            )
+            if password_hash is None:
+                return Response({"detail": "Invalid or expired recovery token"}, status=400)
+            if not password_hash.is_valid():
+                password_hash.delete()
+                return Response({"detail": "Invalid or expired recovery token"}, status=400)
+
+            user = password_hash.user
+            if getattr(user, "is_suspended", False) or user.is_managed:
+                password_hash.delete()
+                return Response({"detail": "Invalid or expired recovery token"}, status=400)
+
+            user.set_password(password)
+            user.refresh_session_nonce()
+            user.save()
+            password_hash.delete()
+
+            transaction.on_commit(
+                lambda: user_service.verify_user_email(email=user.email, user_id=user.id),
+                using=database,
+            )
+
+        capture_security_activity(
+            account=user,
+            type="password-changed",
+            actor=user,
+            ip_address=request.META["REMOTE_ADDR"],
+            send_email=True,
+        )
+        reset_2fa_rate_limits(user.id)
+
+        return Response(status=204)

--- a/src/sentry/api/serializers/models/auth.py
+++ b/src/sentry/api/serializers/models/auth.py
@@ -240,3 +240,22 @@ def serialize_activation(
         raise ValueError(f"Unsupported activation result for method: {method}")
 
     return serialize(challenge, user, AuthMfaChallengeSerializer())
+
+
+class AuthRecoveryAccepted:
+    pass
+
+
+class AuthRecoveryAcceptedSerializerResponse(TypedDict):
+    detail: str
+
+
+class AuthRecoveryAcceptedSerializer(Serializer[AuthRecoveryAcceptedSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthRecoveryAccepted,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthRecoveryAcceptedSerializerResponse:
+        return {"detail": "If an eligible account exists, a recovery email has been sent."}

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -733,6 +733,7 @@ from .endpoints.auth_2fa import AuthTwoFactorChallengeEndpoint, AuthTwoFactorEnd
 from .endpoints.auth_config import AuthConfigEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.auth_login import AuthLoginEndpoint
+from .endpoints.auth_recovery import AuthRecoveryConfirmEndpoint, AuthRecoveryEndpoint
 from .endpoints.auth_validate import AuthValidateEndpoint
 from .endpoints.broadcast_details import BroadcastDetailsEndpoint
 from .endpoints.broadcast_index import BroadcastIndexEndpoint
@@ -1085,6 +1086,16 @@ AUTH_URLS = [
         r"^login/$",
         AuthLoginEndpoint.as_view(),
         name="sentry-api-0-auth-login",
+    ),
+    re_path(
+        r"^recovery/$",
+        AuthRecoveryEndpoint.as_view(),
+        name="sentry-api-0-auth-recovery",
+    ),
+    re_path(
+        r"^recovery/confirm/$",
+        AuthRecoveryConfirmEndpoint.as_view(),
+        name="sentry-api-0-auth-recovery-confirm",
     ),
     re_path(
         r"^2fa/$",

--- a/src/sentry/users/services/lost_password_hash/impl.py
+++ b/src/sentry/users/services/lost_password_hash/impl.py
@@ -1,4 +1,4 @@
-import datetime
+from django.utils import timezone
 
 from sentry.users.models.lostpasswordhash import LostPasswordHash
 from sentry.users.services.lost_password_hash import LostPasswordHashService, RpcLostPasswordHash
@@ -18,7 +18,7 @@ class DatabaseLostPasswordHashService(LostPasswordHashService):
         # See: https://github.com/getsentry/sentry/pull/17299
         password_hash, created = LostPasswordHash.objects.get_or_create(user_id=user_id)
         if not password_hash.is_valid():
-            password_hash.date_added = datetime.datetime.now()
+            password_hash.date_added = timezone.now()
             password_hash.set_hash()
             password_hash.save()
         return serialize_lostpasswordhash(password_hash)

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -155,6 +155,8 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/auth/$'),
   new RegExp('^api/0/auth/config/$'),
   new RegExp('^api/0/auth/login/$'),
+  new RegExp('^api/0/auth/recovery/$'),
+  new RegExp('^api/0/auth/recovery/confirm/$'),
   new RegExp('^api/0/auth/2fa/$'),
   new RegExp('^api/0/auth/2fa/challenge/$'),
   new RegExp('^api/0/auth/validate/$'),

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -28,6 +28,8 @@ export type KnownSentryApiUrls =
   | '/auth/2fa/challenge/'
   | '/auth/config/'
   | '/auth/login/'
+  | '/auth/recovery/'
+  | '/auth/recovery/confirm/'
   | '/auth/validate/'
   | '/authenticators/'
   | '/broadcasts/'

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -1,7 +1,12 @@
+from datetime import timedelta
 from unittest.mock import ANY, MagicMock, patch
 
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone
+from rest_framework.response import Response
+from rest_framework.test import APIClient
 
 from sentry.auth.authenticators.base import ActivationChallengeResult, ActivationMessageResult
 from sentry.auth.authenticators.sms import SmsInterface
@@ -9,6 +14,8 @@ from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.authenticators.u2f import U2fInterface
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.users.models.lostpasswordhash import LostPasswordHash
+from sentry.users.models.useremail import UserEmail
 from sentry.utils.auth import SsoSession
 
 
@@ -511,3 +518,250 @@ class AuthLoginEndpointTest(APITestCase):
         assert [str(s) for s in response.data["errors"]["__all__"]] == [
             "You have made too many failed authentication attempts. Please try again later."
         ]
+
+
+@control_silo_test
+class AuthRecoveryEndpointTest(APITestCase):
+    def request_recovery(
+        self, user: str | None = None, client: APIClient | None = None
+    ) -> Response:
+        return (client or self.client).post(
+            reverse("sentry-api-0-auth-recovery"),
+            data={"user": user or self.user.email},
+        )
+
+    def confirm_recovery(
+        self,
+        token: str,
+        password: str = "new-secure-password",
+        client: APIClient | None = None,
+    ) -> Response:
+        return (client or self.client).post(
+            reverse("sentry-api-0-auth-recovery-confirm"),
+            data={"userId": self.user.id, "token": token, "password": password},
+        )
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_request_recovery(self, send_recovery_email: MagicMock) -> None:
+        response = self.request_recovery()
+
+        assert response.status_code == 202
+        assert response.data == {
+            "detail": "If an eligible account exists, a recovery email has been sent."
+        }
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+        send_recovery_email.assert_called_once_with(self.user, password_hash.hash, "127.0.0.1")
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_request_recovery_does_not_reveal_account_status(
+        self, send_recovery_email: MagicMock
+    ) -> None:
+        unknown_response = self.request_recovery("unknown@example.com")
+        self.user.update(is_suspended=True)
+        suspended_response = self.request_recovery()
+
+        assert unknown_response.status_code == 202
+        assert suspended_response.status_code == 202
+        assert unknown_response.data == suspended_response.data
+        assert not LostPasswordHash.objects.exists()
+        send_recovery_email.assert_not_called()
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_request_recovery_does_not_send_for_managed_account(
+        self, send_recovery_email: MagicMock
+    ) -> None:
+        self.user.update(is_managed=True)
+
+        response = self.request_recovery()
+
+        assert response.status_code == 202
+        assert not LostPasswordHash.objects.exists()
+        send_recovery_email.assert_not_called()
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_request_recovery_does_not_send_for_ambiguous_email(
+        self, send_recovery_email: MagicMock
+    ) -> None:
+        """Do not choose an account when legacy duplicate primary emails are ambiguous."""
+        shared_email = "shared@example.com"
+        self.user.update(email=shared_email)
+        other_user = self.create_user(email="other@example.com")
+        other_user.update(email=shared_email)
+
+        response = self.request_recovery(shared_email)
+
+        assert response.status_code == 202
+        assert not LostPasswordHash.objects.exists()
+        send_recovery_email.assert_not_called()
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_request_recovery_rotates_expired_token(self, send_recovery_email: MagicMock) -> None:
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+        expired_token = password_hash.hash
+        password_hash.update(date_added=timezone.now() - timedelta(hours=2))
+
+        response = self.request_recovery()
+
+        assert response.status_code == 202
+        password_hash.refresh_from_db()
+        assert password_hash.hash != expired_token
+        assert send_recovery_email.call_count == 2
+        assert send_recovery_email.call_args.args[1] == password_hash.hash
+
+    @patch(
+        "sentry.api.endpoints.auth_recovery.ratelimiter.backend.is_limited",
+        return_value=True,
+    )
+    def test_request_recovery_rate_limited(self, is_limited: MagicMock) -> None:
+        response = self.client.post(reverse("sentry-api-0-auth-recovery"), data={})
+
+        assert response.status_code == 429
+        assert response.data == {"detail": "Too many password recovery attempts"}
+
+    @patch("sentry.api.endpoints.auth_recovery.capture_security_activity")
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_changes_password_without_login(
+        self, send_recovery_email: MagicMock, capture_security_activity: MagicMock
+    ) -> None:
+        previous_nonce = self.user.session_nonce
+        user_email = UserEmail.objects.get(user=self.user, email=self.user.email)
+        user_email.update(is_verified=False)
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.confirm_recovery(password_hash.hash)
+
+        assert response.status_code == 204
+        assert response.content == b""
+        assert "_auth_user_id" not in self.client.session
+        assert not LostPasswordHash.objects.filter(user=self.user).exists()
+        self.user.refresh_from_db()
+        user_email.refresh_from_db()
+        assert self.user.check_password("new-secure-password")
+        assert self.user.session_nonce != previous_nonce
+        assert user_email.is_verified
+        capture_security_activity.assert_called_once_with(
+            account=self.user,
+            type="password-changed",
+            actor=self.user,
+            ip_address="127.0.0.1",
+            send_email=True,
+        )
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_invalidates_existing_session(
+        self, send_recovery_email: MagicMock
+    ) -> None:
+        self.login_as(self.user)
+        assert self.client.get(reverse("sentry-api-0-auth")).status_code == 200
+        recovery_client = APIClient()
+        self.request_recovery(client=recovery_client)
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+
+        response = self.confirm_recovery(password_hash.hash, client=recovery_client)
+
+        assert response.status_code == 204
+        assert self.client.get(reverse("sentry-api-0-auth")).status_code == 400
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_token_cannot_be_replayed(
+        self, send_recovery_email: MagicMock
+    ) -> None:
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+
+        first_response = self.confirm_recovery(password_hash.hash)
+        second_response = self.confirm_recovery(password_hash.hash, "another-secure-password")
+
+        assert first_response.status_code == 204
+        assert second_response.status_code == 400
+        assert second_response.data == {"detail": "Invalid or expired recovery token"}
+        self.user.refresh_from_db()
+        assert self.user.check_password("new-secure-password")
+
+    def test_confirm_recovery_rejects_invalid_token(self) -> None:
+        previous_password = self.user.password
+
+        response = self.confirm_recovery("invalid-token")
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid or expired recovery token"}
+        self.user.refresh_from_db()
+        assert self.user.password == previous_password
+        assert "_auth_user_id" not in self.client.session
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_rejects_expired_token(self, send_recovery_email: MagicMock) -> None:
+        previous_password = self.user.password
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+        password_hash.update(date_added=timezone.now() - timedelta(hours=2))
+
+        response = self.confirm_recovery(password_hash.hash)
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid or expired recovery token"}
+        self.user.refresh_from_db()
+        assert self.user.password == previous_password
+        assert "_auth_user_id" not in self.client.session
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_rejects_suspended_account(
+        self, send_recovery_email: MagicMock
+    ) -> None:
+        previous_password = self.user.password
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+        self.user.update(is_suspended=True)
+
+        response = self.confirm_recovery(password_hash.hash)
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid or expired recovery token"}
+        self.user.refresh_from_db()
+        assert self.user.password == previous_password
+        assert not LostPasswordHash.objects.filter(user=self.user).exists()
+
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_rejects_managed_account(self, send_recovery_email: MagicMock) -> None:
+        previous_password = self.user.password
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+        self.user.update(is_managed=True)
+
+        response = self.confirm_recovery(password_hash.hash)
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Invalid or expired recovery token"}
+        self.user.refresh_from_db()
+        assert self.user.password == previous_password
+        assert not LostPasswordHash.objects.filter(user=self.user).exists()
+
+    @patch(
+        "sentry.api.endpoints.auth_recovery.ratelimiter.backend.is_limited",
+        return_value=True,
+    )
+    def test_confirm_recovery_rate_limited(self, is_limited: MagicMock) -> None:
+        response = self.client.post(reverse("sentry-api-0-auth-recovery-confirm"), data={})
+
+        assert response.status_code == 429
+        assert response.data == {"detail": "Too many password recovery attempts"}
+
+    @override_settings(
+        AUTH_PASSWORD_VALIDATORS=[
+            {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"}
+        ]
+    )
+    @patch("sentry.users.models.lostpasswordhash.LostPasswordHash.send_recover_password_email")
+    def test_confirm_recovery_validates_password(self, send_recovery_email: MagicMock) -> None:
+        self.request_recovery()
+        password_hash = LostPasswordHash.objects.get(user=self.user)
+
+        response = self.confirm_recovery(password_hash.hash, self.user.username)
+
+        assert response.status_code == 400
+        assert response.data == {"password": ["The password is too similar to the username."]}
+        assert LostPasswordHash.objects.filter(user=self.user).exists()
+        assert "_auth_user_id" not in self.client.session


### PR DESCRIPTION
Adds private API endpoints for requesting a password-recovery email and confirming a recovery token with a new password. Recovery requests return the same accepted response for unknown and ineligible accounts, preserving the existing account-enumeration protections and rate limits.

Confirmation validates the user, token, expiration, and password policy before atomically consuming the token. A successful reset verifies the primary email, invalidates existing sessions, resets two-factor attempt limits, and does not implicitly sign the user in. The confirmation endpoint establishes the API contract for the later React recovery-confirmation flow.