### PR TITLE
feat(dynamic-sampling): cache org feature flags for per-org dynamic sampling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1160,7 +1160,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "schedule": timedelta(seconds=10),
     },
     "dynamic-sampling-cache-dynamic-sampling-feature-flags": {
-        "task": "telemetry-experience:sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
+        "task": "telemetry-experience:sentry.dynamic_sampling.per_org.cache_dynamic_sampling_feature_flags",
         "schedule": crontab("0", "*", "*", "*", "*"),
     },
     "weekly-escalating-forecast": {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1159,7 +1159,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "telemetry-experience:sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
         "schedule": timedelta(seconds=10),
     },
-    "dynamic-sampling-refresh-orgs-with-dynamic-sampling": {
+    "dynamic-sampling-cache-dynamic-sampling-feature-flags": {
         "task": "telemetry-experience:sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
         "schedule": crontab("0", "*", "*", "*", "*"),
     },

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -880,6 +880,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.deletions.tasks.scheduled",
     "sentry.deletions.tasks.seer",
     "sentry.demo_mode.tasks",
+    "sentry.dynamic_sampling.per_org.feature_cache",
     "sentry.dynamic_sampling.per_org.scheduler",
     "sentry.dynamic_sampling.tasks.boost_low_volume_projects",
     "sentry.dynamic_sampling.tasks.boost_low_volume_transactions",
@@ -1157,6 +1158,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     "dynamic-sampling-schedule-per-org-calculations": {
         "task": "telemetry-experience:sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
         "schedule": timedelta(seconds=10),
+    },
+    "dynamic-sampling-refresh-orgs-with-dynamic-sampling": {
+        "task": "telemetry-experience:sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
+        "schedule": crontab("0", "*", "*", "*", "*"),
     },
     "weekly-escalating-forecast": {
         "task": "issues:sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",

--- a/src/sentry/dynamic_sampling/per_org/feature_cache.py
+++ b/src/sentry/dynamic_sampling/per_org/feature_cache.py
@@ -111,7 +111,11 @@ def refresh_orgs_with_dynamic_sampling() -> int:
         orjson.dumps(org_ids),
         ex=int(CACHE_TTL.total_seconds()),
     )
-    metrics.gauge("dynamic_sampling.per_org.feature_cache.size", len(org_ids))
+    metrics.distribution(
+        "dynamic_sampling.per_org.feature_cache.size",
+        len(org_ids),
+        sample_rate=1.0,
+    )
     return len(org_ids)
 
 

--- a/src/sentry/dynamic_sampling/per_org/feature_cache.py
+++ b/src/sentry/dynamic_sampling/per_org/feature_cache.py
@@ -82,6 +82,16 @@ def _orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[i
     return [org.id for org in organizations if results.get(f"organization:{org.id}", False)]
 
 
+@instrumented_task(
+    name="sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
+    namespace=telemetry_experience_tasks,
+    processing_deadline_duration=10 * 60,
+    # A refresh still queued when the next one is due would write an older answer over a
+    # newer one. Drop it and let the next run rebuild the entry.
+    expires=REFRESH_INTERVAL,
+    retry=Retry(times=2, delay=30),
+    silo_mode=SiloMode.CELL,
+)
 def refresh_orgs_with_dynamic_sampling() -> int:
     """
     Evaluate the dynamic sampling feature for every candidate organization and cache the
@@ -117,17 +127,3 @@ def refresh_orgs_with_dynamic_sampling() -> int:
         sample_rate=1.0,
     )
     return len(org_ids)
-
-
-@instrumented_task(
-    name="sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
-    namespace=telemetry_experience_tasks,
-    processing_deadline_duration=10 * 60,
-    # A refresh still queued when the next one is due would write an older answer over a
-    # newer one. Drop it and let the next run rebuild the entry.
-    expires=REFRESH_INTERVAL,
-    retry=Retry(times=2, delay=30),
-    silo_mode=SiloMode.CELL,
-)
-def refresh_orgs_with_dynamic_sampling_task() -> None:
-    refresh_orgs_with_dynamic_sampling()

--- a/src/sentry/dynamic_sampling/per_org/feature_cache.py
+++ b/src/sentry/dynamic_sampling/per_org/feature_cache.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import timedelta
+
+import orjson
+import sentry_sdk
+from django.db.models import Exists, OuterRef, QuerySet
+from taskbroker_client.retry import Retry
+
+from sentry import features
+from sentry.constants import ObjectStatus
+from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
+from sentry.dynamic_sampling.utils import DYNAMIC_SAMPLING_FEATURE
+from sentry.models.organization import Organization, OrganizationStatus
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import telemetry_experience_tasks
+from sentry.utils import metrics
+from sentry.utils.iterators import chunked
+from sentry.utils.query import RangeQuerySetWrapper
+
+logger = logging.getLogger(__name__)
+
+ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY = "ds::per_org:orgs_with_dynamic_sampling"
+# Long enough that an hourly refresh can fail for most of a day before the scheduler
+# loses its filter, short enough that an abandoned key does not outlive the pipeline.
+CACHE_TTL = timedelta(hours=24)
+REFRESH_INTERVAL = timedelta(hours=1)
+# How many organizations one feature-flag batch and one database page cover.
+CHUNK_SIZE = 10_000
+
+
+def candidate_organizations() -> QuerySet[Organization]:
+    """
+    Every organization the per-org pipeline could schedule, before any feature check.
+
+    The single definition of the population, so the cache is built from the same rows the
+    scheduler filters. A mismatch here would silently drop organizations from the pipeline.
+    """
+    return Organization.objects.filter(
+        Exists(
+            Project.objects.filter(
+                organization_id=OuterRef("pk"),
+                status=ObjectStatus.ACTIVE,
+            )
+        ),
+        status=OrganizationStatus.ACTIVE,
+    )
+
+
+def get_orgs_with_dynamic_sampling() -> list[int] | None:
+    """
+    The cached organization ids that have dynamic sampling, or None when there is no
+    usable cache entry.
+
+    None means "unknown", not "none of them". Callers must fall back to the unfiltered
+    population, because a cold cache would otherwise stop the pipeline entirely.
+    """
+    try:
+        cached = get_redis_client_for_ds().get(ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY)
+        org_ids = None if cached is None else [int(org_id) for org_id in orjson.loads(cached)]
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
+        org_ids = None
+
+    metrics.incr(
+        "dynamic_sampling.per_org.feature_cache.read",
+        tags={"result": "miss" if org_ids is None else "hit"},
+    )
+    return org_ids
+
+
+def _orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[int]:
+    # A None result means the check failed, which would otherwise read as "none of them".
+    results = features.batch_has_for_organizations(DYNAMIC_SAMPLING_FEATURE, organizations)
+    if results is None:
+        raise RuntimeError(f"Unable to evaluate {DYNAMIC_SAMPLING_FEATURE} for a batch of orgs")
+
+    return [org.id for org in organizations if results.get(f"organization:{org.id}", False)]
+
+
+def refresh_orgs_with_dynamic_sampling() -> int:
+    """
+    Evaluate the dynamic sampling feature for every candidate organization and cache the
+    ids that have it. Returns how many were cached.
+
+    An empty result leaves the previous entry in place. Every candidate losing the feature
+    within one hour means the feature backend is answering wrongly, and serving that answer
+    would stop the pipeline for everyone until the next successful refresh.
+    """
+    org_ids: list[int] = []
+    for organizations in chunked(
+        RangeQuerySetWrapper[Organization](candidate_organizations(), step=CHUNK_SIZE),
+        CHUNK_SIZE,
+    ):
+        org_ids.extend(_orgs_with_dynamic_sampling(organizations))
+
+    if not org_ids:
+        logger.warning(
+            "dynamic_sampling.per_org.feature_cache.empty_refresh",
+            extra={"feature": DYNAMIC_SAMPLING_FEATURE},
+        )
+        metrics.incr("dynamic_sampling.per_org.feature_cache.empty_refresh")
+        return 0
+
+    get_redis_client_for_ds().set(
+        ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY,
+        orjson.dumps(org_ids),
+        ex=int(CACHE_TTL.total_seconds()),
+    )
+    metrics.gauge("dynamic_sampling.per_org.feature_cache.size", len(org_ids))
+    return len(org_ids)
+
+
+@instrumented_task(
+    name="sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
+    namespace=telemetry_experience_tasks,
+    processing_deadline_duration=10 * 60,
+    # A refresh still queued when the next one is due would write an older answer over a
+    # newer one. Drop it and let the next run rebuild the entry.
+    expires=REFRESH_INTERVAL,
+    retry=Retry(times=2, delay=30),
+    silo_mode=SiloMode.CELL,
+)
+def refresh_orgs_with_dynamic_sampling_task() -> None:
+    refresh_orgs_with_dynamic_sampling()

--- a/src/sentry/dynamic_sampling/per_org/feature_cache.py
+++ b/src/sentry/dynamic_sampling/per_org/feature_cache.py
@@ -29,14 +29,11 @@ ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY = "ds::per_org:orgs_with_dynamic_sampling"
 # loses its filter, short enough that an abandoned key does not outlive the pipeline.
 CACHE_TTL = timedelta(hours=24)
 REFRESH_INTERVAL = timedelta(hours=1)
-# How many organizations one feature-flag batch and one database page cover.
 CHUNK_SIZE = 10_000
 
 
 def candidate_organizations() -> QuerySet[Organization]:
     """
-    Every organization the per-org pipeline could schedule, before any feature check.
-
     The single definition of the population, so the cache is built from the same rows the
     scheduler filters. A mismatch here would silently drop organizations from the pipeline.
     """
@@ -53,9 +50,6 @@ def candidate_organizations() -> QuerySet[Organization]:
 
 def get_orgs_with_dynamic_sampling() -> list[int] | None:
     """
-    The cached organization ids that have dynamic sampling, or None when there is no
-    usable cache entry.
-
     None means "unknown", not "none of them". Callers must fall back to the unfiltered
     population, because a cold cache would otherwise stop the pipeline entirely.
     """
@@ -83,7 +77,7 @@ def _orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[i
 
 
 @instrumented_task(
-    name="sentry.dynamic_sampling.per_org.refresh_orgs_with_dynamic_sampling",
+    name="sentry.dynamic_sampling.per_org.cache_dynamic_sampling_feature_flags",
     namespace=telemetry_experience_tasks,
     processing_deadline_duration=10 * 60,
     # A refresh still queued when the next one is due would write an older answer over a
@@ -92,11 +86,8 @@ def _orgs_with_dynamic_sampling(organizations: Sequence[Organization]) -> list[i
     retry=Retry(times=2, delay=30),
     silo_mode=SiloMode.CELL,
 )
-def refresh_orgs_with_dynamic_sampling() -> int:
+def cache_dynamic_sampling_feature_flags() -> int:
     """
-    Evaluate the dynamic sampling feature for every candidate organization and cache the
-    ids that have it. Returns how many were cached.
-
     An empty result leaves the previous entry in place. Every candidate losing the feature
     within one hour means the feature backend is answering wrongly, and serving that answer
     would stop the pipeline for everyone until the next successful refresh.

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -5,12 +5,11 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
 import sentry_sdk
-from django.db.models import Exists, F, OuterRef
+from django.db.models import F
 from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
 from sentry import features
-from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.calculations import (
     apply_project_sample_rate_overrides,
@@ -32,6 +31,10 @@ from sentry.dynamic_sampling.per_org.configuration import (
     BaseDynamicSamplingConfiguration,
     ProjectSampleRates,
     get_configuration,
+)
+from sentry.dynamic_sampling.per_org.feature_cache import (
+    candidate_organizations,
+    get_orgs_with_dynamic_sampling,
 )
 from sentry.dynamic_sampling.per_org.gate import (
     is_org_in_recalibration_rollout,
@@ -57,8 +60,7 @@ from sentry.dynamic_sampling.per_org.telemetry import (
 from sentry.dynamic_sampling.rules.utils import OrganizationId
 from sentry.dynamic_sampling.tasks.common import get_organization_volume
 from sentry.dynamic_sampling.utils import DYNAMIC_SAMPLING_FEATURE
-from sentry.models.organization import Organization, OrganizationStatus
-from sentry.models.project import Project
+from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import telemetry_experience_tasks
@@ -291,20 +293,20 @@ def schedule_per_org_calculations() -> None:
         )
         return kept
 
+    organizations = candidate_organizations()
+    # None means the cache has no usable entry, not that no org has the feature. Falling
+    # back to the full population keeps the pipeline running on a cold cache; the per-item
+    # check still rejects any org that does not qualify.
+    orgs_with_dynamic_sampling = get_orgs_with_dynamic_sampling()
+    if orgs_with_dynamic_sampling is not None:
+        organizations = organizations.filter(id__in=orgs_with_dynamic_sampling)
+
     scheduler = CursoredScheduler(
         name="ds_per_org",
         schedule_key="dynamic-sampling-schedule-per-org-calculations",
-        queryset=Organization.objects.filter(
-            Exists(
-                Project.objects.filter(
-                    organization_id=OuterRef("pk"),
-                    status=ObjectStatus.ACTIVE,
-                )
-            ),
-            status=OrganizationStatus.ACTIVE,
-        )
-        .annotate(_order_bucket=Mod(F("id"), 10))
-        .order_by("_order_bucket", "id"),
+        queryset=organizations.annotate(_order_bucket=Mod(F("id"), 10)).order_by(
+            "_order_bucket", "id"
+        ),
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -5,8 +5,6 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
 import sentry_sdk
-from django.db.models import F
-from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
 from sentry import features
@@ -304,14 +302,11 @@ def schedule_per_org_calculations() -> None:
     scheduler = CursoredScheduler(
         name="ds_per_org",
         schedule_key="dynamic-sampling-schedule-per-org-calculations",
-        queryset=organizations.annotate(_order_bucket=Mod(F("id"), 10)).order_by(
-            "_order_bucket", "id"
-        ),
+        queryset=organizations,
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
         prevalidate_batch=keep_orgs_with_dynamic_sampling,
-        preserve_queryset_order=True,
     )
     scheduler.tick()
 

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -292,9 +292,8 @@ def schedule_per_org_calculations() -> None:
         return kept
 
     organizations = candidate_organizations()
-    # None means the cache has no usable entry, not that no org has the feature. Falling
-    # back to the full population keeps the pipeline running on a cold cache; the per-item
-    # check still rejects any org that does not qualify.
+    # A cold cache reads as None, and falling back to the full population keeps the
+    # pipeline running. The per-item check still rejects any org that does not qualify.
     orgs_with_dynamic_sampling = get_orgs_with_dynamic_sampling()
     if orgs_with_dynamic_sampling is not None:
         organizations = organizations.filter(id__in=orgs_with_dynamic_sampling)

--- a/tests/sentry/dynamic_sampling/per_org/test_feature_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_feature_cache.py
@@ -1,0 +1,101 @@
+from unittest.mock import patch
+
+import orjson
+import pytest
+
+from sentry.constants import ObjectStatus
+from sentry.dynamic_sampling.per_org.feature_cache import (
+    ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY,
+    candidate_organizations,
+    get_orgs_with_dynamic_sampling,
+    refresh_orgs_with_dynamic_sampling,
+)
+from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
+from sentry.models.organization import OrganizationStatus
+from sentry.testutils.cases import TestCase
+
+FEATURE = "organizations:dynamic-sampling"
+
+
+class FeatureCacheTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        get_redis_client_for_ds().delete(ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY)
+
+    def _org_with_project(self):
+        org = self.create_organization()
+        self.create_project(organization=org)
+        return org
+
+    def test_candidate_organizations_needs_an_active_org_and_project(self) -> None:
+        with_project = self._org_with_project()
+        without_projects = self.create_organization()
+
+        inactive_org = self._org_with_project()
+        inactive_org.status = OrganizationStatus.PENDING_DELETION
+        inactive_org.save()
+
+        with_inactive_project = self.create_organization()
+        project = self.create_project(organization=with_inactive_project)
+        project.status = ObjectStatus.PENDING_DELETION
+        project.save()
+
+        org_ids = set(candidate_organizations().values_list("id", flat=True))
+
+        assert with_project.id in org_ids
+        assert without_projects.id not in org_ids
+        assert inactive_org.id not in org_ids
+        assert with_inactive_project.id not in org_ids
+
+    def test_refresh_caches_only_orgs_with_the_feature(self) -> None:
+        with_feature = self._org_with_project()
+        without_feature = self._org_with_project()
+
+        with self.feature({FEATURE: [with_feature.slug]}):
+            assert refresh_orgs_with_dynamic_sampling() == 1
+
+        assert get_orgs_with_dynamic_sampling() == [with_feature.id]
+        assert without_feature.id not in (get_orgs_with_dynamic_sampling() or [])
+
+    def test_refresh_sets_the_ttl(self) -> None:
+        org = self._org_with_project()
+
+        with self.feature({FEATURE: [org.slug]}):
+            refresh_orgs_with_dynamic_sampling()
+
+        ttl = get_redis_client_for_ds().ttl(ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY)
+        assert 0 < ttl <= 24 * 60 * 60
+
+    def test_an_empty_refresh_keeps_the_previous_entry(self) -> None:
+        org = self._org_with_project()
+        with self.feature({FEATURE: [org.slug]}):
+            refresh_orgs_with_dynamic_sampling()
+
+        with self.feature({FEATURE: []}):
+            assert refresh_orgs_with_dynamic_sampling() == 0
+
+        assert get_orgs_with_dynamic_sampling() == [org.id]
+
+    def test_refresh_raises_when_the_feature_cannot_be_evaluated(self) -> None:
+        self._org_with_project()
+
+        with (
+            patch("sentry.features.batch_has_for_organizations", return_value=None),
+            pytest.raises(RuntimeError),
+        ):
+            refresh_orgs_with_dynamic_sampling()
+
+    def test_a_missing_entry_reads_as_unknown(self) -> None:
+        assert get_orgs_with_dynamic_sampling() is None
+
+    def test_unreadable_entry_reads_as_unknown(self) -> None:
+        get_redis_client_for_ds().set(ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY, "not json")
+
+        assert get_orgs_with_dynamic_sampling() is None
+
+    def test_reads_back_what_the_refresh_wrote(self) -> None:
+        get_redis_client_for_ds().set(
+            ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY, orjson.dumps([11, 22, 33])
+        )
+
+        assert get_orgs_with_dynamic_sampling() == [11, 22, 33]

--- a/tests/sentry/dynamic_sampling/per_org/test_feature_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_feature_cache.py
@@ -6,9 +6,9 @@ import pytest
 from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.per_org.feature_cache import (
     ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY,
+    cache_dynamic_sampling_feature_flags,
     candidate_organizations,
     get_orgs_with_dynamic_sampling,
-    refresh_orgs_with_dynamic_sampling,
 )
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.models.organization import OrganizationStatus
@@ -52,7 +52,7 @@ class FeatureCacheTest(TestCase):
         without_feature = self._org_with_project()
 
         with self.feature({FEATURE: [with_feature.slug]}):
-            assert refresh_orgs_with_dynamic_sampling() == 1
+            assert cache_dynamic_sampling_feature_flags() == 1
 
         assert get_orgs_with_dynamic_sampling() == [with_feature.id]
         assert without_feature.id not in (get_orgs_with_dynamic_sampling() or [])
@@ -61,7 +61,7 @@ class FeatureCacheTest(TestCase):
         org = self._org_with_project()
 
         with self.feature({FEATURE: [org.slug]}):
-            refresh_orgs_with_dynamic_sampling()
+            cache_dynamic_sampling_feature_flags()
 
         ttl = get_redis_client_for_ds().ttl(ORGS_WITH_DYNAMIC_SAMPLING_CACHE_KEY)
         assert 0 < ttl <= 24 * 60 * 60
@@ -69,10 +69,10 @@ class FeatureCacheTest(TestCase):
     def test_an_empty_refresh_keeps_the_previous_entry(self) -> None:
         org = self._org_with_project()
         with self.feature({FEATURE: [org.slug]}):
-            refresh_orgs_with_dynamic_sampling()
+            cache_dynamic_sampling_feature_flags()
 
         with self.feature({FEATURE: []}):
-            assert refresh_orgs_with_dynamic_sampling() == 0
+            assert cache_dynamic_sampling_feature_flags() == 0
 
         assert get_orgs_with_dynamic_sampling() == [org.id]
 
@@ -83,7 +83,7 @@ class FeatureCacheTest(TestCase):
             patch("sentry.features.batch_has_for_organizations", return_value=None),
             pytest.raises(RuntimeError),
         ):
-            refresh_orgs_with_dynamic_sampling()
+            cache_dynamic_sampling_feature_flags()
 
     def test_a_missing_entry_reads_as_unknown(self) -> None:
         assert get_orgs_with_dynamic_sampling() is None

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -136,6 +136,48 @@ class SchedulePerOrgCalculationsTest(TestCase):
         assert org_without_projects.id not in org_ids
         assert org_with_inactive_project.id not in org_ids
 
+    def _scheduled_org_ids(self) -> set[int]:
+        """The organizations the scheduler's queryset would page through."""
+        with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:
+            MockScheduler.return_value.tick.return_value = False
+            schedule_per_org_calculations()
+
+            queryset = MockScheduler.call_args.kwargs["queryset"]
+            return set(queryset.values_list("id", flat=True))
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_queryset_is_filtered_by_the_cached_orgs(self) -> None:
+        cached = self.create_organization()
+        self.create_project(organization=cached)
+        uncached = self.create_organization()
+        self.create_project(organization=uncached)
+
+        with patch(f"{SCHEDULER}.get_orgs_with_dynamic_sampling", return_value=[cached.id]):
+            org_ids = self._scheduled_org_ids()
+
+        assert cached.id in org_ids
+        assert uncached.id not in org_ids
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_a_cold_cache_falls_back_to_every_candidate_org(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with patch(f"{SCHEDULER}.get_orgs_with_dynamic_sampling", return_value=None):
+            org_ids = self._scheduled_org_ids()
+
+        assert org.id in org_ids
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_an_empty_cached_set_schedules_nothing(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with patch(f"{SCHEDULER}.get_orgs_with_dynamic_sampling", return_value=[]):
+            org_ids = self._scheduled_org_ids()
+
+        assert org_ids == set()
+
     def _prevalidated_org_ids(self) -> set[int]:
         """Run the real prevalidate_batch callback over every org in the queryset."""
         with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:


### PR DESCRIPTION
- Adds an hourly task that evaluates `organizations:dynamic-sampling` for every org in chunks of 10,000 and caches the matching ids in Redis for 24 hours
- The per-org scheduler filters its queryset with `id__in` on that cached set
- If the cache is empty, the scheduler falls back to the original every-ten-minutes query
- Also remove the ordering of the queryset by modulo on purpose - this is solved by the prevalidation

Contributes to TET-2820