### PR TITLE
chore(autofix): Use bash tools flag to enable repo checks

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -611,9 +611,7 @@ def trigger_autofix_agent(
         group,
         user_context,
         run_state=run_state,
-        should_run_repo_checks=features.has(
-            "organizations:autofix-should-run-repo-checks", group.organization
-        ),
+        should_run_repo_checks=enable_bash_tools,
     )
     prompt_metadata = {
         "step": step.value,

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -581,6 +581,12 @@ def trigger_autofix_agent(
     ) or features.has("organizations:autofix-pr-iteration-manual", group.organization)
     is_iteration_step = step == AutofixStep.PR_ITERATION
 
+    # If autofix-should-run-repo-checks is enabled,
+    # we should force bash tools on as it is dependent on bash tools
+    enable_bash_tools = enable_bash_tools or features.has(
+        "organizations:autofix-should-run-repo-checks", group.organization
+    )
+
     client = get_autofix_agent_client(
         group,
         enable_bash_tools=enable_bash_tools,


### PR DESCRIPTION
Consolidate the 2 flags as repo checks require bash tools and we always want repo checks when bash tools are enabled.