### PR TITLE
fix(devenv): chain prek hooks under Cursor's dispatcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,12 @@ Use the right AGENTS.md for the area you're working in:
 
 Workflow steering (commit, pre-commit, hybrid cloud, etc.) lives in **skills** (`.agents/skills/`). Attach or read the area `AGENTS.md` when working in that tree. Add or update guidance in the appropriate AGENTS.md or skill—do not duplicate long guidance in editor-specific rule files.
 
+## Cursor Cloud specific instructions
+
+Cloud agent VMs are Linux. The dashboard install script (`devenv --nocoderoot sync`) needs `uv` on `PATH` before sync — devenv no longer installs it, and `brew install uv` is macOS-only. CI uses `astral-sh/setup-uv`; cloud install should do the equivalent.
+
+Cursor sets local `core.hooksPath` to its agent hooks. Do not `git config --unset` that. `devenv sync` prepares prek hook environments without installing git hooks when `core.hooksPath` is already set.
+
 ## Viewer/Organization Context
 
 - Viewer identity is wired through the app via the `ViewerContext` contextvar; use `sentry.viewer_context.get_viewer_context()` instead of explicitly threading org/user identity when the current viewer is in scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Workflow steering (commit, pre-commit, hybrid cloud, etc.) lives in **skills** (
 
 Cloud agent VMs are Linux. The dashboard install script (`devenv --nocoderoot sync`) needs `uv` on `PATH` before sync — devenv no longer installs it, and `brew install uv` is macOS-only. CI uses `astral-sh/setup-uv`; cloud install should do the equivalent.
 
-Cursor sets local `core.hooksPath` to its agent hooks. Do not `git config --unset` that. `devenv sync` prepares prek hook environments without installing git hooks when `core.hooksPath` is already set.
+Cursor sets local `core.hooksPath` to a dispatcher that runs `.git/hooks` first, then Cursor's `*.cursor` hooks (secrets scan, co-author). Do not leave that `hooksPath` unset. `devenv sync` briefly unsets it only so `prek install` can write into `.git/hooks`, then restores Cursor's dispatcher so both hook sets run.
 
 ## Viewer/Organization Context
 

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -176,25 +176,64 @@ exec {binroot}/node-env/bin/pnpm "$@"
     )
 
 
-def git_core_hooks_path(reporoot: str) -> str | None:
+def git_config_get(reporoot: str, key: str) -> str | None:
     try:
