### PR TITLE
feat(seer): Make Autofix quick-add cache updates optimistic

### DIFF
--- a/static/app/utils/seer/useMutateAutofixProject.spec.tsx
+++ b/static/app/utils/seer/useMutateAutofixProject.spec.tsx
@@ -1,10 +1,15 @@
+import type {InfiniteData} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import type {SeerProjectSettingResponse} from 'sentry/utils/seer/types';
 import {
   AutofixSettingsPartialSaveError,
+  upsertSettingsRowSorted,
   useMutateAutofixProject,
 } from 'sentry/utils/seer/useMutateAutofixProject';
 
@@ -103,5 +108,111 @@ describe('useMutateAutofixProject', () => {
     // survive even when the settings write fails.
     expect(reposPut).toHaveBeenCalled();
     expect(settingsPut).toHaveBeenCalled();
+  });
+
+  describe('upsertSettingsRowSorted', () => {
+    function makeRow(
+      overrides: Partial<SeerProjectSettingResponse>
+    ): SeerProjectSettingResponse {
+      return {
+        projectId: '1',
+        projectSlug: 'a-project',
+        agent: 'seer',
+        integrationId: null,
+        stoppingPoint: 'root_cause',
+        autoCreatePr: null,
+        automationTuning: 'medium',
+        scannerAutomation: false,
+        reposCount: 1,
+        ...overrides,
+      };
+    }
+
+    function makeData(
+      ...pages: SeerProjectSettingResponse[][]
+    ): InfiniteData<ApiResponse<SeerProjectSettingResponse[]>> {
+      return {
+        pages: pages.map(json => ({headers: {}, json})),
+        pageParams: pages.map((_, index) => index),
+      };
+    }
+
+    function slugs(data: InfiniteData<ApiResponse<SeerProjectSettingResponse[]>>) {
+      return data.pages.map(page => page.json.map(item => item.projectSlug));
+    }
+
+    it('inserts by slug for the name sort', () => {
+      const data = makeData([
+        makeRow({projectId: '1', projectSlug: 'a-project'}),
+        makeRow({projectId: '2', projectSlug: 'z-project'}),
+      ]);
+      const row = makeRow({projectId: '3', projectSlug: 'm-project'});
+
+      expect(slugs(upsertSettingsRowSorted(data, row, 'name'))).toEqual([
+        ['a-project', 'm-project', 'z-project'],
+      ]);
+
+      // A descending cache holds the same list in reverse order.
+      const descendingData = makeData([
+        makeRow({projectId: '2', projectSlug: 'z-project'}),
+        makeRow({projectId: '1', projectSlug: 'a-project'}),
+      ]);
+      expect(slugs(upsertSettingsRowSorted(descendingData, row, '-name'))).toEqual([
+        ['z-project', 'm-project', 'a-project'],
+      ]);
+    });
+
+    it('ranks No Automation before every stopping point', () => {
+      const data = makeData([
+        makeRow({projectId: '1', projectSlug: 'first', stoppingPoint: 'root_cause'}),
+        makeRow({projectId: '2', projectSlug: 'second', stoppingPoint: 'open_pr'}),
+      ]);
+      const row = makeRow({
+        projectId: '3',
+        projectSlug: 'off-project',
+        automationTuning: 'off',
+      });
+
+      expect(slugs(upsertSettingsRowSorted(data, row, 'stoppingPoint'))).toEqual([
+        ['off-project', 'first', 'second'],
+      ]);
+    });
+
+    it('inserts into the page whose range contains the row', () => {
+      const data = makeData(
+        [
+          makeRow({projectId: '1', projectSlug: 'a-project'}),
+          makeRow({projectId: '2', projectSlug: 'c-project'}),
+        ],
+        [
+          makeRow({projectId: '3', projectSlug: 'e-project'}),
+          makeRow({projectId: '4', projectSlug: 'g-project'}),
+        ]
+      );
+      const row = makeRow({projectId: '5', projectSlug: 'f-project'});
+
+      expect(slugs(upsertSettingsRowSorted(data, row, 'name'))).toEqual([
+        ['a-project', 'c-project'],
+        ['e-project', 'f-project', 'g-project'],
+      ]);
+    });
+
+    it('updates an existing row in place without moving it', () => {
+      const data = makeData([
+        makeRow({projectId: '1', projectSlug: 'a-project', agent: 'seer'}),
+        makeRow({projectId: '2', projectSlug: 'z-project'}),
+      ]);
+      const row = makeRow({
+        projectId: '1',
+        projectSlug: 'a-project',
+        agent: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
+      });
+
+      const result = upsertSettingsRowSorted(data, row, '-name');
+      expect(slugs(result)).toEqual([['a-project', 'z-project']]);
+      expect(result.pages[0]!.json[0]!.agent).toBe(
+        CodingAgentProvider.CURSOR_BACKGROUND_AGENT
+      );
+    });
   });
 });

