### PR TITLE
ref(auth): Extract two-factor rate limit helpers

### DIFF
--- a/src/sentry/auth/twofactor.py
+++ b/src/sentry/auth/twofactor.py
@@ -1,0 +1,71 @@
+from urllib.parse import urlencode
+
+from django.urls import reverse
+from django.utils import timezone
+
+from sentry import options
+from sentry import ratelimits as ratelimiter
+from sentry.utils.email import MessageBuilder
+from sentry.utils.geo import geo_by_addr
+from sentry.utils.http import absolute_uri
+
+MFA_RATE_LIMITS = {
+    "auth-2fa:user:{user_id}": {
+        "limit": 5,
+        "window": 20,
+    },
+    "auth-2fa-long:user:{user_id}": {
+        "limit": 20,
+        "window": 60 * 60,
+    },
+}
+
+
+def is_2fa_rate_limited(user_id: int) -> bool:
+    results = [
+        ratelimiter.backend.is_limited(
+            key_template.format(user_id=user_id),
+            limit=rate_limit["limit"],
+            window=rate_limit["window"],
+        )
+        for key_template, rate_limit in MFA_RATE_LIMITS.items()
+    ]
+    return any(results)
+
+
+def reset_2fa_rate_limits(user_id: int) -> None:
+    for key_template, rate_limit in MFA_RATE_LIMITS.items():
+        ratelimiter.backend.reset(
+            key_template.format(user_id=user_id),
+            window=rate_limit["window"],
+        )
+
+
+def send_2fa_rate_limit_notification(*, user_id: int, email: str, ip_address: str) -> None:
+    if ratelimiter.backend.is_limited(
+        f"auth-2fa-failed-notification:user:{user_id}", limit=1, window=30 * 60
+    ):
+        return
+
+    recover_uri = "{path}?{query}".format(
+        path=reverse("sentry-account-recover"), query=urlencode({"email": email})
+    )
+    context = {
+        "datetime": timezone.now(),
+        "email": email,
+        "geo": geo_by_addr(ip_address),
+        "ip_address": ip_address,
+        "url": absolute_uri(reverse("sentry-account-settings-security")),
+        "recover_url": absolute_uri(recover_uri),
+    }
+
+    subject = "Suspicious Activity Detected"
+    template = "mfa-too-many-attempts"
+    message = MessageBuilder(
+        subject="{}{}".format(options.get("mail.subject-prefix"), subject),
+        template=f"sentry/emails/{template}.txt",
+        html_template=f"sentry/emails/{template}.html",
+        type="user.mfa-too-many-attempts",
+        context=context,
+    )
+    message.send_async([email])

--- a/src/sentry/users/api/endpoints/user_password.py
+++ b/src/sentry/users/api/endpoints/user_password.py
@@ -9,12 +9,12 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.auth import password_validation
+from sentry.auth.twofactor import reset_2fa_rate_limits
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.security.utils import capture_security_activity
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.bases.user import UserEndpoint
 from sentry.users.models.user import User
-from sentry.web.frontend.twofactor import reset_2fa_rate_limits
 
 
 class UserPasswordSerializer(serializers.Serializer[User]):

--- a/src/sentry/users/web/accounts.py
+++ b/src/sentry/users/web/accounts.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
 from sentry import options
+from sentry.auth.twofactor import reset_2fa_rate_limits
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.organizations.services.organization import organization_service
@@ -31,7 +32,6 @@ from sentry.utils import auth
 from sentry.utils.signing import unsign
 from sentry.web.decorators import login_required, set_referrer_policy
 from sentry.web.frontend.base import control_silo_view
-from sentry.web.frontend.twofactor import reset_2fa_rate_limits
 from sentry.web.helpers import render_to_response
 
 logger = logging.getLogger("sentry.accounts")

--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -1,22 +1,16 @@
 import logging
 import time
 from base64 import b64encode
-from urllib.parse import urlencode
 
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
-from django.urls import reverse
-from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from sentry import options
-from sentry import ratelimits as ratelimiter
 from sentry.auth.authenticators.sms import SMSRateLimitExceeded
 from sentry.auth.authenticators.u2f import U2fInterface
+from sentry.auth.twofactor import is_2fa_rate_limited, send_2fa_rate_limit_notification
 from sentry.users.models.authenticator import Authenticator
 from sentry.utils import auth, json
-from sentry.utils.email import MessageBuilder
-from sentry.utils.geo import geo_by_addr
-from sentry.utils.http import absolute_uri
 from sentry.web.client_config import get_client_config
 from sentry.web.forms.accounts import TwoFactorForm
 from sentry.web.frontend.base import BaseView, control_silo_view
@@ -26,36 +20,6 @@ COOKIE_NAME = "s2fai"
 COOKIE_MAX_AGE = 60 * 60 * 24 * 31
 
 logger = logging.getLogger(__name__)
-
-MFA_RATE_LIMITS = {
-    "auth-2fa:user:{user_id}": {
-        "limit": 5,
-        "window": 20,
-    },
-    "auth-2fa-long:user:{user_id}": {
-        "limit": 20,
-        "window": 60 * 60,
-    },
-}
-
-
-def is_rate_limited(user_id: int) -> bool:
-    result = False
-    for key_template, rl in MFA_RATE_LIMITS.items():
-        result = result or ratelimiter.backend.is_limited(
-            key_template.format(user_id=user_id),
-            limit=rl["limit"],
-            window=rl["window"],
-        )
-    return result
-
-
-def reset_2fa_rate_limits(user_id: int):
-    for key_template, rl in MFA_RATE_LIMITS.items():
-        ratelimiter.backend.reset(
-            key_template.format(user_id=user_id),
-            window=rl["window"],
-        )
 
 
 @control_silo_view
