### PR TITLE
feat(seer): Add analytics to the Autofix Overview page

### DIFF
--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -1,5 +1,19 @@
+import type {
+  PullRequestChecksStatus,
+  PullRequestReviewStatus,
+} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
+
+// Pipeline stage a run is bucketed into on the Autofix Overview page. Mirrors
+// the `AutofixStateKey` union in the overview view without importing across the
+// utils -> views layer boundary.
+type AutofixOverviewSection =
+  | 'needs_investigation'
+  | 'solution_ready'
+  | 'code_changes_ready'
+  | 'review_pr'
+  | 'merged';
 
 export type SeerAnalyticsEventsParameters = {
   'ai_query.applied': {
@@ -72,6 +86,24 @@ export type SeerAnalyticsEventsParameters = {
     group_id: string;
     organization: Organization;
     run_id: string;
+    section: AutofixOverviewSection;
+  };
+  'autofix.overview.code_changes_expanded': {
+    group_id: string;
+    organization: Organization;
+    run_id: string;
+    section: AutofixOverviewSection;
+  };
+  'autofix.overview.filter_changed': {
+    filter_type: 'sort' | 'assignee' | 'activity' | 'view_tab';
+    organization: Organization;
+    value: string;
+  };
+  'autofix.overview.issue_clicked': {
+    group_id: string;
+    organization: Organization;
+    run_id: string;
+    section: AutofixOverviewSection;
   };
   'autofix.overview.milestone_advanced': {
     from_milestone: string;
@@ -84,6 +116,15 @@ export type SeerAnalyticsEventsParameters = {
     group_id: string;
     organization: Organization;
     run_id: string;
+    section: AutofixOverviewSection;
+  };
+  'autofix.overview.pr_clicked': {
+    group_id: string;
+    organization: Organization;
+    run_id: string;
+    section: AutofixOverviewSection;
+    checks_status?: PullRequestChecksStatus;
+    review_status?: PullRequestReviewStatus;
   };
   'autofix.pr_iteration.feedback': {
     group_id: string;
@@ -202,8 +243,12 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'autofix.create_pr_clicked': 'Autofix: Create PR Setup Clicked',
   'autofix.evidence.clicked': 'Autofix: Evidence Clicked',
   'autofix.overview.action_clicked': 'Autofix Overview: Action Clicked',
+  'autofix.overview.code_changes_expanded': 'Autofix Overview: Code Changes Expanded',
+  'autofix.overview.filter_changed': 'Autofix Overview: Filter Changed',
+  'autofix.overview.issue_clicked': 'Autofix Overview: Issue Clicked',
   'autofix.overview.milestone_advanced': 'Autofix Overview: Milestone Advanced',
   'autofix.overview.open_seer_clicked': 'Autofix Overview: Open Seer Clicked',
+  'autofix.overview.pr_clicked': 'Autofix Overview: PR Clicked',
   'autofix.pr_iteration.feedback': 'Autofix: PR Iteration Feedback',
   'autofix.root_cause.find_solution': 'Autofix: Root Cause Find Solution',
   'autofix.root_cause.re_run': 'Autofix: Root Cause Re-run',

--- a/static/app/views/seerWorkflows/overview/codeChanges.tsx
+++ b/static/app/views/seerWorkflows/overview/codeChanges.tsx
@@ -1,3 +1,5 @@
+import {useRef} from 'react';
+
 import {DiffFileType} from 'sentry/components/events/autofix/types';
 import {t} from 'sentry/locale';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
@@ -33,13 +35,27 @@ function groupByRepo(codeChanges: OverviewCodeChangeFile[]): RepoFileGroup[] {
   return [...groups.values()];
 }
 
-export function CodeChanges({codeChanges}: {codeChanges: OverviewCodeChangeFile[]}) {
+export function CodeChanges({
+  codeChanges,
+  onFirstExpand,
+}: {
+  codeChanges: OverviewCodeChangeFile[];
+  onFirstExpand?: () => void;
+}) {
   const {expandedKeys, toggle} = useExpandedKeys();
+  const firedRef = useRef(false);
+  const handleToggle = (key: string, expanded: boolean) => {
+    if (expanded && !firedRef.current) {
+      firedRef.current = true;
+      onFirstExpand?.();
+    }
+    toggle(key, expanded);
+  };
   return (
     <ChangedFilesSection
       groups={groupByRepo(codeChanges)}
       expandedKeys={expandedKeys}
-      onToggle={toggle}
+      onToggle={handleToggle}
     />
   );
 }

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -137,6 +137,16 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       {replace: true}
     );
 
+  const trackFilterChanged = (
+    filterType: 'sort' | 'assignee' | 'activity' | 'view_tab',
+    value: string
+  ) =>
+    trackAnalytics('autofix.overview.filter_changed', {
+      organization,
+      filter_type: filterType,
+      value,
+    });
+
   const {
     data,
     projectConfig,
@@ -236,11 +246,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
         )}
         <DatePageFilter
           onChange={update =>
-            trackAnalytics('autofix.overview.filter_changed', {
-              organization,
-              filter_type: 'activity',
-              value: update.relative ?? 'absolute',
-            })
+            trackFilterChanged('activity', update.relative ?? 'absolute')
           }
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
@@ -250,11 +256,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           runs={allRuns}
           value={assignee}
           onChange={next => {
-            trackAnalytics('autofix.overview.filter_changed', {
-              organization,
-              filter_type: 'assignee',
-              value: bucketAssignee(next, user.id),
-            });
+            trackFilterChanged('assignee', bucketAssignee(next, user.id));
             setQueryParam('assignee', next ?? undefined);
           }}
           loading={isPending}
@@ -263,11 +265,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           value={sort}
           options={SORT_OPTIONS}
           onChange={selected => {
-            trackAnalytics('autofix.overview.filter_changed', {
-              organization,
-              filter_type: 'sort',
-              value: selected.value,
-            });
+            trackFilterChanged('sort', selected.value);
             setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value);
           }}
           trigger={triggerProps => (
@@ -314,11 +312,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
               <Tabs
                 value={view}
                 onChange={next => {
-                  trackAnalytics('autofix.overview.filter_changed', {
-                    organization,
-                    filter_type: 'view_tab',
-                    value: next,
-                  });
+                  trackFilterChanged('view_tab', next);
                   setQueryParam('view', next === 'all' ? undefined : next);
                 }}
               >

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -24,6 +24,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -31,6 +32,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
 import {OverviewCard} from './issueCard';
@@ -46,6 +48,7 @@ import {
 } from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
+import {useOverviewAnalytics} from './useOverviewAnalytics';
 import {useOverviewSeerDrawer} from './useOverviewSeerDrawer';
 
 const SeerTrialCTA = OverrideOrDefault({
@@ -58,6 +61,23 @@ const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
   {value: 'events', label: t('Most events')},
   {value: 'users', label: t('Most users')},
 ];
+
+// Buckets the assignee filter value (a raw `type:id` actor string) for
+// analytics, avoiding actor-id PII/cardinality. Null means the filter was
+// cleared back to all assignees.
+function bucketAssignee(value: string | null, currentUserId: string): string {
+  if (!value) {
+    return 'all';
+  }
+  if (value === 'unassigned') {
+    return 'unassigned';
+  }
+  const [type, id] = value.split(':');
+  if (type === 'team') {
+    return 'team';
+  }
+  return id === currentUserId ? 'me' : 'user';
+}
 
 export default function AutofixOverview() {
   const organization = useOrganization();
@@ -94,6 +114,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   const {initiallyLoaded: projectsLoaded} = useProjects();
   const location = useLocation();
   const navigate = useNavigate();
+  const user = useUser();
   useOverviewSeerDrawer();
   const [collapsedGroups, setCollapsedGroups] = useLocalStorageState<StatusGroupKey[]>(
     'seer-autofix-overview:collapsed-groups',
@@ -134,6 +155,13 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   useMilestoneAdvanceToasts(data, enrichedSettled);
   const unconfiguredProjects =
     projectConfig?.filter(project => !project.hasReposConnected) ?? [];
+  useOverviewAnalytics({
+    data,
+    isPending,
+    numProjectsSelected: selection.projects.length,
+    numUnconfiguredProjects: unconfiguredProjects.length,
+    statsPeriod: selection.datetime.period,
+  });
   const allUnconfigured =
     unconfiguredProjects.length > 0 &&
     unconfiguredProjects.length === projectConfig?.length;
@@ -207,6 +235,13 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           <ProjectFilterSkeleton />
         )}
         <DatePageFilter
+          onChange={update =>
+            trackAnalytics('autofix.overview.filter_changed', {
+              organization,
+              filter_type: 'activity',
+              value: update.relative ?? 'absolute',
+            })
+          }
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
           )}
@@ -214,15 +249,27 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
         <AssigneeFilter
           runs={allRuns}
           value={assignee}
-          onChange={next => setQueryParam('assignee', next ?? undefined)}
+          onChange={next => {
+            trackAnalytics('autofix.overview.filter_changed', {
+              organization,
+              filter_type: 'assignee',
+              value: bucketAssignee(next, user.id),
+            });
+            setQueryParam('assignee', next ?? undefined);
+          }}
           loading={isPending}
         />
         <CompactSelect
           value={sort}
           options={SORT_OPTIONS}
-          onChange={selected =>
-            setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value)
-          }
+          onChange={selected => {
+            trackAnalytics('autofix.overview.filter_changed', {
+              organization,
+              filter_type: 'sort',
+              value: selected.value,
+            });
+            setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value);
+          }}
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
@@ -266,9 +313,14 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             <Fragment>
               <Tabs
                 value={view}
-                onChange={next =>
-                  setQueryParam('view', next === 'all' ? undefined : next)
-                }
+                onChange={next => {
+                  trackAnalytics('autofix.overview.filter_changed', {
+                    organization,
+                    filter_type: 'view_tab',
+                    value: next,
+                  });
+                  setQueryParam('view', next === 'all' ? undefined : next);
+                }}
               >
                 <TabList>
                   <TabList.Item key="all">

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -170,6 +170,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     isPending,
     numProjectsSelected: selection.projects.length,
     numUnconfiguredProjects: unconfiguredProjects.length,
+    projectConfigPending,
     statsPeriod: selection.datetime.period,
   });
   const allUnconfigured =

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -35,7 +35,9 @@ import type {
   PullRequestChecksStatus,
   PullRequestReviewStatus,
 } from 'sentry/types/integrations';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {CodeChanges} from './codeChanges';
 import {OpenSeerButton} from './openSeerButton';
