### PR TITLE
feat(sentry-apps): collapse template configuration panels

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
@@ -73,7 +73,7 @@ describe('PermissionsObserver', () => {
     ).not.toBeChecked();
   });
 
-  it('renders the permissions panel statically by default', () => {
+  it('renders static panels by default', () => {
     render(
       <PermissionsObserver
         scopes={[]}
@@ -91,23 +91,36 @@ describe('PermissionsObserver', () => {
     expect(screen.queryByRole('button', {name: 'Webhooks'})).not.toBeInTheDocument();
   });
 
-  it('can render the permissions panel collapsed', async () => {
+  it('renders both panels collapsed when enabled', async () => {
     render(
       <PermissionsObserver
         scopes={['project:read']}
-        events={[]}
+        events={['issue.created']}
         newApp={false}
-        collapsePermissions
+        collapsePanels
         onScopesChange={noop}
         onEventsChange={noop}
       />
     );
 
+    expect(screen.getByRole('button', {name: 'Permissions'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    expect(screen.getByRole('button', {name: 'Webhooks'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
     expect(screen.queryByRole('textbox', {name: 'Project'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', {name: 'issue'})).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: 'Permissions'}));
 
     expect(screen.getByRole('textbox', {name: 'Project'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Webhooks'}));
+
+    expect(screen.getByRole('checkbox', {name: 'issue'})).toBeInTheDocument();
   });
 
   it.each([
@@ -126,7 +139,7 @@ describe('PermissionsObserver', () => {
       scopes: ['project:read'],
       events: [],
       newApp: false,
-      collapsePermissions: true,
+      collapsePanels: true,
       onScopesChange: noop,
       onEventsChange: noop,
     };

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -32,7 +32,7 @@ type Props = {
   newApp: boolean;
   scopes: Scope[];
   appPublished?: boolean;
-  collapsePermissions?: boolean;
+  collapsePanels?: boolean;
   continuousIntegrationError?: string;
   onEventsChange?: (events: WebhookSubscription[]) => void;
   onScopesChange?: (scopes: Scope[]) => void;
@@ -44,7 +44,7 @@ export function PermissionsObserver({
   events: initialEvents,
   newApp,
   scopes,
-  collapsePermissions = false,
+  collapsePanels = false,
   continuousIntegrationError,
   onEventsChange,
   onScopesChange,
@@ -126,7 +126,7 @@ export function PermissionsObserver({
     </Fragment>
   );
 
-  const permissionsPanel = collapsePermissions ? (
+  const permissionsPanel = collapsePanels ? (
     <CollapsiblePanel title={t('Permissions')} forceExpanded={forcePermissionsExpanded}>
       {permissionsContent}
     </CollapsiblePanel>
@@ -137,19 +137,27 @@ export function PermissionsObserver({
     </Panel>
   );
 
+  const webhooksContent = (
+    <Subscriptions
+      permissions={permissions}
+      events={events}
+      onChange={handleEventChange}
+    />
+  );
+
+  const webhooksPanel = collapsePanels ? (
+    <CollapsiblePanel title={t('Webhooks')}>{webhooksContent}</CollapsiblePanel>
+  ) : (
+    <Panel>
+      <PanelHeader>{t('Webhooks')}</PanelHeader>
+      <PanelBody>{webhooksContent}</PanelBody>
+    </Panel>
+  );
+
   return (
     <Fragment>
       {permissionsPanel}
-      <Panel>
-        <PanelHeader>{t('Webhooks')}</PanelHeader>
-        <PanelBody>
-          <Subscriptions
-            permissions={permissions}
-            events={events}
-            onChange={handleEventChange}
-          />
-        </PanelBody>
-      </Panel>
+      {webhooksPanel}
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -278,7 +278,7 @@ describe('Sentry Application Details', () => {
         features: ['sentry-apps-creation-templates'],
       });
 
-      it('prefills the form from the template', () => {
+      it('prefills the form from the template', async () => {
         render(<SentryApplicationDetails />, {
           initialRouterConfig: templateRouterConfig,
           organization,
@@ -294,6 +294,12 @@ describe('Sentry Application Details', () => {
           'aria-expanded',
           'false'
         );
+        expect(screen.getByRole('button', {name: 'Webhooks'})).toHaveAttribute(
+          'aria-expanded',
+          'false'
+        );
+
+        await userEvent.click(screen.getByRole('button', {name: 'Webhooks'}));
 
         expect(screen.getByRole('checkbox', {name: 'issue'})).toBeEnabled();
         expect(screen.getByRole('checkbox', {name: 'issue'})).toBePartiallyChecked();

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -515,7 +515,7 @@ function ClaudeRoutineTemplateForm() {
         scopes={CLAUDE_ROUTINE_SCOPES}
         events={CLAUDE_ROUTINE_EVENTS}
         newApp
-        collapsePermissions
+        collapsePanels
         permissionErrors={scopeErrors.permissions}
         continuousIntegrationError={scopeErrors.continuousIntegration}
         onScopesChange={scopes => form.setFieldValue('scopes', scopes)}


### PR DESCRIPTION
Following up https://github.com/getsentry/sentry/pull/121640, also collapse webhooks sections in sentry app templates.

Resolves https://linear.app/getsentry/issue/ISWF-3211/clean-up-claude-routine-template-ui