### PR TITLE
feat(cursor-origin): frontend for the Cursor Origin integration (6/6)

### DIFF
--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -23,6 +23,10 @@ const FEATURE_GATED_PROVIDERS: Array<{
     flag: 'seer-gitlab-support',
     providerIds: ['gitlab', 'integrations:gitlab'],
   },
+  {
+    flag: 'seer-cursor-origin-support',
+    providerIds: ['cursor_origin', 'integrations:cursor_origin'],
+  },
 ];
 
 /**

--- a/static/app/components/onboarding/scm/scmProviderOrder.ts
+++ b/static/app/components/onboarding/scm/scmProviderOrder.ts
@@ -5,7 +5,12 @@ import type {IntegrationProvider} from 'sentry/types/integrations';
  * render as top-level pill buttons; everything else follows in its original
  * order (grouped into the "More" dropdown there).
  */
-const PRIMARY_PROVIDER_KEYS: readonly string[] = ['github', 'gitlab', 'bitbucket'];
+const PRIMARY_PROVIDER_KEYS: readonly string[] = [
+  'github',
+  'gitlab',
+  'bitbucket',
+  'cursor_origin',
+];
 
 /** Sort rank for a provider key: primaries by their index, everything else after. */
 function providerOrderRank(key: string): number {

--- a/static/app/components/onboarding/scm/useScmPlatformDetection.ts
+++ b/static/app/components/onboarding/scm/useScmPlatformDetection.ts
@@ -17,12 +17,18 @@ interface PlatformDetectionResponse {
   platforms: DetectedPlatform[];
 }
 
-const SUPPORTED_PROVIDER = 'integrations:github';
+// Providers whose backend client can serve platform detection. Kept in sync with
+// SUPPORTED_PROVIDERS in organization_repository_platforms.py -- a repo not listed
+// here skips detection and falls back to the manual platform picker.
+const SUPPORTED_PROVIDERS: readonly string[] = [
+  'integrations:github',
+  'integrations:cursor_origin',
+];
 
 export function useScmPlatformDetection(repository: Repository | undefined) {
   const organization = useOrganization();
   const repoId = repository?.id;
-  const isSupported = repository?.provider.id === SUPPORTED_PROVIDER;
+  const isSupported = SUPPORTED_PROVIDERS.includes(repository?.provider.id ?? '');
   // Empty id means we have an optimistic repo from useScmRepoSelection;
   // the resolved repo with a real id arrives via a subsequent onSelect
   // call. The query can only fetch once we have a real id.

--- a/static/app/components/pipeline/integrationCursorOrigin/index.tsx
+++ b/static/app/components/pipeline/integrationCursorOrigin/index.tsx
@@ -1,0 +1,116 @@
+import {useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {useRedirectPopupStep} from 'sentry/components/pipeline/shared/useRedirectPopupStep';
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+interface InstallStepData {
+  installUrl?: string;
+}
+
+interface InstallAdvanceData {
+  state: string;
+  installation_id?: string;
+  installation_receipt?: string;
+}
+
+/**
+ * Cursor Origin installs in a single step.
+ *
+ * Origin's install redirect returns a signed installation receipt directly, so
+ * unlike GitHub there is no separate OAuth login leg and no organization
+ * selection — one popup and the pipeline is done.
+ */
+function InstallStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<InstallStepData, InstallAdvanceData>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      // `state` is always present on a well-formed callback, since we put it
+      // there. Passing an empty string through when it is missing lets the
+      // backend reject it with a real "invalid state" message rather than
+      // having the step silently do nothing.
+      advance({
+        state: data.state ?? '',
+        installation_receipt: data.installation_receipt,
+        installation_id: data.installation_id,
+      });
+    },
+    [advance]
+  );
+
+  const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData?.installUrl,
+    onCallback: handleCallback,
+  });
+
+  if (stepData === null) {
+    return null;
+  }
+
+  if (isWaitingForCallback || isAdvancing) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            'Complete the installation in the popup window. Once finished, this page will update automatically.'
+          )}
+        </Text>
+        <Button size="sm" onClick={openPopup} busy={isAdvancing}>
+          {t('Reopen installation window')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="lg" align="start">
+      <Text>
+        {t(
+          'Install the Sentry app on your Cursor Origin codebase to connect your repositories.'
+        )}
+      </Text>
+      {popupStatus === 'failed-to-open' && (
+        <Text variant="danger" size="sm">
+          {t(
+            'The installation popup was blocked by your browser. Please ensure popups are allowed and try again.'
+          )}
+        </Text>
+      )}
+      <Button
+        size="sm"
+        variant="primary"
+        onClick={openPopup}
+        disabled={!stepData.installUrl}
+      >
+        {t('Install Cursor Origin App')}
+      </Button>
+    </Stack>
+  );
+}
+
+export const cursorOriginIntegrationPipeline = {
+  type: 'integration',
+  provider: 'cursor_origin',
+  actionTitle: t('Installing Cursor Origin Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'install',
+      shortDescription: t('Installing Cursor Origin Application'),
+      component: InstallStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -4,6 +4,7 @@ import {bitbucketIntegrationPipeline} from './integrationBitbucket';
 import {bitbucketServerIntegrationPipeline} from './integrationBitbucketServer';
 import {claudeCodeIntegrationPipeline} from './integrationClaudeCode';
 import {cursorIntegrationPipeline} from './integrationCursor';
+import {cursorOriginIntegrationPipeline} from './integrationCursorOrigin';
 import {datadogIntegrationPipeline} from './integrationDatadog';
 import {discordIntegrationPipeline} from './integrationDiscord';
 import {gcpIntegrationPipeline} from './integrationGcp';
@@ -32,6 +33,7 @@ export const PIPELINE_REGISTRY = [
   bitbucketServerIntegrationPipeline,
   claudeCodeIntegrationPipeline,
   cursorIntegrationPipeline,
+  cursorOriginIntegrationPipeline,
   datadogIntegrationPipeline,
   discordIntegrationPipeline,
   dummyIntegrationPipeline,

--- a/static/app/components/repositories/repoProviderIcon.tsx
+++ b/static/app/components/repositories/repoProviderIcon.tsx
@@ -5,7 +5,18 @@ import {IconGithub} from 'sentry/icons/iconGithub';
 import {IconGitlab} from 'sentry/icons/iconGitlab';
 import {IconOpen} from 'sentry/icons/iconOpen';
 import {IconVsts} from 'sentry/icons/iconVsts';
+import {PluginIcon} from 'sentry/icons/pluginIcon';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
+
+/**
+ * sentry/icons has no monochrome brand glyph for Cursor, so the real logo asset is
+ * used instead. `PluginIcon` sizes in pixels while the icon map speaks `IconSize`
+ * tokens, so the two are bridged here rather than at every call site.
+ * `getIntegrationIcon` does the same thing for the same reason.
+ */
+function IconCursor({size = 'md'}: SVGIconProps) {
+  return <PluginIcon pluginId="cursor" size={size === 'sm' || size === 'xs' ? 14 : 20} />;
+}
 
 const PROVIDER_ICONS = {
   github: IconGithub,
@@ -17,6 +28,8 @@ const PROVIDER_ICONS = {
   'integrations:vsts': IconVsts,
   gitlab: IconGitlab,
   'integrations:gitlab': IconGitlab,
+  cursor_origin: IconCursor,
+  'integrations:cursor_origin': IconCursor,
 };
 
 interface Props extends SVGIconProps {

--- a/static/app/icons/pluginIcon.tsx
+++ b/static/app/icons/pluginIcon.tsx
@@ -49,6 +49,9 @@ const PLUGIN_ICONS = {
   aws_lambda: aws,
   claude_code,
   cursor,
+  // Origin is a Cursor product and ships no separate mark of its own, so it uses
+  // the Cursor logo. Swap this if Origin gets its own.
+  cursor_origin: cursor,
   datadog,
   datadog_pat: datadog,
   asana,

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -238,6 +238,10 @@ export const getIntegrationDisplayName = (integrationType?: string) => {
       return 'Jira Server';
     case 'perforce':
       return 'Perforce';
+    case 'cursor':
+      return 'Cursor';
+    case 'cursor_origin':
+      return 'Cursor Origin';
     case 'vsts':
       return 'Azure DevOps';
     default:

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -12,6 +12,7 @@ import {
   IconSentry,
   IconVsts,
 } from 'sentry/icons';
+import {PluginIcon} from 'sentry/icons/pluginIcon';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {getOverride} from 'sentry/overrideRegistry';
@@ -207,6 +208,11 @@ export const getIntegrationIcon = (
       return <IconJira size={iconSize} />;
     case 'perforce':
       return <IconPerforce size={iconSize} />;
+    case 'cursor':
+    case 'cursor_origin':
+      // sentry/icons has no monochrome brand glyph for Cursor, so use the real
+      // logo asset rather than falling through to IconGeneric.
+      return <PluginIcon pluginId="cursor" size={iconSize === 'sm' ? 16 : 20} />;
     case 'vsts':
       return <IconVsts size={iconSize} />;
     default:

--- a/static/app/views/settings/organizationIntegrations/constants.tsx
+++ b/static/app/views/settings/organizationIntegrations/constants.tsx
@@ -29,6 +29,7 @@ export const POPULARITY_WEIGHT: Record<string, number> = {
   msteams: 15,
   aws_lambda: 10,
   cursor: 14,
+  cursor_origin: 14,
 
   // Plugins
   webhooks: 10,

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -126,6 +126,7 @@ const SCM_PROVIDER_ORDER = [
   'bitbucket',
   'bitbucket_server',
   'vsts',
+  'cursor_origin',
 ];
 
 export default function OrganizationRepositories() {


### PR DESCRIPTION
The frontend half of the Cursor Origin integration: install pipeline UI, logo and display-name lookups, provider ordering, platform-detection support, and the Seer feature gate.

**This is PR 6 of 6.** The work was one branch; it is split because `static/` and `src/` do not deploy atomically, and because a 2,300-line integration is not reviewable in one sitting.

| | PR | Contents |
|---|---|---|
| 1 | [#122294](https://github.com/getsentry/sentry/pull/122294) | client, install pipeline, repository provider, registration, feature gate |
| 2 | [#122298](https://github.com/getsentry/sentry/pull/122298) | platform detection generalised to a `Protocol` |
| 3 | [#122301](https://github.com/getsentry/sentry/pull/122301) | webhooks + commit tracking |
| 4 | [#122302](https://github.com/getsentry/sentry/pull/122302) | Seer / SCM wiring |
| 5 | [#122303](https://github.com/getsentry/sentry/pull/122303) | Git-over-HTTPS archive and commit helpers |
| **6** | **this one** | frontend (`static/` only) |

**This PR is based on `master`, not on PR 5.** It is `static/`-only — 10 files, no `src/` — which is what the non-atomic-deploy check requires.

## Ordering: it depends on the backend, and it is still safe to deploy in either order

It depends on the backend PRs for the feature flags and the repository-platforms endpoint. It is nevertheless safe to ship before, after, or between them, and the reason is stronger than "the changes are additive" — **the backend never lists the provider while the flag is off, so every addition here is unreachable rather than merely harmless.** Verified file by file:

- **Install pipeline UI** (`pipeline/integrationCursorOrigin/`, `pipeline/registry.tsx`) — reached only from the Add Installation button, which only renders for a provider the API returns. Flag off, no provider, no button.
- **`FEATURE_GATED_PROVIDERS`** (`autofix/utils.tsx`) — gates a provider the API never reports as connected until PR 4 lands *and* `organizations:seer-cursor-origin-support` is on.
- **`useScmPlatformDetection.ts`** — a repo whose provider the backend does not support gets a 400 and falls back to the manual picker, exactly as today.
- **Icons, display name, ordering, popularity weight** — keyed on a provider string that no repository or integration carries until the backend exists.

## What changes

- **Install pipeline** — one step, not GitHub's two: Origin's redirect returns a signed installation receipt directly, so there is no OAuth login leg and no organization selection.
- **Icons, in two independent places.** `getIntegrationIcon` is a separate switch over `sentry/icons` components and has nothing to do with `PLUGIN_ICONS`, so registering the logo in one did not affect the repositories page or the connect-provider dropdown — both fell through to `IconGeneric`. `RepoProviderIcon`'s `PROVIDER_ICONS` was a third gap, and its fall-through also called `Sentry.logger.error` **on every render**, so that one was generating error noise as well as looking wrong.
- **Display name.** `getIntegrationDisplayName` had no cursor case and returned `''`, so the caller's `getIntegrationDisplayName(stripped) || repository.provider` fallback printed the raw `"integrations:cursor_origin"` — which is why the label kept a prefix the caller had already stripped.
- **Ordering and popularity.** Providers missing from `POPULARITY_WEIGHT` fall back to `?? 1`, the lowest value in the table, so Origin sorted below every plugin in the integration directory. Weighted 14 to match the sibling Cursor integration — above GitLab/Bitbucket at 10, below GitHub at 20.

Origin ships no separate brand mark of its own, and `sentry/icons` has no monochrome Cursor glyph, so these route through `PluginIcon` and reuse the real Cursor asset rather than inventing or hand-drawing one. That routing is **scoped to `cursor`/`cursor_origin`** rather than making `PluginIcon` the general fallback, which would change icons app-wide for every provider currently landing on `IconGeneric`.

## Dependencies / TODO

Written for someone who has never heard of Cursor Origin. Cursor Origin is a source-code-management provider being added in this stack; PR 1 adds its backend client and install flow.

- **`SUPPORTED_PROVIDERS` in `useScmPlatformDetection.ts` is a hand-maintained mirror** of the list in `organization_repository_platforms.py` (PR 2), which is where detection is actually gated. **The two must be edited together.** Listing a provider here early is inert rather than broken — the backend 400s and the UI falls back to the manual picker — but the reverse (backend only) means the UI never asks. Both sides carry a comment pointing at the other.
- **`FEATURE_GATED_PROVIDERS` must stay in sync with the backend's `SEER_SUPPORTED_SCM_PROVIDERS`** (PR 4) and its flag, or the UI and backend disagree about whether Origin is available.
- **`repoProviderIcon.tsx` has no spec file**, despite now carrying provider-specific behaviour and an error-logging fall-through. Worth adding; not done here.
- **The logo is Cursor's mark**, because Origin ships none of its own. Swap it if that changes.

## Note on CI

`master` currently fails `pnpm run lint:js` (8 errors) and `pnpm run typecheck` (2 errors) in `static/app/components/core/input/otpInput.tsx`. **This is not from this PR** — it reproduces on a detached checkout of plain `master`, independently of any branch. Please check that any red is in *this* PR's files before attributing it here.

## Verification

Exercised against a real Origin installation: the install flow completes through this UI, the repository renders with the Cursor logo and the name "Cursor", and platform detection runs against an Origin repository instead of dropping to the manual picker.

**Testing this feature needs both halves.** Because the split separates `static/` from `src/`, exercising the install flow locally requires this PR plus the backend stack in one tree. That is a real cost of the split and worth knowing before anyone tries to reproduce.

---

**Reference:** [#122180](https://github.com/getsentry/sentry/pull/122180) is the original single-branch version of this work — all six PRs' worth of changes in one draft, kept open for history. It carries the Warden review that produced the security fixes in PRs 1 and 3. It is superseded by this stack and should not be merged.
