### PR TITLE
fix(difs): Skip permanently corrupt DIFs when migrating

### DIFF
--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -212,6 +212,12 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
             extra={"debug_file_id": debug_file.id, "file_id": file.id},
         )
 
+    if recorded_size is None:
+        logger.warning(
+            "debug_files.objectstore_migration.size_missing",
+            extra={"debug_file_id": debug_file.id, "file_id": file.id},
+        )
+
     try:
         tmp, local_checksum, local_size = _spool_and_validate_with_retry(
             file,

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -27,6 +27,8 @@ from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 
 logger = logging.getLogger(__name__)
 
+_FILESTORE_DOWNLOAD_ATTEMPTS = 3
+
 
 def migrate_debug_file(debug_file: ProjectDebugFile) -> None:
     """Migrate one File-backed DIF, or drop the legacy File from a dual-written DIF."""
@@ -62,8 +64,30 @@ class PostMigrationMetadata:
     checksum: str
 
 
-class MigrationIntegrityError(Exception):
-    """Payload checksum/size did not match the legacy File."""
+class ObjectstoreIntegrityError(Exception):
+    """Objectstore payload checksum/size did not match the legacy File."""
+
+
+class FilestoreIntegrityError(Exception):
+    """Downloaded filestore payload did not match the File record."""
+
+    def __init__(
+        self,
+        *,
+        checksum: str,
+        expected_checksum: str | None,
+        size: int,
+        expected_size: int | None,
+    ) -> None:
+        self.checksum = checksum
+        self.expected_checksum = expected_checksum
+        self.size = size
+        self.expected_size = expected_size
+        super().__init__(
+            f"Filestore payload does not match File record "
+            f"(checksum={checksum!r} expected={expected_checksum!r}, "
+            f"size={size} expected={expected_size})"
+        )
 
 
 def _sha1_stream(stream: IO[bytes]) -> tuple[str, int]:
@@ -101,19 +125,53 @@ def _spool_to_tempfile(file: File) -> tuple[IO[bytes], str, int]:
     return tmp, digest.hexdigest(), size
 
 
+def _spool_and_validate_with_retry(
+    file: File,
+    *,
+    expected_checksum: str | None,
+    expected_size: int | None,
+) -> tuple[IO[bytes], str, int]:
+    """Download and validate a File, retrying filestore integrity mismatches."""
+
+    def attempt() -> tuple[IO[bytes], str, int]:
+        tmp, checksum, size = _spool_to_tempfile(file)
+        checksum_matches = expected_checksum is None or checksum == expected_checksum
+        size_matches = expected_size is None or size == expected_size
+        if checksum_matches and size_matches:
+            return tmp, checksum, size
+
+        tmp.close()
+        raise FilestoreIntegrityError(
+            checksum=checksum,
+            expected_checksum=expected_checksum,
+            size=size,
+            expected_size=expected_size,
+        )
+
+    base_delay = exponential_delay(2)
+    policy = ConditionalRetryPolicy(
+        test_function=lambda attempt_number, error: (
+            isinstance(error, FilestoreIntegrityError)
+            and attempt_number < _FILESTORE_DOWNLOAD_ATTEMPTS
+        ),
+        delay_function=lambda n: random.uniform(base_delay(n), base_delay(n) * 2),
+    )
+    return policy(attempt)
+
+
 def _get_object_with_retry(session: Session, storage_path: str) -> GetResponse:
     """Retry verification reads without re-uploading the DIF."""
 
     def get_object() -> GetResponse:
         response = session.get(storage_path)
         if response is None:
-            raise MigrationIntegrityError("Object not found in Objectstore")
+            raise ObjectstoreIntegrityError("Object not found in Objectstore")
         return response
 
     base_delay = exponential_delay(2)
     policy = ConditionalRetryPolicy(
         test_function=lambda attempt_number, error: (
-            not isinstance(error, MigrationIntegrityError) and attempt_number <= 3
+            not isinstance(error, ObjectstoreIntegrityError) and attempt_number <= 3
         ),
         delay_function=lambda n: random.uniform(base_delay(n), base_delay(n) * 2),
     )
@@ -127,7 +185,7 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
         Metadata to commit, or ``None`` to skip.
 
     Raises:
-        MigrationIntegrityError: Local File or Objectstore payload mismatch.
+        ObjectstoreIntegrityError: Objectstore payload mismatch.
         Exception: I/O, network, or other failures during spool/upload/verify.
     """
     file = debug_file.file
@@ -157,16 +215,30 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
             extra={"debug_file_id": debug_file.id, "file_id": file.id},
         )
 
-    tmp, local_checksum, local_size = _spool_to_tempfile(file)
+    try:
+        tmp, local_checksum, local_size = _spool_and_validate_with_retry(
+            file,
+            expected_checksum=recorded_checksum,
+            expected_size=recorded_size,
+        )
+    except FilestoreIntegrityError as error:
+        logger.warning(
+            "debug_files.objectstore_migration.filestore_integrity_mismatch",
+            extra={
+                "debug_file_id": debug_file.id,
+                "file_id": file.id,
+                "attempts": _FILESTORE_DOWNLOAD_ATTEMPTS,
+                "checksum": error.checksum,
+                "expected_checksum": error.expected_checksum,
+                "size": error.size,
+                "expected_size": error.expected_size,
+            },
+        )
+        return None
+
     try:
         expected_checksum = recorded_checksum or local_checksum
         expected_size = recorded_size if recorded_size is not None else local_size
-        if local_checksum != expected_checksum or local_size != expected_size:
-            raise MigrationIntegrityError(
-                f"Filestore payload does not match File record "
-                f"(checksum={local_checksum!r} expected={expected_checksum!r}, "
-                f"size={local_size} expected={expected_size})"
-            )
         storage_path = session.put(
             tmp,
             key=f"legacy.{debug_file.id}",
@@ -194,7 +266,7 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
                 "debug_files.objectstore_migration.unverified_object_delete_failed",
                 extra={"debug_file_id": debug_file.id, "storage_path": storage_path},
             )
-        raise MigrationIntegrityError(
+        raise ObjectstoreIntegrityError(
             f"Objectstore payload does not match File "
             f"(checksum={remote_checksum!r} expected={expected_checksum!r}, "
             f"size={remote_size} expected={expected_size})"

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -198,7 +198,7 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
 
     content_type = file.headers.get("Content-Type", "application/octet-stream")
     date_created = file.timestamp
-    recorded_checksum = file.checksum
+    recorded_checksum = file.checksum or None
     recorded_size = file.size
     file_format = KNOWN_DIF_FORMATS.get(content_type.lower(), "unknown")
     filename = (
@@ -206,7 +206,7 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
         f"{_dif_file_extension(file_format, debug_file.file_type)}"
     )
 
-    if not recorded_checksum:
+    if recorded_checksum is None:
         logger.warning(
             "debug_files.objectstore_migration.checksum_missing",
             extra={"debug_file_id": debug_file.id, "file_id": file.id},
@@ -233,7 +233,7 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
         return None
 
     try:
-        expected_checksum = recorded_checksum or local_checksum
+        expected_checksum = recorded_checksum if recorded_checksum is not None else local_checksum
         expected_size = recorded_size if recorded_size is not None else local_size
         storage_path = session.put(
             tmp,

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -27,8 +27,6 @@ from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 
 logger = logging.getLogger(__name__)
 
-_FILESTORE_DOWNLOAD_ATTEMPTS = 3
-
 
 def migrate_debug_file(debug_file: ProjectDebugFile) -> None:
     """Migrate one File-backed DIF, or drop the legacy File from a dual-written DIF."""
@@ -151,8 +149,7 @@ def _spool_and_validate_with_retry(
     base_delay = exponential_delay(2)
     policy = ConditionalRetryPolicy(
         test_function=lambda attempt_number, error: (
-            isinstance(error, FilestoreIntegrityError)
-            and attempt_number < _FILESTORE_DOWNLOAD_ATTEMPTS
+            isinstance(error, FilestoreIntegrityError) and attempt_number < 3
         ),
         delay_function=lambda n: random.uniform(base_delay(n), base_delay(n) * 2),
     )
@@ -227,7 +224,6 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
             extra={
                 "debug_file_id": debug_file.id,
                 "file_id": file.id,
-                "attempts": _FILESTORE_DOWNLOAD_ATTEMPTS,
                 "checksum": error.checksum,
                 "expected_checksum": error.expected_checksum,
                 "size": error.size,

--- a/tests/sentry/debug_files/objectstore_migration/test_utils.py
+++ b/tests/sentry/debug_files/objectstore_migration/test_utils.py
@@ -45,6 +45,30 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
         assert self.debug_file.checksum is not None
         assert not File.objects.filter(id=file_id).exists()
 
+    @requires_objectstore
+    def test_migrates_file_with_empty_checksum(self) -> None:
+        file = self.debug_file.file
+        assert file is not None
+        expected_checksum = file.checksum
+        assert expected_checksum is not None
+        file.checksum = ""
+        file.save(update_fields=["checksum"])
+
+        with (
+            patch("sentry.debug_files.objectstore_migration.utils.logger.warning") as warning,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            migrate_debug_file(self.debug_file)
+
+        warning.assert_any_call(
+            "debug_files.objectstore_migration.checksum_missing",
+            extra={"debug_file_id": self.debug_file.id, "file_id": file.id},
+        )
+        self.debug_file.refresh_from_db()
+        assert self.debug_file.file_id is None
+        assert self.debug_file.storage_path is not None
+        assert self.debug_file.checksum == expected_checksum
+
     def test_integrity_failure_does_not_cut_over(self) -> None:
         session = MagicMock()
         session.get.side_effect = lambda *args, **kwargs: MagicMock(

--- a/tests/sentry/debug_files/objectstore_migration/test_utils.py
+++ b/tests/sentry/debug_files/objectstore_migration/test_utils.py
@@ -69,6 +69,30 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
         assert self.debug_file.storage_path is not None
         assert self.debug_file.checksum == expected_checksum
 
+    @requires_objectstore
+    def test_migrates_file_with_missing_size(self) -> None:
+        file = self.debug_file.file
+        assert file is not None
+        expected_size = file.size
+        assert expected_size is not None
+        file.size = None
+        file.save(update_fields=["size"])
+
+        with (
+            patch("sentry.debug_files.objectstore_migration.utils.logger.warning") as warning,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            migrate_debug_file(self.debug_file)
+
+        warning.assert_any_call(
+            "debug_files.objectstore_migration.size_missing",
+            extra={"debug_file_id": self.debug_file.id, "file_id": file.id},
+        )
+        self.debug_file.refresh_from_db()
+        assert self.debug_file.file_id is None
+        assert self.debug_file.storage_path is not None
+        assert self.debug_file.file_size == expected_size
+
     def test_integrity_failure_does_not_cut_over(self) -> None:
         session = MagicMock()
         session.get.side_effect = lambda *args, **kwargs: MagicMock(

--- a/tests/sentry/debug_files/objectstore_migration/test_utils.py
+++ b/tests/sentry/debug_files/objectstore_migration/test_utils.py
@@ -9,7 +9,7 @@ from django.core.files.base import ContentFile
 
 from sentry.debug_files.objectstore_migration import migrate_debug_file
 from sentry.debug_files.objectstore_migration.utils import (
-    MigrationIntegrityError,
+    ObjectstoreIntegrityError,
     PostMigrationMetadata,
     commit,
 )
@@ -57,7 +57,7 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
                 return_value=session,
             ),
             patch("sentry.utils.retries.time.sleep"),
-            pytest.raises(MigrationIntegrityError),
+            pytest.raises(ObjectstoreIntegrityError),
         ):
             session.put.return_value = "uploaded-key"
             migrate_debug_file(self.debug_file)


### PR DESCRIPTION
Retries a `File` download up to three times when its checksum or size does not match the `File` record., then skips it and logs it with DIF and File ID.
This prevents permanently corrupted files from stopping a migration shard.