### PR TITLE
feat(seer): Gate Autofix Overview endpoint behind autofix-overview-page

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -9,10 +9,11 @@ from typing import NamedTuple, cast
 
 from django.db.models import Exists, OuterRef, Q
 from pydantic import ValidationError
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import search
+from sentry import features, search
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -347,6 +348,11 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationSeerAutofixOverviewPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has(
+            "organizations:autofix-overview-page", organization, actor=request.user
+        ):
+            raise PermissionDenied
+
         projects = self.get_projects(request, organization)
         project_ids = [p.id for p in projects]
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -84,6 +84,13 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
+        feature = self.feature("organizations:autofix-overview-page")
+        feature.__enter__()
+        self.addCleanup(feature.__exit__, None, None, None)
+
+    def test_requires_autofix_overview_page_feature(self):
+        with self.feature({"organizations:autofix-overview-page": False}):
+            self.get_error_response(self.organization.slug, status_code=403)
 
     def _run_for_group(self, group, description):
         run = self.create_seer_run(organization=self.organization)
@@ -1105,6 +1112,9 @@ class OrganizationSeerAutofixOverviewStatusExpandTest(APITestCase, SnubaTestCase
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
+        feature = self.feature("organizations:autofix-overview-page")
+        feature.__enter__()
+        self.addCleanup(feature.__exit__, None, None, None)
 
     def _run_for_group(self, group, description, state_id):
         run = self.create_seer_run(organization=self.organization)


### PR DESCRIPTION
Adds a backend feature check to the Autofix Overview endpoint (`GET /organizations/{org}/seer/autofix-overview/`) so it requires `organizations:autofix-overview-page`, raising `PermissionDenied` otherwise.

## Why
Until now the endpoint was gated only by `org:read`, while the flag gated only the page and its nav entry in the frontend (getsentry/sentry#122307). That meant any org member could hit the route directly and trigger its expensive Snuba/Postgres work regardless of the flag. Gating the backend on the same flag keeps data access and page access in agreement and matches the convention used by sibling Seer endpoints (e.g. `organization_seer_workflows`, `project_seer_night_shift`, `organization_seer_runs`), which all `features.has(...)` before doing work.

We reuse the single `autofix-overview-page` UI-exposure flag rather than introducing a separate backend flag; the rollout is an early dev-team gate and there's no reason yet for backend access and UI visibility to diverge.

## Deploy ordering
Stacked on the flag registration in getsentry/sentry#122306 — **that must land first** or this endpoint 403s everyone.

Refs AIML-3326