### PR TITLE
ref(incidents): Ungate the incident read endpoints

### DIFF
--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -3,7 +3,6 @@ from typing import Any
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 
-from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.utils import to_valid_int_id
@@ -36,9 +35,6 @@ class IncidentEndpoint(OrganizationEndpoint):
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         args, kwargs = super().convert_args(request, *args, **kwargs)
         organization = kwargs["organization"]
-
-        if not features.has("organizations:incidents", organization, actor=request.user):
-            raise ResourceDoesNotExist
 
         validated_incident_identifier = to_valid_int_id(
             "incident_identifier", incident_identifier, raise_404=True

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -5,7 +5,6 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -68,9 +67,6 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         # be removed and this override eliminated in favour of a WE-aware IncidentEndpoint.
         args, kwargs = OrganizationEndpoint.convert_args(self, request, *args, **kwargs)
         organization = kwargs["organization"]
-
-        if not features.has("organizations:incidents", organization, actor=request.user):
-            raise ResourceDoesNotExist
 
         if request.method == "GET":
             gop: GroupOpenPeriod | None = None

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -15,7 +15,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.incident import IncidentPermission
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -63,9 +62,6 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
 
         :auth: required
         """
-        if not features.has("organizations:incidents", organization, actor=request.user):
-            raise ResourceDoesNotExist
-
         # Parse query parameters (shared between both implementations)
         projects = self.get_projects(request, organization)
         envs = self.get_environments(request, organization)

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -6,7 +6,6 @@ from sentry.incidents.models.incident import IncidentStatus
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.migration_helpers.alert_rule import migrate_alert_rule
 from sentry.workflow_engine.models import IncidentGroupOpenPeriod
@@ -36,17 +35,10 @@ class BaseIncidentDetailsTest(APITestCase):
     def test_no_perms(self) -> None:
         incident = self.create_incident()
         self.login_as(self.create_user())
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(incident.organization.slug, incident.id)
+        resp = self.get_response(incident.organization.slug, incident.id)
         assert resp.status_code == 403
 
-    def test_no_feature(self) -> None:
-        incident = self.create_incident()
-        resp = self.get_response(incident.organization.slug, incident.id)
-        assert resp.status_code == 404
 
-
-@with_feature(["organizations:incidents"])
 class WorkflowEngineIncidentDetailsTest(APITestCase):
     endpoint = "sentry-api-0-organization-incident-details"
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
-@with_feature(["organizations:incidents", "organizations:performance-view"])
+@with_feature("organizations:performance-view")
 class WorkflowEngineIncidentListTest(APITestCase):
     endpoint = "sentry-api-0-organization-incident-index"
 


### PR DESCRIPTION
The organizations:incidents flag is being made available to all plans. This PR is one of many to remove checks for this flag around the codebase.

Fixes ISWF-3270