### PR TITLE
fix(api): Reject negative issue snooze conditions

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -70,17 +70,17 @@ class GroupValidator(serializers.Serializer[Group]):
     # These fields are not documented in the API docs. #
     ####################################################
     # These are already covered by the `statusDetails` serializer field.
-    ignoreDuration = serializers.IntegerField()
-    ignoreCount = serializers.IntegerField()
-    ignoreWindow = serializers.IntegerField(max_value=7 * 24 * 60)
-    ignoreUserCount = serializers.IntegerField()
-    ignoreUserWindow = serializers.IntegerField(max_value=7 * 24 * 60)
+    ignoreDuration = serializers.IntegerField(min_value=0)
+    ignoreCount = serializers.IntegerField(min_value=0)
+    ignoreWindow = serializers.IntegerField(min_value=0, max_value=7 * 24 * 60)
+    ignoreUserCount = serializers.IntegerField(min_value=0)
+    ignoreUserWindow = serializers.IntegerField(min_value=0, max_value=7 * 24 * 60)
     # The `inboxDetails`` field is empty.
     inboxDetails = InboxDetailsValidator()
     # The `snooze` field is deprecated.
     # TODO(dcramer): remove in 9.0
     # for the moment, the CLI sends this for any issue update, so allow nulls
-    snoozeDuration = serializers.IntegerField(allow_null=True)
+    snoozeDuration = serializers.IntegerField(allow_null=True, min_value=0)
 
     def validate_assignedTo(self, value: Actor | None) -> Actor | None:
         if not value:

--- a/src/sentry/api/helpers/group_index/validators/status_details.py
+++ b/src/sentry/api/helpers/group_index/validators/status_details.py
@@ -33,20 +33,24 @@ class StatusDetailsValidator(serializers.Serializer[StatusDetailsResult]):
         help_text="The commit data that the issue should use for resolution.", required=False
     )
     ignoreDuration = serializers.IntegerField(
-        help_text="Ignore the issue until for this many minutes."
+        help_text="Ignore the issue until for this many minutes.", min_value=0
     )
     ignoreCount = serializers.IntegerField(
-        help_text="Ignore the issue until it has occurred this many times in `ignoreWindow` minutes."
+        help_text="Ignore the issue until it has occurred this many times in `ignoreWindow` minutes.",
+        min_value=0,
     )
     ignoreWindow = serializers.IntegerField(
         help_text="Ignore the issue until it has occurred `ignoreCount` times in this many minutes. (Max: 1 week)",
+        min_value=0,
         max_value=7 * 24 * 60,
     )
     ignoreUserCount = serializers.IntegerField(
-        help_text="Ignore the issue until it has affected this many users in `ignoreUserWindow` minutes."
+        help_text="Ignore the issue until it has affected this many users in `ignoreUserWindow` minutes.",
+        min_value=0,
     )
     ignoreUserWindow = serializers.IntegerField(
         help_text="Ignore the issue until it has affected `ignoreUserCount` users in this many minutes. (Max: 1 week)",
+        min_value=0,
         max_value=7 * 24 * 60,
     )
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4170,6 +4170,22 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.data["statusDetails"]["ignoreUntil"] == snooze.until
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
 
+    def test_rejects_negative_snooze_count(self) -> None:
+        group = self.create_group(status=GroupStatus.RESOLVED)
+
+        self.login_as(user=self.user)
+
+        self.get_error_response(
+            qs_params={"id": group.id},
+            status="ignored",
+            ignoreCount=-1,
+            status_code=400,
+        )
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.RESOLVED
+        assert not GroupSnooze.objects.filter(group=group).exists()
+
     def test_snooze_user_count(self) -> None:
         for i in range(10):
             event = self.store_event(


### PR DESCRIPTION
Validate both legacy and nested snooze fields before they reach GroupSnooze database constraints.

Fixes SENTRY-5RZC
