### PR TITLE
fix(autofix): Show start card when no run exists

### DIFF
--- a/static/app/components/events/autofix/v3/content.spec.tsx
+++ b/static/app/components/events/autofix/v3/content.spec.tsx
@@ -1,0 +1,64 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
+
+import {SeerDrawerContent} from './content';
+
+function makeAutofix(
+  overrides: Partial<ReturnType<typeof useExplorerAutofix>> = {}
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    runState: null,
+    autofixFormatted: null,
+    startStep: jest.fn(),
+    createPR: jest.fn(),
+    reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: jest.fn(),
+    warnings: [],
+    isLoading: false,
+    isWaitingForRun: false,
+    isPolling: false,
+    ...overrides,
+  };
+}
+
+function makeAiConfig(
+  overrides: Partial<ReturnType<typeof useAiConfig>> = {}
+): ReturnType<typeof useAiConfig> {
+  return {
+    areAiFeaturesAllowed: true,
+    hasAutofix: true,
+    hasAutofixQuota: true,
+    hasGithubIntegration: true,
+    hasResources: false,
+    hasSummary: true,
+    isAutofixSetupLoading: false,
+    orgNeedsGenAiAcknowledgement: false,
+    refetchAutofixSetup: jest.fn(),
+    seerReposLinked: true,
+    ...overrides,
+  };
+}
+
+describe('SeerDrawerContent', () => {
+  it('allows starting Autofix when no run exists', async () => {
+    const startStep = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <SeerDrawerContent
+        aiConfig={makeAiConfig()}
+        autofix={makeAutofix({startStep})}
+        group={GroupFixture()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Start Analysis'}));
+
+    expect(startStep).toHaveBeenCalledWith('root_cause');
+  });
+});

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -15,6 +15,7 @@ import {
   useExplorerAutofix,
   type AutofixSection,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixStartCard} from 'sentry/components/events/autofix/v3/autofixStartCard';
 import {CodeChangesCard} from 'sentry/components/events/autofix/v3/codeChangesCard';
 import {CodingAgentsCard} from 'sentry/components/events/autofix/v3/codingAgentsCard';
 import {SeerDrawerNextStep} from 'sentry/components/events/autofix/v3/nextStep';
@@ -54,7 +55,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
   }
 
   if (!autofix.runState && aiConfig.hasAutofix) {
-    return null; // TODO: should this have an empty state?
+    return <AutofixStartCard autofix={autofix} group={group} />;
   }
 
   return (


### PR DESCRIPTION
Quick Fix links from the issue list can open the Autofix drawer before a run
exists. The drawer previously rendered nothing in this state, leaving users
with an empty panel. This renders the existing Autofix start card so users can
begin analysis, while preserving the current loading and existing-run states.

Fixes AIML-3364

| Before | After |
| --- | --- |
|<img width="862" height="615" alt="quick-fix-before" src="https://github.com/user-attachments/assets/f7b102b5-fca3-410c-8e06-12a03039d17b" />|<img width="865" height="593" alt="quick-fix-after" src="https://github.com/user-attachments/assets/0de333c4-0e33-4fb9-b45d-c9a0d66dc786" />|
