### PR TITLE
fix(auth): lock the invited email on the invite registration form

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -11,20 +11,24 @@
   {% endif %}
 
   <div class="auth-container p-t-1 border-bottom">
-    <h3>{% trans "Sign in to continue" %}</h3>
-    <ul class="nav nav-tabs auth-toggle m-b-0">
-      <li{% if op == "login" %} class="active"{% endif %}>
-        <a href="#login" data-toggle="tab">{% trans "Sign In" %}</a>
-      </li>
-      {% if CAN_REGISTER %}
-        <li{% if op == "register" %} class="active"{% endif %}>
-          <a href="#register" data-toggle="tab">{% trans "Register" %}</a>
+    {% if is_invite_registration %}
+      <h3>{% trans "Create your account" %}</h3>
+    {% else %}
+      <h3>{% trans "Sign in to continue" %}</h3>
+      <ul class="nav nav-tabs auth-toggle m-b-0">
+        <li{% if op == "login" %} class="active"{% endif %}>
+          <a href="#login" data-toggle="tab">{% trans "Sign In" %}</a>
         </li>
-      {% endif %}
-      <li{% if op == "sso" %} class="active"{% endif %}>
-        <a href="#sso" data-toggle="tab">{% trans "Single Sign-On" %}</a>
-      </li>
-    </ul>
+        {% if CAN_REGISTER %}
+          <li{% if op == "register" %} class="active"{% endif %}>
+            <a href="#register" data-toggle="tab">{% trans "Register" %}</a>
+          </li>
+        {% endif %}
+        <li{% if op == "sso" %} class="active"{% endif %}>
+          <a href="#sso" data-toggle="tab">{% trans "Single Sign-On" %}</a>
+        </li>
+      </ul>
+    {% endif %}
   </div>
   <div class="tab-content">
     <div class="tab-pane{% if op == "login" %} active{% endif %}" id="login">
@@ -113,6 +117,11 @@
 
             <div class="auth-footer m-t-1">
               <button type="submit" class="btn btn-primary">{% trans "Continue" %}</button>
+              {% if is_invite_registration %}
+                <a class="secondary" href="#login" data-toggle="tab">
+                  {% trans "Already have an account? Sign in" %}
+                </a>
+              {% endif %}
               <a class="secondary" href="https://sentry.io/privacy/" target="_blank">
                 {% trans "Privacy Policy" %}
               </a>

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -305,13 +305,21 @@ class AuthLoginView(BaseView):
         Extracts the register form from a request, then formats and returns it.
         """
         op = request.POST.get("op")
-        initial_data = {"username": request.session.get("invite_email", "")}
-        return RegistrationForm(
+        invite_email = request.session.get("invite_email", "")
+        initial_data = {"username": invite_email}
+        form = RegistrationForm(
             request.POST if op == "register" else None,
             initial=initial_data,
             # Custom auto_id to avoid ID collision with AuthenticationForm.
             auto_id="id_registration_%s",
         )
+        if invite_email:
+            # The invited email is the source of truth while accepting an
+            # invite. Disabling (rather than just pre-filling) the field means
+            # Django ignores any submitted value and always uses `initial`,
+            # so the field can't be tampered with client-side.
+            form.fields["username"].disabled = True
+        return form
 
     def handle_new_user_creation(
         self,
@@ -559,6 +567,9 @@ class AuthLoginView(BaseView):
             "show_login_banner": settings.SHOW_LOGIN_BANNER,
             "show_partner_login_banner": request.GET.get("partner") is not None,
             "referrer": request.GET.get("referrer"),
+            # When arriving to register via an org invite, skip the Sign In /
+            # SSO tab chrome and show a single, direct registration form.
+            "is_invite_registration": bool(request.session.get("invite_email")),
         }
         default_context.update(additional_context.run_callbacks(request=request))
         return default_context

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -229,11 +229,8 @@ class AuthLoginView(BaseView):
 
         organization: RpcOrganization | None = kwargs.pop("organization", None)
 
-        # Check `op == "login"` first: registration is allowed for the whole
-        # invite session (can_register), but a user on that same page can
-        # still submit the login form (e.g. via the "Already have an
-        # account? Sign in" link), and that submission must be routed to the
-        # login handler regardless of can_register.
+        # can_register is true for the whole invite session, so check
+        # op == "login" first or a login submit would hit the register handler.
         if op == "login":
             return self.handle_login_form_submit(
                 request=request, organization=organization, **kwargs
@@ -311,19 +308,15 @@ class AuthLoginView(BaseView):
         """
         op = request.POST.get("op")
         invite_email = request.session.get("invite_email", "")
