### PR TITLE
hackweek: Trusted Types

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -486,6 +486,7 @@ export default typescript.config([
       '@sentry/no-static-translations': 'error',
       '@sentry/no-raw-css-in-styled': 'error',
       '@sentry/no-styled-shortcut': 'error',
+      '@sentry/no-trusted-types-sinks': 'error',
       '@sentry/no-useless-css-interpolation-semicolon': 'error',
       '@sentry/no-unnecessary-use-callback': 'error',
     },

--- a/package.json
+++ b/package.json
@@ -349,7 +349,8 @@
       "unrs-resolver"
     ],
     "patchedDependencies": {
-      "zod@4.3.5": "patches/zod@4.3.5.patch"
+      "zod@4.3.5": "patches/zod@4.3.5.patch",
+      "zrender@6.1.0": "patches/zrender@6.1.0.patch"
     }
   },
   "APIMethod": "stub",

--- a/patches/zrender@6.1.0.patch
+++ b/patches/zrender@6.1.0.patch
@@ -1,0 +1,83 @@
+diff --git a/lib/canvas/Painter.js b/lib/canvas/Painter.js
+index 78dc6c8d46eca79366f5190a7c191410f8133816..3c79bc4e8abc8917458a0297159c5a0a307b01c8 100644
+--- a/lib/canvas/Painter.js
++++ b/lib/canvas/Painter.js
+@@ -111,7 +111,7 @@ var CanvasPainter = (function () {
+         var rootStyle = root.style;
+         if (rootStyle) {
+             util.disableUserSelect(root);
+-            root.innerHTML = '';
++            root.textContent = '';
+         }
+         this.storage = storage;
+         this._prevDisplayList = [];
+@@ -685,7 +685,7 @@ var CanvasPainter = (function () {
+         });
+     };
+     CanvasPainter.prototype.dispose = function () {
+-        this.root.innerHTML = '';
++        this.root.textContent = '';
+         this.root =
+             this.storage =
+                 this._domRoot =
+diff --git a/lib/svg/Painter.js b/lib/svg/Painter.js
+index 2db019c7e9ac4b13947d0bb9220fdecbfa591d2f..b514a95dd529b76e1bea37953dfd00ed065f4b5a 100644
+--- a/lib/svg/Painter.js
++++ b/lib/svg/Painter.js
+@@ -187,7 +187,7 @@ var SVGPainter = (function () {
+     };
+     SVGPainter.prototype.dispose = function () {
+         if (this.root) {
+-            this.root.innerHTML = '';
++            this.root.textContent = '';
+         }
+         this._svgDom =
+             this._viewport =
+@@ -198,7 +198,7 @@ var SVGPainter = (function () {
+     };
+     SVGPainter.prototype.clear = function () {
+         if (this._svgDom) {
+-            this._svgDom.innerHTML = null;
++            this._svgDom.textContent = '';
+         }
+         this._oldVNode = null;
+     };
+diff --git a/lib/svg-legacy/Painter.js b/lib/svg-legacy/Painter.js
+index 5ca3b0d2fb308a7e9019a5dcb0869ce05ea130db..a818d6be22e8fa7c35634841d02eefd503a24828 100644
+--- a/lib/svg-legacy/Painter.js
++++ b/lib/svg-legacy/Painter.js
+@@ -258,7 +258,7 @@ var SVGPainter = (function () {
+         return this._height;
+     };
+     SVGPainter.prototype.dispose = function () {
+-        this.root.innerHTML = '';
++        this.root.textContent = '';
+         this._svgRoot =
+             this._backgroundRoot =
+                 this._svgDom =
+diff --git a/lib/svg-legacy/helper/ClippathManager.js b/lib/svg-legacy/helper/ClippathManager.js
+index d99b65aeec73c96cb3d981a87752467819757517..1383275a0c58c5e86ec029eb05a4eaf18ad5ef44 100644
+--- a/lib/svg-legacy/helper/ClippathManager.js
++++ b/lib/svg-legacy/helper/ClippathManager.js
+@@ -73,7 +73,7 @@ var ClippathManager = (function (_super) {
+             }
+             path.brush(clipPath);
+             var pathEl = this.getSvgElement(clipPath);
+-            clipPathEl.innerHTML = '';
++            clipPathEl.textContent = '';
+             clipPathEl.appendChild(pathEl);
+             parentEl.setAttribute('clip-path', getIdURL(id));
+             if (clipPaths.length > 1) {
+diff --git a/lib/svg-legacy/helper/GradientManager.js b/lib/svg-legacy/helper/GradientManager.js
+index 7d413a137ebdc956c646e293820a745812b98a15..e802f747bae4e6b94271bb840958ee883047f55e 100644
+--- a/lib/svg-legacy/helper/GradientManager.js
++++ b/lib/svg-legacy/helper/GradientManager.js
+@@ -96,7 +96,7 @@ var GradientManager = (function (_super) {
+         dom.setAttribute('gradientUnits', gradient.global
+             ? 'userSpaceOnUse'
+             : 'objectBoundingBox');
+-        dom.innerHTML = '';
++        dom.textContent = '';
+         var colors = gradient.colorStops;
+         for (var i = 0, len = colors.length; i < len; ++i) {
+             var stop_1 = createElement('stop');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ patchedDependencies:
   zod@4.3.5:
     hash: 2bb6d33b2c713a7a2c559c18ad0aa6cfb261f01d935ee1288dfec6c84411aa76
     path: patches/zod@4.3.5.patch
+  zrender@6.1.0:
+    hash: a5b5e574364a10d3bbfef07def8f1f327eb54709ca887b1b9681bf949df0f89d
+    path: patches/zrender@6.1.0.patch
 
 importers:
 
@@ -534,7 +537,7 @@ importers:
         version: 4.3.5(patch_hash=2bb6d33b2c713a7a2c559c18ad0aa6cfb261f01d935ee1288dfec6c84411aa76)
       zrender:
         specifier: 6.1.0
-        version: 6.1.0
+        version: 6.1.0(patch_hash=a5b5e574364a10d3bbfef07def8f1f327eb54709ca887b1b9681bf949df0f89d)
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -13708,7 +13711,7 @@ snapshots:
   echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 6.1.0
+      zrender: 6.1.0(patch_hash=a5b5e574364a10d3bbfef07def8f1f327eb54709ca887b1b9681bf949df0f89d)
 
   editorconfig@3.0.2:
     dependencies:
@@ -18876,7 +18879,7 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zrender@6.1.0:
+  zrender@6.1.0(patch_hash=a5b5e574364a10d3bbfef07def8f1f327eb54709ca887b1b9681bf949df0f89d):
     dependencies:
       tslib: 2.3.0
 

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -540,6 +540,7 @@ const appConfig: Configuration = {
   },
   output: {
     crossOriginLoading: 'anonymous',
+    trustedTypes: {policyName: 'sentry-bundler', onPolicyCreationFailure: 'continue'},
     // Clean the output dir before emit, but keep the service-worker assets
     // emitted by the separate `workerConfig` compiler below. Both compilers
     // write to this same `dist` path and run in parallel, so without `keep`

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -597,6 +597,28 @@ COOP_ENABLED = False
 COOP_REPORT_ONLY = True
 COOP_REPORT_TO: str | None = None
 
+# Trusted Types (https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API)
+# is delivered on its own Content-Security-Policy-Report-Only header, separate
+# from the CSP_* settings, so that turning it on cannot alter the CSP we enforce.
+#
+# Requires CSP_REPORT_ONLY = False. When the CSP itself is report-only, django-csp
+# owns the report-only header name and this middleware cannot claim it; see
+# SecurityHeadersMiddleware.add_trusted_types_header.
+TRUSTED_TYPES_ENABLED = False
+
+# Policy names the browser will accept `createPolicy()` calls for. Anything not
+# listed here fails to register, so keep it in sync with the policies the
+# frontend actually installs.
+TRUSTED_TYPES_POLICIES = [
+    "dompurify",
+    "sentry-script-url",
+    "sentry-bundler",
+]
+
+# Where violation reports are sent. With no report URI the browser still reports
+# to the devtools console, which is enough for local work.
+TRUSTED_TYPES_REPORT_URI: str | None = None
+
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -619,6 +619,13 @@ TRUSTED_TYPES_POLICIES = [
 # to the devtools console, which is enough for local work.
 TRUSTED_TYPES_REPORT_URI: str | None = None
 
+if ENVIRONMENT == "development":
+    # Collect locally. Also needs CSP_REPORT_ONLY = False, otherwise django-csp
+    # owns the report-only header and the middleware stands down.
+    TRUSTED_TYPES_ENABLED = True
+    # The dev-server error overlay installs its own policy.
+    TRUSTED_TYPES_POLICIES += ["rspack-dev-server#overlay"]
+
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned

--- a/src/sentry/middleware/security.py
+++ b/src/sentry/middleware/security.py
@@ -1,9 +1,17 @@
+import logging
+
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+TRUSTED_TYPES_HEADER = "Content-Security-Policy-Report-Only"
+
+_warned_about_report_only_csp = False
 
 
 class SecurityHeadersMiddleware(MiddlewareMixin):
@@ -16,6 +24,8 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
             response.setdefault("X-Frame-Options", "deny")
         response.setdefault("X-Content-Type-Options", "nosniff")
         response.setdefault("X-XSS-Protection", "1; mode=block")
+
+        self.add_trusted_types_header(response)
 
         # Add COOP and Report-To headers if COOP_ENABLED
         if getattr(settings, "COOP_ENABLED", False):
@@ -41,3 +51,36 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
                 )
 
         return response
+
+    def add_trusted_types_header(self, response: Response) -> None:
+        if not getattr(settings, "TRUSTED_TYPES_ENABLED", False):
+            return
+
+        # This middleware runs before CSPMiddleware on the response path, and
+        # django-csp bails when its header name is already set. So when the CSP is
+        # itself report-only we would be dropping the entire CSP to deliver
+        # Trusted Types, which is never worth it.
+        if getattr(settings, "CSP_REPORT_ONLY", False):
+            global _warned_about_report_only_csp
+            if not _warned_about_report_only_csp:
+                _warned_about_report_only_csp = True
+                logger.warning(
+                    "trusted_types.disabled_by_report_only_csp",
+                    extra={"header": TRUSTED_TYPES_HEADER},
+                )
+            return
+
+        if TRUSTED_TYPES_HEADER in response:
+            return
+
+        directives = ["require-trusted-types-for 'script'"]
+
+        policies = getattr(settings, "TRUSTED_TYPES_POLICIES", None) or []
+        if policies:
+            directives.append("trusted-types " + " ".join(policies))
+
+        report_uri = getattr(settings, "TRUSTED_TYPES_REPORT_URI", None)
+        if report_uri:
+            directives.append(f"report-uri {report_uri}")
+
+        response[TRUSTED_TYPES_HEADER] = "; ".join(directives)

--- a/static/app/bootstrap/commonInitialization.tsx
+++ b/static/app/bootstrap/commonInitialization.tsx
@@ -3,6 +3,7 @@ import {MotionGlobalConfig} from 'framer-motion';
 import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'sentry/constants';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
+import {installTrustedTypesPolicies} from 'sentry/utils/trustedTypes';
 
 if (IS_ACCEPTANCE_TEST || NODE_ENV === 'test') {
   MotionGlobalConfig.skipAnimations = true;
@@ -13,5 +14,6 @@ export function commonInitialization(config: Config) {
     import(/* webpackMode: "eager" */ 'sentry/utils/silenceReactUnsafeWarnings');
   }
 
+  installTrustedTypesPolicies();
   ConfigStore.loadInitialData(config);
 }

--- a/static/app/bootstrap/renderDom.tsx
+++ b/static/app/bootstrap/renderDom.tsx
@@ -1,6 +1,8 @@
 import type React from 'react';
 import {createRoot} from 'react-dom/client';
 
+import {captureSplashLoader} from 'sentry/utils/splashLoader';
+
 export function renderDom<T extends React.ComponentType<any>>(
   Component: T,
   container: string,
@@ -13,6 +15,8 @@ export function renderDom<T extends React.ComponentType<any>>(
   if (!rootEl) {
     return;
   }
+
+  captureSplashLoader(rootEl);
 
   const root = createRoot(rootEl);
   root.render(<Component {...props} />);

--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -73,6 +73,7 @@ export function DefaultCodeBlock({children, lang}: {children: string; lang?: str
 }
 
 export function DefaultHtmlBlock({html}: {html: string}) {
+  // eslint-disable-next-line @sentry/no-trusted-types-sinks -- callers pass sanitizeHtml() output; see token.tsx
   return <span dangerouslySetInnerHTML={{__html: html}} />;
 }
 

--- a/static/app/components/events/interfaces/csp/help/effectiveDirectives.tsx
+++ b/static/app/components/events/interfaces/csp/help/effectiveDirectives.tsx
@@ -1,106 +1,106 @@
-import {t} from 'sentry/locale';
+import {tctCode} from 'sentry/locale';
 
 export const effectiveDirectives = {
-  'base-uri': t(
-    `The <code>base-uri</code> directive defines the URIs that a user agent
+  'base-uri': tctCode(
+    `The [code:base-uri] directive defines the URIs that a user agent
   may use as the document base URL. If this value is absent, then any URI
   is allowed. If this directive is absent, the user agent will use the
-  value in the <code>&lt;base&gt;</code> element.`
+  value in the [code:<base>] element.`
   ),
-  'child-src': t(
-    `The <code>child-src</code> directive defines the valid sources for
+  'child-src': tctCode(
+    `The [code:child-src] directive defines the valid sources for
   web workers and nested browsing contexts loaded using elements such as
-  <code>&lt;frame&gt;</code> and <code>&lt;iframe&gt;</code>.`
+  [code:<frame>] and [code:<iframe>].`
   ),
-  'connect-src': t(
-    `The <code>connect-src</code> directive defines valid sources for fetch,
-  <code>XMLHttpRequest</code>, <code>WebSocket</code>, and
-  <code>EventSource</code> connections.`
+  'connect-src': tctCode(
+    `The [code:connect-src] directive defines valid sources for fetch,
+  [code:XMLHttpRequest], [code:WebSocket], and
+  [code:EventSource] connections.`
   ),
-  'font-src': t(
-    `The <code>font-src</code> directive specifies valid sources for fonts
-  loaded using <code>@font-face</code>.`
+  'font-src': tctCode(
+    `The [code:font-src] directive specifies valid sources for fonts
+  loaded using [code:@font-face].`
   ),
-  'form-action': t(
-    `The <code>form-action</code> directive specifies valid endpoints for
-  <code>&lt;form&gt;</code> submissions.`
+  'form-action': tctCode(
+    `The [code:form-action] directive specifies valid endpoints for
+  [code:<form>] submissions.`
   ),
-  'frame-ancestors': t(
-    `The <code>frame-ancestors</code> directive specifies valid parents that
-  may embed a page using the <code>&lt;frame&gt;</code> and
-  <code>&lt;iframe&gt;</code> elements.`
+  'frame-ancestors': tctCode(
+    `The [code:frame-ancestors] directive specifies valid parents that
+  may embed a page using the [code:<frame>] and
+  [code:<iframe>] elements.`
   ),
-  'img-src': t(
-    `The <code>img-src</code> directive specifies valid sources of images and
+  'img-src': tctCode(
+    `The [code:img-src] directive specifies valid sources of images and
   favicons.`
   ),
-  'prefetch-src': t(
-    `The <code>prefetch-src</code> directive restricts the URLs
+  'prefetch-src': tctCode(
+    `The [code:prefetch-src] directive restricts the URLs
       from which resources may be prefetched or prerendered.`
   ),
-  'manifest-src': t(
-    `The <code>manifest-src</code> directive specifies which manifest can be
+  'manifest-src': tctCode(
+    `The [code:manifest-src] directive specifies which manifest can be
   applied to the resource.`
   ),
-  'media-src': t(
-    `The <code>media-src</code> directive specifies valid sources for loading
-  media using the <code>&lt;audio&gt;</code> and <code>&lt;video&gt;</code>
+  'media-src': tctCode(
+    `The [code:media-src] directive specifies valid sources for loading
+  media using the [code:<audio>] and [code:<video>]
   elements.`
   ),
-  'object-src': t(
-    `The <code>object-src</code> directive specifies valid sources for the
-  <code>&lt;object&gt;</code>, <code>&lt;embed&gt;</code>, and
-  <code>&lt;applet&gt;</code> elements.`
+  'object-src': tctCode(
+    `The [code:object-src] directive specifies valid sources for the
+  [code:<object>], [code:<embed>], and
+  [code:<applet>] elements.`
   ),
-  'plugin-types': t(
-    `The <code>plugin-types</code> directive specifies the valid plugins that
+  'plugin-types': tctCode(
+    `The [code:plugin-types] directive specifies the valid plugins that
   the user agent may invoke.`
   ),
-  referrer: t(
-    `The <code>referrer</code> directive specifies information in the
-  <code>Referer</code> header for links away from a page.`
+  referrer: tctCode(
+    `The [code:referrer] directive specifies information in the
+  [code:Referer] header for links away from a page.`
   ),
-  'script-src': t(
-    `The <code>script-src</code> directive specifies valid sources
-  for JavaScript. When either the <code>script-src</code> or the
-  <code>default-src</code> directive is included, inline script and
-  <code>eval()</code> are disabled unless you specify 'unsafe-inline'
+  'script-src': tctCode(
+    `The [code:script-src] directive specifies valid sources
+  for JavaScript. When either the [code:script-src] or the
+  [code:default-src] directive is included, inline script and
+  [code:eval()] are disabled unless you specify 'unsafe-inline'
   and 'unsafe-eval', respectively.`
   ),
-  'script-src-elem': t(
-    `The <code>script-src-elem</code> directive applies to all script requests
+  'script-src-elem': tctCode(
+    `The [code:script-src-elem] directive applies to all script requests
       and element contents. It does not apply to scripts defined in attributes.`
   ),
-  'script-src-attr': t(
-    `The <code>script-src-attr</code> directive applies to event handlers and, if present,
-      it will override the <code>script-src</code> directive for relevant checks.`
+  'script-src-attr': tctCode(
+    `The [code:script-src-attr] directive applies to event handlers and, if present,
+      it will override the [code:script-src] directive for relevant checks.`
   ),
-  'style-src': t(
-    `The <code>style-src</code> directive specifies valid sources for
+  'style-src': tctCode(
+    `The [code:style-src] directive specifies valid sources for
   stylesheets. This includes both externally-loaded stylesheets and inline
-  use of the <code>&lt;style&gt;</code> element and HTML style attributes.
+  use of the [code:<style>] element and HTML style attributes.
   Stylesheets from sources that aren't included in the source list are not
-  requested or loaded. When either the <code>style-src</code> or the
-  <code>default-src</code> directive is included, inline use of the
-  <code>&lt;style&gt;</code> element and HTML style attributes are disabled
+  requested or loaded. When either the [code:style-src] or the
+  [code:default-src] directive is included, inline use of the
+  [code:<style>] element and HTML style attributes are disabled
   unless you specify 'unsafe-inline'.`
   ),
-  'style-src-elem': t(
-    `The <code>style-src-elem</code> directive applies to all styles except
+  'style-src-elem': tctCode(
+    `The [code:style-src-elem] directive applies to all styles except
       those defined in inline attributes.`
   ),
-  'style-src-attr': t(
-    `The <code>style-src-attr</code> directive applies to inline style attributes and, if present,
-      it will override the <code>style-src</code> directive for relevant checks.`
+  'style-src-attr': tctCode(
+    `The [code:style-src-attr] directive applies to inline style attributes and, if present,
+      it will override the [code:style-src] directive for relevant checks.`
   ),
-  'frame-src': t(
-    `The <code>frame-src</code> directive specifies valid sources for nested
+  'frame-src': tctCode(
+    `The [code:frame-src] directive specifies valid sources for nested
   browsing contexts loading using elements such as
-  <code>&lt;frame&gt;</code> and <code>&lt;iframe&gt;</code>.`
+  [code:<frame>] and [code:<iframe>].`
   ),
-  'worker-src': t(
-    `The <code>worker-src</code> directive specifies valid sources for
-  <code>Worker<code>, <code>SharedWorker</code>, or
-  <code>ServiceWorker</code> scripts.`
+  'worker-src': tctCode(
+    `The [code:worker-src] directive specifies valid sources for
+  [code:Worker], [code:SharedWorker], or
+  [code:ServiceWorker] scripts.`
   ),
 };

--- a/static/app/components/events/interfaces/csp/help/index.tsx
+++ b/static/app/components/events/interfaces/csp/help/index.tsx
@@ -17,10 +17,6 @@ export type HelpProps = {
 };
 
 export function CSPHelp({data: {effective_directive: key}}: HelpProps) {
-  const getHelp = () => ({
-    __html: effectiveDirectives[key],
-  });
-
   const getLinkHref = () => {
     const baseLink =
       'https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#';
@@ -49,7 +45,7 @@ export function CSPHelp({data: {effective_directive: key}}: HelpProps) {
       <h4>
         <code>{key}</code>
       </h4>
-      <blockquote dangerouslySetInnerHTML={getHelp()} />
+      <blockquote>{effectiveDirectives[key]}</blockquote>
       <StyledP>
         <span>{'\u2014 MDN ('}</span>
         <span>{getLink()}</span>

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -20,6 +20,7 @@ interface OnboardingCodeSnippetProps extends Omit<
  * @returns object with keys as tokens and values as array of HTMLSpanElement
  */
 export function replaceTokensWithSpan(element: HTMLElement) {
+  // eslint-disable-next-line @sentry/no-trusted-types-sinks -- TODO: removed by the CodeBlock -> usePrismTokens migration
   element.innerHTML = element.innerHTML.replace(
     /(___ORG_AUTH_TOKEN___)/g,
     '<span data-token="$1"></span>'

--- a/static/app/debug/notifications/previews/emailPreview.tsx
+++ b/static/app/debug/notifications/previews/emailPreview.tsx
@@ -88,6 +88,7 @@ function EmailHtmlPreview({html}: {html: string}) {
       if (!node) {
         return;
       }
+      // eslint-disable-next-line @sentry/no-trusted-types-sinks -- sanitized above; the rule cannot see through useMemo
       node.srcdoc = sanitized;
       node.onload = () => {
         const doc = node.contentDocument;

--- a/static/app/debug/notifications/previews/emailPreview.tsx
+++ b/static/app/debug/notifications/previews/emailPreview.tsx
@@ -1,4 +1,6 @@
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import dompurify from 'dompurify';
 
 import {Container, Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
@@ -47,9 +49,7 @@ export function EmailPreview({
         <Stack padding="xl">
           <Text bold>{subject}</Text>
           <Text variant="muted">To: user@example.com</Text>
-          {emailFormat === EmailFormat.HTML && (
-            <div dangerouslySetInnerHTML={{__html: html_content}} />
-          )}
+          {emailFormat === EmailFormat.HTML && <EmailHtmlPreview html={html_content} />}
           {emailFormat === EmailFormat.TXT && (
             <EmailTextBlock>
               <pre>{text_content}</pre>
@@ -60,6 +60,59 @@ export function EmailPreview({
     </DebugNotificationsPreview>
   );
 }
+
+/**
+ * Emails are whole documents, so render one in an iframe rather than splicing
+ * it into this page. Injecting it inline drops everything outside `<body>` and
+ * lets the email's `<style>` and Sentry's own CSS bleed into each other, which
+ * makes the preview unfaithful.
+ *
+ * `sandbox` without `allow-scripts` keeps the document inert; `allow-same-origin`
+ * is only there so we can read `scrollHeight` to size the frame.
+ */
+function EmailHtmlPreview({html}: {html: string}) {
+  const [height, setHeight] = useState(320);
+
+  const sanitized = useMemo(
+    () =>
+      dompurify.sanitize(html, {
+        WHOLE_DOCUMENT: true,
+        ADD_TAGS: ['meta'],
+        ADD_ATTR: ['name', 'content', 'charset'],
+      }),
+    [html]
+  );
+
+  const frameRef = useCallback(
+    (node: HTMLIFrameElement | null) => {
+      if (!node) {
+        return;
+      }
+      node.srcdoc = sanitized;
+      node.onload = () => {
+        const doc = node.contentDocument;
+        if (doc) {
+          setHeight(doc.documentElement.scrollHeight);
+        }
+      };
+    },
+    [sanitized]
+  );
+
+  return (
+    <EmailFrame
+      ref={frameRef}
+      sandbox="allow-same-origin"
+      title="Email preview"
+      style={{height}}
+    />
+  );
+}
+
+const EmailFrame = styled('iframe')`
+  width: 100%;
+  border: 0;
+`;
 
 const EmailTextBlock = styled('code')`
   margin: ${p => p.theme.space.md} 0;

--- a/static/app/debug/notifications/types.ts
+++ b/static/app/debug/notifications/types.ts
@@ -21,7 +21,7 @@ export interface NotificationTemplateRegistration {
   };
   previews: {
     [NotificationProviderKey.EMAIL]: {
-      html_content: TrustedHTML;
+      html_content: string;
       subject: string;
       text_content: string;
     };

--- a/static/app/serviceWorker/client/serviceWorkerContext.tsx
+++ b/static/app/serviceWorker/client/serviceWorkerContext.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 import {useFrontendVersion} from 'sentry/components/frontendVersionContext';
 import {isServiceWorkerSupported} from 'sentry/serviceWorker/client/isServiceWorkerSupported';
 import {ServiceWorkerController} from 'sentry/serviceWorker/client/serviceWorkerInterface';
+import {getSentryScriptUrlPolicy} from 'sentry/utils/trustedTypes';
 
 const DEBUG_LOGGING = false;
 
@@ -16,7 +17,11 @@ function log(message: string, options?: Sentry.metrics.MetricOptions) {
 }
 
 function getWorkerUrl(): string {
-  return window.__SENTRY_DEV_UI ? '/entrypoints/service-worker.js' : '/service-worker.js';
+  const url = window.__SENTRY_DEV_UI
+    ? '/entrypoints/service-worker.js'
+    : '/service-worker.js';
+
+  return (getSentryScriptUrlPolicy()?.createScriptURL(url) ?? url) as unknown as string;
 }
 
 const Context = createContext({

--- a/static/app/utils/demoMode/utils.tsx
+++ b/static/app/utils/demoMode/utils.tsx
@@ -72,6 +72,7 @@ function initDemoAnalytics() {
     mainScript.id = 'plausible-script';
     mainScript.defer = true;
     mainScript.setAttribute('data-domain', window.location.hostname);
+    // eslint-disable-next-line @sentry/no-trusted-types-sinks -- TODO: cross-origin script, needs a policy decision
     mainScript.src = 'https://plausible.io/js/script.pageview-props.tagged-events.js';
 
     const queueScript = document.createElement('script');

--- a/static/app/utils/demoMode/utils.tsx
+++ b/static/app/utils/demoMode/utils.tsx
@@ -76,8 +76,11 @@ function initDemoAnalytics() {
 
     const queueScript = document.createElement('script');
     queueScript.id = 'plausible-queue-script';
-    queueScript.textContent =
-      'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }';
+    queueScript.appendChild(
+      document.createTextNode(
+        'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }'
+      )
+    );
 
     document.head.appendChild(mainScript);
     document.head.appendChild(queueScript);

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -95,7 +95,7 @@ const ALLOWED_TAGS = [
   'sup',
 ];
 
-const ALLOWED_ATTR = ['href', 'title', 'alt', 'class', 'id', 'align'];
+const ALLOWED_ATTR = ['href', 'title', 'alt', 'class', 'align'];
 
 export function sanitizeHtml(html: string) {
   return dompurify.sanitize(html, {

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -101,7 +101,8 @@ export function sanitizeHtml(html: string) {
   return dompurify.sanitize(html, {
     ALLOWED_TAGS,
     ALLOWED_ATTR,
-  });
+    RETURN_TRUSTED_TYPE: true,
+  }) as unknown as string;
 }
 
 function postprocess(html: string) {

--- a/static/app/utils/marked/markedText.tsx
+++ b/static/app/utils/marked/markedText.tsx
@@ -64,5 +64,6 @@ export function MarkedText<T extends React.ElementType = typeof defaultElement>(
 
   const Component = as || defaultElement;
 
+  // eslint-disable-next-line @sentry/no-trusted-types-sinks -- renderedHtml comes from the sanitized marked renderers
   return <Component dangerouslySetInnerHTML={{__html: renderedHtml}} {...props} />;
 }

--- a/static/app/utils/profiling/renderers/testUtils.tsx
+++ b/static/app/utils/profiling/renderers/testUtils.tsx
@@ -64,6 +64,7 @@ export class FlamegraphRendererDOM extends FlamegraphRenderer {
       div.style.width = `${rect.width}px`;
       div.style.height = `${rect.height}px`;
       div.style.backgroundColor = color;
+      // eslint-disable-next-line @sentry/no-trusted-types-sinks -- test-only renderer, not shipped
       div.innerHTML = frame.frame.name;
       div.setAttribute('data-test-id', 'flamegraph-frame');
       this.container.appendChild(div);

--- a/static/app/utils/replays/extractDomNodes.tsx
+++ b/static/app/utils/replays/extractDomNodes.tsx
@@ -94,11 +94,13 @@ function removeChildLevel(max: number, collection: HTMLCollection, current = 0) 
       child.textContent = '/* Inline CSS */';
     }
     if (child.nodeName === 'svg') {
-      child.innerHTML = '<!-- SVG -->';
+      child.replaceChildren(document.createComment(' SVG '));
     }
     if (max <= current) {
       if (child.childElementCount > 0) {
-        child.innerHTML = `<!-- ${child.childElementCount} descendents -->`;
+        child.replaceChildren(
+          document.createComment(` ${child.childElementCount} descendents `)
+        );
       }
     } else {
       removeChildLevel(max, child.children, current + 1);

--- a/static/app/utils/replays/extractDomNodes.tsx
+++ b/static/app/utils/replays/extractDomNodes.tsx
@@ -112,6 +112,7 @@ function removeNodesAtLevel(html: string, level: number): string {
   const parser = new DOMParser();
 
   try {
+    // eslint-disable-next-line @sentry/no-trusted-types-sinks -- TODO: replay HTML genuinely needs a TrustedHTML
     const doc = parser.parseFromString(html, 'text/html');
     removeChildLevel(level, doc.body.children);
     return doc.body.innerHTML;

--- a/static/app/utils/splashLoader.ts
+++ b/static/app/utils/splashLoader.ts
@@ -1,0 +1,17 @@
+let splashLoader: Element | null = null;
+
+/**
+ * Remember the loader that the server-rendered Django view put inside the React
+ * root, before React's first commit removes it. Holding a reference keeps the
+ * detached node alive so it can be re-parented later.
+ *
+ * Note we deliberately do not detach it here — leaving the removal to React's
+ * own commit avoids a blank flash between bootstrap and first paint.
+ */
+export function captureSplashLoader(container: Element) {
+  splashLoader = container.querySelector('.splash-loader');
+}
+
+export function getSplashLoader() {
+  return splashLoader;
+}

--- a/static/app/utils/trustedTypes.ts
+++ b/static/app/utils/trustedTypes.ts
@@ -1,0 +1,69 @@
+import dompurify from 'dompurify';
+
+declare global {
+  interface Window {
+    trustedTypes?: {
+      createPolicy: (
+        name: string,
+        rules: {
+          createHTML?: (input: string) => string;
+          createScript?: (input: string) => string;
+          createScriptURL?: (input: string) => string;
+        }
+      ) => TrustedTypePolicy;
+    };
+  }
+
+  interface TrustedTypePolicy {
+    createHTML: (input: string) => TrustedHTML;
+    createScriptURL: (input: string) => TrustedScriptURL;
+    name: string;
+  }
+
+  interface TrustedHTML {
+    toString(): string;
+  }
+
+  interface TrustedScriptURL {
+    toString(): string;
+  }
+}
+
+let sentryScriptUrlPolicy: TrustedTypePolicy | null = null;
+
+export function trustedTypesSupported(): boolean {
+  return typeof window !== 'undefined' && typeof window.trustedTypes === 'object';
+}
+
+export function installTrustedTypesPolicies(): void {
+  if (!trustedTypesSupported()) {
+    return;
+  }
+
+  try {
+    dompurify.sanitize('', {RETURN_TRUSTED_TYPE: true});
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Trusted Types: failed to warm dompurify policy', err);
+  }
+
+  if (!sentryScriptUrlPolicy) {
+    try {
+      sentryScriptUrlPolicy = window.trustedTypes!.createPolicy('sentry-script-url', {
+        createScriptURL: (input: string) => {
+          if (new URL(input, window.location.origin).origin !== window.location.origin) {
+            throw new TypeError(`sentry-script-url: refusing cross-origin ${input}`);
+          }
+          return input;
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Trusted Types: failed to create sentry-script-url policy', err);
+    }
+  }
+}
+
+export function getSentryScriptUrlPolicy(): TrustedTypePolicy | null {
+  return sentryScriptUrlPolicy;
+}

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useCallback, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
-import dompurify from 'dompurify';
 import type {SeriesOption, YAXisComponentOption} from 'echarts';
 import type {
   TooltipFormatterCallback,
@@ -279,13 +279,14 @@ export function CategoricalSeriesWidgetVisualization(
               }
             }
 
-            // param.marker is an HTML string with a colored circle, sanitize it
-            const marker = typeof param.marker === 'string' ? param.marker : '';
-
             return (
               <div key={param.seriesIndex}>
                 <span className="tooltip-label">
-                  <span dangerouslySetInnerHTML={{__html: dompurify.sanitize(marker)}} />{' '}
+                  <SeriesMarker
+                    markerColor={
+                      typeof param.color === 'string' ? param.color : 'transparent'
+                    }
+                  />{' '}
                   <strong>{displayName}</strong>
                 </span>{' '}
                 {formattedValue}
@@ -405,3 +406,16 @@ export function CategoricalSeriesWidgetVisualization(
 
 CategoricalSeriesWidgetVisualization.LoadingPlaceholder = WidgetLoadingPanel;
 CategoricalSeriesWidgetVisualization.NoData = WidgetNoDataPanel;
+
+/**
+ * Mirrors the marker ECharts generates for tooltips, which we would otherwise
+ * receive as an HTML string in `param.marker`.
+ */
+const SeriesMarker = styled('span')<{markerColor: string}>`
+  display: inline-block;
+  margin-right: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 10px;
+  background-color: ${p => p.markerColor};
+`;

--- a/static/app/views/organizationContainer.spec.tsx
+++ b/static/app/views/organizationContainer.spec.tsx
@@ -1,0 +1,159 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ROOT_ELEMENT} from 'sentry/constants';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {captureSplashLoader} from 'sentry/utils/splashLoader';
+import {OrganizationContainer} from 'sentry/views/organizationContainer';
+
+function makeReactRoot() {
+  const rootEl = document.createElement('div');
+  rootEl.id = ROOT_ELEMENT;
+  rootEl.innerHTML =
+    '<div class="splash-loader"><div data-test-id="loading-indicator">loading</div></div>';
+  document.body.appendChild(rootEl);
+  return rootEl;
+}
+
+describe('OrganizationContainer', () => {
+  let rootEl: HTMLElement | undefined;
+
+  beforeEach(() => {
+    OrganizationStore.reset();
+  });
+
+  afterEach(() => {
+    rootEl?.remove();
+    rootEl = undefined;
+    // Reset the module-level captured loader between tests
+    captureSplashLoader(document.createElement('div'));
+  });
+
+  describe('loading', () => {
+    it('re-parents the server-rendered loader', () => {
+      rootEl = makeReactRoot();
+      const indicator = rootEl.querySelector('[data-test-id="loading-indicator"]');
+      captureSplashLoader(rootEl);
+
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      // The node was moved, not copied — so there is exactly one of it, and it
+      // is the very node the server rendered.
+      expect(screen.getByTestId('loading-indicator')).toBe(indicator);
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+
+    it('shows the loader again after an org switch, not a copy of the app', () => {
+      rootEl = makeReactRoot();
+      const indicator = rootEl.querySelector('[data-test-id="loading-indicator"]');
+      captureSplashLoader(rootEl);
+
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onUpdate(OrganizationFixture());
+      });
+      expect(screen.getByText('content')).toBeInTheDocument();
+
+      // Simulate React having taken over the root with real app DOM. Reading
+      // innerHTML here used to snapshot the whole previous org's UI.
+      rootEl.innerHTML = '<main>previous org ui</main>';
+
+      // An org switch resets the store back to loading
+      act(() => {
+        OrganizationStore.reset();
+      });
+
+      // Drop the stand-in root, so anything left in the document mentioning the
+      // previous org can only be a copy the component made.
+      rootEl.remove();
+
+      expect(screen.queryByText('previous org ui')).not.toBeInTheDocument();
+      expect(screen.getByTestId('loading-indicator')).toBe(indicator);
+    });
+
+    it('renders without throwing when no loader was captured', () => {
+      expect(() =>
+        render(
+          <OrganizationContainer>
+            <div>content</div>
+          </OrganizationContainer>
+        )
+      ).not.toThrow();
+
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loaded', () => {
+    it('renders children once the organization resolves', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onUpdate(OrganizationFixture());
+      });
+
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+  });
+
+  describe('errors', () => {
+    it('renders children without an organization for ORG_NO_ACCESS', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        // 401 is what the store maps to ORG_NO_ACCESS
+        OrganizationStore.onFetchOrgError({status: 401} as any);
+      });
+
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+
+    it('renders a not-found alert for ORG_NOT_FOUND', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onFetchOrgError({status: 404} as any);
+      });
+
+      expect(screen.getByTestId('org-loading-error')).toBeInTheDocument();
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+
+    it('renders a generic loading error for other failures', () => {
+      render(
+        <OrganizationContainer>
+          <div>content</div>
+        </OrganizationContainer>
+      );
+
+      act(() => {
+        OrganizationStore.onFetchOrgError({status: 500} as any);
+      });
+
+      expect(screen.getByText('There was an error loading data.')).toBeInTheDocument();
+      expect(screen.queryByText('content')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/organizationContainer.tsx
+++ b/static/app/views/organizationContainer.tsx
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import {Outlet} from 'react-router-dom';
 import {useProfiler} from '@sentry/react';
 
@@ -5,10 +6,11 @@ import {Alert} from '@sentry/scraps/alert';
 import {Container} from '@sentry/scraps/layout';
 
 import {LoadingError} from 'sentry/components/loadingError';
-import {ORGANIZATION_FETCH_ERROR_TYPES, ROOT_ELEMENT} from 'sentry/constants';
+import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {getSplashLoader} from 'sentry/utils/splashLoader';
 
 function OrganizationLoadingIndicator() {
   /* Track how long this component is rendered for. */
@@ -18,19 +20,23 @@ function OrganizationLoadingIndicator() {
 
   /**
    * This is the initial loader React will render as the app bootstraps.
-   * Rather than rendering a loader component, we can reuse the existing DOM
+   * Rather than rendering a loader component, we re-parent the existing DOM
    * provided by the server-rendered Django view!
    *
    * This ensures there are no layout shifts as the app initially boots up
-   * because the DOM is exactly the same and React doesn't have to reconcile
-   * the fallback state.
+   * because it is literally the same node, so React has nothing to reconcile.
+   *
+   * `appendChild` moves the node rather than copying it, so re-mounting (an org
+   * switch resets the store back to loading) picks the same loader back up.
    */
-  const root = document.getElementById(ROOT_ELEMENT);
-  // There is no scenario in which this component is rendering,
-  // but the root element where the app is mounted doesn't exist
-  const ssrLoader = root!.innerHTML;
+  const loaderRef = useCallback((node: HTMLDivElement | null) => {
+    const loader = getSplashLoader();
+    if (node && loader) {
+      node.appendChild(loader);
+    }
+  }, []);
 
-  return <div dangerouslySetInnerHTML={{__html: ssrLoader}} />;
+  return <div ref={loaderRef} />;
 }
 
 interface Props {

--- a/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
@@ -31,9 +31,17 @@ export function RecoveryCodes({
     // @ts-expect-error TS(7015): Element implicitly has an 'any' type because index... Remove this comment to see the full error message
     // eslint-disable-next-line @typescript-eslint/dot-notation
     const iframe = window.frames['printable'];
-    iframe.document.write(codes.join('<br>'));
+    const doc = iframe.document;
+
+    doc.body.replaceChildren();
+    codes.forEach((code, i) => {
+      if (i > 0) {
+        doc.body.appendChild(doc.createElement('br'));
+      }
+      doc.body.appendChild(doc.createTextNode(code));
+    });
+
     iframe.print();
-    iframe.document.close();
   };
 
   if (!isEnrolled || !codes) {

--- a/static/eslint/eslintPluginSentry/index.ts
+++ b/static/eslint/eslintPluginSentry/index.ts
@@ -7,6 +7,7 @@ import {noQueryDataTypeParameters} from './noQueryDataTypeParameters';
 import {noRawCssInStyled} from './noRawCssInStyled';
 import {noStaticTranslations} from './noStaticTranslations';
 import {noStyledShortcut} from './noStyledShortcut';
+import {noTrustedTypesSinks} from './noTrustedTypesSinks';
 import {noUnnecessaryTypeAnnotation} from './noUnnecessaryTypeAnnotation';
 import {noUnnecessaryTypeNarrowing} from './noUnnecessaryTypeNarrowing';
 import {noUnnecessaryUseCallback} from './noUnnecessaryUseCallback';
@@ -22,6 +23,7 @@ export const rules = {
   'no-raw-css-in-styled': noRawCssInStyled,
   'no-static-translations': noStaticTranslations,
   'no-styled-shortcut': noStyledShortcut,
+  'no-trusted-types-sinks': noTrustedTypesSinks,
   'no-useless-css-interpolation-semicolon': noUselessCssInterpolationSemicolon,
   'no-unnecessary-type-annotation': noUnnecessaryTypeAnnotation,
   'no-unnecessary-type-narrowing': noUnnecessaryTypeNarrowing,

--- a/static/eslint/eslintPluginSentry/noTrustedTypesSinks.spec.ts
+++ b/static/eslint/eslintPluginSentry/noTrustedTypesSinks.spec.ts
@@ -1,0 +1,142 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noTrustedTypesSinks} from './noTrustedTypesSinks';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-trusted-types-sinks', noTrustedTypesSinks, {
+  valid: [
+    // Sanitizer calls are the supported way to feed a sink
+    {
+      code: '<div dangerouslySetInnerHTML={{__html: sanitizeHtml(raw)}} />',
+      filename: 'file.tsx',
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={{__html: singleLineRenderer(text)}} />',
+      filename: 'file.tsx',
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={{__html: sanitizedMarked(body)}} />',
+      filename: 'file.tsx',
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(note, {})}} />',
+      filename: 'file.tsx',
+    },
+    // A local const holding a sanitizer result resolves through
+    {
+      code: 'const sanitized = sanitizeHtml(raw); const el = <div dangerouslySetInnerHTML={{__html: sanitized}} />;',
+      filename: 'file.tsx',
+    },
+    // Not sinks: only <script> makes these dangerous, only document has write
+    {code: 'div.textContent = userInput;', filename: 'file.ts'},
+    {code: 'img.src = url;', filename: 'file.ts'},
+    {code: 'iframe.src = url;', filename: 'file.ts'},
+    {code: 'stream.write(chunk);', filename: 'file.ts'},
+    {code: 'logger.writeln(msg);', filename: 'file.ts'},
+    // Reading is not a sink
+    {code: 'const html = el.innerHTML;', filename: 'file.ts'},
+    // Sanitized assignment is allowed
+    {code: 'el.innerHTML = sanitizeHtml(raw);', filename: 'file.ts'},
+  ],
+  invalid: [
+    // Values the rule cannot see into must be reported, not assumed safe
+    {
+      code: '<div dangerouslySetInnerHTML={getHelp()} />',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={htmlProps} />',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={{...getHelp()}} />',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={{__html: rawHtmlString}} />',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    {
+      code: '<div dangerouslySetInnerHTML={{__html: `<b>${name}</b>`}} />',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    // A let, or a const not initialized from a sanitizer, does not resolve
+    {
+      code: 'let sanitized = sanitizeHtml(raw); const el = <div dangerouslySetInnerHTML={{__html: sanitized}} />;',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    {
+      code: 'const notSafe = someOtherFn(raw); const el = <div dangerouslySetInnerHTML={{__html: notSafe}} />;',
+      filename: 'file.tsx',
+      errors: [{messageId: 'jsxSink'}],
+    },
+    {
+      code: 'el.innerHTML = userInput;',
+      filename: 'file.ts',
+      errors: [{messageId: 'assignmentSink'}],
+    },
+    {
+      code: "el.innerHTML = '';",
+      filename: 'file.ts',
+      errors: [{messageId: 'assignmentSink'}],
+    },
+    {
+      code: 'el.outerHTML = userInput;',
+      filename: 'file.ts',
+      errors: [{messageId: 'assignmentSink'}],
+    },
+    {
+      code: 'frame.srcdoc = userInput;',
+      filename: 'file.ts',
+      errors: [{messageId: 'assignmentSink'}],
+    },
+    {
+      code: "el.insertAdjacentHTML('beforeend', userInput);",
+      filename: 'file.ts',
+      errors: [{messageId: 'callSink'}],
+    },
+    {
+      code: 'document.write(userInput);',
+      filename: 'file.ts',
+      errors: [{messageId: 'callSink'}],
+    },
+    {
+      code: 'iframe.document.write(codes.join("<br>"));',
+      filename: 'file.ts',
+      errors: [{messageId: 'callSink'}],
+    },
+    {
+      code: "new DOMParser().parseFromString(html, 'text/html');",
+      filename: 'file.ts',
+      errors: [{messageId: 'callSink'}],
+    },
+    {
+      code: "range.createContextualFragment('<b>x</b>');",
+      filename: 'file.ts',
+      errors: [{messageId: 'callSink'}],
+    },
+    // <script> element writes are TrustedScript sinks
+    {
+      code: "queueScript.textContent = 'window.x = 1';",
+      filename: 'file.ts',
+      errors: [{messageId: 'scriptSink'}],
+    },
+    {
+      code: "mainScript.text = 'window.x = 1';",
+      filename: 'file.ts',
+      errors: [{messageId: 'scriptSink'}],
+    },
+    {
+      code: "mainScript.src = 'https://plausible.io/js/script.js';",
+      filename: 'file.ts',
+      errors: [{messageId: 'scriptSink'}],
+    },
+  ],
+});

--- a/static/eslint/eslintPluginSentry/noTrustedTypesSinks.ts
+++ b/static/eslint/eslintPluginSentry/noTrustedTypesSinks.ts
@@ -1,0 +1,222 @@
+import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
+import {AST_NODE_TYPES, ESLintUtils} from '@typescript-eslint/utils';
+import {DefinitionType} from '@typescript-eslint/scope-manager';
+
+/**
+ * Functions that return a value already run through a sanitizer, so their
+ * result is safe to hand to an injection sink. Keep this list short — every
+ * entry is a promise that the function sanitizes, not merely that its current
+ * callers happen to pass safe input.
+ */
+const SANITIZERS = new Set([
+  'sanitizeHtml',
+  'sanitizedMarked',
+  'asyncSanitizedMarked',
+  'singleLineRenderer',
+]);
+
+/** Member calls treated as sanitizers, matched on the property name. */
+const SANITIZER_METHODS = new Set(['sanitize']);
+
+/** `el.<name> = value` */
+const ASSIGNMENT_SINKS = new Set(['innerHTML', 'outerHTML', 'srcdoc']);
+
+/** Sinks only when the element is a `<script>`; see the comment at the use site. */
+const SCRIPT_SINKS = new Set(['textContent', 'text', 'innerText', 'src']);
+
+/** `el.<name>(value)` */
+const CALL_SINKS = new Set([
+  'insertAdjacentHTML',
+  'createContextualFragment',
+  'setHTMLUnsafe',
+  'parseFromString',
+  'write',
+  'writeln',
+]);
+
+function isSanitizerCall(node: TSESTree.Node | null | undefined): boolean {
+  if (node?.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+  const {callee} = node;
+  if (callee.type === AST_NODE_TYPES.Identifier) {
+    return SANITIZERS.has(callee.name);
+  }
+  if (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    return SANITIZER_METHODS.has(callee.property.name);
+  }
+  return false;
+}
+
+/**
+ * Resolve an identifier back to a single `const x = sanitizeHtml(...)` in
+ * scope. Deliberately shallow: one definition, one initializer. Anything less
+ * obvious should be explicit at the call site rather than inferred here.
+ */
+function resolvesToSanitizer(
+  node: TSESTree.Node,
+  scope: TSESLint.Scope.Scope | null
+): boolean {
+  if (node.type !== AST_NODE_TYPES.Identifier) {
+    return false;
+  }
+  for (let current = scope; current; current = current.upper) {
+    const variable = current.variables.find(v => v.name === node.name);
+    if (!variable) {
+      continue;
+    }
+    if (variable.defs.length !== 1) {
+      return false;
+    }
+    const def = variable.defs[0]!;
+    return (
+      def.type === DefinitionType.Variable &&
+      def.parent.kind === 'const' &&
+      isSanitizerCall(def.node.init)
+    );
+  }
+  return false;
+}
+
+export const noTrustedTypesSinks = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow writing unsanitized values to Trusted Types injection sinks',
+    },
+    schema: [],
+    messages: {
+      jsxSink:
+        'dangerouslySetInnerHTML is a Trusted Types injection sink. Pass a value from a sanitizer (sanitizeHtml, singleLineRenderer, sanitizedMarked, or DOMPurify.sanitize with RETURN_TRUSTED_TYPE), or render the content as JSX instead.',
+      assignmentSink:
+        'Assigning to `{{name}}` is a Trusted Types injection sink. Build DOM nodes instead (createElement / createTextNode / createComment / replaceChildren), or assign a value from a sanitizer.',
+      callSink:
+        '`{{name}}` is a Trusted Types injection sink. Build DOM nodes instead, or pass a value from a sanitizer.',
+      scriptSink:
+        'Writing to a script element is a Trusted Types injection sink. Use `script.appendChild(document.createTextNode(...))`, which is not a sink.',
+    },
+  },
+  create(context) {
+    function isSafe(node: TSESTree.Node | null | undefined): boolean {
+      if (!node) {
+        return false;
+      }
+      if (isSanitizerCall(node)) {
+        return true;
+      }
+      return resolvesToSanitizer(node, context.sourceCode.getScope(node));
+    }
+
+    return {
+      JSXAttribute(node) {
+        if (
+          node.name.type !== AST_NODE_TYPES.JSXIdentifier ||
+          node.name.name !== 'dangerouslySetInnerHTML' ||
+          node.value?.type !== AST_NODE_TYPES.JSXExpressionContainer
+        ) {
+          return;
+        }
+
+        const {expression} = node.value;
+
+        // An inline object is the only shape we can judge statically. Anything
+        // else — `{...getHelp()}`, a spread, an identifier — hides the value, so
+        // it has to be reported rather than assumed safe.
+        if (expression.type !== AST_NODE_TYPES.ObjectExpression) {
+          context.report({node, messageId: 'jsxSink'});
+          return;
+        }
+
+        const html = expression.properties.find(
+          (p): p is TSESTree.Property =>
+            p.type === AST_NODE_TYPES.Property &&
+            p.key.type === AST_NODE_TYPES.Identifier &&
+            p.key.name === '__html'
+        );
+
+        // A spread (`{...obj}`) also hides `__html`.
+        const hasSpread = expression.properties.some(
+          p => p.type === AST_NODE_TYPES.SpreadElement
+        );
+
+        if (!html) {
+          if (hasSpread) {
+            context.report({node, messageId: 'jsxSink'});
+          }
+          return;
+        }
+
+        if (!isSafe(html.value)) {
+          context.report({node, messageId: 'jsxSink'});
+        }
+      },
+
+      AssignmentExpression(node) {
+        const {left} = node;
+        if (
+          left.type !== AST_NODE_TYPES.MemberExpression ||
+          left.property.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return;
+        }
+
+        const name = left.property.name;
+
+        // `textContent` / `text` / `innerText` / `src` are only sinks on
+        // <script>, which we cannot detect without type information — `img.src`
+        // is fine. Fall back to flagging when the object is *named* like a
+        // script element, which covers the realistic `createElement('script')`
+        // pattern without drowning every `img.src = url` in false positives.
+        if (
+          SCRIPT_SINKS.has(name) &&
+          left.object.type === AST_NODE_TYPES.Identifier &&
+          /script/i.test(left.object.name)
+        ) {
+          context.report({node, messageId: 'scriptSink'});
+          return;
+        }
+
+        if (ASSIGNMENT_SINKS.has(name) && !isSafe(node.right)) {
+          context.report({node, messageId: 'assignmentSink', data: {name}});
+        }
+      },
+
+      CallExpression(node) {
+        const {callee} = node;
+        if (
+          callee.type !== AST_NODE_TYPES.MemberExpression ||
+          callee.property.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return;
+        }
+
+        const name = callee.property.name;
+        if (!CALL_SINKS.has(name)) {
+          return;
+        }
+
+        // `write`/`writeln` are only sinks on a document.
+        if (name === 'write' || name === 'writeln') {
+          const obj = callee.object;
+          const isDocument =
+            (obj.type === AST_NODE_TYPES.Identifier && obj.name === 'document') ||
+            (obj.type === AST_NODE_TYPES.MemberExpression &&
+              obj.property.type === AST_NODE_TYPES.Identifier &&
+              obj.property.name === 'document');
+          if (!isDocument) {
+            return;
+          }
+        }
+
+        const value = name === 'insertAdjacentHTML' ? node.arguments[1] : node.arguments[0];
+        if (!isSafe(value)) {
+          context.report({node, messageId: 'callSink', data: {name}});
+        }
+      },
+    };
+  },
+});

--- a/static/gsApp/views/subscriptionPage/partnershipNote.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/partnershipNote.spec.tsx
@@ -1,0 +1,62 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PartnershipNote} from 'getsentry/views/subscriptionPage/partnershipNote';
+
+// The real note, verbatim from getsentry nintendo_configs.py
+const NINTENDO_NOTE =
+  'Contact <a href="https://developer.nintendo.com/group/development/g1kr9vj6/tech-info/crash-analysis-service-support" target="_blank" rel="noreferrer">Nintendo Developer Portal</a> support to make changes to your subscription.';
+
+function subscriptionWithNote(supportNote: string) {
+  const organization = OrganizationFixture();
+  const subscription = SubscriptionFixture({organization});
+  subscription.partner = {
+    externalId: 'x',
+    isActive: true,
+    name: '',
+    partnership: {displayName: 'Nintendo', id: 'NT', supportNote},
+  };
+  return subscription;
+}
+
+describe('PartnershipNote', () => {
+  it('preserves the partner link, including target and rel', () => {
+    render(<PartnershipNote subscription={subscriptionWithNote(NINTENDO_NOTE)} />);
+
+    const link = screen.getByRole('link', {
+      name: 'Nintendo Developer Portal',
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining('developer.nintendo.com')
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+    expect(screen.getByText(/support to make changes/)).toBeInTheDocument();
+  });
+
+  it('strips script tags and event handlers', () => {
+    render(
+      <PartnershipNote
+        subscription={subscriptionWithNote(
+          'Hi<script>window.pwned=1</script><img src=x onerror="window.pwned=1">there'
+        )}
+      />
+    );
+
+    const note = screen.getByTestId('partnership-note');
+    expect(note.querySelector('script')).toBeNull();
+    expect(note.querySelector('[onerror]')).toBeNull();
+    expect(note).toHaveTextContent('Hithere');
+  });
+
+  it('falls back to the default message with no partner', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization});
+    render(<PartnershipNote subscription={subscription} />);
+
+    expect(screen.getByText(/Contact us at/)).toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/subscriptionPage/partnershipNote.tsx
+++ b/static/gsApp/views/subscriptionPage/partnershipNote.tsx
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {tct} from 'sentry/locale';
@@ -19,12 +21,19 @@ export function PartnershipNote({subscription}: Props) {
     <Panel data-test-id="partnership-note">
       <PanelBody withPadding>
         {subscription.partner ? (
-          // usually we pass it through sentry.utils.marked but
-          // markdown doesn't support adding attributes to links
+          // Kept as HTML because the note is authored with a target/rel link.
+          // Note the `<Markdown>` renderer *does* set those (external links go
+          // through ExternalLink) — it is the HTML-string pipeline in
+          // utils/marked that strips them.
           <TextBlock
             noMargin
             dangerouslySetInnerHTML={{
-              __html: subscription.partner?.partnership.supportNote || '',
+              __html: DOMPurify.sanitize(
+                subscription.partner?.partnership.supportNote || '',
+                // `target` is not in DOMPurify's default allowlist, and the note
+                // links out to the partner's own support site.
+                {ADD_ATTR: ['target']}
+              ),
             }}
           />
         ) : (

--- a/tests/sentry/middleware/test_security.py
+++ b/tests/sentry/middleware/test_security.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from django.test import RequestFactory, override_settings
 from rest_framework.response import Response
@@ -104,3 +104,103 @@ class SecurityHeadersMiddlewareTest(TestCase):
         assert report_to["max_age"] == 86400
         assert len(report_to["endpoints"]) == 1
         assert report_to["endpoints"][0]["url"] == "https://example.com/callback/"
+
+    def test_trusted_types_header_not_set_when_disabled(self) -> None:
+        """TRUSTED_TYPES_ENABLED defaults to False, so no extra policy is emitted."""
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert "Content-Security-Policy-Report-Only" not in processed_response
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False)
+    def test_trusted_types_header_set_when_enabled(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Content-Security-Policy-Report-Only"] == (
+            "require-trusted-types-for 'script'; trusted-types dompurify sentry-script-url sentry-bundler"
+        )
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False)
+    def test_trusted_types_header_does_not_touch_enforced_csp(self) -> None:
+        """The enforced Content-Security-Policy must be left completely alone."""
+        request = self.factory.get("/")
+        response = Response()
+        response["Content-Security-Policy"] = "default-src 'none'; script-src 'self'"
+        processed_response = self.middleware.process_response(request, response)
+
+        assert (
+            processed_response["Content-Security-Policy"] == "default-src 'none'; script-src 'self'"
+        )
+        assert (
+            "require-trusted-types-for" in processed_response["Content-Security-Policy-Report-Only"]
+        )
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=True)
+    def test_trusted_types_header_skipped_when_django_csp_owns_report_only(self) -> None:
+        """
+        django-csp emits the -Report-Only header itself when CSP_REPORT_ONLY is on, and
+        bails if that header already exists. Claiming the name here would silently drop
+        the entire CSP, so the middleware must stand down.
+        """
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert "Content-Security-Policy-Report-Only" not in processed_response
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=True)
+    def test_trusted_types_warns_once_when_skipped(self) -> None:
+        """
+        Standing down is correct but invisible, so someone who enables the setting and
+        sees nothing gets a log line pointing at why. Once per process, not per request.
+        """
+        from sentry.middleware import security
+
+        security._warned_about_report_only_csp = False
+
+        request = self.factory.get("/")
+        with mock.patch.object(security.logger, "warning") as mock_warning:
+            self.middleware.process_response(request, Response())
+            self.middleware.process_response(request, Response())
+
+        assert mock_warning.call_count == 1
+        assert mock_warning.call_args[0][0] == "trusted_types.disabled_by_report_only_csp"
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False)
+    def test_trusted_types_header_does_not_overwrite_existing(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        response["Content-Security-Policy-Report-Only"] = "default-src 'none'"
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Content-Security-Policy-Report-Only"] == "default-src 'none'"
+
+    @override_settings(
+        TRUSTED_TYPES_ENABLED=True,
+        CSP_REPORT_ONLY=False,
+        TRUSTED_TYPES_REPORT_URI="https://example.com/security/?sentry_key=abc",
+    )
+    def test_trusted_types_header_includes_report_uri(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert processed_response["Content-Security-Policy-Report-Only"] == (
+            "require-trusted-types-for 'script'; "
+            "trusted-types dompurify sentry-script-url sentry-bundler; "
+            "report-uri https://example.com/security/?sentry_key=abc"
+        )
+
+    @override_settings(TRUSTED_TYPES_ENABLED=True, CSP_REPORT_ONLY=False, TRUSTED_TYPES_POLICIES=[])
+    def test_trusted_types_header_omits_empty_policy_allowlist(self) -> None:
+        request = self.factory.get("/")
+        response = Response()
+        processed_response = self.middleware.process_response(request, response)
+
+        assert (
+            processed_response["Content-Security-Policy-Report-Only"]
+            == "require-trusted-types-for 'script'"
+        )


### PR DESCRIPTION
Hackweek spike: everything below, on one branch, to see it working end to end. Not for merge — the pieces ship as the PRs listed here.

[Notion: Hackweek: Trusted Types](https://www.notion.so/sentry/Hackweek-Trusted-Types-3c08b10e4b5d80ccb553fedd4a137076)

### Already split out

Legend: ✅ merged · 👀 in review · 🚧 draft — **6 / 11 merged**

| | | |
|---|---|---|
| ✅ | #122318 | csp help → JSX |
| 🚧 | #122319 | org loading indicator |
| ✅ | #122322 | chart tooltip marker |
| ✅ | #122323 | partner support note |
| ✅ | #122347 | printable recovery codes |
| ✅ | #122348 | demo analytics shim |
| ✅ | #122349 | replay placeholder comments |
| ✅ | #122355 | drop `id` from the sanitizer allowlist |
| ✅ | #122356 | email preview iframe |
| 🚧 | #122358 | report-only header |
| 👀 | [zrender#1167](https://github.com/ecomfe/zrender/pull/1167) | upstream `textContent` fix |

### Next

1. Frontend policies + zrender patch (commits 11–12) as PRs
2. Enable collection in dev, triage the stream
3. Lint rule
4. Remaining sinks: Prism / `CodeBlock`, ECharts tooltip, rrweb-player, `showReportDialog`, replay `DOMParser`
5. Decide the cross-origin demo analytics script — allowlist or leave unrouted
6. Enforce

https://claude.ai/code/session_01T35on2nNWQAfBWfSA9eBp1