### PR TITLE
fix(ui): Respect effective project access without membership

### DIFF
--- a/static/app/components/noProjectMessage.spec.tsx
+++ b/static/app/components/noProjectMessage.spec.tsx
@@ -12,6 +12,7 @@ import {TeamStore} from 'sentry/stores/teamStore';
 describe('NoProjectMessage', () => {
   beforeEach(() => {
     ProjectsStore.reset();
+    ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser: false});
   });
 
   const org = OrganizationFixture();
@@ -132,6 +133,35 @@ describe('NoProjectMessage', () => {
       'aria-disabled',
       'true'
     );
+  });
+
+  it('renders children when the user has access without project membership', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    render(
+      <NoProjectMessage organization={org}>
+        <div data-test-id="child">Test</div>
+      </NoProjectMessage>
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(
+      screen.queryByText('You need at least one project to use this view')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows empty message to non-members when membership is required', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    render(
+      <NoProjectMessage organization={org} superuserNeedsToBeProjectMember>
+        {null}
+      </NoProjectMessage>
+    );
+
+    expect(
+      screen.getByText('You need at least one project to use this view')
+    ).toBeInTheDocument();
   });
 
   it('shows empty message to superusers that are not members', () => {

--- a/static/app/components/noProjectMessage.spec.tsx
+++ b/static/app/components/noProjectMessage.spec.tsx
@@ -150,11 +150,26 @@ describe('NoProjectMessage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows empty message to non-members when membership is required', () => {
+  it('renders children for non-superusers when superuserNeedsToBeProjectMember', () => {
     ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
 
     render(
       <NoProjectMessage organization={org} superuserNeedsToBeProjectMember>
+        <div data-test-id="child">Test</div>
+      </NoProjectMessage>
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(
+      screen.queryByText('You need at least one project to use this view')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows empty message to non-members when requireProjectMembership', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    render(
+      <NoProjectMessage organization={org} requireProjectMembership>
         {null}
       </NoProjectMessage>
     );

--- a/static/app/components/noProjectMessage.tsx
+++ b/static/app/components/noProjectMessage.tsx
@@ -16,16 +16,19 @@ import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 type Props = {
   organization: Organization;
   children?: React.ReactNode;
+  requireProjectMembership?: boolean;
   superuserNeedsToBeProjectMember?: boolean;
 };
 
 export function NoProjectMessage({
   children,
   organization,
+  requireProjectMembership,
   superuserNeedsToBeProjectMember,
 }: Props) {
   const {projects} = useProjects();
   const {hasProjectAccess, projectsLoaded} = useHasProjectAccess({
+    requireProjectMembership,
     superuserNeedsToBeProjectMember,
   });
 

--- a/static/app/utils/useHasProjectAccess.spec.tsx
+++ b/static/app/utils/useHasProjectAccess.spec.tsx
@@ -7,10 +7,14 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 
 import {useHasProjectAccess} from './useHasProjectAccess';
 
+function setSuperuser(isSuperuser: boolean) {
+  ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser});
+}
+
 describe('useHasProjectAccess', () => {
   beforeEach(() => {
     ProjectsStore.reset();
-    ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser: false});
+    setSuperuser(false);
   });
 
   it('returns false when there are no projects', () => {
@@ -22,68 +26,123 @@ describe('useHasProjectAccess', () => {
     expect(result.current.projectsLoaded).toBe(true);
   });
 
-  it('returns true when user is a member of a project with access', () => {
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: true})]);
+  describe('regular users', () => {
+    it('returns true when the user is a member of a project with access', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: true})]);
 
-    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+      const {result} = renderHookWithProviders(() => useHasProjectAccess());
 
-    expect(result.current.hasProjectAccess).toBe(true);
+      expect(result.current.hasProjectAccess).toBe(true);
+    });
+
+    it('returns true when the user has access without being a project member', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+      const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+      expect(result.current.hasProjectAccess).toBe(true);
+    });
+
+    it('returns false when the user has access to no project', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([
+        ProjectFixture({hasAccess: false, isMember: false}),
+      ]);
+
+      const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+      expect(result.current.hasProjectAccess).toBe(false);
+    });
+
+    // The API cannot return this combination: `has_access` is satisfied by
+    // `is_member`, so membership always implies access. Asserted here to pin the
+    // conservative behaviour if the serializer ever changes.
+    it('returns false for a member of a project reported as inaccessible', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: false, isMember: true})]);
+
+      const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+      expect(result.current.hasProjectAccess).toBe(false);
+    });
+
+    it('is unaffected by superuserNeedsToBeProjectMember', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+      const {result} = renderHookWithProviders(() =>
+        useHasProjectAccess({superuserNeedsToBeProjectMember: true})
+      );
+
+      expect(result.current.hasProjectAccess).toBe(true);
+    });
+
+    it('needs membership when requireProjectMembership is set', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+      const {result} = renderHookWithProviders(() =>
+        useHasProjectAccess({requireProjectMembership: true})
+      );
+
+      expect(result.current.hasProjectAccess).toBe(false);
+    });
+
+    it('returns true for a member when requireProjectMembership is set', () => {
+      setSuperuser(false);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: true})]);
+
+      const {result} = renderHookWithProviders(() =>
+        useHasProjectAccess({requireProjectMembership: true})
+      );
+
+      expect(result.current.hasProjectAccess).toBe(true);
+    });
   });
 
