### PR TITLE
feat(auth): Add two-factor authentication hooks

### DIFF
--- a/static/app/views/authV2/authLogin/hooks/useSecondFactorAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useSecondFactorAuth.spec.tsx
@@ -1,0 +1,193 @@
+import type {ReactNode} from 'react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {
+  secondFactorMethodsQueryOptions,
+  useSecondFactorAuth,
+  useSecondFactorChallenge,
+  useSecondFactorMethods,
+  useCancelSecondFactorAuth,
+} from './useSecondFactorAuth';
+
+describe('useSecondFactorMethods', () => {
+  it('fetches the available authentication methods when enabled', async () => {
+    const response = {
+      mfaRequired: true as const,
+      mfaMethods: [{id: 'totp' as const}, {id: 'recovery' as const}],
+    };
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      body: response,
+    });
+
+    const {result} = renderHookWithProviders(() => useSecondFactorMethods(true));
+
+    await waitFor(() => expect(result.current.data).toEqual(response));
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch the available authentication methods when disabled', () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      body: {mfaRequired: true, mfaMethods: [{id: 'totp'}]},
+    });
+
+    const {result} = renderHookWithProviders(() => useSecondFactorMethods(false));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCancelSecondFactorAuth', () => {
+  it('cancels the pending authentication and clears cached methods', async () => {
+    const queryClient = makeTestQueryClient();
+    const methodsResponse = {
+      mfaRequired: true as const,
+      mfaMethods: [{id: 'totp' as const}],
+    };
+    queryClient.setQueryData(secondFactorMethodsQueryOptions.queryKey, {
+      headers: {},
+      json: methodsResponse,
+    });
+    const cancelRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'DELETE',
+      statusCode: 204,
+    });
+    const {result} = renderHookWithProviders(useCancelSecondFactorAuth, {
+      additionalWrapper: ({children}: {children?: ReactNode}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    act(() => result.current.cancel());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(
+      queryClient.getQueryData(secondFactorMethodsQueryOptions.queryKey)
+    ).toBeUndefined();
+    expect(cancelRequest).toHaveBeenCalledWith(
+      '/auth/2fa/',
+      expect.objectContaining({method: 'DELETE'})
+    );
+  });
+});
+
+describe('useSecondFactorChallenge', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records when an SMS challenge was activated', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_234_567);
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {method: 'sms', expiresIn: 45},
+    });
+    const {result} = renderHookWithProviders(useSecondFactorChallenge);
+
+    act(() => result.current.activate('sms'));
+
+    await waitFor(() =>
+      expect(result.current.result).toEqual({
+        method: 'sms',
+        expiresIn: 45,
+        activatedAt: 1_234_567,
+      })
+    );
+    expect(request).toHaveBeenCalledWith(
+      '/auth/2fa/challenge/',
+      expect.objectContaining({method: 'POST', data: {method: 'sms'}})
+    );
+  });
+
+  it('preserves a WebAuthn challenge response', async () => {
+    const response = {
+      method: 'u2f' as const,
+      challenge: {webAuthnAuthenticationData: 'challenge-data'},
+    };
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: response,
+    });
+    const {result} = renderHookWithProviders(useSecondFactorChallenge);
+
+    act(() => result.current.activate('u2f'));
+
+    await waitFor(() => expect(result.current.result).toEqual(response));
+  });
+});
+
+describe('useSecondFactorAuth', () => {
+  it('submits the authentication response', async () => {
+    const response = {nextUri: '/organizations/', user: UserFixture()};
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      body: response,
+    });
+    const {result} = renderHookWithProviders(useSecondFactorAuth);
+
+    act(() => result.current.authenticate({method: 'totp', otp: '123456'}));
+
+    await waitFor(() => expect(result.current.result).toEqual(response));
+    expect(request).toHaveBeenCalledWith(
+      '/auth/2fa/',
+      expect.objectContaining({
+        method: 'POST',
+        data: {method: 'totp', otp: '123456'},
+      })
+    );
+  });
+
+  it('submits a WebAuthn authentication response', async () => {
+    const response = {nextUri: '/organizations/', user: UserFixture()};
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      body: response,
+    });
+    const {result} = renderHookWithProviders(useSecondFactorAuth);
+    const webAuthnResponse = {
+      authenticatorData: 'authenticator-data',
+      clientData: 'client-data',
+      keyHandle: 'key-handle',
+      signatureData: 'signature-data',
+    };
+
+    act(() => result.current.authenticate({method: 'u2f', response: webAuthnResponse}));
+
+    await waitFor(() => expect(result.current.result).toEqual(response));
+    expect(request).toHaveBeenCalledWith(
+      '/auth/2fa/',
+      expect.objectContaining({
+        method: 'POST',
+        data: {method: 'u2f', response: webAuthnResponse},
+      })
+    );
+  });
+
+  it('returns an authentication error', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Invalid authentication code'},
+    });
+    const {result} = renderHookWithProviders(useSecondFactorAuth);
+
+    act(() => result.current.authenticate({method: 'totp', otp: 'incorrect'}));
+
+    await waitFor(() =>
+      expect(result.current.errorMessage).toBe('Invalid authentication code')
+    );
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/static/app/views/authV2/authLogin/hooks/useSecondFactorAuth.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useSecondFactorAuth.tsx
@@ -1,0 +1,156 @@
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+import {t} from 'sentry/locale';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {getRequestErrorUserMessage} from 'sentry/utils/requestError/getRequestErrorUserMessage';
+import type {AuthenticatedResult, MfaMethod} from 'sentry/views/authV2/authLogin/types';
+
+import {authConfigQueryOptions} from './useAuthConfig';
+
+export type SecondFactorAuthResult = AuthenticatedResult;
+
+interface MfaMethodsResponse {
+  mfaMethods: MfaMethod[];
+  mfaRequired: true;
+}
+
+interface SmsChallengeResponse {
+  expiresIn: number;
+  method: 'sms';
+}
+
+interface WebAuthnChallengeResponse {
+  challenge: {
+    webAuthnAuthenticationData: string;
+  };
+  method: 'u2f';
+}
+
+type MfaChallengeResponse = SmsChallengeResponse | WebAuthnChallengeResponse;
+
+interface SmsChallengeResult extends SmsChallengeResponse {
+  activatedAt: number;
+}
+
+type MfaChallengeResult = SmsChallengeResult | WebAuthnChallengeResponse;
+
+export interface WebAuthnResponse {
+  authenticatorData: string;
+  clientData: string;
+  keyHandle: string;
+  signatureData: string;
+}
+
+export type SecondFactorCredentials =
+  | {method: Exclude<MfaMethod['id'], 'u2f'>; otp: string}
+  | {method: 'u2f'; response: WebAuthnResponse};
+
+type SecondFactorChallengeMethod = Extract<MfaMethod['id'], 'sms' | 'u2f'>;
+
+export const secondFactorMethodsQueryOptions = apiOptions.as<MfaMethodsResponse>()(
+  '/auth/2fa/',
+  {staleTime: 0}
+);
+
+export function useSecondFactorMethods(enabled: boolean) {
+  return useQuery({
+    ...secondFactorMethodsQueryOptions,
+    enabled,
+  });
+}
+
+export function useSecondFactorChallenge() {
+  const mutation = useMutation({
+    mutationFn: async (
+      method: SecondFactorChallengeMethod
+    ): Promise<MfaChallengeResult> => {
+      const response = await fetchMutation<MfaChallengeResponse>({
+        url: getApiUrl('/auth/2fa/challenge/'),
+        method: 'POST',
+        data: {method},
+      });
+
+      return response.method === 'sms'
+        ? {...response, activatedAt: Date.now()}
+        : response;
+    },
+  });
+
+  return {
+    activate: mutation.mutate,
+    errorMessage: mutation.error
+      ? getRequestErrorUserMessage(
+          mutation.error,
+          t('Unable to send an authentication challenge. Please try again.')
+        )
+      : null,
+    isPending: mutation.isPending,
+    reset: mutation.reset,
+    result: mutation.data ?? null,
+  };
+}
+
+export function useSecondFactorAuth() {
+  const mutation = useMutation({
+    mutationFn: (credentials: SecondFactorCredentials) =>
+      fetchMutation<SecondFactorAuthResult>({
+        url: getApiUrl('/auth/2fa/'),
+        method: 'POST',
+        data: credentials,
+      }),
+  });
+
+  return {
+    authenticate: mutation.mutate,
+    errorMessage: mutation.error
+      ? getRequestErrorUserMessage(
+          mutation.error,
+          t('Unable to verify the authentication code. Please try again.')
+        )
+      : null,
+    isPending: mutation.isPending,
+    reset: mutation.reset,
+    result: mutation.data ?? null,
+  };
+}
+
+export function useCancelSecondFactorAuth() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: () =>
+      fetchMutation<void>({
+        url: getApiUrl('/auth/2fa/'),
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      // Remove rather than invalidate because these methods belong to the cancelled
+      // MFA session. A later session must not render them while refetching or if the
+      // refetch fails.
+      queryClient.removeQueries({queryKey: secondFactorMethodsQueryOptions.queryKey});
+      queryClient.setQueryData(authConfigQueryOptions.queryKey, cachedResponse => {
+        if (!cachedResponse || 'nextUri' in cachedResponse.json) {
+          return cachedResponse;
+        }
+
+        return {
+          ...cachedResponse,
+          json: {...cachedResponse.json, pendingMfa: null},
+        };
+      });
+      void queryClient.invalidateQueries({queryKey: authConfigQueryOptions.queryKey});
+    },
+  });
+
+  return {
+    cancel: mutation.mutate,
+    errorMessage: mutation.error
+      ? getRequestErrorUserMessage(
+          mutation.error,
+          t('Unable to cancel two-factor authentication. Please try again.')
+        )
+      : null,
+    isPending: mutation.isPending,
+  };
+}


### PR DESCRIPTION
Adds query and mutation adapters for second-factor method discovery, SMS/WebAuthn challenge activation, OTP/WebAuthn completion, and cancellation. Challenge-capable methods and completion credentials remain narrowly typed to their wire payloads.

Successful cancellation clears `pendingMfa` in the raw auth-config cache immediately, then revalidates the config in the background. This lets the login UI return without depending on the refetch succeeding.
