### PR TITLE
fix(objectstore): Handle ranges for compressed objects

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -83,21 +83,55 @@ class ObjectstoreEndpoint(Endpoint):
         headers.pop("Content-Length", None)
         headers.pop("Transfer-Encoding", None)
 
+        query_string = request.META.get("QUERY_STRING") or None
+        accepted_encodings = parse_accept_encoding(request.headers.get("Accept-Encoding", ""))
+
+        if request.method == "GET" and "Range" in headers:
+            head_headers = headers.copy()
+            head_headers.pop("Range")
+            head_headers.pop("If-Range", None)
+
+            forward_range = False
+            try:
+                with requests.request(
+                    "HEAD",
+                    url=target_url,
+                    headers=head_headers,
+                    params=query_string,
+                    stream=True,
+                    allow_redirects=False,
+                ) as head_response:
+                    content_encoding = (
+                        head_response.headers.get("Content-Encoding", "").strip().lower()
+                    )
+                    forward_range = 200 <= head_response.status_code < 300 and (
+                        not content_encoding
+                        or "*" in accepted_encodings
+                        or content_encoding in accepted_encodings
+                    )
+            except requests.RequestException:
+                # Without reliable metadata, fall back to a decodable full response.
+                forward_range = False
+
+            if not forward_range:
+                headers.pop("Range")
+                headers.pop("If-Range", None)
+
         response = requests.request(
             request.method,
             url=target_url,
             headers=headers,
             data=get_raw_body(request._request),
-            params=request.META.get("QUERY_STRING") or None,
+            params=query_string,
             stream=True,
             allow_redirects=False,
         )
 
         content_encoding = response.headers.get("Content-Encoding", "").strip().lower()
-        accepted_encodings = parse_accept_encoding(request.headers.get("Accept-Encoding", ""))
         decode_content = (
             response.status_code != 206
             and bool(content_encoding)
+            and "*" not in accepted_encodings
             and content_encoding not in accepted_encodings
         )
 

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -95,7 +95,11 @@ class ObjectstoreEndpoint(Endpoint):
 
         content_encoding = response.headers.get("Content-Encoding", "").strip().lower()
         accepted_encodings = parse_accept_encoding(request.headers.get("Accept-Encoding", ""))
-        decode_content = bool(content_encoding) and content_encoding not in accepted_encodings
+        decode_content = (
+            response.status_code != 206
+            and bool(content_encoding)
+            and content_encoding not in accepted_encodings
+        )
 
         return stream_response(response, decode_content=decode_content)
 

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -105,9 +105,7 @@ class ObjectstoreEndpoint(Endpoint):
                         head_response.headers.get("Content-Encoding", "").strip().lower()
                     )
                     forward_range = 200 <= head_response.status_code < 300 and (
-                        not content_encoding
-                        or "*" in accepted_encodings
-                        or content_encoding in accepted_encodings
+                        not content_encoding or content_encoding in accepted_encodings
                     )
             except requests.RequestException:
                 # Without reliable metadata, fall back to a decodable full response.
@@ -131,7 +129,6 @@ class ObjectstoreEndpoint(Endpoint):
         decode_content = (
             response.status_code != 206
             and bool(content_encoding)
-            and "*" not in accepted_encodings
             and content_encoding not in accepted_encodings
         )
 

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -150,6 +150,38 @@ class ObjectstoreEndpointTest(TransactionTestCase):
         with dctx.stream_reader(raw_body) as reader:
             assert reader.read() == data
 
