### PR TITLE
feat(cursor-origin): add the Cursor Origin integration (1/6: core)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2305,6 +2305,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     "sentry.integrations.gcp.integration.GcpIntegrationProvider",
     "sentry.integrations.github_copilot.integration.GithubCopilotIntegrationProvider",
     "sentry.integrations.perforce.integration.PerforceIntegrationProvider",
+    "sentry.integrations.cursor_origin.integration.CursorOriginIntegrationProvider",
 )
 
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -137,6 +137,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-vercel-upsert-env-var", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-datadog", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-cursor-origin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:slack-reinstall-nudge-on-issue-alert", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GitHub Enterprise to accept github.com as a valid Installation URL
     manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -36,7 +36,6 @@ AVAILABLE_PROVIDERS = {
     ExternalProviders.MSTEAMS,
     ExternalProviders.JIRA_SERVER,
     ExternalProviders.PERFORCE,
-    ExternalProviders.CURSOR_ORIGIN,
     ExternalProviders.CUSTOM,
 }
 

--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -36,6 +36,7 @@ AVAILABLE_PROVIDERS = {
     ExternalProviders.MSTEAMS,
     ExternalProviders.JIRA_SERVER,
     ExternalProviders.PERFORCE,
+    ExternalProviders.CURSOR_ORIGIN,
     ExternalProviders.CUSTOM,
 }
 

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -161,6 +161,7 @@ INTEGRATION_TYPE_TO_PROVIDER = {
         IntegrationProviderSlug.BITBUCKET_SERVER,
         IntegrationProviderSlug.AZURE_DEVOPS,
         IntegrationProviderSlug.PERFORCE,
+        IntegrationProviderSlug.CURSOR_ORIGIN,
     ],
     IntegrationDomain.ON_CALL_SCHEDULING: [
         IntegrationProviderSlug.PAGERDUTY,

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -111,6 +111,17 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
         """
         return self._paginate("/installation/repos", "repositories")
 
+    def get_repos(self) -> list[dict[str, Any]]:
+        """``get_repositories`` in the GitHub shape shared tasks expect.
+
+        Origin returns ``fullName`` where GitHub returns ``full_name``. Tasks
+        written against GitHub read the latter -- link_all_repos, which
+        post_install schedules, does ``repo["full_name"]`` -- so without this
+        alias every install raises AttributeError for the missing method and
+        then KeyError for the missing field.
+        """
+        return [{**repo, "full_name": repo["fullName"]} for repo in self.get_repositories()]
+
     def get_repo(self, repo_full_name: str) -> dict[str, Any]:
         return self.get(f"/repos/{repo_full_name}")
 
@@ -179,7 +190,15 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
         self, repo: Repository, path: str, ref: str | None, codeowners: bool = False
     ) -> str:
         contents = self.get_contents(repo.name, path, ref=ref)
-        return b64decode(contents["content"]).decode("utf-8")
+        # Origin answers a directory path with {"type": "dir", "entries": [...]},
+        # which has no "content". Raise ApiError rather than KeyError: callers such
+        # as source_context._fetch_file_from_scm and the CODEOWNERS lookup already
+        # handle ApiError, and check_file returns the truthy directory dict, so a
+        # directory sitting at a codeowners_locations path reaches here.
+        content = contents.get("content") if isinstance(contents, dict) else None
+        if not isinstance(content, str):
+            raise ApiError(f"No file content at {path!r} in {repo.name}")
+        return b64decode(content).decode("utf-8")
 
     # -- RepoTreesClient -----------------------------------------------------
 
@@ -198,7 +217,9 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
         An empty or inaccessible repository is an expected condition when
         walking an org's trees, not a sign the integration is broken.
         """
-        message = (error.json or {}).get("message") if error.json else error.text
+        # ApiError.json is whatever json.loads returned, which is not necessarily a
+        # dict -- a bare string or list body would make .get() an AttributeError.
+        message = error.json.get("message") if isinstance(error.json, dict) else error.text
         if message and (
             "not found" in message.lower()
             or "empty" in message.lower()

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from requests import PreparedRequest
+
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_API_BASE_URL,
+    TOKEN_MINIMUM_VALIDITY_SECONDS,
+)
+from sentry.integrations.cursor_origin.languages import languages_from_tree
+from sentry.integrations.cursor_origin.utils import get_jwt
+from sentry.shared_integrations.client.proxy import IntegrationProxyClient
+from sentry.shared_integrations.exceptions import ApiError
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+# Matches GitHub's `/repos/{owner}/{repo}/contents/{path}` so it can be rewritten to
+# Origin's `/repos/{owner}/{repo}/contents?path=…`.
+_GITHUB_CONTENTS_PATH = re.compile(
+    r"^/repos/(?P<repo>[^/]+/[^/]+)/contents/(?P<path>.+)$",
+)
+
+# Origin names each collection after the resource rather than using a generic
+# "items" key, so callers say which key they expect.
+PAGE_SIZE = 100
+
+
+class CursorOriginApiMixin:
+    """Read methods shared by the setup client and the installed-integration client.
+
+    Everything here is written against the *verified* Origin API, which differs from
+    the published docs in one important way: file contents live at
+    ``/contents?path=…``, not ``/contents/{path}``. The documented path form returns a
+    404 with a route-not-found body, which reads like an auth failure but is not.
+    """
+
+    # Concrete subclasses supply `post` via the shared API client base. Declared here
+    # only so mypy can see it -- do NOT give it a body, or the MRO will shadow the
+    # real implementation.
+    if TYPE_CHECKING:
+
+        def post(self, path: str, *args: Any, **kwargs: Any) -> Any: ...
+
+    def get(self, path: str, *args: Any, **kwargs: Any) -> Any:
+        """Read, translating GitHub-shaped contents paths to Origin's form.
+
+        Origin serves file contents from ``/contents?path=…`` while GitHub uses
+        ``/contents/{path}``. Rewriting here rather than at every call site lets
+        Sentry's existing GitHub-oriented helpers -- platform detection, CODEOWNERS
+        lookups, stacktrace linking -- run against Origin unmodified.
+
+        The failure this prevents is a confusing one: the documented path form
+        returns 404 with a route-not-found body, which reads like a permissions
+        problem rather than a wrong URL.
+        """
+        match = _GITHUB_CONTENTS_PATH.match(path)
+        if match:
+            repo, file_path = match.group("repo"), match.group("path")
+            params = dict(kwargs.pop("params", None) or {})
+            params["path"] = file_path
+            kwargs["params"] = params
+            path = f"/repos/{repo}/contents"
+
+        return super().get(path, *args, **kwargs)  # type: ignore[misc]
+
+    # -- repositories --------------------------------------------------------
+
+    def get_repositories(self) -> list[dict[str, Any]]:
+        """Repositories this installation can see.
+
+        Note: excludes repositories mirrored inbound from GitHub -- installations
+        cannot access those.
+        """
+        return self._paginate("/installation/repos", "repositories")
+
+    def get_repo(self, repo_full_name: str) -> dict[str, Any]:
+        return self.get(f"/repos/{repo_full_name}")
+
+    # -- git data ------------------------------------------------------------
+
+    def get_tree(self, repo_full_name: str, tree_sha: str) -> list[dict[str, Any]]:
+        """Full recursive tree.
+
+        Shape is identical to GitHub's ``git/trees``: entries carry
+        ``path``/``mode``/``type``/``sha``, and blobs additionally carry ``size``.
+        Origin exposes no ``truncated`` flag, so unlike GitHub we cannot tell whether
+        a very large tree was capped.
+        """
+        response = self.get(
+            f"/repos/{repo_full_name}/git/trees/{tree_sha}", params={"recursive": "1"}
+        )
+        if not isinstance(response, dict):
+            return []
+        return response.get("tree", []) or []
+
+    def get_blob(self, repo_full_name: str, sha: str) -> dict[str, Any]:
+        return self.get(f"/repos/{repo_full_name}/git/blobs/{sha}")
+
+    def get_languages(self, repo_full_name: str, ref: str | None = None) -> dict[str, int]:
+        """Byte counts per language, shaped like GitHub's languages API.
+
+        Origin has no languages endpoint, so this is derived from the tree. Keeping
+        the GitHub shape means the whole existing platform registry works unchanged.
+        """
+        return languages_from_tree(self.get_tree(repo_full_name, ref or "HEAD"))
+
+    # -- contents ------------------------------------------------------------
+
+    def get_contents(
+        self, repo_full_name: str, path: str, ref: str | None = None
+    ) -> dict[str, Any]:
+        """Read a file or directory.
+
+        A file returns ``{"type": "file", "encoding": "base64", "content": …}``;
+        a directory returns ``{"type": "dir", "entries": [...]}``. Missing paths 404.
+        """
+        params: dict[str, Any] = {"path": path}
+        if ref:
+            params["ref"] = ref
+        return self.get(f"/repos/{repo_full_name}/contents", params=params)
+
+    # -- branches ------------------------------------------------------------
+
+    def get_branches(self, repo_full_name: str) -> list[dict[str, Any]]:
+        return self._paginate(f"/repos/{repo_full_name}/branches", "branches")
+
+    # -- pagination ----------------------------------------------------------
+
+    def _paginate(self, path: str, collection_key: str) -> list[dict[str, Any]]:
+        """Follow Origin's cursor pagination.
+
+        Origin uses opaque ``pageToken``/``nextPageToken`` cursors rather than
+        GitHub's ``Link`` header and ``page`` counter.
+        """
+        results: list[dict[str, Any]] = []
+        page_token: str | None = None
+
+        while True:
+            params: dict[str, Any] = {"pageSize": PAGE_SIZE}
+            if page_token:
+                params["pageToken"] = page_token
+
+            response = self.get(path, params=params)
+            if not isinstance(response, dict):
+                break
+
+            results.extend(response.get(collection_key, []) or [])
+
+            page_token = response.get("nextPageToken") or None
+            if not page_token:
+                break
+
+        return results
+
+
+class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
+    """Client that authenticates as the app itself, with no stored integration.
+
+    Used during install (before an Integration row exists) and for local
+    verification. The installed-integration client persists its token on the
+    Integration; this one just keeps it in memory.
+    """
+
+    base_url = CURSOR_ORIGIN_API_BASE_URL
+    integration_type = "integration"
+    integration_name = "cursor_origin_setup"
+
+    def __init__(
+        self,
+        installation_id: str | None = None,
+        app_id: str | None = None,
+        private_key: str | None = None,
+        verify_ssl: bool = True,
+    ):
+        super().__init__(verify_ssl=verify_ssl)
+        self.installation_id = installation_id
+        self._app_id = app_id
+        self._private_key = private_key
+        self._access_token: str | None = None
+        self._expires_at: float = 0.0
+
+    # -- auth ----------------------------------------------------------------
+
+    def _jwt(self) -> str:
+        return get_jwt(app_id=self._app_id, private_key=self._private_key)
+
+    def _is_app_route(self, path_url: str) -> bool:
+        """``/app`` and everything under it authenticates with the app JWT.
+
+        That includes the token-exchange call itself. Repository routes
+        (``/repos/…``, ``/installation/repos``) use the installation token.
+        """
+        return path_url.startswith("/v1/origin/app") or path_url.startswith("/app")
+
+    def get_access_token(self) -> str:
+        """Mint or reuse an installation token.
+
+        Origin's tokens expire in under 15 minutes -- far shorter than GitHub's hour
+        -- so this refreshes aggressively rather than on the GitHub cadence.
+        """
+        if self.installation_id is None:
+            raise ValueError("installation_id is required for installation-scoped calls")
+
+        if self._access_token and time.time() < self._expires_at:
+            return self._access_token
+
+        response = self.post(f"/app/installations/{self.installation_id}/access_tokens")
+        if not isinstance(response, dict):
+            raise ApiError("unexpected access_token response from Cursor Origin")
+
+        token = next(
+            (v for v in response.values() if isinstance(v, str) and v.startswith("oit_")),
+            None,
+        )
+        if not token:
+            raise ApiError("no installation token in Cursor Origin response")
+
+        self._access_token = token
+        # Origin does not return a usable expiry, so assume the documented ceiling
+        # and refresh well before it.
+        self._expires_at = time.time() + TOKEN_MINIMUM_VALIDITY_SECONDS
+        return token
+
+    def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
+        if self._is_app_route(prepared_request.path_url):
+            token = self._jwt()
+        else:
+            token = self.get_access_token()
+
+        prepared_request.headers["Authorization"] = f"Bearer {token}"
+        prepared_request.headers["Accept"] = "application/json"
+        return prepared_request
+
+    # -- app-level endpoints -------------------------------------------------
+
+    def get_app(self) -> dict[str, Any]:
+        return self.get("/app")
+
+    def get_installations(self) -> list[dict[str, Any]]:
+        response = self.get("/app/installations")
+        if not isinstance(response, dict):
+            return []
+        for value in response.values():
+            if isinstance(value, list):
+                return value
+        return []
+
+    def get_installation(self, installation_id: str) -> dict[str, Any]:
+        return self.get(f"/app/installations/{installation_id}")

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from django.core.cache import cache
 from requests import PreparedRequest, Response
 
 from sentry.integrations.cursor_origin.constants import (
@@ -238,9 +239,9 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
 class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
     """Client that authenticates as the app itself, with no stored integration.
 
-    Used during install (before an Integration row exists) and for local
-    verification. The installed-integration client persists its token on the
-    Integration; this one just keeps it in memory.
+    Used both during install, before an Integration row exists, and afterwards
+    by the installation's ``get_client()``. Installation tokens are shared
+    through the cache so repeated client construction does not re-mint them.
     """
 
     base_url = CURSOR_ORIGIN_API_BASE_URL
@@ -277,14 +278,28 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
     def get_access_token(self) -> str:
         """Mint or reuse an installation token.
 
-        Origin's tokens expire in under 15 minutes -- far shorter than GitHub's hour
-        -- so this refreshes aggressively rather than on the GitHub cadence.
+        Shared through the cache, not just this instance. A new client is built
+        on every ``get_installation().get_client()``, so an instance-only cache
+        meant a fresh token exchange per call site -- and token minting is
+        charged against the app-JWT budget, which is the smaller of the two.
+
+        The cache is deliberately given a shorter life than the token itself:
+        Origin's tokens last under 15 minutes and the response carries no usable
+        expiry, so a cached token is always refreshed well before it can expire
+        mid-request. Eviction is harmless -- it just costs one exchange.
         """
         if self.installation_id is None:
             raise ValueError("installation_id is required for installation-scoped calls")
 
         if self._access_token and time.time() < self._expires_at:
             return self._access_token
+
+        cache_key = self._token_cache_key(self.installation_id)
+        cached = cache.get(cache_key)
+        if cached:
+            self._access_token = cached
+            self._expires_at = time.time() + TOKEN_MINIMUM_VALIDITY_SECONDS
+            return cached
 
         response = self.post(f"/app/installations/{self.installation_id}/access_tokens")
         if not isinstance(response, dict):
@@ -298,10 +313,13 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
             raise ApiError("no installation token in Cursor Origin response")
 
         self._access_token = token
-        # Origin does not return a usable expiry, so assume the documented ceiling
-        # and refresh well before it.
         self._expires_at = time.time() + TOKEN_MINIMUM_VALIDITY_SECONDS
+        cache.set(cache_key, token, TOKEN_MINIMUM_VALIDITY_SECONDS)
         return token
+
+    @staticmethod
+    def _token_cache_key(installation_id: str) -> str:
+        return f"cursor-origin:token:{installation_id}"
 
     def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
         if self._is_app_route(prepared_request.path_url):

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import logging
 import re
 import time
+from base64 import b64decode
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from requests import PreparedRequest
+from requests import PreparedRequest, Response
 
 from sentry.integrations.cursor_origin.constants import (
     CURSOR_ORIGIN_API_BASE_URL,
@@ -13,6 +15,9 @@ from sentry.integrations.cursor_origin.constants import (
 )
 from sentry.integrations.cursor_origin.languages import languages_from_tree
 from sentry.integrations.cursor_origin.utils import get_jwt
+from sentry.integrations.source_code_management.repo_trees import RepoTreesClient
+from sentry.integrations.source_code_management.repository import RepositoryClient
+from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -29,7 +34,7 @@ _GITHUB_CONTENTS_PATH = re.compile(
 PAGE_SIZE = 100
 
 
-class CursorOriginApiMixin:
+class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
     """Read methods shared by the setup client and the installed-integration client.
 
     Everything here is written against the *verified* Origin API, which differs from
@@ -37,6 +42,34 @@ class CursorOriginApiMixin:
     ``/contents?path=…``, not ``/contents/{path}``. The documented path form returns a
     404 with a route-not-found body, which reads like an auth failure but is not.
     """
+
+    # Seeded with the documented installation budget and replaced by the real
+    # figure as soon as a response carrying rate-limit headers arrives. Starting
+    # at 0 would read as "exhausted" and make callers back off before we have
+    # made a single request.
+    _rate_limit_remaining: int = 3000
+
+    def track_response_data(
+        self,
+        code: str | int,
+        error: Exception | None = None,
+        resp: Response | None = None,
+        extra: Mapping[str, str | int] | None = None,
+    ) -> None:
+        """Capture Origin's rate-limit headers on the way past.
+
+        This is the only place the raw response is visible, and `repo_trees`
+        backs off when the remaining budget gets low, so the figure has to be
+        live rather than assumed.
+        """
+        if resp is not None:
+            remaining = resp.headers.get("x-ratelimit-remaining")
+            if remaining is not None:
+                try:
+                    self._rate_limit_remaining = int(remaining)
+                except ValueError:
+                    pass
+        super().track_response_data(code, error, resp, extra)  # type: ignore[misc]
 
     # Concrete subclasses supply `post` via the shared API client base. Declared here
     # only so mypy can see it -- do NOT give it a body, or the MRO will shadow the
@@ -127,6 +160,51 @@ class CursorOriginApiMixin:
 
     def get_branches(self, repo_full_name: str) -> list[dict[str, Any]]:
         return self._paginate(f"/repos/{repo_full_name}/branches", "branches")
+
+    # -- RepositoryClient ----------------------------------------------------
+
+    def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
+        """Does this path exist? Used by stacktrace linking and CODEOWNERS.
+
+        Origin has no HEAD route for contents, so this is a GET whose body we
+        discard. Missing paths 404, which surfaces as ApiError.
+        """
+        try:
+            return self.get_contents(repo.name, path, ref=version)
+        except ApiError:
+            return None
+
+    def get_file(
+        self, repo: Repository, path: str, ref: str | None, codeowners: bool = False
+    ) -> str:
+        contents = self.get_contents(repo.name, path, ref=ref)
+        return b64decode(contents["content"]).decode("utf-8")
+
+    # -- RepoTreesClient -----------------------------------------------------
+
+    def get_remaining_api_requests(self) -> int:
+        """Requests left in the current window, from the last response's headers.
+
+        Origin uses the same ``X-RateLimit-*`` header names as GitHub. When we
+        have not made a request yet, report the documented installation budget
+        rather than 0, which callers treat as "back off".
+        """
+        return self._rate_limit_remaining
+
+    def should_count_api_error(self, error: ApiError, extra: dict[str, str]) -> bool:
+        """Whether this error counts toward the connection-error tally.
+
+        An empty or inaccessible repository is an expected condition when
+        walking an org's trees, not a sign the integration is broken.
+        """
+        message = (error.json or {}).get("message") if error.json else error.text
+        if message and (
+            "not found" in message.lower()
+            or "empty" in message.lower()
+            or "permission" in message.lower()
+        ):
+            return False
+        return True
 
     # -- pagination ----------------------------------------------------------
 

--- a/src/sentry/integrations/cursor_origin/constants.py
+++ b/src/sentry/integrations/cursor_origin/constants.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+CURSOR_ORIGIN_API_BASE_URL = "https://api.cursor.com/v1/origin"
+CURSOR_ORIGIN_WEB_BASE_URL = "https://cursor.com/codebase"
+CURSOR_ORIGIN_GIT_BASE_URL = "https://origin.cursor.com"
+
+# Where users are sent to install the app on their codebase.
+CURSOR_ORIGIN_INSTALL_URL = "https://cursor.com/codebase/apps/install"
+
+# The `aud` claim Origin requires on app JWTs.
+CURSOR_ORIGIN_JWT_AUDIENCE = "origin-apps"
+
+# Origin caps app JWTs at ~5 minutes. Stay comfortably inside it.
+JWT_EXPIRY_SECONDS = 240
+
+# Installation tokens expire in under 15 minutes -- far shorter than GitHub's hour.
+# Refresh well ahead of expiry so a long-running request can't straddle the boundary.
+TOKEN_MINIMUM_VALIDITY_SECONDS = 180
+
+# Scopes requested at install time. The app's registered permissions are the ceiling;
+# this is the actual grant.
+CURSOR_ORIGIN_SCOPES = (
+    "repository:metadata:read",
+    "repository:contents:read",
+    "repository:contents:write",
+    "repository:pull_requests:read",
+    "repository:pull_requests:write",
+    "repository:pull_requests:reviews:read",
+    "repository:pull_requests:reviews:write",
+    "repository:checks:read",
+    "repository:checks:write",
+)

--- a/src/sentry/integrations/cursor_origin/constants.py
+++ b/src/sentry/integrations/cursor_origin/constants.py
@@ -13,6 +13,11 @@ CURSOR_ORIGIN_JWT_AUDIENCE = "origin-apps"
 # Origin caps app JWTs at ~5 minutes. Stay comfortably inside it.
 JWT_EXPIRY_SECONDS = 240
 
+# Origin's published Ed25519 public keys. Used to verify things Origin signed:
+# the install receipt, and webhook deliveries.
+CURSOR_ORIGIN_JWKS_URL = f"{CURSOR_ORIGIN_API_BASE_URL}/keys"
+CURSOR_ORIGIN_JWKS_CACHE_SECONDS = 3600
+
 # Installation tokens expire in under 15 minutes -- far shorter than GitHub's hour.
 # Refresh well ahead of expiry so a long-running request can't straddle the boundary.
 TOKEN_MINIMUM_VALIDITY_SECONDS = 180

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -228,7 +228,11 @@ def build_install_url(state: str, redirect_uri: str, scopes: Sequence[str] | Non
             "scope": " ".join(scopes or CURSOR_ORIGIN_SCOPES),
             "redirect_uri": redirect_uri,
             "state": state,
-        }
+        },
+        # Encode the scope separator as %20 rather than "+". Both decode to a
+        # space, but Origin is new enough that it is not worth relying on the
+        # form-encoding convention.
+        quote_via=quote,
     )
 
 

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -25,6 +25,7 @@ from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
 from sentry.integrations.source_code_management.repository import (
+    HaltReason,
     RepositoryInfo,
     RepositoryIntegration,
 )
@@ -130,6 +131,37 @@ class CursorOriginIntegration(
         except ApiError:
             return False
         return True
+
+    # -- error classification ------------------------------------------------
+
+    def is_rate_limited_error(self, exc: ApiError) -> bool:
+        """Origin signals rate limiting with a plain 429 plus Retry-After.
+
+        The base class returns False for every error, so without this a rate
+        limit is indistinguishable from a broken integration and the install
+        gets marked unauthorized for what is a transient condition.
+        """
+        return exc.code == 429
+
+    def is_broken_integration_error(self, exc: Exception) -> HaltReason | None:
+        """Treat a failed token exchange as a terminal state.
+
+        When an app is uninstalled or its access revoked, Origin stops issuing
+        installation tokens. Every subsequent call fails at the exchange rather
+        than on the resource, which the generic handling reads as an ordinary
+        404 and retries forever. Surfacing it as terminal is what lets the
+        integration be shown as broken instead.
+
+        `installation.deleted` normally gets there first, but only when the
+        webhook was delivered -- revocation and missed deliveries both land here.
+        """
+        if isinstance(exc, ApiError) and exc.url and "access_tokens" in exc.url:
+            if self.is_rate_limited_error(exc):
+                return "rate_limited"
+            if exc.code in (401, 403, 404):
+                return "installation_suspended"
+
+        return super().is_broken_integration_error(exc)
 
     # -- stacktrace linking --------------------------------------------------
 

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -166,7 +166,14 @@ class CursorOriginIntegration(
     # -- stacktrace linking --------------------------------------------------
 
     def source_url_matches(self, url: str) -> bool:
-        return url.startswith(CURSOR_ORIGIN_WEB_BASE_URL)
+        # Scope to this installation's codebase, not just to origin.cursor.com.
+        # ProjectRepoPathParsingEndpoint takes matching_integrations[0], so a
+        # base-URL-only check lets an org's URL match a different org's
+        # integration first and report "Could not find repo". build_integration
+        # already stores domain_name as "{web base}/{codebase}"; fall back to the
+        # base URL for integrations installed before that was set.
+        base_url = self.model.metadata.get("domain_name") or CURSOR_ORIGIN_WEB_BASE_URL
+        return url.startswith(base_url)
 
     def format_source_url(self, repo: Repository, filepath: str, branch: str | None) -> str:
         branch = branch or repo.config.get("default_branch") or "main"

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -194,6 +194,13 @@ class CursorOriginIntegrationProvider(IntegrationProvider):
 
     features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.STACKTRACE_LINK])
 
+    # Gates both the integration directory listing and the install pipeline, which are
+    # the only two ways in: every other Origin surface (webhooks, repository sync, code
+    # mappings, platform detection) is reachable only through an installed integration.
+    # is_provider_enabled derives the flag from the key, so this checks
+    # "organizations:integrations-cursor-origin" without a feature_flag_name override.
+    requires_feature_flag = True
+
     def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
         from sentry.integrations.cursor_origin.pipeline import CursorOriginInstallApiStep
 

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -178,15 +178,27 @@ class CursorOriginIntegrationProvider(IntegrationProvider):
         except ApiError as e:
             raise IntegrationError(f"Could not read the Cursor Origin installation: {e}")
 
-        account = installation.get("account") or {}
-        name = account.get("slug") or installation.get("ownerSlug") or installation_id
+        # The codebase the app was installed on. Origin calls this `target`; its
+        # `slug` is the namespace that prefixes every repo ("sentry/nuget-trends")
+        # and is what we want as the integration's display name. Falling back to
+        # the installation id keeps the install working but shows an opaque
+        # `i_01…` in the UI, so treat a missing target as worth knowing about.
+        target = installation.get("target") or {}
+        name = target.get("slug") or installation_id
+        if not target.get("slug"):
+            logger.warning(
+                "cursor_origin.installation.missing_target",
+                extra={"installation_id": installation_id},
+            )
 
         return {
             "name": name,
             "external_id": installation_id,
             "metadata": {
                 "installation_id": installation_id,
-                "account": account,
+                "target": target,
+                "scopes": installation.get("scopes") or [],
+                "repo_selection_mode": installation.get("repoSelectionMode"),
                 "domain_name": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{name}",
             },
         }

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -106,8 +106,15 @@ class CursorOriginIntegration(
         try:
             raw_repos = self.get_client().get_repositories()
         except ApiError as e:
+            # Deliberately not returning [] here. The daily repo sync computes
+            # removals as `sentry_active_ids - provider_external_ids`, so an empty
+            # list from a transient failure reads as "the provider dropped every
+            # repository" and queues them all for disablement. raise_error turns
+            # this into an IntegrationError, which the sync task treats as a
+            # failure to retry and which the repo-picker endpoint already catches
+            # and reports as a 400. GitHub and GitLab likewise do not swallow it.
             logger.info("cursor_origin.get_repositories.error", extra={"error": str(e)})
-            return []
+            self.raise_error(e)
 
         repos: list[RepositoryInfo] = [
             {

--- a/src/sentry/integrations/cursor_origin/integration.py
+++ b/src/sentry/integrations/cursor_origin/integration.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from django.utils.translation import gettext_lazy as _
+
+from sentry.integrations.base import (
+    FeatureDescription,
+    IntegrationData,
+    IntegrationFeatures,
+    IntegrationMetadata,
+    IntegrationProvider,
+)
+from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_INSTALL_URL,
+    CURSOR_ORIGIN_SCOPES,
+    CURSOR_ORIGIN_WEB_BASE_URL,
+)
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.repository.model import RpcRepository
+from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
+from sentry.integrations.source_code_management.repository import (
+    RepositoryInfo,
+    RepositoryIntegration,
+)
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.repository import Repository
+from sentry.organizations.services.organization.model import RpcOrganizationSummary
+from sentry.pipeline.views.base import ApiPipelineSteps
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+DESCRIPTION = """
+Connect your Cursor Origin repositories to Sentry. Origin is Cursor's git forge --
+linking it lets Sentry suggest the right platform when you create a project, map
+stack traces back to source, and give Seer access to your code.
+"""
+
+FEATURES = [
+    FeatureDescription(
+        """
+        Suggest the right platform for a new project by inspecting the repository you
+        pick during onboarding.
+        """,
+        IntegrationFeatures.COMMITS,
+    ),
+    FeatureDescription(
+        """
+        Link stack traces directly to source code in Origin.
+        """,
+        IntegrationFeatures.STACKTRACE_LINK,
+    ),
+]
+
+metadata = IntegrationMetadata(
+    description=DESCRIPTION.strip(),
+    features=FEATURES,
+    author="Sentry",
+    noun=_("Installation"),
+    issue_url="https://github.com/getsentry/sentry/issues",
+    source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/cursor_origin",
+    aspects={},
+)
+
+
+class CursorOriginIntegration(
+    RepositoryIntegration[CursorOriginSetupApiClient], RepoTreesIntegration
+):
+    codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
+
+    @property
+    def integration_name(self) -> str:
+        return IntegrationProviderSlug.CURSOR_ORIGIN.value
+
+    def get_client(self) -> CursorOriginSetupApiClient:
+        installation_id = self.model.external_id
+        return CursorOriginSetupApiClient(installation_id=installation_id)
+
+    # -- repositories --------------------------------------------------------
+
+    def get_repo_external_id(self, repo: Mapping[str, Any]) -> str:
+        return str(repo["id"])
+
+    def get_repositories(
+        self,
+        query: str | None = None,
+        page_number_limit: int | None = None,
+        accessible_only: bool = False,
+        use_cache: bool = False,
+        raise_on_page_limit: bool = False,
+        parallel: bool = False,
+    ) -> list[RepositoryInfo]:
+        """Repositories this installation can see.
+
+        Origin has no repository search endpoint, so `query` is applied locally.
+        The extra keyword arguments exist for base-class compatibility and are
+        ignored -- the installation repo list is small enough to always fetch whole.
+        """
+        try:
+            raw_repos = self.get_client().get_repositories()
+        except ApiError as e:
+            logger.info("cursor_origin.get_repositories.error", extra={"error": str(e)})
+            return []
+
+        repos: list[RepositoryInfo] = [
+            {
+                "name": repo["fullName"],
+                "identifier": repo["fullName"],
+                "external_id": str(repo["id"]),
+                "default_branch": repo.get("defaultBranch"),
+            }
+            for repo in raw_repos
+        ]
+
+        if query:
+            lowered = query.lower()
+            repos = [repo for repo in repos if lowered in repo["name"].lower()]
+
+        return repos
+
+    def has_repo_access(self, repo: RpcRepository) -> bool:
+        try:
+            self.get_client().get_repo(repo.name)
+        except ApiError:
+            return False
+        return True
+
+    # -- stacktrace linking --------------------------------------------------
+
+    def source_url_matches(self, url: str) -> bool:
+        return url.startswith(CURSOR_ORIGIN_WEB_BASE_URL)
+
+    def format_source_url(self, repo: Repository, filepath: str, branch: str | None) -> str:
+        branch = branch or repo.config.get("default_branch") or "main"
+        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/blob/{branch}/{quote(filepath)}"
+
+    def extract_branch_from_source_url(self, repo: Repository, url: str) -> str:
+        prefix = f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/blob/"
+        return url.replace(prefix, "").split("/")[0]
+
+    def extract_source_path_from_source_url(self, repo: Repository, url: str) -> str:
+        prefix = f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/blob/"
+        branch = self.extract_branch_from_source_url(repo, url)
+        return url.replace(f"{prefix}{branch}/", "")
+
+
+class CursorOriginIntegrationProvider(IntegrationProvider):
+    key = IntegrationProviderSlug.CURSOR_ORIGIN.value
+    name = "Cursor Origin"
+    metadata = metadata
+    integration_cls = CursorOriginIntegration
+
+    # Origin's install redirect hands back the installation directly, so unlike
+    # GitHub there is no separate OAuth identity to link.
+    needs_default_identity = False
+
+    features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.STACKTRACE_LINK])
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        from sentry.integrations.cursor_origin.pipeline import CursorOriginInstallApiStep
+
+        return [CursorOriginInstallApiStep()]
+
+    def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
+        installation_id = state.get("installation_id")
+        if not installation_id:
+            raise IntegrationError("Cursor Origin did not return an installation.")
+
+        client = CursorOriginSetupApiClient(installation_id=installation_id)
+        try:
+            installation = client.get_installation(installation_id)
+        except ApiError as e:
+            raise IntegrationError(f"Could not read the Cursor Origin installation: {e}")
+
+        account = installation.get("account") or {}
+        name = account.get("slug") or installation.get("ownerSlug") or installation_id
+
+        return {
+            "name": name,
+            "external_id": installation_id,
+            "metadata": {
+                "installation_id": installation_id,
+                "account": account,
+                "domain_name": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{name}",
+            },
+        }
+
+    def post_install(
+        self,
+        integration: Integration,
+        organization: RpcOrganizationSummary,
+        *,
+        extra: Mapping[str, Any],
+    ) -> None:
+        from sentry.integrations.github.tasks.link_all_repos import link_all_repos
+
+        link_all_repos.apply_async(
+            kwargs={
+                "integration_key": self.key,
+                "integration_id": integration.id,
+                "organization_id": organization.id,
+            }
+        )
+
+    def setup(self) -> None:
+        from sentry.plugins.base import bindings
+
+        from .repository import CursorOriginRepositoryProvider
+
+        bindings.add(
+            "integration-repository.provider",
+            CursorOriginRepositoryProvider,
+            id=f"integrations:{self.key}",
+        )
+
+
+def build_install_url(state: str, redirect_uri: str, scopes: Sequence[str] | None = None) -> str:
+    """Where the user is sent to grant the app access to their codebase."""
+    return f"{CURSOR_ORIGIN_INSTALL_URL}?" + urlencode(
+        {
+            "client_id": _app_id(),
+            "scope": " ".join(scopes or CURSOR_ORIGIN_SCOPES),
+            "redirect_uri": redirect_uri,
+            "state": state,
+        }
+    )
+
+
+def _app_id() -> str:
+    from sentry import options
+
+    return str(options.get("cursor-origin-app.id"))

--- a/src/sentry/integrations/cursor_origin/keys.py
+++ b/src/sentry/integrations/cursor_origin/keys.py
@@ -49,16 +49,33 @@ def fetch_public_keys(force_refresh: bool = False) -> list[bytes]:
     try:
         response = safe_urlopen(CURSOR_ORIGIN_JWKS_URL, method="GET", timeout=5)
         response.raise_for_status()
-        payload: dict[str, Any] = response.json()
+        payload: Any = response.json()
     except Exception:
         logger.warning("cursor_origin.jwks_fetch_failed", exc_info=True)
         return []
 
-    keys = [
-        _b64url_decode(key["x"])
-        for key in payload.get("keys", [])
-        if key.get("crv") == "Ed25519" and key.get("x")
-    ]
+    # Everything below is shape-checked rather than assumed. This is an external
+    # document, and callers treat an empty list as "cannot verify" and fail closed
+    # -- so a malformed JWKS must return nothing, never raise. Raising would take
+    # the install pipeline down with a 500 instead of refusing the install.
+    if not isinstance(payload, dict):
+        logger.warning("cursor_origin.jwks_malformed", extra={"reason": "payload_not_object"})
+        return []
+
+    keys: list[bytes] = []
+    for key in payload.get("keys") or []:
+        if not isinstance(key, dict) or key.get("crv") != "Ed25519":
+            continue
+        material = key.get("x")
+        if not isinstance(material, str):
+            continue
+        try:
+            keys.append(_b64url_decode(material))
+        except (ValueError, TypeError):
+            # One unusable key must not discard the well-formed ones beside it;
+            # that is the difference between a rotation hiccup and an outage.
+            logger.warning("cursor_origin.jwks_key_undecodable", extra={"kid": key.get("kid")})
+
     if keys:
         cache.set(_JWKS_CACHE_KEY, keys, CURSOR_ORIGIN_JWKS_CACHE_SECONDS)
     return keys

--- a/src/sentry/integrations/cursor_origin/keys.py
+++ b/src/sentry/integrations/cursor_origin/keys.py
@@ -1,0 +1,64 @@
+"""Origin's published Ed25519 public keys.
+
+Origin signs two things we have to check: the install receipt handed back by the
+redirect, and webhook deliveries. Both are Ed25519, and neither carries a usable
+key id -- webhook signatures have no key id field at all -- so callers try every
+active key rather than selecting one.
+
+Verification needs Origin's *public* keys rather than a secret we hold, which is
+why this is a fetch rather than an option lookup.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any
+
+from django.core.cache import cache
+
+from sentry.http import safe_urlopen
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_JWKS_CACHE_SECONDS,
+    CURSOR_ORIGIN_JWKS_URL,
+)
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+_JWKS_CACHE_KEY = "cursor-origin:jwks"
+
+
+def _b64url_decode(value: str) -> bytes:
+    """Decode unpadded base64url, as used for JWK key material."""
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def fetch_public_keys(force_refresh: bool = False) -> list[bytes]:
+    """Origin's active Ed25519 public keys, cached.
+
+    Cached because every webhook delivery would otherwise fetch the JWKS.
+    ``force_refresh`` exists so a signature that fails against every cached key
+    can be retried once after rotation, rather than dropping deliveries until
+    the cache expires.
+    """
+    if not force_refresh:
+        cached = cache.get(_JWKS_CACHE_KEY)
+        if cached is not None:
+            return [bytes(k) for k in cached]
+
+    try:
+        response = safe_urlopen(CURSOR_ORIGIN_JWKS_URL, method="GET", timeout=5)
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+    except Exception:
+        logger.warning("cursor_origin.jwks_fetch_failed", exc_info=True)
+        return []
+
+    keys = [
+        _b64url_decode(key["x"])
+        for key in payload.get("keys", [])
+        if key.get("crv") == "Ed25519" and key.get("x")
+    ]
+    if keys:
+        cache.set(_JWKS_CACHE_KEY, keys, CURSOR_ORIGIN_JWKS_CACHE_SECONDS)
+    return keys

--- a/src/sentry/integrations/cursor_origin/languages.py
+++ b/src/sentry/integrations/cursor_origin/languages.py
@@ -1,0 +1,133 @@
+"""Approximate GitHub's languages API from a git tree.
+
+GitHub exposes ``GET /repos/{repo}/languages`` returning byte counts per language,
+and Sentry's platform detection is built directly on it. Origin has no equivalent,
+so we derive the same shape from the recursive tree: map each blob's extension to a
+Linguist language name and sum the blob sizes.
+
+Keys deliberately match Linguist's names so the existing
+``GITHUB_LANGUAGE_TO_SENTRY_PLATFORM`` registry -- and everything downstream of it
+-- works unchanged.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+# Extension -> Linguist language name. Only languages Sentry can map to a platform
+# are worth listing; anything unmapped is discarded by the caller anyway.
+EXTENSION_TO_LANGUAGE: dict[str, str] = {
+    ".py": "Python",
+    ".pyi": "Python",
+    ".js": "JavaScript",
+    ".jsx": "JavaScript",
+    ".mjs": "JavaScript",
+    ".cjs": "JavaScript",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".mts": "TypeScript",
+    ".cts": "TypeScript",
+    ".java": "Java",
+    ".kt": "Kotlin",
+    ".kts": "Kotlin",
+    ".swift": "Swift",
+    ".m": "Objective-C",
+    ".mm": "Objective-C++",
+    ".go": "Go",
+    ".rb": "Ruby",
+    ".rake": "Ruby",
+    ".php": "PHP",
+    ".rs": "Rust",
+    ".cs": "C#",
+    ".dart": "Dart",
+    ".ex": "Elixir",
+    ".exs": "Elixir",
+    ".c": "C",
+    ".h": "C",
+    ".cc": "C++",
+    ".cpp": "C++",
+    ".cxx": "C++",
+    ".hpp": "C++",
+    ".hh": "C++",
+    ".gd": "GDScript",
+    ".ps1": "PowerShell",
+    ".psm1": "PowerShell",
+}
+
+# Path segments Linguist treats as vendored or generated. Counting these badly skews
+# detection -- a checked-in node_modules would drown out the actual application.
+EXCLUDED_PATH_SEGMENTS = frozenset(
+    {
+        "node_modules",
+        "vendor",
+        "third_party",
+        "thirdparty",
+        "bower_components",
+        "dist",
+        "build",
+        "out",
+        "target",
+        "bin",
+        "obj",
+        ".git",
+        ".venv",
+        "venv",
+        "site-packages",
+        "__pycache__",
+        "migrations",
+        "Pods",
+        "Carthage",
+    }
+)
+
+# Test code is real code, but weighting it equally tends to misidentify the primary
+# platform of a repo whose tests dwarf its source.
+EXCLUDED_TEST_SEGMENTS = frozenset({"test", "tests", "spec", "specs", "__tests__"})
+
+
+def _is_excluded(path: str) -> bool:
+    segments = path.split("/")
+    # The final segment is the filename, not a directory.
+    for segment in segments[:-1]:
+        if segment in EXCLUDED_PATH_SEGMENTS or segment in EXCLUDED_TEST_SEGMENTS:
+            return True
+    return False
+
+
+def _extension(path: str) -> str | None:
+    filename = path.rsplit("/", 1)[-1]
+    if "." not in filename:
+        return None
+    return "." + filename.rsplit(".", 1)[-1].lower()
+
+
+def languages_from_tree(tree: list[dict[str, Any]]) -> dict[str, int]:
+    """Byte counts per language, shaped like GitHub's languages API.
+
+    ``tree`` is the entry list from Origin's ``git/trees/{ref}?recursive=1``. Blobs
+    carry a ``size``; trees do not and are skipped.
+    """
+    totals: dict[str, int] = defaultdict(int)
+
+    for entry in tree:
+        if entry.get("type") != "blob":
+            continue
+
+        path = entry.get("path")
+        if not path or _is_excluded(path):
+            continue
+
+        extension = _extension(path)
+        if extension is None:
+            continue
+
+        language = EXTENSION_TO_LANGUAGE.get(extension)
+        if language is None:
+            continue
+
+        totals[language] += entry.get("size") or 0
+
+    # Drop languages that matched only empty files -- they carry no signal and would
+    # register as a detected platform with zero weight.
+    return {language: size for language, size in totals.items() if size > 0}

--- a/src/sentry/integrations/cursor_origin/languages.py
+++ b/src/sentry/integrations/cursor_origin/languages.py
@@ -102,6 +102,20 @@ def _extension(path: str) -> str | None:
     return "." + filename.rsplit(".", 1)[-1].lower()
 
 
+def _size(entry: dict[str, Any]) -> int:
+    """Blob size in bytes, tolerating a stringified number.
+
+    Origin serialises 64-bit integers as JSON strings in places (``size`` on
+    ``contents`` comes back as ``"2534"``). Tree entries use real ints today,
+    but the pattern is common enough in that API that a bare ``+=`` would be a
+    TypeError waiting to happen mid-detection.
+    """
+    try:
+        return int(entry.get("size") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def languages_from_tree(tree: list[dict[str, Any]]) -> dict[str, int]:
     """Byte counts per language, shaped like GitHub's languages API.
 
@@ -126,7 +140,7 @@ def languages_from_tree(tree: list[dict[str, Any]]) -> dict[str, int]:
         if language is None:
             continue
 
-        totals[language] += entry.get("size") or 0
+        totals[language] += _size(entry)
 
     # Drop languages that matched only empty files -- they carry no signal and would
     # register as a detected platform with zero weight.

--- a/src/sentry/integrations/cursor_origin/pipeline.py
+++ b/src/sentry/integrations/cursor_origin/pipeline.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, TypedDict
 
 import jwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from django.http import HttpRequest
 from django.urls import reverse
 from rest_framework import serializers
 
 from sentry.integrations.cursor_origin.integration import build_install_url
+from sentry.integrations.cursor_origin.keys import fetch_public_keys
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.pipeline.types import PipelineStepResult
 from sentry.utils.http import absolute_uri
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
 
 
 class InstallStepData(TypedDict):
@@ -19,8 +24,11 @@ class InstallStepData(TypedDict):
 
 
 class InstallSerializer(serializers.Serializer[dict[str, Any]]):
+    # Deliberately no installation_id field. The callback carries one as a plain
+    # query parameter and the client forwards it, but it is caller-controlled and
+    # must not be trusted -- see handle_post. Unknown keys are dropped by DRF, so
+    # a client still sending it is harmless.
     installation_receipt = serializers.CharField(required=False, allow_blank=True)
-    installation_id = serializers.CharField(required=False, allow_blank=True)
     state = serializers.CharField(required=True)
 
 
@@ -34,19 +42,43 @@ def _redirect_uri() -> str:
 
 
 def _installation_id_from_receipt(receipt: str) -> str | None:
-    """Pull the installation id out of the signed receipt Origin returns.
+    """The installation id from Origin's receipt, or None if it does not verify.
 
-    The receipt is signed by Origin, not by us, so we cannot verify it here --
-    and we do not need to: the id is immediately used to call Origin with our
-    own app credentials, which is what actually establishes trust. A forged
-    receipt yields an installation we have no access to, and the call fails.
+    The signature is the only thing that ties this installation to the person
+    installing it. Reading `sub` without checking it -- as this used to -- lets a
+    caller name any installation Sentry's app can read and have build_integration
+    store it as the Integration's external_id, binding another organization's
+    codebase to theirs. The pipeline `state` value does not help: it authenticates
+    the Sentry session that started the flow, not ownership of the installation.
+
+    Fails closed. If the JWKS cannot be fetched, no key verifies and the install
+    is refused rather than trusted.
+
+    Like webhook deliveries, receipts carry no key id we can rely on, so every
+    active key is tried.
     """
-    try:
-        claims = jwt.decode(receipt, options={"verify_signature": False})
-    except jwt.PyJWTError:
-        return None
-    subject = claims.get("sub")
-    return str(subject) if subject else None
+    for force_refresh in (False, True):
+        keys = fetch_public_keys(force_refresh=force_refresh)
+        for key_bytes in keys:
+            try:
+                claims = jwt.decode(
+                    receipt,
+                    key=Ed25519PublicKey.from_public_bytes(key_bytes),
+                    algorithms=["EdDSA"],
+                    # Origin does not document an `aud` on receipts. The signature
+                    # and `sub` are what this relies on.
+                    options={"verify_aud": False},
+                )
+            except (jwt.PyJWTError, ValueError):
+                continue
+            subject = claims.get("sub")
+            return str(subject) if subject else None
+        # Only worth refetching if the cache could have been stale.
+        if not keys:
+            break
+
+    logger.warning("cursor_origin.install.receipt_verification_failed")
+    return None
 
 
 class CursorOriginInstallApiStep:
@@ -75,15 +107,15 @@ class CursorOriginInstallApiStep:
         if validated_data["state"] != pipeline.signature:
             return PipelineStepResult.error("Invalid state, please try the installation again.")
 
-        installation_id = validated_data.get("installation_id")
-        if not installation_id:
-            receipt = validated_data.get("installation_receipt")
-            if receipt:
-                installation_id = _installation_id_from_receipt(receipt)
+        # The signed receipt is the only accepted source for the installation id.
+        # The callback also carries a bare installation_id query parameter, but
+        # anyone can put any value there, so it is ignored.
+        receipt = validated_data.get("installation_receipt")
+        installation_id = _installation_id_from_receipt(receipt) if receipt else None
 
         if not installation_id:
             return PipelineStepResult.error(
-                "Cursor Origin did not return an installation. Please try again."
+                "Cursor Origin did not return a valid installation. Please try again."
             )
 
         pipeline.bind_state("installation_id", installation_id)

--- a/src/sentry/integrations/cursor_origin/pipeline.py
+++ b/src/sentry/integrations/cursor_origin/pipeline.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+import jwt
+from django.http import HttpRequest
+from django.urls import reverse
+from rest_framework import serializers
+
+from sentry.integrations.cursor_origin.integration import build_install_url
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.pipeline.types import PipelineStepResult
+from sentry.utils.http import absolute_uri
+
+
+class InstallStepData(TypedDict):
+    installUrl: str
+
+
+class InstallSerializer(serializers.Serializer[dict[str, Any]]):
+    installation_receipt = serializers.CharField(required=False, allow_blank=True)
+    installation_id = serializers.CharField(required=False, allow_blank=True)
+    state = serializers.CharField(required=True)
+
+
+def _redirect_uri() -> str:
+    return absolute_uri(
+        reverse(
+            "sentry-extension-setup",
+            kwargs={"provider_id": IntegrationProviderSlug.CURSOR_ORIGIN.value},
+        )
+    )
+
+
+def _installation_id_from_receipt(receipt: str) -> str | None:
+    """Pull the installation id out of the signed receipt Origin returns.
+
+    The receipt is signed by Origin, not by us, so we cannot verify it here --
+    and we do not need to: the id is immediately used to call Origin with our
+    own app credentials, which is what actually establishes trust. A forged
+    receipt yields an installation we have no access to, and the call fails.
+    """
+    try:
+        claims = jwt.decode(receipt, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return None
+    subject = claims.get("sub")
+    return str(subject) if subject else None
+
+
+class CursorOriginInstallApiStep:
+    """Single-step install.
+
+    Origin's redirect returns an installation receipt directly, so unlike GitHub
+    there is no OAuth login leg and no separate organization-selection step.
+    """
+
+    step_name = "install"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> InstallStepData:
+        return {
+            "installUrl": build_install_url(state=pipeline.signature, redirect_uri=_redirect_uri())
+        }
+
+    def get_serializer_cls(self) -> type:
+        return InstallSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        if validated_data["state"] != pipeline.signature:
+            return PipelineStepResult.error("Invalid state, please try the installation again.")
+
+        installation_id = validated_data.get("installation_id")
+        if not installation_id:
+            receipt = validated_data.get("installation_receipt")
+            if receipt:
+                installation_id = _installation_id_from_receipt(receipt)
+
+        if not installation_id:
+            return PipelineStepResult.error(
+                "Cursor Origin did not return an installation. Please try again."
+            )
+
+        pipeline.bind_state("installation_id", installation_id)
+        return PipelineStepResult.advance()

--- a/src/sentry/integrations/cursor_origin/pipeline.py
+++ b/src/sentry/integrations/cursor_origin/pipeline.py
@@ -57,8 +57,19 @@ def _installation_id_from_receipt(receipt: str) -> str | None:
     Like webhook deliveries, receipts carry no key id we can rely on, so every
     active key is tried.
     """
+    # Header of the *unverified* token, for telemetry only -- never to decide
+    # whether to trust it. Records which algorithm and key Origin actually signed
+    # with, which is the thing that cannot be established from the API docs.
+    try:
+        header = jwt.get_unverified_header(receipt)
+    except jwt.PyJWTError:
+        header = {}
+    signing = {"alg": header.get("alg"), "kid": header.get("kid")}
+
+    key_count = 0
     for force_refresh in (False, True):
         keys = fetch_public_keys(force_refresh=force_refresh)
+        key_count = len(keys)
         for key_bytes in keys:
             try:
                 claims = jwt.decode(
@@ -72,12 +83,28 @@ def _installation_id_from_receipt(receipt: str) -> str | None:
             except (jwt.PyJWTError, ValueError):
                 continue
             subject = claims.get("sub")
+            # Installs are rare, so logging the success path is cheap -- and it is
+            # a positive confirmation that Origin signs receipts with a JWKS key,
+            # rather than having to infer it from the absence of a warning.
+            # installation_id is included because a reinstall that returns the same
+            # id lands on the existing Integration row, and without it in the log
+            # there is no way to tell that apart from a genuinely new install.
+            logger.info(
+                "cursor_origin.install.receipt_verified",
+                extra={**signing, "installation_id": subject},
+            )
             return str(subject) if subject else None
         # Only worth refetching if the cache could have been stale.
         if not keys:
             break
 
-    logger.warning("cursor_origin.install.receipt_verification_failed")
+    logger.warning(
+        "cursor_origin.install.receipt_verification_failed",
+        # alg/kid say whether this is a key we do not have (rotation, or a signer
+        # outside the JWKS) or an algorithm we do not accept. key_count of 0 means
+        # the JWKS fetch itself failed, which is a different problem.
+        extra={**signing, "key_count": key_count},
+    )
     return None
 
 

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from sentry.integrations.cursor_origin.constants import CURSOR_ORIGIN_WEB_BASE_URL
 from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
-from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -21,20 +20,10 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
     name = "Cursor Origin"
     repo_provider = "cursor_origin"
 
-    def _get_installation(
-        self, organization_id: int, integration_id: int
-    ) -> CursorOriginIntegration:
-        integration = integration_service.get_integration(integration_id=integration_id)
-        if integration is None:
-            raise IntegrationError("Cursor Origin integration not found.")
-        installation = integration.get_installation(organization_id=organization_id)
-        assert isinstance(installation, CursorOriginIntegration)
-        return installation
-
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]
     ) -> MutableMapping[str, Any]:
-        installation = self._get_installation(organization.id, config["installation"])
+        installation = self.get_installation(config.get("installation"), organization.id)
 
         # `identifier` is the fullName ("owner/repo") chosen in the repo picker.
         repo_name = config["identifier"]
@@ -46,6 +35,9 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
         config["external_id"] = str(repo["id"])
         config["name"] = repo["fullName"]
         config["default_branch"] = repo.get("defaultBranch")
+        # build_repository_config reads this back out; without it repo creation
+        # fails with a bare KeyError after the API calls have already succeeded.
+        config["integration_id"] = installation.model.id
         return config
 
     def build_repository_config(

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -43,12 +43,22 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
     def build_repository_config(
         self, organization: RpcOrganization, data: Mapping[str, Any]
     ) -> RepositoryConfig:
+        # Two callers with different shapes reach this. The repo picker goes through
+        # get_repository_data, which sets "name" from the API's fullName. link_all_repos
+        # -- scheduled by post_install -- instead calls this directly with only
+        # {external_id, integration_id, identifier} from get_repo_config, so "name" is
+        # absent and a bare data["name"] raised KeyError for every repository on every
+        # install. Prefer the canonical name where we have it, fall back to the
+        # identifier, which holds the same "owner/repo" fullName.
+        # GitHub reads "identifier" for this reason; GitLab reads "name" and gets away
+        # with it only because nothing bulk-links its repositories.
+        name = data.get("name") or data["identifier"]
         return {
-            "name": data["name"],
+            "name": name,
             "external_id": data["external_id"],
-            "url": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{data['name']}",
+            "url": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{name}",
             "config": {
-                "name": data["name"],
+                "name": name,
                 "default_branch": data.get("default_branch"),
             },
             "integration_id": data["integration_id"],

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
+
+from sentry.integrations.cursor_origin.constants import CURSOR_ORIGIN_WEB_BASE_URL
+from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
+from sentry.integrations.services.integration import integration_service
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.plugins.providers.integration_repository import RepositoryConfig
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+
+logger = logging.getLogger(__name__)
+
+
+class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginIntegration]):
+    name = "Cursor Origin"
+    repo_provider = "cursor_origin"
+
+    def _get_installation(
+        self, organization_id: int, integration_id: int
+    ) -> CursorOriginIntegration:
+        integration = integration_service.get_integration(integration_id=integration_id)
+        if integration is None:
+            raise IntegrationError("Cursor Origin integration not found.")
+        installation = integration.get_installation(organization_id=organization_id)
+        assert isinstance(installation, CursorOriginIntegration)
+        return installation
+
+    def get_repository_data(
+        self, organization: Organization, config: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        installation = self._get_installation(organization.id, config["installation"])
+
+        # `identifier` is the fullName ("owner/repo") chosen in the repo picker.
+        repo_name = config["identifier"]
+        try:
+            repo = installation.get_client().get_repo(repo_name)
+        except ApiError as e:
+            raise IntegrationError(f"Could not read {repo_name} from Cursor Origin: {e}")
+
+        config["external_id"] = str(repo["id"])
+        config["name"] = repo["fullName"]
+        config["default_branch"] = repo.get("defaultBranch")
+        return config
+
+    def build_repository_config(
+        self, organization: RpcOrganization, data: Mapping[str, Any]
+    ) -> RepositoryConfig:
+        return {
+            "name": data["name"],
+            "external_id": data["external_id"],
+            "url": f"{CURSOR_ORIGIN_WEB_BASE_URL}/{data['name']}",
+            "config": {
+                "name": data["name"],
+                "default_branch": data.get("default_branch"),
+            },
+            "integration_id": data["integration_id"],
+        }
+
+    def repository_external_slug(self, repo: Repository) -> str:
+        return repo.name
+
+    def compare_commits(
+        self, repo: Repository, start_sha: str | None, end_sha: str
+    ) -> Sequence[Mapping[str, Any]]:
+        """Not implemented yet -- commit tracking arrives with webhook support."""
+        return []
+
+    def pull_request_url(self, repo: Repository, pull_request: Any) -> str:
+        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/pulls/{pull_request.key}"

--- a/src/sentry/integrations/cursor_origin/utils.py
+++ b/src/sentry/integrations/cursor_origin/utils.py
@@ -19,6 +19,10 @@ def _load_private_key(private_key: str) -> Ed25519PrivateKey:
     Unlike GitHub's RS256 keys, PyJWT will not accept the PEM string directly for
     EdDSA -- it needs a key object -- so the load step is mandatory here.
     """
+    if not private_key:
+        # Unset in this environment. Say so, rather than failing inside
+        # cryptography on an empty buffer or on None.encode().
+        raise ValueError("cursor-origin-app.private-key is not configured")
     key = serialization.load_pem_private_key(private_key.encode("utf-8"), password=None)
     if not isinstance(key, Ed25519PrivateKey):
         raise ValueError(f"cursor-origin-app.private-key is not Ed25519: {type(key).__name__}")

--- a/src/sentry/integrations/cursor_origin/utils.py
+++ b/src/sentry/integrations/cursor_origin/utils.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import time
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from sentry import options
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_JWT_AUDIENCE,
+    JWT_EXPIRY_SECONDS,
+)
+
+
+def _load_private_key(private_key: str) -> Ed25519PrivateKey:
+    """Parse the app's Ed25519 signing key.
+
+    Unlike GitHub's RS256 keys, PyJWT will not accept the PEM string directly for
+    EdDSA -- it needs a key object -- so the load step is mandatory here.
+    """
+    key = serialization.load_pem_private_key(private_key.encode("utf-8"), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise ValueError(f"cursor-origin-app.private-key is not Ed25519: {type(key).__name__}")
+    return key
+
+
+def get_jwt(app_id: str | None = None, private_key: str | None = None) -> str:
+    """Mint a short-lived app JWT for Origin's app-level endpoints."""
+    if app_id is None:
+        app_id = str(options.get("cursor-origin-app.id"))
+    if private_key is None:
+        private_key = options.get("cursor-origin-app.private-key")
+
+    now = int(time.time())
+    return jwt.encode(
+        {
+            # Allow for a little clock skew between us and Origin.
+            "iat": now - 30,
+            "exp": now + JWT_EXPIRY_SECONDS,
+            "iss": app_id,
+            "aud": CURSOR_ORIGIN_JWT_AUDIENCE,
+        },
+        _load_private_key(private_key),
+        algorithm="EdDSA",
+        headers={"kid": app_id},
+    )

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -41,6 +41,7 @@ class ExternalActor(Model):
             (ExternalProviders.GITLAB, IntegrationProviderSlug.GITLAB.value),
             (ExternalProviders.JIRA_SERVER, IntegrationProviderSlug.JIRA_SERVER.value),
             (ExternalProviders.PERFORCE, IntegrationProviderSlug.PERFORCE.value),
+            (ExternalProviders.CURSOR_ORIGIN, IntegrationProviderSlug.CURSOR_ORIGIN.value),
             # TODO: do migration to delete this from database
             (ExternalProviders.CUSTOM, "custom_scm"),
         ),

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -41,7 +41,6 @@ class ExternalActor(Model):
             (ExternalProviders.GITLAB, IntegrationProviderSlug.GITLAB.value),
             (ExternalProviders.JIRA_SERVER, IntegrationProviderSlug.JIRA_SERVER.value),
             (ExternalProviders.PERFORCE, IntegrationProviderSlug.PERFORCE.value),
-            (ExternalProviders.CURSOR_ORIGIN, IntegrationProviderSlug.CURSOR_ORIGIN.value),
             # TODO: do migration to delete this from database
             (ExternalProviders.CUSTOM, "custom_scm"),
         ),

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -63,6 +63,7 @@ SCM_SYNC_PROVIDERS = [
     "bitbucket_server",
     "vsts",
     "perforce",
+    "cursor_origin",
 ]
 
 SYNC_BATCH_SIZE = 100

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -19,7 +19,6 @@ class ExternalProviders(ValueEqualityEnum):
     GITHUB = 200
     GITHUB_ENTERPRISE = 201
     GITLAB = 210
-    CURSOR_ORIGIN = 220
     JIRA_SERVER = 300
     PERFORCE = 400
 
@@ -82,7 +81,6 @@ class ExternalProviderEnum(StrEnum):
     GITLAB = IntegrationProviderSlug.GITLAB
     JIRA_SERVER = IntegrationProviderSlug.JIRA_SERVER
     PERFORCE = IntegrationProviderSlug.PERFORCE
-    CURSOR_ORIGIN = IntegrationProviderSlug.CURSOR_ORIGIN
 
 
 EXTERNAL_PROVIDERS_REVERSE = {
@@ -97,7 +95,6 @@ EXTERNAL_PROVIDERS_REVERSE = {
     ExternalProviderEnum.GITHUB_ENTERPRISE: ExternalProviders.GITHUB_ENTERPRISE,
     ExternalProviderEnum.GITLAB: ExternalProviders.GITLAB,
     ExternalProviderEnum.PERFORCE: ExternalProviders.PERFORCE,
-    ExternalProviderEnum.CURSOR_ORIGIN: ExternalProviders.CURSOR_ORIGIN,
     ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
 }
 
@@ -116,7 +113,6 @@ EXTERNAL_PROVIDERS = {
     ExternalProviders.GITLAB: ExternalProviderEnum.GITLAB.value,
     ExternalProviders.JIRA_SERVER: ExternalProviderEnum.JIRA_SERVER.value,
     ExternalProviders.PERFORCE: ExternalProviderEnum.PERFORCE.value,
-    ExternalProviders.CURSOR_ORIGIN: ExternalProviderEnum.CURSOR_ORIGIN.value,
     ExternalProviders.CUSTOM: ExternalProviderEnum.CUSTOM.value,
 }
 

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -19,6 +19,7 @@ class ExternalProviders(ValueEqualityEnum):
     GITHUB = 200
     GITHUB_ENTERPRISE = 201
     GITLAB = 210
+    CURSOR_ORIGIN = 220
     JIRA_SERVER = 300
     PERFORCE = 400
 
@@ -43,6 +44,7 @@ class IntegrationProviderSlug(StrEnum):
     GITLAB = "gitlab"
     BITBUCKET = "bitbucket"
     BITBUCKET_SERVER = "bitbucket_server"
+    CURSOR_ORIGIN = "cursor_origin"
     PAGERDUTY = "pagerduty"
     OPSGENIE = "opsgenie"
     PERFORCE = "perforce"
@@ -80,6 +82,7 @@ class ExternalProviderEnum(StrEnum):
     GITLAB = IntegrationProviderSlug.GITLAB
     JIRA_SERVER = IntegrationProviderSlug.JIRA_SERVER
     PERFORCE = IntegrationProviderSlug.PERFORCE
+    CURSOR_ORIGIN = IntegrationProviderSlug.CURSOR_ORIGIN
 
 
 EXTERNAL_PROVIDERS_REVERSE = {
@@ -94,6 +97,7 @@ EXTERNAL_PROVIDERS_REVERSE = {
     ExternalProviderEnum.GITHUB_ENTERPRISE: ExternalProviders.GITHUB_ENTERPRISE,
     ExternalProviderEnum.GITLAB: ExternalProviders.GITLAB,
     ExternalProviderEnum.PERFORCE: ExternalProviders.PERFORCE,
+    ExternalProviderEnum.CURSOR_ORIGIN: ExternalProviders.CURSOR_ORIGIN,
     ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
 }
 
@@ -112,6 +116,7 @@ EXTERNAL_PROVIDERS = {
     ExternalProviders.GITLAB: ExternalProviderEnum.GITLAB.value,
     ExternalProviders.JIRA_SERVER: ExternalProviderEnum.JIRA_SERVER.value,
     ExternalProviders.PERFORCE: ExternalProviderEnum.PERFORCE.value,
+    ExternalProviders.CURSOR_ORIGIN: ExternalProviderEnum.CURSOR_ORIGIN.value,
     ExternalProviders.CUSTOM: ExternalProviderEnum.CUSTOM.value,
 }
 

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -9,7 +9,10 @@ from .utils.java import find_java_source_roots
 
 METRIC_PREFIX = "auto_source_code_config"
 DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
-SUPPORTED_INTEGRATIONS = [IntegrationProviderSlug.GITHUB.value]
+SUPPORTED_INTEGRATIONS = [
+    IntegrationProviderSlug.GITHUB.value,
+    IntegrationProviderSlug.CURSOR_ORIGIN.value,
+]
 STACK_ROOT_MAX_LEVEL = 4
 
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -681,6 +681,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Cursor Origin Integration
+register("cursor-origin-app.id", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("cursor-origin-app.name", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("cursor-origin-app.private-key", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register("cursor-origin-app.webhook-secret", flags=FLAG_CREDENTIAL)
+
 # GitHub Console SDK App (separate app for repository invitations)
 register("github-console-sdk-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github-console-sdk-app.installation-id", default="", flags=FLAG_CREDENTIAL)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -684,7 +684,7 @@ register(
 # Cursor Origin Integration
 register("cursor-origin-app.id", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("cursor-origin-app.name", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("cursor-origin-app.private-key", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register("cursor-origin-app.private-key", default="", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("cursor-origin-app.webhook-secret", flags=FLAG_CREDENTIAL)
 
 # GitHub Console SDK App (separate app for repository invitations)

--- a/tests/sentry/integrations/cursor_origin/test_client.py
+++ b/tests/sentry/integrations/cursor_origin/test_client.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.testutils.cases import TestCase
+
+
+class RecordingClient(CursorOriginSetupApiClient):
+    """Captures the request the client would make, without issuing it.
+
+    Overriding `request` short-circuits below the path-rewriting layer, so the
+    rewrite is exercised for real while nothing leaves the process (and no
+    token is minted, since authorize_request never runs).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(installation_id="i_test")
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        self.calls.append((path, kwargs))
+        return {}
+
+
+class ContentsPathRewriteTest(TestCase):
+    """The rewrite that lets Sentry's GitHub-shaped helpers work against Origin.
+
+    Origin serves contents from `/contents?path=...`; the documented
+    `/contents/{path}` form 404s. Detection, CODEOWNERS lookups and stacktrace
+    linking all build the GitHub-shaped path, so the client rewrites it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.api_client = RecordingClient()
+
+    def test_rewrites_github_shaped_contents_path(self) -> None:
+        self.api_client.get("/repos/sentry/nuget-trends/contents/README.md")
+        path, kwargs = self.api_client.calls[-1]
+        assert path == "/repos/sentry/nuget-trends/contents"
+        assert kwargs["params"]["path"] == "README.md"
+
+    def test_preserves_existing_params_when_rewriting(self) -> None:
+        self.api_client.get(
+            "/repos/sentry/nuget-trends/contents/src/App.cs", params={"ref": "main"}
+        )
+        _, kwargs = self.api_client.calls[-1]
+        assert kwargs["params"] == {"ref": "main", "path": "src/App.cs"}
+
+    def test_rewrites_nested_paths_whole(self) -> None:
+        self.api_client.get("/repos/o/r/contents/a/b/c/d.py")
+        path, kwargs = self.api_client.calls[-1]
+        assert path == "/repos/o/r/contents"
+        assert kwargs["params"]["path"] == "a/b/c/d.py"
+
+    def test_leaves_other_paths_alone(self) -> None:
+        for path in (
+            "/repos/o/r/git/trees/main",
+            "/installation/repos",
+            "/repos/o/r/contents",
+        ):
+            self.api_client.get(path)
+            assert self.api_client.calls[-1][0] == path
+
+
+class RateLimitTrackingTest(TestCase):
+    """repo_trees backs off on a low remaining budget, so this has to be real."""
+
+    def test_seeds_with_documented_budget_before_any_request(self) -> None:
+        # Reporting 0 here would read as "exhausted" and make callers back off
+        # before we had made a single request.
+        assert CursorOriginSetupApiClient(installation_id="i_test").get_remaining_api_requests()
+
+    def test_captures_remaining_from_response_headers(self) -> None:
+        client = CursorOriginSetupApiClient(installation_id="i_test")
+
+        class FakeResponse:
+            headers = {"x-ratelimit-remaining": "2847"}
+
+        client.track_response_data(200, None, FakeResponse())  # type: ignore[arg-type]
+        assert client.get_remaining_api_requests() == 2847
+
+    def test_ignores_a_malformed_header(self) -> None:
+        client = CursorOriginSetupApiClient(installation_id="i_test")
+        before = client.get_remaining_api_requests()
+
+        class FakeResponse:
+            headers = {"x-ratelimit-remaining": "not-a-number"}
+
+        client.track_response_data(200, None, FakeResponse())  # type: ignore[arg-type]
+        assert client.get_remaining_api_requests() == before

--- a/tests/sentry/integrations/cursor_origin/test_client.py
+++ b/tests/sentry/integrations/cursor_origin/test_client.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest import mock
+
+import pytest
 
 from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 
 
@@ -90,3 +94,48 @@ class RateLimitTrackingTest(TestCase):
 
         client.track_response_data(200, None, FakeResponse())  # type: ignore[arg-type]
         assert client.get_remaining_api_requests() == before
+
+
+class ClientCrashGuardTest(TestCase):
+    """Regressions for the three client crashes reported on #122180.
+
+    All three are shapes Origin really returns, reached through code paths written
+    against GitHub's shapes.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.api_client = CursorOriginSetupApiClient(installation_id="i_test")
+
+    def test_should_count_api_error_tolerates_a_non_dict_body(self) -> None:
+        # ApiError.json is whatever json.loads returned. A bare string body used to
+        # reach .get() and raise AttributeError (C36-WPK).
+        error = ApiError('"something went wrong"')
+        # ApiError.json is annotated dict[str, Any] | None but holds whatever
+        # json.loads returned. That gap between annotation and runtime is the bug,
+        # so the assertion has to step outside the annotation to state it.
+        body: Any = error.json
+        assert body == "something went wrong"
+        assert self.api_client.should_count_api_error(error, {}) is True
+
+    def test_should_count_api_error_still_reads_a_dict_message(self) -> None:
+        # The guard must not stop expected conditions being discounted.
+        error = ApiError('{"message": "Not Found"}')
+        assert self.api_client.should_count_api_error(error, {}) is False
+
+    def test_get_file_raises_api_error_for_a_directory(self) -> None:
+        # Origin answers a directory path with {"type": "dir", ...} and no
+        # "content". Callers handle ApiError but not KeyError (RNJ-6A9).
+        repo = self.create_repo(project=self.project, name="sentry/nuget-trends")
+        with mock.patch.object(
+            self.api_client, "get_contents", return_value={"type": "dir", "entries": []}
+        ):
+            with pytest.raises(ApiError):
+                self.api_client.get_file(repo, "src", ref=None)
+
+    def test_get_repos_exposes_the_github_shaped_name(self) -> None:
+        # link_all_repos reads repo["full_name"]; Origin returns fullName (5Z5-T9N).
+        with mock.patch.object(
+            self.api_client, "get_repositories", return_value=[{"id": 7, "fullName": "o/r"}]
+        ):
+            assert self.api_client.get_repos() == [{"id": 7, "fullName": "o/r", "full_name": "o/r"}]

--- a/tests/sentry/integrations/cursor_origin/test_error_classification.py
+++ b/tests/sentry/integrations/cursor_origin/test_error_classification.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.testutils.cases import TestCase
+
+TOKEN_URL = "https://api.cursor.com/v1/origin/app/installations/i_01example/access_tokens"
+REPO_URL = "https://api.cursor.com/v1/origin/repos/sentry/nuget-trends"
+
+
+class ErrorClassificationTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            external_id="i_01example",
+            name="sentry",
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, CursorOriginIntegration)
+        self.installation = installation
+
+    def test_rate_limiting_is_recognised(self) -> None:
+        # The base class calls no error rate-limited, so without the override a
+        # 429 would be reported as a broken integration.
+        assert self.installation.is_rate_limited_error(ApiError("slow down", code=429))
+        assert not self.installation.is_rate_limited_error(ApiError("nope", code=404))
+
+    def test_a_failed_token_exchange_is_terminal(self) -> None:
+        # Once an install is revoked, every call fails at the exchange rather
+        # than on the resource. Generic handling reads that as an ordinary 404
+        # and retries forever.
+        for code in (401, 403, 404):
+            assert (
+                self.installation.is_broken_integration_error(
+                    ApiError("gone", code=code, url=TOKEN_URL)
+                )
+                == "installation_suspended"
+            )
+
+    def test_rate_limiting_on_the_token_route_is_not_terminal(self) -> None:
+        assert (
+            self.installation.is_broken_integration_error(
+                ApiError("slow down", code=429, url=TOKEN_URL)
+            )
+            == "rate_limited"
+        )
+
+    def test_a_missing_repository_is_not_terminal(self) -> None:
+        # A 404 on a resource means that resource is gone, not the install.
+        assert (
+            self.installation.is_broken_integration_error(
+                ApiError("no such repo", code=404, url=REPO_URL)
+            )
+            is None
+        )
+
+    def test_falls_back_to_the_shared_classification(self) -> None:
+        assert (
+            self.installation.is_broken_integration_error(ApiUnauthorized("bad token"))
+            == "unauthorized"
+        )

--- a/tests/sentry/integrations/cursor_origin/test_error_classification.py
+++ b/tests/sentry/integrations/cursor_origin/test_error_classification.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+from unittest import mock
+
+import pytest
+
+from sentry.exceptions import InvalidIdentity
 from sentry.integrations.cursor_origin.integration import CursorOriginIntegration
-from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiUnauthorized,
+    IntegrationError,
+)
 from sentry.testutils.cases import TestCase
 
 TOKEN_URL = "https://api.cursor.com/v1/origin/app/installations/i_01example/access_tokens"
@@ -61,3 +70,41 @@ class ErrorClassificationTest(TestCase):
             self.installation.is_broken_integration_error(ApiUnauthorized("bad token"))
             == "unauthorized"
         )
+
+
+class GetRepositoriesFailureTest(TestCase):
+    """A failed repository listing must raise, not come back empty.
+
+    The daily repo sync computes removals as
+    `sentry_active_ids - provider_external_ids`, so an empty list from a transient
+    API failure reads as "the provider dropped every repository" and queues the
+    organization's repos for disablement.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            external_id="i_01example",
+            name="sentry",
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, CursorOriginIntegration)
+        self.installation = installation
+
+    def test_api_error_surfaces_as_integration_error(self) -> None:
+        # IntegrationError is what the sync task treats as a failure to retry, and
+        # what the repo-picker endpoint already catches to return a 400.
+        with mock.patch.object(
+            CursorOriginIntegration, "get_client", side_effect=None
+        ) as get_client:
+            get_client.return_value.get_repositories.side_effect = ApiError("upstream down")
+            with pytest.raises(IntegrationError):
+                self.installation.get_repositories()
+
+    def test_unauthorized_surfaces_as_invalid_identity(self) -> None:
+        with mock.patch.object(CursorOriginIntegration, "get_client") as get_client:
+            get_client.return_value.get_repositories.side_effect = ApiUnauthorized("revoked")
+            with pytest.raises(InvalidIdentity):
+                self.installation.get_repositories()

--- a/tests/sentry/integrations/cursor_origin/test_keys.py
+++ b/tests/sentry/integrations/cursor_origin/test_keys.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+from sentry.integrations.cursor_origin.keys import fetch_public_keys
+from sentry.testutils.cases import TestCase
+
+URLOPEN = "sentry.integrations.cursor_origin.keys.safe_urlopen"
+VALID_X = "PxJ0hMCRAqYcW1S_6E1kPYNlbJWJq4gVPfPRSjNqNXQ"
+
+
+class FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FetchPublicKeysTest(TestCase):
+    """A malformed JWKS must yield no keys, never raise.
+
+    Callers treat an empty list as "cannot verify" and fail closed -- refusing an
+    install. Raising instead turns that into a 500 in the install pipeline, so the
+    shape of an external document must never reach an exception.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # force_refresh everywhere so the Django cache cannot mask a parse result.
+        self.fetch = lambda: fetch_public_keys(force_refresh=True)
+
+    def _with(self, payload: Any) -> list[bytes]:
+        with mock.patch(URLOPEN, return_value=FakeResponse(payload)):
+            return self.fetch()
+
+    def test_reads_a_well_formed_key(self) -> None:
+        keys = self._with({"keys": [{"crv": "Ed25519", "x": VALID_X, "kid": "k1"}]})
+        assert len(keys) == 1
+        assert isinstance(keys[0], bytes)
+
+    def test_payload_is_not_an_object(self) -> None:
+        payloads: tuple[Any, ...] = ([], "nope", 7, None)
+        for payload in payloads:
+            assert self._with(payload) == []
+
+    def test_keys_is_null_or_missing(self) -> None:
+        assert self._with({"keys": None}) == []
+        assert self._with({}) == []
+
+    def test_non_dict_entries_are_skipped(self) -> None:
+        assert self._with({"keys": ["nope", 7, None, []]}) == []
+
+    def test_non_string_x_is_skipped(self) -> None:
+        assert self._with({"keys": [{"crv": "Ed25519", "x": 12345}]}) == []
+
+    def test_undecodable_key_does_not_discard_the_others(self) -> None:
+        # A rotation hiccup on one key must not take verification down entirely.
+        keys = self._with(
+            {
+                "keys": [
+                    {"crv": "Ed25519", "x": "!!!not-base64!!!", "kid": "bad"},
+                    {"crv": "Ed25519", "x": VALID_X, "kid": "good"},
+                ]
+            }
+        )
+        assert len(keys) == 1
+
+    def test_other_curves_are_ignored(self) -> None:
+        assert self._with({"keys": [{"crv": "P-256", "x": VALID_X}]}) == []
+
+    def test_a_fetch_failure_returns_no_keys(self) -> None:
+        with mock.patch(URLOPEN, side_effect=OSError("boom")):
+            assert self.fetch() == []

--- a/tests/sentry/integrations/cursor_origin/test_languages.py
+++ b/tests/sentry/integrations/cursor_origin/test_languages.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from sentry.integrations.cursor_origin.languages import languages_from_tree
+from sentry.testutils.cases import TestCase
+
+
+def blob(path: str, size: int = 100) -> dict[str, object]:
+    return {"path": path, "type": "blob", "size": size, "sha": "x", "mode": "100644"}
+
+
+def tree(path: str) -> dict[str, object]:
+    return {"path": path, "type": "tree", "sha": "x", "mode": "040000"}
+
+
+class LanguagesFromTreeTest(TestCase):
+    def test_sums_bytes_per_language(self) -> None:
+        assert languages_from_tree(
+            [
+                blob("app/main.py", 300),
+                blob("app/util.py", 200),
+                blob("web/index.ts", 50),
+            ]
+        ) == {"Python": 500, "TypeScript": 50}
+
+    def test_uses_linguist_names_so_the_platform_registry_matches(self) -> None:
+        # These keys must match GITHUB_LANGUAGE_TO_SENTRY_PLATFORM exactly, or
+        # detection silently finds nothing.
+        from sentry.integrations.github.platform_registry import (
+            GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
+        )
+
+        detected = languages_from_tree(
+            [blob("Api.cs"), blob("main.go"), blob("app.rb"), blob("lib.rs")]
+        )
+        assert set(detected) <= set(GITHUB_LANGUAGE_TO_SENTRY_PLATFORM)
+        assert detected == {"C#": 100, "Go": 100, "Ruby": 100, "Rust": 100}
+
+    def test_skips_trees_which_carry_no_size(self) -> None:
+        assert languages_from_tree([tree("app"), blob("app/main.py", 10)]) == {"Python": 10}
+
+    def test_excludes_vendored_and_build_output(self) -> None:
+        # A checked-in node_modules or .NET obj/ directory would otherwise
+        # drown out the actual application code.
+        assert languages_from_tree(
+            [
+                blob("src/App.cs", 100),
+                blob("node_modules/left-pad/index.js", 9999),
+                blob("src/obj/Debug/Generated.cs", 9999),
+            ]
+        ) == {"C#": 100}
+
+    def test_excludes_tests(self) -> None:
+        assert languages_from_tree([blob("src/app.py", 100), blob("tests/test_app.py", 9999)]) == {
+            "Python": 100
+        }
+
+    def test_ignores_unmapped_and_extensionless_files(self) -> None:
+        assert languages_from_tree([blob("README.md"), blob("Makefile"), blob("go.sum")]) == {}
+
+    def test_drops_languages_whose_files_are_all_empty(self) -> None:
+        # A zero-weight language would register as a detected platform with no
+        # evidence behind it.
+        assert languages_from_tree([blob("empty.py", 0)]) == {}
+
+    def test_extension_matching_is_case_insensitive(self) -> None:
+        assert languages_from_tree([blob("Program.CS", 10)]) == {"C#": 10}
+
+    def test_empty_tree(self) -> None:
+        assert languages_from_tree([]) == {}

--- a/tests/sentry/integrations/cursor_origin/test_languages.py
+++ b/tests/sentry/integrations/cursor_origin/test_languages.py
@@ -65,5 +65,16 @@ class LanguagesFromTreeTest(TestCase):
     def test_extension_matching_is_case_insensitive(self) -> None:
         assert languages_from_tree([blob("Program.CS", 10)]) == {"C#": 10}
 
+    def test_tolerates_a_stringified_size(self) -> None:
+        # Origin serialises 64-bit ints as JSON strings in places -- `size` on
+        # the contents route comes back as "2534". Tree entries use real ints
+        # today, but a bare += would be a TypeError waiting to happen.
+        assert languages_from_tree([{"path": "a.py", "type": "blob", "size": "300"}]) == {
+            "Python": 300
+        }
+
+    def test_ignores_an_unparseable_size(self) -> None:
+        assert languages_from_tree([{"path": "a.py", "type": "blob", "size": "big"}]) == {}
+
     def test_empty_tree(self) -> None:
         assert languages_from_tree([]) == {}

--- a/tests/sentry/integrations/cursor_origin/test_pipeline.py
+++ b/tests/sentry/integrations/cursor_origin/test_pipeline.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from sentry.integrations.cursor_origin.pipeline import _installation_id_from_receipt
+from sentry.testutils.cases import TestCase
+
+FETCH_KEYS = "sentry.integrations.cursor_origin.pipeline.fetch_public_keys"
+
+
+def _public_bytes(private_key: Ed25519PrivateKey) -> bytes:
+    """The raw public key, in the form the JWKS `x` parameter decodes to."""
+    return private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def _receipt(private_key: Ed25519PrivateKey, subject: str = "in_real") -> str:
+    return jwt.encode({"sub": subject}, private_key, algorithm="EdDSA")
+
+
+class InstallReceiptVerificationTest(TestCase):
+    """The receipt signature is the only thing binding an installation to its installer.
+
+    Trusting `sub` unverified let a caller attach another organization's codebase
+    to their own (Warden E8X-WUV / 9RT-3JX), so what matters most here is what gets
+    *rejected*, not that the happy path works.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.origin_key = Ed25519PrivateKey.generate()
+
+    def test_accepts_a_receipt_signed_by_an_origin_key(self) -> None:
+        with mock.patch(FETCH_KEYS, return_value=[_public_bytes(self.origin_key)]):
+            assert _installation_id_from_receipt(_receipt(self.origin_key)) == "in_real"
+
+    def test_tries_every_published_key(self) -> None:
+        # Receipts carry no key id we can rely on, so one signed by any active key
+        # has to verify -- not only one signed by the first key published.
+        keys = [_public_bytes(Ed25519PrivateKey.generate()), _public_bytes(self.origin_key)]
+        with mock.patch(FETCH_KEYS, return_value=keys):
+            assert _installation_id_from_receipt(_receipt(self.origin_key)) == "in_real"
+
+    def test_rejects_a_receipt_signed_by_an_unknown_key(self) -> None:
+        # The actual attack: a well-formed receipt naming someone else's
+        # installation, signed by a key Origin never published.
+        forged = _receipt(Ed25519PrivateKey.generate(), subject="in_victim")
+        with mock.patch(FETCH_KEYS, return_value=[_public_bytes(self.origin_key)]):
+            assert _installation_id_from_receipt(forged) is None
+
+    def test_rejects_an_unsigned_receipt(self) -> None:
+        # Exactly what the previous verify_signature=False decode accepted.
+        # key=None is how PyJWT expresses the "none" algorithm; the signature is
+        # the point of the test, so the type complaint is not interesting here.
+        unsigned = jwt.encode({"sub": "in_victim"}, key=None, algorithm="none")  # type: ignore[arg-type]
+        with mock.patch(FETCH_KEYS, return_value=[_public_bytes(self.origin_key)]):
+            assert _installation_id_from_receipt(unsigned) is None
+
+    def test_rejects_a_malformed_receipt(self) -> None:
+        with mock.patch(FETCH_KEYS, return_value=[_public_bytes(self.origin_key)]):
+            assert _installation_id_from_receipt("not-a-jwt") is None
+
+    def test_fails_closed_when_no_keys_are_available(self) -> None:
+        # A JWKS outage must refuse the install rather than fall back to trusting
+        # the claim.
+        with mock.patch(FETCH_KEYS, return_value=[]) as fetch:
+            assert _installation_id_from_receipt(_receipt(self.origin_key)) is None
+        assert fetch.called
+
+    def test_rejects_a_verified_receipt_with_no_subject(self) -> None:
+        no_subject = jwt.encode({"iss": "origin"}, self.origin_key, algorithm="EdDSA")
+        with mock.patch(FETCH_KEYS, return_value=[_public_bytes(self.origin_key)]):
+            assert _installation_id_from_receipt(no_subject) is None

--- a/tests/sentry/integrations/cursor_origin/test_repository.py
+++ b/tests/sentry/integrations/cursor_origin/test_repository.py
@@ -73,3 +73,48 @@ class CursorOriginRepositoryProviderTest(TestCase):
         ):
             with pytest.raises(IntegrationError):
                 self.provider.get_repository_data(self.organization, config)
+
+
+class BuildRepositoryConfigShapeTest(TestCase):
+    """build_repository_config is reached with two different config shapes.
+
+    The repo picker goes through get_repository_data, which sets "name". The
+    link_all_repos task that post_install schedules calls it directly with only
+    {external_id, integration_id, identifier}, which used to raise KeyError('name')
+    for every repository on every install.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
+
+    def test_link_all_repos_shape_without_a_name(self) -> None:
+        config = self.provider.build_repository_config(
+            organization=self.organization,
+            data={
+                "external_id": "42",
+                "integration_id": 7,
+                "identifier": "sentry/nuget-trends",
+            },
+        )
+        assert config["name"] == "sentry/nuget-trends"
+        assert config["external_id"] == "42"
+        assert config["integration_id"] == 7
+        assert config["url"].endswith("/sentry/nuget-trends")
+        assert config["config"]["default_branch"] is None
+
+    def test_repo_picker_shape_prefers_the_canonical_name(self) -> None:
+        # get_repository_data overwrites name with the API's fullName, which is the
+        # authoritative casing; identifier is whatever was picked.
+        config = self.provider.build_repository_config(
+            organization=self.organization,
+            data={
+                "external_id": "42",
+                "integration_id": 7,
+                "identifier": "Sentry/NuGet-Trends",
+                "name": "sentry/nuget-trends",
+                "default_branch": "main",
+            },
+        )
+        assert config["name"] == "sentry/nuget-trends"
+        assert config["config"]["default_branch"] == "main"

--- a/tests/sentry/integrations/cursor_origin/test_repository.py
+++ b/tests/sentry/integrations/cursor_origin/test_repository.py
@@ -10,10 +10,10 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.testutils.cases import TestCase
 
 REPO_PAYLOAD: dict[str, Any] = {
-    "id": "r_01m08sz0y6eny815ggv768qsjp",
+    "id": "r_01example000000000000repo",
     "name": "nuget-trends",
     "fullName": "sentry/nuget-trends",
-    "owner": {"slug": "sentry", "id": "ns_01kzygm43nfad9gfxqx3nxqvf4"},
+    "owner": {"slug": "sentry", "id": "ns_01example00000000000000ns"},
     "defaultBranch": "main",
     "cloneUrl": "https://origin.cursor.com/sentry/nuget-trends.git",
 }
@@ -26,7 +26,7 @@ class CursorOriginRepositoryProviderTest(TestCase):
             organization=self.organization,
             provider="cursor_origin",
             name="sentry",
-            external_id="i_01m08t5nksemgsd2agkna3xe1c",
+            external_id="i_01example00000000000inst",
         )
         self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
 
@@ -43,7 +43,7 @@ class CursorOriginRepositoryProviderTest(TestCase):
 
     def test_get_repository_data_maps_origin_fields(self) -> None:
         data = self._get_repository_data()
-        assert data["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert data["external_id"] == "r_01example000000000000repo"
         assert data["name"] == "sentry/nuget-trends"
         assert data["default_branch"] == "main"
 
@@ -60,7 +60,7 @@ class CursorOriginRepositoryProviderTest(TestCase):
         data = self._get_repository_data()
         config = self.provider.build_repository_config(self.organization, data)
         assert config["name"] == "sentry/nuget-trends"
-        assert config["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert config["external_id"] == "r_01example000000000000repo"
         assert config["url"] == "https://cursor.com/codebase/sentry/nuget-trends"
         assert config["integration_id"] == self.integration.id
         assert config["config"]["default_branch"] == "main"

--- a/tests/sentry/integrations/cursor_origin/test_repository.py
+++ b/tests/sentry/integrations/cursor_origin/test_repository.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from sentry.integrations.cursor_origin.repository import CursorOriginRepositoryProvider
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.testutils.cases import TestCase
+
+REPO_PAYLOAD: dict[str, Any] = {
+    "id": "r_01m08sz0y6eny815ggv768qsjp",
+    "name": "nuget-trends",
+    "fullName": "sentry/nuget-trends",
+    "owner": {"slug": "sentry", "id": "ns_01kzygm43nfad9gfxqx3nxqvf4"},
+    "defaultBranch": "main",
+    "cloneUrl": "https://origin.cursor.com/sentry/nuget-trends.git",
+}
+
+
+class CursorOriginRepositoryProviderTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            name="sentry",
+            external_id="i_01m08t5nksemgsd2agkna3xe1c",
+        )
+        self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
+
+    def _get_repository_data(self) -> dict[str, Any]:
+        config: dict[str, Any] = {
+            "installation": self.integration.id,
+            "identifier": "sentry/nuget-trends",
+        }
+        with patch(
+            "sentry.integrations.cursor_origin.client.CursorOriginSetupApiClient.get_repo",
+            return_value=REPO_PAYLOAD,
+        ):
+            return dict(self.provider.get_repository_data(self.organization, config))
+
+    def test_get_repository_data_maps_origin_fields(self) -> None:
+        data = self._get_repository_data()
+        assert data["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert data["name"] == "sentry/nuget-trends"
+        assert data["default_branch"] == "main"
+
+    def test_get_repository_data_sets_integration_id(self) -> None:
+        # build_repository_config reads this key. Omitting it made repository
+        # creation 500 with a bare KeyError *after* both Origin calls had
+        # already succeeded, which read like an API failure rather than a
+        # missing field.
+        assert self._get_repository_data()["integration_id"] == self.integration.id
+
+    def test_build_repository_config_consumes_what_get_repository_data_produces(self) -> None:
+        # The pairing is the point: these two ran fine in isolation while the
+        # handoff between them was broken.
+        data = self._get_repository_data()
+        config = self.provider.build_repository_config(self.organization, data)
+        assert config["name"] == "sentry/nuget-trends"
+        assert config["external_id"] == "r_01m08sz0y6eny815ggv768qsjp"
+        assert config["url"] == "https://cursor.com/codebase/sentry/nuget-trends"
+        assert config["integration_id"] == self.integration.id
+        assert config["config"]["default_branch"] == "main"
+
+    def test_unreadable_repo_raises_integration_error(self) -> None:
+        config = {"installation": self.integration.id, "identifier": "sentry/nope"}
+        with patch(
+            "sentry.integrations.cursor_origin.client.CursorOriginSetupApiClient.get_repo",
+            side_effect=ApiError("not found"),
+        ):
+            with pytest.raises(IntegrationError):
+                self.provider.get_repository_data(self.organization, config)

--- a/tests/sentry/integrations/cursor_origin/test_token_cache.py
+++ b/tests/sentry/integrations/cursor_origin/test_token_cache.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+
+from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.testutils.cases import TestCase
+
+LOCMEM = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+INSTALLATION = "i_01example"
+
+
+@override_settings(CACHES=LOCMEM)
+class InstallationTokenCacheTest(TestCase):
+    """A fresh client per call site must not mean a fresh token per call site.
+
+    `get_installation().get_client()` builds a new client every time, so an
+    instance-only cache meant one token exchange per call. Minting is charged
+    against the app-JWT budget, which is the smaller of Origin's two.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+
+    def _client(self) -> CursorOriginSetupApiClient:
+        return CursorOriginSetupApiClient(installation_id=INSTALLATION)
+
+    def test_a_second_client_reuses_the_cached_token(self) -> None:
+        with patch.object(
+            CursorOriginSetupApiClient, "post", return_value={"token": "oit_first"}
+        ) as post:
+            assert self._client().get_access_token() == "oit_first"
+            assert self._client().get_access_token() == "oit_first"
+            assert self._client().get_access_token() == "oit_first"
+
+        assert post.call_count == 1
+
+    def test_mints_again_once_the_cache_is_gone(self) -> None:
+        # Eviction is harmless -- it costs one exchange, not a failure.
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"token": "oit_a"}):
+            assert self._client().get_access_token() == "oit_a"
+
+        cache.clear()
+
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"token": "oit_b"}):
+            assert self._client().get_access_token() == "oit_b"
+
+    def test_tokens_are_not_shared_between_installations(self) -> None:
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"token": "oit_one"}):
+            CursorOriginSetupApiClient(installation_id="i_one").get_access_token()
+
+        with patch.object(
+            CursorOriginSetupApiClient, "post", return_value={"token": "oit_two"}
+        ) as post:
+            token = CursorOriginSetupApiClient(installation_id="i_two").get_access_token()
+
+        assert token == "oit_two"
+        assert post.call_count == 1
+
+    def test_rejects_a_response_without_a_token(self) -> None:
+        with patch.object(CursorOriginSetupApiClient, "post", return_value={"nope": "x"}):
+            with pytest.raises(ApiError):
+                self._client().get_access_token()
+
+    def test_requires_an_installation_id(self) -> None:
+        with pytest.raises(ValueError):
+            CursorOriginSetupApiClient().get_access_token()
+
+    def test_does_not_cache_across_a_missing_installation(self) -> None:
+        def fake_post(self: Any, path: str, *a: Any, **k: Any) -> dict[str, str]:
+            return {"token": "oit_x"}
+
+        with patch.object(CursorOriginSetupApiClient, "post", fake_post):
+            client = self._client()
+            first = client.get_access_token()
+            # Same instance short-circuits before touching the cache at all.
+            assert client.get_access_token() == first


### PR DESCRIPTION
Adds the Cursor Origin source-code-management integration: API client, install pipeline, repository provider, and the registration needed for repositories, stack-trace linking and automatic code mappings.

**This is PR 1 of 6.** The work was one branch; it is split because `static/` and `src/` do not deploy atomically, and because a 2,300-line integration is not reviewable in one sitting. Each PR stacks on the previous one:

| | PR | Contents |
|---|---|---|
| **1** | **this one** | client, install pipeline, repository provider, registration, feature gate |
| 2 | *next* | platform detection generalised to a `Protocol` (touches shared GitHub code) |
| 3 | | webhooks + commit tracking |
| 4 | | Seer / SCM wiring |
| 5 | | Git-over-HTTPS archive and commit helpers |
| 6 | | frontend (`static/` only) |

## Safe by default

`requires_feature_flag = True`, gated on `organizations:integrations-cursor-origin`.

`is_provider_enabled` is consulted in exactly two places — the integration directory listing and the install pipeline — and **every other Origin surface requires an installed integration to be reachable**. Webhooks, repository sync, auto code mappings, platform detection and the Seer paths in later PRs are all downstream of an install. Flag off means none of it exists.

Two things a reviewer should know about that:

- It gates **new installs and visibility, not existing installations**. Turning the flag off does not disable an org that already installed. It is a rollout control, not a kill switch. A real kill switch is separate work.
- The FlagPole config lands in `sentry-options-automator` **after** this merges, scoped to internal orgs. Until then the flag is simply absent, which reads as off.

## Dependencies / TODO

Written for someone who has never heard of Cursor Origin.

**Deliberate, with reasons:**

- **Installation tokens are not persisted.** `get_client()` mints a fresh token per call rather than storing it on `Integration.metadata` like GitHub. Origin's tokens last under 15 minutes so this is not a correctness bug, but it spends a token exchange per operation and will show as rate-limit pressure under load. Fix is to mirror `GithubProxyClient.get_access_token()`.
- **`compare_commits` returns `[]`** here. Implemented in PR 3, where the webhook and commits API arrive together.
- **`is_broken_integration_error` is unimplemented**, so a revoked installation keeps erroring rather than being marked broken and surfaced.
- **`repo_search` filters client-side.** Origin has no search endpoint, so `get_repositories(query=...)` filters the full list. Fine for small installations, poor for thousands of repos.
- **The languages shim is heuristic.** Origin has no languages API, so `languages.py` approximates GitHub's from the tree. The vendored/test exclusion list is hand-written rather than Linguist's, and `.razor` is unmapped.
- **No `truncated` signal.** GitHub's `git/trees` reports truncation; Origin exposes nothing equivalent, so a very large repo could silently detect against partial data.

**Polish:** the integration detail page links to a `sentry-docs` page that does not exist yet, and the logo is Cursor's mark because Origin ships none of its own.

## Security and correctness fixes included

Nine findings across two review rounds — seven from Warden on the original combined PR, two more from Warden and Copilot on this one — each in its own commit. The one worth reading closely:

**The install receipt is now verified.** It was decoded with `verify_signature=False`, and a bare `installation_id` query parameter was accepted in preference to it. Either route let a caller name any installation Sentry's app can read and bind it to their own organization. The `state` check does not help — it authenticates the Sentry *session*, not ownership of the installation. Now the receipt's Ed25519 signature is checked against Origin's published JWKS and the query parameter is ignored.

Two that are worth calling out because the failure is silent rather than loud:

- **A failed repository listing no longer looks like an empty one.** `get_repositories()` caught `ApiError` and returned `[]`. With `cursor_origin` added to `SCM_SYNC_PROVIDERS`, the daily sync computes `removed_ids = sentry_active_ids - provider_external_ids`, so one transient Origin failure would read as "the provider dropped every repository" and queue the org's repos for disablement. It now raises through `raise_error()`, which the sync task treats as a failure to retry and the repo-picker endpoint already catches for a 400.
- **The JWKS document is treated as untrusted input.** The fetch was inside `try/except` but the parsing was not, so a malformed document raised out of the function. That mattered specifically because the receipt path is documented as *failing closed* — and an exception is not failing closed, it is a 500 out of the install pipeline. The "fails closed" property was only ever true for network failures. Every level is now shape-checked, and one undecodable key is skipped individually rather than discarding the well-formed keys beside it.

The rest: a crash on every install (`link_all_repos` calling a method the client did not have), a `KeyError` building repository configs, `AttributeError` on non-dict error bodies, `KeyError` on directory contents responses, an unconfigured private key crashing unhelpfully, and stack-trace link matching that could select the wrong installation.

**No public API change.** An earlier revision registered `cursor_origin` as an external-actor provider, which altered the `ExternalTeam.provider` and `ExternalUser.provider` schemas. External actors serve the CODEOWNERS path, which this integration does not declare (`features` is `COMMITS` and `STACKTRACE_LINK` only), and nothing referenced the enum outside its own definition — so it was removed rather than documented. The generated OpenAPI schema for this branch is now byte-identical to master.

One Warden finding was a **false positive** and is not fixed: `binascii.Error` *is* a `ValueError` subclass, so the existing handler already caught it. [Replied and resolved on the original PR.](https://github.com/getsentry/sentry/pull/122180#discussion_r3816053938)

## Verification

Unit tests cover the language shim, the contents path rewrite, rate-limit capture, the repository provider in both config shapes, the receipt verification (including what it *rejects*), the client crash guards, every malformed JWKS shape, and the two error mappings for a failed repository listing. 56 tests in `tests/sentry/integrations/cursor_origin/`.

Verified against a real Origin installation, not only tests:

- The install completes and the receipt verifies — Origin signs with EdDSA using a key from `/v1/origin/keys`. Confirmed on two separate installs with the same key id.
- Repository auto-linking creates the repository. This path had **never** worked: one bug masked another, so the second only surfaced once the first was fixed.
- Automatic code mappings derive from real ingested events against an Origin repo.

**Testing this feature needs both halves.** Because the split separates `static/` from `src/`, exercising the install flow locally requires this PR's backend plus PR 6's frontend in one tree. That is a real cost of the split and worth knowing before anyone tries to reproduce.

## Not covered by tests

The install pipeline end-to-end and the integration installation itself are still verified by live runs rather than automated tests.

---

**Reference:** [#122180](https://github.com/getsentry/sentry/pull/122180) is the original single-branch version of this work — all six PRs' worth of changes in one draft, kept open for history. It carries the Warden review that produced the fixes above. It is superseded by this stack and should not be merged.

