### PR TITLE
docs(auth): Clarify organization ID login semantics

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -332,6 +332,11 @@ def login(
     Optionally `after_2fa` can be set to a URL which will be used to override
     the regular session redirect target directly after the 2fa flow.
 
+    `organization_id` identifies the organization whose SSO authentication is
+    being completed. It is preserved through 2FA and marks SSO complete for the
+    organization after login. It must not be used only to select a post-login
+    organization or redirect destination.
+
     Returns boolean indicating if the user was logged in.
     """
     if getattr(user, "is_suspended", False):


### PR DESCRIPTION
Clarify that `organization_id` on `auth.login()` represents the organization whose SSO authentication is completing, persists through 2FA, and marks that organization's SSO session complete. This distinguishes the parameter from ordinary post-login organization selection and redirect context.