### PR TITLE
feat(api): Add organization authentication config endpoint

### DIFF
--- a/src/sentry/api/endpoints/auth_organization_config.py
+++ b/src/sentry/api/endpoints/auth_organization_config.py
@@ -1,0 +1,141 @@
+import logging
+
+from django.urls import reverse
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.auth import (
+    AuthOrganizationConfig,
+    AuthOrganizationConfigSerializer,
+)
+from sentry.auth import access
+from sentry.auth.exceptions import ProviderNotRegistered
+from sentry.constants import WARN_SESSION_EXPIRED
+from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
+from sentry.models.authprovider import AuthProvider
+from sentry.models.organizationavatarreplica import OrganizationAvatarReplica
+from sentry.organizations.services.organization import organization_service
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.auth import construct_link_with_query, has_completed_sso, has_user_registration
+
+logger = logging.getLogger(__name__)
+
+
+@extend_schema(tags=["Users"])
+@control_silo_endpoint
+class AuthOrganizationConfigEndpoint(Endpoint):
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.FOUNDATIONS
+    permission_classes = ()
+
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {RateLimitCategory.IP: RateLimit(limit=20, window=1)},
+        }
+    )
+
+    @extend_schema(
+        operation_id="Retrieve organization login configuration",
+        responses={200: AuthOrganizationConfigSerializer},
+    )
+    def get(self, request: Request, organization_id_or_slug: str) -> Response:
+        organization_context = organization_service.get_organization_by_slug(
+            slug=organization_id_or_slug,
+            only_visible=True,
+            user_id=request.user.id if request.user.is_authenticated else None,
+            include_projects=False,
+            include_teams=False,
+        )
+        if organization_context is None:
+            raise NotFound()
+
+        organization = organization_context.organization
+        auth_provider = AuthProvider.objects.filter(organization_id=organization.id).first()
+        avatar = OrganizationAvatarReplica.objects.filter(organization_id=organization.id).first()
+
+        provider = None
+        if auth_provider is not None:
+            try:
+                provider = auth_provider.get_provider()
+            except ProviderNotRegistered:
+                logger.exception(
+                    "auth.organization_config.provider_not_registered",
+                    extra={"organization_id": organization.id, "provider": auth_provider.provider},
+                )
+                return Response(
+                    {"detail": "Organization authentication is temporarily unavailable"},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
+        organization_access = access.from_request_org_and_scopes(
+            request=request, rpc_user_org_context=organization_context
+        )
+        member_authenticated = bool(
+            request.user.is_authenticated
+            and organization_access.has_scope("org:read")
+            and (
+                not organization_access.requires_sso
+                or (
+                    organization_access.sso_is_valid and has_completed_sso(request, organization.id)
+                )
+            )
+        )
+        join_request_url = None
+        if auth_provider is None and organization.get_option("sentry:join_requests") is not False:
+            join_request_url = construct_link_with_query(
+                path=reverse("sentry-join-request", args=[organization.slug]),
+                query_params=request.GET,
+            )
+
+        warnings = []
+        if (
+            request.user.is_authenticated
+            and organization_context.member is None
+            and not organization_access.has_global_access
+            and not (is_demo_mode_enabled() and is_demo_org(organization))
+        ):
+            warnings.append(
+                f"Your account ({request.user.email}) is not a member of the "
+                f"{organization.name} organization. Ask an organization admin to "
+                "invite you, or sign in with a different account."
+            )
+
+        session_expired = "session_expired" in request.COOKIES
+        if session_expired:
+            warnings.append(str(WARN_SESSION_EXPIRED))
+
+        auth_org_config = AuthOrganizationConfig(
+            authenticated=request.user.is_authenticated,
+            member_authenticated=member_authenticated,
+            can_register=bool(has_user_registration() or request.session.get("can_register")),
+            join_request_url=join_request_url,
+            login_method="sso" if provider is not None else "password",
+            sso_required=bool(auth_provider is not None and not auth_provider.flags.allow_unlinked),
+            organization={
+                "avatarUrl": (
+                    avatar.absolute_url()
+                    if avatar is not None and avatar.avatar_type == 1
+                    else None
+                ),
+                "name": organization.name,
+                "slug": organization.slug,
+            },
+            provider={"key": provider.key, "name": provider.name} if provider else None,
+            warnings=warnings,
+        )
+        response = Response(
+            serialize(auth_org_config, request.user, AuthOrganizationConfigSerializer()),
+            status=status.HTTP_200_OK,
+        )
+        if session_expired:
+            response.delete_cookie("session_expired")
+
+        return response

--- a/src/sentry/api/serializers/models/auth.py
+++ b/src/sentry/api/serializers/models/auth.py
@@ -259,3 +259,67 @@ class AuthRecoveryAcceptedSerializer(Serializer[AuthRecoveryAcceptedSerializerRe
         **kwargs: Any,
     ) -> AuthRecoveryAcceptedSerializerResponse:
         return {"detail": "If an eligible account exists, a recovery email has been sent."}
+
+
+class AuthOrganizationConfigOrganization(TypedDict):
+    avatarUrl: str | None
+    name: str
+    slug: str
+
+
+class AuthOrganizationConfigProvider(TypedDict):
+    key: str
+    name: str
+
+
+# Serializer attribute maps use response objects as identity-keyed dictionary keys.
+@dataclass(eq=False)
+class AuthOrganizationConfig:
+    """Organization login configuration and the caller's authentication state."""
+
+    authenticated: bool
+    """Whether the caller has a global Sentry session."""
+
+    member_authenticated: bool
+    """Whether the caller can access this organization, including required SSO."""
+
+    can_register: bool
+    join_request_url: str | None
+    login_method: Literal["password", "sso"]
+    sso_required: bool
+    organization: AuthOrganizationConfigOrganization
+    provider: AuthOrganizationConfigProvider | None
+    warnings: list[str]
+
+
+class AuthOrganizationConfigSerializerResponse(TypedDict):
+    authenticated: bool
+    memberAuthenticated: bool
+    canRegister: bool
+    joinRequestUrl: str | None
+    loginMethod: Literal["password", "sso"]
+    ssoRequired: bool
+    organization: AuthOrganizationConfigOrganization
+    provider: AuthOrganizationConfigProvider | None
+    warnings: list[str]
+
+
+class AuthOrganizationConfigSerializer(Serializer[AuthOrganizationConfigSerializerResponse]):
+    def serialize(
+        self,
+        obj: AuthOrganizationConfig,
+        attrs: Mapping[str, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> AuthOrganizationConfigSerializerResponse:
+        return {
+            "authenticated": obj.authenticated,
+            "memberAuthenticated": obj.member_authenticated,
+            "canRegister": obj.can_register,
+            "joinRequestUrl": obj.join_request_url,
+            "loginMethod": obj.login_method,
+            "ssoRequired": obj.sso_required,
+            "organization": obj.organization,
+            "provider": obj.provider,
+            "warnings": obj.warnings,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -733,6 +733,7 @@ from .endpoints.auth_2fa import AuthTwoFactorChallengeEndpoint, AuthTwoFactorEnd
 from .endpoints.auth_config import AuthConfigEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.auth_login import AuthLoginEndpoint
+from .endpoints.auth_organization_config import AuthOrganizationConfigEndpoint
 from .endpoints.auth_recovery import AuthRecoveryConfirmEndpoint, AuthRecoveryEndpoint
 from .endpoints.auth_validate import AuthValidateEndpoint
 from .endpoints.broadcast_details import BroadcastDetailsEndpoint
@@ -1086,6 +1087,11 @@ AUTH_URLS = [
         r"^login/$",
         AuthLoginEndpoint.as_view(),
         name="sentry-api-0-auth-login",
+    ),
+    re_path(
+        r"^organizations/(?P<organization_id_or_slug>[^/]+)/config/$",
+        AuthOrganizationConfigEndpoint.as_view(),
+        name="sentry-api-0-auth-organization-config",
     ),
     re_path(
         r"^recovery/$",

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -101,6 +101,7 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.artifactbundle import ArtifactBundle
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
+from sentry.models.avatars.organization_avatar import OrganizationAvatar
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitcomparison import CommitComparison
@@ -526,6 +527,12 @@ class Factories:
         if owner:
             Factories.create_member(organization=org, user_id=owner.id, role="owner")
         return org
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_organization_avatar(*args, **kwargs) -> OrganizationAvatar:
+        with outbox_runner():
+            return OrganizationAvatar.objects.create(*args, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -185,6 +185,9 @@ class Fixtures:
     def create_organization(self, *args, **kwargs):
         return Factories.create_organization(*args, **kwargs)
 
+    def create_organization_avatar(self, *args, **kwargs):
+        return Factories.create_organization_avatar(*args, **kwargs)
+
     def create_investigation(self, *args, **kwargs):
         return Factories.create_investigation(*args, **kwargs)
 

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -155,6 +155,7 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/auth/$'),
   new RegExp('^api/0/auth/config/$'),
   new RegExp('^api/0/auth/login/$'),
+  new RegExp('^api/0/auth/organizations/[^/]+/config/$'),
   new RegExp('^api/0/auth/recovery/$'),
   new RegExp('^api/0/auth/recovery/confirm/$'),
   new RegExp('^api/0/auth/2fa/$'),

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -28,6 +28,7 @@ export type KnownSentryApiUrls =
   | '/auth/2fa/challenge/'
   | '/auth/config/'
   | '/auth/login/'
+  | '/auth/organizations/$organizationIdOrSlug/config/'
   | '/auth/recovery/'
   | '/auth/recovery/confirm/'
   | '/auth/validate/'

--- a/tests/sentry/api/endpoints/test_auth_organization_config.py
+++ b/tests/sentry/api/endpoints/test_auth_organization_config.py
@@ -1,0 +1,198 @@
+from unittest import mock
+
+from sentry.auth.exceptions import ProviderNotRegistered
+from sentry.organizations.services.organization import organization_service
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+
+
+@control_silo_test
+class AuthOrganizationConfigEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-auth-organization-config"
+    method = "get"
+
+    def test_password_login_configuration_is_public(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data == {
+            "authenticated": False,
+            "memberAuthenticated": False,
+            "canRegister": False,
+            "joinRequestUrl": "/join-request/acme/",
+            "loginMethod": "password",
+            "ssoRequired": False,
+            "organization": {
+                "avatarUrl": None,
+                "name": "Acme",
+                "slug": "acme",
+            },
+            "provider": None,
+            "warnings": [],
+        }
+
+    def test_sso_login_configuration(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        self.create_auth_provider(organization_id=organization.id, provider="dummy")
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["loginMethod"] == "sso"
+        assert response.data["provider"] == {"key": "dummy", "name": "Dummy"}
+        assert response.data["ssoRequired"] is True
+        assert response.data["joinRequestUrl"] is None
+
+    def test_sso_is_optional_when_unlinked_members_are_allowed(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        auth_provider = self.create_auth_provider(organization_id=organization.id, provider="dummy")
+        auth_provider.flags.allow_unlinked = True
+        auth_provider.save()
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["loginMethod"] == "sso"
+        assert response.data["ssoRequired"] is False
+
+    def test_unregistered_sso_provider_is_temporarily_unavailable(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        self.create_auth_provider(organization_id=organization.id, provider="dummy")
+
+        with mock.patch(
+            "sentry.api.endpoints.auth_organization_config.AuthProvider.get_provider",
+            side_effect=ProviderNotRegistered("dummy"),
+        ):
+            response = self.get_error_response(organization.slug, status_code=503)
+
+        assert response.data == {"detail": "Organization authentication is temporarily unavailable"}
+
+    def test_avatar_url(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        file = self.create_file(name="avatar.png")
+        avatar = self.create_organization_avatar(
+            organization=organization,
+            avatar_type=1,
+            file_id=file.id,
+        )
+
+        response = self.get_success_response(organization.slug)
+        with assume_test_silo_mode(SiloMode.CELL):
+            avatar_url = avatar.absolute_url()
+
+        assert response.data["organization"]["avatarUrl"] == avatar_url
+
+    def test_letter_avatar_has_no_url(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        self.create_organization_avatar(organization=organization, avatar_type=0)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["organization"]["avatarUrl"] is None
+
+    def test_unknown_organization(self) -> None:
+        self.get_error_response("does-not-exist", status_code=404)
+
+    def test_authenticated_non_member_warning(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        user = self.create_user(email="user@example.com")
+        self.login_as(user)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["authenticated"] is True
+        assert response.data["memberAuthenticated"] is False
+        assert response.data["warnings"] == [
+            "Your account (user@example.com) is not a member of the Acme organization. "
+            "Ask an organization admin to invite you, or sign in with a different account."
+        ]
+
+    def test_authenticated_member_can_access_password_organization(self) -> None:
+        user = self.create_user(email="user@example.com")
+        organization = self.create_organization(owner=user, name="Acme", slug="acme")
+        self.login_as(user)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["memberAuthenticated"] is True
+
+    def test_superuser_without_membership_has_global_access(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        superuser = self.create_user(email="superuser@example.com", is_superuser=True)
+        self.login_as(superuser, superuser=True)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["memberAuthenticated"] is True
+        assert response.data["warnings"] == []
+
+    def test_reuses_membership_from_organization_context(self) -> None:
+        user = self.create_user(email="user@example.com")
+        organization = self.create_organization(owner=user, name="Acme", slug="acme")
+        self.login_as(user)
+
+        with mock.patch.object(
+            organization_service,
+            "check_membership_by_id",
+            wraps=organization_service.check_membership_by_id,
+        ) as check_membership:
+            self.get_success_response(organization.slug)
+
+        check_membership.assert_not_called()
+
+    def test_authenticated_member_requires_sso(self) -> None:
+        owner = self.create_user(email="owner@example.com")
+        organization = self.create_organization(owner=owner, name="Acme", slug="acme")
+        user = self.create_user(email="user@example.com")
+        self.create_member(organization=organization, user=user)
+        self.create_auth_provider(organization_id=organization.id, provider="dummy")
+        self.login_as(user)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["authenticated"] is True
+        assert response.data["memberAuthenticated"] is False
+
+    def test_authenticated_member_has_completed_sso(self) -> None:
+        owner = self.create_user(email="owner@example.com")
+        organization = self.create_organization(owner=owner, name="Acme", slug="acme")
+        user = self.create_user(email="user@example.com")
+        self.create_member(organization=organization, user=user)
+        auth_provider = self.create_auth_provider(organization_id=organization.id, provider="dummy")
+        self.create_auth_identity(auth_provider=auth_provider, user_id=user.id, ident=user.email)
+        member = organization_service.check_membership_by_id(
+            organization_id=organization.id, user_id=user.id
+        )
+        assert member is not None
+        setattr(member.flags, "sso:linked", True)
+        organization_service.update_membership_flags(organization_member=member)
+        self.login_as(user, organization_id=organization.id)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["memberAuthenticated"] is True
+
+    def test_join_requests_disabled(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        with assume_test_silo_mode(SiloMode.CELL):
+            organization.update_option("sentry:join_requests", False)
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["joinRequestUrl"] is None
+
+    def test_preserves_query_string_in_join_request_url(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+
+        response = self.get_success_response(organization.slug, next="/issues/")
+
+        assert response.data["joinRequestUrl"] == "/join-request/acme/?next=%2Fissues%2F"
+
+    def test_session_expired_warning(self) -> None:
+        organization = self.create_organization(name="Acme", slug="acme")
+        self.client.cookies["session_expired"] = "1"
+
+        response = self.get_success_response(organization.slug)
+
+        assert response.data["warnings"] == ["Your session has expired."]
+        assert response.cookies["session_expired"]["max-age"] == 0


### PR DESCRIPTION
Adds a private, unauthenticated organization authentication-config endpoint for the React login flow. The response describes the organization, password or SSO login method, provider metadata, whether SSO is required, registration and join-request state, caller authentication state, and relevant warnings without establishing a new session. SSO remains optional when the provider allows unlinked members, and the endpoint is rate-limited by IP.

`authenticated` reports the caller’s global Sentry session, while `userIsAuthenticated` additionally requires usable access to the requested organization, including completed SSO where required. A persisted configuration whose provider is no longer registered returns a generic temporary-unavailability response rather than offering an invalid password fallback.