-  it('returns true when user has access without being a project member', () => {
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+  describe('superusers', () => {
+    it('returns true with access but no membership', () => {
+      setSuperuser(true);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
 
-    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+      const {result} = renderHookWithProviders(() => useHasProjectAccess());
 
-    expect(result.current.hasProjectAccess).toBe(true);
-  });
+      expect(result.current.hasProjectAccess).toBe(true);
+    });
 
-  it('returns false when the user has access to no project', () => {
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: false, isMember: false})]);
+    it('needs membership when superuserNeedsToBeProjectMember is set', () => {
+      setSuperuser(true);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
 
-    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+      const {result} = renderHookWithProviders(() =>
+        useHasProjectAccess({superuserNeedsToBeProjectMember: true})
+      );
 
-    expect(result.current.hasProjectAccess).toBe(false);
-  });
+      expect(result.current.hasProjectAccess).toBe(false);
+    });
 
-  // The API cannot return this combination: `has_access` is satisfied by
-  // `is_member`, so membership always implies access. Asserted here to pin the
-  // conservative behaviour if the serializer ever changes.
-  it('returns false for a member of a project reported as inaccessible', () => {
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: false, isMember: true})]);
+    it('returns true when a member and superuserNeedsToBeProjectMember is set', () => {
+      setSuperuser(true);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: true})]);
 
-    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+      const {result} = renderHookWithProviders(() =>
+        useHasProjectAccess({superuserNeedsToBeProjectMember: true})
+      );
 
-    expect(result.current.hasProjectAccess).toBe(false);
-  });
+      expect(result.current.hasProjectAccess).toBe(true);
+    });
 
-  it('returns true for superusers with access but no membership', () => {
-    ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser: true});
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+    it('needs membership when requireProjectMembership is set', () => {
+      setSuperuser(true);
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
 
-    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+      const {result} = renderHookWithProviders(() =>
+        useHasProjectAccess({requireProjectMembership: true})
+      );
 
-    expect(result.current.hasProjectAccess).toBe(true);
-  });
-
-  it('superusers need membership when superuserNeedsToBeProjectMember', () => {
-    ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser: true});
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
-
-    const {result} = renderHookWithProviders(() =>
-      useHasProjectAccess({superuserNeedsToBeProjectMember: true})
-    );
-
-    expect(result.current.hasProjectAccess).toBe(false);
-  });
-
-  it('non-superusers need membership when superuserNeedsToBeProjectMember', () => {
-    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
-
-    const {result} = renderHookWithProviders(() =>
-      useHasProjectAccess({superuserNeedsToBeProjectMember: true})
-    );
-
-    expect(result.current.hasProjectAccess).toBe(false);
+      expect(result.current.hasProjectAccess).toBe(false);
+    });
   });
 });

--- a/static/app/utils/useHasProjectAccess.spec.tsx
+++ b/static/app/utils/useHasProjectAccess.spec.tsx
@@ -29,4 +29,61 @@ describe('useHasProjectAccess', () => {
 
     expect(result.current.hasProjectAccess).toBe(true);
   });
