### PR TITLE
fix(scraps): Stop AlertLink collapsing inside flex containers

### DIFF
--- a/static/app/components/core/alert/alertLink.tsx
+++ b/static/app/components/core/alert/alertLink.tsx
@@ -89,12 +89,14 @@ const ExternalLinkWithTextDecoration = styled(ExternalLink)<{
   variant: AlertProps['variant'];
 }>`
   display: block;
+  width: 100%;
   cursor: pointer;
   ${p => textDecorationStyles({type: p.variant, theme: p.theme})}
 `;
 
 const LinkWithTextDecoration = styled(Link)<{variant: AlertProps['variant']}>`
   display: block;
+  width: 100%;
   cursor: pointer;
   ${p => textDecorationStyles({type: p.variant, theme: p.theme})}
 `;

--- a/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
@@ -63,7 +63,7 @@ export function FeedbackItemHeader({eventData, feedbackItem, onBackToList}: Prop
       {eventData && feedbackItem.project ? (
         <ErrorBoundary mini>
           <Flex wrap="wrap" justify="between" align="center" gap="md">
-            <Flex direction="row" gap="md">
+            <Flex direction="row" gap="md" flex="1 1 auto">
               <ExternalIssueList
                 group={feedbackItem as unknown as Group}
                 event={eventData}


### PR DESCRIPTION
AlertPanel gained `container-type: inline-size` in #121420. Inline-size containment makes an element's intrinsic width contribution zero, so any Alert in a shrink-to-fit context collapses to its minimum width. That PR added `width: 100%` to `Alert.Container` to compensate, but AlertLink's anchor wrappers were missed.

Give both AlertLink wrappers `width: 100%` — a no-op in normal block flow, fills the line when the anchor is a flex item — and let the external issue wrapper in the feedback item header grow so that percentage resolves against a definite width. The user feedback viewer was rendering "Track this issue in Jira, GitHub, etc." as a sliver of text wrapping one word per line.

Spotted in this replay: https://sentry.sentry.io/explore/replays/5f1109fad5d6487aa912098d9cecf71d/?t=37