@@ -143,30 +107,6 @@ class TwoFactorAuthView(BaseView):
             ):
                 return interface
 
-    def send_notification_email(self, email, ip_address):
-        recover_uri = "{path}?{query}".format(
-            path=reverse("sentry-account-recover"), query=urlencode({"email": email})
-        )
-        context = {
-            "datetime": timezone.now(),
-            "email": email,
-            "geo": geo_by_addr(ip_address),
-            "ip_address": ip_address,
-            "url": absolute_uri(reverse("sentry-account-settings-security")),
-            "recover_url": absolute_uri(recover_uri),
-        }
-
-        subject = "Suspicious Activity Detected"
-        template = "mfa-too-many-attempts"
-        msg = MessageBuilder(
-            subject="{}{}".format(options.get("mail.subject-prefix"), subject),
-            template=f"sentry/emails/{template}.txt",
-            html_template=f"sentry/emails/{template}.html",
-            type="user.mfa-too-many-attempts",
-            context=context,
-        )
-        msg.send_async([email])
-
     def handle(self, request: HttpRequest) -> HttpResponse:
         user = auth.get_pending_2fa_user(request)
         if user is None:
@@ -182,14 +122,12 @@ class TwoFactorAuthView(BaseView):
         challenge = activation = None
         interface = self.negotiate_interface(request, interfaces)
 
-        if request.method == "POST" and is_rate_limited(user.id):
-            # prevent spamming due to failed 2FA attempts
-            if not ratelimiter.backend.is_limited(
-                f"auth-2fa-failed-notification:user:{user.id}", limit=1, window=30 * 60
-            ):
-                self.send_notification_email(
-                    email=user.username, ip_address=request.META["REMOTE_ADDR"]
-                )
+        if request.method == "POST" and is_2fa_rate_limited(user.id):
+            send_2fa_rate_limit_notification(
+                user_id=user.id,
+                email=user.username,
+                ip_address=request.META["REMOTE_ADDR"],
+            )
 
             return HttpResponse(
                 "You have made too many 2FA attempts. Please try again later.",

--- a/tests/sentry/auth/test_twofactor.py
+++ b/tests/sentry/auth/test_twofactor.py
@@ -1,0 +1,62 @@
+from unittest import mock
+
+from django.core import mail
+
+from sentry.auth.twofactor import (
+    is_2fa_rate_limited,
+    reset_2fa_rate_limits,
+    send_2fa_rate_limit_notification,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class TwoFactorRateLimitHelpersTest(TestCase):
+    @mock.patch("sentry.auth.twofactor.ratelimiter.backend.is_limited", side_effect=[False, True])
+    def test_rate_limits(self, is_limited: mock.MagicMock) -> None:
+        assert is_2fa_rate_limited(123)
+        assert is_limited.call_args_list == [
+            mock.call("auth-2fa:user:123", limit=5, window=20),
+            mock.call("auth-2fa-long:user:123", limit=20, window=60 * 60),
+        ]
+
+    @mock.patch("sentry.auth.twofactor.ratelimiter.backend.is_limited", side_effect=[True, False])
+    def test_checks_long_rate_limit_when_short_rate_limit_is_reached(
+        self, is_limited: mock.MagicMock
+    ) -> None:
+        assert is_2fa_rate_limited(123)
+        assert is_limited.call_args_list == [
+            mock.call("auth-2fa:user:123", limit=5, window=20),
+            mock.call("auth-2fa-long:user:123", limit=20, window=60 * 60),
+        ]
+
+    @mock.patch("sentry.auth.twofactor.ratelimiter.backend.reset")
+    def test_reset_rate_limits(self, reset: mock.MagicMock) -> None:
+        reset_2fa_rate_limits(123)
+        assert reset.call_args_list == [
+            mock.call("auth-2fa:user:123", window=20),
+            mock.call("auth-2fa-long:user:123", window=60 * 60),
+        ]
+
+    @mock.patch("sentry.auth.twofactor.ratelimiter.backend.is_limited", side_effect=[False, True])
+    def test_notification_is_throttled(self, is_limited: mock.MagicMock) -> None:
+        with self.tasks(), outbox_runner():
+            send_2fa_rate_limit_notification(
+                user_id=123,
+                email="user@example.com",
+                ip_address="127.0.0.1",
+            )
+            send_2fa_rate_limit_notification(
+                user_id=123,
+                email="user@example.com",
+                ip_address="127.0.0.1",
+            )
+
+        assert is_limited.call_args_list == [
+            mock.call("auth-2fa-failed-notification:user:123", limit=1, window=30 * 60),
+            mock.call("auth-2fa-failed-notification:user:123", limit=1, window=30 * 60),
+        ]
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == ["user@example.com"]


### PR DESCRIPTION
Moves two-factor attempt limiting, reset behavior, and suspicious-activity notification delivery into the auth domain so both legacy and API authentication flows can share one implementation.

The existing legacy flow and password-change consumers retain their current behavior. The following API PR uses the extracted helpers to preserve notification parity when two-factor attempts are rate-limited.