+
+  it('returns true when user has access without being a project member', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+    expect(result.current.hasProjectAccess).toBe(true);
+  });
+
+  it('returns false when the user has access to no project', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: false, isMember: false})]);
+
+    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+    expect(result.current.hasProjectAccess).toBe(false);
+  });
+
+  // The API cannot return this combination: `has_access` is satisfied by
+  // `is_member`, so membership always implies access. Asserted here to pin the
+  // conservative behaviour if the serializer ever changes.
+  it('returns false for a member of a project reported as inaccessible', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: false, isMember: true})]);
+
+    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+    expect(result.current.hasProjectAccess).toBe(false);
+  });
+
+  it('returns true for superusers with access but no membership', () => {
+    ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser: true});
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    const {result} = renderHookWithProviders(() => useHasProjectAccess());
+
+    expect(result.current.hasProjectAccess).toBe(true);
+  });
+
+  it('superusers need membership when superuserNeedsToBeProjectMember', () => {
+    ConfigStore.set('user', {...ConfigStore.get('user'), isSuperuser: true});
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    const {result} = renderHookWithProviders(() =>
+      useHasProjectAccess({superuserNeedsToBeProjectMember: true})
+    );
+
+    expect(result.current.hasProjectAccess).toBe(false);
+  });
+
+  it('non-superusers need membership when superuserNeedsToBeProjectMember', () => {
+    ProjectsStore.loadInitialData([ProjectFixture({hasAccess: true, isMember: false})]);
+
+    const {result} = renderHookWithProviders(() =>
+      useHasProjectAccess({superuserNeedsToBeProjectMember: true})
+    );
+
+    expect(result.current.hasProjectAccess).toBe(false);
+  });
 });

--- a/static/app/utils/useHasProjectAccess.tsx
+++ b/static/app/utils/useHasProjectAccess.tsx
@@ -1,10 +1,15 @@
 import {useProjects} from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 
 type Options = {
   /**
-   * When true, the user must be an explicit member of a project they have
-   * access to. Use this for views that cannot render anything useful without
-   * team membership.
+   * When true, every user must also be a project member to count as having
+   * access. Use this for views that cannot render anything useful without team
+   * membership, regardless of who is looking at them.
+   */
+  requireProjectMembership?: boolean;
+  /**
+   * When true, superusers must also be a project member to count as having access.
    */
   superuserNeedsToBeProjectMember?: boolean;
 };
