### PR TITLE
feat(auth): Add email authentication form

### DIFF
--- a/static/app/views/authV2/authLogin/components/emailAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/emailAuth.spec.tsx
@@ -1,0 +1,251 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {EmailAuth} from './emailAuth';
+
+describe('EmailAuth', () => {
+  it('submits credentials and reports authenticated users', async () => {
+    const user = UserFixture();
+    const onAuthResult = jest.fn();
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user},
+    });
+    render(<EmailAuth onAuthResult={onAuthResult} />);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Email'}),
+      'user@example.com'
+    );
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
+    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        '/auth/login/',
+        expect.objectContaining({
+          method: 'POST',
+          data: {username: 'user@example.com', password: 'secret', orgSlug: null},
+        })
+      )
+    );
+    await waitFor(() =>
+      expect(onAuthResult).toHaveBeenCalledWith({
+        status: 'authenticated',
+        nextUri: '/organizations/',
+        user,
+      })
+    );
+  });
+
+  it('submits credentials populated without change events', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user: UserFixture()},
+    });
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    const email = screen.getByRole('textbox', {name: 'Email'});
+    const password = screen.getByLabelText('Password');
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+      email,
+      'user@example.com'
+    );
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+      password,
+      'secret'
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        '/auth/login/',
+        expect.objectContaining({
+          data: {username: 'user@example.com', password: 'secret', orgSlug: null},
+        })
+      )
+    );
+  });
+
+  it('preserves credentials populated without change events after an error', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'Login attempt failed',
+        errors: {__all__: ['Invalid email or password']},
+      },
+    });
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    const email = screen.getByRole('textbox', {name: 'Email'});
+    const password = screen.getByLabelText('Password');
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+      email,
+      'user@example.com'
+    );
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+      password,
+      'wrong'
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Invalid email or password'
+    );
+    expect(email).toHaveValue('user@example.com');
+    expect(password).toHaveValue('wrong');
+  });
+
+  it('reports required MFA methods', async () => {
+    const onAuthResult = jest.fn();
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 202,
+      body: {
+        mfaRequired: true,
+        mfaMethods: [{id: 'totp'}, {id: 'recovery'}],
+      },
+    });
+    render(<EmailAuth onAuthResult={onAuthResult} />);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Email'}),
+      'user@example.com'
+    );
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
+    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+
+    await waitFor(() =>
+      expect(onAuthResult).toHaveBeenCalledWith({
+        status: 'mfa-required',
+        methods: [{id: 'totp'}, {id: 'recovery'}],
+      })
+    );
+  });
+
+  it('shows login errors and clears them when credentials change', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'Login attempt failed',
+        errors: {__all__: ['Invalid email or password']},
+      },
+    });
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Email'}),
+      'user@example.com'
+    );
+    await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Invalid email or password'
+    );
+
+    await userEvent.type(screen.getByLabelText('Password'), '!');
+
+    expect(screen.queryByText('Invalid email or password')).not.toBeInTheDocument();
+  });
+
+  it('toggles password visibility', async () => {
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    const password = screen.getByLabelText('Password');
+    expect(screen.queryByRole('button', {name: 'Show password'})).not.toBeInTheDocument();
+
+    await userEvent.type(password, 'secret');
+    const visibilityButton = screen.getByRole('button', {name: 'Show password'});
+    expect(password).toHaveAttribute('type', 'password');
+
+    await userEvent.click(visibilityButton);
+    expect(password).toHaveAttribute('type', 'text');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Hide password'}));
+    expect(password).toHaveAttribute('type', 'password');
+  });
+
+  it('enters and exits password recovery', async () => {
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Forgot password?'}));
+
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Back to Login'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
+
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Forgot password?'})).toBeInTheDocument();
+  });
+
+  it('shows password recovery errors', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/recovery/',
+      method: 'POST',
+      statusCode: 429,
+      body: {detail: 'Too many password recovery attempts'},
+    });
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Forgot password?'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Email'}),
+      'user@example.com'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Too many password recovery attempts'
+    );
+    expect(screen.getByRole('textbox', {name: 'Email'})).toBeInTheDocument();
+  });
+
+  it('shows confirmation after requesting a recovery email', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/recovery/',
+      method: 'POST',
+      statusCode: 202,
+      body: {
+        detail: 'If an eligible account exists, a recovery email has been sent.',
+      },
+    });
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Forgot password?'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Email'}),
+      'user@example.com'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    const notification = await screen.findByRole('status');
+    expect(notification).toHaveTextContent(
+      'A recovery link has been sent to user@example.com (only if there is a Sentry account for that email!).'
+    );
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Reset Password'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Use a different email'})
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
+
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+    expect(screen.queryByText(/A recovery link has been sent/)).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/authV2/authLogin/components/emailAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/emailAuth.tsx
@@ -1,0 +1,216 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {InputGroup} from '@sentry/scraps/input';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {IconArrow, IconHide, IconShow} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {
+  useEmailAuth,
+  type EmailAuthResult,
+} from 'sentry/views/authV2/authLogin/hooks/useEmailAuth';
+import {usePasswordReset} from 'sentry/views/authV2/authLogin/hooks/usePasswordReset';
+
+interface EmailAuthProps {
+  onAuthResult: (result: EmailAuthResult) => void;
+  /**
+   * A hint for the post-authentication destination. Organization SSO requirements
+   * may send the user elsewhere.
+   */
+  organizationSlug?: string;
+}
+
+export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isPasswordRecovery, setIsPasswordRecovery] = useState(false);
+  const [recoveryEmail, setRecoveryEmail] = useState('');
+  const emailAuth = useEmailAuth(organizationSlug);
+  const passwordReset = usePasswordReset();
+  const passwordVisibilityLabel = isPasswordVisible
+    ? t('Hide password')
+    : t('Show password');
+  const authError = emailAuth.errorMessage;
+  const errorMessage = passwordReset.errorMessage ?? authError;
+  const isPending = emailAuth.isPending || passwordReset.isPending;
+
+  function handleEmailChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setEmail(event.currentTarget.value);
+    emailAuth.reset();
+    passwordReset.reset();
+  }
+
+  function handlePasswordChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setPassword(event.currentTarget.value);
+    emailAuth.reset();
+  }
+
+  function setPasswordRecoveryMode(enabled: boolean) {
+    emailAuth.reset();
+    passwordReset.reset();
+    setIsPasswordRecovery(enabled);
+  }
+
+  useEffect(() => {
+    if (emailAuth.result) {
+      onAuthResult(emailAuth.result);
+    }
+  }, [emailAuth.result, onAuthResult]);
+
+  return (
+    <form
+      onSubmit={event => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        const submittedEmail = formData.get('email');
+        const submittedPassword = formData.get('password');
+
+        if (typeof submittedEmail !== 'string') {
+          return;
+        }
+
+        setEmail(submittedEmail);
+
+        if (isPasswordRecovery) {
+          setRecoveryEmail(submittedEmail);
+          passwordReset.requestPasswordReset(submittedEmail);
+        } else if (typeof submittedPassword === 'string') {
+          setPassword(submittedPassword);
+          emailAuth.authenticate({
+            email: submittedEmail,
+            password: submittedPassword,
+          });
+        }
+      }}
+    >
+      <Container>
+        {errorMessage && (
+          <Container paddingBottom="md">
+            <Alert.Container>
+              <Alert role="alert" variant="danger" showIcon={false}>
+                {errorMessage}
+              </Alert>
+            </Alert.Container>
+          </Container>
+        )}
+        {passwordReset.result ? (
+          <Alert role="status" variant="muted" showIcon={false}>
+            {tct(
+              'A recovery link has been sent to [email] (only if there is a Sentry account for that email!).',
+              {
+                email: (
+                  <Text as="span" bold>
+                    {recoveryEmail}
+                  </Text>
+                ),
+              }
+            )}
+          </Alert>
+        ) : (
+          <InputGroup>
+            <InputGroup.Input
+              type="email"
+              name="email"
+              value={email}
+              autoComplete="email"
+              disabled={isPending}
+              placeholder={
+                isPasswordRecovery ? t('Email of account to recover') : t('Email')
+              }
+              aria-label={t('Email')}
+              aria-invalid={Boolean(errorMessage)}
+              required
+              onChange={handleEmailChange}
+            />
+          </InputGroup>
+        )}
+        {!isPasswordRecovery && (
+          <Container paddingTop="md">
+            <InputGroup>
+              <InputGroup.Input
+                type={isPasswordVisible ? 'text' : 'password'}
+                name="password"
+                value={password}
+                autoComplete="current-password"
+                disabled={isPending}
+                placeholder={t('Password')}
+                aria-label={t('Password')}
+                aria-invalid={Boolean(authError)}
+                required
+                onChange={handlePasswordChange}
+              />
+              <InputGroup.TrailingItems>
+                {password && (
+                  <Button
+                    aria-label={passwordVisibilityLabel}
+                    icon={isPasswordVisible ? <IconHide /> : <IconShow />}
+                    size="zero"
+                    tooltipProps={{title: passwordVisibilityLabel}}
+                    variant="transparent"
+                    onClick={() => setIsPasswordVisible(visible => !visible)}
+                  />
+                )}
+              </InputGroup.TrailingItems>
+            </InputGroup>
+          </Container>
+        )}
+        <Flex paddingTop="md">
+          <Container flex="1" paddingTop="sm">
+            {!passwordReset.result && !isPasswordRecovery && (
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                busy={emailAuth.isPending}
+              >
+                {t('Log in to Sentry')}
+              </Button>
+            )}
+            {!passwordReset.result && isPasswordRecovery && (
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                busy={passwordReset.isPending}
+              >
+                {t('Reset Password')}
+              </Button>
+            )}
+          </Container>
+          <Flex flex="1" justify="end">
+            {isPasswordRecovery ? (
+              <ForgotPasswordButton
+                disabled={isPending}
+                variant="transparent"
+                size="xs"
+                icon={<IconArrow direction="left" />}
+                onClick={() => setPasswordRecoveryMode(false)}
+              >
+                {t('Back to Login')}
+              </ForgotPasswordButton>
+            ) : (
+              <ForgotPasswordButton
+                disabled={isPending}
+                variant="transparent"
+                size="xs"
+                onClick={() => setPasswordRecoveryMode(true)}
+              >
+                {t('Forgot password?')}
+              </ForgotPasswordButton>
+            )}
+          </Flex>
+        </Flex>
+      </Container>
+    </form>
+  );
+}
+
+const ForgotPasswordButton = styled(Button)`
+  color: ${p => p.theme.tokens.content.secondary};
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+`;


### PR DESCRIPTION
Adds the accessible email/password sign-in and recovery form on top of the preceding hooks. Login and recovery share email state and transitions, while dynamic errors use live alert semantics and recovery confirmation remains owned by the form.