### PR TITLE
feat(auth): Add two-factor authentication form

### DIFF
--- a/static/app/components/webAuthn/handlers.tsx
+++ b/static/app/components/webAuthn/handlers.tsx
@@ -72,7 +72,9 @@ export async function handleEnroll(challengeData: ChallengeData) {
 /**
  * Perform a WebAuthn assertion (login) using an existing credential.
  */
-export async function handleSign(challengeData: ChallengeData) {
+export async function handleSign(
+  challengeData: Pick<ChallengeData, 'webAuthnAuthenticationData'>
+) {
   if (!challengeData.webAuthnAuthenticationData) {
     return null;
   }

--- a/static/app/views/authV2/authLogin/components/recovery2faMethod.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/recovery2faMethod.spec.tsx
@@ -1,0 +1,22 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {Recovery2FAMethod} from './recovery2faMethod';
+import {mockElementFromPoint} from './testUtils';
+
+describe('Recovery2FAMethod', () => {
+  mockElementFromPoint();
+
+  it('submits an uppercase recovery code', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <Recovery2FAMethod isProcessing={false} onSubmit={onSubmit} resetKey={null} />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'One-time password'}),
+      'abcd1234'
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith('ABCD1234');
+  });
+});

--- a/static/app/views/authV2/authLogin/components/recovery2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/recovery2faMethod.tsx
@@ -1,0 +1,30 @@
+import {OTPInput} from '@sentry/scraps/input';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+interface Recovery2FAMethodProps {
+  isProcessing: boolean;
+  onSubmit: (otp: string) => void;
+  resetKey: string | null;
+}
+
+export function Recovery2FAMethod({
+  isProcessing,
+  onSubmit,
+  resetKey,
+}: Recovery2FAMethodProps) {
+  return (
+    <Stack gap="md" align="center">
+      <Text as="p">{t('Enter a one-time-use recovery code')}</Text>
+      <OTPInput
+        key={resetKey}
+        disabled={isProcessing}
+        format="AAAA-AAAA"
+        onComplete={onSubmit}
+        uppercase
+      />
+    </Stack>
+  );
+}

