### PR TITLE
fix(billing): Sanitize the partner support note

### DIFF
--- a/static/gsApp/views/subscriptionPage/partnershipNote.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/partnershipNote.spec.tsx
@@ -1,0 +1,59 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PartnershipNote} from 'getsentry/views/subscriptionPage/partnershipNote';
+
+// A partner support note with an inline link, matching what partners configure.
+const PARTNER_NOTE =
+  'Contact <a href="https://partner.example.com/support" target="_blank" rel="noreferrer">Partner Support Portal</a> support to make changes to your subscription.';
+
+function subscriptionWithNote(supportNote: string) {
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({organization});
+  subscription.partner = {
+    externalId: 'x',
+    isActive: true,
+    name: '',
+    partnership: {displayName: 'Partner', id: 'PN', supportNote},
+  };
+  return subscription;
+}
+
+describe('PartnershipNote', () => {
+  it('preserves the partner link, including target and rel', () => {
+    render(<PartnershipNote subscription={subscriptionWithNote(PARTNER_NOTE)} />);
+
+    const link = screen.getByRole('link', {
+      name: 'Partner Support Portal',
+    });
+    expect(link).toHaveAttribute('href', expect.stringContaining('partner.example.com'));
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+    expect(screen.getByText(/support to make changes/)).toBeInTheDocument();
+  });
+
+  it('strips script tags and event handlers', () => {
+    render(
+      <PartnershipNote
+        subscription={subscriptionWithNote(
+          'Hi<script>window.pwned=1</script><img src=x onerror="window.pwned=1">there'
+        )}
+      />
+    );
+
+    const note = screen.getByTestId('partnership-note');
+    expect(note.querySelector('script')).toBeNull();
+    expect(note.querySelector('[onerror]')).toBeNull();
+    expect(note).toHaveTextContent('Hithere');
+  });
+
+  it('falls back to the default message with no partner', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization});
+    render(<PartnershipNote subscription={subscription} />);
+
+    expect(screen.getByText(/Contact us at/)).toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/subscriptionPage/partnershipNote.tsx
+++ b/static/gsApp/views/subscriptionPage/partnershipNote.tsx
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {tct} from 'sentry/locale';
@@ -19,12 +21,15 @@ export function PartnershipNote({subscription}: Props) {
     <Panel data-test-id="partnership-note">
       <PanelBody withPadding>
         {subscription.partner ? (
-          // usually we pass it through sentry.utils.marked but
-          // markdown doesn't support adding attributes to links
           <TextBlock
             noMargin
             dangerouslySetInnerHTML={{
-              __html: subscription.partner?.partnership.supportNote || '',
+              __html: DOMPurify.sanitize(
+                subscription.partner?.partnership.supportNote || '',
+                // The note links out to the partner's support site; `target` is
+                // not in DOMPurify's default allowlist.
+                {ADD_ATTR: ['target']}
+              ),
             }}
           />
         ) : (


### PR DESCRIPTION
The partner support note is server-supplied HTML rendered straight through `dangerouslySetInnerHTML` with no sanitizer.

Nothing untrusted reaches it today — every value is a hardcoded literal in the partnership config, and the only non-empty one is a single link. So this is not a live vulnerability. But the config documents the field as "plain HTML", and nothing enforces that; if the note ever becomes configurable (an admin field, a provisioning API), the sink is already there and unguarded.

Run it through DOMPurify. `target` has to be added explicitly: it is not in DOMPurify's default attribute allowlist, and the note links out to the partner's own support site, so without it the link would silently stop opening in a new tab. `rel` is already allowed by default.

Also adds a spec, which this component did not have — covering the link case (`target` and `rel` preserved), sanitization of injected script and event-handler attributes, and the no-partner fallback.