### PR TITLE
feat(seer): Warn when selected projects can't run Autofix

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1589,6 +1589,24 @@ describe('AutofixOverview', () => {
     ).toBeInTheDocument();
   });
 
+  it('retries the project config request from the error state', async () => {
+    const {projectConfigRequest} = mockOverview({
+      base: {},
+      baseStatusCode: 500,
+      enrichedStatusCode: 500,
+      projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
+    });
+
+    renderPage();
+
+    const retry = await screen.findByRole('button', {name: 'Retry'}, {timeout: 5000});
+    expect(projectConfigRequest).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(retry);
+
+    await waitFor(() => expect(projectConfigRequest).toHaveBeenCalledTimes(2));
+  });
+
   it('replaces the overview content when the org is eligible for Seer but has not purchased it', () => {
     const {statusPollRequest, enrichedRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -111,12 +111,16 @@ describe('AutofixOverview', () => {
     enrichedStatusCode,
     baseStatusCode,
     truncated,
+    projectConfig,
+    projectConfigAsyncDelay,
   }: {
     base: Partial<AutofixOverviewResponse['runsByMilestone']>;
     baseStatusCode?: number;
     enriched?: Partial<AutofixOverviewResponse['runsByMilestone']>;
     enrichedAsyncDelay?: number | Promise<void>;
     enrichedStatusCode?: number;
+    projectConfig?: AutofixOverviewResponse['projectConfig'];
+    projectConfigAsyncDelay?: number | Promise<void>;
     truncated?: AutofixOverviewResponse['truncatedMilestones'];
   }) {
     const statusPollRequest = MockApiClient.addMockResponse({
@@ -137,7 +141,17 @@ describe('AutofixOverview', () => {
         truncatedMilestones: truncated ?? [],
       },
     });
-    return {statusPollRequest, enrichedRequest};
+    const projectConfigRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({expand: ['projectConfig']})],
+      asyncDelay: projectConfigAsyncDelay,
+      body: {
+        runsByMilestone: {...emptyMilestones, ...base},
+        truncatedMilestones: truncated ?? [],
+        ...(projectConfig ? {projectConfig} : {}),
+      },
+    });
+    return {statusPollRequest, enrichedRequest, projectConfigRequest};
   }
 
   // The un-expanded call cannot reach Snuba, so it nulls out the issue stats.
@@ -1607,5 +1621,92 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('button', {name: 'Create Plan 1'})
     ).toBeInTheDocument();
