### PR TITLE
fix(workflow_engine): Fix TaggedEventHandler logging

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -91,7 +91,7 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
 
         # This represents the fetched tag values given the provided key
         # so eg. if the key is 'environment' and the tag_value is 'production'
-        tag_values = (
+        tag_values = tuple(
             v.lower()
             for k, v in raw_tags
             if k.lower() == key or tagstore.backend.get_standardized_key(k) == key

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -1,4 +1,5 @@
 from typing import Any, Mapping
+from unittest.mock import patch
 
 import pytest
 from jsonschema import ValidationError
@@ -180,6 +181,15 @@ class TestTaggedEventCondition(ConditionTestCase):
             }
         )
         self.assert_does_not_pass(self.dc, self.event_data)
+
+    def test_logs_processed_values(self) -> None:
+        with patch(
+            "sentry.workflow_engine.handlers.condition.tagged_event_handler.logger"
+        ) as mock_logger:
+            self.assert_passes(self.dc, self.event_data)
+
+        processed_values = mock_logger.debug.call_args.kwargs["extra"]["processed_values"]
+        assert set(processed_values) == {"sentry.example", "foo.bar"}
 
     def test_does_not_equal(self) -> None:
         self.dc.comparison.update(


### PR DESCRIPTION
Logging a generator gives us no real info, we should log the tuple.
