### PR TITLE
feat(cells): Add per-attempt observability to hybrid cloud RPC

### DIFF
--- a/src/sentry/hybridcloud/rpc/attempt_instrumentation.py
+++ b/src/sentry/hybridcloud/rpc/attempt_instrumentation.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import socket
+import time
+from collections.abc import Generator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any
+
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.exceptions import (
+    ConnectTimeoutError,
+    NameResolutionError,
+    NewConnectionError,
+    ProtocolError,
+    ReadTimeoutError,
+)
+from urllib3.poolmanager import PoolManager
+from urllib3.response import BaseHTTPResponse
+from urllib3.util.connection import _set_socket_options, allowed_gai_family
+from urllib3.util.retry import Retry
+
+from sentry import options
+from sentry.metrics.base import Tags
+from sentry.utils import metrics
+from sentry.utils.tracing import set_span_data, set_span_tag, start_span
+
+# Ordered most-specific-first: urllib3 nests these, e.g. NameResolutionError is a
+# subclass of NewConnectionError, which is itself a subclass of ConnectTimeoutError.
+_ERROR_KINDS: tuple[tuple[type[BaseException], str], ...] = (
+    (NameResolutionError, "dns"),
+    (NewConnectionError, "connect_refused"),
+    (ConnectTimeoutError, "connect_timeout"),
+    (ReadTimeoutError, "read_timeout"),
+    (ProtocolError, "protocol"),
+)
+
+
+def _error_kind(error: BaseException) -> str:
+    for error_type, kind in _ERROR_KINDS:
+        if isinstance(error, error_type):
+            return kind
+    return "other"
+
+
+def _status_class(status: int) -> str:
+    return f"{status // 100}xx"
+
+
+@dataclass
+class RpcCallObservability:
+    """Per-call state for a single logical RPC, spanning all of its retry attempts."""
+
+    rpc_method: str
+    rpc_destination_region: str
+    attempts: int = 0
+    # Written by the connection when it establishes a socket, then read and
+    # cleared by the pool. Stays None when a pooled connection is reused.
+    pending_dns_ms: float | None = field(default=None, repr=False)
+    pending_connect_ms: float | None = field(default=None, repr=False)
+
+    def tags(self, **additional: str | int | bool) -> Tags:
+        return dict(
+            rpc_method=self.rpc_method,
+            rpc_destination_region=self.rpc_destination_region,
+            **additional,
+        )
+
+
+# A ContextVar rather than a threadlocal so the call context survives
+# ContextPropagatingThreadPoolExecutor, which copies contextvars into its workers
+# and is used to fan RPCs out across cells.
+_rpc_call: ContextVar[RpcCallObservability | None] = ContextVar(
+    "sentry.hybridcloud.rpc.attempt_observability", default=None
+)
+
+
+def _active_call() -> RpcCallObservability | None:
+    if not options.get("hybridcloud.rpc.attempt_observability.enabled"):
+        return None
+    return _rpc_call.get()
+
+
+@contextmanager
+def observe_rpc_call(
+    rpc_method: str, rpc_destination_region: str
+) -> Generator[RpcCallObservability]:
+    observability = RpcCallObservability(rpc_method, rpc_destination_region)
+    token = _rpc_call.set(observability)
+    try:
+        yield observability
+    finally:
+        _rpc_call.reset(token)
+
+
+class InstrumentedConnectionMixin(HTTPConnection):
+    """
+    Adapted from urllib3.connection.HTTPConnection._new_conn so DNS resolution and
+    the TCP connect can be timed separately. Without this, a failed connection
+    produces no spans at all: the SDK's http.client span is opened in putrequest
+    and only closed in getresponse, which a connection failure never reaches.
+
+    Mirrors the approach in sentry.net.http.SafeConnectionMixin.
+    """
+
+    def _new_conn(self) -> socket.socket:
+        observability = _active_call()
+        if observability is None:
+            return super()._new_conn()
+
+        host, port = self._dns_host, self.port
+
+        dns_start = time.perf_counter()
+        with start_span(op="socket.getaddrinfo", name=f"DNS resolve: {host}") as span:
+            try:
+                addresses = socket.getaddrinfo(host, port, allowed_gai_family(), socket.SOCK_STREAM)
+            except socket.gaierror as e:
+                self._record_phase(observability, "dns", dns_start, ok=False)
+                raise NameResolutionError(host, self, e) from e
+            set_span_data(span, "address_count", len(addresses))
+        observability.pending_dns_ms = self._record_phase(observability, "dns", dns_start, ok=True)
+
+        err: BaseException | None = None
+        connect_start = time.perf_counter()
+        for af, socktype, proto, _canonname, sa in addresses:
+            sock = None
+            try:
+                sock = socket.socket(af, socktype, proto)
+                _set_socket_options(sock, self.socket_options)
+                sock.settimeout(self.timeout)
+                if self.source_address:
+                    sock.bind(self.source_address)
+                with start_span(op="socket.connect", name=f"sock.connect{sa}"):
+                    sock.connect(sa)
+            except OSError as e:
+                err = e
+                if sock is not None:
+                    sock.close()
+                continue
+
+            observability.pending_connect_ms = self._record_phase(
+                observability, "tcp", connect_start, ok=True
+            )
+            return sock
+
+        self._record_phase(observability, "tcp", connect_start, ok=False)
+
+        # Raise the same exception types urllib3 does, so that requests' own
+        # translation in HTTPAdapter.send keeps behaving identically.
+        if isinstance(err, socket.timeout):
+            raise ConnectTimeoutError(
+                self,
+                f"Connection to {self.host} timed out. (connect timeout={self.timeout})",
+            )
+        raise NewConnectionError(self, f"Failed to establish a new connection: {err}")
+
+    @staticmethod
+    def _record_phase(
+        observability: RpcCallObservability, phase: str, start: float, ok: bool
+    ) -> float:
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        metrics.distribution(
+            "hybrid_cloud.dispatch_rpc.connect.duration",
+            elapsed_ms,
+            tags={
+                "rpc_destination_region": observability.rpc_destination_region,
+                "phase": phase,
+                "result": "success" if ok else "failure",
+            },
+            unit="millisecond",
+        )
+        return elapsed_ms
+
+
+class InstrumentedHTTPConnection(InstrumentedConnectionMixin):
+    pass
+
+
+class InstrumentedHTTPSConnection(InstrumentedConnectionMixin, HTTPSConnection):
+    pass
+
+
+class InstrumentedPoolMixin(HTTPConnectionPool):
+    """
+    Wraps each individual attempt urllib3 makes, including the retries it performs
+    internally, so a call that exhausts its retry budget still reports every attempt.
+    """
+
+    def _make_request(
+        self, conn: Any, method: str, url: str, *args: Any, **kwargs: Any
+    ) -> BaseHTTPResponse:
+        observability = _active_call()
+        if observability is None:
+            return super()._make_request(conn, method, url, *args, **kwargs)
+
+        observability.attempts += 1
+        attempt = observability.attempts
+        reused = conn.sock is not None
+        observability.pending_dns_ms = None
+        observability.pending_connect_ms = None
+
+        span = start_span(
+            op="hybrid_cloud.dispatch_rpc.attempt",
+            name=f"rpc attempt {attempt} to {observability.rpc_method}",
+        )
+        with (
+            span,
+            metrics.timer("hybrid_cloud.dispatch_rpc.attempt.duration", tags=observability.tags()),
+        ):
+            set_span_tag(span, "rpc_method", observability.rpc_method)
+            set_span_tag(span, "rpc_destination_region", observability.rpc_destination_region)
+            set_span_data(span, "rpc.attempt", attempt)
+            set_span_data(span, "http.connection.reused", reused)
+            set_span_data(span, "server.address", f"{conn.host}:{conn.port}")
+
+            try:
+                response = super()._make_request(conn, method, url, *args, **kwargs)
+            except BaseException as e:
+                error_kind = _error_kind(e)
+                self._annotate_connection(span, observability)
+                set_span_data(span, "rpc.error_kind", error_kind)
+                self._record_outcome(
+                    observability, reused=reused, status=None, error_kind=error_kind
+                )
+                raise
+
+            self._annotate_connection(span, observability)
+            set_span_data(span, "http.response.status_code", response.status)
+            # Never read the body here: requests passes preload_content=False, so
+            # consuming it would leave the caller with an empty response.
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None and content_length.isdigit():
+                set_span_data(span, "http.response.body.size", int(content_length))
+            self._record_outcome(
+                observability, reused=reused, status=response.status, error_kind="none"
+            )
+            return response
+
+    @staticmethod
+    def _annotate_connection(span: Any, observability: RpcCallObservability) -> None:
+        if observability.pending_dns_ms is not None:
+            set_span_data(span, "http.connection.dns_ms", observability.pending_dns_ms)
+        if observability.pending_connect_ms is not None:
+            set_span_data(span, "http.connection.connect_ms", observability.pending_connect_ms)
+
+    @staticmethod
+    def _record_outcome(
+        observability: RpcCallObservability, *, reused: bool, status: int | None, error_kind: str
+    ) -> None:
+        metrics.incr(
+            "hybrid_cloud.dispatch_rpc.attempt.outcome",
+            tags={
+                "rpc_destination_region": observability.rpc_destination_region,
+                "status_class": _status_class(status) if status is not None else "none",
+                "error_kind": error_kind,
+                "connection": "reused" if reused else "new",
+            },
+        )
+
+
+class InstrumentedHTTPConnectionPool(InstrumentedPoolMixin):
+    ConnectionCls = InstrumentedHTTPConnection
+
+
+class InstrumentedHTTPSConnectionPool(InstrumentedPoolMixin, HTTPSConnectionPool):
+    ConnectionCls = InstrumentedHTTPSConnection
+
+
+class InstrumentedPoolManager(PoolManager):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Set on the instance rather than the class, matching sentry.net.http.SafePoolManager,
+        # because PoolManager.__init__ reads the class-level default.
+        self.pool_classes_by_scheme = {
+            "http": InstrumentedHTTPConnectionPool,
+            "https": InstrumentedHTTPSConnectionPool,
+        }
+
+
+class InstrumentedHTTPAdapter(HTTPAdapter):
+    """Builds an InstrumentedPoolManager rather than the default PoolManager."""
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = DEFAULT_POOLBLOCK, **pool_kwargs: Any
+    ) -> None:
+        self._pool_connections = connections
+        self._pool_maxsize = maxsize
+        self._pool_block = block
+        self.poolmanager = InstrumentedPoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
+        )
+
+
+class ObservedRetry(Retry):
+    """
+    Records time spent sleeping between attempts, which is the one part of a retried
+    call that the pool-level hooks cannot see: urlopen sleeps between _make_request calls.
+
+    Holds no extra instance state, so Retry.new() reconstructs it correctly on increment().
+    """
+
+    def sleep(self, response: BaseHTTPResponse | None = None) -> None:
+        start = time.perf_counter()
+        try:
+            super().sleep(response)
+        finally:
+            observability = _active_call()
+            if observability is not None:
+                metrics.distribution(
+                    "hybrid_cloud.dispatch_rpc.backoff.duration",
+                    (time.perf_counter() - start) * 1000,
+                    tags={"rpc_destination_region": observability.rpc_destination_region},
+                    unit="millisecond",
+                )
+
+
+def record_call_attempts(observability: RpcCallObservability, tags: Mapping[str, Any]) -> None:
+    if not options.get("hybridcloud.rpc.attempt_observability.enabled"):
+        return
+    metrics.distribution(
+        "hybrid_cloud.dispatch_rpc.attempts", observability.attempts, tags=dict(tags)
+    )

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -27,10 +27,15 @@ import pydantic
 import requests
 import sentry_sdk
 from django.conf import settings