-        path = subprocess.check_output(
-            ("git", "config", "--get", "core.hooksPath"),
+        value = subprocess.check_output(
+            ("git", "config", "--get", key),
             cwd=reporoot,
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()
     except subprocess.CalledProcessError:
         return None
-    return path or None
+    return value or None
 
 
-def prek_sync_cmd(reporoot: str) -> tuple[str, ...]:
-    # Cursor Cloud (and similar) own core.hooksPath. `prek install` refuses
-    # to overwrite that; still prepare hook environments so `prek run` works.
-    if git_core_hooks_path(reporoot):
-        return ("prek", "prepare-hooks")
-    return ("prek", "install", "--prepare-hooks", "-f")
+def cursor_agent_hooks_path(reporoot: str) -> str | None:
+    """Return Cursor's core.hooksPath when its dispatcher is installed.
+
+    Cursor Cloud sets core.hooksPath to a dispatcher that runs the original
+    hooks at `.cursor-original-hooks-path` (normally .git/hooks) and then
+    Cursor's own `*.cursor` hooks. We should install prek into .git/hooks so
+    both run — not skip prek install, and not leave core.hooksPath unset.
+    """
+    hooks_path = git_config_get(reporoot, "core.hooksPath")
+    if hooks_path is None:
+        return None
+    original_ptr = os.path.join(hooks_path, ".cursor-original-hooks-path")
+    dispatcher = os.path.join(hooks_path, ".dispatcher")
+    if os.path.isfile(original_ptr) and os.path.isfile(dispatcher):
+        return hooks_path
+    return None
+
+
+class _install_prek_without_cursor_hooks_path:
+    """Temporarily clear local core.hooksPath so `prek install` can write to .git/hooks."""
+
+    def __init__(self, reporoot: str) -> None:
+        self.reporoot = reporoot
+        self._cursor_hooks_path: str | None = None
+
+    def __enter__(self) -> None:
+        self._cursor_hooks_path = cursor_agent_hooks_path(self.reporoot)
+        if self._cursor_hooks_path is None:
+            return
+        print(
+            "Cursor agent hooks detected; installing prek into .git/hooks "
+            "(Cursor's dispatcher will run those, then its own hooks)."
+        )
+        subprocess.check_call(
+            ("git", "config", "--local", "--unset-all", "core.hooksPath"),
+            cwd=self.reporoot,
+        )
+
+    def __exit__(self, *exc: object) -> None:
+        if self._cursor_hooks_path is None:
+            return
+        subprocess.check_call(
+            ("git", "config", "--local", "core.hooksPath", self._cursor_hooks_path),
+            cwd=self.reporoot,
+        )
 
 
 def main(context: dict[str, str]) -> int:
@@ -318,17 +357,18 @@ def main(context: dict[str, str]) -> int:
     ):
         return 1
 
-    if not run_procs(
-        repo,
-        reporoot,
-        venv_dir,
-        (
-            ("prek dependencies", prek_sync_cmd(reporoot), {}),
-            ("fast editable", ("python3", "-m", "tools.fast_editable", "--path", "."), {}),
-        ),
-        verbose,
-    ):
-        return 1
+    with _install_prek_without_cursor_hooks_path(reporoot):
+        if not run_procs(
+            repo,
+            reporoot,
+            venv_dir,
+            (
+                ("prek dependencies", ("prek", "install", "--prepare-hooks", "-f"), {}),
+                ("fast editable", ("python3", "-m", "tools.fast_editable", "--path", "."), {}),
+            ),
+            verbose,
+        ):
+            return 1
 
     # Agent skills are non-fatal — private skill repos may not be accessible in CI
     if os.path.exists(f"{reporoot}/agents.toml") and shutil.which(

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -176,6 +176,27 @@ exec {binroot}/node-env/bin/pnpm "$@"
     )
 
 
+def git_core_hooks_path(reporoot: str) -> str | None:
+    try:
+        path = subprocess.check_output(
+            ("git", "config", "--get", "core.hooksPath"),
+            cwd=reporoot,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return path or None
+
+
+def prek_sync_cmd(reporoot: str) -> tuple[str, ...]:
+    # Cursor Cloud (and similar) own core.hooksPath. `prek install` refuses
+    # to overwrite that; still prepare hook environments so `prek run` works.
+    if git_core_hooks_path(reporoot):
+        return ("prek", "prepare-hooks")
+    return ("prek", "install", "--prepare-hooks", "-f")
+
+
 def main(context: dict[str, str]) -> int:
     repo = context["repo"]
     reporoot = context["reporoot"]
@@ -208,7 +229,11 @@ def main(context: dict[str, str]) -> int:
         os.remove(f"{reporoot}/.devenv/bin/uvx")
 
     if not shutil.which("uv"):
-        print("\n\n\ndevenv is no longer managing uv; please run `brew install uv`.\n\n\n")
+        if constants.DARWIN:
+            hint = "please run `brew install uv`."
+        else:
+            hint = "please install uv (https://docs.astral.sh/uv/getting-started/installation/)."
+        print(f"\n\n\ndevenv is no longer managing uv; {hint}\n\n\n")
         return 1
 
     from devenv.lib import node
@@ -298,7 +323,7 @@ def main(context: dict[str, str]) -> int:
         reporoot,
         venv_dir,
         (
-            ("prek dependencies", ("prek", "install", "--prepare-hooks", "-f"), {}),
+            ("prek dependencies", prek_sync_cmd(reporoot), {}),
             ("fast editable", ("python3", "-m", "tools.fast_editable", "--path", "."), {}),
         ),
         verbose,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`devenv sync` fails on Cursor Cloud with:

```
error: Cowardly refusing to install hooks with `core.hooksPath` set.
```

Cursor Cloud sets local `core.hooksPath` to a dispatcher. That dispatcher is meant to **wrap** repo hooks: it runs `$ORIGINAL_HOOKS_PATH/$HOOK_NAME` (recorded as `/workspace/.git/hooks`) and then Cursor's `*.cursor` hooks (secrets scan, co-author).

Skipping `prek install` entirely would drop sentry's pre-commit/pre-push hooks. Unsetting `core.hooksPath` permanently would drop Cursor's hooks.

## Solution

Only when Cursor's dispatcher is present (`.dispatcher` + `.cursor-original-hooks-path`):

1. Briefly unset local `core.hooksPath` so `prek install --prepare-hooks -f` can write into `.git/hooks`.
2. Restore Cursor's `hooksPath`.

Git then runs Cursor's dispatcher, which runs prek (and post-merge/post-checkout) first, then Cursor's hooks.

Other `core.hooksPath` owners are not special-cased.

Linux missing-`uv` messaging no longer says `brew install uv`. Cloud install still needs `uv` on PATH before `devenv --nocoderoot sync` (dashboard environment script).

## Testing

- Temp git repo with a copied Cursor dispatcher: detection matches, `hooksPath` is unset only inside the context manager, then restored.
- Repo with a non-Cursor `hooksPath`: left alone.
- This workspace still has `core.hooksPath` pointing at the Cursor dispatcher, with original path `/workspace/.git/hooks`.
- `python3 -m py_compile devenv/sync.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b95d0065-43f0-4f44-9006-b127ec439df8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b95d0065-43f0-4f44-9006-b127ec439df8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

