### PR TITLE
Prevent API from updating loader version

### DIFF
--- a/src/sentry/core/endpoints/project_key_details.py
+++ b/src/sentry/core/endpoints/project_key_details.py
@@ -26,7 +26,6 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.project_examples import ProjectExamples
 from sentry.apidocs.parameters import GlobalParams, ProjectParams
 from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
-from sentry.loader.browsersdkversion import get_default_sdk_version_for_project
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus
 
@@ -113,7 +112,6 @@ class ProjectKeyDetailsEndpoint(ProjectKeyEndpoint):
         Update various settings for a client key.
         """
         serializer = ProjectKeyPutSerializer(data=request.data, partial=True)
-        default_version = get_default_sdk_version_for_project(project)
 
         if not serializer.is_valid():
             return Response(as_validation_errors(serializer), status=status.HTTP_400_BAD_REQUEST)
@@ -123,9 +121,8 @@ class ProjectKeyDetailsEndpoint(ProjectKeyEndpoint):
             project_key.label = result["name"]
         if not project_key.data:
             project_key.data = {}
-        project_key.data["browserSdkVersion"] = (
-            default_version if not result.get("browserSdkVersion") else result["browserSdkVersion"]
-        )
+        if result.get("browserSdkVersion"):
+            project_key.data["browserSdkVersion"] = result["browserSdkVersion"]
 
         result_dynamic_sdk_options = result.get("dynamicSdkLoaderOptions")
         if result_dynamic_sdk_options:

--- a/tests/sentry/core/endpoints/test_project_key_details.py
+++ b/tests/sentry/core/endpoints/test_project_key_details.py
@@ -163,7 +163,29 @@ class UpdateProjectKeyTest(APITestCase):
         response = self.client.put(url, {})
         assert response.status_code == 200
         key = ProjectKey.objects.get(id=key.id)
-        assert key.data["browserSdkVersion"] == get_default_sdk_version_for_project(project)
+        assert "browserSdkVersion" not in (key.data or {})
+        assert response.data["browserSdkVersion"] == get_default_sdk_version_for_project(project)
+
+    def test_put_without_browser_sdk_version_preserves_existing(self) -> None:
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        key.data = {**(key.data or {}), "browserSdkVersion": "10.x"}
+        key.save()
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-key-details",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+                "key_id": key.public_key,
+            },
+        )
+        response = self.client.put(url, {"name": "hello world"})
+        assert response.status_code == 200
+        key = ProjectKey.objects.get(id=key.id)
+        assert key.label == "hello world"
+        assert key.data["browserSdkVersion"] == "10.x"
+        assert response.data["browserSdkVersion"] == "10.x"
 
     def test_set_browser_sdk_version(self) -> None:
         project = self.create_project()


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/122438

The API endpoints change the JS Loader version to the project's default when it is not explicitly set in the PUT request. This change prevents it.