### PR TITLE
fix(search): Reject boolean has filters in issue search

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -888,12 +888,14 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         return remove_optional_nodes(flatten(children[0]))
 
     def visit_boolean_operator(self, node: Node, children: tuple[QueryOp]) -> QueryOp:
+        self._validate_boolean_support()
+        return children[0]
+
+    def _validate_boolean_support(self) -> None:
         if not self.config.allow_boolean:
             raise InvalidSearchQuery(
                 'Boolean statements containing "OR" or "AND" are not supported in this search'
             )
-
-        return children[0]
 
     def visit_free_text_unquoted(self, node: Node, children: object) -> str | None:
         return node.text.strip(" ") or None
@@ -1855,16 +1857,21 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             Node,
             list[SearchKey],
         ],
-    ) -> ParenExpression:
+    ) -> SearchFilter | ParenExpression:
         (negation, _, _, _, search_keys) = children
         search_keys = self._validate_has_search_keys(negation, search_keys)
 
         operator = "=" if is_negated(negation) else "!="
-        joining_operator: QueryOp = "AND" if is_negated(negation) else "OR"
         search_value = SearchValue("")
         all_filters = [
             SearchFilter(search_key, operator, search_value) for search_key in search_keys
         ]
+        if not self.config.allow_boolean:
+            if len(all_filters) > 1:
+                self._validate_boolean_support()
+            return all_filters[0]
+
+        joining_operator: QueryOp = "AND" if is_negated(negation) else "OR"
         tokens: list[QueryToken] = []
         for index, search_filter in enumerate(all_filters):
             tokens.append(search_filter)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1081,6 +1081,19 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
         with pytest.raises(InvalidSearchQuery):
             parse_search_query('has:"hi there"')
 
+    def test_has_in_filter_with_boolean_disabled(self) -> None:
+        config = SearchConfig.create_from(default_config, allow_boolean=False)
+
+        assert parse_search_query("has:[release]", config=config) == [
+            SearchFilter(
+                key=SearchKey(name="release"),
+                operator="!=",
+                value=SearchValue(raw_value=""),
+            )
+        ]
+        with pytest.raises(InvalidSearchQuery, match="Boolean statements"):
+            parse_search_query("has:[release,zoo]", config=config)
+
     def test_not_has_team_key_transaction_allowed_when_disabled(self) -> None:
         config = SearchConfig.create_from(default_config, allow_not_has_filter=False)
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -420,21 +420,24 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_success_response(project_id=[-1])
         assert response.status_code == 200
 
-    def test_boolean_search_feature_flag(self) -> None:
+    def test_boolean_search_not_supported(self) -> None:
         self.login_as(user=self.user)
+        expected_detail = (
+            'Error parsing search query: Boolean statements containing "OR" or "AND" are not '
+            "supported in this search"
+        )
+
         response = self.get_response(sort_by="date", query="title:hello OR title:goodbye")
         assert response.status_code == 400
-        assert (
-            response.data["detail"]
-            == 'Error parsing search query: Boolean statements containing "OR" or "AND" are not supported in this search'
-        )
+        assert response.data["detail"] == expected_detail
 
         response = self.get_response(sort_by="date", query="title:hello AND title:goodbye")
         assert response.status_code == 400
-        assert (
-            response.data["detail"]
-            == 'Error parsing search query: Boolean statements containing "OR" or "AND" are not supported in this search'
-        )
+        assert response.data["detail"] == expected_detail
+
+        response = self.get_response(sort_by="date", query="has:[title,message]")
+        assert response.status_code == 400
+        assert response.data["detail"] == expected_detail
 
     def test_invalid_query(self) -> None:
         now = timezone.now()


### PR DESCRIPTION
In issue search, we disable boolean queries, but doing something like `has:[field_a, field_b, ...]` gets converted into `has:field_a OR has:field_b OR ...` which bypasses the disabling of the booleans.

Enforce the boolean-disabled parser contract so issue endpoints return 400.

Fixes SENTRY-5MB0