### PR TITLE
test(incidents): Remove inert organizations:incidents test wrappers

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -132,14 +132,13 @@ class AlertRuleDetailsBase(AlertRuleBase):
         original_method = self.method
         self.endpoint = "sentry-api-0-organization-alert-rules"
         self.method = "get"
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
-            assert len(resp.data) >= 1
-            serialized_alert_rule = resp.data[0]
-            if serialized_alert_rule["environment"]:
-                serialized_alert_rule["environment"] = serialized_alert_rule["environment"][0]
-            else:
-                serialized_alert_rule.pop("environment", None)
+        resp = self.get_success_response(self.organization.slug)
+        assert len(resp.data) >= 1
+        serialized_alert_rule = resp.data[0]
+        if serialized_alert_rule["environment"]:
+            serialized_alert_rule["environment"] = serialized_alert_rule["environment"][0]
+        else:
+            serialized_alert_rule.pop("environment", None)
         self.endpoint = original_endpoint
         self.method = original_method
         return serialized_alert_rule
@@ -209,16 +208,14 @@ class AlertRuleDetailsBase(AlertRuleBase):
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
         )
         self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, 1234)
+        resp = self.get_response(self.organization.slug, 1234)
 
         assert resp.status_code == 404
 
     def test_permissions(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.create_user())
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, self.alert_rule.id)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id)
 
         assert resp.status_code == 403
 
@@ -227,8 +224,7 @@ class AlertRuleDetailsBase(AlertRuleBase):
         self.login_as(self.user)
         project = self.alert_rule.projects.get()
         Project.objects.get(id=project.id).delete()
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, self.alert_rule.id)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id)
 
         assert resp.status_code == 404
 
@@ -311,8 +307,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def test_simple(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
+        resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
         detector = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id).detector
         assert resp.data == serialize(
@@ -320,7 +315,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:incidents")
     def test_workflow_engine_serializer(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -337,7 +331,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         assert resp.data["name"] == self.detector.name
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:incidents")
     def test_pending_deletion_detector_returns_404(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -372,10 +365,9 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         alert_rule = self.create_alert_rule(aggregate="count_unique(tags[sentry:user])")
         self.create_alert_rule_trigger(alert_rule, "critical", 100)
         dual_write_alert_rule(alert_rule)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, alert_rule.id)
-            assert resp.data["aggregate"] == "count_unique(tags[sentry:user])"
-            assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
+        resp = self.get_success_response(self.organization.slug, alert_rule.id)
+        assert resp.data["aggregate"] == "count_unique(tags[sentry:user])"
+        assert alert_rule.snuba_query.aggregate == "count_unique(tags[sentry:user])"
 
     def test_expand_latest_incident(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
@@ -420,18 +412,16 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             incident_identifier=incident.identifier,
         )
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, expand=["latestIncident"]
-            )
-            no_expand_resp = self.get_success_response(self.organization.slug, alert_rule.id)
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, expand=["latestIncident"]
+        )
+        no_expand_resp = self.get_success_response(self.organization.slug, alert_rule.id)
 
         assert resp.data["latestIncident"] is not None
         assert resp.data["latestIncident"]["id"] == str(incident.id)
         assert "latestIncident" not in no_expand_resp.data
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     def test_static_detection_type(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -467,7 +457,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             self.create_alert_rule(threshold_type=AlertRuleThresholdType.ABOVE_AND_BELOW)
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     def test_percent_detection_type(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -508,7 +497,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             )
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -588,7 +576,6 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             )
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     def test_missing_threshold(self) -> None:
         """Test that we throw a validation error when the trigger is missing alertThreshold"""
         self.create_team(organization=self.organization, members=[self.user])
@@ -652,8 +639,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             ],
             status=200,
         )
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, rule.id)
+        resp = self.get_response(self.organization.slug, rule.id)
 
         assert resp.status_code == 200
         assert len(responses.calls) == 1
@@ -717,19 +703,18 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             ],
             status=200,
         )
-        with self.feature("organizations:incidents"):
-            with mock.patch.object(app_service, "get_component_contexts") as mock_get:
-                mock_get.return_value = get_context_response
-                resp = self.get_response(self.organization.slug, rule.id)
+        with mock.patch.object(app_service, "get_component_contexts") as mock_get:
+            mock_get.return_value = get_context_response
+            resp = self.get_response(self.organization.slug, rule.id)
 
-                assert mock_get.call_count == 1
-                mock_get.assert_called_with(
-                    filter={
-                        "app_ids": [sentry_app.id],
-                        "organization_id": self.organization.id,
-                    },
-                    component_type="alert-rule-action",
-                )
+            assert mock_get.call_count == 1
+            mock_get.assert_called_with(
+                filter={
+                    "app_ids": [sentry_app.id],
+                    "organization_id": self.organization.id,
+                },
+                component_type="alert-rule-action",
+            )
 
         assert resp.status_code == 200
         assert len(responses.calls) == 1
@@ -774,8 +759,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         dual_write_alert_rule(self.rule)
 
         responses.add(responses.GET, "http://example.com/sentry/members", json={}, status=404)
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, self.rule.id)
+        resp = self.get_response(self.organization.slug, self.rule.id)
 
         assert resp.status_code == 200
 
@@ -794,8 +778,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         self.login_as(self.user)
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, alert_rule=self.alert_rule)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug, self.alert_rule.id)
+        response = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
         assert response.data["snooze"] is False
         assert "snoozeCreatedBy" not in response.data
@@ -810,15 +793,13 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         user2 = self.create_user("user2@example.com")
         self.snooze_rule(owner_id=user2.id, alert_rule=self.alert_rule)
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(self.organization.slug, self.alert_rule.id)
+        response = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
         assert response.data["snooze"] is True
         assert response.data["snoozeForEveryone"] is True
         assert "snoozeCreatedBy" not in response.data
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    @with_feature("organizations:incidents")
     def test_non_dual_written_detector_serialization(self) -> None:
         """A detector created directly (not via dual-write from AlertRule) is
         serialized into the AlertRule-compatible format by the detail endpoint."""
