### PR TITLE
fix(issue-inbox): Auto-select first issue on tab change

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -1304,6 +1304,85 @@ describe('InboxPage', () => {
       expect(await screen.findByText('No Issues in your Inbox!')).toBeInTheDocument();
     });
 
+    it('auto-selects the first issue when switching assignee tabs', async () => {
+      const myTeamsGroup = GroupFixture({
+        ...fixProposedGroup,
+        id: '201',
+        metadata: {
+          ...fixProposedGroup.metadata,
+          title: 'My teams issue',
+        },
+      });
+      const allGroup = GroupFixture({
+        ...fixProposedGroup,
+        id: '301',
+        metadata: {
+          ...fixProposedGroup.metadata,
+          title: 'All assignees issue',
+        },
+      });
+
+      function mockSectionsForTab(
+        assignmentQuerySuffix: string,
+        firstGroup: typeof fixProposedGroup
+      ) {
+        for (const progress of [
+          'fix_proposed',
+          'diagnosed',
+          'assigned',
+          'identified',
+          'fix_applied',
+        ]) {
+          mockSection(
+            `issue.progress:${progress} is:unresolved${assignmentQuerySuffix}`,
+            progress === 'fix_proposed' ? [firstGroup] : []
+          );
+        }
+      }
+
+      mockSuccessfulSections();
+      mockIssuePreview();
+      mockSectionsForTab(' assigned_or_suggested:[me,my_teams]', myTeamsGroup);
+      mockSectionsForTab('', allGroup);
+      mockIssuePreview({group: myTeamsGroup});
+      mockIssuePreview({group: allGroup});
+
+      const {router} = render(<InboxPage />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      await waitFor(() => {
+        expect(router.location.query.preview).toBe(fixProposedGroup.id);
+      });
+
+      await userEvent.click(screen.getByRole('radio', {name: /^My Teams/}));
+
+      await waitFor(() => {
+        expect(router.location.query).toEqual(
+          expect.objectContaining({assignment: 'my_teams', preview: myTeamsGroup.id})
+        );
+      });
+      expect(
+        within(screen.getByRole('region', {name: 'Fix Proposed'})).getByRole('link', {
+          name: /My teams issue/,
+        })
+      ).toHaveAttribute('aria-current', 'true');
+
+      await userEvent.click(screen.getByRole('radio', {name: /^All/}));
+
+      await waitFor(() => {
+        expect(router.location.query).toEqual(
+          expect.objectContaining({assignment: 'all', preview: allGroup.id})
+        );
+      });
+      expect(
+        within(screen.getByRole('region', {name: 'Fix Proposed'})).getByRole('link', {
+          name: /All assignees issue/,
+        })
+      ).toHaveAttribute('aria-current', 'true');
+    });
+
     it('follows section order even when a later section resolves first', async () => {
       // Diagnosed resolves immediately, Fix Proposed only after a delay. Both
       // have issues, so taking whichever result arrives first would select the

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -9,7 +9,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import orderBy from 'lodash/orderBy';
-import {parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
+import {parseAsString, parseAsStringLiteral, useQueryStates} from 'nuqs';
 
 import {ActorAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Badge} from '@sentry/scraps/badge';
@@ -162,49 +162,55 @@ export default function InboxPage() {
 }
 
 function useSelectFirstLoadedIssue({
+  assignmentFilter,
   disabled,
   onSelect,
-  resetKey,
   sections,
 }: {
+  assignmentFilter: AssignmentFilter;
   disabled: boolean;
   onSelect: (issueId: string) => void;
-  resetKey: AssignmentFilter;
   sections: InboxSectionConfig[];
 }) {
-  const sectionResults = useRef(new Map<string, string | null>());
-  const hasFinished = useRef(disabled);
-  const previousResetKey = useRef(resetKey);
-
-  if (previousResetKey.current !== resetKey) {
-    previousResetKey.current = resetKey;
-    sectionResults.current.clear();
-    hasFinished.current = disabled;
-  }
+  const selectionState = useRef({
+    assignmentFilter,
+    sectionResults: new Map<string, string | null>(),
+    hasFinished: disabled,
+  });
 
   return (sectionKey: string, firstIssueId: string | null) => {
-    if (hasFinished.current) {
+    let currentState = selectionState.current;
+    if (currentState.assignmentFilter !== assignmentFilter) {
+      currentState = {
+        assignmentFilter,
+        sectionResults: new Map(),
+        hasFinished: disabled,
+      };
+      selectionState.current = currentState;
+    }
+
+    if (currentState.hasFinished) {
       return;
     }
     if (disabled) {
-      hasFinished.current = true;
+      currentState.hasFinished = true;
       return;
     }
 
-    sectionResults.current.set(sectionKey, firstIssueId);
+    currentState.sectionResults.set(sectionKey, firstIssueId);
     for (const section of sections) {
-      if (!sectionResults.current.has(section.key)) {
+      if (!currentState.sectionResults.has(section.key)) {
         return;
       }
 
-      const issueId = sectionResults.current.get(section.key);
+      const issueId = currentState.sectionResults.get(section.key);
       if (issueId) {
-        hasFinished.current = true;
+        currentState.hasFinished = true;
         onSelect(issueId);
         return;
       }
     }
-    hasFinished.current = true;
+    currentState.hasFinished = true;
   };
 }
 
@@ -305,15 +311,20 @@ function InboxContent() {
   const resizableContainerRef = useRef<HTMLDivElement>(null);
   const organization = useOrganization();
   const hasSeer = orgHasSeerAccess(organization);
-  const [assignmentFilter, setAssignmentFilter] = useQueryState(
-    ASSIGNMENT_QUERY_PARAM,
-    parseAsStringLiteral(ASSIGNMENT_FILTERS)
-      .withDefault('me')
-      .withOptions({history: 'replace'})
-  );
-  const [selectedIssueId, setSelectedIssueId] = useQueryState(
-    SELECTED_ISSUE_QUERY_PARAM,
-    parseAsString.withOptions({history: 'replace'})
+  const [
+    {
+      [ASSIGNMENT_QUERY_PARAM]: assignmentFilter,
+      [SELECTED_ISSUE_QUERY_PARAM]: selectedIssueId,
+    },
+    setInboxQueryState,
+  ] = useQueryStates(
+    {
+      [ASSIGNMENT_QUERY_PARAM]: parseAsStringLiteral(ASSIGNMENT_FILTERS).withDefault(
+        'me'
+      ),
+      [SELECTED_ISSUE_QUERY_PARAM]: parseAsString,
+    },
+    {history: 'replace'}
   );
   const assignmentCounts = useAssignmentCounts();
   const sections = SECTIONS.filter(
@@ -333,11 +344,18 @@ function InboxContent() {
   });
 
   const handleInitialSectionResult = useSelectFirstLoadedIssue({
+    assignmentFilter,
     disabled: !isDesktop || selectedIssueId !== null,
-    onSelect: issueId => void setSelectedIssueId(issueId),
-    resetKey: assignmentFilter,
+    // Keep both params in this update so selecting a preview cannot overwrite
+    // the pending assignment change that triggered the new section requests.
+    onSelect: issueId =>
+      void setInboxQueryState({assignment: assignmentFilter, preview: issueId}),
     sections,
   });
+
+  const handleAssignmentFilterChange = (filter: AssignmentFilter) => {
+    void setInboxQueryState({assignment: filter, preview: null});
+  };
 
   return (
     <Stack flex={1} minHeight={0} contain="size" overflow="hidden">
@@ -373,7 +391,7 @@ function InboxContent() {
             </Heading>
             <AssignmentTabs
               assignmentFilter={assignmentFilter}
-              setAssignmentFilter={setAssignmentFilter}
+              setAssignmentFilter={handleAssignmentFilterChange}
             />
           </Flex>
           <Stack flex={1} minHeight={0} overflowY="auto" overscrollBehavior="contain">
@@ -426,7 +444,7 @@ function InboxContent() {
                 size="xs"
                 variant="link"
                 icon={<IconArrow direction="left" size="xs" />}
-                onClick={() => void setSelectedIssueId(null)}
+                onClick={() => void setInboxQueryState({preview: null})}
               >
                 {t('Back to inbox')}
               </Button>


### PR DESCRIPTION
If you select an issue you / your teams are not assigned to in 'all', then tab back to inbox, the issue stays in the preview even though it isn't in the list of issues in the inbox anymore. The solution I tried here was to auto select the first issue whenever the user changes tabs in the inbox, instead of only auto selecting the first issue if there is no issue in the preview area. very open to feedback on approach