+  });
+
+  it('shows the setup empty state when no selected project has a repo connected', async () => {
+    mockOverview({
+      base: {},
+      projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Set up Seer to start fixing issues')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('You don’t have any Autofix runs...yet.')
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Set up Seer'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/'
+    );
+  });
+
+  it('does not flash the generic empty state while project config is loading', async () => {
+    const deferred = deferEnriched();
+    mockOverview({
+      base: {},
+      projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
+      projectConfigAsyncDelay: deferred.promise,
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
+    expect(
+      screen.queryByText('You don’t have any Autofix runs...yet.')
+    ).not.toBeInTheDocument();
+
+    deferred.resolve();
+
+    expect(
+      await screen.findByText('Set up Seer to start fixing issues')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('You don’t have any Autofix runs...yet.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the subset warning banner naming only the unconfigured projects', async () => {
+    mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+      projectConfig: [
+        {id: '2', slug: 'alpha-project', hasReposConnected: true},
+        {id: '3', slug: 'beta-project', hasReposConnected: false},
+      ],
+    });
+
+    renderPage();
+
+    const banner = await screen.findByText(/Seer isn't set up for/);
+    expect(banner).toHaveTextContent(
+      "Seer isn't set up for beta-project. Set it up here."
+    );
+    expect(banner).not.toHaveTextContent('alpha-project');
+    expect(screen.getByRole('link', {name: 'here'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/'
+    );
+    expect(
+      screen.queryByText('Set up Seer to start fixing issues')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows no setup warning when every selected project is configured', async () => {
+    mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+      projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: true}],
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('button', {name: 'Create Plan 1'})
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Seer isn't set up for/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Set up Seer to start fixing issues')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {EmptyState} from '@sentry/scraps/emptyState';
@@ -37,6 +37,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
 import {useMilestoneAdvanceToasts} from './milestoneToast';
+import {ProjectSetupWarning} from './projectSetupWarning';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
@@ -107,6 +108,8 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
 
   const {
     data,
+    projectConfig,
+    projectConfigPending,
     isPending,
     isError,
     enrichmentPending,
@@ -120,6 +123,12 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     enabled: pageFiltersReady,
   });
   useMilestoneAdvanceToasts(data, enrichedSettled);
+  const unconfiguredProjects =
+    projectConfig?.filter(project => !project.hasReposConnected) ?? [];
+  const allUnconfigured =
+    unconfiguredProjects.length > 0 &&
+    unconfiguredProjects.length === projectConfig?.length;
+  const someUnconfigured = unconfiguredProjects.length > 0 && !allUnconfigured;
   const allRuns = useMemo(
     () => Object.values(data?.runsByMilestone ?? {}).flat(),
     [data]
@@ -158,6 +167,30 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
         : [...new Set([...previous, ...populatedKeys])]
     );
   };
+
+  let noRunsContent: React.ReactNode;
+  if (projectConfigPending) {
+    noRunsContent = <LoadingIndicator />;
+  } else if (allUnconfigured) {
+    noRunsContent = (
+      <EmptyState
+        padding="3xl"
+        title={t('Set up Seer to start fixing issues')}
+        description={t(
+          'None of your selected projects have a repository connected. Connect one so Seer can start working on your issues.'
+        )}
+        action={
+          <LinkButton variant="primary" to={`/settings/${organization.slug}/seer/`}>
+            {t('Set up Seer')}
+          </LinkButton>
+        }
+      />
+    );
+  } else {
+    noRunsContent = (
+      <EmptyState padding="3xl" title={t('You don’t have any Autofix runs...yet.')} />
+    );
+  }
 
   return (
     <Stack gap="lg" padding="lg xl">
@@ -199,12 +232,18 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           </Button>
         </Flex>
       </Flex>
+      {someUnconfigured && (
+        <ProjectSetupWarning
+          unconfiguredProjects={unconfiguredProjects}
+          orgSlug={organization.slug}
+        />
+      )}
       {isError ? (
         <LoadingError onRetry={refetch} />
       ) : isPending ? (
         <LoadingIndicator />
       ) : allRuns.length === 0 ? (
-        <EmptyState padding="3xl" title={t('You don’t have any Autofix runs...yet.')} />
+        noRunsContent
       ) : assigneeRuns.length === 0 ? (
         <EmptyState
           padding="3xl"

--- a/static/app/views/seerWorkflows/overview/projectSetupWarning.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/projectSetupWarning.spec.tsx
@@ -1,0 +1,69 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ProjectSetupWarning} from './projectSetupWarning';
+import type {ProjectConfig} from './types';
+
+function project(slug: string): ProjectConfig {
+  return {id: slug, slug, hasReposConnected: false};
+}
+
+describe('ProjectSetupWarning', () => {
+  it('names a single project and links to org Seer settings', () => {
+    render(
+      <ProjectSetupWarning unconfiguredProjects={[project('alpha')]} orgSlug="acme" />
+    );
+
+    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
+      "Seer isn't set up for alpha. Set it up here."
+    );
+    expect(screen.getByRole('link', {name: 'here'})).toHaveAttribute(
+      'href',
+      '/settings/acme/seer/'
+    );
+  });
+
+  it('joins two projects with "and"', () => {
+    render(
+      <ProjectSetupWarning
+        unconfiguredProjects={[project('alpha'), project('beta')]}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
+      "Seer isn't set up for alpha and beta. Set it up here."
+    );
+  });
+
+  it('oxford-joins three projects', () => {
+    render(
+      <ProjectSetupWarning
+        unconfiguredProjects={[project('alpha'), project('beta'), project('gamma')]}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
+      "Seer isn't set up for alpha, beta, and gamma. Set it up here."
+    );
+  });
+
+  it('truncates past three with an "and N others" tail', () => {
+    render(
+      <ProjectSetupWarning
+        unconfiguredProjects={[
+          project('alpha'),
+          project('beta'),
+          project('gamma'),
+          project('delta'),
+          project('epsilon'),
+        ]}
+        orgSlug="acme"
+      />
+    );
+
+    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
+      "Seer isn't set up for alpha, beta, gamma, and 2 others. Set it up here."
+    );
+  });
+});

--- a/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
+++ b/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
@@ -1,0 +1,40 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Link} from '@sentry/scraps/link';
+
+import {t, tct, tn} from 'sentry/locale';
+import {oxfordizeArray} from 'sentry/utils/oxfordizeArray';
+
+import type {ProjectConfig} from './types';
+
+const MAX_NAMES = 3;
+
+interface Props {
+  orgSlug: string;
+  unconfiguredProjects: ProjectConfig[];
+}
+
+function formatProjectNames(slugs: string[]) {
+  const visible = slugs.slice(0, MAX_NAMES);
+  const remaining = slugs.length - visible.length;
+
+  if (remaining > 0) {
+    return `${visible.join(', ')}, ${tn('and %s other', 'and %s others', remaining)}`;
+  }
+
+  return oxfordizeArray(visible);
+}
+
+export function ProjectSetupWarning({unconfiguredProjects, orgSlug}: Props) {
+  const names = formatProjectNames(unconfiguredProjects.map(project => project.slug));
+
+  return (
+    <Alert.Container>
+      <Alert variant="warning" showIcon>
+        {tct("Seer isn't set up for [names]. Set it up [link].", {
+          names,
+          link: <Link to={`/settings/${orgSlug}/seer/`}>{t('here')}</Link>,
+        })}
+      </Alert>
+    </Alert.Container>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
+++ b/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
@@ -28,13 +28,11 @@ export function ProjectSetupWarning({unconfiguredProjects, orgSlug}: Props) {
   const names = formatProjectNames(unconfiguredProjects.map(project => project.slug));
 
   return (
-    <Alert.Container>
-      <Alert variant="warning" showIcon>
-        {tct("Seer isn't set up for [names]. Set it up [link].", {
-          names,
-          link: <Link to={`/settings/${orgSlug}/seer/`}>{t('here')}</Link>,
-        })}
-      </Alert>
-    </Alert.Container>
+    <Alert variant="warning" showIcon>
+      {tct("Seer isn't set up for [names]. Set it up [link].", {
+        names,
+        link: <Link to={`/settings/${orgSlug}/seer/`}>{t('here')}</Link>,
+      })}
+    </Alert>
   );
 }

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -209,7 +209,14 @@ export interface OverviewRun {
   codeChanges?: OverviewCodeChangeFile[];
 }
 
+export interface ProjectConfig {
+  hasReposConnected: boolean;
+  id: string;
+  slug: string;
+}
+
 export interface AutofixOverviewResponse {
   runsByMilestone: Record<MilestoneKey, OverviewRun[]>;
+  projectConfig?: ProjectConfig[];
   truncatedMilestones?: MilestoneKey[];
 }

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -214,6 +214,7 @@ export function useAutofixOverview({
     refetch: () => {
       statusPollQuery.refetch();
       enrichedQuery.refetch();
+      projectConfigQuery.refetch();
     },
   };
 }

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -145,7 +145,9 @@ export function useAutofixOverview({
   selection: PageFilters;
   sort: OverviewSort;
 }) {
-  const overviewQuery = (query: {expand?: Array<'scmInfo' | 'issueStats' | 'status'>}) =>
+  const overviewQuery = (query: {
+    expand?: Array<'scmInfo' | 'issueStats' | 'status' | 'projectConfig'>;
+  }) =>
     apiOptions.as<AutofixOverviewResponse>()(
       '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
       {
@@ -177,6 +179,12 @@ export function useAutofixOverview({
     refetchInterval: POLL_INTERVAL,
   });
 
+  const projectConfigQuery = useQuery({
+    ...overviewQuery({expand: ['projectConfig']}),
+    enabled,
+    placeholderData: keepPreviousData,
+  });
+
   const enrichedRefetch = enrichedQuery.refetch;
   useEffect(() => {
     if (shouldRefetchEnriched(statusPollQuery.data, enrichedQuery.data)) {
@@ -192,6 +200,8 @@ export function useAutofixOverview({
 
   return {
     data,
+    projectConfig: projectConfigQuery.data?.projectConfig,
+    projectConfigPending: projectConfigQuery.isLoading,
     isPending: !data,
     // Error only once both fail with nothing to show; the poll alone may still be
     // recovered by an in-flight enriched call.


### PR DESCRIPTION
The Autofix overview only ever listed projects that had produced runs, so a selected project with no Seer repository mapping — which can never run Autofix — was invisible, with no hint that it needed setup. This wires up the `projectConfig` expand (shipped in #122261) to surface that state:

- **All selected projects unconfigured** → the empty state becomes a setup prompt ("Set up Seer to start fixing issues") with a button to the org Seer settings, instead of the generic "no runs yet" copy.
- **A subset unconfigured** → a persistent warning banner above the list names the unconfigured projects (truncated to "…and N others") and links to setup. It stays visible even when other projects have runs.

The per-project signal is `hasReposConnected` (an active `SeerProjectRepository` with a supported provider), the same eligibility the per-card handoff already uses. `projectConfig` carries each project's slug, so the banner needs no separate project lookup.

The summary rides its own query keyed on the project selection rather than the enriched `scmInfo`/`issueStats` request or the 10s status poll, so it paints without waiting on Snuba and never inflates the poll. Because that query resolves independently of the runs query, the empty-state branch holds a loading indicator until `projectConfig` settles — otherwise the generic "no runs" state would briefly flash before swapping to the setup prompt when a project is unconfigured.

Refs AIML-3329
