### PR TITLE
ref: Update sentry-protos to 0.63.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.2.6",
-  "sentry-protos>=0.62.3",
+  "sentry-protos>=0.63.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==1.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2361,7 +2361,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.2.6" },
-    { name = "sentry-protos", specifier = ">=0.62.3" },
+    { name = "sentry-protos", specifier = ">=0.63.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==1.5.0" },
@@ -2541,7 +2541,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.62.3"
+version = "0.63.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs" },
@@ -2549,7 +2549,7 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.62.3-py3-none-any.whl", hash = "sha256:2f59f07bd6c263e6b4b1cc4ad68a6d36ed95803fa3f8f9b224db84818e4a1cd4" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.63.0-py3-none-any.whl", hash = "sha256:1c7f5d7f122bf4dcd5f5784f7f21e5b743ae94a09fa48105f6323f40d996b53f" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update sentry-protos dependency from 0.62.3 to 0.63.0

## Release notes
https://github.com/getsentry/sentry-protos/releases/tag/0.63.0

## Test plan
- CI passes with updated dependency