### PR TITLE
fix(insights): Repair legacy `/performance/<module>/` redirects

### DIFF
--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -2,6 +2,7 @@ import {matchRoutes, type RouteObject} from 'react-router-dom';
 
 import * as constants from 'sentry/constants';
 import {buildRoutes} from 'sentry/router/routes';
+import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 
 // Setup a module mock so that we can replace
@@ -76,6 +77,19 @@ function getMatchedPaths(routes: RouteObject[], url: string): string[] {
   return matches.map(m => m.route.path ?? '(layout)');
 }
 
+/**
+ * Resolves the URL a redirect route sends the user to, the same way the
+ * `Redirect` element does at runtime.
+ */
+function getRedirectTarget(routes: RouteObject[], url: string): string | undefined {
+  const matches = matchRoutes(routes, url);
+  const match = matches?.at(-1);
+  const to = (match?.route.element as React.ReactElement<{to?: string}> | undefined)
+    ?.props.to;
+
+  return to === undefined ? undefined : replaceRouterParams(to, match!.params);
+}
+
 describe('buildRoutes()', () => {
   // Until customer-domains is enabled for single-tenant, self-hosted and path
   // based slug routes are removed we need to ensure
@@ -137,6 +151,22 @@ describe('buildRoutes()', () => {
         '/organizations/test-org/explore/nonexistent-page/also-nonexistent-page/'
       );
       expect(matchedPaths).toContain('*');
+    });
+  });
+
+  describe('legacy insights module redirects', () => {
+    // Sub-paths collapse onto the module landing page rather than carrying
+    // over, since a `redirectTo` string cannot interpolate a wildcard match.
+    it.each([
+      ['/organizations/test-org/performance/database/', '/insights/backend/database/'],
+      [
+        '/organizations/test-org/performance/database/spans/span/abc123/',
+        '/insights/backend/database/',
+      ],
+      ['/organizations/test-org/performance/http/domains/', '/insights/backend/http/'],
+      ['/organizations/test-org/performance/pageloads/', '/insights/frontend/pageloads/'],
+    ])('redirects %s to %s', (from, to) => {
+      expect(getRedirectTarget(buildRoutes(), from)).toBe(to);
     });
   });
 

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1729,7 +1729,7 @@ function buildRoutes(): RouteObject[] {
             path: `${moduleBaseURL}/*`,
             redirectTo: `/${DOMAIN_VIEW_BASE_URL}/${getModuleView(
               moduleUrlToModule[moduleBaseURL]!
-            )}${moduleBaseURL}/:splat`,
+            )}/${moduleBaseURL}/`,
           }
         : null
     )


### PR DESCRIPTION
Legacy `/performance/<module>/*` URLs redirected to a broken target that 404'd: `/performance/database/` sent users to `/insights/backenddatabase/:splat`.

Two problems combined into that URL:

- The domain view and module base URL were joined without a separator, producing `backenddatabase` instead of `backend/database`. Introduced when the domain view segment was added to the redirect target.
- `:splat` was never substituted. It was a react-router 3 param name; react-router 6 exposes the wildcard match as `*`, and a `redirectTo` string is handed to `Navigate` verbatim, so nothing ever replaced it.

This opts for a simple fix to target module landing pages rather than build out wildcard interpolation.

Example replay (error at 2s): https://sentry.sentry.io/explore/replays/8cb8dbb5091f452d9c701838f5317e07/