### PR TITLE
feat(autofix): Register autofix-overview-page feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -275,6 +275,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display the Seer Night Shift UI
     manager.add("organizations:seer-night-shift-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Expose the Autofix Overview page and its nav entry
+    manager.add("organizations:autofix-overview-page", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Route autofix RCA through the Seer autofix feature
     manager.add("organizations:autofix-rca-in-seer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Roll out structured LLM page context on STRUCTURED_CONTEXT_ROUTES to all orgs


### PR DESCRIPTION
Registers a dedicated `organizations:autofix-overview-page` FlagPole flag (exposed to the frontend) to gate the Autofix Overview page and its navigation entry, independent of the existing inbox / night-shift flags.

This is the backend half of AIML-3326 and lands **first** so the frontend flag check resolves. The frontend PR that adds the nav entry and switches the Overview page's access gate to this flag is getsentry/sentry#122307.

Refs AIML-3326