### PR TITLE
feat(seer): Prefetch PR file diffs on hover over code changes

### DIFF
--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -41,13 +41,15 @@ export function ChangedFilesSection({
   groups,
   expandedKeys,
   onToggle,
+  onMouseEnter,
 }: {
   expandedKeys: Set<string>;
   groups: RepoFileGroup[];
   onToggle: (key: string, expanded: boolean) => void;
+  onMouseEnter?: () => void;
 }) {
   return (
-    <Stack gap="md">
+    <Stack gap="md" onMouseEnter={onMouseEnter}>
       <Flex gap="xs" align="center">
         <IconCode size="xs" variant="secondary" aria-hidden />
         <Text size="xs" bold variant="secondary">

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1284,6 +1284,66 @@ describe('AutofixOverview', () => {
     expect(screen.getAllByText('src/sentry/foo.py')).toHaveLength(1);
   });
 
+  it('prefetches PR file diffs when the code changes section is hovered', async () => {
+    mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [
+              {
+                id: '77',
+                number: 42,
+                url: 'https://github.com/getsentry/sentry/pull/42',
+                status: 'open',
+                checksStatus: null,
+                reviewStatus: null,
+                failedChecks: [],
+                files: [
+                  {
+                    path: 'src/sentry/foo.py',
+                    additions: 2,
+                    deletions: 1,
+                    changeType: 'MODIFIED',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const filesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/pull-requests/77/files/`,
+      body: {
+        files: [
+          {
+            path: 'src/sentry/foo.py',
+            patch: '@@ -1,2 +1,3 @@\n keep\n-drop\n+addedone\n+addedtwo',
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    const section = await screen.findByText('Code Changes');
+    expect(filesRequest).not.toHaveBeenCalled();
+
+    await userEvent.hover(section);
+    await waitFor(() => expect(filesRequest).toHaveBeenCalledTimes(1));
+
+    await userEvent.unhover(section);
+    await userEvent.hover(section);
+    expect(filesRequest).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: /src\/sentry\/foo\.py/})
+    );
+    expect(await screen.findByText('addedone')).toBeInTheDocument();
+    expect(filesRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('renders the deleted-file view when a deleted file has no patch', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Text} from '@sentry/scraps/text';
@@ -85,6 +85,7 @@ export function PullRequestFiles({
 }) {
   const files = pullRequest.files;
   const {expandedKeys, toggle} = useExpandedKeys();
+  const [shouldFetch, setShouldFetch] = useState(false);
 
   const {data, isPending, isError} = useQuery({
     ...apiOptions.as<PullRequestFilesResponse>()(
@@ -94,7 +95,7 @@ export function PullRequestFiles({
         staleTime: QUERY_STALE_TIME,
       }
     ),
-    enabled: expandedKeys.size > 0,
+    enabled: shouldFetch || expandedKeys.size > 0,
   });
 
   const diffByPath = useMemo(
@@ -123,6 +124,11 @@ export function PullRequestFiles({
   ];
 
   return (
-    <ChangedFilesSection groups={groups} expandedKeys={expandedKeys} onToggle={toggle} />
+    <ChangedFilesSection
+      groups={groups}
+      expandedKeys={expandedKeys}
+      onToggle={toggle}
+      onMouseEnter={() => setShouldFetch(true)}
+    />
   );
 }


### PR DESCRIPTION
On review-PR cards in the Autofix overview, the "Code Changes" box (`PullRequestFiles`) fetches every file's patch in one request, but the query was gated on `expandedKeys.size > 0` — so the fetch only started on the first expand and the user waited on a spinner. Hovering the section now flips a `shouldFetch` flag that also enables the query, so by the time a file is expanded the diff is already cached and renders instantly.

The flag is set-once and the query key is unchanged, so repeated `mouseenter` and a later expand reuse the same in-flight/cached request (React Query dedupes; `QUERY_STALE_TIME` prevents refetch). Keyboard users are unaffected — expanding still triggers the fetch via the existing `expandedKeys` path.

The hover hook is an optional prop on the shared `ChangedFilesSection`. The autofix "Code Changes generated" variant (`CodeChanges`) already has its patches in props with no API request, so it doesn't pass the prop and stays instant as before — this is `PullRequestFiles`-only.
