### PR TITLE
fix(search): Allow Command Palette from query builder

### DIFF
--- a/static/app/components/commandPalette/constants.ts
+++ b/static/app/components/commandPalette/constants.ts
@@ -1,0 +1,1 @@
+export const COMMAND_PALETTE_HOTKEYS = ['mod+shift+p', 'mod+k'];

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -3,6 +3,7 @@ import {createContext, useContext, useEffect, useReducer, useRef} from 'react';
 import {useHotkeys} from '@sentry/scraps/hotkey';
 
 import {toggleCommandPalette} from 'sentry/actionCreators/modal';
+import {COMMAND_PALETTE_HOTKEYS} from 'sentry/components/commandPalette/constants';
 import {unreachable} from 'sentry/utils/unreachable';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -197,7 +198,7 @@ export function CommandPaletteHotkeys() {
 
   useHotkeys([
     {
-      match: ['mod+shift+p', 'mod+k'],
+      match: COMMAND_PALETTE_HOTKEYS,
       includeInputs: true,
       callback: () => {
         if (!organization) {

--- a/static/app/components/core/hotkey/index.tsx
+++ b/static/app/components/core/hotkey/index.tsx
@@ -1,4 +1,4 @@
 /** @public */
 export {Kbd} from './kbd';
 export {Hotkey} from './hotkey';
-export {useHotkeys} from './useHotkeys';
+export {matchesHotkey, useHotkeys} from './useHotkeys';

--- a/static/app/components/core/hotkey/useHotkeys.spec.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.spec.tsx
@@ -1,6 +1,6 @@
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
-import {useHotkeys} from '@sentry/scraps/hotkey';
+import {matchesHotkey, useHotkeys} from '@sentry/scraps/hotkey';
 
 jest.mock('@react-aria/utils', () => ({
   ...jest.requireActual('@react-aria/utils'),
@@ -61,6 +61,12 @@ describe('useHotkeys', () => {
 
     expect(evt.preventDefault).toHaveBeenCalled();
     expect(callback).toHaveBeenCalled();
+  });
+
+  it('does not match while an IME is composing text', () => {
+    expect(
+      matchesHotkey('mod+k', makeKeyEventFixture('k', {ctrlKey: true, isComposing: true}))
+    ).toBe(false);
   });
 
   it('handles multiple matches', () => {

--- a/static/app/components/core/hotkey/useHotkeys.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.tsx
@@ -35,6 +35,34 @@ type Hotkey = {
   skipPreventDefault?: boolean;
 };
 
+function shouldIgnoreHotkeyEvent(event: KeyboardEvent): boolean {
+  return event.isComposing;
+}
+
+/**
+ * Returns whether an event should trigger one of the supplied hotkey matches.
+ * Uses the same platform-aware modifier and keyboard-layout behavior as
+ * useHotkeys, and never matches while an IME is composing text.
+ */
+export function matchesHotkey(match: string[] | string, event: KeyboardEvent): boolean {
+  if (shouldIgnoreHotkeyEvent(event)) {
+    return false;
+  }
+
+  return toArray(match).some(keyset => {
+    const keys = keyset
+      .toLowerCase()
+      .split('+')
+      .map(key => canonicalize(key));
+    const unusedModifiers = MODIFIER_KEYS.filter(modifier => !keys.includes(modifier));
+
+    return (
+      keys.every(key => matchesKey(key, event)) &&
+      unusedModifiers.every(modifier => !matchesKey(modifier, event))
+    );
+  });
+}
+
 /**
  * Pass in the hotkey combinations under match and the corresponding callback
  * function to be called. Separate key names with +. For example,
@@ -55,7 +83,7 @@ export function useHotkeys(hotkeys: Hotkey[]): void {
     const onKeyDown = (evt: KeyboardEvent) => {
       // Skip IME composition events — event.key may be undefined or 'Process'
       // and hotkeys should never fire while the user is composing a character.
-      if (evt.isComposing) {
+      if (shouldIgnoreHotkeyEvent(evt)) {
         return;
       }
       for (const hotkey of hotkeysRef.current) {
@@ -63,30 +91,17 @@ export function useHotkeys(hotkeys: Hotkey[]): void {
           continue;
         }
         const preventDefault = !hotkey.skipPreventDefault;
-        const keysets = toArray(hotkey.match).map(keys => keys.toLowerCase());
+        const inputHasFocus =
+          !hotkey.includeInputs && evt.target instanceof HTMLElement
+            ? ['textarea', 'input'].includes(evt.target.tagName.toLowerCase())
+            : false;
 
-        for (const keyset of keysets) {
-          const keys = keyset.split('+').map(k => canonicalize(k));
-          const unusedModifiers = MODIFIER_KEYS.filter(
-            modifier => !keys.includes(modifier)
-          );
-
-          const allKeysPressed =
-            keys.every(key => matchesKey(key, evt)) &&
-            unusedModifiers.every(modifier => !matchesKey(modifier, evt));
-
-          const inputHasFocus =
-            !hotkey.includeInputs && evt.target instanceof HTMLElement
-              ? ['textarea', 'input'].includes(evt.target.tagName.toLowerCase())
-              : false;
-
-          if (allKeysPressed && !inputHasFocus) {
-            if (preventDefault) {
-              evt.preventDefault();
-            }
-            hotkey.callback(evt);
-            return;
+        if (matchesHotkey(hotkey.match, evt) && !inputHasFocus) {
+          if (preventDefault) {
+            evt.preventDefault();
           }
+          hotkey.callback(evt);
+          return;
         }
       }
     };

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -13,7 +13,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
+import {GlobalModal} from '@sentry/scraps/modal';
+
 import * as indicators from 'sentry/actionCreators/indicator';
+import {CommandPaletteHotkeys} from 'sentry/components/commandPalette/ui/commandPaletteStateContext';
 import {
   SearchQueryBuilder,
   type SearchQueryBuilderProps,
@@ -196,25 +199,28 @@ describe('SearchQueryBuilder', () => {
     searchSource: '',
   };
 
-  it('allows the command palette shortcut while filter suggestions are open', async () => {
-    const pressedKeys: KeyboardEvent[] = [];
-    const onKeyDown = (event: KeyboardEvent) => pressedKeys.push(event);
-    document.addEventListener('keydown', onKeyDown);
-
-    try {
-      render(<SearchQueryBuilder {...defaultProps} />);
+  it.each([
+    ['Ctrl+K', '{Control>}k{/Control}'],
+    ['Ctrl+Shift+P', '{Control>}{Shift>}p{/Shift}{/Control}'],
+  ])(
+    'opens the command palette from an open suggestions menu with %s',
+    async (_label, keys) => {
+      render(
+        <Fragment>
+          <CommandPaletteHotkeys />
+          <GlobalModal />
+          <SearchQueryBuilder {...defaultProps} />
+        </Fragment>
+      );
 
       await userEvent.click(getLastInput());
       await screen.findByRole('listbox');
-      await userEvent.keyboard('{Control>}k{/Control}');
 
-      expect(pressedKeys).toContainEqual(
-        expect.objectContaining({key: 'k', ctrlKey: true})
-      );
-    } finally {
-      document.removeEventListener('keydown', onKeyDown);
+      await userEvent.keyboard(keys);
+
+      expect(await screen.findByRole('textbox', {name: 'Search commands'})).toHaveFocus();
     }
-  });
+  );
 
   it('displays a placeholder when empty', async () => {
     render(<SearchQueryBuilder {...defaultProps} placeholder="foo" />);

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -196,6 +196,26 @@ describe('SearchQueryBuilder', () => {
     searchSource: '',
   };
 
+  it('allows the command palette shortcut while filter suggestions are open', async () => {
+    const pressedKeys: KeyboardEvent[] = [];
+    const onKeyDown = (event: KeyboardEvent) => pressedKeys.push(event);
+    document.addEventListener('keydown', onKeyDown);
+
+    try {
+      render(<SearchQueryBuilder {...defaultProps} />);
+
+      await userEvent.click(getLastInput());
+      await screen.findByRole('listbox');
+      await userEvent.keyboard('{Control>}k{/Control}');
+
+      expect(pressedKeys).toContainEqual(
+        expect.objectContaining({key: 'k', ctrlKey: true})
+      );
+    } finally {
+      document.removeEventListener('keydown', onKeyDown);
+    }
+  });
+
   it('displays a placeholder when empty', async () => {
     render(<SearchQueryBuilder {...defaultProps} placeholder="foo" />);
     expect(await screen.findByPlaceholderText('foo')).toBeInTheDocument();

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -495,14 +495,14 @@ export function SearchQueryBuilderCombobox<
         state.close();
       },
       onKeyDown: e => {
-        onKeyDown?.(e, {state});
-
         // React Aria's selectable collection stops key events from bubbling out of
         // an open combobox. Let the global command palette shortcut through.
         if (matchesHotkey(COMMAND_PALETTE_HOTKEYS, e.nativeEvent)) {
           e.continuePropagation();
           return;
         }
+
+        onKeyDown?.(e, {state});
 
         if (e.key === 'Escape') {
           state.close();

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -23,9 +23,11 @@ import {
   ListBox,
 } from '@sentry/scraps/compactSelect';
 import type {SelectKey, SelectOptionOrSectionWithKey} from '@sentry/scraps/compactSelect';
+import {matchesHotkey} from '@sentry/scraps/hotkey';
 import {Input, useAutosizeInput} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
 
+import {COMMAND_PALETTE_HOTKEYS} from 'sentry/components/commandPalette/constants';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Overlay} from 'sentry/components/overlay';
 import {AskSeer} from 'sentry/components/searchQueryBuilder/askSeer/askSeer';
@@ -494,6 +496,13 @@ export function SearchQueryBuilderCombobox<
       },
       onKeyDown: e => {
         onKeyDown?.(e, {state});
+
+        // React Aria's selectable collection stops key events from bubbling out of
+        // an open combobox. Let the global command palette shortcut through.
+        if (matchesHotkey(COMMAND_PALETTE_HOTKEYS, e.nativeEvent)) {
+          e.continuePropagation();
+          return;
+        }
 
         if (e.key === 'Escape') {
           state.close();


### PR DESCRIPTION
Command Palette shortcuts now reach the global hotkey listener while Search Query Builder suggestions are open. The palette and combobox share one shortcut definition and matching logic so their behavior stays aligned.

Normal combobox keyboard handling remains unchanged; the change only releases Command Palette shortcuts from React Aria's selectable-collection event boundary.
