### PR TITLE
feat(cursor-origin): Git-over-HTTPS archive and commit helpers for Seer (5/6)

### DIFF
--- a/src/sentry/integrations/cursor_origin/git.py
+++ b/src/sentry/integrations/cursor_origin/git.py
@@ -194,6 +194,18 @@ def commit_and_push(
     with cloned_repo(clone_url) as repo_dir:
         run = lambda *args: _run(["git", *args], cwd=repo_dir)
 
+        # Checked explicitly rather than left to the push, because the caller's recovery
+        # depends on recognizing this case: Seer retries with a suffixed branch name when
+        # the message says the branch already exists. Git's own rejection for a diverged
+        # ref says "Updates were rejected because the remote contains work..." instead,
+        # which Seer would not match, and it would surface as a hard failure.
+        try:
+            _run(["git", "rev-parse", "--verify", f"origin/{branch}"], cwd=repo_dir)
+        except CursorOriginGitError:
+            pass  # Expected: the branch does not exist yet, which is the normal case.
+        else:
+            raise CursorOriginGitError(f"Branch already exists: {branch}")
+
         # Detach at the base commit so the new branch starts exactly there, whatever the
         # clone happened to check out.
         run("checkout", "--quiet", "--detach", base_sha)

--- a/src/sentry/integrations/cursor_origin/git.py
+++ b/src/sentry/integrations/cursor_origin/git.py
@@ -1,0 +1,225 @@
+"""Git-over-HTTPS operations for Cursor Origin.
+
+Every other SCM operation in this integration is a REST call, and Seer reaches those
+through the SCM proxy (``/api/0/internal/scm-rpc/``): Seer's provider composes a
+request, Sentry executes it with the installation credentials, and the raw response is
+streamed back. Seer holds no forge credentials -- that is true of GitLab entirely, and
+of GitHub's default path.
+
+Origin cannot be served that way for two operations, and the reason is not a missing
+endpoint we could add later:
+
+* **There is no archive route.** ``tarball``/``zipball``/``archive`` all 404, so a repo
+  cannot be materialized with a GET the way GitHub's and GitLab's can.
+* **There is no write route for a commit, branch, ref, blob, or tree.** The entire
+  git-write surface is Git-over-HTTPS. ``create_commit`` is not merely unimplemented in
+  the scm provider; there is nothing to implement it with.
+
+Git-over-HTTPS is a different protocol to a different host (``origin.cursor.com``, not
+``api.cursor.com``), so the REST proxy cannot carry it. Something has to run ``git``
+where the credentials are, and that is here. Seer reaches these over the seer-rpc
+channel instead, which keeps the invariant that matters: the Origin app key and the
+installation tokens minted from it never leave Sentry.
+
+The token is passed to git in the clone URL, matching how Seer's own
+``CachedRepoManager`` does it. That puts it in the child process's argv, and ``git
+clone`` persists it into the clone's ``.git/config`` -- both are bounded here by the
+clone living in a temporary directory that is removed on the way out, but neither is
+something to copy into a multi-tenant context without revisiting.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from typing import Any
+
+from sentry.integrations.cursor_origin.constants import CURSOR_ORIGIN_GIT_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+# A clone of a repository we are about to archive or commit to. Origin repositories are
+# ordinary git repositories, so this is bounded by the repo, not by our use of it.
+GIT_TIMEOUT_SECONDS = 600
+
+# Written into the commit when the caller supplies no author. Seer normally passes one.
+DEFAULT_AUTHOR_NAME = "Seer by Sentry"
+DEFAULT_AUTHOR_EMAIL = "noreply@sentry.io"
+
+
+class CursorOriginGitError(Exception):
+    """A git invocation against Origin failed.
+
+    Carries a message already scrubbed of the access token -- see ``_run``.
+    """
+
+
+def build_clone_url(repo_full_name: str, access_token: str) -> str:
+    """``https://x-access-token:{token}@origin.cursor.com/{owner}/{repo}.git``.
+
+    ``repo_full_name`` is Origin's ``fullName`` (``sentry/nuget-trends``), which is what
+    Sentry stores as ``Repository.name``.
+    """
+    return f"https://x-access-token:{access_token}@{CURSOR_ORIGIN_GIT_BASE_URL.removeprefix('https://')}/{repo_full_name}.git"
+
+
+# Credentials embedded in a URL, as git echoes them back in its own error text
+# ("unable to access 'https://x-access-token:oit_...@origin.cursor.com/...'"). Matched
+# on the URL shape rather than on the token value so that scrubbing does not depend on
+# the caller remembering to pass the secret in.
+_URL_CREDENTIALS = re.compile(r"(?<=//)[^/\s@]+:[^/\s@]+(?=@)")
+
+
+def _scrub(text: str) -> str:
+    return _URL_CREDENTIALS.sub("<redacted>", text)
+
+
+def _run(args: Sequence[str], *, cwd: str | None = None) -> bytes:
+    """Run a git command, raising ``CursorOriginGitError`` with scrubbed output."""
+    try:
+        completed = subprocess.run(
+            list(args),
+            cwd=cwd,
+            capture_output=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            # Never let git stop for credentials; fail instead of hanging a worker.
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+    except subprocess.TimeoutExpired as e:
+        raise CursorOriginGitError(f"git timed out after {GIT_TIMEOUT_SECONDS}s") from e
+
+    if completed.returncode != 0:
+        stderr = _scrub(completed.stderr.decode("utf-8", "replace"))
+        raise CursorOriginGitError(f"git failed ({completed.returncode}): {stderr.strip()[:500]}")
+
+    return completed.stdout
+
+
+@contextmanager
+def cloned_repo(clone_url: str) -> Iterator[str]:
+    """Clone ``clone_url`` into a temporary directory, yielding its path.
+
+    The clone is full rather than shallow on purpose: callers address arbitrary commits
+    (Seer materializes a specific ``base_sha``, not a branch tip), and fetching an
+    arbitrary sha into a shallow clone depends on the server allowing
+    ``uploadpack.allowReachableSHA1InWant``, which Origin does not document either way.
+    A full clone is the option that does not depend on an unverified server setting.
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="cursor-origin-")
+    repo_dir = os.path.join(tmp_dir, "repo")
+    try:
+        _run(["git", "clone", "--quiet", clone_url, repo_dir])
+        yield repo_dir
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def archive_ref(clone_url: str, ref: str, *, prefix: str) -> bytes:
+    """Return a gzipped tar of ``ref``, shaped like GitHub's and GitLab's tarballs.
+
+    ``--prefix`` is not cosmetic. Seer's extraction assumes a single top-level directory
+    and moves its *contents* into place (``sandbox/providers/local.py``); a tar whose
+    entries sit at the root would extract to a wrong tree rather than fail, so this is
+    one of the places where getting it wrong is silent.
+    """
+    with cloned_repo(clone_url) as repo_dir:
+        return _run(["git", "archive", "--format=tar.gz", f"--prefix={prefix}/", ref], cwd=repo_dir)
+
+
+def _apply_action(repo_dir: str, action: dict[str, Any]) -> None:
+    """Apply one commit action to the working tree.
+
+    The shapes mirror scm-platform's commit-action dataclasses (``WriteCommitAction``
+    and friends), flattened to JSON so they survive the seer-rpc hop.
+    """
+    kind = action.get("kind")
+
+    if kind in ("create", "update", "write"):
+        path = os.path.join(repo_dir, action["filename"])
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        content = action["content"]
+        if action.get("encoding") == "base64":
+            with open(path, "wb") as f:
+                f.write(base64.b64decode(content))
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+    elif kind == "delete":
+        path = os.path.join(repo_dir, action["filename"])
+        if os.path.exists(path):
+            os.remove(path)
+
+    elif kind == "move":
+        src = os.path.join(repo_dir, action["old_filename"])
+        dst = os.path.join(repo_dir, action["new_filename"])
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.move(src, dst)
+
+    elif kind == "chmod":
+        path = os.path.join(repo_dir, action["filename"])
+        mode = 0o755 if action.get("executable") else 0o644
+        os.chmod(path, mode)
+
+    else:
+        raise CursorOriginGitError(f"Unsupported commit action: {kind!r}")
+
+
+def commit_and_push(
+    *,
+    clone_url: str,
+    branch: str,
+    base_sha: str,
+    message: str,
+    actions: list[dict[str, Any]],
+    author_name: str | None = None,
+    author_email: str | None = None,
+) -> str:
+    """Create ``branch`` at ``base_sha`` with ``actions`` applied, push it, return the sha.
+
+    Pushed with a plain (non-force) ref create, so a branch that already exists on the
+    remote fails rather than being overwritten. Seer retries with a suffixed name when a
+    branch collides, which only works if the collision is reported rather than absorbed.
+    """
+    author_name = author_name or DEFAULT_AUTHOR_NAME
+    author_email = author_email or DEFAULT_AUTHOR_EMAIL
+
+    with cloned_repo(clone_url) as repo_dir:
+        run = lambda *args: _run(["git", *args], cwd=repo_dir)
+
+        # Detach at the base commit so the new branch starts exactly there, whatever the
+        # clone happened to check out.
+        run("checkout", "--quiet", "--detach", base_sha)
+        run("switch", "--quiet", "--create", branch)
+
+        for action in actions:
+            _apply_action(repo_dir, action)
+
+        run("add", "--all")
+
+        # An autofix that produced no net change would otherwise create an empty commit
+        # and an empty pull request. Seer checks `ahead_by` afterwards, but failing here
+        # is clearer than opening a PR with nothing in it.
+        if not _run(["git", "status", "--porcelain"], cwd=repo_dir):
+            raise CursorOriginGitError("No changes to commit")
+
+        run(
+            "-c",
+            f"user.name={author_name}",
+            "-c",
+            f"user.email={author_email}",
+            "commit",
+            "--quiet",
+            "--message",
+            message,
+        )
+        run("push", "--quiet", "origin", f"{branch}:refs/heads/{branch}")
+
+        return _run(["git", "rev-parse", "HEAD"], cwd=repo_dir).decode().strip()

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import hashlib
 import hmac