@@ -935,8 +916,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
         self.alert_rule.snuba_query.aggregate = "upsampled_count()"
         self.alert_rule.snuba_query.save()
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
+        resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
         assert resp.data["aggregate"] == "count()", (
             "GET should return count() to user, hiding internal upsampled_count() storage"
@@ -957,7 +937,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["name"] = "what"
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
@@ -999,7 +979,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert AlertRuleDetector.objects.filter(alert_rule_id=alert_rule.id).exists()
         AlertRuleWorkflow.objects.filter(alert_rule_id=alert_rule.id).delete()
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_error_response(
                 self.organization.slug,
                 alert_rule.id,
@@ -1030,7 +1010,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule["dataset"] = "events"
         serialized_alert_rule["name"] = "Updated to Count Rule"
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
@@ -1067,7 +1047,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # Update only the name, not the aggregate
         serialized_alert_rule["name"] = "Updated Name Only"
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
@@ -1092,10 +1072,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
         serialized_alert_rule = self.get_serialized_alert_rule()
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         existing_sub = self.alert_rule.snuba_query.subscriptions.first()
 
@@ -1121,17 +1100,16 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["triggers"][0]["label"] = "goodbye"
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
-            )
-            assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
-            serialized_alert_rule["triggers"][0]["label"] = "critical"
-            serialized_alert_rule["triggers"][1]["label"] = "goodbye"
-            resp = self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
-            )
-            assert resp.data == {"nonFieldErrors": ['Trigger 2 must be labeled "warning"']}
+        resp = self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+        )
+        assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
+        serialized_alert_rule["triggers"][0]["label"] = "critical"
+        serialized_alert_rule["triggers"][1]["label"] = "goodbye"
+        resp = self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+        )
+        assert resp.data == {"nonFieldErrors": ['Trigger 2 must be labeled "warning"']}
 
     def test_update_trigger_id_not_belonging_to_alert_rule(self) -> None:
         self.create_member(
@@ -1149,11 +1127,10 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["triggers"][0]["id"] = other_trigger.id
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
-            )
-            assert "do not belong to this alert rule" in str(resp.data)
+        resp = self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+        )
+        assert "do not belong to this alert rule" in str(resp.data)
 
     def test_update_action_id_not_belonging_to_trigger(self) -> None:
         self.create_member(
@@ -1170,11 +1147,10 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         foreign_action_id = serialized_alert_rule["triggers"][1]["actions"][0]["id"]
         serialized_alert_rule["triggers"][0]["actions"][0]["id"] = foreign_action_id
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
-            )
-            assert "do not belong to this trigger" in str(resp.data)
+        resp = self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+        )
+        assert "do not belong to this trigger" in str(resp.data)
 
     def test_update_trigger_alert_threshold(self) -> None:
         self.create_member(
@@ -1189,10 +1165,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule["triggers"][1]["alertThreshold"] = 125
         serialized_alert_rule["name"] = "AUniqueName"
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         assert resp.data["name"] == "AUniqueName"
         assert resp.data["triggers"][1]["alertThreshold"] == 125
@@ -1212,10 +1187,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule["resolveThreshold"] = None
         serialized_alert_rule["name"] = "AUniqueName"
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         alert_rule.refresh_from_db()
         assert resp.data["name"] == "AUniqueName"
@@ -1236,10 +1210,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule["resolveThreshold"] = 75
         serialized_alert_rule["name"] = "AUniqueName"
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
         assert resp.data["name"] == "AUniqueName"
         assert resp.data["resolveThreshold"] == 75
 
@@ -1255,10 +1228,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         serialized_alert_rule["triggers"].pop(1)
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         assert len(resp.data["triggers"]) == 1
 
@@ -1285,7 +1257,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert AlertRuleDetector.objects.filter(alert_rule_id=alert_rule.id).exists()
         AlertRuleWorkflow.objects.filter(alert_rule_id=alert_rule.id).delete()
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_error_response(
                 self.organization.slug,
                 alert_rule.id,
@@ -1308,10 +1280,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         serialized_alert_rule["triggers"].pop(1)
 
-        with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        self.get_success_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
         assert AlertRuleTrigger.objects.filter(alert_rule_id=alert_rule.id).count() == 1
         # we test the logic for this method elsewhere, so just test that it's correctly called
         assert mock_dual_delete.call_count == 1
@@ -1343,8 +1312,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         put_payload["triggers"][0]["id"] = critical_trigger.id
         put_payload["triggers"].pop(1)
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
+        resp = self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
 
         assert len(resp.data["triggers"]) == 1
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
@@ -1379,15 +1347,13 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         # TEST 1: if we update the critical trigger threshold, the resolve threshold shouldn't change
         put_payload["triggers"][0]["alertThreshold"] = 300
-        with self.feature("organizations:incidents"):
-            self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
+        self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
         assert_dual_written_resolution_threshold_equals(alert_rule, old_threshold)
 
         # TEST 2: if we update the warning trigger threshold, the resolve threshold also changes
         new_threshold = 100
         put_payload["triggers"][1]["alertThreshold"] = new_threshold
-        with self.feature("organizations:incidents"):
-            self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
+        self.get_success_response(self.organization.slug, alert_rule.id, **put_payload)
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
     def test_update_trigger_threshold_dual_update_resolve_noop(self) -> None:
@@ -1408,10 +1374,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         new_threshold = 125
         serialized_alert_rule["triggers"][1]["alertThreshold"] = new_threshold
-        with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        self.get_success_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
         # remains unchanged
         assert_dual_written_resolution_threshold_equals(alert_rule, resolve_threshold)
 
@@ -1433,10 +1396,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         serialized_alert_rule["resolveThreshold"] = None
         new_threshold = serialized_alert_rule["triggers"][1]["alertThreshold"]
-        with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        self.get_success_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
         # resolve threshold changes to the warning threshold
         assert_dual_written_resolution_threshold_equals(alert_rule, new_threshold)
 
@@ -1456,14 +1416,13 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         test_params["triggers"][0]["alertThreshold"] = 300
         test_params["triggers"][1]["alertThreshold"] = 50
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             self.get_success_response(self.organization.slug, self.alert_rule.id, **test_params)
 
         # resolve threshold changes to the warning threshold
         assert_dual_written_resolution_threshold_equals(self.alert_rule, 50)
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -1485,7 +1444,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -1510,7 +1468,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -1537,7 +1494,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -1585,20 +1541,18 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         serialized_alert_rule["triggers"][1]["actions"].pop(1)
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         assert len(resp.data["triggers"][1]["actions"]) == 1
 
         # Delete the last one.
         serialized_alert_rule["triggers"][1]["actions"].pop()
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
-            )
+        resp = self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+        )
         assert resp.data == {
             "nonFieldErrors": [
                 "Each trigger must have an associated action for this alert to fire."
@@ -1622,10 +1576,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         action = AlertRuleTriggerAction.objects.get(id=serialized_action["id"])
         warning_trigger_id = serialized_alert_rule["triggers"][1]["id"]
 
-        with self.feature("organizations:incidents"):
-            self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        self.get_success_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
 
         assert (
             AlertRuleTriggerAction.objects.filter(alert_rule_trigger_id=warning_trigger_id).count()
@@ -1650,10 +1601,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule["triggers"][0]["actions"][0]["targetType"] = "user"
         serialized_alert_rule["triggers"][0]["actions"][0]["targetIdentifier"] = self.user.id
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         # And it comes back successfully changed:
         assert resp.data["triggers"][0]["actions"][0]["targetType"] == "user"
@@ -1676,10 +1626,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         serialized_alert_rule["triggers"][0]["alertThreshold"] = 50  # Invalid
         serialized_alert_rule.pop("resolveThreshold")
-        with self.feature("organizations:incidents"):
-            self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
-            )
+        self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **serialized_alert_rule
+        )
 
     def test_update_snapshot(self) -> None:
         self.create_member(
@@ -1694,10 +1643,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule.status = AlertRuleStatus.SNAPSHOT.value
         alert_rule.save()
 
-        with self.feature("organizations:incidents"):
-            self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=404, **serialized_alert_rule
-            )
+        self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=404, **serialized_alert_rule
+        )
 
     def test_no_owner(self) -> None:
         self.create_member(
@@ -1710,10 +1658,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["owner"] = None
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         alert_rule.refresh_from_db()
         detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
@@ -1736,14 +1683,12 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             organizationmember__user_id=self.user.id,
             team=self.team,
         ).delete()
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
+        resp = self.get_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
         assert resp.status_code == 200
         self.create_team_membership(team=self.team, member=om)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         alert_rule.refresh_from_db()
         detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
