### PR TITLE
ref(dashboards): Build the tooltip series marker as JSX

### DIFF
--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useCallback, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
-import dompurify from 'dompurify';
 import type {SeriesOption, YAXisComponentOption} from 'echarts';
 import type {
   TooltipFormatterCallback,
@@ -293,13 +293,14 @@ export function CategoricalSeriesWidgetVisualization(
               }
             }
 
-            // param.marker is an HTML string with a colored circle, sanitize it
-            const marker = typeof param.marker === 'string' ? param.marker : '';
-
             return (
               <div key={param.seriesIndex}>
                 <span className="tooltip-label">
-                  <span dangerouslySetInnerHTML={{__html: dompurify.sanitize(marker)}} />{' '}
+                  <SeriesMarker
+                    markerColor={
+                      typeof param.color === 'string' ? param.color : 'transparent'
+                    }
+                  />{' '}
                   <strong>{displayName}</strong>
                 </span>{' '}
                 {formattedValue}
@@ -419,3 +420,16 @@ export function CategoricalSeriesWidgetVisualization(
 
 CategoricalSeriesWidgetVisualization.LoadingPlaceholder = WidgetLoadingPanel;
 CategoricalSeriesWidgetVisualization.NoData = WidgetNoDataPanel;
+
+/**
+ * Mirrors the marker ECharts generates for tooltips, which we would otherwise
+ * receive as an HTML string in `param.marker`.
+ */
+const SeriesMarker = styled('span')<{markerColor: string}>`
+  display: inline-block;
+  margin-right: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: ${p => p.markerColor};
+`;


### PR DESCRIPTION
The categorical series tooltip received ECharts' `param.marker` — an HTML string containing a styled empty `<span>` — ran it through DOMPurify, and injected the result with `dangerouslySetInnerHTML`.

The tooltip is already rendered as React, so there is no reason to round-trip through an HTML string and a sanitizer for a coloured dot. The marker is now a styled component driven by `param.color`.

The styles match what ECharts generates for a top-level tooltip marker (`format.js`): `display:inline-block`, `margin-right:4px`, a 10px circle, series colour. So the rendering is unchanged.

Also drops the `dompurify` import from this module.