### PR TITLE
feat(auth): Add React auth config query

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -32,6 +32,8 @@ const productionEntryPoints = [
   'static/app/components/connectRepository/**/*.{ts,tsx}',
   // TODO: Remove when wired into the React authentication flow
   'static/app/components/brandPageLayout/**/*.{ts,tsx}',
+  // React authentication routes are discovered dynamically by the frontend route registry
+  'static/app/views/authV2/authLogin/**/*.{ts,tsx}',
   // https://github.com/getsentry/sentry/pull/121178
   'static/app/components/core/table/*.tsx',
   'static/app/components/core/dragHandle/*.tsx',

--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -140,12 +140,20 @@ export type UserEnrolledAuthenticator = {
  */
 export type AuthConfig = {
   canRegister: boolean;
-  githubLoginLink: string;
-  googleLoginLink: string;
   hasNewsletter: boolean;
+  pendingMfa: {
+    mfaMethods: Array<{id: 'recovery' | 'sms' | 'totp' | 'u2f'}>;
+    mfaRequired: true;
+  } | null;
   serverHostname: string;
-  vstsLoginLink: string;
+  githubLoginLink?: string;
+  googleLoginLink?: string;
+  loginBanner?: string;
+  vstsLoginLink?: string;
+  warning?: string;
 };
+
+export type AuthConfigResponse = AuthConfig | {nextUri: string};
 
 // Users can have SSO providers of their own (social login with github)
 // and organizations can have SSO configuration for SAML/google domain/okta.

--- a/static/app/views/authV2/authLogin/hooks/useAuthConfig.spec.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useAuthConfig.spec.tsx
@@ -1,0 +1,25 @@
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {AuthConfig} from 'sentry/types/auth';
+
+import {useAuthConfig} from './useAuthConfig';
+
+describe('useAuthConfig', () => {
+  it('fetches the authentication configuration', async () => {
+    const response: AuthConfig = {
+      canRegister: true,
+      hasNewsletter: false,
+      pendingMfa: null,
+      serverHostname: 'sentry.example.com',
+    };
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/config/',
+      body: response,
+    });
+
+    const {result} = renderHookWithProviders(useAuthConfig);
+
+    await waitFor(() => expect(result.current.data).toEqual(response));
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/authV2/authLogin/hooks/useAuthConfig.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useAuthConfig.tsx
@@ -1,0 +1,13 @@
+import {useQuery} from '@tanstack/react-query';
+
+import type {AuthConfigResponse} from 'sentry/types/auth';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+export const authConfigQueryOptions = apiOptions.as<AuthConfigResponse>()(
+  '/auth/config/',
+  {staleTime: 0}
+);
+
+export function useAuthConfig() {
+  return useQuery(authConfigQueryOptions);
+}


### PR DESCRIPTION
Adds the zero-stale-time React query that bootstraps the login experience from `/auth/config/`, including the authenticated redirect outcome and the nullable nested `pendingMfa` contract used to resume an interrupted two-factor login. The shared query options also give later MFA cancellation code a type-safe cache key to update and invalidate.

The React auth directory is registered as a Knip entry point because these route modules are discovered dynamically. This frontend layer depends on the backend auth-config contract landing first.
