### PR TITLE
fix(autofix): Turn off the context engine for autofix runs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -398,6 +398,7 @@ class SeerAgentClient:
         metadata: dict[str, Any] | None = None,
         request: Request | None = None,
         override_ce_enable: bool = True,
+        force_ce: bool | None = None,
         ui_tools: str | None = None,
         record_in_history: bool = True,
         on_run_created: Callable[[SeerRun], None] | None = None,
@@ -413,6 +414,8 @@ class SeerAgentClient:
             metadata: Optional metadata to store with the run (e.g., stopping_point). group_id is
                 added automatically when the client was constructed with a group.
             request: Optional rest_framework Request object from endpoints.
+            force_ce: If set, forces the context engine on/off for this run, ignoring
+                the org flag and rollout.
 
         Returns:
             SeerRun: The mirror row for the run. Its seer_run_state_id is the id
@@ -496,6 +499,7 @@ class SeerAgentClient:
         agent_run_options.update(
             self._build_agent_run_options(
                 override_ce_enable=override_ce_enable,
+                force_ce=force_ce,
             )
         )
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -654,6 +654,7 @@ def trigger_autofix_agent(
             artifact_key=artifact_key,
             artifact_schema=artifact_schema,
             metadata=metadata,
+            force_ce=False,
         )
         run_id = run.seer_run_state_id
 

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -104,6 +104,33 @@ class TestSeerAgentClient(TestCase):
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @override_options({"seer.explorer.context-engine-rollout": 1.0})
+    def test_start_run_context_engine_follows_rollout(self, mock_post, mock_access):
+        mock_access.return_value = (True, None)
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user)
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert body["agent_run_options"]["is_context_engine_enabled"] is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @override_options({"seer.explorer.context-engine-rollout": 1.0})
+    def test_start_run_force_ce_overrides_rollout(self, mock_post, mock_access):
+        """force_ce=False keeps the context engine off even at full rollout."""
+        mock_access.return_value = (True, None)
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user)
+        client.start_run("Test query", force_ce=False)
+
+        body = mock_post.call_args[0][0]
+        assert body["agent_run_options"]["is_context_engine_enabled"] is False
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_start_run_with_request(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run passes request object to collect_user_org_context"""


### PR DESCRIPTION
Turn off the context engine more/again. Previous attempts got the new path but not the main one in use currently.