### PR TITLE
ref(hybridcloud): Clarify scheduled outbox model setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -438,10 +438,12 @@ TEMPLATES = [
     }
 ]
 
-SENTRY_OUTBOX_MODELS: Mapping[str, list[str]] = {
+SENTRY_HYBRIDCLOUD_OUTBOX_MODELS: Mapping[str, list[str]] = {
     "CONTROL": ["sentry.ControlOutbox"],
     "CELL": ["sentry.CellOutbox"],
 }
+# Backwards-compatible alias for getsentry, which extends this mapping with UsageOutbox.
+SENTRY_OUTBOX_MODELS = SENTRY_HYBRIDCLOUD_OUTBOX_MODELS
 
 # Do not modify reordering
 # The applications listed first in INSTALLED_APPS have precedence

--- a/src/sentry/hybridcloud/outbox/base.py
+++ b/src/sentry/hybridcloud/outbox/base.py
@@ -449,7 +449,9 @@ def run_outbox_replications_for_self_hosted(*args: Any, **kwds: Any) -> None:
     ):
         pass
 
-    for outbox_name in (name for names in settings.SENTRY_OUTBOX_MODELS.values() for name in names):
+    for outbox_name in (
+        name for names in settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS.values() for name in names
+    ):
         logger.info("Processing %ss...", outbox_name)
         outbox_model: type[OutboxBase] = OutboxBase.from_outbox_name(outbox_name)
         for shard_attrs in outbox_model.find_scheduled_shards():

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -75,7 +75,7 @@ def schedule_batch(
     scheduled_count = 0
 
     try:
-        for outbox_name in settings.SENTRY_OUTBOX_MODELS[silo_mode.name]:
+        for outbox_name in settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS[silo_mode.name]:
             outbox_model: type[OutboxBase] = OutboxBase.from_outbox_name(outbox_name)
             scheduled_count += schedule_outbox_model(
                 silo_mode=silo_mode,
@@ -160,7 +160,7 @@ def drain_outbox_shards(
 ) -> None:
     try:
         if outbox_name is None:
-            outbox_name = settings.SENTRY_OUTBOX_MODELS["CELL"][0]
+            outbox_name = settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS["CELL"][0]
 
         assert outbox_name, "Could not determine outbox name"
         outbox_model: type[CellOutboxBase] = CellOutboxBase.from_outbox_name(outbox_name)
@@ -184,7 +184,7 @@ def drain_outbox_shards_control(
 ) -> None:
     try:
         if outbox_name is None:
-            outbox_name = settings.SENTRY_OUTBOX_MODELS["CONTROL"][0]
+            outbox_name = settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS["CONTROL"][0]
 
         assert outbox_name, "Could not determine outbox name"
         outbox_model: type[ControlOutboxBase] = ControlOutboxBase.from_outbox_name(outbox_name)

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -717,10 +717,10 @@ def validate_outbox_config() -> None:
     from sentry.hybridcloud.models.outbox import CellOutboxBase, ControlOutboxBase
     from sentry.issues.models.groupactionlogoutbox import GroupActionLogOutbox
 
-    for outbox_name in settings.SENTRY_OUTBOX_MODELS["CONTROL"]:
+    for outbox_name in settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS["CONTROL"]:
         ControlOutboxBase.from_outbox_name(outbox_name)
 
-    for outbox_name in settings.SENTRY_OUTBOX_MODELS["CELL"]:
+    for outbox_name in settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS["CELL"]:
         CellOutboxBase.from_outbox_name(outbox_name)
 
     CellOutboxBase.from_outbox_name(GroupActionLogOutbox._meta.label)

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -47,7 +47,7 @@ def outbox_runner(wrapped: Any | None = None) -> Any:
 
     outbox_models = [
         OutboxBase.from_outbox_name(outbox_name)
-        for outbox_names in settings.SENTRY_OUTBOX_MODELS.values()
+        for outbox_names in settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS.values()
         for outbox_name in outbox_names
     ]
     outbox_models.append(GroupActionLogOutbox)

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -2,6 +2,7 @@ import types
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings as django_settings
 from django.core.cache import caches
 from django.test import override_settings
 
@@ -265,6 +266,10 @@ def test_validate_outbox_config_includes_group_action_log_outbox() -> None:
         validate_outbox_config()
 
     validate_cell_outbox.assert_any_call(GroupActionLogOutbox._meta.label)
+
+
+def test_legacy_outbox_model_setting_alias() -> None:
+    assert django_settings.SENTRY_OUTBOX_MODELS is django_settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS
 
 
 def test_require_secret_key(settings) -> None:


### PR DESCRIPTION
Rename `SENTRY_OUTBOX_MODELS` since we're adding a new outbox model that won't be included in this group. Follow up to rename this in getsentry as well.