@@ -1758,7 +1703,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
         test_params.update({"name": "what"})
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, self.alert_rule.id, **test_params
             )
@@ -1792,10 +1737,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule_dict["alertType"] = "eap_metrics"
         alert_rule_dict["extrapolation_mode"] = "server_weighted"
 
-        with self.feature("organizations:incidents"):
-            self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **alert_rule_dict
-            )
+        self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **alert_rule_dict
+        )
 
     def test_invalid_extrapolation_mode_save_not_migrated_alert(self) -> None:
         self.create_member(
@@ -1812,10 +1756,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule_dict["alertType"] = "eap_metrics"
         alert_rule_dict["extrapolation_mode"] = "none"
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, alert_rule.id, status_code=400, **alert_rule_dict
-            )
+        resp = self.get_error_response(
+            self.organization.slug, alert_rule.id, status_code=400, **alert_rule_dict
+        )
 
         assert (
             resp.data["nonFieldErrors"][0]
@@ -1840,7 +1783,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["query"] = "user.modified:query"
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             self.get_success_response(
                 self.organization.slug, alert_rule.id, **serialized_alert_rule
             )
@@ -1862,9 +1805,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule_dict["dataset"] = "transactions"
 
         with (
-            self.feature(
-                ["organizations:incidents", "organizations:discover-saved-queries-deprecation"]
-            ),
+            self.feature(["organizations:discover-saved-queries-deprecation"]),
             outbox_runner(),
         ):
             self.get_error_response(
@@ -1888,9 +1829,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule_dict["dataset"] = "generic_metrics"
 
         with (
-            self.feature(
-                ["organizations:incidents", "organizations:discover-saved-queries-deprecation"]
-            ),
+            self.feature(["organizations:discover-saved-queries-deprecation"]),
             outbox_runner(),
         ):
             self.get_error_response(
@@ -1928,7 +1867,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
                 resp = self.get_success_response(self.organization.slug, alert_rule.id, **put_data)
@@ -2015,8 +1954,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             # The trigger code would accept channelId to be a string and that is why I don't cast it to an int
             test_params["triggers"][0]["actions"][0]["inputChannelId"] = channelID
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
         return resp
 
     @patch(
@@ -2057,8 +1995,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             },
         ]
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
 
         # A task with this uuid has been scheduled because there's a Slack channel async search
         assert resp.data["uuid"] == "abc123"
@@ -2395,7 +2332,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             },
         ]
 
-        with self.feature("organizations:incidents"), self.tasks():
+        with self.tasks():
             resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
 
         # A task with this uuid has been scheduled because there's a Slack channel async search
@@ -2448,7 +2385,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             },
         ]
 
-        with self.feature("organizations:incidents"), self.tasks():
+        with self.tasks():
             resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
         assert resp.data["uuid"] == "abc123"
         assert (
@@ -2489,7 +2426,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
                 ],
             },
         ]
-        with self.feature("organizations:incidents"), self.tasks():
+        with self.tasks():
             resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
         assert resp.status_code == 400
         assert (
@@ -2522,10 +2459,9 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
             "sentryAppId": sentry_app.id,
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
 
         alert_rule.refresh_from_db()
         alert_rule.name = "ValidSentryAppTestRule"
@@ -2559,7 +2495,7 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
                 }
             ],
         }
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             self.get_success_response(
                 self.organization.slug,
                 self.alert_rule.id,
@@ -2616,7 +2552,7 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
             }
         ]
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             self.get_success_response(
                 self.organization.slug,
                 self.alert_rule.id,
@@ -2675,7 +2611,7 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
             }
         ]
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_response(self.organization.slug, self.alert_rule.id, **test_params)
         assert resp.status_code == 500
         assert error_message in resp.data["detail"]
@@ -2690,7 +2626,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         )
         self.login_as(self.user)
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             resp = self.get_success_response(
                 self.organization.slug, self.alert_rule.id, status_code=204
             )
@@ -2725,10 +2661,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             # We attach the rule to an incident so the rule is snapshotted instead of deleted.
             incident = self.create_incident(alert_rule=self.alert_rule)
 
-            with self.feature("organizations:incidents"):
-                self.get_success_response(
-                    self.organization.slug, self.alert_rule.id, status_code=204
-                )
+            self.get_success_response(self.organization.slug, self.alert_rule.id, status_code=204)
 
             alert_rule = AlertRule.objects_with_snapshots.get(id=self.alert_rule.id)
 
@@ -2752,8 +2685,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             organizationmember__user_id=self.user.id,
             team=self.team,
         ).delete()
-        with self.feature("organizations:incidents"):
-            self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)
+        self.get_success_response(self.organization.slug, alert_rule.id, status_code=204)
 
     def test_project_permission(self) -> None:
         """Test that a user can't delete an alert in a project they do not have access to"""
@@ -2779,11 +2711,9 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         other_alert_rule.save()
         migrate_alert_rule(other_alert_rule)
 
-        with self.feature("organizations:incidents"):
-            self.get_error_response(self.organization.slug, alert_rule.id, status_code=403)
+        self.get_error_response(self.organization.slug, alert_rule.id, status_code=403)
 
-        with self.feature("organizations:incidents"):
-            self.get_success_response(self.organization.slug, other_alert_rule.id, status_code=204)
+        self.get_success_response(self.organization.slug, other_alert_rule.id, status_code=204)
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_detector_deleted(self) -> None:
@@ -2819,7 +2749,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         ard = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id)
         fake_detector_id = get_fake_id_from_object_id(ard.detector_id)
 
-        with self.feature("organizations:incidents"), outbox_runner():
+        with outbox_runner():
             self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
 
         with self.tasks():

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -189,8 +189,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         ProjectTeam.objects.create(project=self.project, team=team)
 
         self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
 
         assert resp.data[0] == serialize(
             self.detector, self.user, WorkflowEngineDetectorSerializer()
@@ -202,7 +201,6 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         self.login_as(self.user)
 
         with (
-            self.feature("organizations:incidents"),
             self.feature("organizations:workflow-engine-rule-serializers"),
         ):
             resp = self.get_success_response(self.organization.slug)
@@ -220,7 +218,6 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         self.login_as(self.user)
 
         with (
-            self.feature("organizations:incidents"),
             self.feature("organizations:workflow-engine-rule-serializers"),
         ):
             resp = self.get_success_response(org.slug)
@@ -232,8 +229,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         ProjectTeam.objects.create(project=self.project, team=team)
         self.login_as(self.user)
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_response(self.organization.slug)
+        resp = self.get_response(self.organization.slug)
 
         assert resp[ALERT_RULES_COUNT_HEADER] == "1"
         assert resp[MAX_QUERY_SUBSCRIPTIONS_HEADER] == "1000"
@@ -253,8 +249,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         self.alert_rule.snuba_query.save()
 
         self.login_as(self.user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
 
         rule = next(rule for rule in resp.data if rule["id"] == str(self.alert_rule.id))
 
@@ -268,9 +263,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         self.detector.update(enabled=False)
         self.login_as(self.user)
 
-        with self.feature(
-            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
-        ):
+        with self.feature(["organizations:workflow-engine-rule-serializers"]):
             resp = self.get_success_response(self.organization.slug)
 
         assert resp.data[0]["snooze"] is True
@@ -280,9 +273,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         ProjectTeam.objects.create(project=self.project, team=team)
         self.login_as(self.user)
 
-        with self.feature(
-            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
-        ):
+        with self.feature(["organizations:workflow-engine-rule-serializers"]):
             resp = self.get_success_response(self.organization.slug)
 
         assert "snooze" not in resp.data[0]
@@ -306,9 +297,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         data_source.detectors.add(single_written_detector)
 
         self.login_as(self.user)
-        with self.feature(
-            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
-        ):
+        with self.feature(["organizations:workflow-engine-rule-serializers"]):
             resp = self.get_success_response(self.organization.slug)
 
         assert len(resp.data) == 2
@@ -335,9 +324,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         data_source.detectors.add(single_written_detector)
 
         self.login_as(self.user)
-        with self.feature(
-            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
-        ):
+        with self.feature(["organizations:workflow-engine-rule-serializers"]):
             resp = self.get_success_response(self.organization.slug)
 
         assert resp[ALERT_RULES_COUNT_HEADER] == "2"
@@ -355,9 +342,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
         )
 
         self.login_as(self.user)
-        with self.feature(
-            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
-        ):
+        with self.feature(["organizations:workflow-engine-rule-serializers"]):
             resp = self.get_success_response(self.organization.slug)
 
         assert len(resp.data) == 1
@@ -395,9 +380,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorkflowEngineSerializer
             )
 
         self.login_as(self.user)
