### PR TITLE
feat(workflow_engine): Add option to enable debug logging by workflow id

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3513,6 +3513,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.process_workflows_debug_workflow_ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Safe default limit for workflows. Should be high enough to cover almost all orgs,
 # low enough to have no concerns about stability impact.
 register(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -585,6 +585,10 @@ def process_workflows(
         log_context.set_verbose(True)
 
     workflows = get_workflows_by_detectors(event_detectors.detectors, environment)
+    debug_workflow_ids = options.get("workflow_engine.process_workflows_debug_workflow_ids")
+    if any(workflow.id in debug_workflow_ids for workflow in workflows):
+        log_context.set_verbose(True)
+
     wrong_org_workflows = {wf for wf in workflows if wf.organization_id != organization.id}
     if wrong_org_workflows:
         logger.warning(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -143,6 +143,26 @@ class TestProcessWorkflows(BaseWorkflowTest):
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
+    @patch("sentry.workflow_engine.processors.workflow.log_context.set_verbose")
+    def test_enables_debug_logging_for_selected_workflow(self, mock_set_verbose: MagicMock) -> None:
+        with self.options(
+            {"workflow_engine.process_workflows_debug_workflow_ids": [self.error_workflow.id]}
+        ):
+            process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
+
+        mock_set_verbose.assert_called_once_with(True)
+
+    @patch("sentry.workflow_engine.processors.workflow.log_context.set_verbose")
+    def test_does_not_enable_debug_logging_for_unselected_workflow(
+        self, mock_set_verbose: MagicMock
+    ) -> None:
+        with self.options(
+            {"workflow_engine.process_workflows_debug_workflow_ids": [self.workflow.id]}
+        ):
+            process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
+
+        mock_set_verbose.assert_not_called()
+
     @patch("sentry.workflow_engine.processors.action.fire_actions")
     def test_process_workflows_event(self, mock_fire_actions: MagicMock) -> None:
         # Create an action so fire_actions will be called


### PR DESCRIPTION
Debug logs can be high volume, and enabling them at an organization level may generate more volume than we want to store or sift though.
This adds an option for specifying workflow IDs that, when present, trigger debug logging for the rest of the (non-delayed) workflow evaluation.
