### PR TITLE
ref(incidents): Ungate the alert rule index endpoints

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -30,7 +30,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCRIPTIONS_HEADER
 from sentry.api.helpers.deprecation import deprecated
@@ -157,9 +156,6 @@ VALID_COMBINED_RULE_SORT_KEYS = {"date_added", "name", "incident_status", "date_
 def create_metric_alert(
     request: Request, organization: Organization, project: Project | None = None
 ) -> HttpResponseBase:
-    if not features.has("organizations:incidents", organization, actor=request.user):
-        raise ResourceDoesNotExist
-
     data = deepcopy(request.data)
 
     if features.has("organizations:discover-saved-queries-deprecation", organization) and data.get(
@@ -235,9 +231,6 @@ class AlertRuleFetchMixin(Endpoint):
         organization: Organization,
         projects: Sequence[Project],
     ) -> HttpResponseBase:
-        if not features.has("organizations:incidents", organization, actor=request.user):
-            raise ResourceDoesNotExist
-
         if "latestIncident" in request.GET.getlist("expand", []) and not is_frontend_request(
             request
         ):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -227,12 +227,6 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
 
         assert resp.data == []
 
-    def test_no_feature(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-        resp = self.get_response(self.organization.slug)
-        assert resp.status_code == 404
-
     def test_response_headers(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)
@@ -1626,10 +1620,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 ],
             )
             assert resp.json() == {"projects": ["Invalid project"]}
-
-    def test_no_feature(self) -> None:
-        resp = self.get_response(self.organization.slug)
-        assert resp.status_code == 404
 
     def test_no_perms(self) -> None:
         with (

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -18,8 +18,7 @@ class AlertRuleListEndpointTest(APITestCase):
         _, _, _, detector, _, _, _, _ = migrate_alert_rule(alert_rule)
 
         self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, self.project.slug)
+        resp = self.get_success_response(self.organization.slug, self.project.slug)
 
         assert len(resp.data) == 1
         assert resp.data[0]["name"] == detector.name
@@ -31,19 +30,12 @@ class AlertRuleListEndpointTest(APITestCase):
         perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
         migrate_alert_rule(perf_alert_rule)
         self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, self.project.slug)
-            assert len(resp.data) == 1
-            assert resp.data[0]["name"] == alert_rule.name
+        resp = self.get_success_response(self.organization.slug, self.project.slug)
+        assert len(resp.data) == 1
+        assert resp.data[0]["name"] == alert_rule.name
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(self.organization.slug, self.project.slug)
             assert len(resp.data) == 2
             names = {item["name"] for item in resp.data}
             assert names == {alert_rule.name, perf_alert_rule.name}
-
-    def test_no_feature(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
-        self.login_as(self.user)
-        resp = self.get_response(self.organization.slug, self.project.slug)
-        assert resp.status_code == 404


### PR DESCRIPTION
The organizations:incidents flag is being made available to all plans. This PR is one of many to remove checks for this flag around the codebase.

Fixes ISWF-3270