-        with self.feature(
-            ["organizations:incidents", "organizations:workflow-engine-rule-serializers"]
-        ):
+        with self.feature(["organizations:workflow-engine-rule-serializers"]):
             resp = self.get_success_response(self.organization.slug)
 
         results_by_name = {item["name"]: item for item in resp.data}
@@ -425,7 +408,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     def test_simple(self) -> None:
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -461,7 +444,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -491,7 +474,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -515,7 +498,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_error_response(
                 self.organization.slug,
@@ -530,7 +513,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     def test_create_alert_rule_aci(self) -> None:
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             self.alert_rule_dict["resolveThreshold"] = 50
             resp = self.get_success_response(
@@ -553,7 +536,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert_alert_rule_trigger_action_migrated(actions[0], Action.Type.EMAIL)
         assert_alert_rule_trigger_action_migrated(actions[1], Action.Type.EMAIL)
 
-    @with_feature("organizations:incidents")
     def test_invalid_threshold_type(self) -> None:
         """
         Test that a comparison alert (percent based) can't use the above and below threshold type
@@ -579,7 +561,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -626,7 +607,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -660,7 +640,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:ourlogs-enabled")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -695,7 +674,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:tracemetrics-enabled")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -746,7 +724,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
             with (
                 outbox_runner(),
-                self.feature(["organizations:incidents", "organizations:performance-view"]),
+                self.feature("organizations:performance-view"),
             ):
                 with patch.object(
                     _snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen
@@ -787,7 +765,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 [
-                    "organizations:incidents",
                     "organizations:performance-view",
                     "organizations:ourlogs-enabled",
                 ]
@@ -836,7 +813,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 {
-                    "organizations:incidents": True,
                     "organizations:performance-view": True,
                     "organizations:tracemetrics-enabled": False,
                 },
@@ -866,7 +842,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 [
-                    "organizations:incidents",
                     "organizations:performance-view",
                     "organizations:tracemetrics-enabled",
                 ]
@@ -906,7 +881,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 [
-                    "organizations:incidents",
                     "organizations:performance-view",
                     "organizations:tracemetrics-enabled",
                 ]
@@ -961,7 +935,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -979,7 +952,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -999,7 +971,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -1023,7 +994,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert mock_seer_request.call_count == 1
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     def test_anomaly_detection_alert_validation_error(self) -> None:
         data = self.dynamic_alert_rule_dict
         data["time_window"] = 10
@@ -1039,7 +1009,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     def test_multiple_projects(self) -> None:
         new_project = self.create_project()
         data = {**self.alert_rule_dict, "projects": [self.project.slug, new_project.slug]}
-        with outbox_runner(), self.feature(["organizations:incidents"]):
+        with outbox_runner():
             response_data = self.get_error_response(
                 self.organization.slug,
                 method=responses.POST,
@@ -1053,7 +1023,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 [
-                    "organizations:incidents",
                     "organizations:performance-view",
                 ]
             ),
@@ -1076,7 +1045,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 [
-                    "organizations:incidents",
                     "organizations:performance-view",
                     "organizations:dynamic-sampling",
                 ]
@@ -1129,17 +1097,15 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
     @override_settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=1)
     def test_enforce_max_subscriptions(self) -> None:
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, status_code=201, **self.alert_rule_dict
-            )
+        resp = self.get_success_response(
+            self.organization.slug, status_code=201, **self.alert_rule_dict
+        )
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(self.organization.slug, **self.alert_rule_dict)
-            assert resp.data[0] == "You may not exceed 1 metric alerts per organization"
+        resp = self.get_error_response(self.organization.slug, **self.alert_rule_dict)
+        assert resp.data[0] == "You may not exceed 1 metric alerts per organization"
 
     @override_settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=1)
     def test_enforce_max_subscriptions_with_override(self) -> None:
@@ -1149,39 +1115,35 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 "metric_alerts.extended_max_subscriptions": 3,
             }
         ):
-            with self.feature("organizations:incidents"):
-                resp = self.get_success_response(
-                    self.organization.slug, status_code=201, **self.alert_rule_dict
-                )
+            resp = self.get_success_response(
+                self.organization.slug, status_code=201, **self.alert_rule_dict
+            )
             alert_rule = AlertRule.objects.get(id=resp.data["id"])
             detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
             assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
             alert_rule_dict_2 = self.alert_rule_dict.copy()
             alert_rule_dict_2["name"] = "Test Rule 2"
-            with self.feature("organizations:incidents"):
-                resp = self.get_success_response(
-                    self.organization.slug, status_code=201, **alert_rule_dict_2
-                )
+            resp = self.get_success_response(
+                self.organization.slug, status_code=201, **alert_rule_dict_2
+            )
             alert_rule_2 = AlertRule.objects.get(id=resp.data["id"])
             detector_2 = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule_2.id)
             assert resp.data == serialize(detector_2, self.user, WorkflowEngineDetectorSerializer())
 
             alert_rule_dict_3 = self.alert_rule_dict.copy()
             alert_rule_dict_3["name"] = "Test Rule 3"
-            with self.feature("organizations:incidents"):
-                resp = self.get_success_response(
-                    self.organization.slug, status_code=201, **alert_rule_dict_3
-                )
+            resp = self.get_success_response(
+                self.organization.slug, status_code=201, **alert_rule_dict_3
+            )
             alert_rule_3 = AlertRule.objects.get(id=resp.data["id"])
             detector_3 = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule_3.id)
             assert resp.data == serialize(detector_3, self.user, WorkflowEngineDetectorSerializer())
 
             alert_rule_dict_4 = self.alert_rule_dict.copy()
             alert_rule_dict_4["name"] = "Test Rule 4"
-            with self.feature("organizations:incidents"):
-                resp = self.get_error_response(self.organization.slug, **alert_rule_dict_4)
-                assert resp.data[0] == "You may not exceed 3 metric alerts per organization"
+            resp = self.get_error_response(self.organization.slug, **alert_rule_dict_4)
+            assert resp.data[0] == "You may not exceed 3 metric alerts per organization"
 
     def test_sentry_app(self) -> None:
         other_org = self.create_organization(owner=self.user)
@@ -1201,10 +1163,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "sentryAppId": sentry_app.id,
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, status_code=201, **valid_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, status_code=201, **valid_alert_rule
+        )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
@@ -1229,8 +1190,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "sentryAppId": sentry_app.id,
         }
 
-        with self.feature("organizations:incidents"):
-            self.get_error_response(self.organization.slug, status_code=400, **valid_alert_rule)
+        self.get_error_response(self.organization.slug, status_code=400, **valid_alert_rule)
 
     def test_invalid_sentry_app(self) -> None:
         valid_alert_rule = deepcopy(self.alert_rule_dict)
@@ -1242,8 +1202,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "sentryAppId": "invalid",
         }
 
-        with self.feature("organizations:incidents"):
-            self.get_error_response(self.organization.slug, status_code=400, **valid_alert_rule)
+        self.get_error_response(self.organization.slug, status_code=400, **valid_alert_rule)
 
     def test_no_config_sentry_app(self) -> None:
         sentry_app = self.create_sentry_app(is_alertable=True)
@@ -1267,7 +1226,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 }
             ],
         }
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             self.get_success_response(self.organization.slug, status_code=201, **alert_rule)
 
     @responses.activate
@@ -1317,7 +1276,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             self.get_success_response(self.organization.slug, status_code=201, **alert_rule)
 
     @responses.activate
@@ -1377,7 +1336,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             assert (
                 self.get_error_response(
                     self.organization.slug, status_code=400, **alert_rule
@@ -1434,7 +1393,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_response(self.organization.slug, **alert_rule)
 
         assert resp.status_code == 500
@@ -1460,10 +1419,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature("organizations:incidents"):
-            self.get_error_response(
-                self.organization.slug, status_code=400, **rule_one_trigger_no_label
-            )
+        self.get_error_response(
+            self.organization.slug, status_code=400, **rule_one_trigger_no_label
+        )
 
     def test_only_critical_trigger(self) -> None:
         rule_one_trigger_only_critical = {
@@ -1485,10 +1443,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 }
             ],
         }
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(
-                self.organization.slug, status_code=201, **rule_one_trigger_only_critical
-            )
+        resp = self.get_success_response(
+            self.organization.slug, status_code=201, **rule_one_trigger_only_critical
+        )
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
@@ -1505,11 +1462,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "owner": self.user.id,
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, status_code=400, **rule_no_triggers
-            )
-            assert resp.data == {"triggers": ["This field is required."]}
+        resp = self.get_error_response(self.organization.slug, status_code=400, **rule_no_triggers)
+        assert resp.data == {"triggers": ["This field is required."]}
 
     def test_no_critical_trigger(self) -> None:
         rule_one_trigger_only_warning = {
@@ -1532,11 +1486,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, status_code=400, **rule_one_trigger_only_warning
-            )
-            assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
+        resp = self.get_error_response(
+            self.organization.slug, status_code=400, **rule_one_trigger_only_warning
+        )
+        assert resp.data == {"nonFieldErrors": ['Trigger 1 must be labeled "critical"']}
 
     def test_critical_trigger_no_action(self) -> None:
         rule_one_trigger_only_critical_no_action = {
@@ -1551,10 +1504,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "triggers": [{"label": "critical", "alertThreshold": 75}],
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, status_code=400, **rule_one_trigger_only_critical_no_action
-            )
+        resp = self.get_error_response(
+            self.organization.slug, status_code=400, **rule_one_trigger_only_critical_no_action
+        )
         assert resp.data == {
             "nonFieldErrors": [
                 "Each trigger must have an associated action for this alert to fire."
@@ -1580,46 +1532,44 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug, status_code=400, **rule_one_trigger_no_target_id
-            )
+        resp = self.get_error_response(
+            self.organization.slug, status_code=400, **rule_one_trigger_no_target_id
+        )
         assert resp.data[0] == ErrorDetail(
             string="One or more of your actions is missing a target identifier.", code="invalid"
         )
 
     def test_invalid_projects(self) -> None:
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug,
-                status_code=400,
-                projects=[
-                    self.project.slug,
-                    self.create_project(organization=self.create_organization()).slug,
-                ],
-                name="an alert",
-                owner=self.user.id,
-                thresholdType=1,
-                query="hi",
-                aggregate="count()",
-                timeWindow=10,
-                alertThreshold=1000,
-                resolveThreshold=100,
-                triggers=[
-                    {
-                        "label": "critical",
-                        "alertThreshold": 200,
-                        "actions": [
-                            {
-                                "type": "email",
-                                "targetType": "team",
-                                "targetIdentifier": self.team.id,
-                            }
-                        ],
-                    }
-                ],
-            )
-            assert resp.json() == {"projects": ["Invalid project"]}
+        resp = self.get_error_response(
+            self.organization.slug,
+            status_code=400,
+            projects=[
+                self.project.slug,
+                self.create_project(organization=self.create_organization()).slug,
+            ],
+            name="an alert",
+            owner=self.user.id,
+            thresholdType=1,
+            query="hi",
+            aggregate="count()",
+            timeWindow=10,
+            alertThreshold=1000,
+            resolveThreshold=100,
+            triggers=[
+                {
+                    "label": "critical",
+                    "alertThreshold": 200,
+                    "actions": [
+                        {
+                            "type": "email",
+                            "targetType": "team",
+                            "targetIdentifier": self.team.id,
+                        }
+                    ],
+                }
+            ],
+        )
+        assert resp.json() == {"projects": ["Invalid project"]}
 
     def test_no_perms(self) -> None:
         with (
@@ -1627,8 +1577,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_context(transaction.atomic(using=router.db_for_write(OrganizationMember))),
         ):
             OrganizationMember.objects.filter(user_id=self.user.id).update(role="member")
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
+        resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
         assert resp.status_code == 201
 
         member_user = self.create_user()
@@ -1660,41 +1609,39 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(team_admin_user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
+        resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
         assert resp.status_code == 201
 
         # verify that a team admin cannot create an alert for a project their team doesn't own
-        with self.feature("organizations:incidents"):
-            resp = self.get_error_response(
-                self.organization.slug,
-                status_code=400,
-                projects=[
-                    self.create_project(organization=self.create_organization()).slug,
-                ],
-                name="an alert",
-                owner=team_admin_user.id,
-                thresholdType=1,
-                query="hi",
-                aggregate="count()",
-                timeWindow=10,
-                alertThreshold=1000,
-                resolveThreshold=100,
-                triggers=[
-                    {
-                        "label": "critical",
-                        "alertThreshold": 200,
-                        "actions": [
-                            {
-                                "type": "email",
-                                "targetType": "team",
-                                "targetIdentifier": self.team.id,
-                            }
-                        ],
-                    }
-                ],
-            )
-            assert resp.json() == {"projects": ["Invalid project"]}
+        resp = self.get_error_response(
+            self.organization.slug,
+            status_code=400,
+            projects=[
+                self.create_project(organization=self.create_organization()).slug,
+            ],
+            name="an alert",
+            owner=team_admin_user.id,
+            thresholdType=1,
+            query="hi",
+            aggregate="count()",
+            timeWindow=10,
+            alertThreshold=1000,
+            resolveThreshold=100,
+            triggers=[
+                {
+                    "label": "critical",
+                    "alertThreshold": 200,
+                    "actions": [
+                        {
+                            "type": "email",
+                            "targetType": "team",
+                            "targetIdentifier": self.team.id,
+                        }
+                    ],
+                }
+            ],
+        )
+        assert resp.json() == {"projects": ["Invalid project"]}
 
         # verify that a regular team member cannot create an alert
         self.login_as(member_user)
@@ -1708,8 +1655,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
         self.organization.update_option("sentry:alerts_member_write", True)
         self.login_as(member_user)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
+        resp = self.get_success_response(self.organization.slug, **self.alert_rule_dict)
         assert resp.status_code == 201
 
     def test_no_owner(self) -> None:
@@ -1733,8 +1679,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug, status_code=201, **rule_data)
+        resp = self.get_success_response(self.organization.slug, status_code=201, **rule_data)
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
@@ -1760,10 +1705,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 },
             ],
         }
-        with self.feature(["organizations:incidents"]):
-            resp = self.get_success_response(
-                self.organization.slug, status_code=202, **valid_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, status_code=202, **valid_alert_rule
+        )
         assert resp.data["uuid"] == "abc123"
         assert not AlertRule.objects.filter(name="JustAValidTestRule").exists()
         kwargs = {
@@ -1801,7 +1745,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             ],
         }
 
-        with self.feature("organizations:incidents"), self.tasks():
+        with self.tasks():
             resp = self.get_response(self.organization.slug, **test_params)
         assert resp.data["uuid"] == "abc123"
         assert mock_get_channel_id.call_count == 1
@@ -1835,7 +1779,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 ],
             },
         ]
-        with self.feature("organizations:incidents"), self.tasks():
+        with self.tasks():
             resp = self.get_response(self.organization.slug, **test_params)
         assert resp.data["uuid"] == "abc123"
         assert (
@@ -1868,7 +1812,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 ],
             },
         ]
-        with self.feature("organizations:incidents"), self.tasks():
+        with self.tasks():
             resp = self.get_response(self.organization.slug, **test_params)
         assert resp.status_code == 400
         # Did not increment from the last assertion because we early out on the validation error
@@ -1877,7 +1821,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     def test_performance_dataset(self) -> None:
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
                 "organizations:dynamic-sampling",
             ]
@@ -1908,7 +1851,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     def test_alert_with_metrics_layer(self) -> None:
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
                 "organizations:dynamic-sampling",
             ]
@@ -1945,7 +1887,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         alert_rule_dict["name"] = char_256_name
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -1961,7 +1903,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         alert_rule_dict["name"] = char_257_name
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_error_response(
                 self.organization.slug, status_code=400, **alert_rule_dict
@@ -1976,11 +1918,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             "dataset": "transactions",
             "eventTypes": ["transaction"],
         }
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_response(self.organization.slug, **valid_alert_rule)
             assert resp.status_code == 201
 
-    @with_feature("organizations:incidents")
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @patch("sentry.quotas.backend.get_metric_detector_limit")
     def test_metric_alert_limit(self, mock_get_limit: MagicMock) -> None:
@@ -2022,7 +1963,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             **data,
         )
 
-    @with_feature("organizations:incidents")
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     @patch("sentry.quotas.backend.get_metric_detector_limit")
     @patch("sentry.incidents.endpoints.organization_alert_rule_index.log_alerting_quota_hit")
@@ -2034,7 +1974,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         self.get_error_response(self.organization.slug, status_code=400, **data)
         mock_log.assert_called_once()
 
-    @with_feature("organizations:incidents")
     @with_feature("organizations:workflow-engine-metric-detector-limit")
     def test_metric_alert_limit_unlimited_plan(self) -> None:
         # create orphaned metric alert
@@ -2065,13 +2004,13 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         # Below the 5-minute floor
         data["timeWindow"] = 1
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert "Invalid Time Window" in resp.data["nonFieldErrors"][0]
 
         # Above the floor but not a valid granularity (7 minutes = 420 seconds)
         data["timeWindow"] = 7
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert "Invalid Time Window" in resp.data["nonFieldErrors"][0]
 
@@ -2080,9 +2019,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         data["dataset"] = "transactions"
         data["alertType"] = "performance"
 
-        with self.feature(
-            ["organizations:incidents", "organizations:discover-saved-queries-deprecation"]
-        ):
+        with self.feature(["organizations:discover-saved-queries-deprecation"]):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
             resp.data[0]
@@ -2097,7 +2034,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:discover-saved-queries-deprecation",
                 "organizations:performance-view",
             ]
@@ -2115,7 +2051,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             resp = self.get_success_response(self.organization.slug, status_code=201, **data)
         assert "id" in resp.data
@@ -2135,7 +2071,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
                 resp = self.get_success_response(self.organization.slug, status_code=201, **data)
@@ -2163,7 +2099,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         data["dataset"] = "events_analytics_platform"
         data["alertType"] = "eap_metrics"
         data["extrapolation_mode"] = "server_weighted"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert (
             resp.data[0]
@@ -2191,7 +2127,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         data = deepcopy(self.alert_rule_dict)
         data["owner"] = f"team:{other_team.id}"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert resp.data == {"owner": ["You can only assign teams you are a member of"]}
 
@@ -2210,7 +2146,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         data = deepcopy(self.alert_rule_dict)
         data["owner"] = f"team:{self.team.id}"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(self.organization.slug, status_code=201, **data)
         assert resp.data["owner"] == f"team:{self.team.id}"
 
@@ -2231,7 +2167,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         data = deepcopy(self.alert_rule_dict)
         data["owner"] = f"team:{other_team.id}"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(self.organization.slug, status_code=201, **data)
         assert resp.data["owner"] == f"team:{other_team.id}"
 
@@ -2255,7 +2191,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         data = deepcopy(self.alert_rule_dict)
         data["owner"] = f"team:{other_team.id}"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(self.organization.slug, status_code=201, **data)
         assert resp.data["owner"] == f"team:{other_team.id}"
 
@@ -2285,7 +2221,7 @@ class AlertRuleCreateDeltaTest(AlertRuleIndexBase, SnubaTestCase):
         old_dict["name"] = "OldSerializerRule"
         with (
             outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.feature("organizations:performance-view"),
         ):
             old_resp = self.get_success_response(
                 self.organization.slug, status_code=201, **old_dict
@@ -2299,7 +2235,6 @@ class AlertRuleCreateDeltaTest(AlertRuleIndexBase, SnubaTestCase):
             outbox_runner(),
             self.feature(
                 [
-                    "organizations:incidents",
                     "organizations:performance-view",
                     "organizations:workflow-engine-rule-serializers",
                 ]
@@ -2367,7 +2302,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
         }
 
     def test_simple_crash_rate_alerts_for_sessions(self) -> None:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(
                 self.organization.slug, status_code=201, **self.valid_alert_rule
             )
@@ -2382,7 +2317,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
                 "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             }
         )
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(
                 self.organization.slug, status_code=201, **self.valid_alert_rule
             )
@@ -2393,7 +2328,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
 
     def test_simple_crash_rate_alerts_for_sessions_drops_event_types(self) -> None:
         self.valid_alert_rule["eventTypes"] = ["error"]
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(
                 self.organization.slug, status_code=201, **self.valid_alert_rule
             )
@@ -2404,7 +2339,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
 
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self) -> None:
         self.valid_alert_rule["timeWindow"] = "90"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_error_response(
                 self.organization.slug, status_code=400, **self.valid_alert_rule
             )
@@ -2416,7 +2351,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
 
     def test_simple_crash_rate_alerts_for_non_supported_aggregate(self) -> None:
         self.valid_alert_rule.update({"aggregate": "count(sessions)"})
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_error_response(
                 self.organization.slug, status_code=400, **self.valid_alert_rule
             )
@@ -2442,10 +2377,9 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
                 "actions": self.slack_action,
             },
         ]
-        with self.feature(["organizations:incidents"]):
-            resp = self.get_success_response(
-                self.organization.slug, status_code=202, **self.valid_alert_rule
-            )
+        resp = self.get_success_response(
+            self.organization.slug, status_code=202, **self.valid_alert_rule
+        )
         assert resp.data["uuid"] == "abc123"
         assert not AlertRule.objects.filter(name="JustAValidTestRule").exists()
         kwargs = {

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -142,8 +142,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             source=RuleSource.CRON_MONITOR,
         )
 
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
+        resp = self.get_success_response(self.organization.slug)
 
         assert len(resp.data) == 1
         assert cron_rule.id not in (r["id"] for r in resp.data), resp.data
@@ -151,17 +150,16 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
     def test_no_perf_alerts(self) -> None:
         self.create_alert_rule()
         perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
-        with self.feature("organizations:incidents"):
-            resp = self.get_success_response(self.organization.slug)
-            assert perf_alert_rule.id not in [x["id"] for x in list(resp.data)]
+        resp = self.get_success_response(self.organization.slug)
+        assert perf_alert_rule.id not in [x["id"] for x in list(resp.data)]
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             resp = self.get_success_response(self.organization.slug)
             assert perf_alert_rule.id in [int(x["id"]) for x in list(resp.data)]
 
     def test_simple(self) -> None:
         self.setup_rules()
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -206,7 +204,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             ).values_list("detector_id", flat=True)
         ).update(enabled=False)
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -233,7 +231,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
     def test_invalid_limit(self) -> None:
         self.setup_rules()
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "notaninteger"}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -243,7 +241,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
     def test_limit_as_1_with_paging_sort_name(self) -> None:
         self.setup_rules()
         # Test Limit as 1, no cursor:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "1",
                 "project": str(self.project.id),
@@ -262,7 +260,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         next_cursor = links[1]["cursor"]
         # Test Limit as 1, next page of previous request:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "cursor": next_cursor,
                 "per_page": "1",
@@ -302,7 +300,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         # Test Limit as 1, no cursor:
         url = f"/api/0/organizations/{self.org.slug}/combined-rules/"
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "1",
                 "project": str(self.project.id),
@@ -323,7 +321,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         next_cursor = links[1]["cursor"]
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "cursor": next_cursor,
                 "per_page": "1",
@@ -341,7 +339,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.setup_rules()
 
         # Test Limit as 1, no cursor:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "1", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -358,7 +356,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         next_cursor = links[1]["cursor"]
 
         # Test Limit as 1, next page of previous request:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"cursor": next_cursor, "per_page": "1", "project": str(self.project.id)}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -373,7 +371,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.setup_rules()
 
         # Test Limit as 2, no cursor:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "2", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -391,7 +389,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         next_cursor = links[1]["cursor"]
         # Test Limit 2, next page of previous request:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"cursor": next_cursor, "per_page": "2", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -409,7 +407,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         next_cursor = links[1]["cursor"]
 
         # Test Limit 2, next page of previous request - should get no results since there are only 4 total:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"cursor": next_cursor, "per_page": "2", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -437,7 +435,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             organization=self.organization, projects=[self.project]
         )
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "2", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -455,7 +453,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         next_cursor = links[1]["cursor"]
         assert next_cursor.split(":")[1] == "1"  # Assert offset is properly calculated.
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"cursor": next_cursor, "per_page": "2", "project": self.project_ids}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -493,7 +491,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -517,7 +514,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -548,13 +544,13 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             }
         )
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             response = self.get_error_response(self.organization.slug, project=[other_project.id])
             assert response.data["detail"] == "You do not have permission to perform this action."
 
     def test_team_filter(self) -> None:
         self.setup_rules()
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": [self.project.id]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -563,7 +559,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = response.data
         assert len(result) == 3
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id],
@@ -576,7 +572,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = response.data
         assert len(result) == 1
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id],
@@ -589,7 +585,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = response.data
         assert len(result) == 2
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id, self.project2.id],
@@ -602,7 +598,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = response.data
         assert len(result) == 3
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": [self.project.id], "team": ["unassigned"]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -617,7 +613,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             date_added=before_now(minutes=3),
             owner=None,
         )
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": [self.project.id], "team": ["unassigned"]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -626,14 +622,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = response.data
         assert len(result) == 2
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": [self.project.id], "team": ["notvalid"]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )
         assert response.status_code == 400
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10", "project": [self.project.id], "team": ["myteams"]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -642,7 +638,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = response.data
         assert len(result) == 2
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id, self.project2.id],
@@ -666,7 +662,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "owner": f"team:{self.team.id}",
             }
         )
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id],
@@ -694,7 +690,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -718,7 +713,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -768,7 +762,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             }
         )
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [str(another_project.id)],
@@ -780,7 +774,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         assert response.status_code == 200
         assert len(response.data) == 2
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [str(another_project.id)],
@@ -796,7 +790,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.setup_rules()
         another_org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         another_org_team = self.create_team(organization=another_org, name="Meow Band", members=[])
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id],
@@ -822,7 +816,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.create_member(user=user2, organization=self.organization, role="member", teams=[team2])
         self.login_as(user2)
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [project2.id],
@@ -845,7 +839,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -867,7 +860,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -885,7 +877,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -903,7 +894,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -921,7 +911,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -939,7 +928,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -960,7 +948,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -1069,7 +1056,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -1104,7 +1090,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         # Test paging with the status setup:
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -1131,7 +1116,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         # Get next page, we should be between the two status':
         with self.feature(
             [
-                "organizations:incidents",
                 "organizations:performance-view",
             ]
         ):
@@ -1237,7 +1221,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             incident_identifier=crit_incident.identifier,
         )
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {
                 "per_page": "10",
                 "project": [self.project.id],
@@ -1279,7 +1263,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         team.delete()
         Detector.objects.filter(owner_team_id=team_id).update(owner_team_id=None)
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             request_data = {"per_page": "10"}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
@@ -1331,7 +1315,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         transaction_rule = self.create_alert_rule(dataset=Dataset.Transactions)
         events_rule = self.create_alert_rule(dataset=Dataset.Events)
 
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             transactions_res = self.get_success_response(
                 self.organization.slug, dataset=[Dataset.Transactions.value]
             )
@@ -1343,10 +1327,9 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             )
             self.assert_alert_rule_serialized(events_rule, events_res.data[0], skip_dates=True)
 
-        with self.feature("organizations:incidents"):
-            # without performance-view, we should only see events rules
-            res = self.get_success_response(self.organization.slug)
-            self.assert_alert_rule_serialized(events_rule, res.data[0], skip_dates=True)
+        # without performance-view, we should only see events rules
+        res = self.get_success_response(self.organization.slug)
+        self.assert_alert_rule_serialized(events_rule, res.data[0], skip_dates=True)
 
     def test_alert_type_filter(self) -> None:
         # Setup one of each type of alert rule
@@ -1365,7 +1348,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         cron_rule = self.create_monitor(project=self.project)
 
         features = [
-            "organizations:incidents",
             "organizations:performance-view",
         ]
 
@@ -1410,7 +1392,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 assert {r["id"] for r in response.data} == expected_ids
 
     def test_invalid_sort_key(self) -> None:
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+        with self.feature("organizations:performance-view"):
             response = self.get_error_response(
                 self.organization.slug, sort=["invalid_field"], status_code=400
             )
@@ -1419,7 +1401,6 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
 
 @with_feature(
     [
-        "organizations:incidents",
         "organizations:performance-view",
         "organizations:workflow-engine-rule-serializers",
     ]
@@ -1647,13 +1628,12 @@ class OrganizationCombinedRuleIndexWorkflowEngineTest(BaseAlertRuleSerializerTes
         assert len(response.data) == 1
         assert len(response.data[0]["actions"]) == 0
 
-        with self.feature("organizations:incidents"):
-            response = self.get_success_response(
-                self.organization.slug,
-                project=[self.project.id],
-            )
-            assert response.status_code == 200
+        response = self.get_success_response(
+            self.organization.slug,
+            project=[self.project.id],
+        )
+        assert response.status_code == 200
 
-            assert len(response.data) == 1
-            assert len(response.data[0]["actions"]) == 0
-            assert response.data[0]["id"] == str(rule.id)
+        assert len(response.data) == 1
+        assert len(response.data[0]["actions"]) == 0
+        assert response.data[0]["id"] == str(rule.id)

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -20,7 +20,6 @@ from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenP
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Detector, DetectorGroup
 from tests.sentry.incidents.utils.test_metric_issue_base import BaseMetricIssueTest
@@ -197,7 +196,6 @@ class BuildMetricAlertChartTest(TestCase):
 
 class FetchOpenPeriodsTest(BaseMetricIssueTest):
     @freeze_time(frozen_time)
-    @with_feature("organizations:incidents")
     def test_get_open_periods_from_detector(self) -> None:
         group = self.create_group(
             project=self.project, type=MetricIssue.type_id, priority=PriorityLevel.HIGH
@@ -241,7 +239,6 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
         assert closed_activity_resp["dateCreated"] == closed_gopa.date_added
 
     @freeze_time(frozen_time)
-    @with_feature("organizations:incidents")
     def test_pending_deletion_detector_not_resolved_to_alert_rule(self) -> None:
         self.create_detector()  # dummy so detector ID != alert rule ID
         detector = self.create_detector(project=self.project)
@@ -272,7 +269,6 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
         assert len(chart_data) == 0
 
     @freeze_time(frozen_time)
-    @with_feature("organizations:incidents")
     def test_use_open_period_serializer(self) -> None:
         detector = self.create_detector(project=self.project)
         group = self.create_group(type=MetricIssue.type_id, priority=PriorityLevel.HIGH)
@@ -304,7 +300,6 @@ class FetchOpenPeriodsTest(BaseMetricIssueTest):
         assert activities[0]["value"] == PriorityLevel(group.priority).to_str()
 
     @freeze_time(frozen_time)
-    @with_feature("organizations:incidents")
     def test_use_open_period_serializer_with_offset(self) -> None:
         group = self.create_group(type=MetricIssue.type_id, priority=PriorityLevel.HIGH)
 

--- a/tests/sentry/integrations/slack/tasks/test_tasks.py
+++ b/tests/sentry/integrations/slack/tasks/test_tasks.py
@@ -306,8 +306,7 @@ class SlackTasksTest(TestCase):
         }
 
         with self.tasks():
-            with self.feature(["organizations:incidents"]):
-                find_channel_id_for_alert_rule(**data)
+            find_channel_id_for_alert_rule(**data)
 
         rule = AlertRule.objects.get(name="New Rule")
         assert rule.created_by_id == self.user.id
@@ -337,8 +336,7 @@ class SlackTasksTest(TestCase):
         }
 
         with self.tasks():
-            with self.feature(["organizations:incidents"]):
-                find_channel_id_for_alert_rule(**data)
+            find_channel_id_for_alert_rule(**data)
 
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_set_value.assert_called_with("failed")
@@ -364,8 +362,7 @@ class SlackTasksTest(TestCase):
         }
 
         with self.tasks():
-            with self.feature(["organizations:incidents"]):
-                find_channel_id_for_alert_rule(**data)
+            find_channel_id_for_alert_rule(**data)
 
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_set_value.assert_called_with("failed")
@@ -393,13 +390,12 @@ class SlackTasksTest(TestCase):
         # Catch the exception we've side-effected in the serializer
         with pytest.raises(Exception, match="something broke!"):
             with self.tasks():
-                with self.feature(["organizations:incidents"]):
-                    find_channel_id_for_alert_rule(
-                        data=data,
-                        uuid=self.uuid,
-                        organization_id=self.organization.id,
-                        user_id=self.user.id,
-                    )
+                find_channel_id_for_alert_rule(
+                    data=data,
+                    uuid=self.uuid,
+                    organization_id=self.organization.id,
+                    user_id=self.user.id,
+                )
 
         assert not AlertRule.objects.filter(name="New Rule").exists()
         mock_get_channel_id.assert_called_with(
@@ -435,8 +431,7 @@ class SlackTasksTest(TestCase):
         }
 
         with self.tasks():
-            with self.feature(["organizations:incidents"]):
-                find_channel_id_for_alert_rule(**data)
+            find_channel_id_for_alert_rule(**data)
 
         rule = AlertRule.objects.get(name="New Rule")
         mock_set_value.assert_called_with("success", rule.id)
@@ -470,8 +465,7 @@ class SlackTasksTest(TestCase):
         }
 
         with self.tasks():
-            with self.feature(["organizations:incidents"]):
-                find_channel_id_for_alert_rule(**data)
+            find_channel_id_for_alert_rule(**data)
 
         rule = AlertRule.objects.get(name="New Rule")
         mock_set_value.assert_called_with("success", rule.id)

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -83,7 +83,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         )
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -118,7 +117,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == seer_return_value["timeseries"]
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -158,7 +156,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == seer_return_value["timeseries"]
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -186,7 +183,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == []
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -214,7 +210,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == {"detail": "Unable to get historical anomaly data"}
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -244,7 +239,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == {"detail": "Unable to get historical anomaly data"}
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -274,7 +268,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == {"detail": "Unable to get historical anomaly data"}
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -308,7 +301,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == {"detail": "Unable to get historical anomaly data"}
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
@@ -340,7 +332,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == {"detail": "Unable to get historical anomaly data"}
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     def test_rejects_project_not_in_organization(self) -> None:
         """Test that POST fails when project doesn't belong to the organization"""
         other_org = self.create_organization(owner=self.user)
@@ -357,7 +348,6 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
         assert resp.data == {"detail": "You do not have permission to perform this action."}
 
     @with_feature("organizations:anomaly-detection-alerts")
-    @with_feature("organizations:incidents")
     def test_rejects_nonexistent_project(self) -> None:
         """Test that POST fails when project doesn't exist"""
         self.login_as(self.user)


### PR DESCRIPTION
The organizations:incidents flag is being made available to all plans. This PR is one of many to remove checks for this flag around the codebase.

Fixes ISWF-3270