### PR TITLE
ref(sentryapp): Parse buffered request dicts into the RPC model directly

### DIFF
--- a/src/sentry/sentry_apps/services/app_request/serial.py
+++ b/src/sentry/sentry_apps/services/app_request/serial.py
@@ -3,15 +3,4 @@ from sentry.utils.sentry_apps.request_buffer import SentryAppRequest
 
 
 def serialize_rpc_sentry_app_request(request: SentryAppRequest) -> RpcSentryAppRequest:
-    return RpcSentryAppRequest(
-        date=request.get("date"),
-        response_code=request.get("response_code"),
-        webhook_url=request.get("webhook_url"),
-        organization_id=request.get("organization_id"),
-        event_type=request.get("event_type"),
-        error_id=request.get("error_id"),
-        project_id=request.get("project_id"),
-        request_body=request.get("request_body"),
-        request_headers=request.get("request_headers"),
-        response_body=request.get("response_body"),
-    )
+    return RpcSentryAppRequest.parse_obj(request)


### PR DESCRIPTION
serialize_rpc_sentry_app_request mapped all ten fields by hand. That was necessary when it took a dict[str, Any], but the input has been the SentryAppRequest TypedDict since the control endpoint landed, and every key already matches the RPC model.

The manual mapping was the one place in the chain that failed silently: a field added to the TypedDict but missed here was dropped with no error, while every other site raises. parse_obj keeps behavior identical, since pydantic gives optional fields an implicit None default and ignores extra keys.