### PR TITLE
ref(csp): Render effective-directive help as JSX

### DIFF
--- a/static/app/components/events/interfaces/csp/help/effectiveDirectives.tsx
+++ b/static/app/components/events/interfaces/csp/help/effectiveDirectives.tsx
@@ -1,106 +1,106 @@
-import {t} from 'sentry/locale';
+import {tctCode} from 'sentry/locale';
 
 export const effectiveDirectives = {
-  'base-uri': t(
-    `The <code>base-uri</code> directive defines the URIs that a user agent
+  'base-uri': tctCode(
+    `The [code:base-uri] directive defines the URIs that a user agent
   may use as the document base URL. If this value is absent, then any URI
   is allowed. If this directive is absent, the user agent will use the
-  value in the <code>&lt;base&gt;</code> element.`
+  value in the [code:<base>] element.`
   ),
-  'child-src': t(
-    `The <code>child-src</code> directive defines the valid sources for
+  'child-src': tctCode(
+    `The [code:child-src] directive defines the valid sources for
   web workers and nested browsing contexts loaded using elements such as
-  <code>&lt;frame&gt;</code> and <code>&lt;iframe&gt;</code>.`
+  [code:<frame>] and [code:<iframe>].`
   ),
-  'connect-src': t(
-    `The <code>connect-src</code> directive defines valid sources for fetch,
-  <code>XMLHttpRequest</code>, <code>WebSocket</code>, and
-  <code>EventSource</code> connections.`
+  'connect-src': tctCode(
+    `The [code:connect-src] directive defines valid sources for fetch,
+  [code:XMLHttpRequest], [code:WebSocket], and
+  [code:EventSource] connections.`
   ),
-  'font-src': t(
-    `The <code>font-src</code> directive specifies valid sources for fonts
-  loaded using <code>@font-face</code>.`
+  'font-src': tctCode(
+    `The [code:font-src] directive specifies valid sources for fonts
+  loaded using [code:@font-face].`
   ),
-  'form-action': t(
-    `The <code>form-action</code> directive specifies valid endpoints for
-  <code>&lt;form&gt;</code> submissions.`
+  'form-action': tctCode(
+    `The [code:form-action] directive specifies valid endpoints for
+  [code:<form>] submissions.`
   ),
-  'frame-ancestors': t(
-    `The <code>frame-ancestors</code> directive specifies valid parents that
-  may embed a page using the <code>&lt;frame&gt;</code> and
-  <code>&lt;iframe&gt;</code> elements.`
+  'frame-ancestors': tctCode(
+    `The [code:frame-ancestors] directive specifies valid parents that
+  may embed a page using the [code:<frame>] and
+  [code:<iframe>] elements.`
   ),
-  'img-src': t(
-    `The <code>img-src</code> directive specifies valid sources of images and
+  'img-src': tctCode(
+    `The [code:img-src] directive specifies valid sources of images and
   favicons.`
   ),
-  'prefetch-src': t(
-    `The <code>prefetch-src</code> directive restricts the URLs
+  'prefetch-src': tctCode(
+    `The [code:prefetch-src] directive restricts the URLs
       from which resources may be prefetched or prerendered.`
   ),
-  'manifest-src': t(
-    `The <code>manifest-src</code> directive specifies which manifest can be
+  'manifest-src': tctCode(
+    `The [code:manifest-src] directive specifies which manifest can be
   applied to the resource.`
   ),
-  'media-src': t(
-    `The <code>media-src</code> directive specifies valid sources for loading
-  media using the <code>&lt;audio&gt;</code> and <code>&lt;video&gt;</code>
+  'media-src': tctCode(
+    `The [code:media-src] directive specifies valid sources for loading
+  media using the [code:<audio>] and [code:<video>]
   elements.`
   ),
-  'object-src': t(
-    `The <code>object-src</code> directive specifies valid sources for the
-  <code>&lt;object&gt;</code>, <code>&lt;embed&gt;</code>, and
-  <code>&lt;applet&gt;</code> elements.`
+  'object-src': tctCode(
+    `The [code:object-src] directive specifies valid sources for the
+  [code:<object>], [code:<embed>], and
+  [code:<applet>] elements.`
   ),
-  'plugin-types': t(
-    `The <code>plugin-types</code> directive specifies the valid plugins that
+  'plugin-types': tctCode(
+    `The [code:plugin-types] directive specifies the valid plugins that
   the user agent may invoke.`
   ),
-  referrer: t(
-    `The <code>referrer</code> directive specifies information in the
-  <code>Referer</code> header for links away from a page.`
+  referrer: tctCode(
+    `The [code:referrer] directive specifies information in the
+  [code:Referer] header for links away from a page.`
   ),
-  'script-src': t(
-    `The <code>script-src</code> directive specifies valid sources
-  for JavaScript. When either the <code>script-src</code> or the
-  <code>default-src</code> directive is included, inline script and
-  <code>eval()</code> are disabled unless you specify 'unsafe-inline'
+  'script-src': tctCode(
+    `The [code:script-src] directive specifies valid sources
+  for JavaScript. When either the [code:script-src] or the
+  [code:default-src] directive is included, inline script and
+  [code:eval()] are disabled unless you specify 'unsafe-inline'
   and 'unsafe-eval', respectively.`
   ),
-  'script-src-elem': t(
-    `The <code>script-src-elem</code> directive applies to all script requests
+  'script-src-elem': tctCode(
+    `The [code:script-src-elem] directive applies to all script requests
       and element contents. It does not apply to scripts defined in attributes.`
   ),
-  'script-src-attr': t(
-    `The <code>script-src-attr</code> directive applies to event handlers and, if present,
-      it will override the <code>script-src</code> directive for relevant checks.`
+  'script-src-attr': tctCode(
+    `The [code:script-src-attr] directive applies to event handlers and, if present,
+      it will override the [code:script-src] directive for relevant checks.`
   ),
-  'style-src': t(
-    `The <code>style-src</code> directive specifies valid sources for
+  'style-src': tctCode(
+    `The [code:style-src] directive specifies valid sources for
   stylesheets. This includes both externally-loaded stylesheets and inline
-  use of the <code>&lt;style&gt;</code> element and HTML style attributes.
+  use of the [code:<style>] element and HTML style attributes.
   Stylesheets from sources that aren't included in the source list are not
-  requested or loaded. When either the <code>style-src</code> or the
-  <code>default-src</code> directive is included, inline use of the
-  <code>&lt;style&gt;</code> element and HTML style attributes are disabled
+  requested or loaded. When either the [code:style-src] or the
+  [code:default-src] directive is included, inline use of the
+  [code:<style>] element and HTML style attributes are disabled
   unless you specify 'unsafe-inline'.`
   ),
-  'style-src-elem': t(
-    `The <code>style-src-elem</code> directive applies to all styles except
+  'style-src-elem': tctCode(
+    `The [code:style-src-elem] directive applies to all styles except
       those defined in inline attributes.`
   ),
-  'style-src-attr': t(
-    `The <code>style-src-attr</code> directive applies to inline style attributes and, if present,
-      it will override the <code>style-src</code> directive for relevant checks.`
+  'style-src-attr': tctCode(
+    `The [code:style-src-attr] directive applies to inline style attributes and, if present,
+      it will override the [code:style-src] directive for relevant checks.`
   ),
-  'frame-src': t(
-    `The <code>frame-src</code> directive specifies valid sources for nested
+  'frame-src': tctCode(
+    `The [code:frame-src] directive specifies valid sources for nested
   browsing contexts loading using elements such as
-  <code>&lt;frame&gt;</code> and <code>&lt;iframe&gt;</code>.`
+  [code:<frame>] and [code:<iframe>].`
   ),
-  'worker-src': t(
-    `The <code>worker-src</code> directive specifies valid sources for
-  <code>Worker<code>, <code>SharedWorker</code>, or
-  <code>ServiceWorker</code> scripts.`
+  'worker-src': tctCode(
+    `The [code:worker-src] directive specifies valid sources for
+  [code:Worker], [code:SharedWorker], or
+  [code:ServiceWorker] scripts.`
   ),
 };

--- a/static/app/components/events/interfaces/csp/help/index.tsx
+++ b/static/app/components/events/interfaces/csp/help/index.tsx
@@ -17,10 +17,6 @@ export type HelpProps = {
 };
 
 export function CSPHelp({data: {effective_directive: key}}: HelpProps) {
-  const getHelp = () => ({
-    __html: effectiveDirectives[key],
-  });
-
   const getLinkHref = () => {
     const baseLink =
       'https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#';
@@ -49,7 +45,7 @@ export function CSPHelp({data: {effective_directive: key}}: HelpProps) {
       <h4>
         <code>{key}</code>
       </h4>
-      <blockquote dangerouslySetInnerHTML={getHelp()} />
+      <blockquote>{effectiveDirectives[key]}</blockquote>
       <StyledP>
         <span>{'\u2014 MDN ('}</span>
         <span>{getLink()}</span>


### PR DESCRIPTION
The CSP effective-directive help strings embedded literal `<code>` tags and escaped angle brackets (`&lt;base&gt;`), then rendered them through `dangerouslySetInnerHTML`.

Two problems with that: translators had to carry HTML markup, and nothing validates it — a missing slash in the `worker-src` entry (`<code>Worker<code>`) had been producing nested unbalanced tags.

This converts the strings to `tctCode()` with `[code:...]` groups, so the markup is real JSX and the translated text holds only text. The rendered output is unchanged: same `<code>` elements, same literal angle brackets, so existing CSS still applies.

`tctCode` already exists in `locale.tsx` for exactly this, and the `{code: <code />}` idiom appears ~500 times elsewhere in the codebase.