### PR TITLE
fix(seer): Scope autofix overview to the selected projects

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -347,7 +347,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSeerAutofixOverviewPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:
-        projects = self.get_projects(request, organization, include_all_accessible=True)
+        projects = self.get_projects(request, organization)
         project_ids = [p.id for p in projects]
 
         start, end = get_date_range_from_stats_period(request.GET)

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -669,6 +669,22 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert set(config) == {str(selected.id)}
         assert str(other.id) not in config
 
+    def test_project_config_scopes_to_member_projects_by_default(self):
+        org = self.create_organization(owner=self.create_user())
+        member = self.create_user()
+        my_team = self.create_team(organization=org)
+        self.create_member(user=member, organization=org, teams=[my_team])
+        mine = self.create_project(organization=org, teams=[my_team])
+        other_team = self.create_team(organization=org)
+        theirs = self.create_project(organization=org, teams=[other_team])
+        self.login_as(member)
+
+        resp = self.get_success_response(org.slug, qs_params={"expand": "projectConfig"})
+
+        config = self._project_config_by_id(resp)
+        assert str(mine.id) in config
+        assert str(theirs.id) not in config
+
     def test_project_config_eligibility_is_one_query(self):
         for _ in range(3):
             project = self.create_project(organization=self.organization)


### PR DESCRIPTION
The Autofix overview endpoint resolved its project set with `get_projects(request, organization, include_all_accessible=True)`. With no explicit project selection — the "My Projects" default sends an empty `project` param — that flag routes permission checks through `has_project_access` (every project the viewer *can* reach) instead of `has_project_membership` (the projects they're actually a member of). For a viewer with broad org access that's every project in the org, not their handful.

This was invisible while the response only surfaced projects that had runs. The new `projectConfig` summary returns one entry per resolved project, so it exposed the full accessible set — e.g. ~180 projects where the selector shows ~18.

Dropping the flag makes the endpoint honor the page-filter selection like every other "My Projects" view:

- empty selection → member projects
- `-1` (All Projects) sentinel → all accessible (unchanged; `get_projects` handles the sentinel)
- explicit project ids → those

This scopes both `projectConfig` and the runs list to the selection. A new test logs in as a regular member on one team and asserts a project on a team they're not on is absent from the default response.

Refs AIML-3329
