### PR TITLE
fix(seer): Refresh the org Autofix lists after project repo changes

### DIFF
--- a/static/app/utils/seer/seerProjectRepos.spec.tsx
+++ b/static/app/utils/seer/seerProjectRepos.spec.tsx
@@ -1,11 +1,18 @@
+import type {QueryClient} from '@tanstack/react-query';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {
   fetchProjectHasNonGithubRepo,
+  getDeleteSeerProjectRepoOptions,
+  getMutateSeerProjectReposOptionsAddRepo,
   getSeerProjectReposInfiniteQueryOptions,
 } from 'sentry/utils/seer/seerProjectRepos';
+import {getInfiniteSeerProjectsSettingsQueryOptions} from 'sentry/utils/seer/seerProjectSettings';
+import {getInfiniteSeerProjectSuggestionsQueryOptions} from 'sentry/utils/seer/seerProjectSuggestions';
 
 const organization = OrganizationFixture({slug: 'org-slug'});
 const project = {slug: 'project-slug'};
@@ -84,5 +91,89 @@ describe('fetchProjectHasNonGithubRepo', () => {
     ).resolves.toBe(false);
     // The complete fresh cache is reused; no extra request is made.
     expect(reposMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('organization list refresh after repo changes', () => {
+  const settingsListQueryKey = getInfiniteSeerProjectsSettingsQueryOptions({
+    organization,
+    query: {},
+  }).queryKey;
+  const suggestionsQueryKey = getInfiniteSeerProjectSuggestionsQueryOptions({
+    organization,
+    enabled: true,
+  }).queryKey;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  // Repo membership decides whether a project appears in the org suggestions
+  // or settings list, so both cached lists must go stale after add/remove. A
+  // missing invalidation fails silently: the table just stays outdated until
+  // a reload.
+  function seedListCaches(queryClient: QueryClient) {
+    const emptyList = {pages: [{headers: {}, json: []}], pageParams: [undefined]};
+    queryClient.setQueryData(settingsListQueryKey, emptyList);
+    queryClient.setQueryData(suggestionsQueryKey, emptyList);
+  }
+
+  function expectListsInvalidated(queryClient: QueryClient) {
+    expect(queryClient.getQueryState(settingsListQueryKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(suggestionsQueryKey)?.isInvalidated).toBe(true);
+  }
+
+  it('invalidates both org lists after removing a repo', async () => {
+    const deleteMock = MockApiClient.addMockResponse({
+      url: `${reposUrl}1/`,
+      method: 'DELETE',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(
+      () => {
+        const queryClient = useQueryClient();
+        return {
+          queryClient,
+          mutation: useMutation(
+            getDeleteSeerProjectRepoOptions({organization, project, queryClient})
+          ),
+        };
+      },
+      {organization}
+    );
+    seedListCaches(result.current.queryClient);
+
+    result.current.mutation.mutate({repoId: '1'});
+
+    await waitFor(() => expect(deleteMock).toHaveBeenCalled());
+    await waitFor(() => expectListsInvalidated(result.current.queryClient));
+  });
+
+  it('invalidates both org lists after adding repos', async () => {
+    const addMock = MockApiClient.addMockResponse({
+      url: reposUrl,
+      method: 'POST',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(
+      () => {
+        const queryClient = useQueryClient();
+        return {
+          queryClient,
+          mutation: useMutation(
+            getMutateSeerProjectReposOptionsAddRepo({organization, project, queryClient})
+          ),
+        };
+      },
+      {organization}
+    );
+    seedListCaches(result.current.queryClient);
+
+    result.current.mutation.mutate({repos: [{repositoryId: '7'}]});
+
+    await waitFor(() => expect(addMock).toHaveBeenCalled());
+    await waitFor(() => expectListsInvalidated(result.current.queryClient));
   });
 });

--- a/static/app/utils/seer/seerProjectRepos.ts
+++ b/static/app/utils/seer/seerProjectRepos.ts
@@ -12,6 +12,8 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {organizationRepositoriesInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
+import {getInfiniteSeerProjectsSettingsQueryOptions} from 'sentry/utils/seer/seerProjectSettings';
+import {getInfiniteSeerProjectSuggestionsQueryOptions} from 'sentry/utils/seer/seerProjectSuggestions';
 import type {
   SeerProjectMutateRepoPayload,
   SeerProjectRepoCreateInput,
@@ -73,6 +75,25 @@ function getRepoLookupFromCache(
     }
   }
   return lookup;
+}
+
+// Repo membership drives both org-level lists on /settings/seer/projects/: a
+// project's first repo removes it from the suggestions, removing its last repo
+// makes it a suggestion again, and the settings list shows a repo count.
+function invalidateOrganizationSeerProjectLists(
+  queryClient: QueryClient,
+  organization: Organization
+) {
+  const {queryKey: settingsListQueryKey} = getInfiniteSeerProjectsSettingsQueryOptions({
+    organization,
+    query: {},
+  });
+  queryClient.invalidateQueries({queryKey: [settingsListQueryKey[0]], exact: false});
+  const {queryKey: suggestionsQueryKey} = getInfiniteSeerProjectSuggestionsQueryOptions({
+    organization,
+    enabled: true,
+  });
+  queryClient.invalidateQueries({queryKey: [suggestionsQueryKey[0]], exact: false});
 }
 
 function getSeerProjectRepoQueryOptions({
@@ -270,6 +291,7 @@ export function getDeleteSeerProjectRepoOptions({
         queryClient.invalidateQueries({queryKey: context.singleQueryKey});
       }
       queryClient.invalidateQueries({queryKey: [infiniteUrl], exact: false});
+      invalidateOrganizationSeerProjectLists(queryClient, organization);
     },
   });
 }
@@ -457,6 +479,7 @@ export function getMutateSeerProjectReposOptionsAddRepo({
         });
       }
       queryClient.invalidateQueries({queryKey: [infiniteUrl], exact: false});
+      invalidateOrganizationSeerProjectLists(queryClient, organization);
     },
   });
 }


### PR DESCRIPTION
## TLDR

Removing or adding a project's Autofix repositories now refreshes the org project table without a page reload, because the repo mutations invalidate the cached suggestion and settings lists.

## Details

Repo membership decides which org list a project belongs to: its first repo removes it from the suggestions, removing its last repo makes it a suggestion again, and the settings list shows a repo count. `getDeleteSeerProjectRepoOptions` and `getMutateSeerProjectReposOptionsAddRepo` previously only touched the per-project repo caches, so the table on /settings/seer/projects/ stayed stale until its 60s staleTime expired or the page was reloaded. Both mutations now invalidate the two org list prefixes in `onSettled`, matching what `useMutateAutofixProject` already does. Invalidation only, no optimistic inverse, so the row moves when the refetch lands.
