### PR TITLE
feat(explore): Support array attributes in the column picker

### DIFF
--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -30,6 +30,11 @@ interface BuildAttributeOptionsParams {
   stringTags: TagCollection;
   traceItemType: TraceItemDataset;
   /**
+   * Array attributes. Empty unless the caller opts in (gated behind the array
+   * feature flag upstream), so callers that don't support arrays are unaffected.
+   */
+  arrayTags?: TagCollection;
+  /**
    * How to determine the kind for extra columns. Pass a concrete `FieldKind`
    * to hardcode one, or a function to derive it per column. Defaults to
    * `classifyTagKey`.
@@ -46,6 +51,7 @@ export function buildAttributeOptions({
   booleanTags,
   numberTags,
   stringTags,
+  arrayTags = {},
   traceItemType,
   extraColumns = [],
   extraColumnKind = classifyTagKey,
@@ -57,18 +63,21 @@ export function buildAttributeOptions({
   // the first occurrence by `option.value`. Number/MEASUREMENT comes before
   // string/TAG and boolean/BOOLEAN so that a key present in multiple typed
   // collections preserves its measurement variant, matching the hand-rolled
-  // ordering before this helper was extracted.
+  // ordering before this helper was extracted. Array keys are deduped against
+  // their string twins upstream, so they can safely trail the scalar types.
   return [
     ...Object.values(numberTags).map(tag => optionFromTag(tag, traceItemType)),
     ...Object.values(stringTags).map(tag => optionFromTag(tag, traceItemType)),
     ...Object.values(booleanTags).map(tag => optionFromTag(tag, traceItemType)),
+    ...Object.values(arrayTags).map(tag => optionFromTag(tag, traceItemType)),
     ...extraColumns
       .filter(
         column =>
           column &&
           !(column in stringTags) &&
           !(column in numberTags) &&
-          !(column in booleanTags)
+          !(column in booleanTags) &&
+          !(column in arrayTags)
       )
       .map(column =>
         optionFromTag(

--- a/static/app/views/explore/hooks/useValidatedExploreColumns.tsx
+++ b/static/app/views/explore/hooks/useValidatedExploreColumns.tsx
@@ -41,6 +41,7 @@ export function useValidatedExploreColumns({
     boolean: booleanAttributes,
     number: numberAttributes,
     string: stringAttributes,
+    array: arrayAttributes,
   } = attributes;
 
   const validatedColumnData = useMemo(
@@ -51,12 +52,14 @@ export function useValidatedExploreColumns({
           boolean: booleanAttributes,
           number: numberAttributes,
           string: stringAttributes,
+          array: arrayAttributes,
         },
         fields,
         validationData,
       }),
     [
       aggregateFields,
+      arrayAttributes,
       booleanAttributes,
       fields,
       numberAttributes,

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -315,6 +315,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
       boolean: validatedBooleanAttributes,
       number: validatedNumberAttributes,
       string: validatedStringAttributes,
+      array: validatedArrayAttributes,
     },
     fieldTypes: validatedFieldTypes,
     fields: validatedFields,
@@ -362,6 +363,7 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
           stringTags={validatedStringAttributes}
           numberTags={validatedNumberAttributes}
           booleanTags={validatedBooleanAttributes}
+          arrayTags={validatedArrayAttributes}
           validatedFieldTypes={validatedFieldTypes}
           hiddenKeys={HiddenColumnEditorLogFields}
           traceItemType={TraceItemDataset.LOGS}

--- a/static/app/views/explore/logs/useValidatedLogsTabColumns.tsx
+++ b/static/app/views/explore/logs/useValidatedLogsTabColumns.tsx
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 
 import type {Sort} from 'sentry/utils/discover/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePersistedLogsPageParams} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useLogItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
@@ -13,9 +14,14 @@ import {
 } from 'sentry/views/explore/queryParams/context';
 
 export function useValidatedLogsTabColumns() {
+  const organization = useOrganization();
   const mode = useQueryParamsMode();
   const setFields = useSetQueryParamsFields();
   const [_, setPersistentParams] = usePersistedLogsPageParams();
+
+  // Array attributes are gated behind the array feature flag. When it's off the
+  // fetch is disabled, so the collection stays empty and nothing else changes.
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
 
   const {attributes: stringAttributes} = useLogItemAttributes(
     {},
@@ -32,6 +38,11 @@ export function useValidatedLogsTabColumns() {
     'boolean',
     HiddenLogSearchFields
   );
+  const {attributes: arrayAttributes} = useLogItemAttributes(
+    {enabled: supportsArrays},
+    'array',
+    HiddenLogSearchFields
+  );
   const {data: validationData, isFetching: isValidatingColumns} = useValidateLogsTab();
 
   const persistCleanedFields = useCallback(
@@ -46,6 +57,7 @@ export function useValidatedLogsTabColumns() {
       boolean: booleanAttributes,
       number: numberAttributes,
       string: stringAttributes,
+      array: arrayAttributes,
     },
     isValidating: isValidatingColumns,
     onFieldsCleanup: persistCleanedFields,

--- a/static/app/views/explore/spans/hooks/useValidatedSpansTabColumns.tsx
+++ b/static/app/views/explore/spans/hooks/useValidatedSpansTabColumns.tsx
@@ -1,3 +1,4 @@
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {Tab} from 'sentry/views/explore/hooks/useTab';
 import {useSpanItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
@@ -5,9 +6,18 @@ import {useValidatedExploreColumns} from 'sentry/views/explore/hooks/useValidate
 import {useValidateSpansTab} from 'sentry/views/explore/spans/hooks/useValidateSpansTab';
 
 export function useValidatedSpansTabColumns(tab: Mode | Tab) {
+  const organization = useOrganization();
+  // Array attributes are gated behind the array feature flag. When it's off the
+  // fetch is disabled, so the collection stays empty and nothing else changes.
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
+
   const {attributes: numberAttributes} = useSpanItemAttributes({}, 'number');
   const {attributes: stringAttributes} = useSpanItemAttributes({}, 'string');
   const {attributes: booleanAttributes} = useSpanItemAttributes({}, 'boolean');
+  const {attributes: arrayAttributes} = useSpanItemAttributes(
+    {enabled: supportsArrays},
+    'array'
+  );
   const {data: validationData, isFetching: isValidatingColumns} = useValidateSpansTab({
     enabled: tab === Tab.SPAN || tab === Mode.AGGREGATE,
   });
@@ -16,6 +26,7 @@ export function useValidatedSpansTabColumns(tab: Mode | Tab) {
       boolean: booleanAttributes,
       number: numberAttributes,
       string: stringAttributes,
+      array: arrayAttributes,
     },
     isValidating: isValidatingColumns,
     shouldCleanupAggregateColumns: tab === Mode.AGGREGATE,

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -68,6 +68,15 @@ const enrichedBooleanTags: TagCollection = {
   },
 };
 
+// Array attributes are keyed by their backend form and carry the array kind.
+const arrayTags: TagCollection = {
+  'tags[my.tags,array]': {
+    key: 'tags[my.tags,array]',
+    name: 'my.tags',
+    kind: FieldKind.ARRAY,
+  },
+};
+
 describe('ColumnEditorModal', () => {
   it('allows closes modal on apply', async () => {
     const onClose = jest.fn();
@@ -421,6 +430,67 @@ describe('ColumnEditorModal', () => {
     const columns = screen.getAllByTestId('editor-column');
     expect(columns[0]).toHaveTextContent('span.is_segment');
     expect(columns[0]).toHaveTextContent('boolean');
+    expect(columns[1]).toHaveTextContent('id');
+    expect(columns[1]).toHaveTextContent('string');
+  });
+
+  it('displays array tags in column options with correct type', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id']}
+            onColumnsChange={() => {}}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={{}}
+            arrayTags={arrayTags}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    const column = screen.getByTestId('editor-column');
+    await userEvent.click(within(column).getByRole('button', {name: 'Column id string'}));
+
+    const columnOptions = await screen.findAllByRole('option');
+    const arrayOptions = columnOptions.filter(option =>
+      option.textContent?.includes('array')
+    );
+    expect(arrayOptions).toHaveLength(1);
+    expect(arrayOptions[0]).toHaveTextContent('my.tags');
+    expect(arrayOptions[0]).toHaveTextContent('array');
+  });
+
+  it('renders existing array column with correct type badge', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['tags[my.tags,array]', 'id']}
+            onColumnsChange={() => {}}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={{}}
+            arrayTags={arrayTags}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
+
+    const columns = screen.getAllByTestId('editor-column');
+    expect(columns[0]).toHaveTextContent('my.tags');
+    expect(columns[0]).toHaveTextContent('array');
     expect(columns[1]).toHaveTextContent('id');
     expect(columns[1]).toHaveTextContent('string');
   });

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -24,6 +24,7 @@ import {
   prettifyTagKey,
 } from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {
   DASHBOARD_ONLY_SPAN_ATTRIBUTES,
@@ -45,6 +46,7 @@ interface ColumnEditorModalProps extends ModalRenderProps {
   numberTags: TagCollection;
   onColumnsChange: (columns: string[]) => void;
   stringTags: TagCollection;
+  arrayTags?: TagCollection;
   handleReset?: () => void;
   hiddenKeys?: string[];
   isDocsButtonHidden?: boolean;
@@ -64,6 +66,7 @@ export function ColumnEditorModal({
   booleanTags,
   numberTags,
   stringTags,
+  arrayTags = {},
   hiddenKeys,
   isDocsButtonHidden = false,
   handleReset,
@@ -77,11 +80,13 @@ export function ColumnEditorModal({
         stringTags,
         numberTags,
         booleanTags,
+        arrayTags,
         hiddenKeys,
         traceItemType,
         validatedFieldTypes,
       }),
     [
+      arrayTags,
       booleanTags,
       columns,
       hiddenKeys,
@@ -212,6 +217,11 @@ function ColumnEditorRow({
   const debouncedSearch = useDebouncedValue(search, 250);
   const hasSearch = debouncedSearch.length > 0;
 
+  // Array attributes are gated behind the array feature flag. When it's off the
+  // array search is disabled, matching the empty base options the modal receives.
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
+
   // The parent's tag collections come pre-filtered: useSpanItemAttributes folds in
   // DASHBOARD_ONLY_SPAN_ATTRIBUTES, and log callers pass HiddenColumnEditorLogFields
   // via hiddenKeys. The bare useTraceItemDatasetAttributes does neither, so merge
@@ -257,8 +267,20 @@ function ColumnEditorRow({
       'boolean',
       searchHiddenKeys
     );
+  const {attributes: searchedArrayTags, isLoading: arrayLoading} =
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {
+        search: debouncedSearch,
+        enabled: hasSearch && supportsArrays,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'array',
+      searchHiddenKeys
+    );
 
-  const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
+  const isSearchLoading =
+    hasSearch && (stringLoading || numberLoading || booleanLoading || arrayLoading);
 
   // Feed CompactSelect the full base list at all times so its built-in matcher
   // can filter synchronously while typing. Once the debounced server search
@@ -273,6 +295,7 @@ function ColumnEditorRow({
       stringTags: searchedStringTags,
       numberTags: searchedNumberTags,
       booleanTags: searchedBooleanTags,
+      arrayTags: searchedArrayTags,
       hiddenKeys,
       traceItemType,
     });
@@ -291,6 +314,7 @@ function ColumnEditorRow({
     searchedStringTags,
     searchedNumberTags,
     searchedBooleanTags,
+    searchedArrayTags,
     hiddenKeys,
     traceItemType,
   ]);
@@ -392,6 +416,7 @@ interface BuildColumnOptionsParams {
   numberTags: TagCollection;
   stringTags: TagCollection;
   traceItemType: TraceItemDataset;
+  arrayTags?: TagCollection;
   hiddenKeys?: string[];
   validatedFieldTypes?: Partial<Record<string, FieldValueType>>;
 }
@@ -401,6 +426,7 @@ function buildColumnOptions({
   stringTags,
   numberTags,
   booleanTags,
+  arrayTags = {},
   hiddenKeys,
   traceItemType,
   validatedFieldTypes,
@@ -410,6 +436,7 @@ function buildColumnOptions({
     numberTags: removeHiddenKeys(numberTags, hidden),
     stringTags: removeHiddenKeys(stringTags, hidden),
     booleanTags: removeHiddenKeys(booleanTags, hidden),
+    arrayTags: removeHiddenKeys(arrayTags, hidden),
     traceItemType,
     extraColumns: columns.filter(
       column => !hidden.has(column) && !hidden.has(prettifyTagKey(column))
@@ -428,6 +455,9 @@ function fieldKindFromFieldType(fieldType?: FieldValueType) {
   }
   if (fieldType === FieldValueType.STRING) {
     return FieldKind.TAG;
+  }
+  if (fieldType === FieldValueType.ARRAY) {
+    return FieldKind.ARRAY;
   }
   return null;
 }

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -53,6 +53,7 @@ export function ExploreTables(props: ExploreTablesProps) {
       boolean: validatedBooleanTags,
       number: validatedNumberTags,
       string: validatedStringTags,
+      array: validatedArrayTags,
     },
     fieldTypes: validatedFieldTypes,
     fields: validatedFields,
@@ -69,6 +70,7 @@ export function ExploreTables(props: ExploreTablesProps) {
           stringTags={validatedStringTags}
           numberTags={validatedNumberTags}
           booleanTags={validatedBooleanTags}
+          arrayTags={validatedArrayTags}
           requiredTags={['id']}
           validatedFieldTypes={validatedFieldTypes}
         />

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -35,6 +35,15 @@ describe('addValidatedFieldTypesToMeta', () => {
     expect(meta.fields?.['span.duration']).toBe(FieldValueType.DURATION);
   });
 
+  it('types array columns from validated field types', () => {
+    const meta = addValidatedFieldTypesToMeta({
+      meta: {fields: {}},
+      validatedFieldTypes: {'tags[my.tags,array]': FieldValueType.ARRAY},
+    });
+
+    expect(meta.fields?.['tags[my.tags,array]']).toBe(FieldValueType.ARRAY);
+  });
+
   it('passes validated field types to table column metadata', () => {
     const eventView = EventView.fromLocation(
       LocationFixture({query: {field: ['sentry.duration']}})

--- a/static/app/views/explore/utils/columnValidation.spec.tsx
+++ b/static/app/views/explore/utils/columnValidation.spec.tsx
@@ -119,4 +119,42 @@ describe('getValidatedColumnData', () => {
     // ...and is removed from the string collection it was misclassified under.
     expect(result.attributes.string['custom.tags']).toBeUndefined();
   });
+
+  it('keeps known array attributes as arrays even if validation reports a scalar type', () => {
+    // Before the backend validate change ships, the endpoint maps array search
+    // types to "number". The attributes endpoint still identifies the attribute
+    // as an array, so it must win and the column must not be downgraded.
+    const validationData: EventValidationData = {
+      dataset: [],
+      environment: [],
+      field: [{attrType: 'number', error: null, name: 'custom.tags', valid: true}],
+      orderby: [],
+      projects: [],
+      query: {error: null, fields: [], valid: true},
+      valid: true,
+    };
+
+    const result = getValidatedColumnData({
+      aggregateFields: [],
+      attributes: {
+        boolean: {},
+        number: {},
+        string: {},
+        array: {
+          'custom.tags': {
+            key: 'custom.tags',
+            name: 'custom.tags',
+            kind: FieldKind.ARRAY,
+          },
+        },
+      },
+      fields: ['custom.tags'],
+      validationData,
+    });
+
+    expect(result.fields).toEqual(['custom.tags']);
+    expect(result.fieldTypes).toEqual({'custom.tags': FieldValueType.ARRAY});
+    expect(result.attributes.array['custom.tags']?.kind).toBe(FieldKind.ARRAY);
+    expect(result.attributes.number['custom.tags']).toBeUndefined();
+  });
 });

--- a/static/app/views/explore/utils/columnValidation.spec.tsx
+++ b/static/app/views/explore/utils/columnValidation.spec.tsx
@@ -85,4 +85,38 @@ describe('getValidatedColumnData', () => {
       )
     ).toEqual(['custom.user', 'avg(custom.duration)']);
   });
+
+  it('types array attributes and moves them into the array collection', () => {
+    const validationData: EventValidationData = {
+      dataset: [],
+      environment: [],
+      field: [{attrType: 'array', error: null, name: 'custom.tags', valid: true}],
+      orderby: [],
+      projects: [],
+      query: {error: null, fields: [], valid: true},
+      valid: true,
+    };
+
+    const result = getValidatedColumnData({
+      aggregateFields: [],
+      // The attribute arrives typed as a string; validation should reclassify it.
+      attributes: {
+        boolean: {},
+        number: {},
+        string: {
+          'custom.tags': {key: 'custom.tags', name: 'custom.tags', kind: FieldKind.TAG},
+        },
+        array: {},
+      },
+      fields: ['custom.tags'],
+      validationData,
+    });
+
+    // The array column persists through cleanup.
+    expect(result.fields).toEqual(['custom.tags']);
+    expect(result.fieldTypes).toEqual({'custom.tags': FieldValueType.ARRAY});
+    expect(result.attributes.array['custom.tags']?.kind).toBe(FieldKind.ARRAY);
+    // ...and is removed from the string collection it was misclassified under.
+    expect(result.attributes.string['custom.tags']).toBeUndefined();
+  });
 });

--- a/static/app/views/explore/utils/columnValidation.tsx
+++ b/static/app/views/explore/utils/columnValidation.tsx
@@ -10,6 +10,7 @@ export interface AttributeCollections {
   boolean: TagCollection;
   number: TagCollection;
   string: TagCollection;
+  array?: TagCollection;
 }
 
 export function getColumnFieldsForValidation({
@@ -55,6 +56,7 @@ export function getValidatedColumnData({
     boolean: {...attributes.boolean},
     number: {...attributes.number},
     string: {...attributes.string},
+    array: {...attributes.array},
   };
   const fieldTypes: Partial<Record<string, FieldValueType>> = {};
   const invalidFields = new Set<string>();
@@ -88,6 +90,10 @@ export function getValidatedColumnData({
       fieldTypes[item.name] = FieldValueType.STRING;
     }
 
+    if (item.attrType === 'array') {
+      fieldTypes[item.name] = FieldValueType.ARRAY;
+    }
+
     if (aggregateExpressions.has(item.name)) {
       continue;
     }
@@ -95,6 +101,7 @@ export function getValidatedColumnData({
     if (item.attrType === 'boolean') {
       delete validatedAttributes.number[item.name];
       delete validatedAttributes.string[item.name];
+      delete validatedAttributes.array[item.name];
       validatedAttributes.boolean[item.name] ??= {
         key: item.name,
         name: prettifyAttributeName(item.name),
@@ -105,6 +112,7 @@ export function getValidatedColumnData({
     if (item.attrType === 'number') {
       delete validatedAttributes.boolean[item.name];
       delete validatedAttributes.string[item.name];
+      delete validatedAttributes.array[item.name];
       validatedAttributes.number[item.name] ??= {
         key: item.name,
         name: prettifyAttributeName(item.name),
@@ -115,10 +123,22 @@ export function getValidatedColumnData({
     if (item.attrType === 'string') {
       delete validatedAttributes.boolean[item.name];
       delete validatedAttributes.number[item.name];
+      delete validatedAttributes.array[item.name];
       validatedAttributes.string[item.name] ??= {
         key: item.name,
         name: prettifyAttributeName(item.name),
         kind: FieldKind.TAG,
+      };
+    }
+
+    if (item.attrType === 'array') {
+      delete validatedAttributes.boolean[item.name];
+      delete validatedAttributes.number[item.name];
+      delete validatedAttributes.string[item.name];
+      validatedAttributes.array[item.name] ??= {
+        key: item.name,
+        name: prettifyAttributeName(item.name),
+        kind: FieldKind.ARRAY,
       };
     }
   }

--- a/static/app/views/explore/utils/columnValidation.tsx
+++ b/static/app/views/explore/utils/columnValidation.tsx
@@ -78,27 +78,38 @@ export function getValidatedColumnData({
       continue;
     }
 
-    if (item.attrType === 'boolean') {
-      fieldTypes[item.name] = FieldValueType.BOOLEAN;
-    }
+    // The attributes endpoint types arrays authoritatively (gated behind the
+    // array feature flag). Trust it even when the validate endpoint reports a
+    // scalar type for the same attribute, so a picked array column keeps its
+    // array type regardless of whether the backend validate change has shipped
+    // yet. When the flag is off, attributes.array is empty and this is a no-op.
+    const isArrayAttribute =
+      item.attrType === 'array' || Boolean(attributes.array?.[item.name]);
 
-    if (item.attrType === 'number') {
-      fieldTypes[item.name] = FieldValueType.NUMBER;
-    }
-
-    if (item.attrType === 'string') {
-      fieldTypes[item.name] = FieldValueType.STRING;
-    }
-
-    if (item.attrType === 'array') {
+    if (isArrayAttribute) {
       fieldTypes[item.name] = FieldValueType.ARRAY;
+    } else if (item.attrType === 'boolean') {
+      fieldTypes[item.name] = FieldValueType.BOOLEAN;
+    } else if (item.attrType === 'number') {
+      fieldTypes[item.name] = FieldValueType.NUMBER;
+    } else if (item.attrType === 'string') {
+      fieldTypes[item.name] = FieldValueType.STRING;
     }
 
     if (aggregateExpressions.has(item.name)) {
       continue;
     }
 
-    if (item.attrType === 'boolean') {
+    if (isArrayAttribute) {
+      delete validatedAttributes.boolean[item.name];
+      delete validatedAttributes.number[item.name];
+      delete validatedAttributes.string[item.name];
+      validatedAttributes.array[item.name] ??= {
+        key: item.name,
+        name: prettifyAttributeName(item.name),
+        kind: FieldKind.ARRAY,
+      };
+    } else if (item.attrType === 'boolean') {
       delete validatedAttributes.number[item.name];
       delete validatedAttributes.string[item.name];
       delete validatedAttributes.array[item.name];
@@ -107,9 +118,7 @@ export function getValidatedColumnData({
         name: prettifyAttributeName(item.name),
         kind: FieldKind.BOOLEAN,
       };
-    }
-
-    if (item.attrType === 'number') {
+    } else if (item.attrType === 'number') {
       delete validatedAttributes.boolean[item.name];
       delete validatedAttributes.string[item.name];
       delete validatedAttributes.array[item.name];
@@ -118,9 +127,7 @@ export function getValidatedColumnData({
         name: prettifyAttributeName(item.name),
         kind: FieldKind.MEASUREMENT,
       };
-    }
-
-    if (item.attrType === 'string') {
+    } else if (item.attrType === 'string') {
       delete validatedAttributes.boolean[item.name];
       delete validatedAttributes.number[item.name];
       delete validatedAttributes.array[item.name];
@@ -128,17 +135,6 @@ export function getValidatedColumnData({
         key: item.name,
         name: prettifyAttributeName(item.name),
         kind: FieldKind.TAG,
-      };
-    }
-
-    if (item.attrType === 'array') {
-      delete validatedAttributes.boolean[item.name];
-      delete validatedAttributes.number[item.name];
-      delete validatedAttributes.string[item.name];
-      validatedAttributes.array[item.name] ??= {
-        key: item.name,
-        name: prettifyAttributeName(item.name),
-        kind: FieldKind.ARRAY,
       };
     }
   }


### PR DESCRIPTION
Array attributes are already supported in Explore search/filter and autocomplete. This surfaces them in the shared column picker ("Edit Table") for spans and logs, gated behind the `trace-item-array-query-support` feature flag so there is no change when it's off.

### Changes

- **Fetch (gated):** the span and log column hooks fetch array attributes only when the org has `trace-item-array-query-support`. When off, the fetch is disabled, the collection is empty, and the UI is unchanged.
- **Picker:** `buildAttributeOptions` and the column editor modal render array attributes as selectable options (with the `array` type badge), and the modal's search fetches arrays too (same flag gate).
- **Validation/cleanup:** validated array columns are typed as `FieldValueType.ARRAY`, moved into a dedicated array collection, and kept mutually exclusive with the scalar collections — so array columns persist through cleanup and carry the array type into the table meta.
- **Render:** the array type reaches `meta` via `validatedFieldTypes`, so cells render through the existing `ArrayValue` renderer and headers resolve to the clean attribute name.

Related PR: https://github.com/getsentry/sentry/pull/122399 

<img width="2419" height="1668" alt="image" src="https://github.com/user-attachments/assets/7d5c52e8-b7df-4fd6-b6ff-f469b1bb4b6b" />


Refs EXP-1140
