### PR TITLE
feat(security): Add a report-only header for Trusted Types

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -597,6 +597,28 @@ COOP_ENABLED = False
 COOP_REPORT_ONLY = True
 COOP_REPORT_TO: str | None = None
 
+# Trusted Types (https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API)
+# is delivered on its own Content-Security-Policy-Report-Only header, separate
+# from the CSP_* settings, so that turning it on cannot alter the CSP we enforce.
+#
+# Requires CSP_REPORT_ONLY = False. When the CSP itself is report-only, django-csp
+# owns the report-only header name and this middleware cannot claim it; see
+# SecurityHeadersMiddleware.add_trusted_types_header.
+TRUSTED_TYPES_ENABLED = False
+
+# Policy names the browser will accept `createPolicy()` calls for. Anything not
+# listed here fails to register, so keep it in sync with the policies the
+# frontend actually installs.
+TRUSTED_TYPES_POLICIES = [
+    "dompurify",
+    "sentry-script-url",
+    "sentry-bundler",
+]
+
+# Where violation reports are sent. With no report URI the browser still reports
+# to the devtools console, which is enough for local work.
+TRUSTED_TYPES_REPORT_URI: str | None = None
+
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned

--- a/src/sentry/middleware/security.py
+++ b/src/sentry/middleware/security.py
@@ -1,9 +1,17 @@
+import logging
+
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+TRUSTED_TYPES_HEADER = "Content-Security-Policy-Report-Only"
+
+_warned_about_report_only_csp = False
 
 
 class SecurityHeadersMiddleware(MiddlewareMixin):
@@ -16,6 +24,8 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
             response.setdefault("X-Frame-Options", "deny")
         response.setdefault("X-Content-Type-Options", "nosniff")
         response.setdefault("X-XSS-Protection", "1; mode=block")
+
+        self.add_trusted_types_header(response)
 
         # Add COOP and Report-To headers if COOP_ENABLED
         if getattr(settings, "COOP_ENABLED", False):
@@ -41,3 +51,36 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
                 )
 
         return response
+
+    def add_trusted_types_header(self, response: Response) -> None:
+        if not getattr(settings, "TRUSTED_TYPES_ENABLED", False):
+            return
+
+        # This middleware runs before CSPMiddleware on the response path, and
+        # django-csp bails when its header name is already set. So when the CSP is
+        # itself report-only we would be dropping the entire CSP to deliver
+        # Trusted Types, which is never worth it.
+        if getattr(settings, "CSP_REPORT_ONLY", False):
+            global _warned_about_report_only_csp
+            if not _warned_about_report_only_csp:
+                _warned_about_report_only_csp = True
+                logger.warning(
+                    "trusted_types.disabled_by_report_only_csp",
+                    extra={"header": TRUSTED_TYPES_HEADER},
+                )
+            return
+
+        if TRUSTED_TYPES_HEADER in response:
+            return
+
+        directives = ["require-trusted-types-for 'script'"]
+
+        policies = getattr(settings, "TRUSTED_TYPES_POLICIES", None) or []
+        if policies:
+            directives.append("trusted-types " + " ".join(policies))
+
+        report_uri = getattr(settings, "TRUSTED_TYPES_REPORT_URI", None)
+        if report_uri:
+            directives.append(f"report-uri {report_uri}")
+
+        response[TRUSTED_TYPES_HEADER] = "; ".join(directives)

--- a/tests/sentry/middleware/test_security.py
+++ b/tests/sentry/middleware/test_security.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from django.test import RequestFactory, override_settings
 from rest_framework.response import Response
@@ -104,3 +104,103 @@ class SecurityHeadersMiddlewareTest(TestCase):
         assert report_to["max_age"] == 86400
         assert len(report_to["endpoints"]) == 1
         assert report_to["endpoints"][0]["url"] == "https://example.com/callback/"