+        # A range of an accepted encoding is served from the compressed representation.
+        range_end = 9
+        get_resp = requests.get(
+            f"{base_url}{object_key}",
+            headers={
+                **auth_headers,
+                "Accept-Encoding": "zstd",
+                "Range": f"bytes=0-{range_end}",
+            },
+            stream=True,
+        )
+        assert_status_code(get_resp, 206)
+        assert get_resp.headers.get("Content-Encoding") == "zstd"
+        assert get_resp.headers.get("Content-Length") == str(range_end + 1)
+        assert get_resp.headers.get("Content-Range") == (f"bytes 0-{range_end}/{len(compressed)}")
+        assert get_resp.raw.read(decode_content=False) == compressed[: range_end + 1]
+
+        # A range of an unacceptable encoding is ignored and the full object is decoded.
+        get_resp = requests.get(
+            f"{base_url}{object_key}",
+            headers={
+                **auth_headers,
+                "Accept-Encoding": "identity",
+                "Range": f"bytes=0-{range_end}",
+            },
+        )
+        assert_status_code(get_resp, 200)
+        assert get_resp.headers.get("Content-Encoding") is None
+        assert get_resp.headers.get("Content-Length") is None
+        assert get_resp.headers.get("Content-Range") is None
+        assert get_resp.content == data
+
     def test_large_payload(self) -> None:
         session = self.get_session()
         data = b"A" * 1_000_000
@@ -306,13 +338,8 @@ class ObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
                 assert close_streaming_response(response) == data
 
 
-class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
+class ObjectstoreProxyRequestForwardingTest(TransactionTestCase):
     def test_query_string_forwarded_verbatim(self) -> None:
-        from rest_framework.request import Request
-        from rest_framework.test import APIRequestFactory
-
-        from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
-
         # The ``:`` and ``+`` would be percent-encoded by ``dict(request.GET)``.
         query = (
             "os_kid=sentry&os_timestamp=2026-07-13T13:19:24+00:00&os_duration=300&os_sig=ab_c-D9z"
@@ -331,36 +358,98 @@ class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
 
         assert mock_request.call_args.kwargs["params"] == query
 
-    def test_partial_response_preserves_content_encoding(self) -> None:
-        compressed = b"compressed range bytes"
+    def test_range_request_serves_full_object_when_encoding_not_accepted(self) -> None:
+        full_object = b"full object"
+        head_response = requests.Response()
+        head_response.status_code = 200
+        head_response.headers = requests.structures.CaseInsensitiveDict(
+            {"Content-Encoding": "zstd"}
+        )
+        head_response.raw = MagicMock()
+
         upstream_response = requests.Response()
-        upstream_response.status_code = 206
+        upstream_response.status_code = 200
         upstream_response.headers = requests.structures.CaseInsensitiveDict(
             {
                 "Content-Encoding": "zstd",
-                "Content-Length": str(len(compressed)),
-                "Content-Range": "bytes 0-21/100",
+                "Content-Length": "8",
             }
         )
         upstream_response.raw = MagicMock()
-        upstream_response.raw.read.side_effect = [compressed, b""]
+        upstream_response.raw.read.side_effect = [full_object, b""]
 
         request = APIRequestFactory().get(
             "/v1/objects/test/org=1/key",
             HTTP_ACCEPT_ENCODING="identity",
+            HTTP_IF_RANGE='"previous-etag"',
             HTTP_RANGE="bytes=0-21",
         )
 
         with patch(
             "sentry.objectstore.endpoints.organization.requests.request",
-            return_value=upstream_response,
-        ):
+            side_effect=[head_response, upstream_response],
+        ) as mock_request:
             response = ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
 
