### PR TITLE
feat(auth): Add organization authentication card

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
@@ -1,0 +1,98 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {AuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
+
+import {OrganizationAuth} from './organizationAuth';
+
+const authOrganization: AuthOrganization = {
+  authenticated: false,
+  memberAuthenticated: false,
+  canRegister: false,
+  joinRequestUrl: '/join-request/acme/',
+  loginMethod: 'sso',
+  ssoRequired: true,
+  organization: {
+    avatarUrl: 'https://example.com/avatar.png',
+    name: 'Acme',
+    slug: 'acme',
+  },
+  provider: {
+    key: 'saml2',
+    name: 'SAML',
+  },
+  warnings: [],
+};
+
+describe('OrganizationAuth', () => {
+  it('renders organization SSO and join request actions', async () => {
+    const onClear = jest.fn();
+    render(<OrganizationAuth authOrganization={authOrganization} onClear={onClear} />);
+
+    expect(screen.getByText('Acme')).toBeInTheDocument();
+    expect(screen.getByText('Requires').parentElement).toHaveTextContent(
+      'Requires sign in with SAML'
+    );
+    const ssoButton = screen.getByRole('button', {name: 'SSO'});
+    expect(ssoButton).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Request to join'})).toHaveAttribute(
+      'href',
+      '/join-request/acme/'
+    );
+    expect(ssoButton.closest('form')).toHaveAttribute('method', 'POST');
+    expect(ssoButton.closest('form')).toHaveFormValues({init: '1'});
+
+    const clearButton = screen.getByRole('button', {
+      name: 'Clear organization login context',
+    });
+    await userEvent.hover(clearButton);
+    expect(
+      await screen.findByText('Clear organization login context')
+    ).toBeInTheDocument();
+
+    await userEvent.click(clearButton);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables SSO and explains when it is not configured', async () => {
+    render(
+      <OrganizationAuth
+        authOrganization={{
+          ...authOrganization,
+          joinRequestUrl: null,
+          loginMethod: 'password',
+          provider: null,
+          ssoRequired: false,
+        }}
+        onClear={jest.fn()}
+      />
+    );
+
+    const ssoButton = screen.getByRole('button', {name: 'SSO'});
+    expect(ssoButton).toBeDisabled();
+    expect(
+      screen.getByText('Members sign in with email and password')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('This organization does not have Single Sign-On configured')
+    ).not.toBeInTheDocument();
+    await userEvent.hover(ssoButton.parentElement!);
+    expect(
+      await screen.findByText('This organization does not have Single Sign-On configured')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Request to join'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('describes optional SSO for members', () => {
+    render(
+      <OrganizationAuth
+        authOrganization={{...authOrganization, ssoRequired: false}}
+        onClear={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Members sign in with SAML')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'SSO'})).toBeEnabled();
+  });
+});

--- a/static/app/views/authV2/authLogin/components/organizationAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.tsx
@@ -1,0 +1,170 @@
+import styled from '@emotion/styled';
+
+import {Avatar} from '@sentry/scraps/avatar';
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconClose, IconMegaphone} from 'sentry/icons';
+import {IdentityIcon} from 'sentry/icons/identityIcon';
+import {t, tct} from 'sentry/locale';
+import {getCsrfToken} from 'sentry/utils/getCsrfToken';
+import type {AuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
+
+interface OrganizationAuthProps {
+  authOrganization: AuthOrganization;
+  onClear?: () => void;
+}
+
+export function OrganizationAuth({authOrganization, onClear}: OrganizationAuthProps) {
+  const {organization, provider, joinRequestUrl, ssoRequired} = authOrganization;
+  const avatarProps = organization.avatarUrl
+    ? ({
+        type: 'upload',
+        uploadUrl: organization.avatarUrl,
+        identifier: organization.slug,
+        name: organization.name,
+      } as const)
+    : ({
+        type: 'letter_avatar',
+        identifier: organization.slug,
+        name: organization.name,
+      } as const);
+  const description = provider
+    ? ssoRequired
+      ? tct('[requires:Requires] sign in with [icon] [provider]', {
+          requires: (
+            <Text as="span" bold>
+              {null}
+            </Text>
+          ),
+          icon: <InlineIdentityIcon providerId={provider.key} />,
+          provider: provider.name,
+        })
+      : tct('Members sign in with [icon] [provider]', {
+          icon: <InlineIdentityIcon providerId={provider.key} />,
+          provider: provider.name,
+        })
+    : t('Members sign in with email and password');
+  const orgBadge = (
+    <Flex align="center" gap="md" flex="1" minWidth="0">
+      <Avatar {...avatarProps} size={32} />
+      <Stack gap="2xs" flex="1" minWidth="0">
+        <Text bold ellipsis>
+          {organization.name}
+        </Text>
+        <Text size="xs" variant="muted">
+          {description}
+        </Text>
+      </Stack>
+    </Flex>
+  );
+  const ssoAction = (
+    <form method="POST">
+      <input type="hidden" name="csrfmiddlewaretoken" value={getCsrfToken()} />
+      <input type="hidden" name="init" value="1" />
+      <Tooltip
+        disabled={Boolean(provider)}
+        title={t('This organization does not have Single Sign-On configured')}
+      >
+        <Button
+          disabled={!provider}
+          type="submit"
+          variant={provider ? 'primary' : undefined}
+        >
+          {t('SSO')}
+        </Button>
+      </Tooltip>
+    </form>
+  );
+
+  return (
+    <OrganizationCardStack
+      gap="0"
+      border="secondary"
+      radius="md"
+      overflow="hidden"
+      position="relative"
+    >
+      <Flex align="center" gap="lg" padding="lg">
+        {orgBadge}
+        {ssoAction}
+      </Flex>
+
+      {joinRequestUrl && (
+        <Flex
+          align="center"
+          justify="between"
+          gap="lg"
+          borderTop="secondary"
+          padding="sm lg"
+        >
+          <Text size="sm">{t('Not a member?')}</Text>
+          <LinkButton
+            href={joinRequestUrl}
+            icon={<IconMegaphone />}
+            size="xs"
+            variant="transparent"
+          >
+            {t('Request to join')}
+          </LinkButton>
+        </Flex>
+      )}
+      {onClear && (
+        <ClearButton
+          aria-label={t('Clear organization login context')}
+          icon={<IconClose />}
+          size="zero"
+          tooltipProps={{title: t('Clear organization login context')}}
+          variant="transparent"
+          onClick={onClear}
+        />
+      )}
+    </OrganizationCardStack>
+  );
+}
+
+const ClearButton = styled(Button)`
+  position: absolute;
+  top: calc(${p => p.theme.space.lg} + 18px);
+  left: calc(100% + ${p => p.theme.space.md});
+  translate: 0 -50%;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 100ms ease;
+
+  @media (hover: none) {
+    opacity: 1;
+    pointer-events: auto;
+  }
+`;
+
+const InlineIdentityIcon = styled(IdentityIcon)`
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  vertical-align: text-bottom;
+  background: transparent;
+
+  > div {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+const OrganizationCardStack = styled(Stack)`
+  &::before {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    left: 100%;
+    width: 42px;
+  }
+
+  &:hover ${ClearButton},
+  &:focus-within ${ClearButton} {
+    opacity: 1;
+    pointer-events: auto;
+  }
+`;


### PR DESCRIPTION
Adds the organization-authentication card shown after slug lookup. It distinguishes required, optional, and unavailable SSO; submits provider login through the existing CSRF-protected browser POST flow; and exposes join-request and clear-context actions when available.

Provider branding uses the generalized inline `IdentityIcon` from the preceding prerequisite PR.