### PR TITLE
feat(dynamic-sampling): Add an option to skip the per-org scheduler prevalidation

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/gate.py
+++ b/src/sentry/dynamic_sampling/per_org/gate.py
@@ -4,6 +4,7 @@ from sentry import options
 from sentry.options.rollout import in_rollout_group
 
 KILLSWITCH_OPTION = "dynamic-sampling.per_org.killswitch"
+SKIP_PREVALIDATION_OPTION = "dynamic-sampling.per_org.skip-prevalidation"
 ROLLOUT_RATE_OPTION = "dynamic-sampling.per_org.rollout-rate"
 RECALIBRATION_ROLLOUT_RATE_OPTION = "dynamic-sampling.per_org.recalibration-rollout-rate"
 METRICS_SAMPLE_RATE_OPTION = "dynamic-sampling.per_org.metrics-sample-rate"
@@ -25,6 +26,10 @@ SAMPLE_RATES_SUMMARY_LOG_ROLLOUT_RATE_OPTION = (
 
 def is_killswitch_engaged() -> bool:
     return bool(options.get(KILLSWITCH_OPTION))
+
+
+def is_prevalidation_skipped() -> bool:
+    return bool(options.get(SKIP_PREVALIDATION_OPTION))
 
 
 def rollout_rate() -> float:

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -37,6 +37,7 @@ from sentry.dynamic_sampling.per_org.gate import (
     is_org_in_recalibration_rollout,
     is_org_in_rollout,
     is_org_in_sample_rates_summary_log_rollout,
+    is_prevalidation_skipped,
     sliding_window_comparison_org_ids,
     transaction_volume_debug_project_ids,
 )
@@ -308,7 +309,9 @@ def schedule_per_org_calculations() -> None:
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
-        prevalidate_batch=keep_orgs_with_dynamic_sampling,
+        # Without it every active org occupies a batch and is filtered at dispatch instead,
+        # which is slower per cycle but keeps a slow cycle-start query off the critical path.
+        prevalidate_batch=None if is_prevalidation_skipped() else keep_orgs_with_dynamic_sampling,
         preserve_queryset_order=True,
     )
     scheduler.tick()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2353,6 +2353,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Skips the batched dynamic sampling feature check the per-org scheduler runs at cycle
+# start. The per-item check at dispatch time still runs, so no org without the feature is
+# processed; the orgs it would have filtered out just occupy the cycle's batches instead.
+register(
+    "dynamic-sampling.per_org.skip-prevalidation",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Deterministic % rollout of the per-org dynamic sampling pipeline, keyed on
 # organization id. A value of 0.0 disables the pipeline for every org; 1.0
 # enables it for every org. Intermediate values select a stable hash-based

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -158,6 +158,21 @@ class SchedulePerOrgCalculationsTest(TestCase):
         assert with_dynamic_sampling.id in org_ids
         assert without_dynamic_sampling.id not in org_ids
 
+    @override_options(
+        {
+            "dynamic-sampling.per_org.rollout-rate": 1.0,
+            "dynamic-sampling.per_org.skip-prevalidation": True,
+        }
+    )
+    def test_skip_prevalidation_option_drops_the_batch_check(self) -> None:
+        self.create_project(organization=self.create_organization())
+
+        with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:
+            MockScheduler.return_value.tick.return_value = False
+            schedule_per_org_calculations()
+
+        assert MockScheduler.call_args.kwargs["prevalidate_batch"] is None
+
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_raises_when_the_feature_cannot_be_evaluated(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
- Adds `dynamic-sampling.per_org.skip-prevalidation`, default `False`, automator-modifiable
- When on, the per-org scheduler passes `prevalidate_batch=None`, so the batched `organizations:dynamic-sampling` check never runs at cycle start
- The per-item check at dispatch time still runs, so no org without the feature is processed — the orgs prevalidation would have filtered out just occupy the cycle's batches instead

Contributes to TET-2820