### PR TITLE
ref(marked): Drop `id` from the sanitizer attribute allowlist

### DIFF
--- a/static/app/utils/marked/marked.spec.tsx
+++ b/static/app/utils/marked/marked.spec.tsx
@@ -234,6 +234,14 @@ describe('marked', () => {
     expect(linkResult).not.toContain('onclick');
   });
 
+  it('strips the id attribute', () => {
+    // `id` is not in the sanitizer allowlist: it is a DOM clobbering primitive,
+    // and nothing in the markdown pipeline produces one.
+    const result = sanitizedMarked('a <span id="location">x</span> b');
+    expect(result).toContain('<span>x</span>');
+    expect(result).not.toContain('id=');
+  });
+
   it('preserves allowed markdown HTML', () => {
     // Bold, italic, code, links, images, lists, tables, blockquotes, headings
     expect(sanitizedMarked('**bold** *italic* `code`')).toBe(

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -95,7 +95,7 @@ const ALLOWED_TAGS = [
   'sup',
 ];
 
-const ALLOWED_ATTR = ['href', 'title', 'alt', 'class', 'id', 'align'];
+const ALLOWED_ATTR = ['href', 'title', 'alt', 'class', 'align'];
 
 export function sanitizeHtml(html: string) {
   return dompurify.sanitize(html, {


### PR DESCRIPTION
`ALLOWED_ATTR` in the markdown sanitizer permits `id`, but nothing in the pipeline produces one — marked stopped emitting header ids by default in v12, and neither `SafeRenderer` nor `NoParagraphRenderer` sets one. Confirmed: `sanitizedMarked('# Heading text')` returns `<h1>Heading text</h1>\n`.

So the attribute only survives when a user writes raw inline HTML in markdown. An attacker-chosen `id` is the DOM clobbering primitive — it shadows `window.x` / `document.x` for any script that reads a global without guarding.

**This is hardening, not a fix.** I looked for a gadget that would make it exploitable and did not find one. The point is that the attribute costs nothing to remove.

`align` is deliberately kept: markdown table syntax generates it (`|:--|--:|` → `<th align="left">` / `<th align="right">`), so removing it would silently break table alignment.

A regression test asserts `id` is stripped, matching the existing per-attribute tests (`style`, event handlers) in `marked.spec.tsx`.