### PR TITLE
ci(snapshots): Upload snapshots only on success

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload snapshots
         id: upload
-        if: ${{ !cancelled() && hashFiles('.artifacts/snapshots/**') != '' }}
+        if: ${{ success() }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SNAPSHOTS_AUTH_TOKEN }}
           BASE_SHA: ${{ steps.merge-base.outputs.sha }}


### PR DESCRIPTION
## Summary

Follow-up to #122272. The "Upload snapshots" step was gated on `!cancelled() && hashFiles('.artifacts/snapshots/**') != ''`. Per review feedback (thanks @jamieQ), simplify it to `success()`.

## Why

The visual diff happens **server-side** — `pnpm run snapshots` just captures screenshots and exits 0 on a normal UI change; the comparison runs in the snapshots service via `--base-sha`. So gating on `success()` does **not** skip UI-change PRs (a common worry — it doesn't apply here).

`success()` is also simpler than the previous gate:

- It **subsumes the empty-dir fix** from #122272: a failed install isn't `success()`, so the upload skips on its own — no `hashFiles` check needed, no cryptic `Path is not a directory` error.
- The only behavior it drops: the old `!cancelled()` also uploaded when the snapshot test step **hard-errored**, pushing the partial screenshot set that captured before the crash. Those uploads are skipped now — which is fine-to-better, since a partial set can read as spurious "removed" diffs. The job still goes red on a hard error; we just don't push an incomplete batch.

## Testing

CI-only; passes actionlint.