@@ -14,15 +19,20 @@ type Options = {
  * and whether the project list has finished loading.
  */
 export function useHasProjectAccess(options?: Options) {
+  const user = useUser();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+
+  const needsMembership =
+    options?.requireProjectMembership ||
+    (user.isSuperuser && options?.superuserNeedsToBeProjectMember);
 
   // `hasAccess` is the backend's effective authorization decision for a
   // project: it already accounts for open membership and organization-level
   // roles, not just team membership. Requiring `isMember` on top of it hides
   // projects the user is genuinely allowed to open.
-  const hasProjectAccess = options?.superuserNeedsToBeProjectMember
-    ? !!projects?.some(p => p.isMember && p.hasAccess)
-    : !!projects?.some(p => p.hasAccess);
+  const hasProjectAccess = !!projects?.some(
+    project => project.hasAccess && (!needsMembership || project.isMember)
+  );
 
   return {hasProjectAccess, projectsLoaded};
 }

--- a/static/app/utils/useHasProjectAccess.tsx
+++ b/static/app/utils/useHasProjectAccess.tsx
@@ -1,9 +1,10 @@
 import {useProjects} from 'sentry/utils/useProjects';
-import {useUser} from 'sentry/utils/useUser';
 
 type Options = {
   /**
-   * When true, superusers must also be a project member to count as having access.
+   * When true, the user must be an explicit member of a project they have
+   * access to. Use this for views that cannot render anything useful without
+   * team membership.
    */
   superuserNeedsToBeProjectMember?: boolean;
 };
@@ -13,13 +14,15 @@ type Options = {
  * and whether the project list has finished loading.
  */
 export function useHasProjectAccess(options?: Options) {
-  const user = useUser();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 
-  const hasProjectAccess =
-    user.isSuperuser && !options?.superuserNeedsToBeProjectMember
-      ? !!projects?.some(p => p.hasAccess)
-      : !!projects?.some(p => p.isMember && p.hasAccess);
+  // `hasAccess` is the backend's effective authorization decision for a
+  // project: it already accounts for open membership and organization-level
+  // roles, not just team membership. Requiring `isMember` on top of it hides
+  // projects the user is genuinely allowed to open.
+  const hasProjectAccess = options?.superuserNeedsToBeProjectMember
+    ? !!projects?.some(p => p.isMember && p.hasAccess)
+    : !!projects?.some(p => p.hasAccess);
 
   return {hasProjectAccess, projectsLoaded};
 }

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -619,7 +619,10 @@ describe('OrganizationStats', () => {
     const newOrg = OrganizationFixture({
       openMembership: false,
     });
-    act(() => ProjectsStore.loadInitialData([ProjectFixture({isMember: false})]));
+    // Without open membership, the API reports no access for a non-member.
+    act(() =>
+      ProjectsStore.loadInitialData([ProjectFixture({hasAccess: false, isMember: false})])
+    );
 
     render(<OrganizationStats />, {
       organization: newOrg,

--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -46,9 +46,7 @@ export default function TeamStatsHealth() {
   const {period, start, end, utc} = dataDatetime(query);
 
   if (teams.length === 0) {
-    return (
-      <NoProjectMessage organization={organization} requireProjectMembership />
-    );
+    return <NoProjectMessage organization={organization} requireProjectMembership />;
   }
 
   if (isError) {

--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -47,7 +47,7 @@ export default function TeamStatsHealth() {
 
   if (teams.length === 0) {
     return (
-      <NoProjectMessage organization={organization} superuserNeedsToBeProjectMember />
+      <NoProjectMessage organization={organization} requireProjectMembership />
     );
   }
 

--- a/static/app/views/organizationStats/teamInsights/issues.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.tsx
@@ -47,9 +47,7 @@ export default function TeamStatsIssues() {
   const {period, start, end, utc} = dataDatetime(query);
 
   if (teams.length === 0) {
-    return (
-      <NoProjectMessage organization={organization} requireProjectMembership />
-    );
+    return <NoProjectMessage organization={organization} requireProjectMembership />;
   }
 
   if (isError) {

--- a/static/app/views/organizationStats/teamInsights/issues.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.tsx
@@ -48,7 +48,7 @@ export default function TeamStatsIssues() {
 
   if (teams.length === 0) {
     return (
-      <NoProjectMessage organization={organization} superuserNeedsToBeProjectMember />
+      <NoProjectMessage organization={organization} requireProjectMembership />
     );
   }
 


### PR DESCRIPTION
## Problem

`useHasProjectAccess` requires `isMember && hasAccess` for every user unless they are a superuser using the default path.

A user can legitimately have project access without being an explicit member of a team that owns the project, for example when the organization allows open membership or when organization-level access grants it.

The API represents this correctly as:

`hasAccess: true`
`isMember: false`

Because `useHasProjectAccess` is an organization-wide gate rather than a per-project permission check, this state can cause `NoProjectMessage` to treat the user as having no project access at all and replace the view with the empty state.

## Reproduction

For a non-superuser:

`project = {hasAccess: true, isMember: false}`

Expected:
`hasProjectAccess === true`

Actual:
`hasProjectAccess === false`

## Root cause

`hasAccess` is already the backend's effective project authorization decision. Requiring `isMember` in addition to it discards valid access states that do not come from explicit team membership.

## Fix

Use `hasAccess` for the default project-access check, which is the backend's effective authorization decision.

`superuserNeedsToBeProjectMember` keeps its original superuser-only contract: it requires explicit membership only when `user.isSuperuser` is true.

Team Insights (`teamInsights/issues.tsx`, `teamInsights/health.tsx`) does need a membership gate for *every* user, not just superusers: both render `NoProjectMessage` with no children when `teams.length === 0`, so a team-less normal user in an open-membership org would otherwise get a blank page instead of the "Join a Team" empty state. The existing `shows users with no teams the join team button` tests cover this and fail without a gate. Those two call sites now use a separately named `requireProjectMembership` option, as suggested in review.

## Tests

Coverage includes:

- normal users with each `hasAccess` / `isMember` combination;
- superuser behavior with and without the membership option;
- non-superusers when the membership option is explicitly enabled;
- `NoProjectMessage` rendering content for effective access without explicit membership;
- preserving the intended empty state for membership-gated views.

## Security

This does not grant new permissions.

`hasAccess` is computed server-side and project API endpoints continue enforcing project authorization independently. The change only stops the frontend from hiding access already granted by the backend.

## Note on option naming

`superuserNeedsToBeProjectMember` is unchanged in meaning and still applies to superusers only. The new `requireProjectMembership` option covers the all-user case that Team Insights actually relies on.

After this change Team Insights is the only consumer of `requireProjectMembership`, and `superuserNeedsToBeProjectMember` has no remaining call sites. Happy to remove it in a follow-up if maintainers prefer, but I've left the documented contract intact here rather than widening the scope of this PR.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

