### PR TITLE
fix(api): Reject negative pagination cursors

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -536,6 +536,9 @@ class GenericOffsetPaginator:
     def get_result(self, limit, cursor=None):
         assert limit > 0
         offset = cursor.offset if cursor is not None else 0
+        if offset < 0:
+            raise BadPaginationError("Pagination offset cannot be negative")
+
         # Request 1 more than limit so we can tell if there is another page
         data = self.data_fn(offset=offset, limit=limit + 1)
 

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -483,6 +483,11 @@ class PaginateTest(APITestCase):
         response = self.view(request)
         assert response.status_code == 400
 
+    def test_negative_cursor(self) -> None:
+        request = self.make_request(GET={"cursor": "0:-1:0"})
+        response = self.view(request)
+        assert response.status_code == 400
+
     def test_non_int_per_page(self) -> None:
         request = self.make_request(GET={"per_page": "nope"})
         response = self.view(request)


### PR DESCRIPTION
If users pass in negative cursors, we raise a 500 rather than a 400. We should validate this so we raise a 400.

Fixes SENTRY-5TES
