### PR TITLE
feat(workflow_engine): Add option to pick workflow_ids that should trigger evaluation logs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3505,6 +3505,14 @@ register(
     default=0.1,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Workflows for which to always try to record evaluation logs.
+register(
+    "workflow_engine.evaluation_log_target_workflow_ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Whether to directly log workflow evaluation logs to Sentry instead of using the stdlib
 # logger (which also logs to Sentry).
 register(

--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -15,6 +15,17 @@ if TYPE_CHECKING:
 WORKFLOW_EVALUATION_LOG_PREFIX = "workflow_engine.process_workflows.evaluation"
 
 
+def should_log(organization: Organization, result: ProcessWorkflowsResult) -> bool:
+    if features.has("organizations:workflow-engine-log-evaluations", organization):
+        return True
+    all_workflow_ids = result.evaluations.keys()
+    if set(options.get("workflow_engine.evaluation_log_target_workflow_ids")).intersection(
+        all_workflow_ids
+    ):
+        return True
+    return random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
+
+
 def emit_workflow_evaluation_logs(
     logger: Logger,
     *,
@@ -23,11 +34,7 @@ def emit_workflow_evaluation_logs(
     log_prefix: str = WORKFLOW_EVALUATION_LOG_PREFIX,
 ) -> bool:
     """Sample a batch and emit one self-contained artifact per workflow evaluation."""
-    should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
-    if not should_log:
-        should_log = random.random() < options.get("workflow_engine.evaluation_log_sample_rate")
-
-    if not should_log:
+    if not should_log(organization, result):
         return False
 
     direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -4,7 +4,10 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.models import DataConditionGroup
-from sentry.workflow_engine.processors.evaluation_logging import emit_workflow_evaluation_logs
+from sentry.workflow_engine.processors.evaluation_logging import (
+    emit_workflow_evaluation_logs,
+    should_log,
+)
 from sentry.workflow_engine.processors.evaluations import (
     DataConditionEvaluation,
     DataConditionGroupEvaluation,
@@ -207,6 +210,22 @@ class TestWorkflowEvaluationArtifact(TestCase):
             )
 
         mock_logger.info.assert_called_once()
+
+    def test_should_log_targeted_workflow(self) -> None:
+        evaluation = self._build_evaluation(workflow_id=10)
+        with (
+            Feature({"organizations:workflow-engine-log-evaluations": False}),
+            override_options(
+                {
+                    "workflow_engine.evaluation_log_target_workflow_ids": [10],
+                    "workflow_engine.evaluation_log_sample_rate": 0.0,
+                }
+            ),
+        ):
+            assert should_log(
+                self.organization,
+                self._build_batch_result({10: evaluation}),
+            )
 
     def test_emitter_respects_sample_rate_when_feature_disabled(self) -> None:
         evaluation = self._build_evaluation()


### PR DESCRIPTION
Evaluation logs are high volume and some orgs evaluate enough that it's undesirable or impractical for us to log all evaluations for that org.
This adds an option that can be used to enable collection for evaluations containing a particular set of workflow IDs only, giving us more fine-grained control.
