### PR TITLE
feat(cursor-origin): wire Seer and SCM support behind a flag (4/6)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -138,6 +138,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-vercel-upsert-env-var", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-datadog", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-cursor-origin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:seer-cursor-origin-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:slack-reinstall-nudge-on-issue-alert", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GitHub Enterprise to accept github.com as a valid Installation URL
     manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/integrations/cursor_origin/client.py
+++ b/src/sentry/integrations/cursor_origin/client.py
@@ -350,8 +350,31 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
         self._private_key = private_key
         self._access_token: str | None = None
         self._expires_at: float = 0.0
+        # Set for the duration of a request that asked for app-level credentials.
+        self._force_app_auth = False
 
     # -- auth ----------------------------------------------------------------
+
+    def request(self, *args: Any, **kwargs: Any) -> Any:
+        """Accept scm-platform's ``credentials_set`` argument.
+
+        Providers in the scm library thread ``credentials_set`` through every
+        call to choose between app-level and installation-level credentials.
+        Sentry's BaseApiClient knows nothing about it, so it has to be consumed
+        here or the call fails with an unexpected-keyword TypeError -- which is
+        how this surfaced: every read through SourceCodeManager blew up before
+        reaching the network.
+
+        "application" means authenticate as the app itself rather than as the
+        installation, which for Origin is the app JWT.
+        """
+        credentials_set = kwargs.pop("credentials_set", None)
+        previous = self._force_app_auth
+        self._force_app_auth = credentials_set == "application"
+        try:
+            return super().request(*args, **kwargs)
+        finally:
+            self._force_app_auth = previous
 
     def _jwt(self) -> str:
         return get_jwt(app_id=self._app_id, private_key=self._private_key)
@@ -411,7 +434,7 @@ class CursorOriginSetupApiClient(CursorOriginApiMixin, IntegrationProxyClient):
         return f"cursor-origin:token:{installation_id}"
 
     def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
-        if self._is_app_route(prepared_request.path_url):
+        if self._force_app_auth or self._is_app_route(prepared_request.path_url):
             token = self._jwt()
         else:
             token = self.get_access_token()

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -106,6 +106,7 @@ _KNOWN_SCM_PROVIDERS = frozenset(
         IntegrationProviderSlug.BITBUCKET_SERVER,
         IntegrationProviderSlug.AZURE_DEVOPS,
         IntegrationProviderSlug.PERFORCE,
+        IntegrationProviderSlug.CURSOR_ORIGIN,
     }
 )
 

--- a/src/sentry/scm/private/helpers.py
+++ b/src/sentry/scm/private/helpers.py
@@ -1,4 +1,6 @@
+import functools
 import importlib
+import logging
 from typing import Any, cast
 
 import sentry_sdk
@@ -7,7 +9,17 @@ from scm.providers.github.provider import GitHubProvider
 from scm.providers.gitlab.provider import GitLabProvider
 from scm.types import Provider, Repository, RepositoryId
 
+from sentry.constants import ObjectStatus
+from sentry.integrations.errors import OrganizationIntegrationNotFound
+from sentry.integrations.services.integration.service import integration_service
+from sentry.models.repository import Repository as RepositoryModel
+from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.utils import metrics
 
