### PR TITLE
feat(hybridcloud): Add member mapping batch lookup

### DIFF
--- a/src/sentry/hybridcloud/services/organizationmember_mapping/impl.py
+++ b/src/sentry/hybridcloud/services/organizationmember_mapping/impl.py
@@ -21,6 +21,18 @@ from sentry.users.models.user import User
 
 
 class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingService):
+    def get_many_by_user_and_organization_ids(
+        self,
+        *,
+        user_id: int,
+        organization_ids: list[int],
+    ) -> list[RpcOrganizationMemberMapping]:
+        mappings = OrganizationMemberMapping.objects.filter(
+            organization_id__in=organization_ids,
+            user_id=user_id,
+        )
+        return [serialize_org_member_mapping(mapping) for mapping in mappings]
+
     def upsert_mapping(
         self,
         *,

--- a/src/sentry/hybridcloud/services/organizationmember_mapping/service.py
+++ b/src/sentry/hybridcloud/services/organizationmember_mapping/service.py
@@ -38,6 +38,16 @@ class OrganizationMemberMappingService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def get_many_by_user_and_organization_ids(
+        self,
+        *,
+        user_id: int,
+        organization_ids: list[int],
+    ) -> list[RpcOrganizationMemberMapping]:
+        pass
+
+    @rpc_method
+    @abstractmethod
     def delete(
         self,
         *,

--- a/tests/sentry/hybridcloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybridcloud/test_organizationmembermapping.py
@@ -1,5 +1,6 @@
 from django.db import router, transaction
 
+from sentry.hybridcloud.rpc.service import dispatch_to_local_service
 from sentry.hybridcloud.services.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
@@ -15,6 +16,55 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 @control_silo_test
 class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
+    def test_get_many_by_user_and_organization_ids_rpc_round_trip(self) -> None:
+        organization = self.organization
+        member_mapping = OrganizationMemberMapping.objects.get(
+            organization_id=organization.id,
+            user_id=self.user.id,
+        )
+
+        response = dispatch_to_local_service(
+            organizationmember_mapping_service.key,
+            "get_many_by_user_and_organization_ids",
+            {
+                "user_id": self.user.id,
+                "organization_ids": [organization.id],
+            },
+        )
+
+        mappings = response["value"]
+        assert len(mappings) == 1
+        assert mappings[0]["organizationmember_id"] == member_mapping.organizationmember_id
+        assert mappings[0]["organization_id"] == organization.id
+        assert mappings[0]["user_id"] == self.user.id
+        assert mappings[0]["role"] == member_mapping.role
+        assert mappings[0]["invite_status"] == member_mapping.invite_status
+
+    def test_get_many_by_user_and_organization_ids(self) -> None:
+        organization = self.organization
+        second_organization = self.create_organization(owner=self.user)
+        other_user = self.create_user("other@example.com")
+        other_organization = self.create_organization(owner=other_user)
+
+        with self.assertNumQueries(1, using=router.db_for_read(OrganizationMemberMapping)):
+            mappings = organizationmember_mapping_service.get_many_by_user_and_organization_ids(
+                user_id=self.user.id,
+                organization_ids=[organization.id, other_organization.id],
+            )
+
+        assert len(mappings) == 1
+        assert mappings[0].organization_id == organization.id
+        assert mappings[0].user_id == self.user.id
+
+        mappings = organizationmember_mapping_service.get_many_by_user_and_organization_ids(
+            user_id=self.user.id,
+            organization_ids=[organization.id, second_organization.id],
+        )
+        assert {mapping.organization_id for mapping in mappings} == {
+            organization.id,
+            second_organization.id,
+        }
+
     def test_upsert_stale_user_id(self) -> None:
         organizationmember_mapping_service.upsert_mapping(
             organization_id=self.organization.id,


### PR DESCRIPTION
Adds a bounded batch lookup to the control-silo organization-member mapping service. Callers can retrieve one user's membership mappings for a specified set of organizations in one indexed query, with the canonical RPC serializer preserving the existing mapping contract.

This is intentionally a standalone service primitive. The authentication endpoint consumer is excluded so the service shape can be confirmed independently before the auth stack adopts it.