### PR TITLE
fix(deps): Bump js-yaml to patch CPU exhaustion vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3668,8 +3668,8 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+  '@tsconfig/node10@1.0.13':
+    resolution: {integrity: sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==}
 
   '@tsconfig/node12@1.0.11':
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
@@ -6678,12 +6678,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.0:
-    resolution: {integrity: sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.1.1:
@@ -9224,7 +9224,7 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       call-me-maybe: 1.0.2
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
 
   '@apm-js-collab/code-transformer-bundler-plugins@0.7.3':
     dependencies:
@@ -9998,7 +9998,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -12177,7 +12177,7 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
 
-  '@tsconfig/node10@1.0.12':
+  '@tsconfig/node10@1.0.13':
     optional: true
 
   '@tsconfig/node12@1.0.11':
@@ -13376,7 +13376,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -15761,12 +15761,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -15851,7 +15851,7 @@ snapshots:
     dependencies:
       commander: 4.1.1
       graphlib: 2.1.8
-      js-yaml: 3.14.0
+      js-yaml: 3.15.1
       lodash: 4.18.1
       native-promise-only: 0.8.1
       path-loader: 1.0.12
@@ -18336,7 +18336,7 @@ snapshots:
   ts-node@10.9.2(@swc/core@1.15.43)(@types/node@24.13.2)(@typescript/typescript6@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node10': 1.0.13
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4


### PR DESCRIPTION
Re-resolves `js-yaml` in `pnpm-lock.yaml` from 3.14.0 to 3.15.1 and from 4.1.1 to 4.3.1, closing seven open Dependabot alerts.

### Why a lockfile refresh is enough

The interesting part is that no `pnpm.overrides` entry and no upstream package bumps are required. All four transitive consumers already declare caret ranges that permit the patched releases — the vulnerable versions were pinned purely by lockfile inertia, not by any upstream constraint:

| Consumer | Pulled in by | Declared range | Was → Now |
|---|---|---|---|
| `@istanbuljs/load-nyc-config@1.1.0` | jest → babel-plugin-istanbul | `^3.13.1` | 3.14.0 → **3.15.1** |
| `json-refs@3.0.15` | `@sentry-internal/api-docs` | `^3.13.1` | 3.14.0 → **3.15.1** |
| `cosmiconfig@9.0.0` | stylelint | `^4.1.0` | 4.1.1 → **4.3.1** |
| `@apidevtools/json-schema-ref-parser@9.0.9` | api-docs → openapi-examples-validator | `^4.1.0` | 4.1.1 → **4.3.1** |

That matters because `@istanbuljs/load-nyc-config` and `json-refs` are both effectively unmaintained — neither has a newer release to move to, so bumping the dependents was never an option. An override would have worked but is unnecessary maintenance surface.

Produced with `pnpm update js-yaml -r --depth Infinity`.

### Alerts resolved

Covers more than the four that prompted this — the same bump satisfies all seven open `js-yaml` alerts:

- GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870 backport) — alerts 677, 678
- GHSA-52cp-r559-cp3m — YAML merge-key chains force quadratic CPU consumption — alerts 632, 633
- GHSA-h67p-54hq-rp68 — alerts 622, 623
- GHSA-mh29-5h37-fv8m — alert 393

All are dev-scope transitives, so there is no production runtime exposure.

### Verification

Each affected toolchain was exercised against the new resolutions:

- `pnpm install --frozen-lockfile` → exit 0 (what CI runs)
- stylelint (cosmiconfig path) → exit 0
- `pnpm run build-deprecated-docs` (json-refs path) → bundled successfully, no output diff
- jest with `--coverage` (load-nyc-config path) → passing
- Confirmed no symlink anywhere in `node_modules` still points at 3.14.0 or 4.1.1

### Note for reviewers

One incidental hunk rode along with the re-resolve: `@tsconfig/node10` 1.0.12 → 1.0.13, an optional types-only dependency of `ts-node`. Happy to strip it if you would rather keep the security bump surgical.

Fixes VULN-2453