### PR TITLE
fix(workflows): Validate nested action filters

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -46,6 +46,17 @@ class ActionFilterInput(DataConditionGroupInput):
     actions: list[ActionInput]
 
 
+class ActionFilterValidator(BaseDataConditionGroupValidator):
+    actions = serializers.ListField(child=serializers.DictField())
+
+    def validate_actions(self, value: ListInputData) -> ListInputData:
+        id_field = serializers.IntegerField()
+        for action in value:
+            if "id" in action:
+                action["id"] = id_field.run_validation(action["id"])
+        return value
+
+
 class WorkflowInput(TypedDict):
     id: NotRequired[str]
     name: str
@@ -83,8 +94,8 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         required=False,
         help_text=WORKFLOW_TRIGGERS_HELP_TEXT,
     )
-    action_filters = serializers.ListField(
-        child=serializers.DictField(),
+    action_filters = ActionFilterValidator(
+        many=True,
         required=False,
         help_text=ACTION_FILTERS_HELP_TEXT,
     )
@@ -119,23 +130,12 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             self._validate_action_filter_ownership(value)
 
         for action_filter in value:
-            actions, condition_group = self._split_action_and_condition_group(action_filter)
-            dcg_validator = BaseDataConditionGroupValidator(
-                data=condition_group, context=self.context
-            )
-            dcg_validator.is_valid(raise_exception=True)
-            action_filter.update(dcg_validator.validated_data)
-
-            validated_actions = []
-            for action in actions:
+            for action in action_filter["actions"]:
                 action_validator = BaseActionValidator(data=action, context=self.context)
                 action_validator.is_valid(raise_exception=True)
 
                 # update because the validated data does not contain "id" for updates
                 action.update(action_validator.validated_data)
-                validated_actions.append(action)
-
-            action_filter["actions"] = validated_actions
 
         return value
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -118,6 +118,22 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         assert response.status_code == 200
         assert updated_workflow.name == "Updated Workflow"
 
+    def test_update_rejects_non_object_actions(self) -> None:
+        self.valid_workflow["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [],
+                "actions": [None],
+            }
+        ]
+
+        self.get_error_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=self.valid_workflow,
+            status_code=400,
+        )
+
     def test_all_projects_workflow_requires_org_write(self) -> None:
         detector = ensure_default_all_projects_detector(self.organization.id)
         self.create_detector_workflow(workflow=self.workflow, detector=detector)


### PR DESCRIPTION
For action filters, we can do some upfront validation so we return a 400 rather than a 500 when trying to parse malformed actions.

Fixes SENTRY-5T8S