### PR TITLE
feat(cursor-origin): receive webhooks and record commits (3/6)

### DIFF
--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -395,3 +395,7 @@ class WebhookProviderIdentifier(IntEnum):
     DISCORD = 12
     VERCEL = 13
     GOOGLE = 14
+    # 15 is left to the in-flight Gitea integration, which claimed it first.
+    # These values are persisted on WebhookPayload rows, so two providers
+    # sharing one would misroute replays after both land.
+    CURSOR_ORIGIN = 16

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -173,6 +173,74 @@ class CursorOriginApiMixin(RepositoryClient, RepoTreesClient):
     def get_branches(self, repo_full_name: str) -> list[dict[str, Any]]:
         return self._paginate(f"/repos/{repo_full_name}/branches", "branches")
 
+    # -- commits -------------------------------------------------------------
+
+    def get_commits(
+        self, repo_full_name: str, sha: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Commits reachable from ``sha``, newest first.
+
+        The ref parameter is spelled ``sha``, as on GitHub. Note that Origin
+        *silently ignores* unknown query parameters rather than rejecting them,
+        so passing ``ref`` here would return a normal 200 with the unfiltered
+        default-branch history -- a wrong answer that looks right.
+
+        ``since``/``until``/``path`` are likewise accepted and ignored, so they
+        are deliberately not offered.
+        """
+        params: dict[str, Any] = {"pageSize": min(limit, PAGE_SIZE)}
+        if sha:
+            params["sha"] = sha
+
+        commits: list[dict[str, Any]] = []
+        page_token: str | None = None
+        while len(commits) < limit:
+            if page_token:
+                # A page token encodes the filters it was issued for, so `sha`
+                # and `pageSize` are ignored once one is supplied.
+                params = {"pageToken": page_token}
+            response = self.get(f"/repos/{repo_full_name}/commits", params=params)
+            if not isinstance(response, dict):
+                break
+            page = response.get("commits") or []
+            commits.extend(page)
+            page_token = response.get("nextPageToken") or None
+            if not page or not page_token:
+                break
+
+        return commits[:limit]
+
+    def get_commit_files(self, repo_full_name: str, sha: str) -> list[dict[str, Any]]:
+        """Files changed by a single commit, GitHub-shaped.
+
+        Entries carry ``filename``/``status``/``patch``. Zero-valued stats keys
+        are omitted rather than sent as 0.
+        """
+        response = self.get(f"/repos/{repo_full_name}/commits/{sha}/files")
+        if not isinstance(response, dict):
+            return []
+        return response.get("files") or []
+
+    def compare_commits(
+        self, repo_full_name: str, start_sha: str, end_sha: str, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Commits between two shas, oldest first, excluding ``start_sha``.
+
+        Origin has a compare endpoint but it returns only counts and boundary
+        commits -- no commit list, and no route anywhere gives the files changed
+        between two arbitrary commits. So the range is rebuilt by walking back
+        from ``end_sha`` until ``start_sha`` is reached.
+
+        If ``start_sha`` is not found within ``limit`` commits the walk is
+        returned as-is: a truncated range beats failing a release entirely.
+        """
+        walked: list[dict[str, Any]] = []
+        for commit in self.get_commits(repo_full_name, sha=end_sha, limit=limit):
+            if commit.get("sha") == start_sha:
+                break
+            walked.append(commit)
+        return list(reversed(walked))
+
     # -- RepositoryClient ----------------------------------------------------
 
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:

--- a/src/sentry/integrations/cursor_origin/constants.py
+++ b/src/sentry/integrations/cursor_origin/constants.py
@@ -35,3 +35,11 @@ CURSOR_ORIGIN_SCOPES = (
     "repository:checks:read",
     "repository:checks:write",
 )
+
+# Origin publishes the Ed25519 public keys it signs webhooks with. Signatures
+# carry no key id, so all active keys are tried.
+CURSOR_ORIGIN_JWKS_URL = f"{CURSOR_ORIGIN_API_BASE_URL}/keys"
+CURSOR_ORIGIN_JWKS_CACHE_SECONDS = 3600
+
+# Origin's guidance for rejecting replayed deliveries.
+WEBHOOK_MAX_AGE_SECONDS = 300

--- a/src/sentry/integrations/cursor_origin/constants.py
+++ b/src/sentry/integrations/cursor_origin/constants.py
@@ -36,10 +36,5 @@ CURSOR_ORIGIN_SCOPES = (
     "repository:checks:write",
 )
 
-# Origin publishes the Ed25519 public keys it signs webhooks with. Signatures
-# carry no key id, so all active keys are tried.
-CURSOR_ORIGIN_JWKS_URL = f"{CURSOR_ORIGIN_API_BASE_URL}/keys"
-CURSOR_ORIGIN_JWKS_CACHE_SECONDS = 3600
-
 # Origin's guidance for rejecting replayed deliveries.
 WEBHOOK_MAX_AGE_SECONDS = 300

--- a/src/sentry/integrations/cursor_origin/repository.py
+++ b/src/sentry/integrations/cursor_origin/repository.py
@@ -15,6 +15,14 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 logger = logging.getLogger(__name__)
 
+# A first release has no previous sha to compare against, so associate a recent
+# slice of history rather than walking back forever.
+RECENT_COMMIT_LIMIT = 20
+
+# Each commit in the range costs an extra request for its changed files, since
+# Origin has no endpoint giving files across a range. Bound the work.
+MAX_COMPARE_COMMITS = 100
+
 
 class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginIntegration]):
     name = "Cursor Origin"
@@ -70,8 +78,81 @@ class CursorOriginRepositoryProvider(IntegrationRepositoryProvider[CursorOriginI
     def compare_commits(
         self, repo: Repository, start_sha: str | None, end_sha: str
     ) -> Sequence[Mapping[str, Any]]:
-        """Not implemented yet -- commit tracking arrives with webhook support."""
-        return []
+        """Commits to associate with a release.
+
+        No start sha means this is the first release for the repository, so fall
+        back to recent history rather than walking to the beginning of time.
+        """
+        installation = self._installation_for(repo)
+        client = installation.get_client()
+        # config["name"] is the one kept in sync, matching how GitHub does it.
+        name = repo.config.get("name") or repo.name
+
+        try:
+            if start_sha is None:
+                commits = client.get_commits(name, sha=end_sha, limit=RECENT_COMMIT_LIMIT)
+            else:
+                commits = client.compare_commits(
+                    name, start_sha, end_sha, limit=MAX_COMPARE_COMMITS
+                )
+            return self._format_commits(client, name, commits)
+        except Exception as e:
+            installation.raise_error(e)
+
+    def _installation_for(self, repo: Repository) -> CursorOriginIntegration:
+        if repo.integration_id is None:
+            raise IntegrationError("Cursor Origin repositories require an integration id.")
+        installation = self.get_installation(repo.integration_id, repo.organization_id)
+        assert isinstance(installation, CursorOriginIntegration)
+        return installation
+
+    def _format_commits(
+        self, client: Any, repo_name: str, commits: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, Any]]:
+        """Convert Origin commits into Sentry's internal shape.
+
+        Origin's commit payload matches GitHub's, but the changed files live on a
+        separate route, so each commit costs one extra request. See
+        sentry.models.Release.set_commits.
+        """
+        return [
+            {
+                "id": commit["sha"],
+                "repository": repo_name,
+                "author_email": commit["commit"]["author"].get("email"),
+                "author_name": commit["commit"]["author"].get("name"),
+                "message": commit["commit"]["message"],
+                "timestamp": self.format_date(commit["commit"]["author"].get("date")),
+                "patch_set": self._transform_patchset(
+                    client.get_commit_files(repo_name, commit["sha"])
+                ),
+            }
+            for commit in commits
+        ]
+
+    def _transform_patchset(
+        self, files: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, Any]]:
+        changes: list[dict[str, str]] = []
+        for change in files:
+            status = change.get("status")
+            filename = change.get("filename")
+            if not filename:
+                continue
+            if status == "modified":
+                changes.append({"path": filename, "type": "M"})
+            elif status == "added":
+                changes.append({"path": filename, "type": "A"})
+            elif status == "removed":
+                changes.append({"path": filename, "type": "D"})
+            elif status == "renamed":
+                # A rename is recorded as a delete plus an add.
+                if previous := change.get("previous_filename"):
+                    changes.append({"path": previous, "type": "D"})
+                changes.append({"path": filename, "type": "A"})
+        return changes
 
     def pull_request_url(self, repo: Repository, pull_request: Any) -> str:
