### PR TITLE
feat(inbound-filters): Offer the catch-all data type in the custom filters UI

### DIFF
--- a/static/app/views/settings/project/projectFilters/customFilters.tsx
+++ b/static/app/views/settings/project/projectFilters/customFilters.tsx
@@ -60,6 +60,7 @@ type CustomInboundFilterCondition = {
 type CustomInboundFilter = {
   active: boolean;
   conditions: CustomInboundFilterCondition[];
+  dataType: FilterDataType;
   dateCreated: string;
   dateUpdated: string;
   id: string;
@@ -68,10 +69,11 @@ type CustomInboundFilter = {
 
 type PropertyOption = {label: string; value: ConditionType};
 
-// The data type a filter applies to. The backend rejects a filter that mixes
-// data types, so a filter targets exactly one, which determines the condition
-// properties available to it. `DATA_TYPES` below describes each one.
-type FilterDataType = 'error' | 'metric' | 'log';
+// The data a filter matches against, stored on the filter itself. It decides which
+// condition properties the filter can use. `all` is the catch-all: it matches every
+// data type, so it takes only the properties every data type carries a field for.
+// `DATA_TYPES` below describes each one.
+type FilterDataType = 'all' | 'error' | 'metric' | 'log';
 
 type DataTypeOption = {label: string; value: FilterDataType};
 
@@ -93,11 +95,14 @@ type DataTypeSpec = {
   label: string;
   // Ingestion feature the org needs before the API accepts a filter on this data
   // type. Offering a data type without it lets the user build a filter the API
-  // rejects on save, so mirror the gating here.
+  // rejects on save, so mirror the gating here. The catch-all needs none: it filters
+  // whichever data types the organization does ingest.
   feature?: string;
 };
 
+// Declaration order is the order of the data type dropdown.
 const DATA_TYPES: Record<FilterDataType, DataTypeSpec> = {
+  all: {label: t('All Data Types')},
   error: {label: t('Errors')},
   metric: {label: t('Metrics'), feature: 'tracemetrics-ingestion'},
   log: {label: t('Logs'), feature: 'ourlogs-ingestion'},
@@ -149,6 +154,7 @@ const CONDITIONS: Record<ConditionType, ConditionSpec> = {
     label: t('Release'),
     placeholder: t('Glob pattern, e.g. 2.41.*'),
     description: {
+      all: t('Matches the release of any data type.'),
       error: t('Matches the release of the error.'),
       log: t('Matches the release attribute of the log.'),
       metric: t('Matches the release attribute of the metric.'),
@@ -177,7 +183,8 @@ function getCondition(property: string): ConditionSpec {
   );
 }
 
-// A data type offers the conditions that read its own fields, plus `release`.
+// A data type offers the conditions that read its own fields, plus the ones every
+// data type carries. The catch-all offers only the latter.
 function getPropertyOptions(dataType: FilterDataType): PropertyOption[] {
   return CONDITION_TYPES.filter(value => {
     const owner = getCondition(value).dataType;
@@ -186,12 +193,13 @@ function getPropertyOptions(dataType: FilterDataType): PropertyOption[] {
 }
 
 // The property a new condition row starts with, and the one existing rows
-// collapse to when the user changes the data type. Every data type owns at least
-// one condition; errors stand in if that ever stops holding.
+// collapse to when the user changes the data type. The catch-all owns no condition
+// of its own, so it falls back to the first one every data type carries.
 function getDefaultProperty(dataType: FilterDataType): ConditionType {
   return (
     CONDITION_TYPES.find(value => getCondition(value).dataType === dataType) ??
-    'error_message'
+    CONDITION_TYPES.find(value => getCondition(value).dataType === undefined) ??
+    'release'
   );
 }
 
@@ -224,17 +232,11 @@ const filterSchema = z.object({
 });
 
 // Expand the API's per-condition value lists into one editable row per value.
-// The data type is not stored on the filter; every condition property except
-// `release` belongs to one data type, so derive it (release-only filters
-// default to errors).
 function filterToFormValues(filter: CustomInboundFilter): FilterFormValues {
   const conditions = filter.conditions.flatMap(condition =>
     condition.value.map(value => ({property: condition.type, value}))
   );
-  const dataType =
-    conditions
-      .map(condition => getCondition(condition.property).dataType)
-      .find(Boolean) ?? 'error';
+  const {dataType} = filter;
   return {
     name: filter.name ?? '',
     dataType,
@@ -357,7 +359,7 @@ function CustomFilterModal({
       </Header>
       <Body>
         <Stack gap="xl">
-          <Grid columns="4fr 1fr" gap="md">
+          <Grid columns="3fr minmax(180px, 1fr)" gap="md">
             <form.AppField name="name">
               {field => (
                 <field.Layout.Stack label={t('Name')} required>
@@ -406,6 +408,13 @@ function CustomFilterModal({
                   const conditions = conditionsField.state.value;
                   return (
                     <Stack gap="lg">
+                      {dataType === 'all' && (
+                        <Text variant="muted" size="sm">
+                          {t(
+                            'This filter applies to every data type Sentry ingests, including ones added later. Only conditions that every data type carries are available.'
+                          )}
+                        </Text>
+                      )}
                       <Stack gap="sm">
                         {conditions.map((condition, index) => (
                           <Grid
@@ -510,11 +519,20 @@ const CHART_HEADROOM = 1.3;
 // it, and keep the right edge clear for the mark line label.
 const CHART_GRID = {top: 6, bottom: 6, left: 0, right: 25, containLabel: false};
 
-// The categories a custom filter drops data in, one per data type the backend
-// accepts. `error` covers default and security events too, which the stats endpoint
-// folds into it. Byte categories, such as `log_byte`, report the same data a second
-// time in bytes, so counting them would multiply what a filter dropped.
-const STATS_CATEGORIES = ['error', 'log_item', 'trace_metric'];
+// The categories a custom filter drops data in. `error` covers default and security
+// events too, which the stats endpoint folds into it. Transactions, replays, and
+// profile chunks are here because Relay reads an error's release field on those as
+// well, so a release condition drops them alongside errors. Byte categories, such as
+// `log_byte`, report the same data a second time in bytes, so counting them would
+// multiply what a filter dropped.
+const STATS_CATEGORIES = [
+  'error',
+  'transaction',
+  'replay',
+  'profile_chunk',
+  'log_item',
+  'trace_metric',
+];
 
 // A custom filter reports under this reason in ingest outcomes, followed by its id.
 // The backend builds the same string when it sends the filter to Relay.
@@ -702,6 +720,7 @@ function matchesQuery(filter: CustomInboundFilter, query: string) {
   }
   const haystack = [
     filter.name ?? '',
+    DATA_TYPES[filter.dataType]?.label ?? filter.dataType,
     ...filter.conditions.flatMap(condition =>
       condition.value.flatMap(value => [
         value,
@@ -789,6 +808,7 @@ export function CustomFilters({project}: {project: Project}) {
         url: listUrl,
         data: {
           name: values.name.trim(),
+          dataType: values.dataType,
           conditions: formValuesToConditions(values),
         },
       }),
@@ -806,7 +826,9 @@ export function CustomFilters({project}: {project: Project}) {
       id,
       data,
     }: {
-      data: Partial<Pick<CustomInboundFilter, 'name' | 'active' | 'conditions'>>;
+      data: Partial<
+        Pick<CustomInboundFilter, 'name' | 'active' | 'dataType' | 'conditions'>
+      >;
       id: string;
     }) =>
       fetchMutation<CustomInboundFilter>({
@@ -842,6 +864,7 @@ export function CustomFilters({project}: {project: Project}) {
       id,
       data: {
         name: values.name.trim(),
+        dataType: values.dataType,
         conditions: formValuesToConditions(values),
       },
     });
@@ -910,6 +933,9 @@ export function CustomFilters({project}: {project: Project}) {
               </SimpleTable.HeaderCell>
               <SimpleTable.HeaderCell divider={false}>{t('Name')}</SimpleTable.HeaderCell>
               <SimpleTable.HeaderCell divider={false}>
+                {t('Data Type')}
+              </SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell divider={false}>
                 {t('Conditions')}
               </SimpleTable.HeaderCell>
               <SimpleTable.HeaderCell divider={false} data-column-name="trend">
@@ -950,6 +976,11 @@ export function CustomFilters({project}: {project: Project}) {
                 </SimpleTable.RowCell>
                 <SimpleTable.RowCell>
                   <Text ellipsis>{filter.name}</Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  <Text ellipsis variant="muted">
+                    {DATA_TYPES[filter.dataType]?.label ?? filter.dataType}
+                  </Text>
                 </SimpleTable.RowCell>
                 <SimpleTable.RowCell>
                   <Stack align="start" gap="xs">
@@ -1028,7 +1059,7 @@ export function CustomFilters({project}: {project: Project}) {
 // width. The dates need the most room, so they go first as the table narrows, then
 // the trend, then the total.
 const CustomFiltersTable = styled(SimpleTable)`
-  grid-template-columns: 90px minmax(160px, 1fr) minmax(240px, 2fr) 110px;
+  grid-template-columns: 90px minmax(160px, 1fr) 120px minmax(240px, 2fr) 110px;
   overflow-x: auto;
 
   [data-column-name='trend'],
@@ -1039,7 +1070,7 @@ const CustomFiltersTable = styled(SimpleTable)`
   }
 
   @container (min-width: ${p => p.theme.container['2xl']}) {
-    grid-template-columns: 90px minmax(160px, 1fr) minmax(240px, 2fr) 90px 110px;
+    grid-template-columns: 90px minmax(160px, 1fr) 120px minmax(240px, 2fr) 90px 110px;
 
     [data-column-name='filtered'] {
       display: flex;
@@ -1048,7 +1079,7 @@ const CustomFiltersTable = styled(SimpleTable)`
 
   @container (min-width: ${p => p.theme.container['3xl']}) {
     grid-template-columns:
-      90px minmax(160px, 1fr) minmax(240px, 2fr) 190px 90px
+      90px minmax(160px, 1fr) 120px minmax(240px, 2fr) 190px 90px
       110px;
 
     [data-column-name='trend'] {
@@ -1058,7 +1089,7 @@ const CustomFiltersTable = styled(SimpleTable)`
 
   @container (min-width: ${p => p.theme.container['4xl']}) {
     grid-template-columns:
-      90px minmax(160px, 1fr) minmax(240px, 2fr) 190px 90px
+      90px minmax(160px, 1fr) 120px minmax(240px, 2fr) 190px 90px
       90px 90px 110px;
 
     [data-column-name='created'],

--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -10,6 +10,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -55,6 +56,7 @@ describe('ProjectFilters', () => {
   type CustomInboundFilter = {
     active: boolean;
     conditions: Array<{type: string; value: string[]}>;
+    dataType: string;
     dateCreated: string;
     dateUpdated: string;
     id: string;
@@ -68,6 +70,7 @@ describe('ProjectFilters', () => {
       id: '1',
       name: 'A filter',
       active: true,
+      dataType: 'error',
       conditions: [{type: 'error_message', value: ['*Error*']}],
       dateCreated: '2024-01-01T00:00:00Z',
       dateUpdated: '2024-01-01T00:00:00Z',
@@ -545,7 +548,14 @@ describe('ProjectFilters', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           outcome: 'filtered',
-          category: ['error', 'log_item', 'trace_metric'],
+          category: [
+            'error',
+            'transaction',
+            'replay',
+            'profile_chunk',
+            'log_item',
+            'trace_metric',
+          ],
           groupBy: ['reason', 'category'],
         }),
       })
@@ -641,6 +651,7 @@ describe('ProjectFilters', () => {
           method: 'POST',
           data: {
             name: 'Block spam messages',
+            dataType: 'error',
             conditions: [{type: 'error_message', value: ['spam']}],
           },
         })
@@ -688,6 +699,7 @@ describe('ProjectFilters', () => {
           method: 'POST',
           data: {
             name: 'Undefined type errors',
+            dataType: 'error',
             conditions: [
               {type: 'error_message', value: ['*undefined*']},
               {type: 'error_type', value: ['TypeError']},
@@ -755,6 +767,7 @@ describe('ProjectFilters', () => {
           method: 'PUT',
           data: {
             name: 'Updated name',
+            dataType: 'error',
             conditions: [{type: 'error_message', value: ['*Error*']}],
           },
         })
@@ -768,6 +781,7 @@ describe('ProjectFilters', () => {
       CustomInboundFilterFixture({
         id: '1',
         name: 'Drop debug log spam',
+        dataType: 'log',
         conditions: [{type: 'log_message', value: ['*DEBUG*']}],
       }),
     ]);
@@ -775,9 +789,9 @@ describe('ProjectFilters', () => {
     await userEvent.click(await screen.findByRole('button', {name: 'Edit filter'}));
     expect(await screen.findByText('Edit Custom Filter')).toBeInTheDocument();
 
-    // The data type is derived from the stored log_message condition and stays
-    // selectable even though the org lacks the logs ingestion feature.
-    expect(screen.getByText('Logs')).toBeInTheDocument();
+    // The stored data type stays selectable even though the org lacks the logs
+    // ingestion feature.
+    expect(within(screen.getByRole('dialog')).getByText('Logs')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('textbox', {name: 'Data Type'}));
     expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
 
@@ -819,6 +833,11 @@ describe('ProjectFilters', () => {
     await userEvent.click(screen.getByRole('textbox', {name: 'Data Type'}));
 
     expect(screen.getByRole('menuitemradio', {name: 'Errors'})).toBeInTheDocument();
+    // The catch-all needs no ingestion feature: it filters whichever data types
+    // the organization does ingest.
+    expect(
+      screen.getByRole('menuitemradio', {name: 'All Data Types'})
+    ).toBeInTheDocument();
     expect(screen.queryByRole('menuitemradio', {name: 'Logs'})).not.toBeInTheDocument();
     expect(
       screen.queryByRole('menuitemradio', {name: 'Metrics'})
@@ -925,6 +944,92 @@ describe('ProjectFilters', () => {
     await userEvent.hover(screen.getByText('matches'));
     expect(
       await screen.findByText('Matches the release attribute of the log.')
+    ).toBeInTheDocument();
+  });
+
+  it('creates a catch-all filter that applies to every data type', async () => {
+    renderInboundFilters([]);
+    expect(await screen.findByText('No inbound filters found')).toBeInTheDocument();
+
+    const createMock = MockApiClient.addMockResponse({
+      url: CUSTOM_INBOUND_FILTERS_URL,
+      method: 'POST',
+      body: CustomInboundFilterFixture({id: '10', name: 'Bad release'}),
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Filter'}));
+    expect(await screen.findByText('Create Custom Filter')).toBeInTheDocument();
+    await userEvent.type(screen.getByRole('textbox', {name: 'Name'}), 'Bad release');
+
+    await userEvent.click(screen.getByRole('textbox', {name: 'Data Type'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'All Data Types'}));
+
+    // The catch-all can only match a field every data type carries, so the
+    // property dropdown narrows to those and the note says why.
+    expect(
+      screen.getByText(/applies to every data type Sentry ingests/)
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('textbox', {name: 'Condition property'}));
+    expect(screen.getByRole('menuitemradio', {name: 'Release'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Error Message'})
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Release'}));
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Condition value'}), '1.2.*');
+    await userEvent.click(screen.getByRole('button', {name: 'Create Filter'}));
+
+    await waitFor(() =>
+      expect(createMock).toHaveBeenCalledWith(
+        CUSTOM_INBOUND_FILTERS_URL,
+        expect.objectContaining({
+          method: 'POST',
+          data: {
+            name: 'Bad release',
+            dataType: 'all',
+            conditions: [{type: 'release', value: ['1.2.*']}],
+          },
+        })
+      )
+    );
+  });
+
+  it('shows the data type of every filter in the table', async () => {
+    renderInboundFilters([
+      CustomInboundFilterFixture({
+        id: '1',
+        name: 'Errors only',
+        dataType: 'error',
+        conditions: [{type: 'release', value: ['1.*']}],
+      }),
+      CustomInboundFilterFixture({
+        id: '2',
+        name: 'Every data type',
+        dataType: 'all',
+        conditions: [{type: 'release', value: ['1.*']}],
+      }),
+    ]);
+
+    expect(await screen.findByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('All Data Types')).toBeInTheDocument();
+  });
+
+  it('explains the release condition of a catch-all filter', async () => {
+    renderInboundFilters([
+      CustomInboundFilterFixture({
+        id: '1',
+        name: 'Every data type',
+        dataType: 'all',
+        conditions: [{type: 'release', value: ['1.*']}],
+      }),
+    ]);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Edit filter'}));
+    expect(await screen.findByText('Edit Custom Filter')).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('matches'));
+    expect(
+      await screen.findByText('Matches the release of any data type.')
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Stacked on #122466. Do not merge before it.

- Adds "All Data Types" to the data type select in the custom filter modal. It narrows the condition properties to the ones every data type carries, and says so, since a catch-all also matches data types added after the filter was written.
- The filter's data type now comes from the API instead of being derived from its conditions.
- The table gains a Data Type column, so the reader sees what a filter deletes without opening it. Search covers it too.
- The per-filter volume now counts transactions, replays, and profile chunks. Relay reads an error's release field on those as well, so a release condition drops them alongside errors.
