### PR TITLE
ref(inbox): use new issue-inbox flag on backend

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -379,8 +379,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-stream-batched-latest-event-attachments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input
     manager.add("organizations:issue-summary-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable new issue stream progress views
-    manager.add("organizations:issue-stream-progress-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show the "recommended" sort as an option in the issue stream sort dropdown
     manager.add("organizations:issue-stream-recommended-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Make the "recommended" sort the default sort in the issue stream

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -185,7 +185,7 @@ def build_activity_notification_data(
     issue_url = group.get_absolute_url()
     if ActivityType(activity.type) in SEER_ACTIVITY_TYPES:
         issue_url = group.get_absolute_url(params={"seerDrawer": "true"})
-        if features.has("organizations:issue-stream-progress-ui", organization):
+        if features.has("organizations:issue-inbox", organization):
             issue_url = organization.absolute_url(
                 f"organizations/{organization.slug}/issues/inbox/",
                 query=urlencode({"project": project.id, "preview": group.id}),

--- a/tests/sentry/notifications/platform/templates/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/test_activity.py
@@ -200,7 +200,7 @@ class ActivityAlertBaseTest(TestCase):
 
         assert data.user_settings_url is None
 
-    @with_feature("organizations:issue-stream-progress-ui")
+    @with_feature("organizations:issue-inbox")
     def test_build_activity_notification_data_seer_activity_inbox_url(self) -> None:
         activity = self.create_group_activity(
             group=self.group, type=ActivityType.SEER_RCA_STARTED.value
@@ -213,7 +213,7 @@ class ActivityAlertBaseTest(TestCase):
         )
         assert absolute_uri(expected_inbox_url) == data.issue_url
 
-    @with_feature("organizations:issue-stream-progress-ui")
+    @with_feature("organizations:issue-inbox")
     def test_build_activity_notification_data_non_seer_activity_uses_issue_url(self) -> None:
         activity = self.create_group_activity(
             group=self.group, type=ActivityType.SET_RESOLVED.value


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/122110 must be merged and deployed first

Drops `issue-stream-progress-ui` for the new `issue-inbox` flag