-        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/pulls/{pull_request.key}"
+        # `/pull/{n}`, not `/pulls/` -- confirmed against Origin's web UI. The
+        # REST route is `/pulls`, which makes this easy to get wrong.
+        return f"{CURSOR_ORIGIN_WEB_BASE_URL}/{repo.name}/pull/{pull_request.key}"

--- a/src/sentry/integrations/cursor_origin/urls.py
+++ b/src/sentry/integrations/cursor_origin/urls.py
@@ -1,0 +1,11 @@
+from django.urls import re_path
+
+from .webhook import CursorOriginWebhookEndpoint
+
+urlpatterns = [
+    re_path(
+        r"^webhook/$",
+        CursorOriginWebhookEndpoint.as_view(),
+        name="sentry-integration-cursor-origin-webhook",
+    ),
+]

--- a/src/sentry/integrations/cursor_origin/webhook.py
+++ b/src/sentry/integrations/cursor_origin/webhook.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import orjson
+from django.http import HttpRequest, HttpResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.constants import ObjectStatus
+from sentry.integrations.cursor_origin.webhook_signature import (
+    is_timestamp_fresh,
+    verify_signature,
+)
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.utils import metrics
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+# Origin's delivery envelope wraps the event, so the type lives in both a header
+# and the body. The header is used, since it is available before parsing.
+EVENT_TYPE_HEADER = "webhook-event-type"
+DELIVERY_ID_HEADER = "webhook-id"
+TIMESTAMP_HEADER = "webhook-timestamp"
+SIGNATURE_HEADER = "webhook-signature"
+INSTALLATION_ID_HEADER = "webhook-installation-id"
+
+
+@control_silo_endpoint
+class CursorOriginWebhookEndpoint(Endpoint):
+    """Receives Cursor Origin webhook deliveries.
+
+    Signature verification is Ed25519 against Origin's published JWKS -- see
+    webhook_signature.py. Deliveries are at-least-once, so consumers must
+    deduplicate on the ``webhook-id`` header.
+
+    Only installation lifecycle is acted on today. Everything else is
+    acknowledged and logged: Origin retries and can disable an endpoint that
+    keeps failing, so returning 200 for an event we do not handle yet is
+    deliberate, not an oversight.
+    """
+
+    authentication_classes = ()
+    permission_classes = ()
+
+    owner = ApiOwner.INTEGRATION_PLATFORM
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        if request.method != "POST":
+            return HttpResponse(status=405)
+        return super().dispatch(request, *args, **kwargs)
+
+    def post(self, request: HttpRequest) -> HttpResponse:
+        delivery_id = request.headers.get(DELIVERY_ID_HEADER)
+        timestamp = request.headers.get(TIMESTAMP_HEADER)
+        signature = request.headers.get(SIGNATURE_HEADER)
+        event_type = request.headers.get(EVENT_TYPE_HEADER)
+
+        if not (delivery_id and timestamp and signature):
+            logger.warning("cursor_origin.webhook.missing_headers")
+            return HttpResponse(status=400)
+
+        body = bytes(request.body)
+        if not body:
+            return HttpResponse(status=400)
+
+        if not is_timestamp_fresh(timestamp):
+            metrics.incr("cursor_origin.webhook.rejected", tags={"reason": "stale"})
+            logger.warning("cursor_origin.webhook.stale", extra={"delivery_id": delivery_id})
+            return HttpResponse(status=400)
+
+        if not verify_signature(delivery_id, timestamp, body, signature):
+            metrics.incr("cursor_origin.webhook.rejected", tags={"reason": "bad_signature"})
+            logger.warning(
+                "cursor_origin.webhook.invalid_signature", extra={"delivery_id": delivery_id}
+            )
+            return HttpResponse(status=401)
+
+        try:
+            payload = orjson.loads(body)
+        except orjson.JSONDecodeError:
+            return HttpResponse(status=400)
+
+        metrics.incr("cursor_origin.webhook.received", tags={"event_type": event_type or "unknown"})
+
+        if event_type == "installation.deleted":
+            self._handle_installation_deleted(request, payload)
+        else:
+            # Acknowledged so Origin stops retrying; handlers land with commit
+            # tracking and PR comments.
+            logger.info(
+                "cursor_origin.webhook.unhandled",
+                extra={"event_type": event_type, "delivery_id": delivery_id},
+            )
+
+        return HttpResponse(status=204)
+
+    def _handle_installation_deleted(self, request: HttpRequest, payload: Any) -> None:
+        """Disable the integration when the app is uninstalled.
+
+        Without this the integration keeps trying to mint tokens for an
+        installation that no longer exists, which surfaces as recurring auth
+        failures rather than as "someone uninstalled it".
+        """
+        installation_id = request.headers.get(INSTALLATION_ID_HEADER) or (
+            payload.get("installationId") if isinstance(payload, dict) else None
+        )
+        if not installation_id:
+            logger.warning("cursor_origin.webhook.deleted_without_installation_id")
+            return
+
+        result = integration_service.organization_contexts(
+            provider=IntegrationProviderSlug.CURSOR_ORIGIN.value,
+            external_id=installation_id,
+        )
+        if result.integration is None:
+            # Possible if the integration was removed in Sentry first.
+            logger.warning(
+                "cursor_origin.webhook.deleted_missing_integration",
+                extra={"installation_id": installation_id},
+            )
+            return
+
+        integration_service.update_integration(
+            integration_id=result.integration.id, status=ObjectStatus.DISABLED
+        )
+        logger.info(
+            "cursor_origin.webhook.installation_deleted",
+            extra={
+                "installation_id": installation_id,
+                "integration_id": result.integration.id,
+            },
+        )

--- a/src/sentry/integrations/cursor_origin/webhook.py
+++ b/src/sentry/integrations/cursor_origin/webhook.py
@@ -41,6 +41,17 @@ SIGNATURE_HEADER = "webhook-signature"
 INSTALLATION_ID_HEADER = "webhook-installation-id"
 
 
+def _envelope_keys(payload: Any) -> list[str]:
+    """Top-level keys of the delivery envelope, for telemetry.
+
+    Key names only, never values, so this is safe to log. Both handlers depend on
+    Origin putting installationId in the signed body, which is inferred rather
+    than documented and could not be confirmed from the recorded deliveries. When
+    that lookup comes back empty, this says what the envelope did contain.
+    """
+    return sorted(payload.keys()) if isinstance(payload, dict) else []
+
+
 @all_silo_endpoint
 class CursorOriginWebhookEndpoint(Endpoint):
     """Receives Cursor Origin webhook deliveries.
@@ -145,7 +156,10 @@ class CursorOriginWebhookEndpoint(Endpoint):
             # installationId in the body, uninstalls stop being handled and this
             # warning says so -- which is the failure we want, rather than acting
             # on a value a replay can choose.
-            logger.warning("cursor_origin.webhook.deleted_without_signed_installation_id")
+            logger.warning(
+                "cursor_origin.webhook.deleted_without_signed_installation_id",
+                extra={"envelope_keys": _envelope_keys(payload)},
+            )
             return
 
         result = integration_service.organization_contexts(
@@ -193,7 +207,10 @@ class CursorOriginWebhookEndpoint(Endpoint):
         # delivery. Scope to the organizations that actually have this installation.
         installation_id = self._signed_installation_id(payload)
         if not installation_id:
-            logger.warning("cursor_origin.webhook.push_without_signed_installation_id")
+            logger.warning(
+                "cursor_origin.webhook.push_without_signed_installation_id",
+                extra={"envelope_keys": _envelope_keys(payload)},
+            )
             return
 
         context = integration_service.organization_contexts(
@@ -208,11 +225,26 @@ class CursorOriginWebhookEndpoint(Endpoint):
             )
             return
 
-        repos = Repository.objects.filter(
-            provider=f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}",
-            external_id=str(repo_id),
-            status=ObjectStatus.ACTIVE,
-            organization_id__in=organization_ids,
+        repos = list(
+            Repository.objects.filter(
+                provider=f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}",
+                external_id=str(repo_id),
+                status=ObjectStatus.ACTIVE,
+                organization_id__in=organization_ids,
+            )
+        )
+        # Positive confirmation that the signed body carried an installation we
+        # could resolve -- otherwise "push tracking works" is only inferrable from
+        # commits appearing. repository_count also shows the scoping doing its job:
+        # it should be the count for this installation, not every organization
+        # sharing the external id.
+        logger.info(
+            "cursor_origin.webhook.push_scoped",
+            extra={
+                "installation_id": installation_id,
+                "organization_count": len(organization_ids),
+                "repository_count": len(repos),
+            },
         )
         for repo in repos:
             for ref_update in ref_updates:

--- a/src/sentry/integrations/cursor_origin/webhook.py
+++ b/src/sentry/integrations/cursor_origin/webhook.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from typing import Any
 
 import orjson
+from dateutil.parser import parse as parse_date
+from django.db import IntegrityError, router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.cursor_origin.webhook_signature import (
     is_timestamp_fresh,
@@ -18,6 +22,10 @@ from sentry.integrations.cursor_origin.webhook_signature import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.repository import Repository
+from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.cursor_origin")
@@ -31,7 +39,7 @@ SIGNATURE_HEADER = "webhook-signature"
 INSTALLATION_ID_HEADER = "webhook-installation-id"
 
 
-@control_silo_endpoint
+@all_silo_endpoint
 class CursorOriginWebhookEndpoint(Endpoint):
     """Receives Cursor Origin webhook deliveries.
 