@@ -50,6 +51,12 @@ from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
 from sentry.identity import default_manager as identity_manager
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.identity.services.identity import identity_service
+from sentry.integrations.cursor_origin.git import (
+    CursorOriginGitError,
+    archive_ref,
+    build_clone_url,
+    commit_and_push,
+)
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import MONITORING_PROVIDERS, IntegrationProviderSlug
@@ -130,6 +137,7 @@ from sentry.seer.seer_setup import get_supported_scm_providers
 from sentry.seer.sentry_data_models import (
     AttributeBucket,
     AttributesAndValuesResponse,
+    CursorOriginGitResponse,
     GetRepoInstallationIdErrorResponse,
     GetRepoInstallationIdSuccessResponse,
     GitHubEnterpriseConfigErrorResponse,
@@ -823,6 +831,128 @@ def get_repo_installation_id(
     )
 
 
+def _cursor_origin_clone_url(
+    *, organization_id: int, provider: str, external_id: str, owner: str, name: str
+) -> tuple[str | None, str | None]:
+    """Resolve a repository to an authenticated Origin clone URL.
+
+    Returns ``(clone_url, error)``. The token is minted here and embedded in the URL
+    that is handed straight to git -- it is never returned to the caller and never
+    crosses the seer-rpc boundary, which is the whole point of doing this in Sentry.
+    """
+    repo = filter_repo_by_provider(organization_id, provider, external_id, owner, name).first()
+    if not repo:
+        return None, "repository_not_found"
+
+    try:
+        organization = Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist:
+        return None, "organization_not_found"
+
+    if repo.provider not in get_supported_scm_providers(organization):
+        logger.warning("seer.cursor_origin.unsupported_provider", extra={"provider": repo.provider})
+        return None, "unsupported_provider"
+
+    if repo.provider != f"integrations:{IntegrationProviderSlug.CURSOR_ORIGIN.value}":
+        return None, "unsupported_provider"
+
+    if repo.integration_id is None:
+        return None, "no_integration"
+
+    integration = integration_service.get_integration(
+        integration_id=repo.integration_id, organization_id=organization_id
+    )
+    if integration is None:
+        return None, "integration_not_found"
+
+    installation = integration.get_installation(organization_id=organization_id)
+    access_token = installation.get_client().get_access_token()
+    return build_clone_url(repo.name, access_token), None
+
+
+def cursor_origin_archive_repo(
+    *,
+    organization_id: int,
+    provider: str,
+    external_id: str,
+    owner: str,
+    name: str,
+    ref: str,
+) -> CursorOriginGitResponse:
+    """Return a gzipped tar of ``ref``, base64-encoded, for Seer to materialize.
+
+    Origin has no archive endpoint, so this clones and runs ``git archive``. Seer's
+    other providers get their tarball streamed through the SCM proxy; Origin cannot,
+    because git is not REST. Base64 in JSON is the cost of reusing the seer-rpc
+    channel rather than adding a binary-streaming endpoint for one provider.
+    """
+    clone_url, error = _cursor_origin_clone_url(
+        organization_id=organization_id,
+        provider=provider,
+        external_id=external_id,
+        owner=owner,
+        name=name,
+    )
+    if clone_url is None:
+        return CursorOriginGitResponse(error=error)
+
+    try:
+        content = archive_ref(clone_url, ref, prefix=f"{owner}-{name}-{ref}")
+    except CursorOriginGitError as e:
+        logger.warning("seer.cursor_origin.archive_failed", extra={"error": str(e)})
+        return CursorOriginGitResponse(error=str(e))
+
+    return CursorOriginGitResponse(content_base64=base64.b64encode(content).decode())
+
+
+def cursor_origin_create_commit(
+    *,
+    organization_id: int,
+    provider: str,
+    external_id: str,
+    owner: str,
+    name: str,
+    branch: str,
+    base_sha: str,
+    message: str,
+    actions: list[dict[str, Any]],
+    author_name: str | None = None,
+    author_email: str | None = None,
+) -> CursorOriginGitResponse:
+    """Create ``branch`` at ``base_sha`` with ``actions`` applied and push it.
+
+    Origin has no REST route to write a commit, branch, ref, blob or tree, so this is
+    the only way Seer can land changes there before opening a pull request.
+    """
+    clone_url, error = _cursor_origin_clone_url(
+        organization_id=organization_id,
+        provider=provider,
+        external_id=external_id,
+        owner=owner,
+        name=name,
+    )
+    if clone_url is None:
+        return CursorOriginGitResponse(error=error)
+
+    try:
+        sha = commit_and_push(
+            clone_url=clone_url,
+            branch=branch,
+            base_sha=base_sha,
+            message=message,
+            actions=actions,
+            author_name=author_name,
+            author_email=author_email,
+        )
+    except CursorOriginGitError as e:
+        # Expected outcomes live here too -- a colliding branch name, or an autofix
+        # that produced no net change. Seer distinguishes them from the message.
+        logger.warning("seer.cursor_origin.commit_failed", extra={"error": str(e)})
+        return CursorOriginGitResponse(error=str(e))
+
+    return CursorOriginGitResponse(sha=sha)
+
+
 def get_project_preferences(*, organization_id: int, project_id: int) -> SeerProjectPreference:
     """Get Seer project preferences for a single project.
 
@@ -979,6 +1109,10 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     "get_organization_projects": seer_rpc(get_organization_projects),
     "get_organization_features": seer_rpc(get_organization_features),
     "get_repo_installation_id": seer_rpc(get_repo_installation_id),
+    #
+    # Cursor Origin git-over-HTTPS (no archive route, no REST commit write)
+    "cursor_origin_archive_repo": seer_rpc(cursor_origin_archive_repo),
+    "cursor_origin_create_commit": seer_rpc(cursor_origin_create_commit),
     #
     # Autofix
     "get_organization_slug": seer_rpc(get_organization_slug),

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -190,6 +190,26 @@ class GetRepoInstallationIdErrorResponse(BaseModel):
     error: str
 
 
+class CursorOriginGitResponse(BaseModel):
+    """Result of a Cursor Origin Git-over-HTTPS operation performed on Sentry's behalf.
+
+    Origin exposes no archive route and no REST write for commits, branches or refs, so
+    Seer cannot reach either through the SCM proxy the way it does for GitHub and
+    GitLab. These operations run in Sentry, where the credentials live, and Seer calls
+    them over seer-rpc. See `sentry.integrations.cursor_origin.git`.
+
+    `error` is a string rather than an exception because the seer-rpc boundary
+    serializes it; a failed git operation is an expected outcome here (a branch that
+    already exists, an autofix that produced no net change), not necessarily a defect.
+    """
+
+    # Gzipped tar of a ref, base64-encoded. Set only by the archive method.
+    content_base64: str | None = None
+    # Sha of the commit that was pushed. Set only by the commit method.
+    sha: str | None = None
+    error: str | None = None
+
+
 class ProfileDetailsResponse(BaseModel):
     profile_matches_issue: Literal[True] = True
     execution_tree: list[ExecutionTreeNode]

--- a/tests/sentry/integrations/cursor_origin/test_git.py
+++ b/tests/sentry/integrations/cursor_origin/test_git.py
@@ -14,6 +14,7 @@ import io
 import os
 import subprocess
 import tarfile
+from pathlib import Path
 
 import pytest
 
@@ -55,7 +56,7 @@ class CursorOriginGitTestBase(TestCase):
         self.base_sha = _git("rev-parse", "HEAD", cwd=work)
 
     @pytest.fixture(autouse=True)
-    def _tmpdir(self, tmp_path):
+    def _tmpdir(self, tmp_path: Path) -> None:
         self.tmpdir = tmp_path
 
 

--- a/tests/sentry/integrations/cursor_origin/test_git.py
+++ b/tests/sentry/integrations/cursor_origin/test_git.py
@@ -1,0 +1,155 @@
+"""Tests for the Cursor Origin Git-over-HTTPS helpers.
+
+These use a local bare repository as the remote rather than mocking ``subprocess``.
+Mocking git here would test the argument strings and nothing else, and the things most
+likely to be wrong are behaviours of real git: whether the archive carries the single
+top-level directory Seer's extractor requires, whether a commit lands on a new branch
+started from an arbitrary base sha, and whether a colliding branch name fails loudly
+(Seer's retry depends on it) rather than being force-overwritten.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import tarfile
+
+import pytest
+
+from sentry.integrations.cursor_origin.git import (
+    CursorOriginGitError,
+    archive_ref,
+    build_clone_url,
+    commit_and_push,
+)
+from sentry.testutils.cases import TestCase
+
+
+def _git(*args: str, cwd: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+class CursorOriginGitTestBase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.remote = str(self.tmpdir / "remote.git")
+        work = str(self.tmpdir / "work")
+        os.makedirs(work)
+
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main", self.remote], check=True, capture_output=True
+        )
+        subprocess.run(["git", "init", "-b", "main", work], check=True, capture_output=True)
+        for name, body in (("README.md", "hello\n"), ("src/app.py", "print('x')\n")):
+            path = os.path.join(work, name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as f:
+                f.write(body)
+        _git("add", "--all", cwd=work)
+        _git("-c", "user.name=t", "-c", "user.email=t@e.com", "commit", "-m", "init", cwd=work)
+        _git("remote", "add", "origin", self.remote, cwd=work)
+        _git("push", "--quiet", "origin", "main", cwd=work)
+        self.base_sha = _git("rev-parse", "HEAD", cwd=work)
+
+    @pytest.fixture(autouse=True)
+    def _tmpdir(self, tmp_path):
+        self.tmpdir = tmp_path
+
+
+class BuildCloneUrlTest(TestCase):
+    def test_embeds_token_against_the_git_host(self) -> None:
+        # origin.cursor.com, not api.cursor.com -- the REST base would 404 for git.
+        assert build_clone_url("sentry/nuget-trends", "oit_abc") == (
+            "https://x-access-token:oit_abc@origin.cursor.com/sentry/nuget-trends.git"
+        )
+
+
+class ArchiveRefTest(CursorOriginGitTestBase):
+    def test_archive_has_exactly_one_top_level_directory(self) -> None:
+        """Seer's extractor moves the *contents* of the single root directory into place.
+
+        A tar whose entries sit at the root extracts to a wrong tree rather than
+        failing, so this is a silent-corruption guard, not a cosmetic one.
+        """
+        blob = archive_ref(self.remote, "main", prefix="nuget-trends-main")
+
+        with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+            names = tar.getnames()
+
+        assert names
+        assert len({n.split("/")[0] for n in names}) == 1
+        assert any(n.endswith("/src/app.py") for n in names)
+
+
+class CommitAndPushTest(CursorOriginGitTestBase):
+    def _push(self, branch: str, actions: list[dict[str, object]], **kwargs: object) -> str:
+        return commit_and_push(
+            clone_url=self.remote,
+            branch=branch,
+            base_sha=self.base_sha,
+            message="autofix: a change",
+            actions=actions,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    def test_creates_branch_with_written_file(self) -> None:
+        sha = self._push(
+            "seer/fix-1",
+            [{"kind": "create", "filename": "src/new.py", "content": "y = 1\n"}],
+        )
+
+        assert _git("rev-parse", "seer/fix-1", cwd=self.remote) == sha
+        assert "src/new.py" in _git("show", "--name-only", "--format=", sha, cwd=self.remote)
+        # Started from base_sha, so it is exactly one commit ahead of main.
+        assert _git("rev-list", "--count", f"main..{sha}", cwd=self.remote) == "1"
+
+    def test_delete_and_move_actions(self) -> None:
+        sha = self._push(
+            "seer/fix-2",
+            [
+                {"kind": "delete", "filename": "README.md"},
+                {"kind": "move", "old_filename": "src/app.py", "new_filename": "src/main.py"},
+            ],
+        )
+
+        tree = _git("ls-tree", "-r", "--name-only", sha, cwd=self.remote).split()
+        assert "README.md" not in tree
+        assert "src/main.py" in tree
+        assert "src/app.py" not in tree
+
+    def test_author_is_recorded(self) -> None:
+        sha = self._push(
+            "seer/fix-3",
+            [{"kind": "create", "filename": "a.txt", "content": "a\n"}],
+            author_name="Seer by Sentry",
+            author_email="noreply@sentry.io",
+        )
+
+        assert _git("log", "-1", "--format=%an <%ae>", sha, cwd=self.remote) == (
+            "Seer by Sentry <noreply@sentry.io>"
+        )
+
+    def test_existing_branch_fails_rather_than_overwriting(self) -> None:
+        """Seer recovers from a collision by retrying with a suffixed name.
+
+        That only works if the push reports the collision -- a force push would
+        silently discard whatever was already on the branch.
+        """
+        actions: list[dict[str, object]] = [
+            {"kind": "create", "filename": "a.txt", "content": "a\n"}
+        ]
+        self._push("seer/dupe", actions)
+
+        with pytest.raises(CursorOriginGitError):
+            self._push("seer/dupe", actions)
+
+    def test_no_op_change_is_refused(self) -> None:
+        """An autofix that changed nothing would otherwise open an empty pull request."""
+        with pytest.raises(CursorOriginGitError, match="No changes to commit"):
+            self._push(
+                "seer/empty",
+                [{"kind": "create", "filename": "README.md", "content": "hello\n"}],
+            )

--- a/tests/sentry/integrations/cursor_origin/test_git.py
+++ b/tests/sentry/integrations/cursor_origin/test_git.py
@@ -143,7 +143,7 @@ class CommitAndPushTest(CursorOriginGitTestBase):
         ]
         self._push("seer/dupe", actions)
 
-        with pytest.raises(CursorOriginGitError):
+        with pytest.raises(CursorOriginGitError, match="Branch already exists"):
             self._push("seer/dupe", actions)
 
     def test_no_op_change_is_refused(self) -> None:


### PR DESCRIPTION
note: This is the real hack that would anyway block this whole thing from merging, so it would need to be worked into a different alternative

-----

Adds Git-over-HTTPS archive and commit+push helpers for Cursor Origin, and exposes them to Seer over two `seer_rpc` methods.

**This is PR 5 of 6.** The work was one branch; it is split because `static/` and `src/` do not deploy atomically, and because a 2,300-line integration is not reviewable in one sitting. Each PR stacks on the previous one:

| | PR | Contents |
|---|---|---|
| 1 | [#122294](https://github.com/getsentry/sentry/pull/122294) | client, install pipeline, repository provider, registration, feature gate |
| 2 | [#122298](https://github.com/getsentry/sentry/pull/122298) | platform detection generalised to a `Protocol` |
| 3 | [#122301](https://github.com/getsentry/sentry/pull/122301) | webhooks + commit tracking |
| 4 | [#122302](https://github.com/getsentry/sentry/pull/122302) | Seer / SCM wiring |
| **5** | **this one** | Git-over-HTTPS archive and commit helpers |
| 6 | [#122304](https://github.com/getsentry/sentry/pull/122304) | frontend (`static/` only) |

## Reviewer warning: this is the least mergeable part of the stack

Stated plainly, because it should not be discovered in review.

**This shells out to `git` from a request path.** It does a **full clone per operation**, and it puts the installation token **in the child process argv** and in the clone's `.git/config`. Those are real objections and I am not arguing them away.

It exists because Origin has no archive route and no REST write for a commit, branch, ref, blob or tree — the entire git surface is Git-over-HTTPS. Seer reaches every other SCM operation through the REST proxy, where Sentry attaches credentials and streams the response back, but that proxy **cannot** carry git: it is a different protocol to a different host (`origin.cursor.com`, not `api.cursor.com`). So the two operations Seer cannot express as REST have to run where the credentials already are.

**If this stays, it wants to move to a task with disk bounds and a credential path that avoids argv.** I would rather land that as follow-up work than block the rest of the stack on it, but a reviewer who wants it gated harder or deferred entirely has a good case.

**It is unreachable without the feature flag** — both RPC methods are reached only for an Origin repository, which requires an installed Origin integration, which requires `organizations:integrations-cursor-origin` (PR 1). Seer's own path additionally requires `organizations:seer-cursor-origin-support` (PR 4), which is off, and inert in production regardless while the `sentry-scm` pin predates the provider.

## What the design does preserve

**The Origin app key and the installation tokens minted from it never leave Sentry.** The token is minted inside `_cursor_origin_clone_url`, embedded in the URL handed to git, and never returned to the caller — Seer learns the sha or the tarball, never the token. That is the same posture as GitLab, where Seer holds no forge credentials at all, and as GitHub's default path.

## Two things that fail silently rather than loudly

Both covered by tests, both worth knowing:

- **`git archive --prefix=` is mandatory.** Seer's extractor assumes a single top-level directory and moves its *contents* into place. A tar with entries at the root yields a **wrong tree** rather than an error.
- **The push is non-forcing.** Seer recovers from a branch-name collision by retrying with a suffix, which only works if the collision is actually reported.

Related, and the reason for one of the commits here: **git does not say "already exists".** Seer decides whether to retry by matching that string (`scm/repo_client.py`, `create_branch_from_changes`), but pushing to a diverged existing ref fails with *"Updates were rejected because the remote contains work that you do not have locally"* — which would not match, turning a recoverable collision into a hard failure of the whole PR step. So the branch is checked explicitly against `origin/{branch}` after the clone and the message is ours. **Force-pushing would also have "worked" and is the wrong fix** — it discards whatever was on that branch.

## Dependencies / TODO

Written for someone who has never heard of Cursor Origin. Cursor Origin is a source-code-management provider being added in this stack; PR 1 adds its client and install flow.

- **Full clone per operation, unbounded.** No depth limit, no disk quota, no size ceiling. A large repository is a large clone in a request path.
- **Token in argv and in `.git/config`.** Visible to anything that can read `/proc` on the host for the life of the child process. A credential helper or `askpass` path would avoid this.
- **Runs in a request path rather than a task.** No timeout budget beyond git's own, and no retry semantics.
- **The archive is base64 inside JSON.** That is the cost of reusing the `seer_rpc` channel rather than adding a binary-streaming endpoint for one provider — ~1MB for a mid-size repo. **If Origin ever ships an archive route, this method should be deleted rather than optimised.**
- **Both methods return an `error` string rather than raising**, because failure here is frequently an expected outcome rather than a defect: a branch name that already exists (Seer retries), or an autofix that produced no net change.

## Verification

Tests run **real git against a local bare repo** rather than mocking `subprocess`. That is deliberate: mocking would assert the argument strings and none of the behaviour above — the `--prefix` requirement and the non-forcing push are only observable by actually running git.

Verified against the live `sentry/nuget-trends` repository: a ~1MB archive with exactly one top-level directory (the shape Seer's extractor requires), and a real branch pushed and then deleted.

The final commit (`test(cursor-origin): annotate the git test tmpdir fixture`) fixes a **pre-existing** mypy failure carried over from the original branch, not one introduced by the split — it reproduces on `bruno/cursor-origin-integration`.

---

**Reference:** [#122180](https://github.com/getsentry/sentry/pull/122180) is the original single-branch version of this work — all six PRs' worth of changes in one draft, kept open for history. It carries the Warden review that produced the security fixes in PRs 1 and 3. It is superseded by this stack and should not be merged.