-        initial_data = {"username": invite_email}
         form = RegistrationForm(
             request.POST if op == "register" else None,
-            initial=initial_data,
+            initial={"username": invite_email},
             # Custom auto_id to avoid ID collision with AuthenticationForm.
             auto_id="id_registration_%s",
         )
-        if invite_email:
-            # The invited email is the source of truth while accepting an
-            # invite. Disabling (rather than just pre-filling) the field means
-            # Django ignores any submitted value and always uses `initial`,
-            # so the field can't be tampered with client-side.
-            form.fields["username"].disabled = True
+        # Disabling (not just pre-filling) makes Django use `initial` no
+        # matter what's submitted, so the invited email can't be tampered with.
+        form.fields["username"].disabled = bool(invite_email)
         return form
 
     def handle_new_user_creation(

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -572,8 +572,6 @@ class AuthLoginView(BaseView):
             "show_login_banner": settings.SHOW_LOGIN_BANNER,
             "show_partner_login_banner": request.GET.get("partner") is not None,
             "referrer": request.GET.get("referrer"),
-            # When arriving to register via an org invite, skip the Sign In /
-            # SSO tab chrome and show a single, direct registration form.
             "is_invite_registration": bool(request.session.get("invite_email")),
         }
         default_context.update(additional_context.run_callbacks(request=request))

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -229,16 +229,21 @@ class AuthLoginView(BaseView):
 
         organization: RpcOrganization | None = kwargs.pop("organization", None)
 
-        if self.can_register(request=request):
+        # Check `op == "login"` first: registration is allowed for the whole
+        # invite session (can_register), but a user on that same page can
+        # still submit the login form (e.g. via the "Already have an
+        # account? Sign in" link), and that submission must be routed to the
+        # login handler regardless of can_register.
+        if op == "login":
+            return self.handle_login_form_submit(
+                request=request, organization=organization, **kwargs
+            )
+        elif self.can_register(request=request):
             return self.handle_register_form_submit(
                 request=request, organization=organization, **kwargs
             )
         else:
-            if op != "login":
-                raise BadRequest()
-            return self.handle_login_form_submit(
-                request=request, organization=organization, **kwargs
-            )
+            raise BadRequest()
 
     def redirect_post_to_sso(self, request: HttpRequest) -> HttpResponseRedirect:
         """

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -361,7 +361,50 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert resp.status_code == 200
         assert resp.context["op"] == "register"
         assert resp.context["register_form"].initial["username"] == "foo@example.com"
+        assert resp.context["register_form"].fields["username"].disabled is True
+        assert resp.context["is_invite_registration"] is True
         self.assertTemplateUsed("sentry/login.html")
+        content = resp.content.decode("utf-8")
+        assert "Create your account" in content
+        assert "nav-tabs" not in content
+        assert "Already have an account? Sign in" in content
+
+    def test_register_without_invite_shows_tabs(self) -> None:
+        with self.allow_registration():
+            register_path = reverse("sentry-register")
+            resp = self.client.get(register_path)
+
+        assert resp.status_code == 200
+        assert resp.context["register_form"].fields["username"].disabled is False
+        assert resp.context["is_invite_registration"] is False
+        content = resp.content.decode("utf-8")
+        assert "nav-tabs" in content
+
+    @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_session")
+    def test_register_ignores_tampered_invite_email(self, from_session: mock.MagicMock) -> None:
+        self.session["invite_email"] = "foo@example.com"
+        self.session["can_register"] = True
+        self.save_session()
+
+        self.client.get(self.path)
+
+        invite_helper = mock.Mock(valid_request=True, organization_id=self.organization.id)
+        from_session.return_value = invite_helper
+
+        resp = self.client.post(
+            self.path,
+            {
+                # A tampered/attacker-supplied email should be ignored in
+                # favor of the invite's email since the field is disabled.
+                "username": "attacker@example.com",
+                "password": "foobar",
+                "name": "Foo Bar",
+                "op": "register",
+            },
+        )
+        assert resp.status_code == 302
+        assert User.objects.filter(username="foo@example.com").exists()
+        assert not User.objects.filter(username="attacker@example.com").exists()
 
     @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_session")
     def test_register_accepts_invite(self, from_session: mock.MagicMock) -> None:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -353,6 +353,9 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
 
             assert resp.status_code == 200
             assert resp.context["op"] == "register"
+            assert resp.context["register_form"].fields["username"].disabled is False
+            assert resp.context["is_invite_registration"] is False
+            assert "nav-tabs" in resp.content.decode("utf-8")
             self.assertTemplateUsed("sentry/login.html")
 
     def test_register_prefills_invite_email(self) -> None:
@@ -386,17 +389,6 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert resp.status_code == 200
         assert "_auth_user_id" in self.client.session
         assert not User.objects.filter(username="foo@example.com").exists()
-
-    def test_register_without_invite_shows_tabs(self) -> None:
-        with self.allow_registration():
-            register_path = reverse("sentry-register")
-            resp = self.client.get(register_path)
-
-        assert resp.status_code == 200
-        assert resp.context["register_form"].fields["username"].disabled is False
-        assert resp.context["is_invite_registration"] is False
-        content = resp.content.decode("utf-8")
-        assert "nav-tabs" in content
 
     @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_session")
     def test_register_ignores_tampered_invite_email(self, from_session: mock.MagicMock) -> None:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -410,8 +410,6 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         resp = self.client.post(
             self.path,
             {
-                # A tampered/attacker-supplied email should be ignored in
-                # favor of the invite's email since the field is disabled.
                 "username": "attacker@example.com",
                 "password": "foobar",
                 "name": "Foo Bar",

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -44,6 +44,11 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
     def allow_registration(self):
         return self.options({"auth.allow-registration": True})
 
+    def set_invite_session(self, email: str = "foo@example.com") -> None:
+        self.session["invite_email"] = email
+        self.session["can_register"] = True
+        self.save_session()
+
     def test_renders_correct_template(self) -> None:
         resp = self.client.get(self.path)
 
@@ -351,9 +356,7 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
             self.assertTemplateUsed("sentry/login.html")
 
     def test_register_prefills_invite_email(self) -> None:
-        self.session["invite_email"] = "foo@example.com"
-        self.session["can_register"] = True
-        self.save_session()
+        self.set_invite_session()
 
         register_path = reverse("sentry-register")
         resp = self.client.get(register_path)
@@ -370,9 +373,7 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert "Already have an account? Sign in" in content
 
     def test_login_form_submit_works_during_invite_registration(self) -> None:
-        self.session["invite_email"] = "foo@example.com"
-        self.session["can_register"] = True
-        self.save_session()
+        self.set_invite_session()
 
         # load it once for test cookie
         self.client.get(self.path)
@@ -399,9 +400,7 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
 
     @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_session")
     def test_register_ignores_tampered_invite_email(self, from_session: mock.MagicMock) -> None:
-        self.session["invite_email"] = "foo@example.com"
-        self.session["can_register"] = True
-        self.save_session()
+        self.set_invite_session()
 
         self.client.get(self.path)
 

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -369,6 +369,23 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert "nav-tabs" not in content
         assert "Already have an account? Sign in" in content
 
+    def test_login_form_submit_works_during_invite_registration(self) -> None:
+        self.session["invite_email"] = "foo@example.com"
+        self.session["can_register"] = True
+        self.save_session()
+
+        # load it once for test cookie
+        self.client.get(self.path)
+
+        resp = self.client.post(
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "login"},
+            follow=True,
+        )
+        assert resp.status_code == 200
+        assert "_auth_user_id" in self.client.session
+        assert not User.objects.filter(username="foo@example.com").exists()
+
     def test_register_without_invite_shows_tabs(self) -> None:
         with self.allow_registration():
             register_path = reverse("sentry-register")


### PR DESCRIPTION
## Summary
- Closes part of #121594. When accepting an org invite, the register form pre-filled the invited email but left it fully editable with no indication it was tied to the invite, and still showed the full Sign In / Register / SSO tab picker.
- Disable the email field server-side when registering via an invite (`request.session["invite_email"]`). Django ignores any submitted value for a `disabled` field and always uses `initial`, so this can't be bypassed by editing the DOM.
- Show a single, direct registration form (heading + form only, no tab picker) for the invite flow, with a small "Already have an account? Sign in" link for the case where the invited user already has an account.
- Self-serve/open registration (`auth.allow-registration`) is unaffected — it still shows the full tabbed picker.

## Test plan
- [x] `tests/sentry/web/frontend/test_auth_login.py`: updated the existing invite-prefill test to assert the field is disabled and the tab chrome is hidden; added a test confirming non-invite registration still shows tabs; added a test confirming a tampered/attacker-supplied email in the POST body is ignored in favor of the session's invite email.
- [ ] CI (pytest/mypy/prek) — this environment can reach GitHub but not Sentry's internal PyPI mirror, so these ran against the code by inspection; verify in CI.