### PR TITLE
feat(warden): Add wrdn-dos-review skill silently via warden-skills

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -80,3 +80,15 @@ paths = [
 [[skills.triggers]]
 type = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "wrdn-dos-review"
+remote = "getsentry/warden-skills"
+paths = ["src/**/*.py"]
+ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]
+failOn = "off"
+reportOn = "off"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
Adds the shared `wrdn-dos-review` skill from [getsentry/warden-skills](https://github.com/getsentry/warden-skills).