--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
@@ -1,0 +1,426 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as webAuthnHandlers from 'sentry/components/webAuthn/handlers';
+
+import {SecondFactorAuth} from './secondFactorAuth';
+import {mockElementFromPoint} from './testUtils';
+
+const publicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  'PublicKeyCredential'
+);
+
+describe('SecondFactorAuth', () => {
+  mockElementFromPoint();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+
+    if (publicKeyCredentialDescriptor) {
+      Object.defineProperty(window, 'PublicKeyCredential', publicKeyCredentialDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'PublicKeyCredential');
+    }
+  });
+
+  it('discovers methods and selects the highest-priority method', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      body: {
+        mfaRequired: true,
+        mfaMethods: [{id: 'recovery'}, {id: 'totp'}],
+      },
+    });
+
+    render(<SecondFactorAuth onBack={jest.fn()} onComplete={jest.fn()} />);
+
+    expect(
+      await screen.findByText('Enter the code from your Authenticator')
+    ).toBeInTheDocument();
+  });
+
+  it('does not reactivate SMS after switching methods', async () => {
+    const challengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {method: 'sms', expiresIn: 45},
+    });
+
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'sms'}, {id: 'recovery'}]}
+        onBack={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+
+    await screen.findByRole('button', {name: 'Resend (45)'});
+    await userEvent.click(screen.getByRole('button', {name: 'Use recovery code'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Use SMS code'}));
+
+    expect(await screen.findByRole('button', {name: 'Resend (45)'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(challengeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes a WebAuthn challenge without additional UI', async () => {
+    const user = UserFixture();
+    const onComplete = jest.fn();
+    const webAuthnResponse = {
+      keyHandle: 'key-handle',
+      clientData: 'client-data',
+      authenticatorData: 'authenticator-data',
+      signatureData: 'signature-data',
+    };
+    const handleSign = jest
+      .spyOn(webAuthnHandlers, 'handleSign')
+      .mockResolvedValue(JSON.stringify(webAuthnResponse));
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      configurable: true,
+      value: function PublicKeyCredential() {},
+    });
+    const challengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'challenge'},
+      },
+    });
+    const authRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user},
+    });
+
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'u2f'}]}
+        onBack={jest.fn()}
+        onComplete={onComplete}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'Waiting for passkey, biometric, or hardware key authentication...'
+      )
+    ).toBeInTheDocument();
+    await waitFor(() => expect(challengeRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(handleSign).toHaveBeenCalledWith({
+        webAuthnAuthenticationData: 'challenge',
+      })
+    );
+    await waitFor(() =>
+      expect(authRequest).toHaveBeenCalledWith(
+        '/auth/2fa/',
+        expect.objectContaining({
+          method: 'POST',
+          data: {method: 'u2f', response: webAuthnResponse},
+        })
+      )
+    );
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith({nextUri: '/organizations/', user})
+    );
+  });
+
+  it('requests a fresh WebAuthn challenge after submission fails', async () => {
+    const webAuthnResponse = {
+      keyHandle: 'key-handle',
+      clientData: 'client-data',
+      authenticatorData: 'authenticator-data',
+      signatureData: 'signature-data',
+    };
+    const handleSign = jest
+      .spyOn(webAuthnHandlers, 'handleSign')
+      .mockResolvedValueOnce(JSON.stringify(webAuthnResponse))
+      .mockResolvedValueOnce(null);
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      configurable: true,
+      value: function PublicKeyCredential() {},
+    });
+    const initialChallengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'initial-challenge'},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Invalid two-factor authentication credentials'},
+    });
+
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'u2f'}]}
+        onBack={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+
+    expect(
+      await screen.findByText('Invalid two-factor authentication credentials')
+    ).toBeVisible();
+    expect(initialChallengeRequest).toHaveBeenCalledTimes(1);
+    expect(handleSign).toHaveBeenCalledTimes(1);
+
+    const retryChallengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'retry-challenge'},
+      },
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+    await waitFor(() => expect(retryChallengeRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(handleSign).toHaveBeenLastCalledWith({
+        webAuthnAuthenticationData: 'retry-challenge',
+      })
+    );
+  });
+
+  it('ignores a WebAuthn assertion after switching methods', async () => {
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      configurable: true,
+      value: function PublicKeyCredential() {},
+    });
+    let resolveAssertion: ((response: string) => void) | undefined;
+    jest.spyOn(webAuthnHandlers, 'handleSign').mockReturnValue(
+      new Promise(resolve => {
+        resolveAssertion = resolve;
+      })
+    );
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'challenge'},
+      },
+    });
+    const authRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user: UserFixture()},
+    });
+
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'u2f'}, {id: 'recovery'}]}
+        onBack={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(resolveAssertion).toBeDefined());
+    await userEvent.click(screen.getByRole('button', {name: 'Use recovery code'}));
+    resolveAssertion?.(
+      JSON.stringify({
+        keyHandle: 'key-handle',
+        clientData: 'client-data',
+        authenticatorData: 'authenticator-data',
+        signatureData: 'signature-data',
+      })
+    );
+
+    await act(async () => {});
+    expect(authRequest).not.toHaveBeenCalled();
+  });
+
+  it('starts a new WebAuthn assertion after switching away and back', async () => {
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      configurable: true,
+      value: function PublicKeyCredential() {},
+    });
+    const handleSign = jest
+      .spyOn(webAuthnHandlers, 'handleSign')
+      .mockReturnValueOnce(new Promise(() => {}))
+      .mockResolvedValueOnce(null);
+    const challenges = ['initial-challenge', 'retry-challenge'];
+    const initialChallengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: () => ({
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: challenges.shift()},
+      }),
+    });
+
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'u2f'}, {id: 'recovery'}]}
+        onBack={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(handleSign).toHaveBeenCalledWith({
+        webAuthnAuthenticationData: 'initial-challenge',
+      })
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Use recovery code'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Use passkey'}));
+
+    await waitFor(() => expect(initialChallengeRequest).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(handleSign).toHaveBeenLastCalledWith({
+        webAuthnAuthenticationData: 'retry-challenge',
+      })
+    );
+  });
+
+  it('returns to login', async () => {
+    const onBack = jest.fn();
+    const cancelRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'DELETE',
+      statusCode: 204,
+    });
+    render(
+      <SecondFactorAuth methods={[{id: 'totp'}]} onBack={onBack} onComplete={jest.fn()} />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
+
+    await waitFor(() => expect(cancelRequest).toHaveBeenCalledTimes(1));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables navigation while authentication is pending', async () => {
+    const response = Promise.withResolvers<{
+      nextUri: string;
+      user: ReturnType<typeof UserFixture>;
+    }>();
+    const onComplete = jest.fn();
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      body: () => response.promise,
+    });
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'totp'}, {id: 'recovery'}]}
+        onBack={jest.fn()}
+        onComplete={onComplete}
+      />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'One-time password'}),
+      '123456'
+    );
+
+    expect(screen.getByRole('button', {name: 'Back to Login'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Use recovery code'})).toBeDisabled();
+    response.resolve({nextUri: '/organizations/', user: UserFixture()});
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+  });
+
+  it('disables authentication controls while cancellation is pending', async () => {
+    const response = Promise.withResolvers<undefined>();
+    const onBack = jest.fn();
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'DELETE',
+      statusCode: 204,
+      body: () => response.promise,
+    });
+    render(
+      <SecondFactorAuth
+        methods={[{id: 'totp'}, {id: 'recovery'}]}
+        onBack={onBack}
+        onComplete={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
+
+    expect(screen.getByRole('textbox', {name: 'One-time password'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Use recovery code'})).toBeDisabled();
+    response.resolve(undefined);
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
+  });
+
+  it('disables WebAuthn retry while cancellation is pending', async () => {
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      configurable: true,
+      value: function PublicKeyCredential() {},
+    });
+    jest
+      .spyOn(webAuthnHandlers, 'handleSign')
+      .mockRejectedValue(new Error('Authentication cancelled'));
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'challenge'},
+      },
+    });
+    const cancellation = Promise.withResolvers<undefined>();
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'DELETE',
+      statusCode: 204,
+      body: () => cancellation.promise,
+    });
+    const onBack = jest.fn();
+    render(
+      <SecondFactorAuth methods={[{id: 'u2f'}]} onBack={onBack} onComplete={jest.fn()} />
+    );
+
+    expect(await screen.findByRole('button', {name: 'Try again'})).toBeEnabled();
+    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
+
+    expect(screen.getByRole('button', {name: 'Try again'})).toBeDisabled();
+    cancellation.resolve(undefined);
+    await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
+  });
+
+  it('replaces a cancellation error when authentication fails', async () => {
+    const onBack = jest.fn();
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'DELETE',
+      statusCode: 500,
+      body: {detail: 'Cancellation failed'},
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/',
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Invalid authentication code'},
+    });
+    render(
+      <SecondFactorAuth methods={[{id: 'totp'}]} onBack={onBack} onComplete={jest.fn()} />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
+
+    expect(await screen.findByText('Cancellation failed')).toBeVisible();
+    expect(onBack).not.toHaveBeenCalled();
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'One-time password'}),
+      '123456'
+    );
+
+    expect(await screen.findByText('Invalid authentication code')).toBeVisible();
+    expect(screen.queryByText('Cancellation failed')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.tsx
@@ -1,0 +1,224 @@
+import {Activity, useEffect, useState} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {
+  type SecondFactorAuthResult,
+  type SecondFactorCredentials,
+  useCancelSecondFactorAuth,
+  useSecondFactorAuth,
+  useSecondFactorMethods,
+} from 'sentry/views/authV2/authLogin/hooks/useSecondFactorAuth';
+import type {MfaMethod} from 'sentry/views/authV2/authLogin/types';
+
+import {Recovery2FAMethod} from './recovery2faMethod';
+import {Sms2FAMethod} from './sms2faMethod';
+import {Totp2FAMethod} from './totp2faMethod';
+import {WebAuthn2FAMethod} from './webAuthn2faMethod';
+
+const SECOND_FACTOR_PRIORITY = [
+  'u2f',
+  'totp',
+  'sms',
+  'recovery',
+] as const satisfies ReadonlyArray<MfaMethod['id']>;
+
+interface SecondFactorAuthProps {
+  onBack: () => void;
+  onComplete: (result: SecondFactorAuthResult) => void;
+  methods?: MfaMethod[];
+}
+
+const METHOD_LABELS: Record<MfaMethod['id'], string> = {
+  u2f: t('Passkey, biometric, hardware key'),
+  totp: t('Authenticator app'),
+  sms: t('Text message'),
+  recovery: t('Recovery code'),
+};
+
+const USE_METHOD_LABELS: Record<MfaMethod['id'], string> = {
+  u2f: t('Use passkey'),
+  totp: t('Use authenticator'),
+  sms: t('Use SMS code'),
+  recovery: t('Use recovery code'),
+};
+
+export function SecondFactorAuth({
+  methods: providedMethods,
+  onBack,
+  onComplete,
+}: SecondFactorAuthProps) {
+  const methodsQuery = useSecondFactorMethods(providedMethods === undefined);
+  const methods = providedMethods ?? methodsQuery.data?.mfaMethods ?? [];
+  const sortedMethods = SECOND_FACTOR_PRIORITY.flatMap(id =>
+    methods.some(method => method.id === id) ? [{id} satisfies MfaMethod] : []
+  );
+  const [selectedMethod, setSelectedMethod] = useState<MfaMethod['id']>();
+  const activeMethod = sortedMethods.some(method => method.id === selectedMethod)
+    ? selectedMethod
+    : sortedMethods[0]?.id;
+  const auth = useSecondFactorAuth();
+  const cancellation = useCancelSecondFactorAuth();
+  const isProcessing = auth.isPending || cancellation.isPending;
+  const authenticate = (credentials: SecondFactorCredentials) => {
+    cancellation.reset();
+    auth.authenticate(credentials);
+  };
+
+  useEffect(() => {
+    if (auth.result) {
+      onComplete(auth.result);
+    }
+  }, [auth.result, onComplete]);
+
+  if (providedMethods === undefined && methodsQuery.isPending) {
+    return <Text variant="muted">{t('Loading authentication methods...')}</Text>;
+  }
+
+  if ((providedMethods === undefined && methodsQuery.isError) || !activeMethod) {
+    return (
+      <Alert.Container>
+        <Alert variant="danger" showIcon={false}>
+          {t('Unable to load authentication methods. Return to login and try again.')}
+        </Alert>
+      </Alert.Container>
+    );
+  }
+
+  const otherMethods = sortedMethods.filter(method => method.id !== activeMethod);
+  const onlyOtherMethod = otherMethods.length === 1 ? otherMethods[0] : undefined;
+  const selectMethod = (method: MfaMethod['id']) => {
+    auth.reset();
+    setSelectedMethod(method);
+  };
+
+  return (
+    <Stack gap="lg">
+      {(auth.errorMessage || cancellation.errorMessage) && (
+        <Alert.Container>
+          <Alert variant="danger" showIcon={false}>
+            {cancellation.errorMessage ?? auth.errorMessage}
+          </Alert>
+        </Alert.Container>
+      )}
+
+      {/* Preserve each method's local state across switches. Remounting the SMS
+          method would automatically request another challenge. */}
+      {sortedMethods.map(method => (
+        <Activity
+          key={method.id}
+          mode={method.id === activeMethod ? 'visible' : 'hidden'}
+        >
+          <MethodInput
+            method={method.id}
+            isActive={method.id === activeMethod}
+            isProcessing={isProcessing}
+            resetKey={auth.errorMessage}
+            onAuthenticate={authenticate}
+            onResetAuthentication={auth.reset}
+          />
+        </Activity>
+      ))}
+
+      <Flex align="center" justify="between">
+        <Button
+          variant="transparent"
+          size="xs"
+          icon={<IconArrow direction="left" />}
+          busy={cancellation.isPending}
+          disabled={auth.isPending}
+          onClick={() => cancellation.cancel(undefined, {onSuccess: onBack})}
+        >
+          {t('Back to Login')}
+        </Button>
+        {otherMethods.length > 1 ? (
+          <DropdownMenu
+            size="xs"
+            triggerLabel={t('Use Different Method')}
+            triggerProps={{
+              disabled: isProcessing,
+              size: 'xs',
+              variant: 'transparent',
+            }}
+            items={otherMethods.map(method => ({
+              key: method.id,
+              label: METHOD_LABELS[method.id],
+              onAction: () => selectMethod(method.id),
+            }))}
+          />
+        ) : onlyOtherMethod ? (
+          <Button
+            size="xs"
+            variant="transparent"
+            disabled={isProcessing}
+            onClick={() => selectMethod(onlyOtherMethod.id)}
+          >
+            {USE_METHOD_LABELS[onlyOtherMethod.id]}
+          </Button>
+        ) : null}
+      </Flex>
+    </Stack>
+  );
+}
+
+interface MethodInputProps {
+  isActive: boolean;
+  isProcessing: boolean;
+  method: MfaMethod['id'];
+  onAuthenticate: (credentials: SecondFactorCredentials) => void;
+  onResetAuthentication: () => void;
+  resetKey: string | null;
+}
+
+function MethodInput({
+  isActive,
+  isProcessing,
+  method,
+  onAuthenticate,
+  onResetAuthentication,
+  resetKey,
+}: MethodInputProps) {
+  switch (method) {
+    case 'u2f':
+      return (
+        <WebAuthn2FAMethod
+          isActive={isActive}
+          isProcessing={isProcessing}
+          submissionFailed={Boolean(resetKey)}
+          onRetrySubmission={onResetAuthentication}
+          onSubmit={response => onAuthenticate({method, response})}
+        />
+      );
+    case 'sms':
+      return (
+        <Sms2FAMethod
+          isActive={isActive && !isProcessing}
+          isProcessing={isProcessing}
+          onSubmit={otp => onAuthenticate({method, otp})}
+          resetKey={resetKey}
+        />
+      );
+    case 'recovery':
+      return (
+        <Recovery2FAMethod
+          isProcessing={isProcessing}
+          resetKey={resetKey}
+          onSubmit={otp => onAuthenticate({method, otp})}
+        />
+      );
+    case 'totp':
+      return (
+        <Totp2FAMethod
+          isProcessing={isProcessing}
+          resetKey={resetKey}
+          onSubmit={otp => onAuthenticate({method, otp})}
+        />
+      );
+  }
+}

--- a/static/app/views/authV2/authLogin/components/sms2faMethod.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/sms2faMethod.spec.tsx
@@ -1,0 +1,81 @@
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {Sms2FAMethod} from './sms2faMethod';
+
+describe('Sms2FAMethod', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('activates SMS and resends the challenge', async () => {
+    jest.useFakeTimers();
+    const challengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {method: 'sms', expiresIn: 45},
+    });
+    render(
+      <Sms2FAMethod isActive isProcessing={false} onSubmit={jest.fn()} resetKey={null} />
+    );
+
+    const resendButton = await screen.findByRole('button', {name: 'Resend (45)'});
+    expect(resendButton).toHaveAttribute('aria-disabled', 'true');
+
+    act(() => jest.advanceTimersByTime(45_000));
+    expect(screen.getByRole('button', {name: 'Resend'})).toBeEnabled();
+
+    jest.useRealTimers();
+    await userEvent.click(screen.getByRole('button', {name: 'Resend'}));
+
+    await waitFor(() => expect(challengeRequest).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole('button', {name: 'Resend (45)'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('shows the sending state until activation completes', async () => {
+    const activation = Promise.withResolvers<void>();
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      asyncDelay: activation.promise,
+      body: {method: 'sms', expiresIn: 45},
+    });
+    render(
+      <Sms2FAMethod isActive isProcessing={false} onSubmit={jest.fn()} resetKey={null} />
+    );
+
+    expect(await screen.findByText('Sending SMS second factor code...')).toBeVisible();
+    expect(screen.queryByRole('button', {name: /Resend/})).not.toBeInTheDocument();
+
+    act(() => activation.resolve());
+
+    expect(await screen.findByRole('button', {name: 'Resend (45)'})).toBeVisible();
+  });
+
+  it('allows a failed activation to be retried', async () => {
+    const initialRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      statusCode: 503,
+      body: {detail: 'Unable to send SMS code'},
+    });
+    render(
+      <Sms2FAMethod isActive isProcessing={false} onSubmit={jest.fn()} resetKey={null} />
+    );
+
+    expect(await screen.findByText('Unable to send SMS code')).toBeVisible();
+    expect(initialRequest).toHaveBeenCalledTimes(1);
+
+    const retryRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {method: 'sms', expiresIn: 45},
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+    await waitFor(() => expect(retryRequest).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('button', {name: 'Resend (45)'})).toBeVisible();
+  });
+});

