### PR TITLE
ref(demo): Attach the analytics queue shim as a text node

### DIFF
--- a/static/app/utils/demoMode/utils.tsx
+++ b/static/app/utils/demoMode/utils.tsx
@@ -76,8 +76,9 @@ function initDemoAnalytics() {
 
     const queueScript = document.createElement('script');
     queueScript.id = 'plausible-queue-script';
-    queueScript.textContent =
-      'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }';
+    queueScript.append(
+      'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }'
+    );
 
     document.head.appendChild(mainScript);
     document.head.appendChild(queueScript);


### PR DESCRIPTION
Groundwork for [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API); no behaviour change.

Assigning to a `<script>` element's `textContent` is a Trusted Types injection sink, so it is rejected on a page that sets `require-trusted-types-for 'script'`. `append(...)` with a string creates a text node instead — not a sink, and otherwise equivalent (same resulting `textContent` and `text`).

Note this does not make the function fully compliant: `mainScript.src` points at a cross-origin analytics script, which is a `TrustedScriptURL` sink and needs a policy decision rather than a mechanical change. Left as-is deliberately.

Both paths are behind `isDemoModeActive()`.