### PR TITLE
style: Enable no-useless-computed-key and autofix violations

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -412,6 +412,7 @@ export default typescript.config([
       'no-script-url': 'error',
       'no-self-compare': 'error',
       'no-sequences': 'error',
+      'no-useless-computed-key': 'error',
       'object-shorthand': ['error', 'properties'],
       'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
       quotes: ['error', 'single', {avoidEscape: true, allowTemplateLiterals: false}],

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -210,7 +210,7 @@ export function CommandPalette({
               children: [] as CMDKFlatItem[],
               listItemType: 'action' as const,
               display: {label: t('Tell us what to improve'), icon: <IconMegaphone />},
-              onAction: () => openForm({tags: {['feedback.source']: 'command_palette'}}),
+              onAction: () => openForm({tags: {'feedback.source': 'command_palette'}}),
             },
           ]
         : []),
@@ -1249,7 +1249,7 @@ function CommandPaletteNoResults() {
             variant="primary"
             feedbackOptions={{
               tags: {
-                ['feedback.source']: 'command_palette',
+                'feedback.source': 'command_palette',
               },
             }}
           />

--- a/static/app/components/events/contexts/knownContext/cloudResource.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/cloudResource.spec.tsx
@@ -20,7 +20,7 @@ const MOCK_CLOUD_RESOURCE: CloudResourceContext = {
 };
 
 const MOCK_REDACTION = {
-  ['host.id']: {
+  'host.id': {
     '': {
       chunks: [
         {
@@ -81,7 +81,7 @@ describe('CloudResourceContext', () => {
         event={event}
         type="cloud_resource"
         alias="cloud_resource"
-        value={{...MOCK_CLOUD_RESOURCE, ['host.id']: ''}}
+        value={{...MOCK_CLOUD_RESOURCE, 'host.id': ''}}
       />
     );
 

--- a/static/app/components/events/contexts/knownContext/culture.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/culture.spec.tsx
@@ -20,7 +20,7 @@ const MOCK_CULTURE_CONTEXT: CultureContext = {
 };
 
 const MOCK_REDACTION = {
-  ['timezone']: {
+  timezone: {
     '': {
       chunks: [
         {

--- a/static/app/components/events/contexts/knownContext/missingInstrumentation.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/missingInstrumentation.spec.tsx
@@ -17,7 +17,7 @@ const MOCK_MISSING_INSTRUMENTATION_CONTEXT: MissingInstrumentationContext = {
 };
 
 const MOCK_REDACTION = {
-  ['package']: {
+  package: {
     '': {
       chunks: [
         {

--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -68,8 +68,8 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
       feedbackOptions={{
         messagePlaceholder: t('How can we make feature flags work better for you?'),
         tags: {
-          ['feedback.source']: 'issue_details_feature_flags',
-          ['feedback.owner']: 'replay',
+          'feedback.source': 'issue_details_feature_flags',
+          'feedback.owner': 'replay',
         },
       }}
     />

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -198,9 +198,9 @@ function FeedbackItemContexts({
       ...eventData.contexts,
       feedback: {
         ...eventData.contexts?.feedback,
-        ['auto_spam.detection_enabled']: evidenceObject.spam_detection_enabled,
+        'auto_spam.detection_enabled': evidenceObject.spam_detection_enabled,
         ...(evidenceObject.spam_detection_enabled
-          ? {['auto_spam.is_spam']: evidenceObject.is_spam}
+          ? {'auto_spam.is_spam': evidenceObject.is_spam}
           : {}),
       },
     },

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -40,9 +40,9 @@ export function FeedbackSummaryCategories() {
               ? t('What did you like about the AI-powered summary?')
               : t('How can we make the summary work better for you?'),
           tags: {
-            ['feedback.source']: 'feedback_ai_summary',
-            ['feedback.owner']: 'replay',
-            ['feedback.type']: type,
+            'feedback.source': 'feedback_ai_summary',
+            'feedback.owner': 'replay',
+            'feedback.type': type,
           },
         }}
       >

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/baseAskSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/baseAskSeerComboBox.tsx
@@ -151,11 +151,11 @@ export function BaseAskSeerComboBox<T extends QueryTokensProps>({
       openForm({
         messagePlaceholder: t('Why were these queries incorrect?'),
         tags: {
-          ['feedback.source']: `ai_query.${analyticsArea}`,
-          ['feedback.owner']: 'ml-ai',
-          ['feedback.natural_language_query']: searchQuery,
-          ['feedback.raw_result']: JSON.stringify(queries).replace(/\n/g, ''),
-          ['feedback.num_queries_returned']: queries.length,
+          'feedback.source': `ai_query.${analyticsArea}`,
+          'feedback.owner': 'ml-ai',
+          'feedback.natural_language_query': searchQuery,
+          'feedback.raw_result': JSON.stringify(queries).replace(/\n/g, ''),
+          'feedback.num_queries_returned': queries.length,
         },
       });
     } else {
@@ -585,8 +585,8 @@ export function BaseAskSeerComboBox<T extends QueryTokensProps>({
                         'How can we make Seer search better for you?'
                       ),
                       tags: {
-                        ['feedback.source']: `ai_query.${analyticsArea}`,
-                        ['feedback.owner']: 'ml-ai',
+                        'feedback.source': `ai_query.${analyticsArea}`,
+                        'feedback.owner': 'ml-ai',
                       },
                     })
                   }

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -411,7 +411,7 @@ export function SearchQueryBuilderCombobox<
   isLoading: incomingIsLoading,
   isOpen: incomingIsOpen,
   keepVisibleRef,
-  ['data-test-id']: dataTestId,
+  'data-test-id': dataTestId,
   ref,
 }: SearchQueryBuilderComboboxProps<T>) {
   const {clearSearchQuery, dispatch} = useSearchQueryBuilderState();

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -108,8 +108,8 @@ function FeedbackFooter({
           messagePlaceholder: t('How can we make search better for you?'),
           tags: {
             search_source: searchSource,
-            ['feedback.source']: 'search_query_builder',
-            ['feedback.owner']: 'issues',
+            'feedback.source': 'search_query_builder',
+            'feedback.owner': 'issues',
           },
         }}
       />

--- a/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
@@ -243,7 +243,7 @@ export function useSearchTokenCombobox<T>(
       shouldSelectOnPressUp: true,
       shouldFocusOnHover: true,
       linkBehavior: 'selection' as const,
-      ['UNSTABLE_itemBehavior']: 'action',
+      UNSTABLE_itemBehavior: 'action',
     }),
   };
 }

--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -34,7 +34,7 @@ export const TextOverflow = styled(
     className,
     ellipsisDirection = 'right',
     isParagraph = false,
-    ['data-test-id']: dataTestId,
+    'data-test-id': dataTestId,
     style,
   }: Props) => {
     const Component = isParagraph ? 'p' : 'div';

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -102,7 +102,7 @@ export function ComboBox({
   onInputFocus,
   onOpenChange,
   onOptionSelected,
-  ['data-test-id']: dataTestId,
+  'data-test-id': dataTestId,
   filterValue,
   onInputChange,
   onKeyDown,

--- a/static/app/components/tokenizedInput/token/inputBox.tsx
+++ b/static/app/components/tokenizedInput/token/inputBox.tsx
@@ -45,7 +45,7 @@ export function InputBox({
   onKeyDown,
   onKeyDownCapture,
   onPaste,
-  ['data-test-id']: dataTestId,
+  'data-test-id': dataTestId,
   placeholder,
   ref,
   tabIndex,

--- a/static/app/icons/iconClose.tsx
+++ b/static/app/icons/iconClose.tsx
@@ -5,10 +5,7 @@ interface Props extends SVGIconProps {
   ['data-test-id']?: string;
 }
 
-export function IconClose({
-  ['data-test-id']: dataTestId = 'icon-close',
-  ...props
-}: Props) {
+export function IconClose({'data-test-id': dataTestId = 'icon-close', ...props}: Props) {
   return (
     <SvgIcon {...props} data-test-id={dataTestId}>
       <path d="M12.72 2.22C13.01 1.93 13.49 1.93 13.78 2.22C14.07 2.51 14.07 2.99 13.78 3.28L9.06 8L13.78 12.72C14.07 13.01 14.07 13.49 13.78 13.78C13.49 14.07 13.01 14.07 12.72 13.78L8 9.06L3.28 13.78C2.99 14.07 2.51 14.07 2.22 13.78C1.93 13.49 1.93 13.01 2.22 12.72L6.94 8L2.22 3.28C1.93 2.99 1.93 2.51 2.22 2.22C2.51 1.93 2.99 1.93 3.28 2.22L8 6.94L12.72 2.22Z" />

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -39,15 +39,15 @@ export class CanvasScheduler {
   requestAnimationFrame: number | null = null;
 
   events: EventStore = {
-    ['show in table view']: new Set<FlamegraphEvents['show in table view']>(),
-    ['reset zoom']: new Set<FlamegraphEvents['reset zoom']>(),
-    ['highlight frame']: new Set<FlamegraphEvents['highlight frame']>(),
-    ['highlight span']: new Set<FlamegraphEvents['highlight span']>(),
-    ['highlight ui frame']: new Set<FlamegraphEvents['highlight ui frame']>(),
-    ['set config view']: new Set<FlamegraphEvents['set config view']>(),
-    ['transform config view']: new Set<FlamegraphEvents['transform config view']>(),
-    ['zoom at frame']: new Set<FlamegraphEvents['zoom at frame']>(),
-    ['zoom at span']: new Set<FlamegraphEvents['zoom at span']>(),
+    'show in table view': new Set<FlamegraphEvents['show in table view']>(),
+    'reset zoom': new Set<FlamegraphEvents['reset zoom']>(),
+    'highlight frame': new Set<FlamegraphEvents['highlight frame']>(),
+    'highlight span': new Set<FlamegraphEvents['highlight span']>(),
+    'highlight ui frame': new Set<FlamegraphEvents['highlight ui frame']>(),
+    'set config view': new Set<FlamegraphEvents['set config view']>(),
+    'transform config view': new Set<FlamegraphEvents['transform config view']>(),
+    'zoom at frame': new Set<FlamegraphEvents['zoom at frame']>(),
+    'zoom at span': new Set<FlamegraphEvents['zoom at span']>(),
   };
 
   onDispose(cb: () => void): void {

--- a/static/app/views/automations/components/automationFeedbackButton.tsx
+++ b/static/app/views/automations/components/automationFeedbackButton.tsx
@@ -5,8 +5,8 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 const automationFeedbackOptions = {
   messagePlaceholder: t('How can we improve the alerts experience?'),
   tags: {
-    ['feedback.source']: 'automations',
-    ['feedback.owner']: 'aci',
+    'feedback.source': 'automations',
+    'feedback.owner': 'aci',
   },
 };
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -2110,9 +2110,9 @@ describe('Visualize', () => {
       body: {
         data: [
           {
-            ['metric.name']: 'alpha_metric',
-            ['metric.type']: 'counter',
-            ['count(metric.name)']: 1,
+            'metric.name': 'alpha_metric',
+            'metric.type': 'counter',
+            'count(metric.name)': 1,
           },
         ],
       },

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
@@ -34,29 +34,29 @@ describe('MetricSelectRow', () => {
       body: {
         data: [
           {
-            ['metric.name']: 'alpha_metric',
-            ['metric.type']: 'counter',
-            ['count(metric.name)']: 1,
+            'metric.name': 'alpha_metric',
+            'metric.type': 'counter',
+            'count(metric.name)': 1,
           },
           {
-            ['metric.name']: 'beta_metric',
-            ['metric.type']: 'counter',
-            ['count(metric.name)']: 1,
+            'metric.name': 'beta_metric',
+            'metric.type': 'counter',
+            'count(metric.name)': 1,
           },
           {
-            ['metric.name']: 'counter_metric',
-            ['metric.type']: 'counter',
-            ['count(metric.name)']: 1,
+            'metric.name': 'counter_metric',
+            'metric.type': 'counter',
+            'count(metric.name)': 1,
           },
           {
-            ['metric.name']: 'distribution_metric',
-            ['metric.type']: 'distribution',
-            ['count(metric.name)']: 1,
+            'metric.name': 'distribution_metric',
+            'metric.type': 'distribution',
+            'count(metric.name)': 1,
           },
           {
-            ['metric.name']: 'gauge_metric',
-            ['metric.type']: 'gauge',
-            ['count(metric.name)']: 1,
+            'metric.name': 'gauge_metric',
+            'metric.type': 'gauge',
+            'count(metric.name)': 1,
           },
         ],
       },
@@ -560,14 +560,14 @@ describe('MetricSelectRow', () => {
       body: {
         data: [
           {
-            ['metric.name']: 'counter_metric',
-            ['metric.type']: 'counter',
-            ['count(metric.name)']: 1,
+            'metric.name': 'counter_metric',
+            'metric.type': 'counter',
+            'count(metric.name)': 1,
           },
           {
-            ['metric.name']: 'gauge_metric',
-            ['metric.type']: 'gauge',
-            ['count(metric.name)']: 1,
+            'metric.name': 'gauge_metric',
+            'metric.type': 'gauge',
+            'count(metric.name)': 1,
           },
         ],
       },

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.spec.tsx
@@ -71,14 +71,14 @@ function setupMockApis() {
     body: {
       data: [
         {
-          ['metric.name']: 'alpha_metric',
-          ['metric.type']: 'counter',
-          ['count(metric.name)']: 1,
+          'metric.name': 'alpha_metric',
+          'metric.type': 'counter',
+          'count(metric.name)': 1,
         },
         {
-          ['metric.name']: 'beta_metric',
-          ['metric.type']: 'counter',
-          ['count(metric.name)']: 1,
+          'metric.name': 'beta_metric',
+          'metric.type': 'counter',
+          'count(metric.name)': 1,
         },
       ],
     },

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.spec.tsx
@@ -56,11 +56,11 @@ describe('DetailsWidgetVisualization', () => {
   it('renders a span', () => {
     const span: TestSpan = {
       id: '123',
-      ['span.op']: 'span_op',
-      ['span.description']: 'span_description',
-      ['span.group']: 'span_group',
-      ['span.category']: 'span_category',
-      ['project.id']: 1,
+      'span.op': 'span_op',
+      'span.description': 'span_description',
+      'span.group': 'span_group',
+      'span.category': 'span_category',
+      'project.id': 1,
     };
     render(<DetailsWidgetVisualization span={span} />);
     expect(
@@ -71,11 +71,11 @@ describe('DetailsWidgetVisualization', () => {
   it('renders a db span', async () => {
     const span: TestSpan = {
       id: '123',
-      ['span.op']: 'db',
-      ['span.description']: 'SELECT * FROM users',
-      ['span.group']: 'span_group',
-      ['span.category']: 'db',
-      ['project.id']: 1,
+      'span.op': 'db',
+      'span.description': 'SELECT * FROM users',
+      'span.group': 'span_group',
+      'span.category': 'db',
+      'project.id': 1,
     };
     render(<DetailsWidgetVisualization span={span} />);
 
@@ -89,11 +89,11 @@ describe('DetailsWidgetVisualization', () => {
   it('renders an http domain status link', async () => {
     const span: TestSpan = {
       id: '123',
-      ['span.op']: 'http',
-      ['span.description']: 'GET /users',
-      ['span.group']: 'span_group',
-      ['span.category']: 'http',
-      ['project.id']: 1,
+      'span.op': 'http',
+      'span.description': 'GET /users',
+      'span.group': 'span_group',
+      'span.category': 'http',
+      'project.id': 1,
     };
     render(<DetailsWidgetVisualization span={span} />);
 

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -25,8 +25,8 @@ function FeedbackAction() {
       feedbackOptions={{
         messagePlaceholder: t('What were you doing when this widget broke?'),
         tags: {
-          ['feedback.source']: 'dashboards-widget-render-error',
-          ['feedback.owner']: 'dashboards',
+          'feedback.source': 'dashboards-widget-render-error',
+          'feedback.owner': 'dashboards',
         },
       }}
     >

--- a/static/app/views/detectors/components/monitorFeedbackButton.tsx
+++ b/static/app/views/detectors/components/monitorFeedbackButton.tsx
@@ -5,8 +5,8 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 const monitorFeedbackOptions = {
   messagePlaceholder: t('How can we improve the monitor experience?'),
   tags: {
-    ['feedback.source']: 'monitors',
-    ['feedback.owner']: 'aci',
+    'feedback.source': 'monitors',
+    'feedback.owner': 'aci',
   },
 };
 

--- a/static/app/views/explore/components/attributeBreakdowns/styles.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/styles.tsx
@@ -37,8 +37,8 @@ function FeedbackButton() {
             'How can we make attribute breakdowns work better for you?'
           ),
           tags: {
-            ['feedback.source']: 'attribute-breakdowns',
-            ['feedback.owner']: 'ml-ai',
+            'feedback.source': 'attribute-breakdowns',
+            'feedback.owner': 'ml-ai',
           },
         })
       }

--- a/static/app/views/explore/hooks/useMetricOptions.spec.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.spec.tsx
@@ -50,9 +50,9 @@ describe('useMetricOptions', () => {
   it('fetches metric options from tracemetrics dataset', async () => {
     const mockData = {
       data: [
-        {['metric.name']: 'metric.c', ['metric.type']: 'counter'},
-        {['metric.name']: 'metric.a', ['metric.type']: 'distribution'},
-        {['metric.name']: 'metric.b', ['metric.type']: 'distribution'},
+        {'metric.name': 'metric.c', 'metric.type': 'counter'},
+        {'metric.name': 'metric.a', 'metric.type': 'distribution'},
+        {'metric.name': 'metric.b', 'metric.type': 'distribution'},
       ],
     };
 
@@ -80,9 +80,9 @@ describe('useMetricOptions', () => {
 
     await waitFor(() =>
       expect(result.current.data?.data).toEqual([
-        {['metric.name']: 'metric.a', ['metric.type']: 'distribution'},
-        {['metric.name']: 'metric.b', ['metric.type']: 'distribution'},
-        {['metric.name']: 'metric.c', ['metric.type']: 'counter'},
+        {'metric.name': 'metric.a', 'metric.type': 'distribution'},
+        {'metric.name': 'metric.b', 'metric.type': 'distribution'},
+        {'metric.name': 'metric.c', 'metric.type': 'counter'},
       ])
     );
   });
@@ -90,9 +90,9 @@ describe('useMetricOptions', () => {
   it('sorts metrics alphabetically by name', async () => {
     const mockData = {
       data: [
-        {['metric.name']: 'metric.z', ['metric.type']: 'counter'},
-        {['metric.name']: 'metric.a', ['metric.type']: 'distribution'},
-        {['metric.name']: 'metric.m', ['metric.type']: 'gauge'},
+        {'metric.name': 'metric.z', 'metric.type': 'counter'},
+        {'metric.name': 'metric.a', 'metric.type': 'distribution'},
+        {'metric.name': 'metric.m', 'metric.type': 'gauge'},
       ],
     };
 
@@ -126,9 +126,9 @@ describe('useMetricOptions', () => {
     );
     await waitFor(() =>
       expect(result.current.data?.data).toEqual([
-        {['metric.name']: 'metric.a', ['metric.type']: 'distribution'},
-        {['metric.name']: 'metric.m', ['metric.type']: 'gauge'},
-        {['metric.name']: 'metric.z', ['metric.type']: 'counter'},
+        {'metric.name': 'metric.a', 'metric.type': 'distribution'},
+        {'metric.name': 'metric.m', 'metric.type': 'gauge'},
+        {'metric.name': 'metric.z', 'metric.type': 'counter'},
       ])
     );
   });

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -100,8 +100,8 @@ const LogsPageStack = styled(Stack)`
 const logsFeedbackOptions = {
   messagePlaceholder: t('How can we make logs work better for you?'),
   tags: {
-    ['feedback.source']: 'logs-listing',
-    ['feedback.owner']: 'performance',
+    'feedback.source': 'logs-listing',
+    'feedback.owner': 'performance',
   },
 };
 

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -76,8 +76,8 @@ export default function MetricsContent() {
 const metricsFeedbackOptions = {
   messagePlaceholder: t('How can we make application metrics work better for you?'),
   tags: {
-    ['feedback.source']: 'metrics-listing',
-    ['feedback.owner']: 'performance',
+    'feedback.source': 'metrics-listing',
+    'feedback.owner': 'performance',
   },
 };
 

--- a/static/app/views/explore/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/explore/releases/detail/header/releaseActions.tsx
@@ -34,7 +34,7 @@ type Props = {
 export const releaseFeedbackOptions = {
   messagePlaceholder: t('How can we improve the Releases experience?'),
   tags: {
-    ['feedback.source']: 'release-detail',
+    'feedback.source': 'release-detail',
   },
 };
 

--- a/static/app/views/explore/releases/list/index.tsx
+++ b/static/app/views/explore/releases/list/index.tsx
@@ -116,7 +116,7 @@ function makeReleaseListApiOptions({
 const releasesFeedbackOptions = {
   messagePlaceholder: t('How can we improve the Releases experience?'),
   tags: {
-    ['feedback.source']: 'releases-list-header',
+    'feedback.source': 'releases-list-header',
   },
 };
 

--- a/static/app/views/explore/replays/detail/ai/ai.tsx
+++ b/static/app/views/explore/replays/detail/ai/ai.tsx
@@ -278,9 +278,9 @@ function ThumbsUpDownButton({
             ? t('What did you like about the replay summary and chapters?')
             : t('How can we make the replay summary and chapters work better for you?'),
         tags: {
-          ['feedback.source']: 'replay_ai_summary',
-          ['feedback.owner']: 'replay',
-          ['feedback.type']: type,
+          'feedback.source': 'replay_ai_summary',
+          'feedback.owner': 'replay',
+          'feedback.type': type,
         },
       }}
     >

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -35,7 +35,7 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 const userFeedbackFeedbackOptions = {
   messagePlaceholder: t('How can we improve the User Feedback experience?'),
   tags: {
-    ['feedback.source']: 'feedback-list',
+    'feedback.source': 'feedback-list',
   },
 };
 

--- a/static/app/views/insights/crons/components/checkInCell.tsx
+++ b/static/app/views/insights/crons/components/checkInCell.tsx
@@ -218,7 +218,7 @@ export function CheckInCell({cellKey, project, checkIn}: CheckInRowProps) {
         {groups.map(({id: groupId, shortId}) => (
           <QuickContextHovercard
             dataRow={{
-              ['issue.id']: groupId,
+              'issue.id': groupId,
               issue: shortId,
             }}
             contextType={ContextType.ISSUE}

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -122,8 +122,8 @@ export function DomainViewHeader({
   const feedbackOptions = activeFeedback
     ? {
         tags: {
-          ['feedback.source']: activeFeedback.source,
-          ['feedback.owner']: activeFeedback.owner,
+          'feedback.source': activeFeedback.source,
+          'feedback.owner': activeFeedback.owner,
         },
       }
     : undefined;

--- a/static/app/views/issueDetails/eventGraph.tsx
+++ b/static/app/views/issueDetails/eventGraph.tsx
@@ -247,8 +247,8 @@ export function EventGraph({
   const [legendSelected, setLegendSelected] = useLocalStorageState(
     'issue-details-graph-legend',
     {
-      ['Feature Flags']: true,
-      ['Releases']: false,
+      'Feature Flags': true,
+      Releases: false,
     }
   );
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -219,7 +219,7 @@ const mockGroupApis = (
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/prompts-activity/`,
-    body: {data: {}, features: {['issue_feedback_hidden']: {}}},
+    body: {data: {}, features: {issue_feedback_hidden: {}}},
   });
 
   MockApiClient.addMockResponse({

--- a/static/app/views/issueDetails/header/header.tsx
+++ b/static/app/views/issueDetails/header/header.tsx
@@ -241,7 +241,7 @@ function HeaderActions({group}: {group: Group}) {
         : 'issue_details_n_plus_one_api_calls';
   const feedbackOptions = {
     messagePlaceholder: t('Please provide feedback on the issue Sentry detected.'),
-    tags: {['feedback.source']: feedbackSource},
+    tags: {'feedback.source': feedbackSource},
   };
   const feedbackLabel = t('Give feedback on the issue Sentry detected');
 

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -430,8 +430,8 @@ function TriggeredConditionDetails({
               feedbackOptions={{
                 messagePlaceholder: t('Tell us what you think about this metric issue.'),
                 tags: {
-                  ['feedback.source']: 'metric_issue_details',
-                  ['feedback.owner']: 'aci',
+                  'feedback.source': 'metric_issue_details',
+                  'feedback.owner': 'aci',
                 },
               }}
             />

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -337,8 +337,8 @@ const issueViewsFeedbackOptions = {
   formTitle: t('Give Feedback'),
   messagePlaceholder: t('How can we make issue views better for you?'),
   tags: {
-    ['feedback.source']: 'custom_views',
-    ['feedback.owner']: 'issues',
+    'feedback.source': 'custom_views',
+    'feedback.owner': 'issues',
   },
 };
 

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -96,7 +96,7 @@ export function SupergroupDetailDrawer({
               formTitle: t('Give feedback on Issue Groups'),
               messagePlaceholder: t('How can we make Issue Groups better for you?'),
               tags: {
-                ['feedback.source']: 'supergroup_drawer',
+                'feedback.source': 'supergroup_drawer',
               },
             }}
             tooltipProps={{title: t('Give feedback on Issue Groups')}}

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -199,7 +199,7 @@ export function PrimaryNavigationHelpMenu({
           onAction() {
             openForm?.({
               tags: {
-                ['feedback.source']: 'navigation_sidebar',
+                'feedback.source': 'navigation_sidebar',
               },
             });
           },

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -51,7 +51,7 @@ function TopBarContent() {
     if (isSeerExplorerOpen) {
       return getExplorerFeedbackOptions(seerExplorerRunId);
     }
-    return {tags: {['feedback.source']: 'top_navigation'}};
+    return {tags: {'feedback.source': 'top_navigation'}};
   }, [isSeerExplorerOpen, seerExplorerRunId]);
 
   return (

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -341,8 +341,8 @@ function TraceWaterfallVersionBanner() {
               onClick={() =>
                 openForm({
                   tags: {
-                    ['feedback.source']: 'trace-waterfall-version-message',
-                    ['feedback.owner']: 'performance',
+                    'feedback.source': 'trace-waterfall-version-message',
+                    'feedback.owner': 'performance',
                   },
                 })
               }

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -41,8 +41,8 @@ export interface TraceMetadataHeaderProps {
 const traceViewFeedbackOptions = {
   messagePlaceholder: t('How can we make the trace view better for you?'),
   tags: {
-    ['feedback.source']: 'trace-view',
-    ['feedback.owner']: 'performance',
+    'feedback.source': 'trace-view',
+    'feedback.owner': 'performance',
   },
 };
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
@@ -18,8 +18,8 @@ import {TraceBreadcrumbs} from './traceBreadcrumbs';
 const traceViewFeedbackOptions = {
   messagePlaceholder: t('How can we make the trace view better for you?'),
   tags: {
-    ['feedback.source']: 'trace-view',
-    ['feedback.owner']: 'performance',
+    'feedback.source': 'trace-view',
+    'feedback.owner': 'performance',
   },
 };
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.ssr.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.ssr.spec.tsx
@@ -22,14 +22,14 @@ const ssrTrace = makeTrace({
     makeTransaction({
       start_timestamp: start,
       timestamp: start + 2,
-      ['transaction.op']: 'http.server',
+      'transaction.op': 'http.server',
       event_id: '000',
       project_slug: 'project-0',
       children: [
         makeTransaction({
           start_timestamp: start,
           timestamp: start + 2,
-          ['transaction.op']: 'pageload',
+          'transaction.op': 'pageload',
           children: [],
           event_id: '001',
           project_slug: 'project-1',
@@ -118,15 +118,15 @@ describe('server side rendering', () => {
         transactions: [
           makeTransaction({
             transaction: 'SSR',
-            ['transaction.op']: 'http.server',
+            'transaction.op': 'http.server',
             children: [
               makeTransaction({
                 transaction: 'pageload',
-                ['transaction.op']: 'pageload',
+                'transaction.op': 'pageload',
               }),
               makeTransaction({
                 transaction: 'pageload',
-                ['transaction.op']: 'pageload',
+                'transaction.op': 'pageload',
               }),
             ],
           }),

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -27,24 +27,22 @@ export interface TraceEvents {
 
 export class TraceScheduler {
   events: EventStore = {
-    ['initialize virtualized list']: new Array<
+    'initialize virtualized list': new Array<
       [TraceEventPriority, TraceEvents['initialize virtualized list']]
     >(),
-    ['set container physical space']: new Array<
+    'set container physical space': new Array<
       [TraceEventPriority, TraceEvents['set container physical space']]
     >(),
-    ['initialize trace space']: new Array<
+    'initialize trace space': new Array<
       [TraceEventPriority, TraceEvents['initialize trace space']]
     >(),
-    ['set trace space']: new Array<
-      [TraceEventPriority, TraceEvents['set trace space']]
-    >(),
-    ['divider resize end']: new Array<
+    'set trace space': new Array<[TraceEventPriority, TraceEvents['set trace space']]>(),
+    'divider resize end': new Array<
       [TraceEventPriority, TraceEvents['divider resize end']]
     >(),
-    ['divider resize']: new Array<[TraceEventPriority, TraceEvents['divider resize']]>(),
-    ['set trace view']: new Array<[TraceEventPriority, TraceEvents['set trace view']]>(),
-    ['draw']: new Array<[TraceEventPriority, TraceEvents['draw']]>(),
+    'divider resize': new Array<[TraceEventPriority, TraceEvents['divider resize']]>(),
+    'set trace view': new Array<[TraceEventPriority, TraceEvents['set trace view']]>(),
+    draw: new Array<[TraceEventPriority, TraceEvents['draw']]>(),
   };
 
   once<K extends keyof TraceEvents>(eventName: K, cb: TraceEvents[K]) {

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -753,13 +753,13 @@ export function getExplorerFeedbackOptions(
     formTitle: 'Seer Agent Feedback',
     messagePlaceholder: 'How can we make Seer better for you?',
     tags: {
-      ['feedback.source']: 'seer_explorer',
-      ['feedback.owner']: 'ml-ai',
-      ...(runId === null ? {} : {['seer.run_id']: runId.toString()}),
-      ...(runId === null ? {} : {['explorer_url']: getExplorerUrl(runId)}),
+      'feedback.source': 'seer_explorer',
+      'feedback.owner': 'ml-ai',
+      ...(runId === null ? {} : {'seer.run_id': runId.toString()}),
+      ...(runId === null ? {} : {explorer_url: getExplorerUrl(runId)}),
       ...(runId === null
         ? {}
-        : {['conversations_url']: getConversationsUrlForExternalUse('sentry', runId)}),
+        : {conversations_url: getConversationsUrlForExternalUse('sentry', runId)}),
     },
   };
 }

--- a/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -29,7 +29,7 @@ export function RulesPanel({
   type,
   placeholder,
   controls,
-  ['data-test-id']: dataTestId,
+  'data-test-id': dataTestId,
 }: Props) {
   function renderIcon() {
     switch (provider ?? '') {

--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -501,8 +501,8 @@ const checkoutSuccessFeedbackOptions = {
   formTitle: t('Give feedback'),
   messagePlaceholder: t('How can we make the checkout experience better for you?'),
   tags: {
-    ['feedback.source']: 'checkout_success',
-    ['feedback.owner']: 'billing',
+    'feedback.source': 'checkout_success',
+    'feedback.owner': 'billing',
   },
 };
 


### PR DESCRIPTION
## Summary

- Enables ESLint core's `no-useless-computed-key` rule (autofixable), which flags computed object/destructuring keys that are just a static string literal — e.g. `{['data-test-id']: x}` instead of `{'data-test-id': x}`.
- Applies its autofix across the frontend (49 files).

## Why

Follows up on #122296, where a computed-key destructuring pattern with a default value (`{['data-test-id']: dataTestId = 'icon-close', ...props}`) tripped an internal invariant in Oxlint's `react-compiler` analyzer. That PR fixed one instance by hand. A repo-wide sweep found ~20+ more instances of the same pattern, and this rule prevents new ones from landing without needing a one-off PR every time the analyzer trips on it.

`no-useless-computed-key` is semantically a no-op change — computed key with a literal string and a plain (quoted) key are identical at runtime — verified by `pnpm run typecheck` and the affected test suites passing unchanged.

**Known gap**: this rule only covers `ObjectExpression`/`ObjectPattern` computed keys (object literals and destructuring), not TypeScript interface/type member signatures (`TSPropertySignature`). A handful of interface declarations with the same bracket pattern (e.g. `IconClose`'s own `Props` interface, once #122296 lands) are out of scope for this rule and were left untouched.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] Ran the affected `.spec.tsx` test files — all pass unchanged
- [x] `.venv/bin/prek run -q` (eslint/stylelint/format hooks) passes on the diff