+logger = logging.getLogger(__name__)
+
+
+@functools.cache
 def _cursor_origin_provider_cls() -> Any:
     """The Cursor Origin provider class, when the installed scm build has one.
 
@@ -23,16 +35,17 @@ def _cursor_origin_provider_cls() -> Any:
     try:
         module = importlib.import_module("scm.providers.cursor_origin.provider")
     except ImportError:
+        # Without this the caller returns None, fetch_service_provider returns None,
+        # and scm.helpers.initialize_provider raises ProviderNotFound -- which reads
+        # as "this provider is not supported" when the truth is "the installed
+        # sentry-scm predates it". Say which, so the version mismatch is not
+        # mistaken for a problem with the repository.
+        logger.warning(
+            "cursor_origin.scm_provider_unavailable",
+            extra={"scm_module": "scm.providers.cursor_origin.provider"},
+        )
         return None
     return module.CursorOriginProvider
-
-
-from sentry.constants import ObjectStatus
-from sentry.integrations.errors import OrganizationIntegrationNotFound
-from sentry.integrations.services.integration.service import integration_service
-from sentry.models.repository import Repository as RepositoryModel
-from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.utils import metrics
 
 
 def fetch_service_provider(organization_id: int, repository: Repository) -> Provider | None:

--- a/src/sentry/scm/private/helpers.py
+++ b/src/sentry/scm/private/helpers.py
@@ -1,10 +1,31 @@
-from typing import cast
+import importlib
+from typing import Any, cast
 
 import sentry_sdk
 from django.db.models import Q
 from scm.providers.github.provider import GitHubProvider
 from scm.providers.gitlab.provider import GitLabProvider
 from scm.types import Provider, Repository, RepositoryId
+
+
+def _cursor_origin_provider_cls() -> Any:
+    """The Cursor Origin provider class, when the installed scm build has one.
+
+    WIP. sentry-scm 1.5.0 predates the provider, so a plain import would take
+    down every SCM code path rather than just Origin. Resolved dynamically so
+    this module type-checks identically whether or not the newer build is
+    installed -- a guarded `import` flips between "unresolvable" and "unused
+    ignore" depending on which is present, which makes CI depend on install
+    order.
+
+    Remove this once the sentry-scm pin includes the provider.
+    """
+    try:
+        module = importlib.import_module("scm.providers.cursor_origin.provider")
+    except ImportError:
+        return None
+    return module.CursorOriginProvider
+
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.errors import OrganizationIntegrationNotFound
@@ -31,6 +52,9 @@ def fetch_service_provider(organization_id: int, repository: Repository) -> Prov
         return GitHubProvider(client, organization_id, repository)
     elif integration.provider == "gitlab":
         return GitLabProvider(client, organization_id, repository)
+    elif integration.provider == "cursor_origin":
+        provider_cls = _cursor_origin_provider_cls()
+        return provider_cls(client, organization_id, repository) if provider_cls else None
     else:
         return None
 

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -420,7 +420,13 @@ def deserialize_raw_event(event: SubscriptionEvent) -> EventType | None:
     elif event["type"] == "gitlab":
         raise SCMProviderNotSupported("GitLab has not been implemented.")
     else:
-        assert_never(event["type"])
+        # Deliberately a runtime raise rather than assert_never. The union comes
+        # from the installed sentry-scm, so exhaustiveness here depends on which
+        # build is present: a release that predates a provider makes a branch for
+        # it unreachable, while a newer one makes its absence a non-exhaustive
+        # match. Either way mypy fails somewhere that looks unrelated to the
+        # provider actually being added.
+        raise SCMProviderNotSupported(f"{event['type']} has not been implemented.")
 
 
 def serialize_event(event: EventType) -> str:

--- a/src/sentry/seer/constants.py
+++ b/src/sentry/seer/constants.py
@@ -10,6 +10,8 @@ SeerSCMProvider = Literal[
     "github",
     "github_enterprise",
     "gitlab",
+    "integrations:cursor_origin",
+    "cursor_origin",
 ]
 
 # GitHub providers (bare and `integrations:`-prefixed); mirrors frontend `isGitHubProvider`.
@@ -25,4 +27,12 @@ SEER_SUPPORTED_SCM_PROVIDERS = [*SEER_GITHUB_SCM_PROVIDERS]
 SEER_GITLAB_SCM_PROVIDERS = [
     "integrations:gitlab",
     IntegrationProviderSlug.GITLAB.value,
+]
+
+# WIP. Feature-gated like GitLab was, because Seer's own support is still
+# landing: Origin has no inline review comments, so a review there is one prose
+# comment rather than diff-anchored ones.
+SEER_CURSOR_ORIGIN_SCM_PROVIDERS = [
+    "integrations:cursor_origin",
+    IntegrationProviderSlug.CURSOR_ORIGIN.value,
 ]

--- a/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
@@ -29,6 +29,9 @@ def has_supported_scm_integration(organization: Organization) -> bool:
     if features.has("organizations:seer-gitlab-support", organization):
         providers.append(IntegrationProviderSlug.GITLAB.value)
 
+    if features.has("organizations:seer-cursor-origin-support", organization):
+        providers.append(IntegrationProviderSlug.CURSOR_ORIGIN.value)
+
     organization_integrations = integration_service.get_organization_integrations(
         organization_id=organization.id,
         providers=providers,

--- a/src/sentry/seer/seer_setup.py
+++ b/src/sentry/seer/seer_setup.py
@@ -3,7 +3,11 @@ from django.contrib.auth.models import AnonymousUser
 from sentry import features
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.seer.constants import SEER_GITLAB_SCM_PROVIDERS, SEER_SUPPORTED_SCM_PROVIDERS
+from sentry.seer.constants import (
+    SEER_CURSOR_ORIGIN_SCM_PROVIDERS,
+    SEER_GITLAB_SCM_PROVIDERS,
+    SEER_SUPPORTED_SCM_PROVIDERS,
+)
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 
@@ -12,6 +16,10 @@ def get_supported_scm_providers(organization: Organization | None = None) -> lis
     providers = list(SEER_SUPPORTED_SCM_PROVIDERS)
     if organization is not None and features.has("organizations:seer-gitlab-support", organization):
         providers.extend(SEER_GITLAB_SCM_PROVIDERS)
+    if organization is not None and features.has(
+        "organizations:seer-cursor-origin-support", organization
+    ):
+        providers.extend(SEER_CURSOR_ORIGIN_SCM_PROVIDERS)
     return providers
 
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
@@ -88,6 +88,27 @@ class TestHasSupportedScmIntegration(TestCase):
 
         assert not has_supported_scm_integration(self.organization)
 
+    @with_feature("organizations:seer-cursor-origin-support")
+    def test_cursor_origin_integration_with_feature_flag(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            name="Cursor Origin Test",
+            external_id="i_0123456789",
+        )
+
+        assert has_supported_scm_integration(self.organization)
+
+    def test_cursor_origin_integration_without_feature_flag(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="cursor_origin",
+            name="Cursor Origin Test",
+            external_id="i_0123456789",
+        )
+
+        assert not has_supported_scm_integration(self.organization)
+
 
 class TestIsCodeReviewEnabled(TestCase):
     """Unit tests for is_code_review_enabled()"""


### PR DESCRIPTION
Wires Cursor Origin into Seer's SCM path: `fetch_service_provider()` can build a `CursorOriginProvider`, Origin is added to Seer's supported-provider lists behind a flag, and Seer onboarding counts it as a real SCM.

**This is PR 4 of 6.** The work was one branch; it is split because `static/` and `src/` do not deploy atomically, and because a 2,300-line integration is not reviewable in one sitting. Each PR stacks on the previous one:

| | PR | Contents |
|---|---|---|
| 1 | [#122294](https://github.com/getsentry/sentry/pull/122294) | client, install pipeline, repository provider, registration, feature gate |
| 2 | [#122298](https://github.com/getsentry/sentry/pull/122298) | platform detection generalised to a `Protocol` |
| 3 | [#122301](https://github.com/getsentry/sentry/pull/122301) | webhooks + commit tracking |
| **4** | **this one** | Seer / SCM wiring |
| 5 | [#122303](https://github.com/getsentry/sentry/pull/122303) | Git-over-HTTPS archive and commit helpers |
| 6 | [#122304](https://github.com/getsentry/sentry/pull/122304) | frontend (`static/` only) |

## Read this first: none of this runs in production yet

This is the most important thing about the PR, and it is not a footnote.

`scm-platform` will not be released for a while, so `src/sentry/scm/private/helpers.py` **deliberately keeps** resolving `CursorOriginProvider` through `importlib` rather than importing it. In production, with `sentry-scm==1.5.0` installed:

- `_cursor_origin_provider_cls()` returns `None`
- `fetch_service_provider()` returns `None`
- `scm.helpers.initialize_provider` raises **`ProviderNotFound`**

**Every Seer/SCM path for Origin is therefore inert** — autofix, PR creation, repository reads. This PR adds the wiring; it does not turn anything on.

**Do not replace the `importlib` shim with a plain import, and do not bump the `sentry-scm==1.5.0` pin.** A plain import against 1.5.0 would take down *every* SCM code path rather than just Origin's. A guarded `try/except ImportError` is not better: it flips between "unresolvable import" and "unused type-ignore" depending on which build happens to be installed, which makes type checking depend on install order.

**What unblocks it:** a `sentry-scm` release carrying `scm.providers.cursor_origin`. **What changes then:** bump the pin, delete the shim for a plain import. Reference scm-platform PR #130.

Because "inert" should not mean "inscrutable", a `logger.warning` naming the missing module was added so the resulting `ProviderNotFound` is traceable to a version mismatch rather than sending someone to inspect the repository or the integration. Same class of problem as scm-platform#132 §3.

## Safe by default

`organizations:seer-cursor-origin-support` is registered here and stays **off**. That is what keeps the inert path out of users' way — and it is a second, independent gate on top of `organizations:integrations-cursor-origin` from PR 1, which is what makes an Origin repository exist at all.

The flag mirrors how GitLab is handled. It is flag-gated rather than shipped on because Seer's own Origin support is still WIP — notably Origin has no inline review comments, so a review there is one prose comment rather than diff-anchored ones.

## What changes

- **`fetch_service_provider()`** can build a `CursorOriginProvider` — the RPC proxy needs this before Seer can read anything. Widening Seer's own `SUPPORTED_PROVIDERS` is not sufficient on its own.
- **`SEER_SUPPORTED_SCM_PROVIDERS`** gains Origin behind the flag. The matching frontend entry in `FEATURE_GATED_PROVIDERS` ships in PR 6.
- **`has_supported_scm_integration()`** now counts Origin. This function builds its own provider list rather than calling `get_supported_scm_providers()`, because it needs bare integration slugs and that helper also returns the `"integrations:"`-prefixed `Repository.provider` forms. **The consequence is that every new Seer provider must be added in two places** — Origin was added only to the helper, so org-level Seer onboarding reported "no supported SCM" for an org whose only SCM is Cursor Origin, even with the flag on.
- **`_KNOWN_SCM_PROVIDERS`** gains `cursor_origin`; without it a pull request whose provider normalised to Origin was treated as a value we do not understand.
- **`deserialize_raw_event`** no longer ends in `assert_never` over `ProviderName`. That type is supplied by the *installed* `sentry-scm`, so exhaustiveness checking depended on which build was present: a release predating a provider makes its branch unreachable, a newer one makes its absence a non-exhaustive match. Either way mypy failed somewhere that read as unrelated to the provider being added. It is a runtime raise now, so the module type-checks against both builds.

## Bug found and fixed along the way

SCM providers thread `credentials_set` through every client call, which Sentry's `BaseApiClient` rejects as an unexpected keyword — so **every Origin read blew up before reaching the network.** Found by exercising the real path with a newer `sentry-scm` build present, not by tests.

## Dependencies / TODO

Written for someone who has never heard of Cursor Origin. Cursor Origin is a source-code-management provider being added in this stack; PR 1 adds its client and install flow.

- **The `importlib` shim is temporary and load-bearing.** Covered above. It is the single thing in this PR most likely to be "cleaned up" by someone who does not know why it exists.
- **Two lists must be kept in sync**, in `seer_setup.py` and the onboarding check — `get_supported_scm_providers()` and `has_supported_scm_integration()`. Adding a Seer provider to only one of them produces exactly the silent onboarding failure fixed here. Consolidating them is the real fix and is not attempted here.
- **A third list lives in the frontend.** `FEATURE_GATED_PROVIDERS` in PR 6 must carry the same flag pairing, or the UI and backend disagree about whether Origin is available.
- **`logger.warning` uses the key `scm_module`, not `module`.** `module` is a reserved `LogRecord` attribute and raises `KeyError` at emit time — which would have crashed the very path the log exists to explain. Caught by flake8-sentry S019; please keep the prefixed name.
- **`functools.cache` on the provider lookup** is deliberate: it logs once per process rather than once per SCM call, and failed imports are not cached in `sys.modules`, so the lookup was being retried on every call anyway. The result cannot change within a process — an scm build does not appear at runtime.

## Verification

**Verified against a real installation with the newer scm build present** (not the pinned one): the full path resolves and reads — repository → `CursorOriginProvider` → `get_repository` returning live data. That run is what surfaced the `credentials_set` bug above.

**With the pinned `sentry-scm==1.5.0` — which is what production has — the path is inert by design**, and that is the state this PR ships in. Tests cover the onboarding check, including that an org whose only SCM is Origin is now counted when the flag is on.

The last commit (`fix(cursor-origin): say why the Origin SCM provider is unavailable`) is **not part of the PR split** — it is a deliberate behaviour change, committed separately so the split itself stays verifiable as a pure reorganisation.

---

**Reference:** [#122180](https://github.com/getsentry/sentry/pull/122180) is the original single-branch version of this work — all six PRs' worth of changes in one draft, kept open for history. It carries the Warden review that produced the security fixes in PRs 1 and 3. It is superseded by this stack and should not be merged.
