### PR TITLE
ref(incidents): Ungate the alert rule available actions endpoint

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -8,12 +8,10 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.deprecation import deprecated
 from sentry.constants import ALERTS_API_DEPRECATION_DATE, ALERTS_API_DEPRECATION_KEY
 from sentry.incidents.logic import (
@@ -100,8 +98,6 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
         """
         Fetches actions that an alert rule can perform for an organization
         """
-        if not features.has("organizations:incidents", organization, actor=request.user):
-            raise ResourceDoesNotExist
 
         actions = []
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -148,8 +148,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         assert data["settings"] == test_settings
 
     def test_no_integrations(self) -> None:
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert response.data == [build_action_response(self.email)]
 
@@ -158,8 +157,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
             integration = self.create_provider_integration(external_id="1", provider="slack")
             integration.add_organization(self.organization)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 2
         assert build_action_response(self.email) in response.data
@@ -183,8 +181,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
             )
             other_integration.add_organization(self.organization)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 3
         assert build_action_response(self.email) in response.data
@@ -205,15 +202,10 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
             in response.data
         )
 
-    def test_no_feature(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        self.get_error_response(self.organization.slug, status_code=404)
-
     def test_sentry_apps(self) -> None:
         installation = self.install_new_sentry_app("foo")
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 2
         assert build_action_response(self.email) in response.data
@@ -229,8 +221,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         # Should show up in available actions.
         installation = self.install_new_sentry_app("published", published=True)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 2
         assert (
@@ -246,7 +237,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
             integration = self.create_provider_integration(external_id="1", provider="jira")
             integration.add_organization(self.organization)
 
-        with self.feature(["organizations:incidents", "organizations:integrations-ticket-rules"]):
+        with self.feature("organizations:integrations-ticket-rules"):
             response = self.get_success_response(self.organization.slug)
 
         # There should be no ticket actions for Metric Alerts.
@@ -260,8 +251,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
             )
             integration.add_organization(self.organization)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 1
         assert build_action_response(self.email) in response.data
@@ -273,8 +263,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             org_integration.update(status=ObjectStatus.DISABLED)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 1
         assert build_action_response(self.email) in response.data


### PR DESCRIPTION
The organizations:incidents flag is being made available to all plans. This PR is one of many to remove checks for this flag around the codebase.

Fixes ISWF-3270