@@ -139,6 +141,7 @@ function OverviewAction({
   run: OverviewRun;
   sectionKey: AutofixStateKey;
 }) {
+  const organization = useOrganization();
   const {pullRequests, status} = run;
   if (status === 'processing') {
     return (
@@ -152,7 +155,7 @@ function OverviewAction({
         >
           {getProcessingLabel(sectionKey)}
         </Button>
-        <OpenSeerButton run={run} size="sm" variant="secondary" />
+        <OpenSeerButton run={run} section={sectionKey} size="sm" variant="secondary" />
       </ButtonBar>
     );
   }
@@ -182,11 +185,26 @@ function OverviewAction({
                     icon={<IconMerge />}
                     href={pullRequest.url}
                     external
+                    onClick={() =>
+                      trackAnalytics('autofix.overview.pr_clicked', {
+                        organization,
+                        group_id: run.groupId,
+                        run_id: run.seerRunId,
+                        section: 'merged',
+                        checks_status: pullRequest.checksStatus ?? undefined,
+                        review_status: pullRequest.reviewStatus ?? undefined,
+                      })
+                    }
                   >
                     {label}
                   </LinkButton>
                 </Tooltip>
-                <OpenSeerButton run={run} size="sm" variant="secondary" />
+                <OpenSeerButton
+                  run={run}
+                  section={sectionKey}
+                  size="sm"
+                  variant="secondary"
+                />
               </ButtonBar>
             );
           })}
@@ -218,14 +236,29 @@ function OverviewAction({
       <Stack align="end" gap="xs">
         <ButtonBar>
           <Tooltip title={REVIEW_PR_META.description} skipWrapper>
-            <LinkButton size="sm" variant="primary" href={reviewPullRequest.url} external>
+            <LinkButton
+              size="sm"
+              variant="primary"
+              href={reviewPullRequest.url}
+              external
+              onClick={() =>
+                trackAnalytics('autofix.overview.pr_clicked', {
+                  organization,
+                  group_id: run.groupId,
+                  run_id: run.seerRunId,
+                  section: 'review_pr',
+                  checks_status: reviewPullRequest.checksStatus ?? undefined,
+                  review_status: reviewPullRequest.reviewStatus ?? undefined,
+                })
+              }
+            >
               <Flex as="span" gap="xs" align="center">
                 {t('Review PR #%s', reviewPullRequest.number)}
                 <IconOpen size="xs" />
               </Flex>
             </LinkButton>
           </Tooltip>
-          <OpenSeerButton run={run} size="sm" variant="primary" />
+          <OpenSeerButton run={run} section={sectionKey} size="sm" variant="primary" />
         </ButtonBar>
         {enrichmentPending ? (
           // Two slots mirror the review + checks tags the enriched response
@@ -479,12 +512,20 @@ export function OverviewCard({
   sectionKey: AutofixStateKey;
   statsPeriod: string | null;
 }) {
+  const organization = useOrganization();
   const rootCause = run.rootCause?.oneLineDescription;
   const proposedFix = run.proposedFix?.oneLineSummary;
   const issueUrl = `/organizations/${orgSlug}/issues/${run.groupId}/`;
   const reviewPullRequest =
     sectionKey === 'review_pr' ? selectReviewPullRequest(run.pullRequests) : undefined;
   const changedFiles = reviewPullRequest?.files ?? [];
+  const trackCodeChangesExpanded = () =>
+    trackAnalytics('autofix.overview.code_changes_expanded', {
+      organization,
+      group_id: run.groupId,
+      run_id: run.seerRunId,
+      section: sectionKey,
+    });
 
   return (
     <CardFrame
@@ -507,7 +548,19 @@ export function OverviewCard({
         <LevelBar level={run.issue.level ?? undefined} />
         <Stack minWidth="0" gap="xs">
           <Text bold display="block" textWrap="pretty" wordBreak="break-word" size="lg">
-            <TitleLink to={issueUrl}>{run.title}</TitleLink>
+            <TitleLink
+              to={issueUrl}
+              onClick={() =>
+                trackAnalytics('autofix.overview.issue_clicked', {
+                  organization,
+                  group_id: run.groupId,
+                  run_id: run.seerRunId,
+                  section: sectionKey,
+                })
+              }
+            >
+              {run.title}
+            </TitleLink>
           </Text>
           <Flex wrap="wrap" gap="md" align="center">
             <Flex gap="xs" align="center">
@@ -546,12 +599,19 @@ export function OverviewCard({
         </NarrativeBlock>
       )}
       {sectionKey === 'code_changes_ready' && run.codeChanges?.length ? (
-        <CodeChanges codeChanges={run.codeChanges} />
+        <CodeChanges
+          codeChanges={run.codeChanges}
+          onFirstExpand={trackCodeChangesExpanded}
+        />
       ) : null}
       {enrichmentPending && reviewPullRequest?.url ? (
         <Placeholder height="3rem" />
       ) : reviewPullRequest && changedFiles.length > 0 ? (
-        <PullRequestFiles orgSlug={orgSlug} pullRequest={reviewPullRequest} />
+        <PullRequestFiles
+          orgSlug={orgSlug}
+          pullRequest={reviewPullRequest}
+          onFirstExpand={trackCodeChangesExpanded}
+        />
       ) : null}
     </CardFrame>
   );

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -143,6 +143,15 @@ function OverviewAction({
 }) {
   const organization = useOrganization();
   const {pullRequests, status} = run;
+  const trackPrClicked = (section: 'merged' | 'review_pr', pr: OverviewPullRequest) =>
+    trackAnalytics('autofix.overview.pr_clicked', {
+      organization,
+      group_id: run.groupId,
+      run_id: run.seerRunId,
+      section,
+      checks_status: pr.checksStatus ?? undefined,
+      review_status: pr.reviewStatus ?? undefined,
+    });
   if (status === 'processing') {
     return (
       <ButtonBar>
@@ -185,16 +194,7 @@ function OverviewAction({
                     icon={<IconMerge />}
                     href={pullRequest.url}
                     external
-                    onClick={() =>
-                      trackAnalytics('autofix.overview.pr_clicked', {
-                        organization,
-                        group_id: run.groupId,
-                        run_id: run.seerRunId,
-                        section: 'merged',
-                        checks_status: pullRequest.checksStatus ?? undefined,
-                        review_status: pullRequest.reviewStatus ?? undefined,
-                      })
-                    }
+                    onClick={() => trackPrClicked('merged', pullRequest)}
                   >
                     {label}
                   </LinkButton>
@@ -241,16 +241,7 @@ function OverviewAction({
               variant="primary"
               href={reviewPullRequest.url}
               external
-              onClick={() =>
-                trackAnalytics('autofix.overview.pr_clicked', {
-                  organization,
-                  group_id: run.groupId,
-                  run_id: run.seerRunId,
-                  section: 'review_pr',
-                  checks_status: reviewPullRequest.checksStatus ?? undefined,
-                  review_status: reviewPullRequest.reviewStatus ?? undefined,
-                })
-              }
+              onClick={() => trackPrClicked('review_pr', reviewPullRequest)}
             >
               <Flex as="span" gap="xs" align="center">
                 {t('Review PR #%s', reviewPullRequest.number)}

--- a/static/app/views/seerWorkflows/overview/milestoneToast.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.tsx
@@ -94,7 +94,7 @@ export function MilestoneToast({
       {isActionableSection(sectionKey) && run.status !== 'processing' && (
         <NextActionButton run={run} sectionKey={sectionKey} />
       )}
-      <OpenSeerButton run={run} size="xs" />
+      <OpenSeerButton run={run} section={sectionKey} size="xs" />
     </Flex>
   );
 }

--- a/static/app/views/seerWorkflows/overview/openSeerButton.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/openSeerButton.spec.tsx
@@ -16,17 +16,25 @@ const run = (overrides: Partial<OverviewRun> = {}): OverviewRun =>
 
 describe('OpenSeerButton', () => {
   it('opens the seer drawer for the run and tracks the click', async () => {
-    const {router} = render(<OpenSeerButton run={run()} size="xs" />, {
-      organization,
-      initialRouterConfig: {location: {pathname: '/seer/overview/'}},
-    });
+    const {router} = render(
+      <OpenSeerButton run={run()} section="needs_investigation" size="xs" />,
+      {
+        organization,
+        initialRouterConfig: {location: {pathname: '/seer/overview/'}},
+      }
+    );
 
     await userEvent.click(screen.getByRole('button', {name: 'Open Seer'}));
 
     expect(router.location.query.seerDrawer).toBe('2');
     expect(trackAnalytics).toHaveBeenCalledWith(
       'autofix.overview.open_seer_clicked',
-      expect.objectContaining({organization, group_id: '2', run_id: 'run-1'})
+      expect.objectContaining({
+        organization,
+        group_id: '2',
+        run_id: 'run-1',
+        section: 'needs_investigation',
+      })
     );
   });
 });

--- a/static/app/views/seerWorkflows/overview/openSeerButton.tsx
+++ b/static/app/views/seerWorkflows/overview/openSeerButton.tsx
@@ -9,9 +9,9 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import type {OverviewRun} from './types';
+import type {AutofixStateKey, OverviewRun} from './types';
 
-export function useOpenSeerLink(run: OverviewRun) {
+export function useOpenSeerLink(run: OverviewRun, section: AutofixStateKey) {
   const organization = useOrganization();
   const location = useLocation();
   const to = useMemo(
@@ -27,22 +27,25 @@ export function useOpenSeerLink(run: OverviewRun) {
         organization,
         group_id: run.groupId,
         run_id: run.seerRunId,
+        section,
       }),
-    [organization, run.groupId, run.seerRunId]
+    [organization, run.groupId, run.seerRunId, section]
   );
   return {to, trackOpen};
 }
 
 export function OpenSeerButton({
   run,
+  section,
   size,
   variant = 'secondary',
 }: {
   run: OverviewRun;
+  section: AutofixStateKey;
   size: 'xs' | 'sm';
   variant?: 'primary' | 'secondary';
 }) {
-  const {to, trackOpen} = useOpenSeerLink(run);
+  const {to, trackOpen} = useOpenSeerLink(run, section);
   return (
     <Tooltip title={t('Open Seer')} skipWrapper>
       <LinkButton

--- a/static/app/views/seerWorkflows/overview/overviewActions.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewActions.tsx
@@ -109,6 +109,7 @@ export function useNextAction({
       group_id: run.groupId,
       run_id: run.seerRunId,
       action: config.action,
+      section: sectionKey,
     });
     try {
       await config.trigger(autofix, run.seerRunId);
@@ -133,7 +134,15 @@ export function useNextAction({
       });
       setIsDispatched(false);
     }
-  }, [autofix, config, organization, queryClient, run.groupId, run.seerRunId]);
+  }, [
+    autofix,
+    config,
+    organization,
+    queryClient,
+    run.groupId,
+    run.seerRunId,
+    sectionKey,
+  ]);
 
   return {autofix, config, isDispatched, trigger};
 }

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -33,7 +33,7 @@ export function OverviewCardAction({
   const [menuOpened, setMenuOpened] = useState(false);
 
   const {autofix, config, isDispatched, trigger} = useNextAction({run, sectionKey});
-  const {to: openSeerTo, trackOpen} = useOpenSeerLink(run);
+  const {to: openSeerTo, trackOpen} = useOpenSeerLink(run, sectionKey);
 
   const {hasReposConnected, hasNonGithubRepo} = run.issue.project;
   const repoEligibility =

--- a/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
+++ b/static/app/views/seerWorkflows/overview/pullRequestFiles.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Text} from '@sentry/scraps/text';
@@ -79,13 +79,23 @@ function FileDiff({
 export function PullRequestFiles({
   orgSlug,
   pullRequest,
+  onFirstExpand,
 }: {
   orgSlug: string;
   pullRequest: OverviewPullRequest;
+  onFirstExpand?: () => void;
 }) {
   const files = pullRequest.files;
   const {expandedKeys, toggle} = useExpandedKeys();
   const [shouldFetch, setShouldFetch] = useState(false);
+  const firedRef = useRef(false);
+  const handleToggle = (key: string, expanded: boolean) => {
+    if (expanded && !firedRef.current) {
+      firedRef.current = true;
+      onFirstExpand?.();
+    }
+    toggle(key, expanded);
+  };
 
   const {data, isPending, isError} = useQuery({
     ...apiOptions.as<PullRequestFilesResponse>()(
@@ -127,7 +137,7 @@ export function PullRequestFiles({
     <ChangedFilesSection
       groups={groups}
       expandedKeys={expandedKeys}
-      onToggle={toggle}
+      onToggle={handleToggle}
       onMouseEnter={() => setShouldFetch(true)}
     />
   );

--- a/static/app/views/seerWorkflows/overview/useOverviewAnalytics.ts
+++ b/static/app/views/seerWorkflows/overview/useOverviewAnalytics.ts
@@ -1,0 +1,51 @@
+import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+
+import {type AutofixOverviewResponse, OVERVIEW_SECTIONS} from './types';
+
+interface UseOverviewAnalyticsProps {
+  isPending: boolean;
+  numProjectsSelected: number;
+  numUnconfiguredProjects: number;
+  statsPeriod: string | null;
+  data?: AutofixOverviewResponse;
+}
+
+// Fires the `autofix.overview.page_viewed` route-analytics event with adoption
+// context. Counts come from the unfiltered milestone buckets, not the
+// assignee/view-filtered sections, so they reflect the whole page.
+export function useOverviewAnalytics({
+  data,
+  isPending,
+  numProjectsSelected,
+  numUnconfiguredProjects,
+  statsPeriod,
+}: UseOverviewAnalyticsProps) {
+  useRouteAnalyticsEventNames(
+    'autofix.overview.page_viewed',
+    'Autofix Overview: Page Viewed'
+  );
+
+  const runsByMilestone = data?.runsByMilestone;
+  const allRuns = runsByMilestone ? Object.values(runsByMilestone).flat() : [];
+  const sectionCounts = OVERVIEW_SECTIONS.reduce<Record<string, number>>(
+    (acc, {key, milestone}) => {
+      acc[`runs_${key}`] = runsByMilestone?.[milestone]?.length ?? 0;
+      return acc;
+    },
+    {}
+  );
+
+  useRouteAnalyticsParams(
+    isPending
+      ? {}
+      : {
+          num_runs: allRuns.length,
+          ...sectionCounts,
+          has_in_progress: allRuns.some(run => run.status === 'processing'),
+          num_projects_selected: numProjectsSelected,
+          num_unconfigured_projects: numUnconfiguredProjects,
+          stats_period: statsPeriod,
+        }
+  );
+}

--- a/static/app/views/seerWorkflows/overview/useOverviewAnalytics.ts
+++ b/static/app/views/seerWorkflows/overview/useOverviewAnalytics.ts
@@ -1,3 +1,4 @@
+import {useDisableRouteAnalytics} from 'sentry/utils/routeAnalytics/useDisableRouteAnalytics';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 
@@ -7,6 +8,7 @@ interface UseOverviewAnalyticsProps {
   isPending: boolean;
   numProjectsSelected: number;
   numUnconfiguredProjects: number;
+  projectConfigPending: boolean;
   statsPeriod: string | null;
   data?: AutofixOverviewResponse;
 }
@@ -19,8 +21,14 @@ export function useOverviewAnalytics({
   isPending,
   numProjectsSelected,
   numUnconfiguredProjects,
+  projectConfigPending,
   statsPeriod,
 }: UseOverviewAnalyticsProps) {
+  // Hold the page-view until both the run data and the project config have
+  // settled, otherwise route analytics fires on its own timer with empty
+  // counts (and later param updates are ignored once the event has sent).
+  const isLoading = isPending || projectConfigPending;
+  useDisableRouteAnalytics(isLoading);
   useRouteAnalyticsEventNames(
     'autofix.overview.page_viewed',
     'Autofix Overview: Page Viewed'
@@ -37,7 +45,7 @@ export function useOverviewAnalytics({
   );
 
   useRouteAnalyticsParams(
-    isPending
+    isLoading
       ? {}
       : {
           num_runs: allRuns.length,


### PR DESCRIPTION
Adds frontend analytics instrumentation to the Autofix Overview page. The page previously emitted only three interaction events, so we couldn't answer basic adoption/engagement questions: whether anyone lands on the page, which controls get used, and whether users follow through to the PR.

## What's added

**New events**
- `autofix.overview.page_viewed` — a route-analytics page-view carrying unfiltered run-state counts per pipeline stage plus project-selection context (`num_runs`, `runs_<section>`, `has_in_progress`, `num_projects_selected`, `num_unconfigured_projects`, `stats_period`).
- `autofix.overview.filter_changed` — a single event for the toolbar controls (`filter_type: 'sort' | 'assignee' | 'activity' | 'view_tab'`). The assignee value is bucketed to `me`/`user`/`team`/`unassigned` to avoid actor-id PII and cardinality.
- `autofix.overview.issue_clicked` — issue-title link.
- `autofix.overview.pr_clicked` — merged and review-PR links, with `checks_status`/`review_status` when available.
- `autofix.overview.code_changes_expanded` — fires once per card on the first code-changes expand.

**Retrofit**
- `section` (pipeline stage) is added to the existing `action_clicked` and `open_seer_clicked` events, and standardized across all overview interaction events so a single chart can compare activity per stage.

## Notes for reviewers
- `page_viewed` counts come from the unfiltered `runsByMilestone` buckets (not the assignee/view-filtered sections) so they reflect the whole page.
- `code_changes_expanded` uses a per-card ref guard so it fires at most once per card.
- The "Review PR" fallback button (no PR URL, navigates to the issue) is intentionally left uninstrumented — it's neither a PR link nor the issue-title link.
- Frontend-only; events inherit the existing `seer-night-shift-ui` gate since they only fire when the page renders.

Refs AIML-3356