### PR TITLE
feat(seer): Consolidate Autofix Overview loading states

### DIFF
--- a/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
+++ b/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
@@ -5,6 +5,7 @@ import {Badge} from '@sentry/scraps/badge';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
+import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {Actor} from 'sentry/types/core';
 
@@ -24,10 +25,12 @@ export function AssigneeFilter({
   runs,
   value,
   onChange,
+  loading,
 }: {
   onChange: (value: string | null) => void;
   runs: OverviewRun[];
   value: string | null;
+  loading?: boolean;
 }) {
   const options = useMemo(() => {
     const byValue = new Map<string, {actor: Actor | null; count: number}>();
@@ -67,11 +70,20 @@ export function AssigneeFilter({
     <CompactSelect
       clearable
       search
+      loading={loading}
+      disabled={loading ? false : undefined}
+      menuTitle={loading ? t('Assignee') : undefined}
       options={options}
       value={value ?? undefined}
       onChange={selected => onChange(selected?.value ?? null)}
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={t('Assignee')} />
+        <OverlayTrigger.Button {...triggerProps} prefix={t('Assignee')}>
+          {loading && value ? (
+            <Placeholder height="1rem" width="4rem" />
+          ) : (
+            triggerProps.children
+          )}
+        </OverlayTrigger.Button>
       )}
     />
   );

--- a/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
+++ b/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
@@ -71,7 +71,7 @@ export function AssigneeFilter({
       clearable
       search
       loading={loading}
-      disabled={loading ? false : undefined}
+      disabled={false}
       menuTitle={loading ? t('Assignee') : undefined}
       options={options}
       value={value ?? undefined}

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -17,6 +17,7 @@ import {
 import {useDrawer} from '@sentry/scraps/drawer';
 
 import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
+import {setPageFiltersStorage} from 'sentry/components/pageFilters/persistence';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -434,7 +435,7 @@ describe('AutofixOverview', () => {
   });
 
   it('filters to only in-progress runs when the In Progress tab is selected', async () => {
-    mockOverview({
+    const {statusPollRequest, enrichedRequest} = mockOverview({
       base: {
         autofix_root_cause: [{...rootCauseRun, status: 'processing'}],
         autofix_solution: [solutionRun],
@@ -456,6 +457,36 @@ describe('AutofixOverview', () => {
     expect(
       screen.queryByRole('button', {name: 'Generate code changes 1'})
     ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+    expect(statusPollRequest).toHaveBeenCalledTimes(1);
+    expect(enrichedRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a pinned time window through param navigation instead of resetting it', async () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({datetime: {period: '30d', start: null, end: null, utc: null}})
+    );
+    setPageFiltersStorage(organization.slug, new Set(['datetime']));
+    ProjectsStore.reset();
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [{...rootCauseRun, status: 'processing'}]},
+    });
+
+    const {router} = renderPage();
+    act(() => ProjectsStore.loadInitialData([ProjectFixture()]));
+
+    await screen.findByRole('tab', {name: /All Runs/});
+    await waitFor(() => expect(router.location.query.statsPeriod).toBe('30d'));
+    const requestsBeforeClick = statusPollRequest.mock.calls.length;
+
+    await userEvent.click(screen.getByRole('tab', {name: /In Progress/}));
+
+    expect(router.location.query.view).toBe('in_progress');
+    expect(router.location.query.statsPeriod).toBe('30d');
+    expect(
+      screen.getByRole('button', {name: 'Autofix Activity 30D'})
+    ).toBeInTheDocument();
+    expect(statusPollRequest).toHaveBeenCalledTimes(requestsBeforeClick);
   });
 
   it('shows an empty state on the In Progress tab when nothing is processing', async () => {
@@ -814,7 +845,72 @@ describe('AutofixOverview', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('holds the filter bar as a skeleton until projects finish loading', async () => {
+  it('shows the skeleton again when the selected project changes', async () => {
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+    const otherProject = deferEnriched();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({project: [3]})],
+      asyncDelay: otherProject.promise,
+      body: {runsByMilestone: {...emptyMilestones, autofix_solution: [solutionRun]}},
+    });
+
+    renderPage();
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+
+    act(() => PageFiltersStore.updateProjects([3], null));
+
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
+    expect(
+      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
+    ).not.toBeInTheDocument();
+
+    otherProject.resolve();
+
+    expect(
+      await screen.findByRole('link', {name: 'KeyError in proxy handler'})
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+  });
+
+  it('shows the skeleton again when the time window changes', async () => {
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+    const narrower = deferEnriched();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({statsPeriod: '24h'})],
+      asyncDelay: narrower.promise,
+      body: {runsByMilestone: emptyMilestones},
+    });
+
+    renderPage();
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+
+    act(() =>
+      PageFiltersStore.updateDateTime({period: '24h', start: null, end: null, utc: null})
+    );
+
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
+    expect(
+      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
+    ).not.toBeInTheDocument();
+
+    narrower.resolve();
+
+    expect(
+      await screen.findByText('You don’t have any Autofix runs...yet.')
+    ).toBeInTheDocument();
+  });
+
+  it('holds the project filter as a placeholder until projects finish loading', async () => {
     // Reset the store so `useProjects().initiallyLoaded` is false; without this the
     // project filter would swap "Loading…" for its label and shift the whole row.
     ProjectsStore.reset();
@@ -822,15 +918,15 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    // The real filter controls are gated; a placeholder stands in for them.
-    expect(screen.queryByRole('button', {name: /Sort/})).not.toBeInTheDocument();
-    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
-      0
-    );
+    // The rest of the filter row renders for real from the first frame; only
+    // the project picker waits behind a placeholder.
+    expect(await screen.findByRole('button', {name: /Sort/})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Autofix Activity/})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'project-slug'})).not.toBeInTheDocument();
 
     act(() => ProjectsStore.loadInitialData([ProjectFixture()]));
 
-    expect(await screen.findByRole('button', {name: /Sort/})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'project-slug'})).toBeInTheDocument();
   });
 
   it('renders the changed files of an open pull request', async () => {
@@ -1765,6 +1861,50 @@ describe('AutofixOverview', () => {
 
     expect(
       await screen.findByText('Set up Seer to start fixing issues')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('You don’t have any Autofix runs...yet.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not flash the generic empty state when switching from an unconfigured project to one with runs', async () => {
+    mockOverview({
+      base: {},
+      projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
+    });
+    const configured = deferEnriched();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({project: [3]})],
+      asyncDelay: configured.promise,
+      body: {
+        runsByMilestone: {...emptyMilestones, autofix_root_cause: [rootCauseRun]},
+        truncatedMilestones: [],
+        projectConfig: [{id: '3', slug: 'beta-project', hasReposConnected: true}],
+      },
+    });
+
+    renderPage();
+    expect(
+      await screen.findByText('Set up Seer to start fixing issues')
+    ).toBeInTheDocument();
+
+    act(() => PageFiltersStore.updateProjects([3], null));
+
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
+    expect(
+      screen.queryByText('Set up Seer to start fixing issues')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You don’t have any Autofix runs...yet.')
+    ).not.toBeInTheDocument();
+
+    configured.resolve();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
     expect(
       screen.queryByText('You don’t have any Autofix runs...yet.')

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -763,7 +763,7 @@ describe('AutofixOverview', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('keeps the list up with a spinner while a sort change reloads', async () => {
+  it('keeps the list up silently while a sort change reloads', async () => {
     const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
@@ -793,13 +793,15 @@ describe('AutofixOverview', () => {
     await userEvent.click(screen.getByRole('button', {name: /Sort/}));
     await userEvent.click(screen.getByRole('option', {name: 'Most events'}));
 
-    // The status poll refetches for the new sort, but the old list stays up with
-    // a spinner (keepPreviousData) while the enriched request reloads.
-    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
+    // The status poll refetches for the new sort, but the old list stays up
+    // silently (keepPreviousData) while the enriched request reloads — no spinner
+    // and no skeleton.
+    await waitFor(() => expect(statusPollRequest).toHaveBeenCalledTimes(2));
     expect(
       screen.getByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(statusPollRequest).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
 
     eventsEnriched.resolve();
 
@@ -1731,7 +1733,10 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(
       screen.queryByText('You don’t have any Autofix runs...yet.')
     ).not.toBeInTheDocument();
@@ -1744,6 +1749,38 @@ describe('AutofixOverview', () => {
     expect(
       screen.queryByText('You don’t have any Autofix runs...yet.')
     ).not.toBeInTheDocument();
+  });
+
+  it('waits for project config before painting cards so the warning does not pop in', async () => {
+    const deferred = deferEnriched();
+    mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+      projectConfig: [
+        {id: '2', slug: 'alpha-project', hasReposConnected: true},
+        {id: '3', slug: 'beta-project', hasReposConnected: false},
+      ],
+      projectConfigAsyncDelay: deferred.promise,
+    });
+
+    renderPage();
+
+    // The skeleton holds while project config is loading; neither the cards nor
+    // the setup warning are painted yet.
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
+    expect(
+      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Seer isn't set up for/)).not.toBeInTheDocument();
+
+    deferred.resolve();
+
+    // Once project config resolves, the warning and the cards appear together.
+    expect(await screen.findByText(/Seer isn't set up for/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
   });
 
   it('shows the subset warning banner naming only the unconfigured projects', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -6,6 +6,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -811,6 +812,25 @@ describe('AutofixOverview', () => {
     expect(
       screen.queryByRole('link', {name: 'TypeError in checkout cart'})
     ).not.toBeInTheDocument();
+  });
+
+  it('holds the filter bar as a skeleton until projects finish loading', async () => {
+    // Reset the store so `useProjects().initiallyLoaded` is false; without this the
+    // project filter would swap "Loading…" for its label and shift the whole row.
+    ProjectsStore.reset();
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+
+    renderPage();
+
+    // The real filter controls are gated; a placeholder stands in for them.
+    expect(screen.queryByRole('button', {name: /Sort/})).not.toBeInTheDocument();
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
+
+    act(() => ProjectsStore.loadInitialData([ProjectFixture()]));
+
+    expect(await screen.findByRole('button', {name: /Sort/})).toBeInTheDocument();
   });
 
   it('renders the changed files of an open pull request', async () => {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -549,9 +549,7 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    expect(
-      await screen.findByText('You don’t have any Autofix runs...yet.')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('No Autofix runs')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'project-slug'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Autofix Activity 7D'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /Sort/})).toBeInTheDocument();
@@ -905,9 +903,7 @@ describe('AutofixOverview', () => {
 
     narrower.resolve();
 
-    expect(
-      await screen.findByText('You don’t have any Autofix runs...yet.')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('No Autofix runs')).toBeInTheDocument();
   });
 
   it('holds the project filter as a placeholder until projects finish loading', async () => {
@@ -1660,9 +1656,7 @@ describe('AutofixOverview', () => {
       expect(
         await screen.findByText('No Autofix runs match the selected assignee.')
       ).toBeInTheDocument();
-      expect(
-        screen.queryByText('You don’t have any Autofix runs...yet.')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('No Autofix runs')).not.toBeInTheDocument();
       // No tabs above the message when the filter matches nothing to switch between.
       expect(screen.queryByRole('tab', {name: /All Runs/})).not.toBeInTheDocument();
     });
@@ -1830,9 +1824,7 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByText('Set up Seer to start fixing issues')
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText('You don’t have any Autofix runs...yet.')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No Autofix runs')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Set up Seer'})).toHaveAttribute(
       'href',
       '/settings/org-slug/seer/'
@@ -1853,18 +1845,14 @@ describe('AutofixOverview', () => {
       0
     );
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('You don’t have any Autofix runs...yet.')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No Autofix runs')).not.toBeInTheDocument();
 
     deferred.resolve();
 
     expect(
       await screen.findByText('Set up Seer to start fixing issues')
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText('You don’t have any Autofix runs...yet.')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No Autofix runs')).not.toBeInTheDocument();
   });
 
   it('does not flash the generic empty state when switching from an unconfigured project to one with runs', async () => {
@@ -1897,18 +1885,14 @@ describe('AutofixOverview', () => {
     expect(
       screen.queryByText('Set up Seer to start fixing issues')
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('You don’t have any Autofix runs...yet.')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No Autofix runs')).not.toBeInTheDocument();
 
     configured.resolve();
 
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText('You don’t have any Autofix runs...yet.')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No Autofix runs')).not.toBeInTheDocument();
   });
 
   it('waits for project config before painting cards so the warning does not pop in', async () => {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -1,5 +1,4 @@
 import {type ComponentProps, Fragment, useMemo} from 'react';
-import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
@@ -23,7 +22,6 @@ import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {Sticky} from 'sentry/components/sticky';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {decodeScalar} from 'sentry/utils/queryString';
@@ -37,9 +35,15 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
 import {useMilestoneAdvanceToasts} from './milestoneToast';
-import {FilterBarSkeleton, OverviewSkeleton} from './overviewSkeleton';
+import {OverviewSkeleton, ProjectFilterSkeleton} from './overviewSkeleton';
 import {ProjectSetupWarning} from './projectSetupWarning';
-import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
+import {
+  GroupHeader,
+  STATUS_GROUP_META,
+  StatusGroup,
+  type StatusGroupKey,
+  StatusGroupTooltip,
+} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
 import {useOverviewSeerDrawer} from './useOverviewSeerDrawer';
@@ -65,7 +69,6 @@ export default function AutofixOverview() {
       renderDisabled={() => <NoAccess />}
     >
       <PageFiltersContainer
-        skipInitializeUrlParams
         defaultSelection={{datetime: {period: '7d', start: null, end: null, utc: null}}}
       >
         <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
@@ -155,11 +158,10 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     );
   };
 
+  const resultsPending = isPending || projectConfigPending;
   const populatedKeys = populatedSections.map(section => section.key);
   const allCollapsed =
-    populatedKeys.length > 0
-      ? populatedKeys.every(key => collapsedGroups.includes(key))
-      : collapsedGroups.length > 0;
+    populatedKeys.length > 0 && populatedKeys.every(key => collapsedGroups.includes(key));
 
   const toggleAllGroups = () => {
     setCollapsedGroups(previous =>
@@ -193,54 +195,54 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
 
   return (
     <Stack gap="lg" padding="lg xl">
-      {pageFiltersReady && projectsLoaded ? (
-        <Flex gap="md" align="center" wrap="wrap">
+      <Flex gap="md" align="center" wrap="wrap">
+        {pageFiltersReady && projectsLoaded ? (
           <PageFilterBar condensed>
             <ProjectPageFilter />
           </PageFilterBar>
-          <DatePageFilter
-            trigger={triggerProps => (
-              <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
-            )}
-          />
-          <AssigneeFilter
-            runs={allRuns}
-            value={assignee}
-            onChange={next => setQueryParam('assignee', next ?? undefined)}
-            loading={isPending}
-          />
-          <CompactSelect
-            value={sort}
-            options={SORT_OPTIONS}
-            onChange={selected =>
-              setQueryParam(
-                'sort',
-                selected.value === 'seer' ? undefined : selected.value
-              )
-            }
-            trigger={triggerProps => (
-              <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
-            )}
-          />
-          {(data?.truncatedMilestones?.length ?? 0) > 0 && (
-            <Text size="sm" variant="muted">
-              {t(
-                'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
-              )}
-            </Text>
+        ) : (
+          <ProjectFilterSkeleton />
+        )}
+        <DatePageFilter
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
           )}
-          <Flex marginLeft="auto">
-            <Button onClick={toggleAllGroups} disabled={populatedSections.length === 0}>
-              {allCollapsed ? t('Expand All') : t('Collapse All')}
-            </Button>
-          </Flex>
+        />
+        <AssigneeFilter
+          runs={allRuns}
+          value={assignee}
+          onChange={next => setQueryParam('assignee', next ?? undefined)}
+          loading={isPending}
+        />
+        <CompactSelect
+          value={sort}
+          options={SORT_OPTIONS}
+          onChange={selected =>
+            setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value)
+          }
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
+          )}
+        />
+        {(data?.truncatedMilestones?.length ?? 0) > 0 && (
+          <Text size="sm" variant="muted">
+            {t(
+              'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
+            )}
+          </Text>
+        )}
+        <Flex marginLeft="auto">
+          <Button
+            onClick={toggleAllGroups}
+            disabled={!resultsPending && populatedSections.length === 0}
+          >
+            {allCollapsed ? t('Expand All') : t('Collapse All')}
+          </Button>
         </Flex>
-      ) : (
-        <FilterBarSkeleton />
-      )}
+      </Flex>
       {isError ? (
         <LoadingError onRetry={refetch} />
-      ) : isPending || projectConfigPending ? (
+      ) : resultsPending ? (
         <OverviewSkeleton />
       ) : (
         <Fragment>
@@ -368,24 +370,3 @@ function NoAccess() {
     </Stack>
   );
 }
-
-// Disclosure.Content adds its own horizontal panel padding; cards align to the
-// section edge instead.
-const StatusGroup = styled(Disclosure)`
-  && > * + * {
-    padding-left: 0;
-    padding-right: 0;
-  }
-`;
-
-const GroupHeader = styled(Sticky)`
-  z-index: ${p => p.theme.zIndex.initial + 1};
-  align-self: stretch;
-  background: ${p => p.theme.tokens.background.secondary};
-  border-radius: ${p => p.theme.radius.md};
-
-  &[data-stuck] {
-    border-radius: 0;
-    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  }
-`;

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -32,11 +32,12 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
 import {useMilestoneAdvanceToasts} from './milestoneToast';
-import {OverviewSkeleton} from './overviewSkeleton';
+import {FilterBarSkeleton, OverviewSkeleton} from './overviewSkeleton';
 import {ProjectSetupWarning} from './projectSetupWarning';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
@@ -85,6 +86,7 @@ export default function AutofixOverview() {
 // Owns every request so a feature-disabled org mounts no query at all.
 function AutofixOverviewContent({organization}: {organization: Organization}) {
   const {selection, isReady: pageFiltersReady} = usePageFilters();
+  const {initiallyLoaded: projectsLoaded} = useProjects();
   const location = useLocation();
   const navigate = useNavigate();
   useOverviewSeerDrawer();
@@ -191,43 +193,51 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
 
   return (
     <Stack gap="lg" padding="lg xl">
-      <Flex gap="md" align="center" wrap="wrap">
-        <PageFilterBar condensed>
-          <ProjectPageFilter />
-        </PageFilterBar>
-        <DatePageFilter
-          trigger={triggerProps => (
-            <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
-          )}
-        />
-        <AssigneeFilter
-          runs={allRuns}
-          value={assignee}
-          onChange={next => setQueryParam('assignee', next ?? undefined)}
-        />
-        <CompactSelect
-          value={sort}
-          options={SORT_OPTIONS}
-          onChange={selected =>
-            setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value)
-          }
-          trigger={triggerProps => (
-            <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
-          )}
-        />
-        {(data?.truncatedMilestones?.length ?? 0) > 0 && (
-          <Text size="sm" variant="muted">
-            {t(
-              'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
+      {pageFiltersReady && projectsLoaded ? (
+        <Flex gap="md" align="center" wrap="wrap">
+          <PageFilterBar condensed>
+            <ProjectPageFilter />
+          </PageFilterBar>
+          <DatePageFilter
+            trigger={triggerProps => (
+              <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
             )}
-          </Text>
-        )}
-        <Flex marginLeft="auto">
-          <Button onClick={toggleAllGroups} disabled={populatedSections.length === 0}>
-            {allCollapsed ? t('Expand All') : t('Collapse All')}
-          </Button>
+          />
+          <AssigneeFilter
+            runs={allRuns}
+            value={assignee}
+            onChange={next => setQueryParam('assignee', next ?? undefined)}
+            loading={isPending}
+          />
+          <CompactSelect
+            value={sort}
+            options={SORT_OPTIONS}
+            onChange={selected =>
+              setQueryParam(
+                'sort',
+                selected.value === 'seer' ? undefined : selected.value
+              )
+            }
+            trigger={triggerProps => (
+              <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
+            )}
+          />
+          {(data?.truncatedMilestones?.length ?? 0) > 0 && (
+            <Text size="sm" variant="muted">
+              {t(
+                'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
+              )}
+            </Text>
+          )}
+          <Flex marginLeft="auto">
+            <Button onClick={toggleAllGroups} disabled={populatedSections.length === 0}>
+              {allCollapsed ? t('Expand All') : t('Collapse All')}
+            </Button>
+          </Flex>
         </Flex>
-      </Flex>
+      ) : (
+        <FilterBarSkeleton />
+      )}
       {isError ? (
         <LoadingError onRetry={refetch} />
       ) : isPending || projectConfigPending ? (

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -69,7 +69,9 @@ export default function AutofixOverview() {
       renderDisabled={() => <NoAccess />}
     >
       <PageFiltersContainer
-        defaultSelection={{datetime: {period: '7d', start: null, end: null, utc: null}}}
+        defaultSelection={{
+          datetime: {period: '7d', start: null, end: null, utc: null},
+        }}
       >
         <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
           <Layout.Title>{t('Autofix Overview')}</Layout.Title>
@@ -107,7 +109,10 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
 
   const setQueryParam = (key: string, value: string | undefined) =>
     navigate(
-      {pathname: location.pathname, query: {...location.query, [key]: value}},
+      {
+        pathname: location.pathname,
+        query: {...location.query, [key]: value},
+      },
       {replace: true}
     );
 
@@ -188,9 +193,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       />
     );
   } else {
-    noRunsContent = (
-      <EmptyState padding="3xl" title={t('You don’t have any Autofix runs...yet.')} />
-    );
+    noRunsContent = <EmptyState padding="3xl" title={t('No Autofix runs')} />;
   }
 
   return (

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -16,7 +16,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -37,6 +36,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
 import {useMilestoneAdvanceToasts} from './milestoneToast';
+import {OverviewSkeleton} from './overviewSkeleton';
 import {ProjectSetupWarning} from './projectSetupWarning';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
@@ -113,7 +113,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     isPending,
     isError,
     enrichmentPending,
-    isRefetching,
     refetch,
     enrichedSettled,
   } = useAutofixOverview({
@@ -169,9 +168,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   };
 
   let noRunsContent: React.ReactNode;
-  if (projectConfigPending) {
-    noRunsContent = <LoadingIndicator />;
-  } else if (allUnconfigured) {
+  if (allUnconfigured) {
     noRunsContent = (
       <EmptyState
         padding="3xl"
@@ -218,7 +215,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
         />
-        {isRefetching && <LoadingIndicator mini />}
         {(data?.truncatedMilestones?.length ?? 0) > 0 && (
           <Text size="sm" variant="muted">
             {t(
@@ -232,52 +228,58 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           </Button>
         </Flex>
       </Flex>
-      {someUnconfigured && (
-        <ProjectSetupWarning
-          unconfiguredProjects={unconfiguredProjects}
-          orgSlug={organization.slug}
-        />
-      )}
       {isError ? (
         <LoadingError onRetry={refetch} />
-      ) : isPending ? (
-        <LoadingIndicator />
-      ) : allRuns.length === 0 ? (
-        noRunsContent
-      ) : assigneeRuns.length === 0 ? (
-        <EmptyState
-          padding="3xl"
-          title={t('No Autofix runs match the selected assignee.')}
-        />
+      ) : isPending || projectConfigPending ? (
+        <OverviewSkeleton />
       ) : (
         <Fragment>
-          <Tabs
-            value={view}
-            onChange={next => setQueryParam('view', next === 'all' ? undefined : next)}
-          >
-            <TabList>
-              <TabList.Item key="all">
-                {t('All Runs (%s)', assigneeRuns.length)}
-              </TabList.Item>
-              <TabList.Item key="in_progress">
-                {t('In Progress (%s)', inProgressCount)}
-              </TabList.Item>
-            </TabList>
-          </Tabs>
-          {populatedSections.length === 0 ? (
+          {someUnconfigured && (
+            <ProjectSetupWarning
+              unconfiguredProjects={unconfiguredProjects}
+              orgSlug={organization.slug}
+            />
+          )}
+          {allRuns.length === 0 ? (
+            noRunsContent
+          ) : assigneeRuns.length === 0 ? (
             <EmptyState
               padding="3xl"
-              title={t('No Autofix runs are currently in progress.')}
+              title={t('No Autofix runs match the selected assignee.')}
             />
           ) : (
-            <OverviewSectionList
-              sections={populatedSections}
-              collapsedGroups={collapsedGroups}
-              onToggle={toggleGroup}
-              orgSlug={organization.slug}
-              statsPeriod={selection.datetime.period}
-              enrichmentPending={enrichmentPending}
-            />
+            <Fragment>
+              <Tabs
+                value={view}
+                onChange={next =>
+                  setQueryParam('view', next === 'all' ? undefined : next)
+                }
+              >
+                <TabList>
+                  <TabList.Item key="all">
+                    {t('All Runs (%s)', assigneeRuns.length)}
+                  </TabList.Item>
+                  <TabList.Item key="in_progress">
+                    {t('In Progress (%s)', inProgressCount)}
+                  </TabList.Item>
+                </TabList>
+              </Tabs>
+              {populatedSections.length === 0 ? (
+                <EmptyState
+                  padding="3xl"
+                  title={t('No Autofix runs are currently in progress.')}
+                />
+              ) : (
+                <OverviewSectionList
+                  sections={populatedSections}
+                  collapsedGroups={collapsedGroups}
+                  onToggle={toggleGroup}
+                  orgSlug={organization.slug}
+                  statsPeriod={selection.datetime.period}
+                  enrichmentPending={enrichmentPending}
+                />
+              )}
+            </Fragment>
           )}
         </Fragment>
       )}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {keyframes} from '@emotion/react';
+import {keyframes, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
@@ -487,6 +487,84 @@ export function OverviewCard({
   const changedFiles = reviewPullRequest?.files ?? [];
 
   return (
+    <CardFrame
+      aside={
+        <Fragment>
+          <OverviewAction
+            sectionKey={sectionKey}
+            run={run}
+            reviewPullRequest={reviewPullRequest}
+            issueUrl={issueUrl}
+            enrichmentPending={enrichmentPending}
+          />
+          <PriorityAndAssignee run={run} />
+        </Fragment>
+      }
+    >
+      {/* Grid, not flex: items stretch by default, so the level bar spans
+          every wrapped title line and the text cell can't escape the row */}
+      <Grid columns="max-content minmax(0, 1fr)" gap="sm">
+        <LevelBar level={run.issue.level ?? undefined} />
+        <Stack minWidth="0" gap="xs">
+          <Text bold display="block" textWrap="pretty" wordBreak="break-word" size="lg">
+            <TitleLink to={issueUrl}>{run.title}</TitleLink>
+          </Text>
+          <Flex wrap="wrap" gap="md" align="center">
+            <Flex gap="xs" align="center">
+              <ProjectAvatar
+                project={run.issue.project}
+                size={12}
+                hasTooltip
+                tooltip={run.issue.project.slug}
+              />
+              <Text size="sm" monospace variant="muted">
+                {run.shortId}
+              </Text>
+            </Flex>
+            <IssueVitals
+              run={run}
+              statsPeriod={statsPeriod}
+              enrichmentPending={enrichmentPending}
+            />
+          </Flex>
+        </Stack>
+      </Grid>
+      {rootCause && (
+        <NarrativeBlock
+          icon={<IconBug size="xs" variant="secondary" aria-hidden />}
+          label={t('Root Cause')}
+        >
+          {rootCause}
+        </NarrativeBlock>
+      )}
+      {proposedFix && (
+        <NarrativeBlock
+          icon={<IconCommit size="xs" variant="secondary" aria-hidden />}
+          label={t('Plan')}
+        >
+          {proposedFix}
+        </NarrativeBlock>
+      )}
+      {sectionKey === 'code_changes_ready' && run.codeChanges?.length ? (
+        <CodeChanges codeChanges={run.codeChanges} />
+      ) : null}
+      {enrichmentPending && reviewPullRequest?.url ? (
+        <Placeholder height="3rem" />
+      ) : reviewPullRequest && changedFiles.length > 0 ? (
+        <PullRequestFiles orgSlug={orgSlug} pullRequest={reviewPullRequest} />
+      ) : null}
+    </CardFrame>
+  );
+}
+
+function CardFrame({
+  aside,
+  children,
+}: {
+  aside: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
     <Container background="primary" border="primary" radius="md" padding="xl">
       <Stack gap="xl">
         <Flex
@@ -496,80 +574,66 @@ export function OverviewCard({
           direction={{xs: 'column-reverse', sm: 'row'}}
         >
           <Stack gap="lg" minWidth="0" flex="1">
-            {/* Grid, not flex: items stretch by default, so the level bar spans
-                every wrapped title line and the text cell can't escape the row */}
-            <Grid columns="max-content minmax(0, 1fr)" gap="sm">
-              <LevelBar level={run.issue.level ?? undefined} />
-              <Stack minWidth="0" gap="xs">
-                <Text
-                  bold
-                  display="block"
-                  textWrap="pretty"
-                  wordBreak="break-word"
-                  size="lg"
-                >
-                  <TitleLink to={issueUrl}>{run.title}</TitleLink>
-                </Text>
-                <Flex wrap="wrap" gap="md" align="center">
-                  <Flex gap="xs" align="center">
-                    <ProjectAvatar
-                      project={run.issue.project}
-                      size={12}
-                      hasTooltip
-                      tooltip={run.issue.project.slug}
-                    />
-                    <Text size="sm" monospace variant="muted">
-                      {run.shortId}
-                    </Text>
-                  </Flex>
-                  <IssueVitals
-                    run={run}
-                    statsPeriod={statsPeriod}
-                    enrichmentPending={enrichmentPending}
-                  />
-                </Flex>
-              </Stack>
-            </Grid>
-            {rootCause && (
-              <NarrativeBlock
-                icon={<IconBug size="xs" variant="secondary" aria-hidden />}
-                label={t('Root Cause')}
-              >
-                {rootCause}
-              </NarrativeBlock>
-            )}
-            {proposedFix && (
-              <NarrativeBlock
-                icon={<IconCommit size="xs" variant="secondary" aria-hidden />}
-                label={t('Plan')}
-              >
-                {proposedFix}
-              </NarrativeBlock>
-            )}
-            {sectionKey === 'code_changes_ready' && run.codeChanges?.length ? (
-              <CodeChanges codeChanges={run.codeChanges} />
-            ) : null}
-            {enrichmentPending && reviewPullRequest?.url ? (
-              <Placeholder height="3rem" />
-            ) : reviewPullRequest && changedFiles.length > 0 ? (
-              <PullRequestFiles orgSlug={orgSlug} pullRequest={reviewPullRequest} />
-            ) : null}
+            {children}
           </Stack>
 
           {/* justify=between + parent align=stretch pins the action to the top
               and the priority/assignee controls to the bottom-right */}
           <Stack gap="lg" align="end" justify="between" flexShrink={0} minWidth="0">
-            <OverviewAction
-              sectionKey={sectionKey}
-              run={run}
-              reviewPullRequest={reviewPullRequest}
-              issueUrl={issueUrl}
-              enrichmentPending={enrichmentPending}
-            />
-            <PriorityAndAssignee run={run} />
+            {aside}
           </Stack>
         </Flex>
       </Stack>
     </Container>
+  );
+}
+
+export function TextLineSkeleton({
+  size,
+  width,
+}: {
+  size: 'xs' | 'sm' | 'md' | 'lg';
+  width: string;
+}) {
+  return (
+    <Text as="div" size={size}>
+      <Placeholder height="1lh" width={width} />
+    </Text>
+  );
+}
+
+export function OverviewCardSkeleton() {
+  const theme = useTheme();
+  return (
+    <CardFrame
+      aside={
+        <Fragment>
+          <Placeholder height={theme.form.sm.height} width="9rem" />
+          <Flex gap="xs">
+            <Placeholder height={theme.form.xs.height} width={theme.form.xs.height} />
+            <Placeholder height={theme.form.xs.height} width={theme.form.xs.height} />
+          </Flex>
+        </Fragment>
+      }
+    >
+      <Grid columns="max-content minmax(0, 1fr)" gap="sm">
+        <LevelBar />
+        <Stack minWidth="0" gap="xs">
+          <TextLineSkeleton size="lg" width="70%" />
+          <Flex wrap="wrap" gap="md" align="center">
+            {['4.5rem', '4rem', '5rem', '5rem'].map((width, index) => (
+              <TextLineSkeleton key={index} size="sm" width={width} />
+            ))}
+          </Flex>
+        </Stack>
+      </Grid>
+      {['90%', '75%'].map((width, index) => (
+        <Stack key={index} gap="xs">
+          <TextLineSkeleton size="xs" width="4rem" />
+          <TextLineSkeleton size="sm" width={width} />
+        </Stack>
+      ))}
+      <Placeholder />
+    </CardFrame>
   );
 }

--- a/static/app/views/seerWorkflows/overview/overviewSkeleton.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewSkeleton.tsx
@@ -17,6 +17,20 @@ function CardSkeleton() {
   );
 }
 
+export function FilterBarSkeleton() {
+  return (
+    <Flex gap="md" align="center" aria-hidden>
+      <Placeholder height="36px" width="6rem" />
+      <Placeholder height="36px" width="9rem" />
+      <Placeholder height="36px" width="7rem" />
+      <Placeholder height="36px" width="5rem" />
+      <Flex marginLeft="auto">
+        <Placeholder height="36px" width="6rem" />
+      </Flex>
+    </Flex>
+  );
+}
+
 export function OverviewSkeleton() {
   return (
     <Stack gap="lg" aria-hidden>

--- a/static/app/views/seerWorkflows/overview/overviewSkeleton.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewSkeleton.tsx
@@ -1,0 +1,33 @@
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+
+import {Placeholder} from 'sentry/components/placeholder';
+
+function CardSkeleton() {
+  return (
+    <Container background="primary" border="primary" radius="md" padding="xl">
+      <Stack gap="lg">
+        <Placeholder height="1.25rem" width="60%" />
+        <Flex gap="md" wrap="wrap">
+          <Placeholder height="1rem" width="4rem" />
+          <Placeholder height="1rem" width="5rem" />
+          <Placeholder height="1rem" width="4rem" />
+        </Flex>
+      </Stack>
+    </Container>
+  );
+}
+
+export function OverviewSkeleton() {
+  return (
+    <Stack gap="lg" aria-hidden>
+      {Array.from({length: 2}).map((_, section) => (
+        <Stack gap="md" key={section}>
+          <Placeholder height="1.5rem" width="10rem" />
+          {Array.from({length: 2}).map((__, card) => (
+            <CardSkeleton key={card} />
+          ))}
+        </Stack>
+      ))}
+    </Stack>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/overviewSkeleton.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewSkeleton.tsx
@@ -1,46 +1,47 @@
+import {useTheme} from '@emotion/react';
+
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
 import {Placeholder} from 'sentry/components/placeholder';
 
-function CardSkeleton() {
-  return (
-    <Container background="primary" border="primary" radius="md" padding="xl">
-      <Stack gap="lg">
-        <Placeholder height="1.25rem" width="60%" />
-        <Flex gap="md" wrap="wrap">
-          <Placeholder height="1rem" width="4rem" />
-          <Placeholder height="1rem" width="5rem" />
-          <Placeholder height="1rem" width="4rem" />
-        </Flex>
-      </Stack>
-    </Container>
-  );
-}
+import {OverviewCardSkeleton, TextLineSkeleton} from './issueCard';
+import {GroupHeader, StatusGroup} from './statusGroups';
 
-export function FilterBarSkeleton() {
+export function ProjectFilterSkeleton() {
+  const theme = useTheme();
   return (
-    <Flex gap="md" align="center" aria-hidden>
-      <Placeholder height="36px" width="6rem" />
-      <Placeholder height="36px" width="9rem" />
-      <Placeholder height="36px" width="7rem" />
-      <Placeholder height="36px" width="5rem" />
-      <Flex marginLeft="auto">
-        <Placeholder height="36px" width="6rem" />
-      </Flex>
+    <Flex aria-hidden>
+      <Placeholder height={theme.form.md.height} width="6rem" />
     </Flex>
   );
 }
 
 export function OverviewSkeleton() {
+  const theme = useTheme();
   return (
     <Stack gap="lg" aria-hidden>
-      {Array.from({length: 2}).map((_, section) => (
-        <Stack gap="md" key={section}>
-          <Placeholder height="1.5rem" width="10rem" />
-          {Array.from({length: 2}).map((__, card) => (
-            <CardSkeleton key={card} />
-          ))}
-        </Stack>
+      <Flex align="center" height={theme.form.md.height} marginBottom="xs">
+        {['6rem', '7rem'].map((width, tab) => (
+          <Container key={tab} padding="0 xl">
+            <TextLineSkeleton size="md" width={width} />
+          </Container>
+        ))}
+      </Flex>
+      {['8rem', '10rem'].map((width, section) => (
+        <StatusGroup key={section} size="sm" expanded>
+          <GroupHeader>
+            <Disclosure.Title>
+              <Placeholder height="1lh" width={width} />
+            </Disclosure.Title>
+          </GroupHeader>
+          <Disclosure.Content>
+            <Stack gap="md" paddingTop="sm">
+              <OverviewCardSkeleton />
+              <OverviewCardSkeleton />
+            </Stack>
+          </Disclosure.Content>
+        </StatusGroup>
       ))}
     </Stack>
   );

--- a/static/app/views/seerWorkflows/overview/statusGroups.tsx
+++ b/static/app/views/seerWorkflows/overview/statusGroups.tsx
@@ -1,6 +1,10 @@
+import styled from '@emotion/styled';
+
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {Sticky} from 'sentry/components/sticky';
 import {IconCode, IconCommit, IconMerge, IconPullRequest, IconSearch} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tn} from 'sentry/locale';
@@ -73,3 +77,24 @@ export function StatusGroupTooltip({groupKey}: {groupKey: StatusGroupKey}) {
     </Stack>
   );
 }
+
+// Disclosure.Content adds its own horizontal panel padding; cards align to the
+// section edge instead.
+export const StatusGroup = styled(Disclosure)`
+  && > * + * {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
+
+export const GroupHeader = styled(Sticky)`
+  z-index: ${p => p.theme.zIndex.initial + 1};
+  align-self: stretch;
+  background: ${p => p.theme.tokens.background.secondary};
+  border-radius: ${p => p.theme.radius.md};
+
+  &[data-stuck] {
+    border-radius: 0;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+`;

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
@@ -1,6 +1,7 @@
 import type {AutofixOverviewResponse, OverviewRun, RunStatus} from './types';
 import {
   detectMilestoneAdvances,
+  isSameScope,
   overlayStatus,
   sectionSignature,
   shouldRefetchEnriched,
@@ -159,5 +160,37 @@ describe('shouldRefetchEnriched', () => {
     const poll = response({has_pull_request: [run('r1')]});
     const enriched = response({autofix_root_cause: [run('r1')]});
     expect(shouldRefetchEnriched(poll, enriched)).toBe(true);
+  });
+});
+
+describe('isSameScope', () => {
+  const scope = {project: [2], statsPeriod: '14d'};
+
+  it('is true across a sort or expand change', () => {
+    expect(
+      isSameScope(
+        {...scope, expand: ['status']},
+        {...scope, sort: 'events', expand: ['scmInfo', 'issueStats', 'status']}
+      )
+    ).toBe(true);
+  });
+
+  it('is false when the projects change', () => {
+    expect(isSameScope(scope, {...scope, project: [2, 3]})).toBe(false);
+  });
+
+  it('is false when the time window changes', () => {
+    expect(isSameScope(scope, {...scope, statsPeriod: '24h'})).toBe(false);
+    expect(
+      isSameScope(scope, {
+        project: [2],
+        start: '2026-07-01T00:00:00',
+        end: '2026-07-02T00:00:00',
+      })
+    ).toBe(false);
+  });
+
+  it('is false with no previous query', () => {
+    expect(isSameScope(undefined, scope)).toBe(false);
   });
 });

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -7,6 +7,7 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {CanonicalApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 
 import {
   type AutofixOverviewResponse,
@@ -118,10 +119,8 @@ export function isSameScope(previous: QueryParams, next: QueryParams): boolean {
 }
 
 function queryParamsOf(queryKey: QueryKey): QueryParams {
-  const options = queryKey[1];
-  return options && typeof options === 'object' && 'query' in options
-    ? (options.query as QueryParams)
-    : undefined;
+  const [, options] = queryKey as CanonicalApiQueryKey;
+  return options?.query;
 }
 
 export function overlayStatus(

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -1,5 +1,7 @@
 import {useEffect, useMemo} from 'react';
-import {keepPreviousData, useQuery} from '@tanstack/react-query';
+import {type QueryKey, useQuery} from '@tanstack/react-query';
+import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
@@ -107,6 +109,21 @@ export function shouldRefetchEnriched(
   );
 }
 
+type QueryParams = Record<string, unknown> | undefined;
+
+const SCOPE_FREE_PARAMS = ['sort', 'expand'];
+
+export function isSameScope(previous: QueryParams, next: QueryParams): boolean {
+  return isEqual(omit(previous, SCOPE_FREE_PARAMS), omit(next, SCOPE_FREE_PARAMS));
+}
+
+function queryParamsOf(queryKey: QueryKey): QueryParams {
+  const options = queryKey[1];
+  return options && typeof options === 'object' && 'query' in options
+    ? (options.query as QueryParams)
+    : undefined;
+}
+
 export function overlayStatus(
   base: AutofixOverviewResponse,
   poll: AutofixOverviewResponse | undefined
@@ -147,8 +164,8 @@ export function useAutofixOverview({
 }) {
   const overviewQuery = (query: {
     expand?: Array<'scmInfo' | 'issueStats' | 'status' | 'projectConfig'>;
-  }) =>
-    apiOptions.as<AutofixOverviewResponse>()(
+  }) => {
+    const options = apiOptions.as<AutofixOverviewResponse>()(
       '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
       {
         path: {organizationIdOrSlug: organization.slug},
@@ -162,11 +179,25 @@ export function useAutofixOverview({
         staleTime: QUERY_STALE_TIME,
       }
     );
+    return {
+      ...options,
+      placeholderData: <T>(
+        previousData: T | undefined,
+        previousQuery: {queryKey: QueryKey} | undefined
+      ) =>
+        previousQuery &&
+        isSameScope(
+          queryParamsOf(previousQuery.queryKey),
+          queryParamsOf(options.queryKey)
+        )
+          ? previousData
+          : undefined,
+    };
+  };
 
   const enrichedQuery = useQuery({
     ...overviewQuery({expand: ['scmInfo', 'issueStats', 'status']}),
     enabled,
-    placeholderData: keepPreviousData,
     // Enrichment is progressive polish: fail fast to empty slots rather than
     // shimmering through the default retry backoff.
     retry: 1,
@@ -175,14 +206,12 @@ export function useAutofixOverview({
   const statusPollQuery = useQuery({
     ...overviewQuery({expand: ['status']}),
     enabled,
-    placeholderData: keepPreviousData,
     refetchInterval: POLL_INTERVAL,
   });
 
   const projectConfigQuery = useQuery({
     ...overviewQuery({expand: ['projectConfig']}),
     enabled,
-    placeholderData: keepPreviousData,
   });
 
   const enrichedRefetch = enrichedQuery.refetch;

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -208,8 +208,6 @@ export function useAutofixOverview({
     isError: statusPollQuery.isError && enrichedQuery.isError && !data,
     // Cold-load shimmer only: the poll painted but no enriched payload yet.
     enrichmentPending: Boolean(data) && !enrichedQuery.data && !enrichedQuery.isError,
-    // A later refetch keeps the list up; the caller shows a spinner meanwhile.
-    isRefetching: enrichedQuery.isFetching && Boolean(enrichedQuery.data),
     enrichedSettled: !enrichedQuery.isFetching && Boolean(enrichedQuery.data),
     refetch: () => {
       statusPollQuery.refetch();


### PR DESCRIPTION
Collapse the competing loading treatments on the Autofix Overview page into one coherent, calm experience, so the page stops feeling choppy on load, while polling, and when the query changes.

The page surfaced four separate loading treatments driven by three independent `keepPreviousData` queries (light status poll, enriched detail, project config), each resolving on its own clock:

- Replace the cold-load centered spinner with a card/section-shaped `OverviewSkeleton`, gated on `isPending || projectConfigPending`. Gating on project config too means the "some projects aren't set up" warning and the cards paint together, instead of the warning popping in a beat later and shoving cards down.
- Show the skeleton again when the query scope changes. Previous data is kept only across a sort change (same result set, reordered); a project or date change drops it, so the page no longer sits on stale results or flashes the wrong empty state when moving off an unconfigured project. Same-key refetches (10s status poll, section-change enrichment) stay silent with results on screen.
- Make the skeleton mirror the real page so the swap to content doesn't shift layout: it reuses the actual card frame, sticky group header, and tab geometry, and sizes text lines with `1lh` and controls with `theme.form` height tokens instead of hardcoded dimensions.
- Stabilize the filter row during load: only the project filter (which swaps "Loading…" for its label) is gated behind a placeholder; the date/assignee/sort filters stay mounted, and the assignee picker stays enabled while runs load, showing its loading state in the menu instead of flashing "None" for a preselected value.
- Stop gating URL initialization (`skipInitializeUrlParams`). With a pinned time window restored from storage and no `statsPeriod` in the URL, any in-page param navigation (tabs, sort, assignee, Seer drawer) reset the selection to the 7d default and refetched — the loading state users saw on tab switches was this unintended reset. Writing the resolved filters into the URL on load makes navigation preserve them, matching most pages; default periods still stay out of the URL.

The progressive per-card `enrichmentPending` placeholders are intentionally kept — cards still paint fast from the light poll and fill in enriched detail. Silent same-query refetch, skeleton-on-scope-change, and the single-skeleton cold load are deliberate product decisions, not oversights. Tab switches are asserted to be pure client-side filtering: zero requests, no loading state.

Scope is intentionally "loading indicators only". Known remaining choppiness sources are left as follow-ups: per-card placeholder height mismatches, live section reordering, milestone-toast bursts during polling, and the sticky-header snap.

Refs AIML-3358