+
+    def test_trusted_types_header_not_set_when_disabled(self) -> None:
+        """TRUSTED_TYPES_ENABLED defaults to False, so no extra policy is emitted."""
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert "Content-Security-Policy-Report-Only" not in processed_response
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False)
+    def test_trusted_types_header_set_when_enabled(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Content-Security-Policy-Report-Only"] == (
+            "require-trusted-types-for 'script'; trusted-types dompurify sentry-script-url sentry-bundler"
+        )
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False)
+    def test_trusted_types_header_does_not_touch_enforced_csp(self) -> None:
+        """The enforced Content-Security-Policy must be left completely alone."""
+        request = self.factory.get("/")
+        response = Response()
+        response["Content-Security-Policy"] = "default-src 'none'; script-src 'self'"
+        processed_response = self.middleware.process_response(request, response)
+
+        assert (
+            processed_response["Content-Security-Policy"] == "default-src 'none'; script-src 'self'"
+        )
+        assert (
+            "require-trusted-types-for" in processed_response["Content-Security-Policy-Report-Only"]
+        )
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=True)
+    def test_trusted_types_header_skipped_when_django_csp_owns_report_only(self) -> None:
+        """
+        django-csp emits the -Report-Only header itself when CSP_REPORT_ONLY is on, and
+        bails if that header already exists. Claiming the name here would silently drop
+        the entire CSP, so the middleware must stand down.
+        """
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert "Content-Security-Policy-Report-Only" not in processed_response
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=True)
+    def test_trusted_types_warns_once_when_skipped(self) -> None:
+        """
+        Standing down is correct but invisible, so someone who enables the setting and
+        sees nothing gets a log line pointing at why. Once per process, not per request.
+        """
+        from sentry.middleware import security
+
+        security._warned_about_report_only_csp = False
+
+        request = self.factory.get("/")
+        with mock.patch.object(security.logger, "warning") as mock_warning:
+            self.middleware.process_response(request, Response())
+            self.middleware.process_response(request, Response())
+
+        assert mock_warning.call_count == 1
+        assert mock_warning.call_args[0][0] == "trusted_types.disabled_by_report_only_csp"
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False)
+    def test_trusted_types_header_does_not_overwrite_existing(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        response["Content-Security-Policy-Report-Only"] = "default-src 'none'"
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Content-Security-Policy-Report-Only"] == "default-src 'none'"
+
+    @override_settings(
+        TRUSTED_TYPES_ENABLED=True,
+        CSP_REPORT_ONLY=False,
+        TRUSTED_TYPES_REPORT_URI="https://example.com/security/?sentry_key=abc",
+    )
+    def test_trusted_types_header_includes_report_uri(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Content-Security-Policy-Report-Only"] == (
+            "require-trusted-types-for 'script'; "
+            "trusted-types dompurify sentry-script-url sentry-bundler; "
+            "report-uri https://example.com/security/?sentry_key=abc"
+        )
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False, TRUSTED_TYPES_POLICIES=[])
+    def test_trusted_types_header_omits_empty_policy_allowlist(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert (
+            processed_response["Content-Security-Policy-Report-Only"]
+            == "require-trusted-types-for 'script'"
+        )


### PR DESCRIPTION
Plumbing only — inert until someone sets `TRUSTED_TYPES_ENABLED`. No frontend changes here; the policies this allowlists are installed in a follow-up.

### Why a separate header

[Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) is a CSP directive, so the obvious approach is to add it to the `CSP_*` settings. That doesn't work here: the rollout needs a long report-only period to find every DOM sink in the app and its dependencies, and our production CSP is *enforced*. Flipping it to report-only for that window would drop real XSS protection.

Browsers evaluate each delivered CSP policy independently, and a report-only policy cannot loosen an enforced one. So Trusted Types rides on its own `Content-Security-Policy-Report-Only` header while the enforced CSP is left exactly as it is. Verified empirically in headless Chrome, not assumed.

The settings deliberately live in their own `TRUSTED_TYPES_*` group rather than alongside `CSP_*`, so that enabling collection cannot accidentally ship enforcement.

### The CSP_REPORT_ONLY constraint

This requires `CSP_REPORT_ONLY = False`.

`SecurityHeadersMiddleware` runs before `CSPMiddleware` on the response path, and django-csp bails if its header name is already set. When the CSP is itself report-only, both want `Content-Security-Policy-Report-Only` — and claiming it here would silently drop the entire CSP. Not a trade worth making, so the middleware stands down.

Standing down is correct but invisible, which is its own trap: enable the setting on a stock dev config and nothing happens, with no clue why. So it logs `trusted_types.disabled_by_report_only_csp` once per process.

### Reporting

`TRUSTED_TYPES_REPORT_URI` defaults to `None`, in which case no `report-uri` directive is emitted and violations surface in the devtools console only. That is enough for local work; pointing it at a project is a config change, not a code change.