@@ -92,9 +100,11 @@ class CursorOriginWebhookEndpoint(Endpoint):
 
         if event_type == "installation.deleted":
             self._handle_installation_deleted(request, payload)
+        elif event_type == "repository.pushed":
+            self._handle_push(request, payload)
         else:
-            # Acknowledged so Origin stops retrying; handlers land with commit
-            # tracking and PR comments.
+            # Acknowledged so Origin stops retrying; handlers land with PR
+            # comment and review support.
             logger.info(
                 "cursor_origin.webhook.unhandled",
                 extra={"event_type": event_type, "delivery_id": delivery_id},
@@ -138,3 +148,136 @@ class CursorOriginWebhookEndpoint(Endpoint):
                 "integration_id": result.integration.id,
             },
         )
+
+    def _handle_push(self, request: HttpRequest, payload: Any) -> None:
+        """Record commits from a push.
+
+        Origin's push event carries only ``headCommit`` per ref update, not
+        GitHub's full ``commits[]``, so the range has to be fetched. That is what
+        the repository provider's compare walk already does.
+        """
+        event = (payload or {}).get("event") or {}
+        push = event.get("payload") or {}
+        repo_id = ((push.get("repository") or {}).get("id")) or None
+        ref_updates = push.get("refUpdates") or []
+
+        if not repo_id or not ref_updates:
+            logger.info("cursor_origin.webhook.push_without_refs")
+            return
+
+        repos = Repository.objects.filter(
+            provider=f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}",
+            external_id=str(repo_id),
+            status=ObjectStatus.ACTIVE,
+        )
+        for repo in repos:
+            for ref_update in ref_updates:
+                self._record_ref_update(repo, ref_update)
+
+    def _record_ref_update(self, repo: Repository, ref_update: dict[str, Any]) -> None:
+        ref = ref_update.get("ref") or ""
+        # Tags do not carry commits worth associating.
+        if not ref.startswith("refs/heads/") or ref_update.get("deleted"):
+            return
+
+        head = ref_update.get("headCommit") or {}
+        head_sha = ref_update.get("after") or head.get("sha")
+        if not head_sha:
+            return
+
+        before = ref_update.get("before") or ""
+        if ref_update.get("created") or set(before) == {"0"}:
+            # A created ref has an all-zero `before`, which Origin's compare
+            # rejects outright ("revision not found"). Record just the tip rather
+            # than trying to walk a new branch's entire history.
+            commits: list[dict[str, Any]] = [head] if head.get("sha") else []
+        else:
+            provider = self._repository_provider()
+            try:
+                commits = provider.compare_commits(repo, before, head_sha)
+            except Exception:
+                logger.warning(
+                    "cursor_origin.webhook.push_compare_failed",
+                    extra={"repo_id": repo.id, "ref": ref},
+                    exc_info=True,
+                )
+                return
+            self._create_commits(repo, commits)
+            return
+
+        self._create_commits(repo, [self._as_internal_commit(c) for c in commits])
+
+    @staticmethod
+    def _repository_provider() -> Any:
+        from sentry.plugins.base import bindings
+
+        cls = bindings.get("integration-repository.provider").get(
+            f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}"
+        )
+        return cls(f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}")
+
+    @staticmethod
+    def _as_internal_commit(raw: dict[str, Any]) -> dict[str, Any]:
+        """Shape a raw Origin commit like the provider's compare output."""
+        author = raw.get("author") or {}
+        return {
+            "id": raw.get("sha"),
+            "message": raw.get("message") or "",
+            "author_email": author.get("email"),
+            "author_name": author.get("name"),
+            "timestamp": author.get("date"),
+            "patch_set": [],
+        }
+
+    def _create_commits(self, repo: Repository, commits: Sequence[Mapping[str, Any]]) -> None:
+        authors: dict[str, CommitAuthor] = {}
+        for commit in commits:
+            sha = commit.get("id")
+            message = commit.get("message") or ""
+            if not sha or IntegrationRepositoryProvider.should_ignore_commit(message):
+                continue
+
+            author = self._commit_author(repo, commit, authors)
+            try:
+                with transaction.atomic(router.db_for_write(Commit)):
+                    Commit.objects.create(
+                        repository_id=repo.id,
+                        organization_id=repo.organization_id,
+                        key=sha,
+                        message=message,
+                        author=author,
+                        date_added=self._commit_date(commit.get("timestamp")),
+                    )
+            except IntegrityError:
+                # Deliveries are at-least-once and pushes overlap, so seeing a
+                # commit twice is expected rather than an error.
+                pass
+
+    @staticmethod
+    def _commit_author(
+        repo: Repository, commit: Mapping[str, Any], cache: dict[str, CommitAuthor]
+    ) -> CommitAuthor | None:
+        email = commit.get("author_email")
+        if not email or len(email) > 75:
+            return None
+        if email in cache:
+            return cache[email]
+        author = CommitAuthor.objects.get_or_create(
+            organization_id=repo.organization_id,
+            email=email,
+            defaults={"name": commit.get("author_name")},
+        )[0]
+        cache[email] = author
+        return author
+
+    @staticmethod
+    def _commit_date(timestamp: Any) -> datetime:
+        """Commit date, defaulting to now when Origin gives something unusable."""
+        if isinstance(timestamp, datetime):
+            return timestamp.astimezone(timezone.utc)
+        if isinstance(timestamp, str):
+            try:
+                return parse_date(timestamp).astimezone(timezone.utc)
+            except (ValueError, OverflowError):
+                pass
+        return datetime.now(timezone.utc)

--- a/src/sentry/integrations/cursor_origin/webhook.py
+++ b/src/sentry/integrations/cursor_origin/webhook.py
@@ -30,8 +30,10 @@ from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.cursor_origin")
 
-# Origin's delivery envelope wraps the event, so the type lives in both a header
-# and the body. The header is used, since it is available before parsing.
+# Only webhook-id, webhook-timestamp and the body are covered by the signature.
+# The event-type and installation-id headers are NOT, so they are usable for
+# routing and dispatch but never as the target of an action -- see
+# _signed_installation_id.
 EVENT_TYPE_HEADER = "webhook-event-type"
 DELIVERY_ID_HEADER = "webhook-id"
 TIMESTAMP_HEADER = "webhook-timestamp"
@@ -99,9 +101,9 @@ class CursorOriginWebhookEndpoint(Endpoint):
         metrics.incr("cursor_origin.webhook.received", tags={"event_type": event_type or "unknown"})
 
         if event_type == "installation.deleted":
-            self._handle_installation_deleted(request, payload)
+            self._handle_installation_deleted(payload)
         elif event_type == "repository.pushed":
-            self._handle_push(request, payload)
+            self._handle_push(payload)
         else:
             # Acknowledged so Origin stops retrying; handlers land with PR
             # comment and review support.
@@ -112,18 +114,38 @@ class CursorOriginWebhookEndpoint(Endpoint):
 
         return HttpResponse(status=204)
 
-    def _handle_installation_deleted(self, request: HttpRequest, payload: Any) -> None:
+    @staticmethod
+    def _signed_installation_id(payload: Any) -> str | None:
+        """The installation this delivery is about, from signed material only.
+
+        The signature covers webhook-id, webhook-timestamp and the body -- not
+        webhook-installation-id or webhook-event-type. So the headers are
+        attacker-controlled even on a delivery whose signature is genuine: capture
+        any real delivery, rewrite those two headers, and the signature still
+        verifies. Taking the target from the header let that replay disable an
+        arbitrary integration or attribute commits to another organization.
+
+        Returns None rather than falling back to the header. There is no signed
+        target in that case, so there is nothing safe to act on.
+        """
+        installation_id = payload.get("installationId") if isinstance(payload, dict) else None
+        return str(installation_id) if installation_id else None
+
+    def _handle_installation_deleted(self, payload: Any) -> None:
         """Disable the integration when the app is uninstalled.
 
         Without this the integration keeps trying to mint tokens for an
         installation that no longer exists, which surfaces as recurring auth
         failures rather than as "someone uninstalled it".
         """
