### PR TITLE
ref(incidents): Ungate the alert rule endpoint base classes

### DIFF
--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -61,12 +61,6 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
         project = kwargs["project"]
         validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
 
-        # Allow orgs that have downgraded plans to delete metric alerts
-        if request.method != "DELETE" and not features.has(
-            "organizations:incidents", project.organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
-
         if not request.access.has_project_access(project):
             raise PermissionDenied
 
@@ -90,12 +84,6 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
         organization = kwargs["organization"]
         validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
 
-        # Allow orgs that have downgraded plans to delete metric alerts
-        if request.method != "DELETE" and not features.has(
-            "organizations:incidents", organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
-
         try:
             kwargs["alert_rule"] = AlertRule.objects.get(
                 organization=organization, id=validated_alert_rule_id
@@ -113,12 +101,6 @@ class WorkflowEngineProjectAlertRuleEndpoint(ProjectAlertRuleEndpoint):
         args, kwargs = super(ProjectAlertRuleEndpoint, self).convert_args(request, *args, **kwargs)
         project = kwargs["project"]
         validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
-
-        # Allow orgs that have downgraded plans to delete metric alerts
-        if request.method != "DELETE" and not features.has(
-            "organizations:incidents", project.organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
 
         if not request.access.has_project_access(project):
             raise PermissionDenied
@@ -164,12 +146,6 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         )
         organization = kwargs["organization"]
         validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
-
-        # Allow orgs that have downgraded plans to delete metric alerts
-        if request.method != "DELETE" and not features.has(
-            "organizations:incidents", organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
 
         if request.method in ("GET", "DELETE") or features.has(
             "organizations:workflow-engine-rule-serializers", organization

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -222,14 +222,6 @@ class AlertRuleDetailsBase(AlertRuleBase):
 
         assert resp.status_code == 403
 
-    def test_no_feature(self) -> None:
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
-        resp = self.get_response(self.organization.slug, self.alert_rule.id)
-        assert resp.status_code == 404
-
     def test_no_project(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -2722,13 +2714,6 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
-
-    def test_no_feature(self) -> None:
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
-        self.get_success_response(self.organization.slug, self.alert_rule.id, status_code=204)
 
     def test_snapshot_and_create_new_with_same_name(self) -> None:
         with self.tasks():

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -37,7 +37,7 @@ class AlertRuleDetailsBase(APITestCase):
 
 class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def test_dual_written_resolves_detector(self) -> None:
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id
             )
@@ -48,16 +48,12 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         # Simulate a single-written detector by removing the AlertRuleDetector bridge.
         AlertRuleDetector.objects.filter(detector=self.detector).delete()
         fake_id = get_fake_id_from_object_id(self.detector.id)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, self.project.slug, fake_id)
+        resp = self.get_success_response(self.organization.slug, self.project.slug, fake_id)
         assert resp.data["name"] == self.detector.name
 
     def test_single_written_fake_id_not_found_returns_404(self) -> None:
         fake_id = get_fake_id_from_object_id(999999999)
-        with self.feature("organizations:incidents"):
-            self.get_error_response(
-                self.organization.slug, self.project.slug, fake_id, status_code=404
-            )
+        self.get_error_response(self.organization.slug, self.project.slug, fake_id, status_code=404)
 
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
@@ -89,7 +85,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     def test_simple(self) -> None:
         alert_rule = self.alert_rule
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, self.project.slug, alert_rule.id, **self._put_payload()
             )
@@ -114,15 +110,14 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         AlertRuleDetector.objects.filter(detector=self.detector).delete()
         fake_id = get_fake_id_from_object_id(self.detector.id)
 
-        with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, self.project.slug, fake_id, status_code=204
-            )
+        self.get_success_response(
+            self.organization.slug, self.project.slug, fake_id, status_code=204
+        )
 
         assert not Detector.objects.filter(id=self.detector.id).exists()
 
     def test_dual_written_detector_deleted(self) -> None:
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
             )


### PR DESCRIPTION
The organizations:incidents flag is being made available to all plans. This PR is one of many to remove checks for this flag around the codebase.

Fixes ISWF-3270