### PR TITLE
feat(auth): Add email authentication hooks

### DIFF
--- a/static/app/views/authV2/authLogin/hooks/useEmailAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useEmailAuth.spec.tsx
@@ -1,0 +1,134 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useEmailAuth} from './useEmailAuth';
+
+describe('useEmailAuth', () => {
+  it('authenticates with the login API', async () => {
+    const user = UserFixture();
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user},
+    });
+    const {result} = renderHookWithProviders(useEmailAuth);
+
+    act(() => {
+      result.current.authenticate({email: 'user@example.com', password: 'secret'});
+    });
+
+    await waitFor(() =>
+      expect(result.current.result).toEqual({
+        status: 'authenticated',
+        nextUri: '/organizations/',
+        user,
+      })
+    );
+    expect(request).toHaveBeenCalledWith(
+      '/auth/login/',
+      expect.objectContaining({
+        method: 'POST',
+        data: {username: 'user@example.com', password: 'secret', orgSlug: null},
+      })
+    );
+  });
+
+  it('includes organization context when authenticating', async () => {
+    const user = UserFixture();
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: '/organizations/acme/issues/', user},
+    });
+    const {result} = renderHookWithProviders(() => useEmailAuth('acme'));
+
+    act(() => {
+      result.current.authenticate({email: 'user@example.com', password: 'secret'});
+    });
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        '/auth/login/',
+        expect.objectContaining({
+          method: 'POST',
+          data: {username: 'user@example.com', password: 'secret', orgSlug: 'acme'},
+        })
+      )
+    );
+  });
+
+  it('returns the available MFA methods', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 202,
+      body: {
+        mfaRequired: true,
+        mfaMethods: [{id: 'totp'}, {id: 'recovery'}],
+      },
+    });
+    const {result} = renderHookWithProviders(useEmailAuth);
+
+    act(() => {
+      result.current.authenticate({email: 'user@example.com', password: 'secret'});
+    });
+
+    await waitFor(() =>
+      expect(result.current.result).toEqual({
+        status: 'mfa-required',
+        methods: [{id: 'totp'}, {id: 'recovery'}],
+      })
+    );
+  });
+
+  it('returns the login form error', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'Login attempt failed',
+        errors: {__all__: ['Invalid email or password']},
+      },
+    });
+    const {result} = renderHookWithProviders(useEmailAuth);
+
+    act(() => {
+      result.current.authenticate({email: 'user@example.com', password: 'wrong'});
+    });
+
+    await waitFor(() =>
+      expect(result.current.errorMessage).toBe('Invalid email or password')
+    );
+    expect(result.current.result).toBeNull();
+  });
+
+  it('clears a successful result after a later login error', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user: UserFixture()},
+    });
+    const {result} = renderHookWithProviders(useEmailAuth);
+
+    act(() => {
+      result.current.authenticate({email: 'user@example.com', password: 'secret'});
+    });
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 400,
+      body: {errors: {__all__: ['Invalid email or password']}},
+    });
+    act(() => {
+      result.current.authenticate({email: 'user@example.com', password: 'wrong'});
+    });
+
+    await waitFor(() => expect(result.current.errorMessage).not.toBeNull());
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/static/app/views/authV2/authLogin/hooks/useEmailAuth.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useEmailAuth.tsx
@@ -1,0 +1,85 @@
+import {useMutation} from '@tanstack/react-query';
+
+import {t} from 'sentry/locale';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {getRequestErrorUserMessage} from 'sentry/utils/requestError/getRequestErrorUserMessage';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import type {AuthenticatedResult, MfaMethod} from 'sentry/views/authV2/authLogin/types';
+
+export interface EmailAuthCredentials {
+  email: string;
+  password: string;
+}
+
+export type EmailAuthResult =
+  | {
+      methods: MfaMethod[];
+      status: 'mfa-required';
+    }
+  | (AuthenticatedResult & {status: 'authenticated'});
+
+type EmailAuthResponse =
+  | {
+      mfaMethods: MfaMethod[];
+      mfaRequired: true;
+    }
+  | AuthenticatedResult;
+
+/**
+ * Authenticate with an email address and password. The organization slug is a hint
+ * for the post-authentication destination; organization SSO requirements may send
+ * the user elsewhere.
+ */
+export function useEmailAuth(organizationSlug?: string) {
+  const mutation = useMutation({
+    mutationFn: async ({email, password}: EmailAuthCredentials) => {
+      const response = await fetchMutation<EmailAuthResponse>({
+        url: getApiUrl('/auth/login/'),
+        method: 'POST',
+        data: {
+          username: email,
+          password,
+          orgSlug: organizationSlug ?? null,
+        },
+      });
+
+      if ('mfaRequired' in response) {
+        return {
+          status: 'mfa-required',
+          methods: response.mfaMethods,
+        } satisfies EmailAuthResult;
+      }
+
+      return {
+        status: 'authenticated',
+        nextUri: response.nextUri,
+        user: response.user,
+      } satisfies EmailAuthResult;
+    },
+  });
+
+  return {
+    authenticate: mutation.mutate,
+    errorMessage: mutation.error ? getEmailAuthErrorMessage(mutation.error) : null,
+    isPending: mutation.isPending,
+    reset: mutation.reset,
+    result: mutation.isSuccess ? mutation.data : null,
+  };
+}
+
+function getEmailAuthErrorMessage(error: Error): string {
+  if (error instanceof RequestError) {
+    const errors = error.responseJSON?.errors;
+
+    if (errors && typeof errors === 'object' && '__all__' in errors) {
+      const messages = errors.__all__;
+
+      if (Array.isArray(messages) && typeof messages[0] === 'string') {
+        return messages[0];
+      }
+    }
+  }
+
+  return getRequestErrorUserMessage(error, t('Unable to log in. Please try again.'));
+}

