### PR TITLE
feat(workflow_engine): Comprehensive debug logging for LatestAdoptedReleaseConditionHandler

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
-from sentry.models.release import follows_semver_versioning_scheme
+from sentry.models.release import Release, follows_semver_versioning_scheme
 from sentry.rules.age import AgeComparisonType, ModelAgeType
 from sentry.rules.filters.latest_adopted_release_filter import (
     get_first_last_release_for_event,
@@ -15,6 +15,9 @@ from sentry.workflow_engine.handlers.condition.latest_release_handler import (
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+from sentry.workflow_engine.utils import log_context
+
+logger = log_context.get_logger(__name__)
 
 
 @condition_handler_registry.register(Condition.LATEST_ADOPTED_RELEASE)
@@ -40,10 +43,33 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventDat
         age_comparison = comparison["age_comparison"]
         environment_name = comparison["environment"]
 
+        environment: Environment | None = None
+        latest_project_release: Release | None = None
+        release: Release | None = None
+        order_type: LatestReleaseOrders | None = None
+
+        def log_result(result: bool) -> bool:
+            logger.debug(
+                "workflow_engine.handlers.latest_adopted_release_handler",
+                extra={
+                    "configured_environment": environment_name,
+                    "environment": environment.name if environment else None,
+                    "latest_project_release": (
+                        latest_project_release.version if latest_project_release else None
+                    ),
+                    "event_release": release.version if release else None,
+                    "release_age_type": release_age_type,
+                    "order_type": order_type.name if order_type else None,
+                    "age_comparison": age_comparison,
+                    "evaluation_result": result,
+                },
+            )
+            return result
+
         event = event_data.event
         if isinstance(event, Activity):
             # If the event is an Activity, we cannot determine the latest adopted release
-            return False
+            return log_result(False)
 
         if follows_semver_versioning_scheme(event.organization.id, event.project.id):
             order_type = LatestReleaseOrders.SEMVER
@@ -55,19 +81,19 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventDat
                 event.project.organization_id, environment_name
             )
         except Environment.DoesNotExist:
-            return False
+            return log_result(False)
 
         latest_project_release = get_latest_adopted_release_for_env(environment, event)
         if not latest_project_release:
-            return False
+            return log_result(False)
 
         release = get_first_last_release_for_event(event, release_age_type, order_type)
         if not release:
-            return False
+            return log_result(False)
 
         if age_comparison == AgeComparisonType.NEWER:
-            return is_newer_release(release, latest_project_release, order_type)
+            return log_result(is_newer_release(release, latest_project_release, order_type))
         elif age_comparison == AgeComparisonType.OLDER:
-            return is_newer_release(latest_project_release, release, order_type)
+            return log_result(is_newer_release(latest_project_release, release, order_type))
 
-        return False
+        return log_result(False)

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -156,6 +156,51 @@ class TestLatestAdoptedReleaseCondition(ConditionTestCase):
         self.create_group_release(group=group_3, release=self.middle_release)
         self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event_3, group=group_3))
 
+    @patch("sentry.workflow_engine.handlers.condition.latest_adopted_release_handler.logger")
+    def test_logs_evaluation_result(self, mock_logger: MagicMock) -> None:
+        self.create_group_release(group=self.group, release=self.newest_release)
+
+        self.assert_passes(self.dc, self.event_data)
+
+        mock_logger.debug.assert_called_once_with(
+            "workflow_engine.handlers.latest_adopted_release_handler",
+            extra={
+                "configured_environment": self.prod_env.name,
+                "environment": self.prod_env.name,
+                "latest_project_release": self.middle_release.version,
+                "event_release": self.newest_release.version,
+                "release_age_type": "oldest",
+                "order_type": "SEMVER",
+                "age_comparison": "newer",
+                "evaluation_result": True,
+            },
+        )
+
+    @patch("sentry.workflow_engine.handlers.condition.latest_adopted_release_handler.logger")
+    def test_logs_missing_environment(self, mock_logger: MagicMock) -> None:
+        self.dc.update(
+            comparison={
+                **self.dc.comparison,
+                "environment": "missing",
+            }
+        )
+
+        self.assert_does_not_pass(self.dc, self.event_data)
+
+        mock_logger.debug.assert_called_once_with(
+            "workflow_engine.handlers.latest_adopted_release_handler",
+            extra={
+                "configured_environment": "missing",
+                "environment": None,
+                "latest_project_release": None,
+                "event_release": None,
+                "release_age_type": "oldest",
+                "order_type": "SEMVER",
+                "age_comparison": "newer",
+                "evaluation_result": False,
+            },
+        )
+
     def test_oldest_older(self) -> None:
         self.dc.update(
             comparison={


### PR DESCRIPTION
LatestAdoptedReleaseConditionHandler is much less obvious than many of our conditions, and can potentially produce different results based on mutations in tables elsewhere, so comparison with existing data isn't a reliable source.
Contextual debug logging should let us inspect the execution for opted in orgs without adding too much extra logging noise.