### PR TITLE
fix(seer): Fix milestone toast overflow and trim to single action

### DIFF
--- a/static/app/components/core/toast/toast.tsx
+++ b/static/app/components/core/toast/toast.tsx
@@ -32,7 +32,11 @@ export function Toast({indicator, onDismiss, ...props}: ToastProps) {
     >
       <ToastIcon type={indicator.type} />
       <Container padding="lg">
-        <TextOverflow>{indicator.message}</TextOverflow>
+        {typeof indicator.message === 'string' ? (
+          <TextOverflow>{indicator.message}</TextOverflow>
+        ) : (
+          indicator.message
+        )}
       </Container>
       {indicator.options.undo && typeof indicator.options.undo === 'function' ? (
         <Flex align="center" justify="center" padding="0 lg">

--- a/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.spec.tsx
@@ -40,14 +40,13 @@ describe('MilestoneToast', () => {
     });
   });
 
-  it('shows the milestone and the next-action button plus Open Seer', async () => {
+  it('shows the milestone and the next-action button', async () => {
     render(<MilestoneToast run={run()} toMilestone="autofix_code_changes" />, {
       organization,
     });
 
     expect(screen.getByText('SEER-1: Code Generated')).toBeInTheDocument();
     expect(await screen.findByRole('button', {name: 'Draft PR'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
   });
 
   it('omits the action button when the milestone has no next step', () => {
@@ -56,7 +55,6 @@ describe('MilestoneToast', () => {
     });
 
     expect(screen.getByText('SEER-1: Merged')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
   });
 
@@ -70,7 +68,6 @@ describe('MilestoneToast', () => {
     );
 
     expect(screen.getByText('SEER-1: Code Generated')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Draft PR'})).not.toBeInTheDocument();
   });
 

--- a/static/app/views/seerWorkflows/overview/milestoneToast.tsx
+++ b/static/app/views/seerWorkflows/overview/milestoneToast.tsx
@@ -13,7 +13,6 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import {OpenSeerButton} from './openSeerButton';
 import {
   type ActionableSectionKey,
   isActionableSection,
@@ -94,7 +93,6 @@ export function MilestoneToast({
       {isActionableSection(sectionKey) && run.status !== 'processing' && (
         <NextActionButton run={run} sectionKey={sectionKey} />
       )}
-      <OpenSeerButton run={run} size="xs" />
     </Flex>
   );
 }


### PR DESCRIPTION
The Autofix Overview milestone toast had a visible cutoff along its top edge.

The toast's message is a `Flex` containing a `<Text>` plus interactive buttons, but the shared `Toast` component wraps every message in `TextOverflow`, which is meant for plain single-line strings — it forces `overflow: hidden`, `white-space: nowrap`, and a text `line-height`. That clipping is what cut off the taller button content.

This makes two changes:

- **`toast.tsx`**: only wrap plain string messages in `TextOverflow`; rich React content now renders directly (inside the existing padded `Container`) at full height. String toasts keep their ellipsis behavior unchanged.
- **`milestoneToast.tsx`**: remove the extra Open Seer button from the toast, leaving just the milestone label and its single next-action button (e.g. `Draft PR`). `OpenSeerButton` is still used by `issueCard.tsx`.

Specs updated to drop the now-removed Open Seer assertions.

Note: unit tests could not be run locally — `jest.config.ts` currently fails to parse via ts-node in this environment (reproduces on `master` as well), so this was validated with `pnpm run typecheck` (pass) and `pnpm lint:js` (clean). Worth an eyeball in a running browser before merge.