-        installation_id = request.headers.get(INSTALLATION_ID_HEADER) or (
-            payload.get("installationId") if isinstance(payload, dict) else None
-        )
+        installation_id = self._signed_installation_id(payload)
         if not installation_id:
-            logger.warning("cursor_origin.webhook.deleted_without_installation_id")
+            # Deliberately not read from webhook-installation-id; see
+            # _signed_installation_id. If Origin turns out not to put
+            # installationId in the body, uninstalls stop being handled and this
+            # warning says so -- which is the failure we want, rather than acting
+            # on a value a replay can choose.
+            logger.warning("cursor_origin.webhook.deleted_without_signed_installation_id")
             return
 
         result = integration_service.organization_contexts(
@@ -149,7 +171,7 @@ class CursorOriginWebhookEndpoint(Endpoint):
             },
         )
 
-    def _handle_push(self, request: HttpRequest, payload: Any) -> None:
+    def _handle_push(self, payload: Any) -> None:
         """Record commits from a push.
 
         Origin's push event carries only ``headCommit`` per ref update, not
@@ -165,10 +187,32 @@ class CursorOriginWebhookEndpoint(Endpoint):
             logger.info("cursor_origin.webhook.push_without_refs")
             return
 
+        # Repository is unique on (organization_id, provider, external_id), so the
+        # same external_id legitimately exists in several organizations. Matching on
+        # external_id alone wrote commits into every one of them from a single
+        # delivery. Scope to the organizations that actually have this installation.
+        installation_id = self._signed_installation_id(payload)
+        if not installation_id:
+            logger.warning("cursor_origin.webhook.push_without_signed_installation_id")
+            return
+
+        context = integration_service.organization_contexts(
+            provider=IntegrationProviderSlug.CURSOR_ORIGIN.value,
+            external_id=installation_id,
+        )
+        organization_ids = [oi.organization_id for oi in context.organization_integrations]
+        if context.integration is None or not organization_ids:
+            logger.warning(
+                "cursor_origin.webhook.push_missing_integration",
+                extra={"installation_id": installation_id},
+            )
+            return
+
         repos = Repository.objects.filter(
             provider=f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}",
             external_id=str(repo_id),
             status=ObjectStatus.ACTIVE,
+            organization_id__in=organization_ids,
         )
         for repo in repos:
             for ref_update in ref_updates:
@@ -258,14 +302,19 @@ class CursorOriginWebhookEndpoint(Endpoint):
         repo: Repository, commit: Mapping[str, Any], cache: dict[str, CommitAuthor]
     ) -> CommitAuthor | None:
         email = commit.get("author_email")
-        if not email or len(email) > 75:
+        # Straight from untrusted JSON -- a webhook body, or an API response via
+        # the provider's _format_commits -- so not necessarily a string. len()
+        # raises TypeError on an int, and CommitAuthorManager.get_or_create calls
+        # .lower(), which raises for a list or dict short enough to survive len().
+        if not isinstance(email, str) or not email or len(email) > 75:
             return None
         if email in cache:
             return cache[email]
+        name = commit.get("author_name")
         author = CommitAuthor.objects.get_or_create(
             organization_id=repo.organization_id,
             email=email,
-            defaults={"name": commit.get("author_name")},
+            defaults={"name": name if isinstance(name, str) else None},
         )[0]
         cache[email] = author
         return author

--- a/src/sentry/integrations/cursor_origin/webhook_signature.py
+++ b/src/sentry/integrations/cursor_origin/webhook_signature.py
@@ -1,0 +1,115 @@
+"""Verify Cursor Origin webhook signatures.
+
+Origin signs with Ed25519 rather than an HMAC shared secret, so verification
+needs Origin's *public* keys rather than a secret we hold. They are published as
+a JWKS at a well-known endpoint.
+
+Signatures carry no key id, so every active key is tried until one verifies.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import time
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from django.core.cache import cache
+
+from sentry.http import safe_urlopen
+from sentry.integrations.cursor_origin.constants import (
+    CURSOR_ORIGIN_JWKS_CACHE_SECONDS,
+    CURSOR_ORIGIN_JWKS_URL,
+    WEBHOOK_MAX_AGE_SECONDS,
+)
+
+logger = logging.getLogger("sentry.integrations.cursor_origin")
+
+_JWKS_CACHE_KEY = "cursor-origin:jwks"
+_SIGNATURE_PREFIX = "v1ed,"
+
+
+def _b64url_decode(value: str) -> bytes:
+    """Decode unpadded base64url, as used for JWK key material."""
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def fetch_public_keys(force_refresh: bool = False) -> list[bytes]:
+    """Origin's active Ed25519 public keys, cached.
+
+    Cached because every webhook delivery would otherwise fetch the JWKS.
+    ``force_refresh`` exists so a signature that fails against every cached key
+    can be retried once after rotation, rather than dropping deliveries until
+    the cache expires.
+    """
+    if not force_refresh:
+        cached = cache.get(_JWKS_CACHE_KEY)
+        if cached is not None:
+            return [bytes(k) for k in cached]
+
+    try:
+        response = safe_urlopen(CURSOR_ORIGIN_JWKS_URL, method="GET", timeout=5)
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+    except Exception:
+        logger.warning("cursor_origin.webhook.jwks_fetch_failed", exc_info=True)
+        return []
+
+    keys = [
+        _b64url_decode(key["x"])
+        for key in payload.get("keys", [])
+        if key.get("crv") == "Ed25519" and key.get("x")
+    ]
+    if keys:
+        cache.set(_JWKS_CACHE_KEY, keys, CURSOR_ORIGIN_JWKS_CACHE_SECONDS)
+    return keys
+
+
+def _signed_payload(webhook_id: str, timestamp: str, body: bytes) -> bytes:
+    """The bytes Origin actually signs.
+
+    Note this is the lowercase *hex digest* of the id/timestamp/body triple, not
+    the triple itself and not the raw digest -- signing the wrong one of those
+    three still produces a plausible-looking failure.
+    """
+    digest = hashlib.sha256(b".".join([webhook_id.encode(), timestamp.encode(), body])).hexdigest()
+    return digest.encode()
+
+
+def is_timestamp_fresh(timestamp: str, now: float | None = None) -> bool:
+    """Reject replays. Origin's guidance is a 5 minute window."""
+    try:
+        sent_at = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    return abs((now if now is not None else time.time()) - sent_at) <= WEBHOOK_MAX_AGE_SECONDS
+
+
+def verify_signature(webhook_id: str, timestamp: str, body: bytes, signature: str) -> bool:
+    """Whether ``signature`` is a valid Origin signature for this delivery."""
+    if not signature.startswith(_SIGNATURE_PREFIX):
+        return False
+
+    try:
+        raw_signature = base64.b64decode(signature[len(_SIGNATURE_PREFIX) :])
+    except (ValueError, TypeError):
+        return False
+
+    message = _signed_payload(webhook_id, timestamp, body)
+
+    for force_refresh in (False, True):
+        keys = fetch_public_keys(force_refresh=force_refresh)
+        for key_bytes in keys:
+            try:
+                Ed25519PublicKey.from_public_bytes(key_bytes).verify(raw_signature, message)
+                return True
+            except (InvalidSignature, ValueError):
+                continue
+        # Only worth refetching if the cache could have been stale.
+        if not keys:
+            break
+
+    return False

--- a/src/sentry/integrations/cursor_origin/webhook_signature.py
+++ b/src/sentry/integrations/cursor_origin/webhook_signature.py
@@ -13,59 +13,16 @@ import base64
 import hashlib
 import logging
 import time
-from typing import Any
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from django.core.cache import cache
 
-from sentry.http import safe_urlopen
-from sentry.integrations.cursor_origin.constants import (
-    CURSOR_ORIGIN_JWKS_CACHE_SECONDS,
-    CURSOR_ORIGIN_JWKS_URL,
-    WEBHOOK_MAX_AGE_SECONDS,
-)
+from sentry.integrations.cursor_origin.constants import WEBHOOK_MAX_AGE_SECONDS
+from sentry.integrations.cursor_origin.keys import fetch_public_keys
 
 logger = logging.getLogger("sentry.integrations.cursor_origin")
 
-_JWKS_CACHE_KEY = "cursor-origin:jwks"
 _SIGNATURE_PREFIX = "v1ed,"
