### PR TITLE
fix(seer): Reword autofix overview milestone toasts as completed actions

### DIFF
--- a/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
@@ -45,7 +45,7 @@ describe('MilestoneToast', () => {
       organization,
     });
 
-    expect(screen.getByText('SEER-1 reached Code Changes')).toBeInTheDocument();
+    expect(screen.getByText('SEER-1: Code Generated')).toBeInTheDocument();
     expect(await screen.findByRole('button', {name: 'Draft PR'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
@@ -55,7 +55,7 @@ describe('MilestoneToast', () => {
       organization,
     });
 
-    expect(screen.getByText('SEER-1 reached Merged')).toBeInTheDocument();
+    expect(screen.getByText('SEER-1: Merged')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
   });
@@ -69,7 +69,7 @@ describe('MilestoneToast', () => {
       {organization}
     );
 
-    expect(screen.getByText('SEER-1 reached Code Changes')).toBeInTheDocument();
+    expect(screen.getByText('SEER-1: Code Generated')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
   });

--- a/static/app/views/seerWorkflows/overview/milestoneToast.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.tsx
@@ -23,11 +23,11 @@ import {
 import type {AutofixOverviewResponse, MilestoneKey, OverviewRun} from './types';
 import {detectMilestoneAdvances, type MilestoneAdvance} from './useAutofixOverview';
 
-const MILESTONE_LABELS: Record<MilestoneKey, string> = {
-  autofix_root_cause: t('Root Cause'),
-  autofix_solution: t('Solution'),
-  autofix_code_changes: t('Code Changes'),
-  has_pull_request: t('Pull Request'),
+const MILESTONE_ACTION_LABELS: Record<MilestoneKey, string> = {
+  autofix_root_cause: t('Root Cause Found'),
+  autofix_solution: t('Plan Created'),
+  autofix_code_changes: t('Code Generated'),
+  has_pull_request: t('PR Opened'),
   pull_requests_merged: t('Merged'),
 };
 
@@ -69,7 +69,7 @@ function NextActionButton({
   return (
     <Button
       size="xs"
-      variant="primary"
+      variant="secondary"
       busy={isDispatched}
       disabled={isDispatched || isCreatePrGatePending}
       icon={<config.Icon />}
@@ -90,7 +90,7 @@ export function MilestoneToast({
   const sectionKey = sectionKeyForMilestone(toMilestone);
   return (
     <Flex align="center" gap="md">
-      <Text>{t('%s reached %s', run.shortId, MILESTONE_LABELS[toMilestone])}</Text>
+      <Text>{t('%s: %s', run.shortId, MILESTONE_ACTION_LABELS[toMilestone])}</Text>
       {isActionableSection(sectionKey) && run.status !== 'processing' && (
         <NextActionButton run={run} sectionKey={sectionKey} />
       )}


### PR DESCRIPTION
The Autofix Overview milestone-advance toast now reads as the action that just completed, with the run's short ID first: `SENTRY-5TAH: Plan Created` instead of the generic `SENTRY-5TAH reached Solution`. The per-milestone labels mirror the page's own pipeline step language — Root Cause Found, Plan Created, Code Generated, PR Opened, Merged.

Copy-only change: the next-action button, Open Seer button, advance detection, and analytics are untouched. Colocated tests updated to the new strings.

Refs AIML-3363
