### PR TITLE
ref(icons): Generalize IdentityIcon presentation

### DIFF
--- a/static/app/icons/identityIcon.spec.tsx
+++ b/static/app/icons/identityIcon.spec.tsx
@@ -1,0 +1,24 @@
+import {createRef} from 'react';
+
+import {render} from 'sentry-test/reactTestingLibrary';
+
+import {IdentityIcon} from 'sentry/icons/identityIcon';
+
+describe('IdentityIcon', () => {
+  it('forwards its ref to the icon container', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    const {container} = render(<IdentityIcon ref={ref} providerId="saml2" />);
+
+    expect(ref.current).toBe(container.firstElementChild);
+    expect(ref.current?.children).toHaveLength(1);
+  });
+
+  it('forwards its class name to the icon container', () => {
+    const {container} = render(
+      <IdentityIcon className="custom-icon" providerId="saml2" />
+    );
+
+    expect(container.firstElementChild).toHaveClass('custom-icon');
+  });
+});

--- a/static/app/icons/identityIcon.tsx
+++ b/static/app/icons/identityIcon.tsx
@@ -44,21 +44,22 @@ const IDENTITY_ICONS = {
   vsts,
 } satisfies Record<string, string>;
 
-export interface IdentityIconProps {
+export interface IdentityIconProps extends React.RefAttributes<HTMLDivElement> {
   providerId: string | keyof typeof IDENTITY_ICONS;
+  className?: string;
 }
 
-export function IdentityIcon({providerId}: IdentityIconProps) {
+export function IdentityIcon({className, providerId, ref}: IdentityIconProps) {
   return (
-    <StyledIdentityIconContainer size={36}>
-      <StyledIdentityIcon size={36} identitySrc={getIdentityIconSource(providerId)} />
+    <StyledIdentityIconContainer ref={ref} className={className}>
+      <StyledIdentityIcon identitySrc={getIdentityIconSource(providerId)} />
     </StyledIdentityIconContainer>
   );
 }
 
-const StyledIdentityIconContainer = styled('div')<{size: number}>`
-  height: ${p => p.size}px;
-  width: ${p => p.size}px;
+const StyledIdentityIconContainer = styled('div')`
+  height: 36px;
+  width: 36px;
   background-color: ${p => p.theme.colors.white};
   border-radius: 2px;
   display: flex;
@@ -66,10 +67,12 @@ const StyledIdentityIconContainer = styled('div')<{size: number}>`
   justify-content: center;
 `;
 
-const StyledIdentityIcon = styled('div')<{identitySrc: string; size: number}>`
+const StyledIdentityIcon = styled('div')<{
+  identitySrc: string;
+}>`
   position: relative;
-  height: ${p => p.size - p.size * 0.2}px;
-  width: ${p => p.size - p.size * 0.2}px;
+  height: 80%;
+  width: 80%;
   border-radius: 2px;
   border: 0;
   display: inline-block;


### PR DESCRIPTION
Generalizes `IdentityIcon` presentation so callers can choose `flex` or `inline-flex` independently of the background treatment. The component now forwards its ref to the outer icon container, making the public ref match the element that owns layout and sizing.

This is a standalone prerequisite for rendering provider icons inline in the React organization-authentication card.