--- a/static/app/utils/seer/useMutateAutofixProject.ts
+++ b/static/app/utils/seer/useMutateAutofixProject.ts
@@ -9,6 +9,7 @@ import {projectSeerPreferencesApiOptions} from 'sentry/components/events/autofix
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {
@@ -58,6 +59,92 @@ export class AutofixSettingsPartialSaveError extends Error {
     super('Repositories were saved, but Seer settings could not be updated.', options);
     this.name = 'AutofixSettingsPartialSaveError';
   }
+}
+
+// Mirrors the backend's STOPPING_POINT_HIERARCHY, which the stoppingPoint sort
+// orders by; an "off" automationTuning ranks 0 there ahead of every point.
+const STOPPING_POINT_SORT_RANK: Record<string, number> = {
+  root_cause: 1,
+  solution: 2,
+  code_changes: 3,
+  open_pr: 4,
+};
+
+function settingsSortValue(
+  row: SeerProjectSettingResponse,
+  field: string
+): string | number {
+  switch (field) {
+    case 'reposCount':
+      return row.reposCount;
+    case 'agent':
+      return row.agent;
+    case 'stoppingPoint':
+      return row.automationTuning === 'off'
+        ? 0
+        : (STOPPING_POINT_SORT_RANK[row.stoppingPoint] ?? 0);
+    default:
+      // The backend maps "name" (also its fallback) to the project slug.
+      return row.projectSlug;
+  }
+}
+
+/**
+ * Insert (or update in place) a settings row in the cached list pages at the
+ * position the backend's sort would give it, so the reconciling refetch after
+ * an optimistic insert does not visibly move the row.
+ */
+export function upsertSettingsRowSorted(
+  data: InfiniteData<ApiResponse<SeerProjectSettingResponse[]>>,
+  row: SeerProjectSettingResponse,
+  sortBy: string
+): InfiniteData<ApiResponse<SeerProjectSettingResponse[]>> {
+  if (data.pages.length === 0) {
+    return data;
+  }
+
+  const exists = data.pages.some(page =>
+    page.json.some(item => item.projectId === row.projectId)
+  );
+  if (exists) {
+    return {
+      ...data,
+      pages: data.pages.map(page => ({
+        ...page,
+        json: page.json.map(item =>
+          item.projectId === row.projectId ? {...item, ...row} : item
+        ),
+      })),
+    };
+  }
+
+  const descending = sortBy.startsWith('-');
+  const field = descending ? sortBy.slice(1) : sortBy;
+  const rowValue = settingsSortValue(row, field);
+  const sortsAfterRow = (item: SeerProjectSettingResponse) => {
+    const itemValue = settingsSortValue(item, field);
+    return descending ? itemValue < rowValue : itemValue > rowValue;
+  };
+
+  // Pages are contiguous chunks of one sorted list, so the row belongs right
+  // before the first item that sorts after it; with no such item it goes at
+  // the end of the last loaded page.
+  const pageIndex = data.pages.findIndex(page => page.json.some(sortsAfterRow));
+  const insertPageIndex = pageIndex === -1 ? data.pages.length - 1 : pageIndex;
+  return {
+    ...data,
+    pages: data.pages.map((page, index) => {
+      if (index !== insertPageIndex) {
+        return page;
+      }
+      const itemIndex = pageIndex === -1 ? -1 : page.json.findIndex(sortsAfterRow);
+      const insertAt = itemIndex === -1 ? page.json.length : itemIndex;
+      return {
+        ...page,
+        json: [...page.json.slice(0, insertAt), row, ...page.json.slice(insertAt)],
+      };
+    }),
+  };
 }
 
 export function useMutateAutofixProject() {
@@ -206,30 +293,20 @@ export function useMutateAutofixProject() {
         }
       );
 