--- a/static/app/views/authV2/authLogin/components/sms2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/sms2faMethod.tsx
@@ -1,0 +1,105 @@
+import {useEffect, useState} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {OTPInput} from '@sentry/scraps/input';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct} from 'sentry/locale';
+import {useSecondFactorChallenge} from 'sentry/views/authV2/authLogin/hooks/useSecondFactorAuth';
+
+interface Sms2FAMethodProps {
+  isActive: boolean;
+  isProcessing: boolean;
+  onSubmit: (otp: string) => void;
+  resetKey: string | null;
+}
+
+export function Sms2FAMethod({
+  isActive,
+  isProcessing,
+  onSubmit,
+  resetKey,
+}: Sms2FAMethodProps) {
+  const challenge = useSecondFactorChallenge();
+  const {activate} = challenge;
+  const [hasActivated, setHasActivated] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  useEffect(() => {
+    if (!isActive || hasActivated) {
+      return;
+    }
+
+    setHasActivated(true);
+    activate('sms');
+  }, [activate, hasActivated, isActive]);
+
+  useEffect(() => {
+    if (challenge.result?.method !== 'sms') {
+      return;
+    }
+
+    const expiresAt = challenge.result.activatedAt + challenge.result.expiresIn * 1000;
+    const updateCooldown = () => {
+      setResendCooldown(Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000)));
+    };
+
+    updateCooldown();
+    const interval = window.setInterval(() => {
+      updateCooldown();
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [challenge.result]);
+
+  const smsChallenge = challenge.result?.method === 'sms' ? challenge.result : null;
+
+  return (
+    <Stack gap="md" align="center">
+      {challenge.isPending || (!smsChallenge && !challenge.errorMessage) ? (
+        <Text as="p">{t('Sending SMS second factor code...')}</Text>
+      ) : challenge.errorMessage ? (
+        <Stack gap="sm" align="center">
+          <Alert.Container>
+            <Alert variant="danger" showIcon={false}>
+              {challenge.errorMessage}
+            </Alert>
+          </Alert.Container>
+          <Button
+            disabled={isProcessing}
+            size="xs"
+            variant="transparent"
+            onClick={() => challenge.activate('sms')}
+          >
+            {t('Try again')}
+          </Button>
+        </Stack>
+      ) : (
+        <Text as="p">
+          {tct('A code has been sent by text message. [resend]', {
+            resend: (
+              <Button
+                disabled={isProcessing || resendCooldown > 0}
+                size="zero"
+                variant="transparent"
+                onClick={() => challenge.activate('sms')}
+              >
+                {resendCooldown > 0
+                  ? tct('Resend ([seconds])', {seconds: resendCooldown})
+                  : t('Resend')}
+              </Button>
+            ),
+          })}
+        </Text>
+      )}
+      <OTPInput
+        key={resetKey}
+        disabled={isProcessing || !smsChallenge}
+        format="000000"
+        onComplete={onSubmit}
+      />
+    </Stack>
+  );
+}

--- a/static/app/views/authV2/authLogin/components/testUtils.ts
+++ b/static/app/views/authV2/authLogin/components/testUtils.ts
@@ -1,0 +1,18 @@
+export function mockElementFromPoint(): void {
+  const descriptor = Object.getOwnPropertyDescriptor(document, 'elementFromPoint');
+
+  beforeAll(() => {
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: jest.fn(() => null),
+    });
+  });
+
+  afterAll(() => {
+    if (descriptor) {
+      Object.defineProperty(document, 'elementFromPoint', descriptor);
+    } else {
+      Reflect.deleteProperty(document, 'elementFromPoint');
+    }
+  });
+}