-
-
-def _b64url_decode(value: str) -> bytes:
-    """Decode unpadded base64url, as used for JWK key material."""
-    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
-
-
-def fetch_public_keys(force_refresh: bool = False) -> list[bytes]:
-    """Origin's active Ed25519 public keys, cached.
-
-    Cached because every webhook delivery would otherwise fetch the JWKS.
-    ``force_refresh`` exists so a signature that fails against every cached key
-    can be retried once after rotation, rather than dropping deliveries until
-    the cache expires.
-    """
-    if not force_refresh:
-        cached = cache.get(_JWKS_CACHE_KEY)
-        if cached is not None:
-            return [bytes(k) for k in cached]
-
-    try:
-        response = safe_urlopen(CURSOR_ORIGIN_JWKS_URL, method="GET", timeout=5)
-        response.raise_for_status()
-        payload: dict[str, Any] = response.json()
-    except Exception:
-        logger.warning("cursor_origin.webhook.jwks_fetch_failed", exc_info=True)
-        return []
-
-    keys = [
-        _b64url_decode(key["x"])
-        for key in payload.get("keys", [])
-        if key.get("crv") == "Ed25519" and key.get("x")
-    ]
-    if keys:
-        cache.set(_JWKS_CACHE_KEY, keys, CURSOR_ORIGIN_JWKS_CACHE_SECONDS)
-    return keys
 
 
 def _signed_payload(webhook_id: str, timestamp: str, body: bytes) -> bytes:
@@ -96,6 +53,8 @@ def verify_signature(webhook_id: str, timestamp: str, body: bytes, signature: st
     try:
         raw_signature = base64.b64decode(signature[len(_SIGNATURE_PREFIX) :])
     except (ValueError, TypeError):
+        # Covers binascii.Error for bad padding or non-base64 characters, which is
+        # a ValueError subclass. See test_rejects_malformed_base64.
         return False
 
     message = _signed_payload(webhook_id, timestamp, body)

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -44,6 +44,7 @@ class IntegrationClassification(BaseClassification):
         from .parsers import (
             BitbucketRequestParser,
             BitbucketServerRequestParser,
+            CursorOriginRequestParser,
             DiscordRequestParser,
             GithubEnterpriseRequestParser,
             GithubRequestParser,
@@ -61,6 +62,7 @@ class IntegrationClassification(BaseClassification):
         active_parsers: list[type[BaseRequestParser]] = [
             BitbucketRequestParser,
             BitbucketServerRequestParser,
+            CursorOriginRequestParser,
             DiscordRequestParser,
             GoogleRequestParser,
             GithubEnterpriseRequestParser,

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,5 +1,6 @@
 from .bitbucket import BitbucketRequestParser
 from .bitbucket_server import BitbucketServerRequestParser
+from .cursor_origin import CursorOriginRequestParser
 from .discord import DiscordRequestParser
 from .github import GithubRequestParser
 from .github_enterprise import GithubEnterpriseRequestParser
@@ -16,6 +17,7 @@ from .vsts import VstsRequestParser
 __all__ = (
     "BitbucketRequestParser",
     "BitbucketServerRequestParser",
+    "CursorOriginRequestParser",
     "DiscordRequestParser",
     "GoogleRequestParser",
     "GithubEnterpriseRequestParser",

--- a/src/sentry/middleware/integrations/parsers/cursor_origin.py
+++ b/src/sentry/middleware/integrations/parsers/cursor_origin.py
@@ -2,31 +2,72 @@ from __future__ import annotations
 
 import logging
 
-from django.http.response import HttpResponseBase
+from django.http.response import HttpResponse, HttpResponseBase
 
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.types import IntegrationProviderSlug
 
 logger = logging.getLogger(__name__)
 
+# Origin puts the installation on a header, so the integration can be resolved
+# without parsing the body.
+INSTALLATION_ID_HEADER = "webhook-installation-id"
+EVENT_TYPE_HEADER = "webhook-event-type"
+
+# Events whose handling only touches the control-silo Integration row. Everything
+# else may write region data (commits, pull requests) and has to reach a cell.
+CONTROL_ONLY_EVENT_PREFIX = "installation."
+
 
 class CursorOriginRequestParser(BaseRequestParser):
-    """Keeps Cursor Origin requests in the control silo.
+    """Routes Cursor Origin webhooks to the silo that can act on them.
 
-    The only webhook handled today is ``installation.deleted``, which disables
-    the control-silo ``Integration`` row and touches nothing region-bound, so
-    there is nothing to forward. The parser still has to exist: without one,
+    Installation lifecycle disables the control-silo ``Integration`` row, so it is
+    answered in control. Everything else -- push events creating commits, and
+    later pull request activity -- writes region data and is forwarded to the
+    organizations' cells.
+
+    The parser also has to exist for the mundane reason that without one,
     ``IntegrationClassification`` reports every ``/extensions/cursor-origin/``
-    request as an unknown provider before falling through.
-
-    Handlers that write region data -- commit tracking, PR comments -- will need
-    this to resolve a cell and route through ``get_response_from_webhookpayload``
-    rather than answering in control.
+    request as an unknown provider.
     """
 
     provider = IntegrationProviderSlug.CURSOR_ORIGIN.value
     webhook_identifier = WebhookProviderIdentifier.CURSOR_ORIGIN
 
+    def get_integration_from_request(self) -> Integration | None:
+        installation_id = self.request.headers.get(INSTALLATION_ID_HEADER)
+        if not installation_id:
+            return None
+        return Integration.objects.filter(
+            external_id=installation_id, provider=self.provider
+        ).first()
+
     def get_response(self) -> HttpResponseBase:
-        return self.get_response_from_control_silo()
+        event_type = self.request.headers.get(EVENT_TYPE_HEADER) or ""
+
+        if event_type.startswith(CONTROL_ONLY_EVENT_PREFIX):
+            return self.get_response_from_control_silo()
+
+        integration = self.get_integration_from_request()
+        if not integration:
+            # A delivery for an installation we do not know about. Answering
+            # rather than erroring keeps Origin from retrying forever, and from
+            # disabling the endpoint over deliveries we could never handle.
+            logger.info(
+                "cursor_origin.parser.unknown_installation",
+                extra={"event_type": event_type},
+            )
+            return HttpResponse(status=202)
+
+        cells = self.get_cells_from_organizations()
+        if len(cells) == 0:
+            return self.get_default_missing_integration_response()
+
+        return self.get_response_from_webhookpayload(
+            cells=cells,
+            identifier=integration.id,
+            integration_id=integration.id,
+        )

--- a/src/sentry/middleware/integrations/parsers/cursor_origin.py
+++ b/src/sentry/middleware/integrations/parsers/cursor_origin.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+
+from django.http.response import HttpResponseBase
+
+from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
+from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.types import IntegrationProviderSlug
+
+logger = logging.getLogger(__name__)
+
+
+class CursorOriginRequestParser(BaseRequestParser):
+    """Keeps Cursor Origin requests in the control silo.
+
+    The only webhook handled today is ``installation.deleted``, which disables
+    the control-silo ``Integration`` row and touches nothing region-bound, so
+    there is nothing to forward. The parser still has to exist: without one,
+    ``IntegrationClassification`` reports every ``/extensions/cursor-origin/``
+    request as an unknown provider before falling through.
+
+    Handlers that write region data -- commit tracking, PR comments -- will need
+    this to resolve a cell and route through ``get_response_from_webhookpayload``
+    rather than answering in control.
+    """
+
+    provider = IntegrationProviderSlug.CURSOR_ORIGIN.value
+    webhook_identifier = WebhookProviderIdentifier.CURSOR_ORIGIN
+
+    def get_response(self) -> HttpResponseBase:
+        return self.get_response_from_control_silo()

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1358,6 +1358,10 @@ urlpatterns += [
                     include("sentry.integrations.github_enterprise.urls"),
                 ),
                 re_path(
+                    r"^cursor-origin/",
+                    include("sentry.integrations.cursor_origin.urls"),
+                ),
+                re_path(
                     r"^gitlab/",
                     include("sentry.integrations.gitlab.urls"),
                 ),

--- a/tests/sentry/integrations/cursor_origin/test_commits.py
+++ b/tests/sentry/integrations/cursor_origin/test_commits.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from sentry.integrations.cursor_origin.repository import CursorOriginRepositoryProvider
+from sentry.testutils.cases import TestCase
+
+
+def commit(sha: str, message: str = "msg") -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "commit": {
+            "author": {
+                "name": "Bruno",
+                "email": "bruno@example.com",
+                "date": "2026-01-01T00:00:00Z",
+            },
+            "message": message,
+        },
+    }
+
+
+class CompareCommitsWalkTest(TestCase):
+    """Origin's compare endpoint returns only counts and boundary commits.
+
+    There is no route giving the commits or files between two arbitrary shas, so
+    the range is rebuilt by walking back from the head.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        from sentry.integrations.cursor_origin.client import CursorOriginSetupApiClient
+
+        self.api_client = CursorOriginSetupApiClient(installation_id="i_01example")
+
+    def _walk(self, history: list[str], start: str, end: str) -> list[str]:
+        with patch.object(
+            type(self.api_client), "get_commits", return_value=[commit(s) for s in history]
+        ):
+            result = self.api_client.compare_commits("o/r", start, end)
+        return [c["sha"] for c in result]
+
+    def test_returns_range_oldest_first_excluding_start(self) -> None:
+        # get_commits returns newest first; releases want oldest first, and the
+        # already-released start sha must not be re-associated.
+        assert self._walk(["d", "c", "b", "a"], start="a", end="d") == ["b", "c", "d"]
+
+    def test_single_commit_range(self) -> None:
+        assert self._walk(["b", "a"], start="a", end="b") == ["b"]
+
+    def test_returns_empty_when_head_is_the_start(self) -> None:
+        assert self._walk(["a", "z"], start="a", end="a") == []
+
+    def test_truncates_rather_than_failing_when_start_is_unreachable(self) -> None:
+        # A shallow walk that never finds the start sha still returns what it
+        # saw -- a truncated release beats a failed one.
+        assert self._walk(["d", "c", "b"], start="missing", end="d") == ["b", "c", "d"]
+
+
+class TransformPatchsetTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.provider = CursorOriginRepositoryProvider("integrations:cursor_origin")
+
+    def test_maps_statuses(self) -> None:
+        assert self.provider._transform_patchset(
+            [
+                {"filename": "a.py", "status": "modified"},
+                {"filename": "b.py", "status": "added"},
+                {"filename": "c.py", "status": "removed"},
+            ]
+        ) == [
+            {"path": "a.py", "type": "M"},
+            {"path": "b.py", "type": "A"},
+            {"path": "c.py", "type": "D"},
+        ]
+
+    def test_rename_becomes_a_delete_and_an_add(self) -> None:
+        assert self.provider._transform_patchset(
+            [{"filename": "new.py", "previous_filename": "old.py", "status": "renamed"}]
+        ) == [{"path": "old.py", "type": "D"}, {"path": "new.py", "type": "A"}]
+
+    def test_rename_without_previous_name_still_records_the_add(self) -> None:
+        assert self.provider._transform_patchset([{"filename": "new.py", "status": "renamed"}]) == [
+            {"path": "new.py", "type": "A"}
+        ]
+
+    def test_skips_unknown_status_and_missing_filename(self) -> None:
+        assert (
+            self.provider._transform_patchset(
+                [{"filename": "a.py", "status": "unchanged"}, {"status": "modified"}]
+            )
+            == []
+        )

--- a/tests/sentry/integrations/cursor_origin/test_webhook.py
+++ b/tests/sentry/integrations/cursor_origin/test_webhook.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.cursor_origin.webhook import CursorOriginWebhookEndpoint
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+PROVIDER = IntegrationProviderSlug.CURSOR_ORIGIN.value
+
+
+def _push_payload(installation_id: str | None, repo_id: str, sha: str = "a" * 40) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "event": {
+            "payload": {
+                "repository": {"id": repo_id},
+                "refUpdates": [
+                    {"ref": "refs/heads/main", "headCommit": {"sha": sha}},
+                ],
+            }
+        }
+    }
+    if installation_id is not None:
+        payload["installationId"] = installation_id
+    return payload
+
+
+class PushInstallationScopingTest(TestCase):
+    """A push delivery must only touch repositories of the installation that sent it.
+
+    Repository is unique on (organization_id, provider, external_id), so the same
+    external_id legitimately exists in several organizations. Matching on
+    external_id alone wrote commits into all of them (Warden TKK-PFJ).
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.endpoint = CursorOriginWebhookEndpoint()
+        self.external_repo_id = "repo_shared"
+
+        self.other_org = self.create_organization(name="other-org")
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization, provider=PROVIDER, external_id="in_mine"
+            )
+        self.mine = self.create_repo(
+            project=self.project,
+            name="mine/repo",
+            provider=f"integrations:{PROVIDER}",
+            integration_id=self.integration.id,
+        )
+        self.mine.update(external_id=self.external_repo_id, status=ObjectStatus.ACTIVE)
+
+        other_project = self.create_project(organization=self.other_org)
+        self.theirs = self.create_repo(
+            project=other_project,
+            name="theirs/repo",
+            provider=f"integrations:{PROVIDER}",
+        )
+        self.theirs.update(external_id=self.external_repo_id, status=ObjectStatus.ACTIVE)
+
+    def _run(self, payload: dict[str, Any]) -> None:
+        # _record_ref_update fetches the commit range from Origin; the scoping
+        # decision happens before that, so stub it and assert on which repos are
+        # reached.
+        with mock.patch.object(
+            CursorOriginWebhookEndpoint, "_record_ref_update"
+        ) as record_ref_update:
+            self.endpoint._handle_push(payload)
+        self.reached = [call.args[0].id for call in record_ref_update.call_args_list]
+
+    def test_only_the_sending_installations_repository_is_touched(self) -> None:
+        self._run(_push_payload("in_mine", self.external_repo_id))
+        assert self.reached == [self.mine.id]
+        assert self.theirs.id not in self.reached
+
+    def test_unknown_installation_touches_nothing(self) -> None:
+        self._run(_push_payload("in_nonexistent", self.external_repo_id))
+        assert self.reached == []
+
+    def test_missing_signed_installation_id_touches_nothing(self) -> None:
+        # The id used to come from the unsigned webhook-installation-id header, so
+        # a replayed delivery could aim at any organization. With no signed target
+        # there is nothing safe to act on.
+        self._run(_push_payload(None, self.external_repo_id))
+        assert self.reached == []
+
+
+class InstallationDeletedTest(TestCase):
+    """Uninstall must be driven by signed material, not the header (Warden replay)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.endpoint = CursorOriginWebhookEndpoint()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization, provider=PROVIDER, external_id="in_victim"
+            )
+
+    def test_disables_the_integration_named_in_the_body(self) -> None:
+        self.endpoint._handle_installation_deleted({"installationId": "in_victim"})
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.refresh_from_db()
+        assert self.integration.status == ObjectStatus.DISABLED
+
+    def test_ignores_a_delivery_with_no_signed_installation_id(self) -> None:
+        # A genuine delivery replayed with webhook-event-type rewritten to
+        # installation.deleted must not disable anything.
+        self.endpoint._handle_installation_deleted({"event": {"payload": {}}})
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.refresh_from_db()
+        assert self.integration.status == ObjectStatus.ACTIVE
+
+
+class CommitAuthorTypeTest(TestCase):
+    """author_email arrives from untrusted JSON and is not necessarily a string.
+
+    len() raises TypeError on an int, and CommitAuthorManager.get_or_create calls
+    .lower(), which raises for a list or dict short enough to survive len()
+    (Warden 4NP-B36).
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(project=self.project, name="o/r")
+
+    def _author(self, email: Any) -> CommitAuthor | None:
+        return CursorOriginWebhookEndpoint._commit_author(
+            self.repo, {"author_email": email, "author_name": "A"}, {}
+        )
+
+    def test_non_string_emails_are_ignored_rather_than_raising(self) -> None:
+        for email in (123, ["a@example.com"], {"email": "a@example.com"}, 1.5, True):
+            assert self._author(email) is None
+
+    def test_a_real_email_still_resolves(self) -> None:
+        author = self._author("a@example.com")
+        assert author is not None
+        assert author.email == "a@example.com"
+
+    def test_an_over_long_email_is_ignored(self) -> None:
+        assert self._author("x" * 76 + "@example.com") is None
+
+    def test_a_non_string_name_is_not_stored(self) -> None:
+        author = CursorOriginWebhookEndpoint._commit_author(
+            self.repo, {"author_email": "b@example.com", "author_name": {"first": "A"}}, {}
+        )
+        assert author is not None
+        assert author.name in (None, "")
+
+
+class CommitCreationTest(TestCase):
+    """Commits land against the repository's own organization."""
+
+    def test_commit_is_created_for_the_repository_organization(self) -> None:
+        repo = self.create_repo(project=self.project, name="o/r")
+        endpoint = CursorOriginWebhookEndpoint()
+        endpoint._create_commits(
+            repo,
+            [{"id": "b" * 40, "message": "fix things", "author_email": "c@example.com"}],
+        )
+        commit = Commit.objects.get(repository_id=repo.id, key="b" * 40)
+        assert commit.organization_id == repo.organization_id

--- a/tests/sentry/integrations/cursor_origin/test_webhook_signature.py
+++ b/tests/sentry/integrations/cursor_origin/test_webhook_signature.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from unittest.mock import patch
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from sentry.integrations.cursor_origin.webhook_signature import (
+    is_timestamp_fresh,
+    verify_signature,
+)
+from sentry.testutils.cases import TestCase
+
+WEBHOOK_ID = "whd_01example"
+BODY = b'{"event":{"type":"repository.pushed"}}'
+
+
+def sign(key: Ed25519PrivateKey, webhook_id: str, timestamp: str, body: bytes) -> str:
+    digest = hashlib.sha256(b".".join([webhook_id.encode(), timestamp.encode(), body])).hexdigest()
+    return "v1ed," + base64.b64encode(key.sign(digest.encode())).decode()
+
+
+class TimestampFreshnessTest(TestCase):
+    def test_accepts_recent(self) -> None:
+        assert is_timestamp_fresh(str(int(time.time())))
+
+    def test_rejects_old(self) -> None:
+        assert not is_timestamp_fresh(str(int(time.time()) - 600))
+
+    def test_rejects_far_future(self) -> None:
+        # A clock-skewed sender is one thing; an hour ahead is a replay vector.
+        assert not is_timestamp_fresh(str(int(time.time()) + 3600))
+
+    def test_rejects_garbage(self) -> None:
+        assert not is_timestamp_fresh("not-a-timestamp")
+        assert not is_timestamp_fresh("")
+
+
+class VerifySignatureTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.key = Ed25519PrivateKey.generate()
+        self.public_bytes = self.key.public_key().public_bytes_raw()
+        self.timestamp = str(int(time.time()))
+
+    def _verify(self, signature: str, body: bytes = BODY, keys: list[bytes] | None = None) -> bool:
+        with patch(
+            "sentry.integrations.cursor_origin.webhook_signature.fetch_public_keys",
+            return_value=[self.public_bytes] if keys is None else keys,
+        ):
+            return verify_signature(WEBHOOK_ID, self.timestamp, body, signature)
+
+    def test_accepts_a_valid_signature(self) -> None:
+        assert self._verify(sign(self.key, WEBHOOK_ID, self.timestamp, BODY))
+
+    def test_rejects_when_body_is_tampered_with(self) -> None:
+        signature = sign(self.key, WEBHOOK_ID, self.timestamp, BODY)
+        assert not self._verify(signature, body=BODY + b" ")
+
+    def test_rejects_a_signature_bound_to_a_different_delivery(self) -> None:
+        # The id is part of the signed payload, so a replayed signature from
+        # another delivery must not verify.
+        other = sign(self.key, "whd_01other", self.timestamp, BODY)
+        assert not self._verify(other)
+
+    def test_rejects_a_signature_from_an_unknown_key(self) -> None:
+        stranger = Ed25519PrivateKey.generate()
+        assert not self._verify(sign(stranger, WEBHOOK_ID, self.timestamp, BODY))
+
+    def test_accepts_when_one_of_several_keys_matches(self) -> None:
+        # Signatures carry no key id, so every active key is tried. Rotation
+        # means the right key is often not the first.
+        others = [Ed25519PrivateKey.generate().public_key().public_bytes_raw() for _ in range(2)]
+        assert self._verify(
+            sign(self.key, WEBHOOK_ID, self.timestamp, BODY),
+            keys=[*others, self.public_bytes],
+        )
+
+    def test_rejects_missing_version_prefix(self) -> None:
+        raw = sign(self.key, WEBHOOK_ID, self.timestamp, BODY).removeprefix("v1ed,")
+        assert not self._verify(raw)
+
+    def test_rejects_malformed_base64(self) -> None:
+        assert not self._verify("v1ed,!!!not-base64!!!")
+
+    def test_rejects_when_no_keys_are_available(self) -> None:
+        # A JWKS fetch failure must not fail open.
+        assert not self._verify(sign(self.key, WEBHOOK_ID, self.timestamp, BODY), keys=[])

--- a/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
@@ -1,0 +1,46 @@
+import responses
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory
+
+from sentry.middleware.integrations.classifications import IntegrationClassification
+from sentry.middleware.integrations.parsers.cursor_origin import CursorOriginRequestParser
+from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import assert_no_webhook_payloads
+from sentry.testutils.silo import control_silo_test
+
+WEBHOOK_PATH = "/extensions/cursor-origin/webhook/"
+
+
+@control_silo_test
+class CursorOriginRequestParserTest(TestCase):
+    factory = RequestFactory()
+
+    def get_response(self, request: HttpRequest) -> HttpResponse:
+        return HttpResponse(status=200, content="passthrough")
+
+    @responses.activate
+    def test_routing_all_to_control(self) -> None:
+        request = self.factory.post(WEBHOOK_PATH)
+        parser = CursorOriginRequestParser(request=request, response_handler=self.get_response)
+
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 200
+        assert response.content == b"passthrough"
+        assert len(responses.calls) == 0
+        assert_no_webhook_payloads()
+
+    def test_registered_for_the_hyphenated_url(self) -> None:
+        """The URL says ``cursor-origin`` and the provider slug says
+        ``cursor_origin``; the classification normalizes between them. Without a
+        parser registered under the normalized name it reports every delivery as
+        an unknown provider, so assert the lookup actually lands here.
+        """
+        classification = IntegrationClassification(response_handler=self.get_response)
+        request = self.factory.post(WEBHOOK_PATH)
+
+        provider = classification._identify_provider(request)
+
+        assert provider == "cursor_origin"
+        assert classification.integration_parsers[provider] is CursorOriginRequestParser

--- a/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
@@ -18,13 +18,18 @@ class CursorOriginRequestParserTest(TestCase):
     def get_response(self, request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=200, content="passthrough")
 
-    def _parser(self, event_type: str | None = None, installation_id: str | None = None):
-        headers = {}
+    def _parser(
+        self, event_type: str | None = None, installation_id: str | None = None
+    ) -> CursorOriginRequestParser:
+        # `headers=` with real header names rather than **HTTP_-prefixed environ:
+        # splatting into post() makes mypy match the dict against data/
+        # content_type/secure, and it reads closer to the actual delivery.
+        headers: dict[str, str] = {}
         if event_type:
-            headers["HTTP_WEBHOOK_EVENT_TYPE"] = event_type
+            headers["webhook-event-type"] = event_type
         if installation_id:
-            headers["HTTP_WEBHOOK_INSTALLATION_ID"] = installation_id
-        request = self.factory.post(WEBHOOK_PATH, **headers)
+            headers["webhook-installation-id"] = installation_id
+        request = self.factory.post(WEBHOOK_PATH, headers=headers)
         return CursorOriginRequestParser(request=request, response_handler=self.get_response)
 
     @responses.activate

--- a/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_cursor_origin.py
@@ -18,18 +18,57 @@ class CursorOriginRequestParserTest(TestCase):
     def get_response(self, request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=200, content="passthrough")
 
-    @responses.activate
-    def test_routing_all_to_control(self) -> None:
-        request = self.factory.post(WEBHOOK_PATH)
-        parser = CursorOriginRequestParser(request=request, response_handler=self.get_response)
+    def _parser(self, event_type: str | None = None, installation_id: str | None = None):
+        headers = {}
+        if event_type:
+            headers["HTTP_WEBHOOK_EVENT_TYPE"] = event_type
+        if installation_id:
+            headers["HTTP_WEBHOOK_INSTALLATION_ID"] = installation_id
+        request = self.factory.post(WEBHOOK_PATH, **headers)
+        return CursorOriginRequestParser(request=request, response_handler=self.get_response)
 
-        response = parser.get_response()
+    @responses.activate
+    def test_installation_events_are_answered_in_control(self) -> None:
+        # Disabling the Integration row on uninstall touches only control data,
+        # so there is nothing to forward.
+        response = self._parser(event_type="installation.deleted").get_response()
 
         assert isinstance(response, HttpResponse)
         assert response.status_code == 200
         assert response.content == b"passthrough"
         assert len(responses.calls) == 0
         assert_no_webhook_payloads()
+
+    @responses.activate
+    def test_unknown_installation_is_acknowledged_rather_than_forwarded(self) -> None:
+        # Erroring would make Origin retry forever and eventually disable the
+        # endpoint over deliveries we could never handle.
+        response = self._parser(
+            event_type="repository.pushed", installation_id="i_01nonexistent"
+        ).get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert_no_webhook_payloads()
+
+    @responses.activate
+    def test_push_without_an_installation_header_is_acknowledged(self) -> None:
+        response = self._parser(event_type="repository.pushed").get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert_no_webhook_payloads()
+
+    def test_resolves_the_integration_from_the_header(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            external_id="i_01example",
+            name="sentry",
+        )
+        parser = self._parser(event_type="repository.pushed", installation_id="i_01example")
+
+        assert parser.get_integration_from_request() == integration
 
     def test_registered_for_the_hyphenated_url(self) -> None:
         """The URL says ``cursor-origin`` and the provider slug says


### PR DESCRIPTION
Adds webhook receiving for Cursor Origin — Ed25519 signature verification against Origin's published JWKS, a request parser so deliveries route correctly, uninstall handling, and commit tracking from push events.

**This is PR 3 of 6.** The work was one branch; it is split because `static/` and `src/` do not deploy atomically, and because a 2,300-line integration is not reviewable in one sitting. Each PR stacks on the previous one:

| | PR | Contents |
|---|---|---|
| 1 | [#122294](https://github.com/getsentry/sentry/pull/122294) | client, install pipeline, repository provider, registration, feature gate |
| 2 | [#122298](https://github.com/getsentry/sentry/pull/122298) | platform detection generalised to a `Protocol` |
| **3** | **this one** | webhooks + commit tracking |
| 4 | [#122302](https://github.com/getsentry/sentry/pull/122302) | Seer / SCM wiring |
| 5 | [#122303](https://github.com/getsentry/sentry/pull/122303) | Git-over-HTTPS archive and commit helpers |
| 6 | [#122304](https://github.com/getsentry/sentry/pull/122304) | frontend (`static/` only) |

## What changes

**Webhook endpoint.** Origin had been delivering webhooks since the app was registered with no route to receive them — requests fell through to the frontend catch-all and CSRF middleware rejected them, so "no handler" showed up in logs as a 403 rather than a 404.

Verification is Ed25519, not an HMAC shared secret, so it needs Origin's public keys rather than a secret we hold. They come from a JWKS at `/v1/origin/keys`, cached for an hour and shared with PR 1's install-receipt verification. Signatures carry no key id, so every active key is tried, with one forced refresh so a key rotation does not drop deliveries until the cache expires. **A JWKS fetch failure rejects rather than failing open.**

Two things about the signed payload that are easy to get subtly wrong: the signed material is the lowercase hex digest of `"{id}.{timestamp}.{body}"` — not that triple itself, and not the raw digest bytes — and the delivery id is inside it, so a signature cannot be replayed onto another delivery.

**Request parser.** `IntegrationClassification` intercepts everything under `/extensions/` and normalises the path segment with `.replace("-", "_")`, so `/extensions/cursor-origin/webhook/` resolves to provider `cursor_origin`. With no parser registered under that name, every delivery reported "Unknown provider was extracted from integration extension url" to Sentry before falling through — one error event per delivery, on a path that otherwise worked. `WebhookProviderIdentifier` skips 15, which the in-flight Gitea integration claimed first; the values persist on `WebhookPayload` rows, so sharing one would misroute replays once both land.

**Commit tracking.** `compare_commits` was a stub, so releases from Origin repositories got no commits and suspect-commit attribution did not work. Origin's compare endpoint returns only counts and boundary commits — no commit list — and nothing anywhere gives files changed between two arbitrary shas. The range is rebuilt by walking back from the head sha until the start sha appears, fetching each commit's files individually. Past the cap it returns truncated, on the grounds that a partial release beats a failed one.

## Reachability, and how this differs from the rest of the stack

Worth being direct about: **the webhook endpoint is not behind the feature flag.** It is `csrf_exempt`, `authentication_classes = ()`, `permission_classes = ()`, and registered in `web/urls.py` unconditionally — as GitHub's is. Once this merges the URL is publicly reachable.

What guards it is the signature, in this order: required headers present → timestamp fresh → Ed25519 signature verifies against the JWKS → body parses → dispatch. An unsigned or stale request is rejected before any payload is read, and a delivery naming an installation that does not exist is acknowledged with a 202 without doing anything. The effect of the flag is upstream: with no installations, there is nothing for a valid delivery to act on.

## Security fixes included

Three Warden findings from [#122180](https://github.com/getsentry/sentry/pull/122180), all in `webhook.py`, all the same root cause — trusting the delivery too much.

**Only signed material is trusted (TKK-PFJ, high, plus the header-replay finding).** The signature covers `webhook-id`, `webhook-timestamp` and the body — **not** `webhook-event-type` or `webhook-installation-id`. Those headers are attacker-chosen even on a delivery whose signature is genuine: capture any real delivery, rewrite the two headers, and it still verifies. Two consequences, both fixed:

- `_handle_installation_deleted` read the installation id from the header in preference to the body, so a replayed push could be relabelled `installation.deleted` and aimed at any integration, disabling it.
- `_handle_push` looked repositories up by `external_id` alone. `Repository` is unique on `(organization_id, provider, external_id)`, so the same `external_id` legitimately exists in several organizations — and one delivery wrote commits into all of them. Now scoped to the organizations that hold the sending installation.

Both now take the id from `_signed_installation_id`, which reads the body only and returns `None` rather than falling back to the header. The event-type header is still used for dispatch, but that only selects a handler; each handler re-derives its target from signed data.

**Untrusted types (4NP-B36, high).** `author_email` comes from unvalidated JSON and is not necessarily a string. A truthy non-string passed the `not email` guard and then `len()` raised `TypeError` on an int; a short list or dict survived `len()` and reached `CommitAuthorManager.get_or_create`, which calls `.lower()` on it. Both the push handler and the provider's `_format_commits` funnel through `_commit_author`, so one `isinstance` check covers both. `author_name` gets the same treatment — it is written to a `CharField` and had no more reason to be trusted.

## Dependencies / TODO

Written for someone who has never heard of Cursor Origin. Cursor Origin is a source-code-management provider being added in this stack; PR 1 adds its client and install flow.

**Known gap, deliberately not fixed here:**

- **The request parser routes to a cell using the unsigned event-type header.** Same attacker-controlled header as above. It picks *which cell* processes a delivery, not *what it does* — every handler re-derives its target from signed material — and the middleware runs before signature verification is even possible, since verification needs the JWKS and the body. So it needs a different fix than the one above, not the same one applied again.

**Deliberate, with reasons:**

- **Unhandled events return 204.** Returning success for something we do not handle is deliberate: Origin retries, and can disable an endpoint that keeps failing. Same reasoning behind the 202 for unknown installations and swallowing duplicate commits — deliveries are at-least-once and pushes overlap.
- **Created refs record only the tip commit.** A created ref sends forty zeros as `before`, which Origin's compare rejects with "revision not found" rather than walking. It fails fast rather than running away, but it does fail, so created refs record just `headCommit`.
- **The compare walk is O(commits) API calls.** Each commit's files are fetched individually because no route returns files changed between two shas. Large ranges are capped and returned truncated.
- **Two Origin API traps encoded here**, both of which return a plausible wrong answer rather than an error: the ref parameter on `/commits` is spelled `sha`, and unknown parameters are silently ignored — so passing `ref` yields a normal 200 of unfiltered default-branch history. And a page token encodes the filters it was issued for, so `sha` and `pageSize` must not be resent alongside one.

## Verification

**The push path is confirmed against live deliveries.** Four real `repository.pushed` deliveries resolved through the signed `installationId` alone and scoped to exactly the sending installation's organization; replaying two of them recorded commits where there had been none (0 before, 2 after, correct authors and messages). A 3-commit compare range resolves oldest-first with correct authors, timestamps and patch sets.

**`installation.deleted` is test-covered only.** It reads the same signed field through the same helper as the confirmed push path, but no uninstall delivery has ever been observed. That handler disables an integration, so the distinction matters.

Tests: 12 cover the signature path — tampered bodies, cross-delivery replay, unknown keys, rotation, and the no-keys-available case — plus commit recording, the parser's provider lookup (asserting the `cursor-origin` → `cursor_origin` normalisation itself, which is what was broken), and the webhook handlers driven directly.

Both handlers log the envelope's **top-level key names** (never values) when no signed installation id is present, and a scoped push logs the installation plus how many organizations and repositories matched — so if a future delivery shape breaks this, which one it is stays readable rather than guessable.

---

**Reference:** [#122180](https://github.com/getsentry/sentry/pull/122180) is the original single-branch version of this work — all six PRs' worth of changes in one draft, kept open for history. It carries the Warden review that produced the fixes above. It is superseded by this stack and should not be merged.