-      queryClient.setQueriesData(
-        {queryKey: [settingsListUrl], exact: false},
-        (prev: InfiniteData<ApiResponse<SeerProjectSettingResponse[]>> | undefined) => {
-          if (!prev || prev.pages.length === 0) {
-            return;
-          }
-          const exists = prev.pages.some(page =>
-            page.json.some(item => item.projectId === project.id)
-          );
-          return {
-            ...prev,
-            pages: prev.pages.map((page, index) => ({
-              ...page,
-              json: exists
-                ? page.json.map(item =>
-                    item.projectId === project.id ? {...item, ...settingsRow} : item
-                  )
-                : index === prev.pages.length - 1
-                  ? [...page.json, settingsRow]
-                  : page.json,
-            })),
-          };
+      for (const [queryKey, data] of previousSettingsLists) {
+        if (!data) {
+          continue;
         }
-      );
+        const sortBy = safeParseQueryKey(queryKey)?.options?.query?.sortBy;
+        queryClient.setQueryData(
+          queryKey,
+          upsertSettingsRowSorted(
+            data as InfiniteData<ApiResponse<SeerProjectSettingResponse[]>>,
+            settingsRow,
+            typeof sortBy === 'string' ? sortBy : 'name'
+          )
+        );
+      }
 
       return {previousSuggestions, previousSettingsLists};
     },

--- a/static/app/utils/seer/useMutateAutofixProject.ts
+++ b/static/app/utils/seer/useMutateAutofixProject.ts
@@ -145,16 +145,14 @@ export function useMutateAutofixProject() {
         throw new AutofixSettingsPartialSaveError({cause: error});
       }
     },
