### PR TITLE
hackweek(autofix): link Autofix evidence to the user session

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -18,6 +18,7 @@ import {defined} from 'sentry/utils/defined';
 import {getShortEventId} from 'sentry/utils/events';
 import {getShortCommitHash} from 'sentry/utils/git/getShortCommitHash';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {getSessionDetailUrl} from 'sentry/views/explore/usersessions/sessionLink';
 import {resolveLink, subjectFromToolLink} from 'sentry/views/seerExplorer/links';
 import type {ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
 
@@ -111,6 +112,21 @@ function getTelemetryEvidenceProps({
     return null;
   }
 
+  const {question} = parseArgs(toolCall);
+
+  // When the agent scoped a telemetry query to a user session (session.id:<id>), surface it as
+  // a link to that session's timeline rather than a generic dataset query. This is what ties
+  // Autofix's investigation back to the Sessions explorer.
+  const sessionId = extractSessionId(typeof question === 'string' ? question : '');
+  if (sessionId) {
+    return {
+      to: getSessionDetailUrl(organization, sessionId),
+      icon: <IconCompass />,
+      label: t('Session: %s', getShortEventId(sessionId)),
+      tooltip: typeof question === 'string' ? question : undefined,
+    };
+  }
+
   const target = resolveLink(subjectFromToolLink(toolLink), {
     organization,
     projects,
@@ -119,7 +135,6 @@ function getTelemetryEvidenceProps({
     return null;
   }
 
-  const {question} = parseArgs(toolCall);
   const {dataset} = toolLink.params ?? {};
   const label = getTelemetryEvidenceLabel(
     typeof dataset === 'string' ? dataset : undefined
@@ -374,12 +389,28 @@ function getGitSearchEvidenceProps({
   return null;
 }
 
+function getSessionTimelineEvidenceProps({
+  organization,
+  toolCall,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  const {session_id} = parseArgs(toolCall);
+  if (typeof session_id !== 'string' || !session_id) {
+    return null;
+  }
+  return {
+    to: getSessionDetailUrl(organization, session_id),
+    icon: <IconCompass />,
+    label: t('Session: %s', getShortEventId(session_id)),
+  };
+}
+
 export const AUTOFIX_EVIDENCE_PROPS_RESOLVER: Record<
   string,
   (payload: GetEvidencePropsPayload) => EvidenceButtonProps | null
 > = {
   telemetry_live_search: getTelemetryEvidenceProps,
   get_trace_waterfall: getTraceWaterfallEvidenceProps,
+  get_session_timeline: getSessionTimelineEvidenceProps,
   get_issue_details: getIssueDetailsEvidenceProps,
   get_event_details: getIssueDetailsEvidenceProps,
   get_replay_details: getReplayDetailsEvidenceProps,
@@ -395,6 +426,12 @@ function parseArgs(toolCall: ToolCall): any {
   } catch {
     return {};
   }
+}
+
+/** Pull the session id out of a telemetry query like `session.id:<id> all errors and logs`. */
+function extractSessionId(question: string): string | undefined {
+  const match = question.match(/session\.id:\s*"?([0-9a-fA-F-]{8,})"?/);
+  return match?.[1];
 }
 
 function extractFileName(filePath: string): string | undefined {


### PR DESCRIPTION
## Idea

When Autofix roots-causes an error by reading a user's session, its Evidence should let you follow that reasoning.

This adds a **Session** chip to Autofix's Evidence: when the agent investigated a session (either by querying telemetry scoped to a `session.id`, or via the new `get_session_timeline` tool), the chip links straight to that session's timeline in the Sessions explorer.

So you can go from "the AI concluded X" to the actual session it looked at, in one click.

Stacks on the Sessions explorer work in `hackweek/sessions` (needs `getSessionDetailUrl` / the usersessions route). Backend + Seer changes that produce this evidence are separate PRs.

Draft — hackweek Sessions project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)