### PR TITLE
feat(auth): Add organization selector

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationSlugInput.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationSlugInput.spec.tsx
@@ -1,0 +1,182 @@
+import {QueryClientProvider} from '@tanstack/react-query';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {AuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
+
+import {OrganizationSlugInput} from './organizationSlugInput';
+
+describe('OrganizationSlugInput', () => {
+  it('selects the located organization', async () => {
+    const onSelect = jest.fn();
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      body: {
+        authenticated: false,
+        memberAuthenticated: false,
+        canRegister: false,
+        joinRequestUrl: null,
+        loginMethod: 'sso',
+        ssoRequired: true,
+        organization: {avatarUrl: null, name: 'Acme', slug: 'acme'},
+        provider: {key: 'dummy', name: 'Dummy'},
+        warnings: [],
+      },
+    });
+    render(<OrganizationSlugInput onCancel={jest.fn()} onSelect={onSelect} />);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Organization Slug'}),
+      'acme'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith('acme'));
+  });
+
+  it('latches an invalid organization until the slug changes', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/organizations/missing/config/',
+      statusCode: 404,
+      body: {detail: 'Organization not found'},
+    });
+    const onCancel = jest.fn();
+    const onSelect = jest.fn();
+    const {rerender} = render(
+      <OrganizationSlugInput onCancel={onCancel} onSelect={onSelect} />
+    );
+
+    const input = screen.getByRole('textbox', {name: 'Organization Slug'});
+    await userEvent.type(input, 'missing');
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Organization not found');
+    expect(input).toHaveAccessibleDescription('Organization not found');
+    await waitFor(() =>
+      expect(document.querySelector('[data-tooltip]')).toHaveTextContent(
+        'Organization not found'
+      )
+    );
+    expect(screen.queryByRole('button', {name: 'Locate'})).not.toBeInTheDocument();
+    await waitFor(() => expect(input).toHaveFocus());
+    expect(input).toHaveProperty('selectionStart', 0);
+    expect(input).toHaveProperty('selectionEnd', 'missing'.length);
+
+    const cancelButton = screen.getByRole('button', {name: 'Cancel organization SSO'});
+    await userEvent.click(cancelButton);
+    rerender(<OrganizationSlugInput onCancel={onCancel} onSelect={onSelect} />);
+    expect(cancelButton).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await userEvent.type(input, '-new');
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Locate'})).toBeInTheDocument();
+  });
+
+  it('allows a failed organization lookup to be retried', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      statusCode: 503,
+      body: {detail: 'Organization authentication is temporarily unavailable'},
+    });
+    render(<OrganizationSlugInput onCancel={jest.fn()} onSelect={jest.fn()} />);
+
+    const input = screen.getByRole('textbox', {name: 'Organization Slug'});
+    await userEvent.type(input, 'acme');
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Unable to load organization authentication. Please try again.'
+    );
+    expect(
+      screen.getByRole('textbox', {name: 'Organization Slug'})
+    ).toHaveAccessibleDescription(
+      'Unable to load organization authentication. Please try again.'
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(input).toHaveFocus());
+    expect(input).toHaveProperty('selectionStart', 0);
+    expect(input).toHaveProperty('selectionEnd', 'acme'.length);
+  });
+
+  it('does not select stale cached data when its refetch fails', async () => {
+    const queryClient = makeTestQueryClient();
+    const queryOptions = apiOptions.as<AuthOrganization>()(
+      '/auth/organizations/$organizationIdOrSlug/config/',
+      {path: {organizationIdOrSlug: 'acme'}, staleTime: 0}
+    );
+    queryClient.setQueryData(queryOptions.queryKey, {
+      headers: {},
+      json: {
+        authenticated: false,
+        memberAuthenticated: false,
+        canRegister: false,
+        joinRequestUrl: null,
+        loginMethod: 'sso',
+        ssoRequired: true,
+        organization: {avatarUrl: null, name: 'Acme', slug: 'acme'},
+        provider: {key: 'dummy', name: 'Dummy'},
+        warnings: [],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      statusCode: 503,
+      body: {detail: 'Organization authentication is temporarily unavailable'},
+    });
+    const onSelect = jest.fn();
+    render(<OrganizationSlugInput onCancel={jest.fn()} onSelect={onSelect} />, {
+      additionalWrapper: ({children}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Organization Slug'}),
+      'acme'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Unable to load organization authentication. Please try again.'
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('exits organization selection', async () => {
+    const onCancel = jest.fn();
+    render(<OrganizationSlugInput onCancel={onCancel} onSelect={jest.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel organization SSO'}));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('allows organization selection to be canceled while locating', async () => {
+    const lookup = Promise.withResolvers<void>();
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      asyncDelay: lookup.promise,
+      body: {},
+    });
+    const onCancel = jest.fn();
+    render(<OrganizationSlugInput onCancel={onCancel} onSelect={jest.fn()} />);
+
+    const input = screen.getByRole('textbox', {name: 'Organization Slug'});
+    await userEvent.type(input, 'acme');
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
+    expect(input).toHaveAttribute('readonly');
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel organization SSO'}));
+
+    expect(onCancel).toHaveBeenCalled();
+    lookup.resolve();
+  });
+});

--- a/static/app/views/authV2/authLogin/components/organizationSlugInput.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationSlugInput.tsx
@@ -1,0 +1,142 @@
+import {useEffect, useId, useLayoutEffect, useRef, useState} from 'react';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
+
+import {Button} from '@sentry/scraps/button';
+import {InputGroup} from '@sentry/scraps/input';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconClose, IconExclamation} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {isNotFoundError} from 'sentry/utils/requestError/requestError';
+import {useAuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
+
+interface OrganizationSlugInputProps {
+  onCancel: () => void;
+  onSelect: (organizationSlug: string) => void;
+}
+
+export function OrganizationSlugInput({onCancel, onSelect}: OrganizationSlugInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const errorDescriptionId = useId();
+  const [slug, setSlug] = useState('');
+  const [submittedSlug, setSubmittedSlug] = useState<string>();
+  const normalizedSlug = slug.trim();
+  const organizationQuery = useAuthOrganization(submittedSlug);
+  const hasError = Boolean(submittedSlug && organizationQuery.isError);
+  const organizationNotFound = hasError && isNotFoundError(organizationQuery.error);
+  const errorMessage = hasError
+    ? organizationNotFound
+      ? t('Organization not found')
+      : t('Unable to load organization authentication. Please try again.')
+    : null;
+
+  useEffect(() => {
+    if (
+      !submittedSlug ||
+      !organizationQuery.data ||
+      organizationQuery.isFetching ||
+      organizationQuery.isError
+    ) {
+      return;
+    }
+
+    onSelect(submittedSlug);
+  }, [
+    onSelect,
+    organizationQuery.data,
+    organizationQuery.isError,
+    organizationQuery.isFetching,
+    submittedSlug,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!submittedSlug || !organizationQuery.error) {
+      return;
+    }
+
+    const animationFrame = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [organizationQuery.error, submittedSlug]);
+
+  return (
+    <form
+      onSubmit={event => {
+        event.preventDefault();
+
+        if (!normalizedSlug) {
+          return;
+        }
+
+        if (organizationNotFound) {
+          return;
+        }
+
+        if (submittedSlug === normalizedSlug && organizationQuery.isError) {
+          void organizationQuery.refetch();
+          return;
+        }
+
+        setSubmittedSlug(normalizedSlug);
+      }}
+    >
+      <InputGroup>
+        <InputGroup.Input
+          ref={inputRef}
+          aria-describedby={errorMessage ? errorDescriptionId : undefined}
+          aria-label={t('Organization Slug')}
+          autoCapitalize="none"
+          autoComplete="off"
+          autoFocus
+          data-1p-ignore
+          placeholder={t('Organization Slug')}
+          readOnly={organizationQuery.isFetching}
+          spellCheck={false}
+          value={slug}
+          aria-invalid={hasError}
+          onChange={event => {
+            const nextSlug = event.currentTarget.value;
+            setSlug(nextSlug);
+
+            if (submittedSlug && nextSlug.trim() !== submittedSlug) {
+              setSubmittedSlug(undefined);
+            }
+          }}
+        />
+        <InputGroup.TrailingItems>
+          {errorMessage ? (
+            <Tooltip forceVisible skipWrapper title={errorMessage}>
+              <IconExclamation aria-hidden size="sm" variant="danger" />
+            </Tooltip>
+          ) : null}
+          {!organizationNotFound && normalizedSlug ? (
+            <Button
+              busy={organizationQuery.isFetching}
+              size="zero"
+              type="submit"
+              variant="transparent"
+            >
+              {t('Locate')}
+            </Button>
+          ) : null}
+          <Button
+            aria-label={t('Cancel organization SSO')}
+            icon={<IconClose />}
+            size="zero"
+            tooltipProps={{title: t('Cancel organization SSO')}}
+            variant="transparent"
+            onClick={onCancel}
+          />
+        </InputGroup.TrailingItems>
+      </InputGroup>
+      {errorMessage && (
+        <VisuallyHidden id={errorDescriptionId} role="alert">
+          {errorMessage}
+        </VisuallyHidden>
+      )}
+    </form>
+  );
+}

--- a/static/app/views/authV2/authLogin/hooks/useAuthOrganization.spec.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useAuthOrganization.spec.tsx
@@ -1,0 +1,41 @@
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useAuthOrganization} from './useAuthOrganization';
+
+describe('useAuthOrganization', () => {
+  it('fetches the organization authentication configuration', async () => {
+    const response = {
+      authenticated: false,
+      memberAuthenticated: false,
+      canRegister: false,
+      joinRequestUrl: '/join-request/acme/',
+      loginMethod: 'sso' as const,
+      ssoRequired: true,
+      organization: {
+        avatarUrl: null,
+        name: 'Acme',
+        slug: 'acme',
+      },
+      provider: {
+        key: 'dummy',
+        name: 'Dummy',
+      },
+      warnings: [],
+    };
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      body: response,
+    });
+
+    const {result} = renderHookWithProviders(() => useAuthOrganization('acme'));
+
+    await waitFor(() => expect(result.current.data).toEqual(response));
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch without an organization slug', () => {
+    const {result} = renderHookWithProviders(() => useAuthOrganization());
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/static/app/views/authV2/authLogin/hooks/useAuthOrganization.tsx
+++ b/static/app/views/authV2/authLogin/hooks/useAuthOrganization.tsx
@@ -1,0 +1,34 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+
+export type AuthOrganization = {
+  authenticated: boolean;
+  canRegister: boolean;
+  joinRequestUrl: string | null;
+  loginMethod: 'password' | 'sso';
+  memberAuthenticated: boolean;
+  organization: {
+    avatarUrl: string | null;
+    name: string;
+    slug: string;
+  };
+  provider: {
+    key: string;
+    name: string;
+  } | null;
+  ssoRequired: boolean;
+  warnings: string[];
+};
+
+export function useAuthOrganization(organizationSlug?: string) {
+  return useQuery(
+    apiOptions.as<AuthOrganization>()(
+      '/auth/organizations/$organizationIdOrSlug/config/',
+      {
+        path: organizationSlug ? {organizationIdOrSlug: organizationSlug} : skipToken,
+        staleTime: 0,
+      }
+    )
+  );
+}


### PR DESCRIPTION
Adds organization lookup and an accessible organization-slug selector. Missing organizations remain latched until input changes, while transient or provider failures are described truthfully and can be retried without changing the slug.