### PR TITLE
[Hackathon] feat(traces): show estimated climate impact

### DIFF
--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -244,3 +244,23 @@ function getShortSpanOperationDescription(operation?: string) {
 export function formatDollars(value: number) {
   return `$${formatAbbreviatedNumberWithDynamicPrecision(value)}`;
 }
+
+const CO2E_SCALES = [
+  [1_000_000, 't'],
+  [1_000, 'kg'],
+  [1, 'g'],
+] as const;
+
+const CO2E_SMALLEST_SCALE = [0.001, 'mg'] as const;
+
+export function formatCarbonEmissions(grams: number): string {
+  const [divisor, unit] =
+    CO2E_SCALES.find(([threshold]) => Math.abs(grams) >= threshold) ??
+    CO2E_SMALLEST_SCALE;
+
+  const value = (grams / divisor).toLocaleString(undefined, {
+    maximumSignificantDigits: 3,
+  });
+
+  return `${value} ${unit} CO\u2082e`;
+}

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -68,6 +68,7 @@ export interface TraceItemDetailsResponse {
   itemId: string;
   meta: TraceItemDetailsMeta;
   timestamp: string;
+  estimatedClimateImpactCo2eGrams?: number;
   event?: {
     breadcrumbs?: {values: RawCrumb[]};
     contexts?: EventTransaction['contexts'];

--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -45,6 +45,7 @@ export interface TraceResult {
   slices: number;
   start: number;
   trace: string;
+  estimatedClimateImpactCo2eGrams?: number;
 }
 
 type TraceBreakdownResult = TraceBreakdownProject | TraceBreakdownMissing;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -15,10 +15,9 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {defined} from 'sentry/utils/defined';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {FieldKey} from 'sentry/utils/fields';
-import {formatCarbonEmissions, formatDollars} from 'sentry/utils/formatters';
+import {formatDollars} from 'sentry/utils/formatters';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {looksLikeAJSONArray} from 'sentry/utils/string/looksLikeAJSONArray';
@@ -48,7 +47,6 @@ import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 type CustomRenderersProps = AttributesFieldRendererProps<RenderFunctionBaggage>;
 
 const HIDDEN_ATTRIBUTES = ['is_segment', 'project_id', 'received'];
-const CLIMATE_IMPACT_ATTRIBUTE = 'estimated_climate_impact_co2e_grams';
 const TRUNCATED_TEXT_ATTRIBUTES = ['gen_ai.response.text', 'gen_ai.embeddings.input'];
 
 const jsonRenderer = (props: CustomRenderersProps) => {
@@ -111,20 +109,7 @@ export function AttributesContent({
       : undefined;
 
   const sortedAndFilteredAttributes = useMemo(() => {
-    // The climate impact estimate rides along on the span itself rather than the
-    // trace item attributes, so surface it here as though it were one.
-    const climateImpactGrams =
-      CLIMATE_IMPACT_ATTRIBUTE in node.value
-        ? node.value.estimated_climate_impact_co2e_grams
-        : undefined;
-    const sortedAttributes = sortAttributes(
-      defined(climateImpactGrams)
-        ? [
-            ...attributes,
-            {name: CLIMATE_IMPACT_ATTRIBUTE, type: 'float', value: climateImpactGrams},
-          ]
-        : attributes
-    );
+    const sortedAttributes = sortAttributes(attributes);
 
     const onlyVisibleAttributes = sortedAttributes.filter(
       attribute => !HIDDEN_ATTRIBUTES.includes(attribute.name)
@@ -141,7 +126,7 @@ export function AttributesContent({
     });
 
     return onlyMatchingAttributes;
-  }, [attributes, node, searchQuery]);
+  }, [attributes, searchQuery]);
 
   const customRenderers: Record<
     string,
@@ -210,9 +195,6 @@ export function AttributesContent({
     },
     [SpanFields.GEN_AI_COST_TOTAL_TOKENS]: (props: CustomRenderersProps) => {
       return formatDollars(+Number(props.item.value).toFixed(10));
-    },
-    [CLIMATE_IMPACT_ATTRIBUTE]: (props: CustomRenderersProps) => {
-      return formatCarbonEmissions(Number(props.item.value));
     },
     assertion_failure_data: (props: CustomRenderersProps) => {
       if (props.item.value === null) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -15,9 +15,10 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {defined} from 'sentry/utils/defined';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {FieldKey} from 'sentry/utils/fields';
-import {formatDollars} from 'sentry/utils/formatters';
+import {formatCarbonEmissions, formatDollars} from 'sentry/utils/formatters';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {looksLikeAJSONArray} from 'sentry/utils/string/looksLikeAJSONArray';
@@ -47,6 +48,7 @@ import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 type CustomRenderersProps = AttributesFieldRendererProps<RenderFunctionBaggage>;
 
 const HIDDEN_ATTRIBUTES = ['is_segment', 'project_id', 'received'];
+const CLIMATE_IMPACT_ATTRIBUTE = 'estimated_climate_impact_co2e_grams';
 const TRUNCATED_TEXT_ATTRIBUTES = ['gen_ai.response.text', 'gen_ai.embeddings.input'];
 
 const jsonRenderer = (props: CustomRenderersProps) => {
@@ -109,7 +111,20 @@ export function AttributesContent({
       : undefined;
 
   const sortedAndFilteredAttributes = useMemo(() => {
-    const sortedAttributes = sortAttributes(attributes);
+    // The climate impact estimate rides along on the span itself rather than the
+    // trace item attributes, so surface it here as though it were one.
+    const climateImpactGrams =
+      CLIMATE_IMPACT_ATTRIBUTE in node.value
+        ? node.value.estimated_climate_impact_co2e_grams
+        : undefined;
+    const sortedAttributes = sortAttributes(
+      defined(climateImpactGrams)
+        ? [
+            ...attributes,
+            {name: CLIMATE_IMPACT_ATTRIBUTE, type: 'float', value: climateImpactGrams},
+          ]
+        : attributes
+    );
 
     const onlyVisibleAttributes = sortedAttributes.filter(
       attribute => !HIDDEN_ATTRIBUTES.includes(attribute.name)
@@ -126,7 +141,7 @@ export function AttributesContent({
     });
 
     return onlyMatchingAttributes;
-  }, [attributes, searchQuery]);
+  }, [attributes, node, searchQuery]);
 
   const customRenderers: Record<
     string,
@@ -195,6 +210,9 @@ export function AttributesContent({
     },
     [SpanFields.GEN_AI_COST_TOTAL_TOKENS]: (props: CustomRenderersProps) => {
       return formatDollars(+Number(props.item.value).toFixed(10));
+    },
+    [CLIMATE_IMPACT_ATTRIBUTE]: (props: CustomRenderersProps) => {
+      return formatCarbonEmissions(Number(props.item.value));
     },
     assertion_failure_data: (props: CustomRenderersProps) => {
       if (props.item.value === null) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -2,6 +2,8 @@ import {Fragment, useEffect, useMemo} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import type {Location} from 'history';
 
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
@@ -22,6 +24,7 @@ import type {Project} from 'sentry/types/project';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {defined} from 'sentry/utils/defined';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {formatCarbonEmissions} from 'sentry/utils/formatters';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -609,6 +612,15 @@ function EAPSpanNodeDetailsContent({
           organization={organization}
           project={project}
         />
+
+        {defined(node.value.estimated_climate_impact_co2e_grams) ? (
+          <Flex align="center" gap="md">
+            <Text bold>{t('Climate Impact')}</Text>
+            <Text variant="muted">
+              {formatCarbonEmissions(node.value.estimated_climate_impact_co2e_grams)}
+            </Text>
+          </Flex>
+        ) : null}
 
         {isTransaction && (contexts || extra) ? (
           <Contexts contexts={contexts} extra={extra} project={project} />

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -5,7 +5,9 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {TimeSince} from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils/defined';
 import {getDuration} from 'sentry/utils/duration/getDuration';
+import {formatCarbonEmissions} from 'sentry/utils/formatters';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {
   getTraceMetaLogsCount,
@@ -112,6 +114,7 @@ export function Meta(props: MetaProps) {
     props.metricsEnabled && props.overview.metrics.availability === 'loading';
 
   const repEvent = props.representativeEvent?.event;
+  const climateImpactGrams = props.tree.estimated_climate_impact_co2e_grams;
 
   return (
     <MetaWrapper>
@@ -170,6 +173,19 @@ export function Meta(props: MetaProps) {
           ) : (
             <TraceHeaderComponents.StyledPlaceholder _width={32} _height={20} />
           )}
+        </MetaSection>
+      ) : null}
+      {defined(climateImpactGrams) ? (
+        <MetaSection rightAlignBody headingText={t('Climate Impact')}>
+          <Tooltip
+            showUnderline
+            title={t(
+              'Estimated climate impact of the %s spans in this trace.',
+              spansCount
+            )}
+          >
+            {formatCarbonEmissions(climateImpactGrams)}
+          </Tooltip>
         </MetaSection>
       ) : null}
     </MetaWrapper>

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -6,6 +6,7 @@ import type {Client} from 'sentry/api';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import type {Level, Measurement} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils/defined';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import type {ReplayTrace} from 'sentry/views/explore/replays/detail/trace/useReplayTraces';
 import type {HydratedReplayRecord} from 'sentry/views/explore/replays/types';
@@ -172,6 +173,7 @@ export declare namespace TraceTree {
     additional_attributes?: Record<string, number | string>;
     browser_web_vital?: Record<string, number>;
     description?: string;
+    estimated_climate_impact_co2e_grams?: number;
     measurements?: Record<string, number>;
     mobile_app_vital?: Record<string, number>;
   };
@@ -348,9 +350,22 @@ function fetchTrace(
   );
 }
 
+// `?climate=true` fabricates per-span climate impact so the UI can be exercised locally
+// before the backend starts sending the real field. Values are derived from span duration
+// rather than randomized so they stay stable across renders and reloads.
+function isClimateImpactStubbed(): boolean {
+  return qs.parse(window.location.search).climate === 'true';
+}
+
+function stubSpanClimateImpact(value: TraceTree.EAPSpan): number {
+  const durationMs = (value.end_timestamp - value.start_timestamp) * 1000;
+  return 0.05 * Math.max(durationMs, 1);
+}
+
 export class TraceTree extends TraceTreeEventDispatcher {
   collapsed_nodes = 0;
   eap_spans_count = 0;
+  estimated_climate_impact_co2e_grams: number | null = null;
   projects = new Map<number, TraceTree.Project>();
 
   type: 'loading' | 'empty' | 'error' | 'trace' = 'trace';
@@ -431,6 +446,8 @@ export class TraceTree extends TraceTreeEventDispatcher {
     // Cyclic nodes are skipped and logged for debugging.
     const visitedIds = new Set<string>();
 
+    const stubClimateImpact = isClimateImpactStubbed();
+
     function visit(
       parent: BaseNode,
       value:
@@ -462,6 +479,16 @@ export class TraceTree extends TraceTreeEventDispatcher {
         });
 
         tree.eap_spans_count++;
+
+        if (stubClimateImpact && !defined(value.estimated_climate_impact_co2e_grams)) {
+          value.estimated_climate_impact_co2e_grams = stubSpanClimateImpact(value);
+        }
+
+        if (defined(value.estimated_climate_impact_co2e_grams)) {
+          tree.estimated_climate_impact_co2e_grams =
+            (tree.estimated_climate_impact_co2e_grams ?? 0) +
+            value.estimated_climate_impact_co2e_grams;
+        }
 
         // We only want to add transactions as profiled events.
         if ((node as EapSpanNode).value.is_transaction && node.hasProfiles) {


### PR DESCRIPTION
Part of [EXP-1145](https://linear.app/getsentry/issue/EXP-1145). Hackweek: Climate Impact Data.

Surfaces estimated climate impact in two places on Explore > Traces > (trace):

- **Trace header** — a **Climate Impact** entry in the meta row alongside Issues / Spans / Age / Root Duration, summed across the trace's spans.
- **Span details** — a row in the Attributes table for the selected span.

### Where the number comes from

Both surfaces read the per-span estimate from the `trace/` response. The trace total is accumulated in `TraceTree.FromTrace`, in the same `visit` pass that already counts spans, so walking the tree costs nothing extra and the value stays correct as the tree is rebuilt.

The accumulator is `number | null` rather than `number`. If it defaulted to `0`, every trace would render "Climate Impact 0 g" today, since no span carries the field yet. Staying `null` until at least one span reports a value means the entry is simply absent, and it appears on its own once the API starts sending data. The span attribute row is gated the same way.

The Attributes table is otherwise built from the `trace-items/` response, which does not carry this field. Rather than block on a second endpoint, the estimate is injected into the attribute list as a synthetic row read off the span node.

### Provisional API shape

The backend does not send these fields yet. The types here are a best guess at what EXP-1144 / EXP-1151 will produce and are expected to change:

| Endpoint | Type | Field | Used |
| --- | --- | --- | --- |
| `/organizations/{org}/trace/{traceId}/` | `TraceTree.EAPSpan` | `estimated_climate_impact_co2e_grams` | yes |
| `/organizations/{org}/traces/` | `TraceResult` | `estimatedClimateImpactCo2eGrams` | not yet |
| `/projects/{org}/{project}/trace-items/{id}/` | `TraceItemDetailsResponse` | `estimatedClimateImpactCo2eGrams` | not yet |

Casing differs per endpoint to match what each serializer already does.

### Units

Values are grams of CO2 equivalent. A single span's footprint is small, so grams keeps the wire value a readable number. `formatCarbonEmissions` scales for display across mg / g / kg / t.

### Local testing

`?climate=true` on any trace URL fabricates per-span values so the UI can be exercised before the backend lands. Values are derived from span duration rather than randomized, so they stay stable across renders and reloads. Real API data always takes precedence — the stub only fills in where the field is absent.

### Not included

Gating is currently data presence, not a feature flag. The epic mentions an org setting to enable climate reporting, which likely wants a real flag before this ships anywhere.