### PR TITLE
feat(seer): Expose Autofix Overview page in the issues nav

### DIFF
--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -78,4 +78,33 @@ describe('IssuesSecondaryNavigation', () => {
     expect(screen.queryByRole('link', {name: /Inbox/})).not.toBeInTheDocument();
     expect(request).not.toHaveBeenCalled();
   });
+
+  it('renders the Autofix Overview link when the org has seer-night-shift-ui', async () => {
+    mockInboxCount({});
+    const organizationWithOverview = OrganizationFixture({
+      features: [
+        'issue-stream-progress-ui',
+        'gen-ai-features',
+        'seat-based-seer-enabled',
+        'seer-night-shift-ui',
+      ],
+    });
+
+    renderNavigation(organizationWithOverview);
+
+    const overviewLink = await screen.findByRole('link', {name: /Overview/});
+    expect(overviewLink).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/autofix/overview/'
+    );
+  });
+
+  it('does not render the Autofix Overview link without seer-night-shift-ui', async () => {
+    mockInboxCount({});
+
+    renderNavigation();
+
+    expect(await screen.findByRole('link', {name: 'Feed'})).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: /Overview/})).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -22,6 +22,7 @@ export function IssuesSecondaryNavigation() {
   const baseUrl = `/organizations/${organization.slug}/issues`;
   const hasProgressUi = organization.features.includes('issue-stream-progress-ui');
   const hasInbox = hasProgressUi && orgHasSeerAccess(organization);
+  const hasSeerNightShift = organization.features.includes('seer-night-shift-ui');
   return (
     <Fragment>
       <SecondaryNavigation.Header>{t('Issues')}</SecondaryNavigation.Header>
@@ -87,20 +88,34 @@ export function IssuesSecondaryNavigation() {
             </SecondaryNavigation.ListItem>
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
-        {!hasProgressUi && (
+        {(hasSeerNightShift || !hasProgressUi) && (
           <Fragment>
             <SecondaryNavigation.Separator />
             <SecondaryNavigation.Section id="issues-autofix" title={t('Autofix')}>
               <SecondaryNavigation.List>
-                <SecondaryNavigation.ListItem>
-                  <SecondaryNavigation.Link
-                    to={`${baseUrl}/autofix/recent/`}
-                    analyticsItemName="issues_autofix"
-                    end
-                  >
-                    {t('Recently Run')}
-                  </SecondaryNavigation.Link>
-                </SecondaryNavigation.ListItem>
+                {hasSeerNightShift && (
+                  <SecondaryNavigation.ListItem>
+                    <SecondaryNavigation.Link
+                      to={`${baseUrl}/autofix/overview/`}
+                      analyticsItemName="issues_autofix_overview"
+                      end
+                      trailingItems={<FeatureBadge type="new" />}
+                    >
+                      {t('Overview')}
+                    </SecondaryNavigation.Link>
+                  </SecondaryNavigation.ListItem>
+                )}
+                {!hasProgressUi && (
+                  <SecondaryNavigation.ListItem>
+                    <SecondaryNavigation.Link
+                      to={`${baseUrl}/autofix/recent/`}
+                      analyticsItemName="issues_autofix"
+                      end
+                    >
+                      {t('Recently Run')}
+                    </SecondaryNavigation.Link>
+                  </SecondaryNavigation.ListItem>
+                )}
               </SecondaryNavigation.List>
             </SecondaryNavigation.Section>
           </Fragment>


### PR DESCRIPTION
Adds an **Overview** link under the Autofix section of the issues secondary navigation, making the already-routed Autofix Overview page reachable from the nav.

## What changed
- New `Overview` nav link (→ `/issues/autofix/overview/`) gated by the existing `organizations:seer-night-shift-ui` flag, shown **independently of the inbox / progress UI**.
- Consolidated the Autofix nav section so `Overview` and the existing `Recently Run` link share a single `Autofix` header (no duplicate headers when both are visible). `Recently Run` keeps its existing `!issue-stream-progress-ui` gate — unchanged behavior.
- Added nav tests covering the link's presence with the flag and absence without it.

## Feature flag
Reuses the existing `organizations:seer-night-shift-ui` flag — the same flag that already gates the Overview page itself (`seerWorkflows/overview/index.tsx`) and is already rolled out to the ML-AI team. So nav visibility and page access agree with no new flag, no flagpole change, and no backend/deploy-ordering dependency. This PR is frontend-only.

Refs AIML-3326