### PR TITLE
ref(preprod): Raise rate limits on the artifact image endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -43,15 +43,17 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
-    # Higher limits than default (40 rps, 25 concurrent) since this proxies images from Objectstore (2.5k rps, 1k concurrent capacity).
-    # Snapshot pages load many images in parallel, so per-user is 200 rps/100 concurrent and per-org is 2k rps/100 concurrent.
+    # Higher limits than default (40 rps, 25 concurrent) since this proxies images from Objectstore.
+    # Snapshot pages load many images in parallel, so per-user is 400 rps/200 concurrent and per-org is 4k rps/200 concurrent.
+    # Objectstore's own ceilings are a percentage of a per-pod global_rps and sit well above these:
+    # https://github.com/getsentry/ops/blob/master/k8s/services/objectstore/_values.yaml
     rate_limits = RateLimitConfig(
         limit_overrides={
             "GET": {
-                RateLimitCategory.IP: RateLimit(limit=200, window=1, concurrent_limit=100),
-                RateLimitCategory.USER: RateLimit(limit=200, window=1, concurrent_limit=100),
+                RateLimitCategory.IP: RateLimit(limit=400, window=1, concurrent_limit=200),
+                RateLimitCategory.USER: RateLimit(limit=400, window=1, concurrent_limit=200),
                 RateLimitCategory.ORGANIZATION: RateLimit(
-                    limit=2000, window=1, concurrent_limit=100
+                    limit=4000, window=1, concurrent_limit=200
                 ),
             }
         }


### PR DESCRIPTION
Snapshot pages fan out many image loads in parallel, and `ProjectPreprodArtifactImageEndpoint`
was hitting its ceilings.

| Category | Before | After |
| --- | --- | --- |
| IP | 200 rps / 100 concurrent | 400 rps / 200 concurrent |
| User | 200 rps / 100 concurrent | 400 rps / 200 concurrent |
| Organization | 2000 rps / 100 concurrent | 4000 rps / 200 concurrent |

This only moves Sentry's app-level limiter. It does not resize Objectstore, web pods, or bandwidth caps.

The existing comment claimed Objectstore was good for "~2.5k rps / 1k concurrent", which is stale against prod config ([`rate_limits` in ops](https://github.com/getsentry/ops/blob/master/k8s/services/objectstore/_values.yaml): `global_rps: 20000` per pod, `usecase_pct: 50`, `scope_pct: 33`). Against the real numbers a per-org cap of 4000 rps is still comfortably under the ~6.6k per-scope ceiling.