### PR TITLE
Require session auth for token details endpoints

### DIFF
--- a/src/sentry/api/endpoints/api_token_details.py
+++ b/src/sentry/api/endpoints/api_token_details.py
@@ -9,6 +9,7 @@ from sentry import analytics
 from sentry.analytics.events.api_token_deleted import ApiTokenDeleted
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.endpoints.api_tokens import get_appropriate_user_id
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -36,6 +37,7 @@ class ApiTokenDetailsEndpoint(Endpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.SECURITY
+    authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (
         SentryIsAuthenticated,
         DisallowAgentToken,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
@@ -10,6 +10,7 @@ from sentry.analytics.events.sentry_app_installation_token_deleted import (
 )
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import control_silo_endpoint
 from sentry.api.permissions import DisallowImpersonatedTokenCreation
 from sentry.models.apitoken import ApiToken
@@ -28,6 +29,7 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
     }
+    authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (SentryInternalAppTokenPermission, DisallowImpersonatedTokenCreation)
     allow_disabled_sentry_app_for_methods = {"DELETE"}
 

--- a/tests/sentry/api/endpoints/test_api_token_details.py
+++ b/tests/sentry/api/endpoints/test_api_token_details.py
@@ -48,7 +48,15 @@ class ApiTokenGetTest(APITestCase):
 
     def test_no_auth(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")
-        self.get_error_response(token.id, status_code=status.HTTP_401_UNAUTHORIZED)
+        self.get_error_response(token.id, status_code=status.HTTP_403_FORBIDDEN)
+
+    def test_deny_token_access(self) -> None:
+        token = self.create_user_auth_token(user=self.user, name="token 1")
+        self.get_error_response(
+            token.id,
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
 
     def test_invalid_user_id(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")
@@ -141,7 +149,18 @@ class ApiTokenPutTest(APITestCase):
         token = ApiToken.objects.create(user=self.user, name="token 1")
         payload = {"name": "new token"}
 
-        self.get_error_response(token.id, status_code=status.HTTP_401_UNAUTHORIZED, **payload)
+        self.get_error_response(token.id, status_code=status.HTTP_403_FORBIDDEN, **payload)
+
+    def test_deny_token_access(self) -> None:
+        token = self.create_user_auth_token(user=self.user, name="token 1")
+        self.get_error_response(
+            token.id,
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
+            status_code=status.HTTP_403_FORBIDDEN,
+            name="new token",
+        )
+        token.refresh_from_db()
+        assert token.name == "token 1"
 
     def test_invalid_user_id(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")
@@ -185,7 +204,16 @@ class ApiTokenDeleteTest(APITestCase):
     def test_no_auth(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")
 
-        self.get_error_response(token.id, status_code=status.HTTP_401_UNAUTHORIZED)
+        self.get_error_response(token.id, status_code=status.HTTP_403_FORBIDDEN)
+
+    def test_deny_token_access(self) -> None:
+        token = self.create_user_auth_token(user=self.user, name="token 1")
+        self.get_error_response(
+            token.id,
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+        assert ApiToken.objects.filter(id=token.id).exists()
 
     def test_invalid_user_id(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_token_details.py
@@ -102,6 +102,17 @@ class SentryInternalAppTokenCreationTest(APITestCase):
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
+    def test_deny_token_access(self) -> None:
+        self.login_as(self.user)
+        token = self.create_user_auth_token(user=self.user, scope_list=["org:write"])
+        self.get_error_response(
+            self.internal_sentry_app.slug,
+            self.api_token.id,
+            status_code=status.HTTP_403_FORBIDDEN,
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
+        )
+        assert ApiToken.objects.filter(pk=self.api_token.id).exists()
+
     def test_superuser_can_delete(self) -> None:
         self.login_as(self.superuser, superuser=True)
         self.get_success_response(


### PR DESCRIPTION
Match the collection endpoints so personal and internal integration token details cannot be read, renamed, or revoked with a bearer token.