### PR TITLE
feat(cursor-origin): generalise repository platform detection beyond GitHub (2/6)

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
@@ -8,13 +8,26 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.integrations.api.bases.organization_repository import OrganizationRepositoryEndpoint
-from sentry.integrations.github.client import GitHubApiClient
-from sentry.integrations.github.multi_platform_detection import detect_platforms_multi
+from sentry.integrations.github.multi_platform_detection import (
+    PlatformDetectionClient,
+    detect_platforms_multi,
+)
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiConflictError, ApiError
+
+# Providers whose client can serve platform detection: it needs a GitHub-shaped
+# recursive git tree and Linguist-style language byte counts. Cursor Origin has
+# neither natively -- its client adapts both -- which is why membership here is a
+# property of the client, not of the provider being "GitHub-like".
+SUPPORTED_PROVIDERS = frozenset(
+    {
+        IntegrationProviderSlug.GITHUB.value,
+        IntegrationProviderSlug.CURSOR_ORIGIN.value,
+    }
+)
 
 
 def _capture_detection_exception(type: str, repo_id: int, repo_name: str) -> None:
@@ -33,29 +46,28 @@ class OrganizationRepositoryPlatformsEndpoint(OrganizationRepositoryEndpoint):
     }
 
     def get(self, request: Request, organization: Organization, repo: Repository) -> Response:
-        if (
-            not repo.integration_id
-            or repo.provider != f"integrations:{IntegrationProviderSlug.GITHUB}"
-        ):
+        provider = (repo.provider or "").removeprefix("integrations:")
+        if not repo.integration_id or provider not in SUPPORTED_PROVIDERS:
             return Response(
-                {"detail": "Platform detection is only supported for GitHub repositories."},
+                {"detail": "Platform detection is not supported for this repository."},
                 status=400,
             )
 
         integration = integration_service.get_integration(integration_id=repo.integration_id)
         if integration is None:
-            return Response({"detail": "GitHub integration not found."}, status=400)
+            return Response({"detail": "Integration not found."}, status=400)
 
         org_integration = integration_service.get_organization_integration(
             integration_id=repo.integration_id, organization_id=organization.id
         )
         if org_integration is None:
             return Response(
-                {"detail": "GitHub integration is not configured for this organization."},
-                status=400,
+                {"detail": "Integration is not configured for this organization."}, status=400
             )
 
-        client = GitHubApiClient(integration=integration, org_integration_id=org_integration.id)
+        installation = integration.get_installation(organization_id=organization.id)
+        client = installation.get_client()
+        assert isinstance(client, PlatformDetectionClient)
 
         try:
             platforms = detect_platforms_multi(client, repo.name)["platforms"]
@@ -65,6 +77,6 @@ class OrganizationRepositoryPlatformsEndpoint(OrganizationRepositoryEndpoint):
             return Response({"platforms": []})
         except (ApiError, ValueError):
             _capture_detection_exception("failed", repo.id, repo.name)
-            return Response({"detail": "Failed to detect platforms from GitHub."}, status=502)
+            return Response({"detail": "Failed to detect platforms."}, status=502)
 
         return Response({"platforms": platforms})

--- a/src/sentry/integrations/github/multi_platform_detection.py
+++ b/src/sentry/integrations/github/multi_platform_detection.py
@@ -5,7 +5,7 @@ import time
 from base64 import b64decode
 from collections import defaultdict
 from concurrent.futures import as_completed
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import Any, Protocol, TypedDict, runtime_checkable
 
 import sentry_sdk
 from yaml import YAMLError
@@ -47,8 +47,22 @@ from sentry.utils import json
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.yaml import safe_load
 