+        head_request, object_request = mock_request.call_args_list
+        assert head_request.args == ("HEAD",)
+        assert "Range" not in head_request.kwargs["headers"]
+        assert "If-Range" not in head_request.kwargs["headers"]
+        assert object_request.args == ("GET",)
+        assert "Range" not in object_request.kwargs["headers"]
+        assert "If-Range" not in object_request.kwargs["headers"]
+        assert response.status_code == 200
+        assert "Content-Encoding" not in response
+        assert "Content-Length" not in response
+        assert close_streaming_response(response) == full_object
+        assert upstream_response.raw.decode_content is True
+
+    def test_range_request_serves_encoded_range_when_encoding_accepted(self) -> None:
+        encoded_range = b"encoded range"
+        head_response = requests.Response()
+        head_response.status_code = 200
+        head_response.headers = requests.structures.CaseInsensitiveDict(
+            {"Content-Encoding": "zstd"}
+        )
+        head_response.raw = MagicMock()
+
+        upstream_response = requests.Response()
+        upstream_response.status_code = 206
+        upstream_response.headers = requests.structures.CaseInsensitiveDict(
+            {
+                "Content-Encoding": "zstd",
+                "Content-Length": str(len(encoded_range)),
+                "Content-Range": "bytes 0-12/100",
+            }
+        )
+        upstream_response.raw = MagicMock()
+        upstream_response.raw.read.side_effect = [encoded_range, b""]
+
+        request = APIRequestFactory().get(
+            "/v1/objects/test/org=1/key",
+            HTTP_ACCEPT_ENCODING="zstd",
+            HTTP_IF_RANGE='"current-etag"',
+            HTTP_RANGE="bytes=0-12",
+        )
+
+        with patch(
+            "sentry.objectstore.endpoints.organization.requests.request",
+            side_effect=[head_response, upstream_response],
+        ) as mock_request:
+            response = ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
+
+        head_request, object_request = mock_request.call_args_list
+        assert head_request.args == ("HEAD",)
+        assert "Range" not in head_request.kwargs["headers"]
+        assert "If-Range" not in head_request.kwargs["headers"]
+        assert object_request.args == ("GET",)
+        assert object_request.kwargs["headers"]["Range"] == "bytes=0-12"
+        assert object_request.kwargs["headers"]["If-Range"] == '"current-etag"'
+        assert response.status_code == 206
         assert response["Content-Encoding"] == "zstd"
-        assert response["Content-Length"] == str(len(compressed))
-        assert response["Content-Range"] == "bytes 0-21/100"
-        assert close_streaming_response(response) == compressed
+        assert response["Content-Length"] == str(len(encoded_range))
+        assert response["Content-Range"] == "bytes 0-12/100"
+        assert close_streaming_response(response) == encoded_range
         assert upstream_response.raw.decode_content is False
 
 

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -9,8 +9,10 @@ from django.db import connections
 from django.urls import reverse
 from objectstore_client import Client, Session, Usecase
 from pytest_django.live_server_helper import LiveServer
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
-from sentry.objectstore.endpoints.organization import stream_response
+from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint, stream_response
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.testutils.asserts import assert_status_code
 from sentry.testutils.cases import TransactionTestCase
@@ -328,6 +330,38 @@ class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
             ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
 
         assert mock_request.call_args.kwargs["params"] == query
+
+    def test_partial_response_preserves_content_encoding(self) -> None:
+        compressed = b"compressed range bytes"
+        upstream_response = requests.Response()
+        upstream_response.status_code = 206
+        upstream_response.headers = requests.structures.CaseInsensitiveDict(
+            {
+                "Content-Encoding": "zstd",
+                "Content-Length": str(len(compressed)),
+                "Content-Range": "bytes 0-21/100",
+            }
+        )
+        upstream_response.raw = MagicMock()
+        upstream_response.raw.read.side_effect = [compressed, b""]
+
+        request = APIRequestFactory().get(
+            "/v1/objects/test/org=1/key",
+            HTTP_ACCEPT_ENCODING="identity",
+            HTTP_RANGE="bytes=0-21",
+        )
+
+        with patch(
+            "sentry.objectstore.endpoints.organization.requests.request",
+            return_value=upstream_response,
+        ):
+            response = ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
+
+        assert response["Content-Encoding"] == "zstd"
+        assert response["Content-Length"] == str(len(compressed))
+        assert response["Content-Range"] == "bytes 0-21/100"
+        assert close_streaming_response(response) == compressed
+        assert upstream_response.raw.decode_content is False
 
 
 class ObjectstoreProxyStreamCloseTest(TransactionTestCase):


### PR DESCRIPTION
Range requests through the Objectstore proxy now probe object metadata with `HEAD` before fetching. When the client accepts the stored `Content-Encoding`, the proxy forwards `Range` and preserves the encoded `206` response. Otherwise, it removes the range and returns the decoded full object with `200`.

This adds one metadata request to ranged downloads, but avoids decompressing partial compressed streams while retaining byte ranges for compatible clients.

Close FS-490