--- a/static/app/views/authV2/authLogin/hooks/usePasswordReset.spec.tsx
+++ b/static/app/views/authV2/authLogin/hooks/usePasswordReset.spec.tsx
@@ -1,0 +1,79 @@
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {usePasswordReset} from './usePasswordReset';
+
+describe('usePasswordReset', () => {
+  it('requests a recovery email from the recovery API', async () => {
+    const detail = 'If an eligible account exists, a recovery email has been sent.';
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/recovery/',
+      method: 'POST',
+      statusCode: 202,
+      body: {detail},
+    });
+    const {result} = renderHookWithProviders(usePasswordReset);
+
+    act(() => {
+      result.current.requestPasswordReset('user@example.com');
+    });
+
+    await waitFor(() =>
+      expect(result.current.result).toEqual({status: 'accepted', message: detail})
+    );
+    expect(request).toHaveBeenCalledWith(
+      '/auth/recovery/',
+      expect.objectContaining({
+        method: 'POST',
+        data: {user: 'user@example.com'},
+      })
+    );
+  });
+
+  it('returns the recovery API error', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/recovery/',
+      method: 'POST',
+      statusCode: 429,
+      body: {detail: 'Too many password recovery attempts'},
+    });
+    const {result} = renderHookWithProviders(usePasswordReset);
+
+    act(() => {
+      result.current.requestPasswordReset('user@example.com');
+    });
+
+    await waitFor(() =>
+      expect(result.current.errorMessage).toBe('Too many password recovery attempts')
+    );
+    expect(result.current.result).toBeNull();
+  });
+
+  it('clears an accepted result after a later recovery error', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/recovery/',
+      method: 'POST',
+      statusCode: 202,
+      body: {detail: 'Recovery requested'},
+    });
+    const {result} = renderHookWithProviders(usePasswordReset);
+
+    act(() => {
+      result.current.requestPasswordReset('user@example.com');
+    });
+    await waitFor(() => expect(result.current.result).not.toBeNull());
+
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/auth/recovery/',
+      method: 'POST',
+      statusCode: 429,
+      body: {detail: 'Too many password recovery attempts'},
+    });
+    act(() => {
+      result.current.requestPasswordReset('user@example.com');
+    });
+
+    await waitFor(() => expect(result.current.errorMessage).not.toBeNull());
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/static/app/views/authV2/authLogin/hooks/usePasswordReset.tsx
+++ b/static/app/views/authV2/authLogin/hooks/usePasswordReset.tsx
@@ -1,0 +1,45 @@
+import {useMutation} from '@tanstack/react-query';
+
+import {t} from 'sentry/locale';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {getRequestErrorUserMessage} from 'sentry/utils/requestError/getRequestErrorUserMessage';
+
+export interface PasswordResetResult {
+  message: string;
+  status: 'accepted';
+}
+
+type PasswordResetResponse = {
+  detail: string;
+};
+
+export function usePasswordReset() {
+  const mutation = useMutation({
+    mutationFn: async (email: string) => {
+      const response = await fetchMutation<PasswordResetResponse>({
+        url: getApiUrl('/auth/recovery/'),
+        method: 'POST',
+        data: {user: email},
+      });
+
+      return {
+        status: 'accepted',
+        message: response.detail,
+      } satisfies PasswordResetResult;
+    },
+  });
+
+  return {
+    errorMessage: mutation.error
+      ? getRequestErrorUserMessage(
+          mutation.error,
+          t('Unable to request a password reset. Please try again.')
+        )
+      : null,
+    isPending: mutation.isPending,
+    requestPasswordReset: mutation.mutate,
+    reset: mutation.reset,
+    result: mutation.isSuccess ? mutation.data : null,
+  };
+}

--- a/static/app/views/authV2/authLogin/types.ts
+++ b/static/app/views/authV2/authLogin/types.ts
@@ -1,0 +1,10 @@
+import type {User} from 'sentry/types/user';
+
+export type MfaMethod = {
+  id: 'recovery' | 'sms' | 'totp' | 'u2f';
+};
+
+export interface AuthenticatedResult {
+  nextUri: string;
+  user: User;
+}


### PR DESCRIPTION
Adds the email/password login and password-recovery mutation layer for the React authentication flow. The hooks normalize successful authentication, pending MFA, structured login errors, and recovery’s anti-enumeration response into UI-facing contracts.