### PR TITLE
perf(tasks): Route action log backfills to long pool

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -18,7 +18,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import issues_long_tasks, issues_tasks
 from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.utils import json, metrics
 from sentry.utils.action_log.activity_translator import (
@@ -39,7 +39,8 @@ _GROUP_ACTION_LOG_WRITE_FEATURE = "projects:issue-action-log-write-to-db"
 
 @instrumented_task(
     name="sentry.tasks.backfill_group_action_log.backfill_group_action_log_for_group",
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     silo_mode=SiloMode.CELL,
 )
 def backfill_group_action_log_for_group(
@@ -81,7 +82,8 @@ def backfill_group_action_log_for_group(
 
 @instrumented_task(
     name="sentry.tasks.backfill_group_action_log.reset_and_backfill_group_action_log",
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     silo_mode=SiloMode.CELL,
 )
 def reset_and_backfill_group_action_log(
@@ -121,7 +123,8 @@ def reset_and_backfill_group_action_log(
 
 @instrumented_task(
     name="sentry.tasks.backfill_group_action_log.backfill_group_action_log_for_project",
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     processing_deadline_duration=15 * 60,
     silo_mode=SiloMode.CELL,
 )
@@ -376,8 +379,9 @@ def _complete_project_backfill(project: Project, chain_pr_lifecycle: bool) -> No
         "sentry.tasks.backfill_group_action_log."
         "enroll_organization_projects_for_group_action_log_backfill"
     ),
-    namespace=issues_tasks,
-    processing_deadline_duration=15 * 60,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
+    processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
 )
 def enroll_organization_projects_for_group_action_log_backfill(
@@ -508,8 +512,9 @@ def enroll_organization_projects_for_group_action_log_backfill(
 
 @instrumented_task(
     name="sentry.tasks.backfill_group_action_log.enroll_projects_for_group_action_log_backfill",
-    namespace=issues_tasks,
-    processing_deadline_duration=15 * 60,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
+    processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
 )
 def enroll_projects_for_group_action_log_backfill(
@@ -584,8 +589,9 @@ def enroll_projects_for_group_action_log_backfill(
 
 @instrumented_task(
     name="sentry.tasks.backfill_group_action_log.backfill_group_action_log_for_all_projects",
-    namespace=issues_tasks,
-    processing_deadline_duration=15 * 60,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
+    processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
 )
 def backfill_group_action_log_for_all_projects(

--- a/src/sentry/tasks/backfill_pr_lifecycle_action_log.py
+++ b/src/sentry/tasks/backfill_pr_lifecycle_action_log.py
@@ -9,7 +9,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import issues_long_tasks, issues_tasks
 from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.utils import metrics
 
@@ -22,7 +22,8 @@ _TASK_KEY = "backfill_pr_lifecycle_action_log_for_project"
     name=(
         "sentry.tasks.backfill_pr_lifecycle_action_log.backfill_pr_lifecycle_action_log_for_group"
     ),
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     silo_mode=SiloMode.CELL,
 )
 def backfill_pr_lifecycle_action_log_for_group(
@@ -66,7 +67,8 @@ def backfill_pr_lifecycle_action_log_for_group(
     name=(
         "sentry.tasks.backfill_pr_lifecycle_action_log.backfill_pr_lifecycle_action_log_for_project"
     ),
-    namespace=issues_tasks,
+    namespace=issues_long_tasks,
+    alias_namespace=issues_tasks,
     processing_deadline_duration=15 * 60,
     silo_mode=SiloMode.CELL,
 )


### PR DESCRIPTION
Routes group action log activity, enrollment, coordinator, and PR lifecycle backfill tasks through `issues.long` so the rollout workload is isolated from regular issues processing. The existing `issues` namespace remains registered as an alias to accept activations queued during a rolling deploy.

The lightweight organization/project enrollment and dispatch coordinators now advertise one-minute processing deadlines. Project activity and PR lifecycle batch tasks retain their 15-minute deadlines.
