### PR TITLE
ref(replay): Create placeholder comments as nodes

### DIFF
--- a/static/app/utils/replays/extractDomNodes.tsx
+++ b/static/app/utils/replays/extractDomNodes.tsx
@@ -94,11 +94,13 @@ function removeChildLevel(max: number, collection: HTMLCollection, current = 0) 
       child.textContent = '/* Inline CSS */';
     }
     if (child.nodeName === 'svg') {
-      child.innerHTML = '<!-- SVG -->';
+      child.replaceChildren(document.createComment(' SVG '));
     }
     if (max <= current) {
       if (child.childElementCount > 0) {
-        child.innerHTML = `<!-- ${child.childElementCount} descendents -->`;
+        child.replaceChildren(
+          document.createComment(` ${child.childElementCount} descendents `)
+        );
       }
     } else {
       removeChildLevel(max, child.children, current + 1);


### PR DESCRIPTION
`removeChildLevel` replaces pruned subtrees with a placeholder comment. It did that by assigning comment markup to `innerHTML`, which runs the HTML parser to produce a single comment node. `document.createComment()` produces it directly.

Verified the rendered markup is unchanged — `<!-- SVG -->` and `<!-- N descendents -->` come out identical.

Also relevant to [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API): assigning to `innerHTML` is an injection sink, so this path is rejected on a page that sets `require-trusted-types-for 'script'`.