### PR TITLE
fix(ai): Assign conversation API to telemetry experience

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -211,7 +211,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.DATA_BROWSING
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):


### PR DESCRIPTION
The AI conversation listing endpoint now reports Telemetry Experience as its owner, matching the related conversation-details endpoint.

Refs TET-2873