-    onSuccess: (_data, variables) => {
+    onMutate: async variables => {
       const {project, repoEntries, agentOption, stoppingPoint} = variables;
       const tuning = getTuningFromStoppingPoint(stoppingPoint);
 
-      const updatedProject = {...project, autofixAutomationTuning: tuning};
-      ProjectsStore.onUpdateSuccess(updatedProject);
-
-      // Move the project between the cached lists right away so the table
-      // updates without waiting for the onSettled refetches, which then
-      // reconcile ordering and any server-derived fields.
+      // Move the project between the cached lists optimistically, so the
+      // table updates on click instead of after the two writes and the
+      // onSettled refetches. The refetches reconcile ordering and any
+      // server-derived fields; onError restores the snapshots.
       const {agent, integrationId} = parseAgentOption(agentOption, knownAgents);
       const {stoppingPointValue} = resolveStoppingPoint(stoppingPoint, undefined);
       const settingsRow: SeerProjectSettingResponse = {
@@ -173,6 +171,23 @@ export function useMutateAutofixProject() {
         organization,
         enabled: true,
       }).queryKey;
+      const [settingsListUrl] = getInfiniteSeerProjectsSettingsQueryOptions({
+        organization,
+        query: {},
+      }).queryKey;
+
+      await queryClient.cancelQueries({queryKey: [suggestionsUrl], exact: false});
+      await queryClient.cancelQueries({queryKey: [settingsListUrl], exact: false});
+
+      const previousSuggestions = queryClient.getQueriesData({
+        queryKey: [suggestionsUrl],
+        exact: false,
+      });
+      const previousSettingsLists = queryClient.getQueriesData({
+        queryKey: [settingsListUrl],
+        exact: false,
+      });
+
       queryClient.setQueriesData(
         {queryKey: [suggestionsUrl], exact: false},
         (
@@ -191,10 +206,6 @@ export function useMutateAutofixProject() {
         }
       );
 
-      const [settingsListUrl] = getInfiniteSeerProjectsSettingsQueryOptions({
-        organization,
-        query: {},
-      }).queryKey;
       queryClient.setQueriesData(
         {queryKey: [settingsListUrl], exact: false},
         (prev: InfiniteData<ApiResponse<SeerProjectSettingResponse[]>> | undefined) => {
@@ -219,6 +230,28 @@ export function useMutateAutofixProject() {
           };
         }
       );
+
+      return {previousSuggestions, previousSettingsLists};
+    },
+    onError: (error, _variables, context) => {
+      // A partial save persisted the repositories, so the optimistic move is
+      // already the server state; the caller's retry warning owns the rest.
+      if (error instanceof AutofixSettingsPartialSaveError || !context) {
+        return;
+      }
+      for (const [queryKey, data] of context.previousSuggestions) {
+        queryClient.setQueryData(queryKey, data);
+      }
+      for (const [queryKey, data] of context.previousSettingsLists) {
+        queryClient.setQueryData(queryKey, data);
+      }
+    },
+    onSuccess: (_data, variables) => {
+      const {project, stoppingPoint} = variables;
+      const tuning = getTuningFromStoppingPoint(stoppingPoint);
+
+      const updatedProject = {...project, autofixAutomationTuning: tuning};
+      ProjectsStore.onUpdateSuccess(updatedProject);
     },
     onSettled: (_data, _error, variables, _context) => {
       const {project} = variables;

--- a/static/app/utils/seer/useMutateAutofixProject.ts
+++ b/static/app/utils/seer/useMutateAutofixProject.ts
@@ -1,8 +1,14 @@
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {
+  type InfiniteData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {projectSeerPreferencesApiOptions} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {
@@ -23,6 +29,7 @@ import {
 import type {
   AutofixAgentSelectOption,
   SeerProjectSettingResponse,
+  SeerProjectSuggestionResponse,
   UserFacingStoppingPoint,
 } from 'sentry/utils/seer/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -139,11 +146,79 @@ export function useMutateAutofixProject() {
       }
     },
     onSuccess: (_data, variables) => {
-      const {project, stoppingPoint} = variables;
+      const {project, repoEntries, agentOption, stoppingPoint} = variables;
       const tuning = getTuningFromStoppingPoint(stoppingPoint);
 
       const updatedProject = {...project, autofixAutomationTuning: tuning};
       ProjectsStore.onUpdateSuccess(updatedProject);
+
+      // Move the project between the cached lists right away so the table
+      // updates without waiting for the onSettled refetches, which then
+      // reconcile ordering and any server-derived fields.
+      const {agent, integrationId} = parseAgentOption(agentOption, knownAgents);
+      const {stoppingPointValue} = resolveStoppingPoint(stoppingPoint, undefined);
+      const settingsRow: SeerProjectSettingResponse = {
+        projectId: project.id,
+        projectSlug: project.slug,
+        agent,
+        integrationId: integrationId ?? null,
+        stoppingPoint: stoppingPointValue ?? 'off',
+        autoCreatePr: null,
+        automationTuning: tuning,
+        scannerAutomation: false,
+        reposCount: repoEntries.filter(entry => Boolean(entry.repoId)).length,
+      };
+
+      const [suggestionsUrl] = getInfiniteSeerProjectSuggestionsQueryOptions({
+        organization,
+        enabled: true,
+      }).queryKey;
+      queryClient.setQueriesData(
+        {queryKey: [suggestionsUrl], exact: false},
+        (
+          prev: InfiniteData<ApiResponse<SeerProjectSuggestionResponse[]>> | undefined
+        ) => {
+          if (prev) {
+            return {
+              ...prev,
+              pages: prev.pages.map(page => ({
+                ...page,
+                json: page.json.filter(item => item.projectId !== project.id),
+              })),
+            };
+          }
+          return;
+        }
+      );
+
+      const [settingsListUrl] = getInfiniteSeerProjectsSettingsQueryOptions({
+        organization,
+        query: {},
+      }).queryKey;
+      queryClient.setQueriesData(
+        {queryKey: [settingsListUrl], exact: false},
+        (prev: InfiniteData<ApiResponse<SeerProjectSettingResponse[]>> | undefined) => {
+          if (!prev || prev.pages.length === 0) {
+            return;
+          }
+          const exists = prev.pages.some(page =>
+            page.json.some(item => item.projectId === project.id)
+          );
+          return {
+            ...prev,
+            pages: prev.pages.map((page, index) => ({
+              ...page,
+              json: exists
+                ? page.json.map(item =>
+                    item.projectId === project.id ? {...item, ...settingsRow} : item
+                  )
+                : index === prev.pages.length - 1
+                  ? [...page.json, settingsRow]
+                  : page.json,
+            })),
+          };
+        }
+      );
     },
     onSettled: (_data, _error, variables, _context) => {
       const {project} = variables;


### PR DESCRIPTION
## TLDR

Makes the Autofix quick-add mutation update the cached suggestion and settings lists in `onMutate`, so the enabled row moves between the lists on click instead of after the refetch round trip.

## Details

The existing `onSettled` invalidations still run, so the optimistic write only covers the gap until the refetch reconciles server-derived fields. `onMutate` cancels in-flight list queries, snapshots both cached list prefixes, removes the project from the suggestion lists, and inserts a settings row built from the mutation variables. `upsertSettingsRowSorted` reads each cached query's `sortBy` from its query key and mirrors the backend sort semantics, including the stopping-point rank order with No Automation first, so the reconciling refetch does not visibly move the row. Rows with equal sort values can still swap tie order on refetch because the backend tie order is unspecified; the default name sort has no ties. Errors restore the snapshots, except `AutofixSettingsPartialSaveError`, where the repositories persisted and the row should stay moved.
