### PR TITLE
test(auth): Cover organization login composition

### DIFF
--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
@@ -107,6 +108,136 @@ describe('AuthLogin', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('focuses organization SSO when the authenticated user still requires it', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/config/',
+      body: {nextUri: '/organizations/acme/issues/'},
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      body: {
+        authenticated: true,
+        memberAuthenticated: false,
+        canRegister: false,
+        joinRequestUrl: null,
+        loginMethod: 'sso',
+        ssoRequired: true,
+        organization: {avatarUrl: null, name: 'Acme', slug: 'acme'},
+        provider: {key: 'saml2', name: 'SAML'},
+        warnings: [],
+      },
+    });
+
+    render(<AuthLogin />, {
+      initialRouterConfig: {
+        location: {pathname: '/auth/login/acme/'},
+        route: '/auth/login/:orgSlug/',
+      },
+    });
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'SSO'})).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Clear organization login context'})
+    ).not.toBeInTheDocument();
+    expect(testableWindowLocation.assign).not.toHaveBeenCalled();
+  });
+
+  it('redirects when the authenticated user can access the organization', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/config/',
+      body: {nextUri: '/organizations/acme/issues/'},
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      body: {
+        authenticated: true,
+        memberAuthenticated: true,
+        canRegister: false,
+        joinRequestUrl: null,
+        loginMethod: 'sso',
+        ssoRequired: true,
+        organization: {avatarUrl: null, name: 'Acme', slug: 'acme'},
+        provider: {key: 'saml2', name: 'SAML'},
+        warnings: [],
+      },
+    });
+
+    render(<AuthLogin />, {
+      initialRouterConfig: {
+        location: {pathname: '/auth/login/acme/'},
+        route: '/auth/login/:orgSlug/',
+      },
+    });
+
+    await waitFor(() =>
+      expect(testableWindowLocation.assign).toHaveBeenCalledWith(
+        '/organizations/acme/issues/'
+      )
+    );
+    expect(
+      screen.queryByRole('heading', {name: 'Sign in to Sentry'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('redirects when the authenticated organization is not found', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/config/',
+      body: {nextUri: '/organizations/acme/issues/'},
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      statusCode: 404,
+      body: {detail: 'Organization not found'},
+    });
+
+    render(<AuthLogin />, {
+      initialRouterConfig: {
+        location: {pathname: '/auth/login/acme/'},
+        route: '/auth/login/:orgSlug/',
+      },
+    });
+
+    await waitFor(() =>
+      expect(testableWindowLocation.assign).toHaveBeenCalledWith(
+        '/organizations/acme/issues/'
+      )
+    );
+    expect(
+      screen.queryByRole('heading', {name: 'Sign in to Sentry'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a retry when the authenticated organization lookup fails', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/config/',
+      body: {nextUri: '/organizations/acme/issues/'},
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      statusCode: 503,
+      body: {detail: 'Provider unavailable'},
+    });
+
+    render(<AuthLogin />, {
+      initialRouterConfig: {
+        location: {pathname: '/auth/login/acme/'},
+        route: '/auth/login/:orgSlug/',
+      },
+    });
+
+    expect(
+      await screen.findByText(
+        'Unable to load organization authentication. Please try again.'
+      )
+    ).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeEnabled();
+    expect(testableWindowLocation.assign).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
+  });
+
   it('renders authentication providers from the auth config', async () => {
     MockApiClient.addMockResponse({
       url: '/auth/config/',
@@ -211,5 +342,103 @@ describe('AuthLogin', () => {
 
     expect(await screen.findByRole('heading', {name: 'Sign in to Sentry'})).toBeVisible();
     expect(screen.queryByRole('link', {name: 'Learn more'})).not.toBeInTheDocument();
+  });
+  it('replaces organization lookup with the organization context', async () => {
+    MockApiClient.addMockResponse({
+      url: '/auth/config/',
+      body: {
+        canRegister: true,
+        githubLoginLink: '',
+        googleLoginLink: '',
+        hasNewsletter: false,
+        pendingMfa: null,
+        serverHostname: 'sentry.example.com',
+        vstsLoginLink: '',
+      } satisfies AuthConfig,
+    });
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      body: {
+        authenticated: false,
+        memberAuthenticated: false,
+        canRegister: false,
+        joinRequestUrl: '/join-request/acme/',
+        loginMethod: 'sso',
+        ssoRequired: true,
+        organization: {avatarUrl: null, name: 'Acme', slug: 'acme'},
+        provider: {key: 'saml2', name: 'SAML'},
+        warnings: [],
+      },
+    });
+
+    const {router} = render(<AuthLogin />, {
+      initialRouterConfig: {
+        location: {pathname: '/auth/login/acme/'},
+        route: '/auth/login/:orgSlug?/',
+      },
+    });
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Organization SSO'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'SSO'})).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Clear organization login context'})
+    );
+    expect(router.location.pathname).toBe('/auth/login/');
+  });
+
+  it('performs a full-page navigation after password authentication', async () => {
+    mockAuthConfig();
+    MockApiClient.addMockResponse({
+      url: '/auth/organizations/acme/config/',
+      body: {
+        authenticated: false,
+        memberAuthenticated: false,
+        canRegister: false,
+        joinRequestUrl: null,
+        loginMethod: 'password',
+        ssoRequired: false,
+        organization: {avatarUrl: null, name: 'Acme', slug: 'acme'},
+        provider: null,
+        warnings: [],
+      },
+    });
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: 'https://acme.sentry.io/issues/', user: UserFixture()},
+    });
+
+    render(<AuthLogin />, {
+      initialRouterConfig: {
+        location: {pathname: '/auth/login/acme/'},
+        route: '/auth/login/:orgSlug/',
+      },
+    });
+
+    await userEvent.type(
+      await screen.findByRole('textbox', {name: 'Email'}),
+      'user@example.com'
+    );
+    await userEvent.type(screen.getByLabelText('Password'), 'secret');
+    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        '/auth/login/',
+        expect.objectContaining({
+          method: 'POST',
+          data: {username: 'user@example.com', password: 'secret', orgSlug: 'acme'},
+        })
+      )
+    );
+    await waitFor(() =>
+      expect(testableWindowLocation.assign).toHaveBeenCalledWith(
+        'https://acme.sentry.io/issues/'
+      )
+    );
   });
 });


### PR DESCRIPTION
Adds organization-aware composition coverage: required SSO focus, authenticated organization redirects, 404 fallback, retryable 503 behavior, clearing organization context, and forwarding the selected slug through password login.