### PR TITLE
build(deps): Bump vroomrs to 0.1.24 for pyo3 security fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ dependencies = [
   # note: we cannot resolve urllib3[brotli] but brotli is installed
   #       and will be used
   "urllib3>=2.7.0",
-  "vroomrs>=0.1.23",
+  "vroomrs>=0.1.24",
   "xmlsec>=1.3.17",
   "zstandard>=0.18.0",
   # [begin] getsentry

--- a/uv.lock
+++ b/uv.lock
@@ -2384,7 +2384,7 @@ requires-dist = [
     { name = "ua-parser", specifier = ">=0.10.0" },
     { name = "unidiff", specifier = ">=0.7.4" },
     { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "vroomrs", specifier = ">=0.1.23" },
+    { name = "vroomrs", specifier = ">=0.1.24" },
     { name = "xmlsec", specifier = ">=1.3.17" },
     { name = "zstandard", specifier = ">=0.18.0" },
 ]
@@ -3098,12 +3098,12 @@ wheels = [
 
 [[package]]
 name = "vroomrs"
-version = "0.1.23"
+version = "0.1.24"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/vroomrs-0.1.23-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bc1b1d48df6632c012f99b429c59908130956f114666fa909461d3267080520c" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/vroomrs-0.1.23-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1584857a24ca3e09a5ccc5213a69d359c4493dc2e93a0573c7280a2e167bc80d" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/vroomrs-0.1.23-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46baa2c0db8e64ee990a595d99597206c3d06ebd51e3c8137ec580aaaa403219" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/vroomrs-0.1.24-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:76b3aaed924cac28fca8fba43a57b4c7fcada72bf71cf3e12f45faef2de96365" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/vroomrs-0.1.24-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:081f8fbc76009c631d566c03222baa1a70485bbb61f5d00113cb45ee68230ae8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/vroomrs-0.1.24-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5a75f3050fbf8d100089a38fa273bdae99fb3f6135c18905cf3e57942da686c" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `vroomrs` from **0.1.23** to **0.1.24** to pull a High-severity supply-chain fix into production.

vroomrs 0.1.23 was built on `pyo3` 0.27.1, which has an out-of-bounds read — [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) (`Iterator::nth` / `nth_back` on bound list/tuple iterators compute the index with unchecked arithmetic before bounds validation). vroomrs 0.1.24 upgrades pyo3 to 0.29, which carries the fix. `vroomrs` is used by `src/sentry/profiles/task.py`.

The vroomrs-side change: getsentry/vroomrs#95.

## Changes

- `pyproject.toml`: `vroomrs>=0.1.23` → `vroomrs>=0.1.24` (raise the floor so a vulnerable build can't resolve).
- `uv.lock`: regenerated via `make freeze-requirements`; vroomrs now resolves to the 0.1.24 wheels on the internal index.

Only vroomrs entries changed; `uv lock --check` is clean.

Fixes PRO-44
Refs VULN-2073