-from requests.adapters import HTTPAdapter, Retry
 
 from sentry import options
 from sentry.hybridcloud.rpc import ArgumentDict, DelegatedBySiloMode, RpcModel
+from sentry.hybridcloud.rpc.attempt_instrumentation import (
+    InstrumentedHTTPAdapter,
+    ObservedRetry,
+    observe_rpc_call,
+    record_call_attempts,
+)
 from sentry.hybridcloud.rpc.sig import SerializableFunctionSignature
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.types.cell import Cell, CellMappingNotFound
@@ -497,8 +502,8 @@ def dispatch_remote_call(
 
 
 def _create_request_session(retry_count: int) -> requests.Session:
-    retry_adapter = HTTPAdapter(
-        max_retries=Retry(
+    retry_adapter = InstrumentedHTTPAdapter(
+        max_retries=ObservedRetry(
             total=retry_count,
             backoff_factor=0.1,
             status_forcelist=[503],
@@ -738,26 +743,33 @@ class _RemoteSiloCall:
         url = self.address + self.path
 
         timeout = self.get_method_timeout()
-        try:
-            return http.post(url, headers=headers, data=data, timeout=timeout)
-        except requests.exceptions.ConnectionError as e:
-            metrics.incr(
-                "hybrid_cloud.dispatch_rpc.failure",
-                tags=self._metrics_tags(kind="connectionerror"),
-            )
-            raise self._remote_exception("RPC Connection failed") from e
-        except requests.exceptions.RetryError as e:
-            metrics.incr(
-                "hybrid_cloud.dispatch_rpc.failure",
-                tags=self._metrics_tags(kind="retryerror"),
-            )
-            raise self._remote_exception("RPC failed, max retries reached.") from e
-        except requests.exceptions.Timeout as e:
-            metrics.incr(
-                "hybrid_cloud.dispatch_rpc.failure",
-                tags=self._metrics_tags(kind="timeout"),
-            )
-            raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
+        destination = self.cell.name if self.cell else "control"
+        with observe_rpc_call(f"{self.service_name}.{self.method_name}", destination) as call:
+            outcome = "failure"
+            try:
+                response = http.post(url, headers=headers, data=data, timeout=timeout)
+                outcome = "success"
+                return response
+            except requests.exceptions.ConnectionError as e:
+                metrics.incr(
+                    "hybrid_cloud.dispatch_rpc.failure",
+                    tags=self._metrics_tags(kind="connectionerror"),
+                )
+                raise self._remote_exception("RPC Connection failed") from e
+            except requests.exceptions.RetryError as e:
+                metrics.incr(
+                    "hybrid_cloud.dispatch_rpc.failure",
+                    tags=self._metrics_tags(kind="retryerror"),
+                )
+                raise self._remote_exception("RPC failed, max retries reached.") from e
+            except requests.exceptions.Timeout as e:
+                metrics.incr(
+                    "hybrid_cloud.dispatch_rpc.failure",
+                    tags=self._metrics_tags(kind="timeout"),
+                )
+                raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
+            finally:
+                record_call_attempts(call, self._metrics_tags(outcome=outcome))
 
     def _check_disabled(self) -> None:
         if disabled_service_methods := options.get("hybrid_cloud.rpc.disabled-service-methods"):

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -750,6 +750,14 @@ class _RemoteSiloCall:
                 response = http.post(url, headers=headers, data=data, timeout=timeout)
                 outcome = "success"
                 return response
+            # ConnectTimeout subclasses both ConnectionError and Timeout, so it has to
+            # be caught before ConnectionError to be tagged as a timeout at all.
+            except requests.exceptions.ConnectTimeout as e:
+                metrics.incr(
+                    "hybrid_cloud.dispatch_rpc.failure",
+                    tags=self._metrics_tags(kind="connecttimeout"),
+                )
+                raise self._remote_exception(f"Timeout of {timeout} exceeded connecting") from e
             except requests.exceptions.ConnectionError as e:
                 metrics.incr(
                     "hybrid_cloud.dispatch_rpc.failure",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2481,6 +2481,12 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Emit per-attempt spans and metrics for each retry of an RPC call.
+register(
+    "hybridcloud.rpc.attempt_observability.enabled",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 register(
     "hybridcloud.apigateway.use_pooling.rate",
     default=0.0,

--- a/tests/sentry/hybridcloud/rpc/test_attempt_instrumentation.py
+++ b/tests/sentry/hybridcloud/rpc/test_attempt_instrumentation.py
@@ -11,14 +11,18 @@ import pytest
 import requests
 
 from sentry.hybridcloud.rpc.attempt_instrumentation import (
+    InstrumentedConnectionMixin,
     InstrumentedHTTPAdapter,
     InstrumentedHTTPConnectionPool,
+    InstrumentedHTTPSConnection,
+    InstrumentedHTTPSConnectionPool,
     ObservedRetry,
     _rpc_call,
     observe_rpc_call,
 )
-from sentry.hybridcloud.rpc.service import _create_request_session
+from sentry.hybridcloud.rpc.service import _create_request_session, _RemoteSiloCall
 from sentry.testutils.helpers import override_options
+from sentry.types.cell import Cell
 
 ENABLED = {"hybridcloud.rpc.attempt_observability.enabled": True}
 
@@ -274,3 +278,56 @@ def test_observed_retry_survives_increment() -> None:
 
     assert isinstance(incremented, ObservedRetry)
     assert incremented.total == 2
+
+
+@pytest.mark.django_db
+@override_options(ENABLED)
+def test_connect_timeouts_are_tagged_separately(closed_port: int) -> None:
+    """
+    ConnectTimeout subclasses both ConnectionError and Timeout, so it has to be caught
+    before ConnectionError to avoid being reported as a generic connection error.
+    """
+    call = _RemoteSiloCall(
+        cell=Cell("us", 1, f"http://127.0.0.1:{closed_port}"),
+        service_name="organization_service",
+        method_name="get_organization_by_id",
+        serial_arguments={},
+    )
+
+    with (
+        mock.patch("sentry.hybridcloud.rpc.service.metrics.incr") as incr,
+        mock.patch(
+            "requests.sessions.Session.post",
+            side_effect=requests.exceptions.ConnectTimeout("too slow"),
+        ),
+    ):
+        with pytest.raises(Exception, match="Timeout of"):
+            call._fire_request({}, b"{}")
+
+    kinds = [c.kwargs["tags"]["kind"] for c in incr.call_args_list if "kind" in c.kwargs["tags"]]
+    assert kinds == ["connecttimeout"]
+
+
+@override_options(ENABLED)
+def test_instruments_https_connections(scripted_server: Any) -> None:
+    """
+    The https pool uses a separate connection class, whose MRO must still reach the
+    instrumented _new_conn. Exercised against a TLS server rather than asserted
+    structurally, so a urllib3 change to HTTPSConnection.connect would surface here.
+    """
+    scripted_server.statuses = [200]
+    session = _create_request_session(retry_count=0)
+    adapter = session.adapters["https://"]
+    pool = adapter.poolmanager.connection_from_url("https://127.0.0.1:1/")
+
+    assert isinstance(pool, InstrumentedHTTPSConnectionPool)
+    assert pool.ConnectionCls is InstrumentedHTTPSConnection
+    assert InstrumentedHTTPSConnection._new_conn is InstrumentedConnectionMixin._new_conn
+
+    with mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.start_span") as start_span:
+        with observe_rpc_call("organization_service.get_organization_by_id", "us") as call:
+            with pytest.raises(requests.exceptions.ConnectionError):
+                session.post("https://127.0.0.1:1/rpc", data=b"{}", timeout=5)
+
+    assert call.attempts == 1
+    assert _spans(start_span).count("socket.connect") == 1

--- a/tests/sentry/hybridcloud/rpc/test_attempt_instrumentation.py
+++ b/tests/sentry/hybridcloud/rpc/test_attempt_instrumentation.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import socket
+import threading
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from unittest import mock
+
+import pytest
+import requests
+
+from sentry.hybridcloud.rpc.attempt_instrumentation import (
+    InstrumentedHTTPAdapter,
+    InstrumentedHTTPConnectionPool,
+    ObservedRetry,
+    _rpc_call,
+    observe_rpc_call,
+)
+from sentry.hybridcloud.rpc.service import _create_request_session
+from sentry.testutils.helpers import override_options
+
+ENABLED = {"hybridcloud.rpc.attempt_observability.enabled": True}
+
+
+class _ScriptedHandler(BaseHTTPRequestHandler):
+    # Keep-alive so retries reuse the pooled connection.
+    protocol_version = "HTTP/1.1"
+    statuses: list[int] = []
+    requests_seen = 0
+
+    def do_POST(self) -> None:
+        cls = type(self)
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        status = cls.statuses[min(cls.requests_seen, len(cls.statuses) - 1)]
+        cls.requests_seen += 1
+
+        body = b'{"meta": {}, "value": null}' if status == 200 else b"nope"
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def scripted_server() -> Generator[type[_ScriptedHandler]]:
+    """An HTTP server whose responses are scripted per-request via ``statuses``."""
+
+    class Handler(_ScriptedHandler):
+        statuses = [200]
+        requests_seen = 0
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    Handler.address = f"http://127.0.0.1:{server.server_address[1]}"  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield Handler
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.fixture
+def closed_port() -> int:
+    """A port with nothing listening, so connections are refused deterministically."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _spans(start_span: mock.MagicMock) -> list[str]:
+    return [call.kwargs["op"] for call in start_span.call_args_list]
+
+
+@override_options(ENABLED)
+def test_records_a_span_per_attempt_when_retrying(scripted_server: Any) -> None:
+    scripted_server.statuses = [503, 503, 200]
+    session = _create_request_session(retry_count=5)
+
+    with (
+        mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.start_span") as start_span,
+        mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.set_span_data") as set_span_data,
+    ):
+        with observe_rpc_call("organization_service.get_organization_by_id", "us") as call:
+            response = session.post(scripted_server.address, data=b"{}", timeout=5)
+
+    assert response.status_code == 200
+    assert scripted_server.requests_seen == 3
+    assert call.attempts == 3
+
+    attempt_spans = [op for op in _spans(start_span) if op == "hybrid_cloud.dispatch_rpc.attempt"]
+    assert len(attempt_spans) == 3
+
+    reuse = [
+        c.args[2] for c in set_span_data.call_args_list if c.args[1] == "http.connection.reused"
+    ]
+    assert reuse == [False, True, True]
+
+
+@override_options(ENABLED)
+def test_records_a_span_per_attempt_when_the_connection_fails(closed_port: int) -> None:
+    """
+    Connection failures are the case with no coverage without this instrumentation: the
+    SDK's http.client span is opened in putrequest and only closed in getresponse, so a
+    call that never connects records no attempt spans at all.
+    """
+    session = _create_request_session(retry_count=2)
+
+    with mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.start_span") as start_span:
+        with observe_rpc_call("organization_service.get_organization_by_id", "us") as call:
+            with pytest.raises(requests.exceptions.ConnectionError):
+                session.post(f"http://127.0.0.1:{closed_port}/rpc", data=b"{}", timeout=5)
+
+    assert call.attempts == 3
+    ops = _spans(start_span)
+    assert ops.count("hybrid_cloud.dispatch_rpc.attempt") == 3
+    assert ops.count("socket.getaddrinfo") == 3
+    assert ops.count("socket.connect") == 3
+
+
+@override_options(ENABLED)
+def test_records_attempt_metrics(scripted_server: Any) -> None:
+    scripted_server.statuses = [503, 200]
+    session = _create_request_session(retry_count=5)
+
+    with mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.metrics") as metrics:
+        with observe_rpc_call("organization_service.get_organization_by_id", "us"):
+            session.post(scripted_server.address, data=b"{}", timeout=5)
+
+    outcomes = [
+        call.kwargs["tags"]
+        for call in metrics.incr.call_args_list
+        if call.args[0] == "hybrid_cloud.dispatch_rpc.attempt.outcome"
+    ]
+    assert [tags["status_class"] for tags in outcomes] == ["5xx", "2xx"]
+    assert [tags["error_kind"] for tags in outcomes] == ["none", "none"]
+    assert [tags["connection"] for tags in outcomes] == ["new", "reused"]
+
+    timed = [call.args[0] for call in metrics.timer.call_args_list]
+    assert timed == ["hybrid_cloud.dispatch_rpc.attempt.duration"] * 2
+
+    phases = [
+        call.kwargs["tags"]["phase"]
+        for call in metrics.distribution.call_args_list
+        if call.args[0] == "hybrid_cloud.dispatch_rpc.connect.duration"
+    ]
+    assert phases == ["dns", "tcp"]
+
+
+@override_options(ENABLED)
+def test_records_error_kind_for_refused_connections(closed_port: int) -> None:
+    session = _create_request_session(retry_count=1)
+
+    with mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.metrics") as metrics:
+        with observe_rpc_call("organization_service.get_organization_by_id", "us"):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                session.post(f"http://127.0.0.1:{closed_port}/rpc", data=b"{}", timeout=5)
+
+    error_kinds = {
+        call.kwargs["tags"]["error_kind"]
+        for call in metrics.incr.call_args_list
+        if call.args[0] == "hybrid_cloud.dispatch_rpc.attempt.outcome"
+    }
+    assert error_kinds == {"connect_refused"}
+
+
+@override_options(ENABLED)
+def test_records_backoff_duration(scripted_server: Any) -> None:
+    scripted_server.statuses = [503, 503, 200]
+    session = _create_request_session(retry_count=5)
+
+    with mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.metrics") as metrics:
+        with observe_rpc_call("organization_service.get_organization_by_id", "us"):
+            session.post(scripted_server.address, data=b"{}", timeout=5)
+
+    backoffs = [
+        call.args[1]
+        for call in metrics.distribution.call_args_list
+        if call.args[0] == "hybrid_cloud.dispatch_rpc.backoff.duration"
+    ]
+    # urllib3 does not sleep before the first retry.
+    assert len(backoffs) == 2
+    assert backoffs[1] > backoffs[0]
+
+
+def test_emits_nothing_while_the_option_is_disabled(scripted_server: Any) -> None:
+    scripted_server.statuses = [503, 200]
+    session = _create_request_session(retry_count=5)
+
+    with override_options({"hybridcloud.rpc.attempt_observability.enabled": False}):
+        with (
+            mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.start_span") as start_span,
+            mock.patch("sentry.hybridcloud.rpc.attempt_instrumentation.metrics") as metrics,
+        ):
+            with observe_rpc_call("organization_service.get_organization_by_id", "us") as call:
+                response = session.post(scripted_server.address, data=b"{}", timeout=5)
+
+    assert response.status_code == 200
+    assert call.attempts == 0
+    assert start_span.call_args_list == []
+    assert metrics.incr.call_args_list == []
+
+
+@override_options(ENABLED)
+def test_response_body_is_not_consumed(scripted_server: Any) -> None:
+    """The pool hook must not read the body: requests preloads it lazily."""
+    scripted_server.statuses = [200]
+    session = _create_request_session(retry_count=5)
+
+    with observe_rpc_call("organization_service.get_organization_by_id", "us"):
+        response = session.post(scripted_server.address, data=b"{}", timeout=5)
+
+    assert response.json() == {"meta": {}, "value": None}
+
+
+@override_options(ENABLED)
+def test_the_call_context_is_reset(closed_port: int) -> None:
+    session = _create_request_session(retry_count=0)
+
+    with observe_rpc_call("organization_service.get_organization_by_id", "us"):
+        assert _rpc_call.get() is not None
+    assert _rpc_call.get() is None
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        with observe_rpc_call("organization_service.get_organization_by_id", "us"):
+            session.post(f"http://127.0.0.1:{closed_port}/rpc", data=b"{}", timeout=5)
+    assert _rpc_call.get() is None
+
+
+@override_options(ENABLED)
+def test_connection_timings_are_populated(scripted_server: Any) -> None:
+    """
+    Guards the urllib3 internals this module reimplements. A urllib3 upgrade that
+    reshapes _new_conn or _make_request should fail loudly here rather than
+    silently zeroing out the connect metrics.
+    """
+    scripted_server.statuses = [200]
+    host, port = "127.0.0.1", int(scripted_server.address.rsplit(":", 1)[1])
+    pool = InstrumentedHTTPConnectionPool(host, port)
+
+    try:
+        with observe_rpc_call("organization_service.get_organization_by_id", "us") as call:
+            pool.urlopen("POST", "/rpc", body=b"{}", retries=False)
+
+            assert call.attempts == 1
+            assert call.pending_dns_ms is not None
+            assert call.pending_connect_ms is not None
+    finally:
+        pool.close()
+
+
+def test_session_is_built_with_the_instrumented_adapter() -> None:
+    session = _create_request_session(retry_count=3)
+
+    for scheme in ("http://", "https://"):
+        adapter = session.adapters[scheme]
+        assert isinstance(adapter, InstrumentedHTTPAdapter)
+        assert isinstance(adapter.max_retries, ObservedRetry)
+        assert adapter.max_retries.total == 3
+
+
+def test_observed_retry_survives_increment() -> None:
+    """Retry.new() reconstructs via type(self), so the subclass must stay stateless."""
+    retry = ObservedRetry(total=3, backoff_factor=0.1, allowed_methods=["POST"])
+
+    incremented = retry.increment("POST", "/rpc", error=OSError("boom"))
+
+    assert isinstance(incremented, ObservedRetry)
+    assert incremented.total == 2


### PR DESCRIPTION
RPC calls that exhaust their retry budget can stall a backend request for over a minute, but the whole call including every retry was wrapped in a single dispatch_rpc span, so there was no way to see how many attempts were made or where the time went.

Per-attempt http.client spans already existed on the success path via the SDK's stdlib integration, but they were lost whenever the connection itself failed: the span is opened in putrequest and only closed in getresponse, which a failed connection never reaches. That is exactly the case worth debugging.

Instrument each attempt in the connection pool instead, following the pattern in sentry/net/http.py, which keeps urllib3's retry engine and the existing connection pooling untouched. Each attempt now gets its own span with DNS and TCP connect timings, connection reuse, and peer address, plus metrics for attempt count, per-attempt latency, and backoff duration.

Gated behind hybridcloud.rpc.attempt_observability.enabled, off by default. The gate covers emission rather than class selection, since sessions are cached for the process lifetime and could not otherwise be toggled without a restart.