--- a/static/app/views/authV2/authLogin/components/totp2faMethod.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/totp2faMethod.spec.tsx
@@ -1,0 +1,20 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {mockElementFromPoint} from './testUtils';
+import {Totp2FAMethod} from './totp2faMethod';
+
+describe('Totp2FAMethod', () => {
+  mockElementFromPoint();
+
+  it('submits a six-digit authentication code', async () => {
+    const onSubmit = jest.fn();
+    render(<Totp2FAMethod isProcessing={false} onSubmit={onSubmit} resetKey={null} />);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'One-time password'}),
+      '123456'
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith('123456');
+  });
+});

--- a/static/app/views/authV2/authLogin/components/totp2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/totp2faMethod.tsx
@@ -1,0 +1,25 @@
+import {OTPInput} from '@sentry/scraps/input';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+
+interface Totp2FAMethodProps {
+  isProcessing: boolean;
+  onSubmit: (otp: string) => void;
+  resetKey: string | null;
+}
+
+export function Totp2FAMethod({isProcessing, onSubmit, resetKey}: Totp2FAMethodProps) {
+  return (
+    <Stack gap="md" align="center">
+      <Text as="p">{t('Enter the code from your Authenticator')}</Text>
+      <OTPInput
+        key={resetKey}
+        disabled={isProcessing}
+        format="000000"
+        onComplete={onSubmit}
+      />
+    </Stack>
+  );
+}

