### PR TITLE
fix(explore): Show empty boolean group-by as (no value)

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -237,6 +237,31 @@ describe('getFieldRenderer', () => {
     expect(screen.getByText('true')).toBeInTheDocument();
   });
 
+  it('renders boolean false without coercing empty values', () => {
+    const renderer = getFieldRenderer('boolValue', {boolValue: 'boolean'});
+    const validate = (value: unknown, expected: string) => {
+      const {unmount} = render(
+        renderer(
+          {...data, boolValue: value},
+          {
+            location,
+            navigate: jest.fn(),
+            organization,
+            theme,
+          }
+        ) as React.ReactElement<any, any>
+      );
+      expect(screen.getByText(expected)).toBeInTheDocument();
+      unmount();
+    };
+
+    validate(true, 'true');
+    validate(false, 'false');
+    validate('', '(no value)');
+    validate(null, '(no value)');
+    validate(undefined, '(no value)');
+  });
+
   it('can render integer fields', () => {
     const renderer = getFieldRenderer('numeric', {numeric: 'integer'});
     render(

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -252,7 +252,12 @@ export const FIELD_FORMATTERS: FieldFormatters = {
   boolean: {
     isSortable: true,
     renderFunc: (field, data) => {
-      const value = data[field] ? t('true') : t('false');
+      const fieldValue = data[field];
+      // Render empty values as "(no value)" instead of coercing them to false.
+      if (fieldValue === null || fieldValue === undefined || fieldValue === '') {
+        return <Container>{emptyValue}</Container>;
+      }
+      const value = fieldValue ? t('true') : t('false');
       return <Container>{value}</Container>;
     },
   },

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -606,7 +606,13 @@ function BasicDiscoverRenderer(props: LogFieldRendererProps) {
     castValue = Number(props.item.value);
   }
   if (attributeType === 'bool' || attributeType === 'boolean') {
-    castValue = Boolean(props.item.value);
+    // Keep empty values null so the formatter renders "(no value)", not false.
+    castValue =
+      props.item.value === null ||
+      props.item.value === undefined ||
+      props.item.value === ''
+        ? null
+        : Boolean(props.item.value);
   }
   return (
     <LogBasicRendererContainer align={align}>

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -19,6 +19,7 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import {type OurLogsAggregateResponseItem} from 'sentry/views/explore/logs/types';
 import {type LogsAggregatesTableResult} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 
 import {LogsAggregateTable} from './logsAggregateTable';
@@ -186,6 +187,46 @@ describe('LogsAggregateTable', () => {
       expect(cells[1]).toHaveTextContent(expected[i]![0]!);
       expect(cells[2]).toHaveTextContent(expected[i]![1]!);
     });
+  });
+
+  it('renders an empty boolean group-by as "(no value)" rather than a second false', () => {
+    const booleanRouterConfig = {
+      ...initialRouterConfig,
+      location: {
+        ...initialRouterConfig.location,
+        query: {
+          ...initialRouterConfig.location.query,
+          [LOGS_GROUP_BY_KEY]: 'is_equal',
+          [LOGS_AGGREGATE_SORT_BYS_KEY]: '-count(message)',
+          [LOGS_AGGREGATE_FN_KEY]: 'count',
+          [LOGS_AGGREGATE_PARAM_KEY]: 'message',
+        },
+      },
+    };
+
+    render(
+      <LogsAggregateTableWithParamsProvider
+        aggregatesTableResult={createAggregatesTableResult({
+          data: {
+            // Boolean fields come back as real booleans; the empty bucket as ''.
+            data: [
+              {is_equal: false, 'count(message)': 40_000_000},
+              {is_equal: true, 'count(message)': 1_000_000},
+              {is_equal: '', 'count(message)': 168_000},
+            ] as unknown as OurLogsAggregateResponseItem[],
+            meta: {
+              fields: {is_equal: 'boolean', 'count(message)': 'integer'},
+              units: {},
+            },
+          },
+        })}
+      />,
+      {initialRouterConfig: booleanRouterConfig}
+    );
+
+    expect(screen.getByText('true')).toBeInTheDocument();
+    expect(screen.getByText('(no value)')).toBeInTheDocument();
+    expect(screen.getAllByText('false')).toHaveLength(1);
   });
 
   it('renders top result colors when the page is the first one', () => {


### PR DESCRIPTION
## Summary

Grouping Explore Logs by a boolean attribute (e.g. `tags[is_equal,boolean]`) showed **two `false` rows** in the aggregate table — the real `false` plus a bucket for logs that don't have the attribute set. The chart legend, meanwhile, correctly showed `(no value)`, `true`, and `false`.

The missing bucket comes back as an empty string. The shared boolean field formatter converted it to `false` using JavaScript truthiness (`data[field] ? 'true' : 'false'`), unlike its sibling formatters (date/number/duration), which already render `(no value)` for missing values.

## Changes

- `utils/discover/fieldRenderers.tsx`: the boolean formatter now renders empty values (`null`/`undefined`/`''`) as `(no value)` instead of coercing them to `false`. This is the formatter the logs aggregate table uses, so the duplicate `false` row is gone and the table now matches the chart legend.
- `views/explore/logs/fieldRenderers.tsx`: `BasicDiscoverRenderer` no longer casts empty values to a real `false` before formatting, so the individual-logs rows table behaves the same way.
- Tests: cover boolean `true`/`false`/empty rendering in the shared formatter, and add a boolean group-by case to the logs aggregate table asserting a single `false` row and one `(no value)`.

Refs EXP-1122
