### PR TITLE
fix(ui): Reuse the server-rendered loading indicator node

### DIFF
--- a/static/app/bootstrap/renderDom.tsx
+++ b/static/app/bootstrap/renderDom.tsx
@@ -1,6 +1,8 @@
 import type React from 'react';
 import {createRoot} from 'react-dom/client';
 
+import {captureSplashLoader} from 'sentry/utils/splashLoader';
+
 export function renderDom<T extends React.ComponentType<any>>(
   Component: T,
   container: string,
@@ -13,6 +15,8 @@ export function renderDom<T extends React.ComponentType<any>>(
   if (!rootEl) {
     return;
   }
+
+  captureSplashLoader(rootEl);
 
   const root = createRoot(rootEl);
   root.render(<Component {...props} />);

--- a/static/app/utils/splashLoader.ts
+++ b/static/app/utils/splashLoader.ts
@@ -1,0 +1,26 @@
+let splashLoader: Element | null = null;
+
+/**
+ * Capture the server-rendered loader before React's first commit clears the
+ * root, so the same node can be re-parented later. We only read it — React's
+ * own commit removes it, avoiding a blank flash. Guarded so a later render into
+ * a loader-less container cannot null the reference.
+ */
+export function captureSplashLoader(container: Element) {
+  const loader = container.querySelector('.splash-loader');
+  if (loader) {
+    splashLoader = loader;
+  }
+}
+
+export function getSplashLoader() {
+  return splashLoader;
+}
+
+/**
+ * Clear the captured loader between tests.
+ * @public used only in organizationContainer.spec.tsx (knip prod run ignores specs)
+ */
+export function resetSplashLoader() {
+  splashLoader = null;
+}

--- a/static/app/views/organizationContainer.spec.tsx
+++ b/static/app/views/organizationContainer.spec.tsx
@@ -1,0 +1,158 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ROOT_ELEMENT} from 'sentry/constants';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {captureSplashLoader, resetSplashLoader} from 'sentry/utils/splashLoader';
+import {OrganizationContainer} from 'sentry/views/organizationContainer';
+
+function makeReactRoot() {
+  const rootEl = document.createElement('div');
+  rootEl.id = ROOT_ELEMENT;
+  rootEl.innerHTML =
+    '<div class="splash-loader"><div data-test-id="loading-indicator">loading</div></div>';
+  document.body.appendChild(rootEl);
+  return rootEl;
+}
+
+describe('OrganizationContainer', () => {
+  let rootEl: HTMLElement | undefined;
+
+  beforeEach(() => {
+    OrganizationStore.reset();
+  });
+
+  afterEach(() => {
+    rootEl?.remove();
+    rootEl = undefined;
+    resetSplashLoader();
+  });
+
+  describe('loading', () => {
+    it('re-parents the server-rendered loader', () => {
+      rootEl = makeReactRoot();
+      const indicator = rootEl.querySelector('[data-test-id="loading-indicator"]');
+      captureSplashLoader(rootEl);
+
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      // The node was moved, not copied — so there is exactly one of it, and it
+      // is the very node the server rendered.
+      expect(screen.getByTestId('loading-indicator')).toBe(indicator);
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+
+    it('shows the loader again after an org switch, not a copy of the app', () => {
+      rootEl = makeReactRoot();
+      const indicator = rootEl.querySelector('[data-test-id="loading-indicator"]');
+      captureSplashLoader(rootEl);
+
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onUpdate(OrganizationFixture());
+      });
+      expect(screen.getByText('content')).toBeInTheDocument();
+
+      // Simulate React having taken over the root with real app DOM. Reading
+      // innerHTML here used to snapshot the whole previous org's UI.
+      rootEl.innerHTML = '<main>previous org ui</main>';
+
+      // An org switch resets the store back to loading
+      act(() => {
+        OrganizationStore.reset();
+      });
+
+      // Drop the stand-in root, so anything left in the document mentioning the
+      // previous org can only be a copy the component made.
+      rootEl.remove();
+
+      expect(screen.queryByText('previous org ui')).not.toBeInTheDocument();
+      expect(screen.getByTestId('loading-indicator')).toBe(indicator);
+    });
+
+    it('renders without throwing when no loader was captured', () => {
+      expect(() =>
+        render(
+          <OrganizationContainer>
+            <div>content</div>
+          </OrganizationContainer>
+        )
+      ).not.toThrow();
+
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loaded', () => {
+    it('renders children once the organization resolves', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onUpdate(OrganizationFixture());
+      });
+
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+  });
+
+  describe('errors', () => {
+    it('renders children without an organization for ORG_NO_ACCESS', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        // 401 is what the store maps to ORG_NO_ACCESS
+        OrganizationStore.onFetchOrgError({status: 401} as any);
+      });
+
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+
+    it('renders a not-found alert for ORG_NOT_FOUND', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onFetchOrgError({status: 404} as any);
+      });
+
+      expect(screen.getByTestId('org-loading-error')).toBeInTheDocument();
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+
+    it('renders a generic loading error for other failures', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onFetchOrgError({status: 500} as any);
+      });
+
+      expect(screen.getByText('There was an error loading data.')).toBeInTheDocument();
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/organizationContainer.tsx
+++ b/static/app/views/organizationContainer.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import {Outlet} from 'react-router-dom';
 import {useProfiler} from '@sentry/react';
 
@@ -5,10 +6,11 @@ import {Alert} from '@sentry/scraps/alert';
 import {Container} from '@sentry/scraps/layout';
 
 import {LoadingError} from 'sentry/components/loadingError';
-import {ORGANIZATION_FETCH_ERROR_TYPES, ROOT_ELEMENT} from 'sentry/constants';
+import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {getSplashLoader} from 'sentry/utils/splashLoader';
 
 function OrganizationLoadingIndicator() {
   /* Track how long this component is rendered for. */
@@ -17,20 +19,18 @@ function OrganizationLoadingIndicator() {
   });
 
   /**
-   * This is the initial loader React will render as the app bootstraps.
-   * Rather than rendering a loader component, we can reuse the existing DOM
-   * provided by the server-rendered Django view!
-   *
-   * This ensures there are no layout shifts as the app initially boots up
-   * because the DOM is exactly the same and React doesn't have to reconcile
-   * the fallback state.
+   * Re-parent the server-rendered loader instead of rendering our own, so there
+   * is no layout shift on boot. `appendChild` moves the same node, so an org
+   * switch (store resets to loading) re-mounts and picks it back up.
    */
-  const root = document.getElementById(ROOT_ELEMENT);
-  // There is no scenario in which this component is rendering,
-  // but the root element where the app is mounted doesn't exist
-  const ssrLoader = root!.innerHTML;
+  const loaderRef = useCallback((node: HTMLDivElement | null) => {
+    const loader = getSplashLoader();
+    if (node && loader) {
+      node.appendChild(loader);
+    }
+  }, []);
 
-  return <div dangerouslySetInnerHTML={{__html: ssrLoader}} />;
+  return <div ref={loaderRef} />;
 }
 
 interface Props {


### PR DESCRIPTION
`OrganizationLoadingIndicator` reads the React root's `innerHTML` and re-injects it, so the app reuses the loader the Django view already rendered and there is no layout shift on boot. Reusing that DOM is the right idea, but copying it rather than moving it caused two problems.

**It throws when the root element is absent.** `document.getElementById(ROOT_ELEMENT)` is dereferenced with a non-null assertion. jsdom has no `#blk_router`, which is why this component had no test coverage — any test that rendered it crashed.

**A later render copies whatever is in the root at that moment.** Switching organizations calls `OrganizationStore.reset()` and the store goes back to `loading`. By then the root holds the fully rendered app, so the loading state renders a frozen, non-interactive copy of the previous page instead of the loader. This only reaches users where org URLs are slug-based (self-hosted, single-region, local dev) — on a customer domain the switch crosses origins and does a full page load, so the reset path never runs.

The fix captures the loader node once at bootstrap and re-parents it with `appendChild`, which moves the node instead of cloning it. Being literally the same node, there is nothing for React to reconcile, and a re-mount picks it back up. When no loader exists the component renders an empty `div` rather than throwing.

Detaching the node early was deliberately avoided — that would leave the root empty until React's first commit and risk a blank flash. React's own commit removes it while we hold the reference.

Adds `organizationContainer.spec.tsx`, which is new coverage for this component: the loading behaviour above, plus the three error branches (`ORG_NO_ACCESS`, `ORG_NOT_FOUND`, generic). All 7 fail against the previous implementation.