--- a/static/app/views/authV2/authLogin/components/webAuthn2faMethod.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/webAuthn2faMethod.spec.tsx
@@ -1,0 +1,145 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import * as webAuthnHandlers from 'sentry/components/webAuthn/handlers';
+
+import {WebAuthn2FAMethod} from './webAuthn2faMethod';
+
+const publicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  'PublicKeyCredential'
+);
+
+describe('WebAuthn2FAMethod', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      configurable: true,
+      value: function PublicKeyCredential() {},
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+
+    if (publicKeyCredentialDescriptor) {
+      Object.defineProperty(window, 'PublicKeyCredential', publicKeyCredentialDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'PublicKeyCredential');
+    }
+  });
+
+  it('allows a failed assertion to be retried', async () => {
+    const retryAssertion = Promise.withResolvers<string | null>();
+    const handleSign = jest
+      .spyOn(webAuthnHandlers, 'handleSign')
+      .mockRejectedValueOnce(new Error('Authentication cancelled'))
+      .mockReturnValueOnce(retryAssertion.promise);
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'challenge'},
+      },
+    });
+    render(
+      <WebAuthn2FAMethod
+        isActive
+        isProcessing={false}
+        submissionFailed={false}
+        onRetrySubmission={jest.fn()}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    expect(
+      await screen.findByText('Passkey authentication was unsuccessful.')
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+    await waitFor(() => expect(handleSign).toHaveBeenCalledTimes(2));
+    retryAssertion.resolve(null);
+    expect(
+      await screen.findByText('Passkey authentication was unsuccessful.')
+    ).toBeInTheDocument();
+  });
+
+  it('requests a new challenge after activation fails', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      statusCode: 503,
+      body: {detail: 'Challenge unavailable'},
+    });
+    render(
+      <WebAuthn2FAMethod
+        isActive
+        isProcessing={false}
+        submissionFailed={false}
+        onRetrySubmission={jest.fn()}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText('Challenge unavailable')).toBeVisible();
+    const challengeRequest = MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'challenge'},
+      },
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Try again'}));
+
+    await waitFor(() => expect(challengeRequest).toHaveBeenCalledTimes(1));
+  });
+
+  it('preserves a pending assertion across an equivalent rerender', async () => {
+    let resolveAssertion: ((response: string) => void) | undefined;
+    const handleSign = jest.spyOn(webAuthnHandlers, 'handleSign').mockReturnValue(
+      new Promise(resolve => {
+        resolveAssertion = resolve;
+      })
+    );
+    MockApiClient.addMockResponse({
+      url: '/auth/2fa/challenge/',
+      method: 'POST',
+      body: {
+        method: 'u2f',
+        challenge: {webAuthnAuthenticationData: 'challenge'},
+      },
+    });
+    const onSubmit = jest.fn();
+    const {rerender} = render(
+      <WebAuthn2FAMethod
+        isActive
+        isProcessing={false}
+        submissionFailed={false}
+        onRetrySubmission={jest.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await waitFor(() => expect(resolveAssertion).toBeDefined());
+    rerender(
+      <WebAuthn2FAMethod
+        isActive
+        isProcessing={false}
+        submissionFailed={false}
+        onRetrySubmission={jest.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+    resolveAssertion?.(
+      JSON.stringify({
+        keyHandle: 'key-handle',
+        clientData: 'client-data',
+        authenticatorData: 'authenticator-data',
+        signatureData: 'signature-data',
+      })
+    );
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSign).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
@@ -1,0 +1,153 @@
+import {useEffect, useEffectEvent, useState} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {handleSign} from 'sentry/components/webAuthn/handlers';
+import {t} from 'sentry/locale';
+import {
+  type WebAuthnResponse,
+  useSecondFactorChallenge,
+} from 'sentry/views/authV2/authLogin/hooks/useSecondFactorAuth';
+
+interface WebAuthn2FAMethodProps {
+  isActive: boolean;
+  isProcessing: boolean;
+  onRetrySubmission: () => void;
+  onSubmit: (response: WebAuthnResponse) => void;
+  submissionFailed: boolean;
+}
+
+type WebAuthnError = 'unsupported' | 'failed';
+
+export function WebAuthn2FAMethod({
+  isActive,
+  isProcessing,
+  onRetrySubmission,
+  onSubmit,
+  submissionFailed,
+}: WebAuthn2FAMethodProps) {
+  const challenge = useSecondFactorChallenge();
+  const {activate, reset} = challenge;
+  const [hasActivated, setHasActivated] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [error, setError] = useState<WebAuthnError | null>(null);
+  const submitResponse = useEffectEvent(onSubmit);
+
+  useEffect(() => {
+    if (!isActive || hasActivated) {
+      return;
+    }
+
+    setHasActivated(true);
+    activate('u2f');
+  }, [activate, hasActivated, isActive]);
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    return () => {
+      reset();
+      setHasActivated(false);
+    };
+  }, [isActive, reset]);
+
+  useEffect(() => {
+    if (!isActive || challenge.result?.method !== 'u2f') {
+      return;
+    }
+
+    setError(null);
+
+    if (!window.PublicKeyCredential) {
+      setError('unsupported');
+      return;
+    }
+
+    const webAuthnChallenge = challenge.result.challenge;
+    let cancelled = false;
+
+    async function authenticate() {
+      try {
+        const response = await handleSign(webAuthnChallenge);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (!response) {
+          setError('failed');
+          return;
+        }
+
+        submitResponse(JSON.parse(response) as WebAuthnResponse);
+      } catch (caughtError) {
+        if (cancelled) {
+          return;
+        }
+
+        Sentry.captureException(caughtError);
+        setError('failed');
+      }
+    }
+
+    void authenticate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt, challenge.result, isActive]);
+
+  const errorMessage = challenge.errorMessage
+    ? challenge.errorMessage
+    : error === 'unsupported'
+      ? t('This browser does not support passkey authentication.')
+      : error === 'failed'
+        ? t('Passkey authentication was unsuccessful.')
+        : null;
+
+  if (errorMessage || submissionFailed) {
+    const retry = submissionFailed
+      ? () => {
+          onRetrySubmission();
+          challenge.reset();
+          setHasActivated(false);
+        }
+      : challenge.errorMessage
+        ? () => {
+            challenge.reset();
+            setHasActivated(false);
+          }
+        : error === 'failed'
+          ? () => {
+              setError(null);
+              setAttempt(value => value + 1);
+            }
+          : undefined;
+
+    return (
+      <Stack gap="sm" align="center">
+        {errorMessage && (
+          <Text as="p" variant="danger" align="center">
+            {errorMessage}
+          </Text>
+        )}
+        {retry && (
+          <Button disabled={isProcessing} size="xs" variant="transparent" onClick={retry}>
+            {t('Try again')}
+          </Button>
+        )}
+      </Stack>
+    );
+  }
+
+  return (
+    <Text as="p" align="center">
+      {t('Waiting for passkey, biometric, or hardware key authentication...')}
+    </Text>
+  );
+}

--- a/static/app/views/authV2/authLogin/hooks/useSecondFactorAuth.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useSecondFactorAuth.tsx
@@ -152,5 +152,6 @@ export function useCancelSecondFactorAuth() {
         )
       : null,
     isPending: mutation.isPending,
+    reset: mutation.reset,
   };
 }


### PR DESCRIPTION
Adds the multi-method second-factor surface for TOTP, recovery codes, SMS, and WebAuthn. The component preserves challenge state across method switches, cancels stale WebAuthn assertions, and starts a fresh assertion when the user returns to passkeys.

Back to Login cancels the server-side pending MFA flow before leaving the form. Authentication, cancellation, method switching, resend, and WebAuthn controls are mutually disabled while competing requests are pending, with regression coverage for races and cancellation failures.