-if TYPE_CHECKING:
-    from sentry.integrations.github.client import GitHubBaseClient
+
+@runtime_checkable
+class PlatformDetectionClient(Protocol):
+    """What platform detection actually needs from an SCM client.
+
+    Detection was written against GitHub, but nothing in it is GitHub-specific
+    beyond these two calls -- so any provider whose client can produce a
+    GitHub-shaped git tree and Linguist-style language byte counts can reuse it.
+    Both methods are positional-only so implementations are free to name their
+    parameters to suit their own API.
+    """
+
+    def get(self, path: str, /, *args: Any, **kwargs: Any) -> Any: ...
+
+    def get_languages(self, repo: str, /) -> dict[str, int]: ...
+
 
 # ---------------------------------------------------------------------------
 # File I/O and manifest parsing helpers
@@ -60,7 +74,7 @@ def _ref_params(ref: str | None) -> dict[str, str]:
 
 
 def _get_repo_file_content(
-    client: GitHubBaseClient, repo: str, path: str, ref: str | None = None
+    client: PlatformDetectionClient, repo: str, path: str, ref: str | None = None
 ) -> str | None:
     """Fetch a file's content from a GitHub repo. Returns None if not found."""
     try:
@@ -274,7 +288,7 @@ def _segments_are_ignored(segments: list[str]) -> bool:
 
 
 def _get_tree(
-    client: GitHubBaseClient,
+    client: PlatformDetectionClient,
     repo: str,
     ref: str | None = None,
 ) -> tuple[list[dict[str, Any]], bool]:
@@ -541,7 +555,7 @@ def _framework_matches_scoped(
 
 
 def detect_platforms_multi(
-    client: GitHubBaseClient,
+    client: PlatformDetectionClient,
     repo: str,
     ref: str | None = None,
 ) -> MultiDetectionResult:

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -219,17 +219,17 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
         response = self.get_response(self.organization.slug, 99999)
         assert response.status_code == 404
 
-    def test_non_github_repo(self) -> None:
+    def test_unsupported_provider_repo(self) -> None:
         repo = Repository.objects.create(
             organization_id=self.organization.id,
-            name="non-github-repo",
+            name="unsupported-provider-repo",
             provider="integrations:bitbucket",
             external_id="456",
         )
 
         response = self.get_response(self.organization.slug, repo.id)
         assert response.status_code == 400
-        assert "only supported for GitHub" in response.data["detail"]
+        assert "not supported for this repository" in response.data["detail"]
 
     def test_github_enterprise_repo_rejected(self) -> None:
         repo = Repository.objects.create(
@@ -242,7 +242,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
 
         response = self.get_response(self.organization.slug, repo.id)
         assert response.status_code == 400
-        assert "only supported for GitHub" in response.data["detail"]
+        assert "not supported for this repository" in response.data["detail"]
 
     def test_repo_without_integration(self) -> None:
         repo = Repository.objects.create(


### PR DESCRIPTION
Generalises repository platform detection so it is no longer GitHub-only. `detect_platforms_multi` is retyped against a `PlatformDetectionClient` Protocol, and the endpoint accepts any provider whose client satisfies it.

**This is PR 2 of 6.** The work was one branch; it is split because `static/` and `src/` do not deploy atomically, and because a 2,300-line integration is not reviewable in one sitting. Each PR stacks on the previous one:

| | PR | Contents |
|---|---|---|
| 1 | [#122294](https://github.com/getsentry/sentry/pull/122294) | client, install pipeline, repository provider, registration, feature gate |
| **2** | **this one** | platform detection generalised to a `Protocol` (touches shared GitHub code) |
| 3 | *next* | webhooks + commit tracking |
| 4 | | Seer / SCM wiring |
| 5 | | Git-over-HTTPS archive and commit helpers |
| 6 | | frontend (`static/` only) |

**This is the only PR in the stack that changes an existing non-Origin code path.** Everything else is additive. That is why it is separated out: it wants a reviewer who cares about GitHub platform detection, not about Cursor Origin.

## What changes

Detection was written against `GitHubBaseClient`, but nothing in it is GitHub-specific beyond two calls: a recursive git tree, and Linguist-style language byte counts. Those two calls are now a `runtime_checkable` Protocol, and the type annotations in `multi_platform_detection.py` point at the Protocol instead of the concrete client. No detection logic changed.

The endpoint changes in three ways:

- **Provider check.** `repo.provider != "integrations:github"` becomes membership in a `SUPPORTED_PROVIDERS` frozenset (GitHub, Cursor Origin). GitHub Enterprise stays rejected, as before, and is still covered by a test.
- **Client resolution.** It constructed `GitHubApiClient(...)` directly; it now goes through `installation.get_client()`. For GitHub this is the same object — `GitHubIntegration.get_client()` returns `GitHubApiClient` with the same `org_integration.id` the endpoint was already passing, and its "no org integration" branch is unreachable here because the endpoint returns 400 on that a few lines earlier.
- **Error messages.** The 400 and 502 `detail` strings no longer name GitHub. These are user-visible strings; two tests assert on them and were updated.

## Safe by default

For GitHub repositories the behaviour is unchanged apart from the wording of two error messages.

For Cursor Origin the endpoint is only reachable if an Origin repository exists, which requires an installed Origin integration, which requires `organizations:integrations-cursor-origin` (PR 1). Flag off, and `SUPPORTED_PROVIDERS` lists a provider that no repository can have.

## Dependencies / TODO

Written for someone who has never heard of Cursor Origin. Cursor Origin is a source-code-management provider being added in this stack; PR 1 adds its client and install flow.

**Deliberate, with reasons:**

- **`assert isinstance(client, PlatformDetectionClient)` is a type-narrowing crutch, not a check.** `get_client()` is typed as returning the base integration client, so the call site needs narrowing. A `runtime_checkable` Protocol only verifies that the method *names* exist — not their signatures — so this catches a provider added to `SUPPORTED_PROVIDERS` whose client lacks the methods entirely, and nothing subtler. It also fails as an `AssertionError` (500), not a 400. If a third provider is ever added, this should become an explicit registry mapping provider → client factory, and the failure should be a handled response.
- **`SUPPORTED_PROVIDERS` is a property of the client, not of the provider being "GitHub-like".** Origin has neither a recursive tree API nor a languages API natively; PR 1's client adapts both. Adding a provider to this set is a claim about its client, and is only true if someone has done that adaptation work.
- **The frontend keeps a hand-maintained copy of this list.** PR 6 adds `static/app/components/onboarding/scm/useScmPlatformDetection.ts` with its own `SUPPORTED_PROVIDERS`, used to decide whether to call this endpoint at all. There is no shared source. **The two lists must be edited together** — a provider added here but not there is simply never asked about; added there but not here, and the UI takes a 400. Both sides carry a comment pointing at the other.
- **No `truncated` signal for Origin.** GitHub's `git/trees` reports when a tree was truncated and detection can react; Origin exposes nothing equivalent, so a very large Origin repo could silently detect against partial data. Carried over from PR 1's client; noted here because this is the code path that consumes it.

## Verification

`tests/sentry/integrations/github/test_multi_platform_detection.py` — **all 166 existing tests pass unchanged.** They are the safety net for the retyping: if the Protocol got the shape wrong, or the annotation change disturbed anything, these fail.

`tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py` — 10 tests, 2 updated for the reworded error strings (`test_non_github_repo` renamed to `test_unsupported_provider_repo`). GitHub Enterprise rejection, missing integration, and missing org integration are all still covered.

176 passed locally on this branch.

## Not covered by tests

Detection against a real Cursor Origin repository is not exercised in tests here — the Origin client's tree and languages adapters have their own unit tests in PR 1, but nothing joins them to this endpoint. There is also no test asserting that the `isinstance` narrowing actually holds for each entry in `SUPPORTED_PROVIDERS`, which is the one thing that would make the frozenset self-checking.

---

**Reference:** [#122180](https://github.com/getsentry/sentry/pull/122180) is the original single-branch version of this work — all six PRs' worth of changes in one draft, kept open for history. It carries the Warden review that produced the security fixes in PR 1. It is superseded by this stack and should not be merged.
