### PR TITLE
fix(auth): Restrict console messaging backends to debug mode

### DIFF
--- a/src/sentry/utils/email/backend.py
+++ b/src/sentry/utils/email/backend.py
@@ -23,6 +23,9 @@ def is_smtp_enabled(backend: Backend | None = None) -> bool:
 
 def get_mail_backend() -> Backend:
     backend = options.get("mail.backend")
+    if backend == "console" and not settings.DEBUG:
+        raise RuntimeError("Console email backend is only available in debug mode.")
+
     try:
         return settings.SENTRY_EMAIL_BACKEND_ALIASES[backend]
     except KeyError:

--- a/src/sentry/utils/sms.py
+++ b/src/sentry/utils/sms.py
@@ -3,6 +3,7 @@ from urllib.parse import quote
 
 import phonenumbers
 import requests
+from django.conf import settings
 
 from sentry import options
 
@@ -43,7 +44,9 @@ def phone_number_as_e164(num: str) -> str:
 
 def sms_available() -> bool:
     backend = options.get("sms.backend")
-    return backend == "console" or (backend == "twilio" and bool(options.get("sms.twilio-account")))
+    return (backend == "console" and settings.DEBUG) or (
+        backend == "twilio" and bool(options.get("sms.twilio-account"))
+    )
 
 
 def send_sms(body: str, to: str, from_: str | None = None) -> bool:
@@ -51,6 +54,9 @@ def send_sms(body: str, to: str, from_: str | None = None) -> bool:
     backend = options.get("sms.backend")
 
     if backend == "console":
+        if not settings.DEBUG:
+            raise RuntimeError("Console SMS backend is only available in debug mode.")
+
         logger.info("sms.console", extra={"phone_number": phone_number, "body": body})
         return True
     if backend != "twilio":

--- a/tests/sentry/auth/authenticators/test_sms.py
+++ b/tests/sentry/auth/authenticators/test_sms.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import responses
 from django.http import HttpRequest
+from django.test import override_settings
 
 from sentry.auth.authenticators.sms import SmsInterface, SMSRateLimitExceeded
 from sentry.testutils.cases import TestCase
@@ -124,6 +125,7 @@ class SmsInterfaceTest(TestCase):
 
     @patch("sentry.utils.sms.logger.info")
     @patch("sentry.utils.sms.requests.post")
+    @override_settings(DEBUG=True)
     def test_console_backend(self, requests_post: MagicMock, logger_info: MagicMock) -> None:
         with self.options({"sms.backend": "console", "sms.twilio-account": ""}):
             assert sms_available()
@@ -137,6 +139,15 @@ class SmsInterfaceTest(TestCase):
                 "body": "123456 is your Sentry authentication code.",
             },
         )
+
+    @override_settings(DEBUG=False)
+    def test_console_backend_outside_debug_mode(self) -> None:
+        with self.options({"sms.backend": "console", "sms.twilio-account": ""}):
+            assert not sms_available()
+            with pytest.raises(
+                RuntimeError, match="Console SMS backend is only available in debug mode"
+            ):
+                send_sms("message", "2125550199")
 
     def test_unknown_backend(self) -> None:
         with self.options({"sms.backend": "unknown"}):

--- a/tests/sentry/utils/email/test_backend.py
+++ b/tests/sentry/utils/email/test_backend.py
@@ -1,3 +1,6 @@
+import pytest
+from django.test import override_settings
+
 from sentry.testutils.cases import TestCase
 from sentry.utils.email.backend import get_mail_backend
 
@@ -10,8 +13,18 @@ class GetMailBackendTest(TestCase):
         with self.options({"mail.backend": "dummy"}):
             assert get_mail_backend() == "django.core.mail.backends.dummy.EmailBackend"
 
+        with self.options({"mail.backend": "something.else"}):
+            assert get_mail_backend() == "something.else"
+
+    @override_settings(DEBUG=True)
+    def test_console_backend_in_debug_mode(self) -> None:
         with self.options({"mail.backend": "console"}):
             assert get_mail_backend() == "django.core.mail.backends.console.EmailBackend"
 
-        with self.options({"mail.backend": "something.else"}):
-            assert get_mail_backend() == "something.else"
+    @override_settings(DEBUG=False)
+    def test_console_backend_outside_debug_mode(self) -> None:
+        with self.options({"mail.backend": "console"}):
+            with pytest.raises(
+                RuntimeError, match="Console email backend is only available in debug mode"
+            ):
+                get_mail_backend()


### PR DESCRIPTION
Console email and SMS backends now require debug mode, preventing message contents from being written to production process logs when either backend is misconfigured. SMS availability also reports the console backend as unavailable outside debug mode.