### PR TITLE
ref(settings): Build the printable recovery codes with DOM nodes

### DIFF
--- a/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
@@ -1,3 +1,4 @@
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -27,21 +28,19 @@ export function RecoveryCodes({
   codes,
   onRegenerateBackupCodes,
 }: Props) {
+  const printRef = useRef<HTMLIFrameElement>(null);
+
   const printCodes = () => {
-    // @ts-expect-error TS(7015): Element implicitly has an 'any' type because index... Remove this comment to see the full error message
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    const iframe = window.frames['printable'];
-    const doc = iframe.document;
+    const doc = printRef.current?.contentDocument;
+    if (!doc) {
+      return;
+    }
 
-    doc.body.replaceChildren();
-    codes.forEach((code, i) => {
-      if (i > 0) {
-        doc.body.appendChild(doc.createElement('br'));
-      }
-      doc.body.appendChild(doc.createTextNode(code));
-    });
+    doc.body.replaceChildren(
+      ...codes.map(code => Object.assign(doc.createElement('div'), {textContent: code}))
+    );
 
-    iframe.print();
+    printRef.current?.contentWindow?.print();
   };
 
   if (!isEnrolled || !codes) {
@@ -97,7 +96,7 @@ export function RecoveryCodes({
           <EmptyMessage>{t('You have no more recovery codes to use')}</EmptyMessage>
         )}
       </PanelBody>
-      <iframe data-test-id="frame" name="printable" style={{display: 'none'}} />
+      <iframe ref={printRef} data-test-id="frame" style={{display: 'none'}} />
     </CodeContainer>
   );
 }

--- a/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
@@ -31,9 +31,17 @@ export function RecoveryCodes({
     // @ts-expect-error TS(7015): Element implicitly has an 'any' type because index... Remove this comment to see the full error message
     // eslint-disable-next-line @typescript-eslint/dot-notation
     const iframe = window.frames['printable'];
-    iframe.document.write(codes.join('<br>'));
+    const doc = iframe.document;
+
+    doc.body.replaceChildren();
+    codes.forEach((code, i) => {
+      if (i > 0) {
+        doc.body.appendChild(doc.createElement('br'));
+      }
+      doc.body.appendChild(doc.createTextNode(code));
+    });
+
     iframe.print();
-    iframe.document.close();
   };
 
   if (!isEnrolled || !codes) {


### PR DESCRIPTION
`printCodes` wrote the recovery codes into the hidden print iframe with `document.write(codes.join('<br>'))`.

`document.write` is a Trusted Types injection sink. This builds each code as a DOM node instead and reaches the iframe through a typed React ref, so no sink and no `any`. Same printed output: one code per line.

It is the last case of `document.write` idiom.

Checked the printed PDF file visually - it is the same even though we change `code<br>code` to `<div>code</div>...`