### PR TITLE
perf(inbox): Prefetch issue preview details

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -1,6 +1,5 @@
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -16,11 +15,10 @@ export interface AutofixSetupResponse {
 }
 
 function makeAutofixSetupQueryKey(orgSlug: string, groupId: string): ApiQueryKey {
-  return [
-    getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/setup/', {
-      path: {organizationIdOrSlug: orgSlug, issueId: groupId},
-    }),
-  ];
+  return autofixSetupApiOptions({
+    groupId,
+    organizationSlug: orgSlug,
+  }).queryKey;
 }
 
 export function autofixSetupApiOptions({
@@ -30,16 +28,13 @@ export function autofixSetupApiOptions({
   groupId: string;
   organizationSlug: string;
 }) {
-  return {
-    ...apiOptions.as<AutofixSetupResponse>()(
-      '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/setup/',
-      {
-        path: {organizationIdOrSlug: organizationSlug, issueId: groupId},
-        staleTime: 30_000,
-      }
-    ),
-    retry: false,
-  };
+  return apiOptions.as<AutofixSetupResponse>()(
+    '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/setup/',
+    {
+      path: {organizationIdOrSlug: organizationSlug, issueId: groupId},
+      staleTime: 30_000,
+    }
+  );
 }
 
 export function useAutofixSetup(

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -1,6 +1,7 @@
-import {useQuery} from '@tanstack/react-query';
-
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export interface AutofixSetupResponse {
@@ -12,6 +13,14 @@ export interface AutofixSetupResponse {
     reason: string | null;
   };
   seerReposLinked: boolean;
+}
+
+function makeAutofixSetupQueryKey(orgSlug: string, groupId: string): ApiQueryKey {
+  return [
+    getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/setup/', {
+      path: {organizationIdOrSlug: orgSlug, issueId: groupId},
+    }),
+  ];
 }
 
 export function autofixSetupApiOptions({
@@ -35,21 +44,24 @@ export function autofixSetupApiOptions({
 
 export function useAutofixSetup(
   {groupId}: {groupId: string},
-  {enabled = Boolean(groupId)}: {enabled?: boolean} = {}
+  options: Omit<UseApiQueryOptions<AutofixSetupResponse>, 'staleTime'> = {}
 ) {
   const orgSlug = useOrganization().slug;
 
-  const {data, isPending, refetch} = useQuery({
-    ...autofixSetupApiOptions({groupId, organizationSlug: orgSlug}),
-    enabled,
-  });
+  const queryData = useApiQuery<AutofixSetupResponse>(
+    makeAutofixSetupQueryKey(orgSlug, groupId),
+    {
+      enabled: Boolean(groupId),
+      staleTime: 30_000,
+      retry: false,
+      ...options,
+    }
+  );
 
   return {
-    data,
-    isPending,
-    refetch,
-    canStartAutofix: Boolean(data?.integration.ok),
-    hasAutofixQuota: Boolean(data?.billing?.hasAutofixQuota),
-    seerReposLinked: Boolean(data?.seerReposLinked),
+    ...queryData,
+    canStartAutofix: Boolean(queryData.data?.integration.ok),
+    hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),
+    seerReposLinked: Boolean(queryData.data?.seerReposLinked),
   };
 }

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -1,6 +1,6 @@
-import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useQuery} from '@tanstack/react-query';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export interface AutofixSetupResponse {
@@ -14,34 +14,42 @@ export interface AutofixSetupResponse {
   seerReposLinked: boolean;
 }
 
-function makeAutofixSetupQueryKey(orgSlug: string, groupId: string): ApiQueryKey {
-  return [
-    getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/autofix/setup/', {
-      path: {organizationIdOrSlug: orgSlug, issueId: groupId},
-    }),
-  ];
+export function autofixSetupApiOptions({
+  groupId,
+  organizationSlug,
+}: {
+  groupId: string;
+  organizationSlug: string;
+}) {
+  return {
+    ...apiOptions.as<AutofixSetupResponse>()(
+      '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/setup/',
+      {
+        path: {organizationIdOrSlug: organizationSlug, issueId: groupId},
+        staleTime: 30_000,
+      }
+    ),
+    retry: false,
+  };
 }
 
 export function useAutofixSetup(
   {groupId}: {groupId: string},
-  options: Omit<UseApiQueryOptions<AutofixSetupResponse>, 'staleTime'> = {}
+  {enabled = Boolean(groupId)}: {enabled?: boolean} = {}
 ) {
   const orgSlug = useOrganization().slug;
 
-  const queryData = useApiQuery<AutofixSetupResponse>(
-    makeAutofixSetupQueryKey(orgSlug, groupId),
-    {
-      enabled: Boolean(groupId),
-      staleTime: 0,
-      retry: false,
-      ...options,
-    }
-  );
+  const {data, isPending, refetch} = useQuery({
+    ...autofixSetupApiOptions({groupId, organizationSlug: orgSlug}),
+    enabled,
+  });
 
   return {
-    ...queryData,
-    canStartAutofix: Boolean(queryData.data?.integration.ok),
-    hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),
-    seerReposLinked: Boolean(queryData.data?.seerReposLinked),
+    data,
+    isPending,
+    refetch,
+    canStartAutofix: Boolean(data?.integration.ok),
+    hasAutofixQuota: Boolean(data?.billing?.hasAutofixQuota),
+    seerReposLinked: Boolean(data?.seerReposLinked),
   };
 }

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -243,13 +243,13 @@ const ACTIVE_POLL_INTERVAL = 1000;
  */
 const PR_POLL_INTERVAL = 10000;
 
-function explorerAutofixApiOptions(orgSlug: string, groupId: string) {
+export function explorerAutofixApiOptions(orgSlug: string, groupId: string) {
   return apiOptions.as<ExplorerAutofixResponse>()(
     '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/',
     {
       path: {organizationIdOrSlug: orgSlug, issueId: groupId},
       query: {mode: 'explorer', llmFormat: 'markdown'},
-      staleTime: 0,
+      staleTime: 30_000,
     }
   );
 }

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -319,14 +319,30 @@ export function useLinkedPullRequests({
   const organization = useOrganization();
 
   return useQuery(
-    apiOptions.as<LinkedPullRequestsResponse>()(
-      '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
-      {
-        path: {organizationIdOrSlug: organization.slug, issueId: group.id},
-        query: includeChecksAndReview ? {expand: 'checksAndReview'} : undefined,
-        staleTime: 30_000,
-      }
-    )
+    linkedPullRequestsApiOptions({
+      groupId: group.id,
+      organizationSlug: organization.slug,
+      includeChecksAndReview,
+    })
+  );
+}
+
+export function linkedPullRequestsApiOptions({
+  groupId,
+  organizationSlug,
+  includeChecksAndReview = true,
+}: {
+  groupId: string;
+  organizationSlug: string;
+  includeChecksAndReview?: boolean;
+}) {
+  return apiOptions.as<LinkedPullRequestsResponse>()(
+    '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
+    {
+      path: {organizationIdOrSlug: organizationSlug, issueId: groupId},
+      query: includeChecksAndReview ? {expand: 'checksAndReview'} : undefined,
+      staleTime: 30_000,
+    }
   );
 }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -54,7 +54,6 @@ import {IssueSeenTimes} from 'sentry/views/issueList/pages/issueSeenTimes';
 
 interface IssuePreviewProps {
   groupId: string;
-  initialGroup?: Group;
 }
 
 function useMarkPreviewedGroupSeen(group: Group | undefined) {
@@ -68,9 +67,8 @@ function useMarkPreviewedGroupSeen(group: Group | undefined) {
   }, [groupId, markGroupSeen]);
 }
 
-export function IssuePreview({groupId, initialGroup}: IssuePreviewProps) {
-  const {data: fetchedGroup, isPending, isError} = useGroup({groupId});
-  const group = fetchedGroup ?? initialGroup;
+export function IssuePreview({groupId}: IssuePreviewProps) {
+  const {data: group, isPending, isError} = useGroup({groupId});
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === group?.project.id) ?? group?.project;
@@ -116,16 +114,12 @@ export function IssuePreview({groupId, initialGroup}: IssuePreviewProps) {
         overscrollBehavior="contain"
         padding="lg 2xl"
       >
-        {isPending && !group && <LoadingIndicator />}
-        {isError && !group && <LoadingError />}
+        {isPending && <LoadingIndicator />}
+        {isError && <LoadingError />}
         {group && project && (
           <GroupDataContextProvider group={group} project={project}>
-            <ErrorBoundary key={fetchedGroup ? 'full' : 'initial'} mini>
-              {fetchedGroup ? (
-                <IssuePreviewContent />
-              ) : (
-                <IssuePreviewGroupInfo group={group} project={project} />
-              )}
+            <ErrorBoundary mini>
+              <IssuePreviewContent />
             </ErrorBoundary>
           </GroupDataContextProvider>
         )}
@@ -140,6 +134,8 @@ function IssuePreviewContent() {
   const {group, project} = useGroupData();
   const previewSeer = useIssuePreviewSeer(group, project);
   const linkedPullRequests = useLinkedPullRequests({group});
+  const {title: primaryTitle} = getTitle(group);
+  const secondaryTitle = getMessage(group);
   const disableActions = [
     ReprocessingStatus.REPROCESSING,
     ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT,
@@ -150,7 +146,57 @@ function IssuePreviewContent() {
   );
   return (
     <IssueDetailsContextProvider>
-      <IssuePreviewGroupInfo group={group} project={project} />
+      <Container paddingBottom="sm">
+        <Stack gap="xs">
+          <Container>
+            <Flex align="center" justify="between" gap="md">
+              <Flex align="center" gap="md" minWidth={0}>
+                <Tooltip
+                  title={primaryTitle}
+                  skipWrapper
+                  isHoverable
+                  showOnlyOnOverflow
+                  delay={1000}
+                >
+                  <TitleLink
+                    to={issueDetailsUrl}
+                    analyticsEventKey="issue_inbox.open_issue_clicked"
+                    analyticsEventName="Issue Inbox: Open Issue Clicked"
+                    analyticsParams={{
+                      group_id: group.id,
+                      progress: group.derivedData?.progress,
+                      source: 'title',
+                    }}
+                  >
+                    <Container flex="1" minWidth={0}>
+                      <Heading as="h3" size="lg" ellipsis>
+                        {primaryTitle}
+                      </Heading>
+                    </Container>
+                    <Flex align="center" flexShrink={0}>
+                      <IconOpen size="xs" variant="muted" />
+                    </Flex>
+                  </TitleLink>
+                </Tooltip>
+              </Flex>
+              <IssueSeenTimes group={group} />
+            </Flex>
+            <EventMessage
+              level={group.level}
+              message={secondaryTitle}
+              type={group.type}
+            />
+          </Container>
+          <Flex justify="between" align="center" gap="md">
+            <Flex flex="1" minWidth={0}>
+              <GroupStatusSubtitle group={group} project={project} />
+            </Flex>
+            <Flex align="center" gap="xs" flexShrink={0} wrap="nowrap">
+              <EventUserCounts group={group} project={project} />
+            </Flex>
+          </Flex>
+        </Stack>
+      </Container>
       <Flex
         paddingTop="sm"
         paddingBottom="lg"
@@ -189,110 +235,48 @@ function IssuePreviewContent() {
           />
         </Flex>
       </Flex>
-      <Dividers>
-        {linkedPullRequests.data?.pullRequests.length ? (
-          <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
-            <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
-            <IssuePreviewSection.Content>
-              <LinkedPullRequests group={group} showEmptyState={false} />
-            </IssuePreviewSection.Content>
-          </IssuePreviewSection>
-        ) : null}
-        {previewSeer.isLoading ? (
-          <Placeholder height="120px" />
-        ) : previewSeer.hasAutofix ? (
-          <IssuePreviewSeerContent
-            key={group.id}
-            group={group}
-            project={project}
-            previewSeer={previewSeer}
-          />
-        ) : null}
-        <Container>
-          <ErrorBoundary mini>
-            <FoldSection
-              title={
-                <Heading as="h3" size="md">
-                  {t('Activity')}
-                </Heading>
-              }
-              sectionKey={SectionKey.ACTIVITY}
-            >
-              <ActivitySection
-                group={group}
-                variant="standalone"
-                placeholder={t('Add a comment. Tag users with @, or teams with #')}
-              />
-            </FoldSection>
-          </ErrorBoundary>
-        </Container>
-      </Dividers>
-    </IssueDetailsContextProvider>
-  );
-}
-
-function IssuePreviewGroupInfo({
-  group,
-  project,
-}: {
-  group: Group;
-  project: Group['project'];
-}) {
-  const organization = useOrganization();
-  const {title: primaryTitle} = getTitle(group);
-  const secondaryTitle = getMessage(group);
-  const issueDetailsUrl = normalizeUrl(
-    `/organizations/${organization.slug}/issues/${group.id}/`
-  );
-
-  return (
-    <Container paddingBottom="sm">
-      <Stack gap="xs">
-        <Container>
-          <Flex align="center" justify="between" gap="md">
-            <Flex align="center" gap="md" minWidth={0}>
-              <Tooltip
-                title={primaryTitle}
-                skipWrapper
-                isHoverable
-                showOnlyOnOverflow
-                delay={1000}
+      {/* Top sections load asynchronously, so block everything to avoid pop-in. */}
+      {previewSeer.isLoading || linkedPullRequests.isPending ? (
+        <LoadingIndicator />
+      ) : (
+        <Dividers>
+          {linkedPullRequests.data?.pullRequests.length ? (
+            <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
+              <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
+              <IssuePreviewSection.Content>
+                <LinkedPullRequests group={group} showEmptyState={false} />
+              </IssuePreviewSection.Content>
+            </IssuePreviewSection>
+          ) : null}
+          {previewSeer.hasAutofix && (
+            <IssuePreviewSeerContent
+              key={group.id}
+              group={group}
+              project={project}
+              previewSeer={previewSeer}
+            />
+          )}
+          <Container>
+            <ErrorBoundary mini>
+              <FoldSection
+                title={
+                  <Heading as="h3" size="md">
+                    {t('Activity')}
+                  </Heading>
+                }
+                sectionKey={SectionKey.ACTIVITY}
               >
-                <TitleLink
-                  to={issueDetailsUrl}
-                  analyticsEventKey="issue_inbox.open_issue_clicked"
-                  analyticsEventName="Issue Inbox: Open Issue Clicked"
-                  analyticsParams={{
-                    group_id: group.id,
-                    progress: group.derivedData?.progress,
-                    source: 'title',
-                  }}
-                >
-                  <Container flex="1" minWidth={0}>
-                    <Heading as="h3" size="lg" ellipsis>
-                      {primaryTitle}
-                    </Heading>
-                  </Container>
-                  <Flex align="center" flexShrink={0}>
-                    <IconOpen size="xs" variant="muted" />
-                  </Flex>
-                </TitleLink>
-              </Tooltip>
-            </Flex>
-            <IssueSeenTimes group={group} />
-          </Flex>
-          <EventMessage level={group.level} message={secondaryTitle} type={group.type} />
-        </Container>
-        <Flex justify="between" align="center" gap="md">
-          <Flex flex="1" minWidth={0}>
-            <GroupStatusSubtitle group={group} project={project} />
-          </Flex>
-          <Flex align="center" gap="xs" flexShrink={0} wrap="nowrap">
-            <EventUserCounts group={group} project={project} />
-          </Flex>
-        </Flex>
-      </Stack>
-    </Container>
+                <ActivitySection
+                  group={group}
+                  variant="standalone"
+                  placeholder={t('Add a comment. Tag users with @, or teams with #')}
+                />
+              </FoldSection>
+            </ErrorBoundary>
+          </Container>
+        </Dividers>
+      )}
+    </IssueDetailsContextProvider>
   );
 }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -235,47 +235,46 @@ function IssuePreviewContent() {
           />
         </Flex>
       </Flex>
-      {/* Top sections load asynchronously, so block everything to avoid pop-in. */}
-      {previewSeer.isLoading || linkedPullRequests.isPending ? (
-        <LoadingIndicator />
-      ) : (
-        <Dividers>
-          {linkedPullRequests.data?.pullRequests.length ? (
-            <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
-              <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
-              <IssuePreviewSection.Content>
-                <LinkedPullRequests group={group} showEmptyState={false} />
-              </IssuePreviewSection.Content>
-            </IssuePreviewSection>
-          ) : null}
-          {previewSeer.hasAutofix && (
-            <IssuePreviewSeerContent
-              key={group.id}
-              group={group}
-              project={project}
-              previewSeer={previewSeer}
-            />
-          )}
-          <Container>
-            <ErrorBoundary mini>
-              <FoldSection
-                title={
-                  <Heading as="h3" size="md">
-                    {t('Activity')}
-                  </Heading>
-                }
-                sectionKey={SectionKey.ACTIVITY}
-              >
-                <ActivitySection
-                  group={group}
-                  variant="standalone"
-                  placeholder={t('Add a comment. Tag users with @, or teams with #')}
-                />
-              </FoldSection>
-            </ErrorBoundary>
-          </Container>
-        </Dividers>
-      )}
+      <Dividers>
+        {linkedPullRequests.isPending ? (
+          <Placeholder height="78px" />
+        ) : linkedPullRequests.data?.pullRequests.length ? (
+          <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
+            <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
+            <IssuePreviewSection.Content>
+              <LinkedPullRequests group={group} showEmptyState={false} />
+            </IssuePreviewSection.Content>
+          </IssuePreviewSection>
+        ) : null}
+        {previewSeer.isLoading ? (
+          <Placeholder height="120px" />
+        ) : previewSeer.hasAutofix ? (
+          <IssuePreviewSeerContent
+            key={group.id}
+            group={group}
+            project={project}
+            previewSeer={previewSeer}
+          />
+        ) : null}
+        <Container>
+          <ErrorBoundary mini>
+            <FoldSection
+              title={
+                <Heading as="h3" size="md">
+                  {t('Activity')}
+                </Heading>
+              }
+              sectionKey={SectionKey.ACTIVITY}
+            >
+              <ActivitySection
+                group={group}
+                variant="standalone"
+                placeholder={t('Add a comment. Tag users with @, or teams with #')}
+              />
+            </FoldSection>
+          </ErrorBoundary>
+        </Container>
+      </Dividers>
     </IssueDetailsContextProvider>
   );
 }

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -120,8 +120,12 @@ export function IssuePreview({groupId, initialGroup}: IssuePreviewProps) {
         {isError && !group && <LoadingError />}
         {group && project && (
           <GroupDataContextProvider group={group} project={project}>
-            <ErrorBoundary mini>
-              <IssuePreviewContent />
+            <ErrorBoundary key={fetchedGroup ? 'full' : 'initial'} mini>
+              {fetchedGroup ? (
+                <IssuePreviewContent />
+              ) : (
+                <IssuePreviewGroupInfo group={group} project={project} />
+              )}
             </ErrorBoundary>
           </GroupDataContextProvider>
         )}
@@ -136,8 +140,6 @@ function IssuePreviewContent() {
   const {group, project} = useGroupData();
   const previewSeer = useIssuePreviewSeer(group, project);
   const linkedPullRequests = useLinkedPullRequests({group});
-  const {title: primaryTitle} = getTitle(group);
-  const secondaryTitle = getMessage(group);
   const disableActions = [
     ReprocessingStatus.REPROCESSING,
     ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT,
@@ -148,57 +150,7 @@ function IssuePreviewContent() {
   );
   return (
     <IssueDetailsContextProvider>
-      <Container paddingBottom="sm">
-        <Stack gap="xs">
-          <Container>
-            <Flex align="center" justify="between" gap="md">
-              <Flex align="center" gap="md" minWidth={0}>
-                <Tooltip
-                  title={primaryTitle}
-                  skipWrapper
-                  isHoverable
-                  showOnlyOnOverflow
-                  delay={1000}
-                >
-                  <TitleLink
-                    to={issueDetailsUrl}
-                    analyticsEventKey="issue_inbox.open_issue_clicked"
-                    analyticsEventName="Issue Inbox: Open Issue Clicked"
-                    analyticsParams={{
-                      group_id: group.id,
-                      progress: group.derivedData?.progress,
-                      source: 'title',
-                    }}
-                  >
-                    <Container flex="1" minWidth={0}>
-                      <Heading as="h3" size="lg" ellipsis>
-                        {primaryTitle}
-                      </Heading>
-                    </Container>
-                    <Flex align="center" flexShrink={0}>
-                      <IconOpen size="xs" variant="muted" />
-                    </Flex>
-                  </TitleLink>
-                </Tooltip>
-              </Flex>
-              <IssueSeenTimes group={group} />
-            </Flex>
-            <EventMessage
-              level={group.level}
-              message={secondaryTitle}
-              type={group.type}
-            />
-          </Container>
-          <Flex justify="between" align="center" gap="md">
-            <Flex flex="1" minWidth={0}>
-              <GroupStatusSubtitle group={group} project={project} />
-            </Flex>
-            <Flex align="center" gap="xs" flexShrink={0} wrap="nowrap">
-              <EventUserCounts group={group} project={project} />
-            </Flex>
-          </Flex>
-        </Stack>
-      </Container>
+      <IssuePreviewGroupInfo group={group} project={project} />
       <Flex
         paddingTop="sm"
         paddingBottom="lg"
@@ -276,6 +228,71 @@ function IssuePreviewContent() {
         </Container>
       </Dividers>
     </IssueDetailsContextProvider>
+  );
+}
+
+function IssuePreviewGroupInfo({
+  group,
+  project,
+}: {
+  group: Group;
+  project: Group['project'];
+}) {
+  const organization = useOrganization();
+  const {title: primaryTitle} = getTitle(group);
+  const secondaryTitle = getMessage(group);
+  const issueDetailsUrl = normalizeUrl(
+    `/organizations/${organization.slug}/issues/${group.id}/`
+  );
+
+  return (
+    <Container paddingBottom="sm">
+      <Stack gap="xs">
+        <Container>
+          <Flex align="center" justify="between" gap="md">
+            <Flex align="center" gap="md" minWidth={0}>
+              <Tooltip
+                title={primaryTitle}
+                skipWrapper
+                isHoverable
+                showOnlyOnOverflow
+                delay={1000}
+              >
+                <TitleLink
+                  to={issueDetailsUrl}
+                  analyticsEventKey="issue_inbox.open_issue_clicked"
+                  analyticsEventName="Issue Inbox: Open Issue Clicked"
+                  analyticsParams={{
+                    group_id: group.id,
+                    progress: group.derivedData?.progress,
+                    source: 'title',
+                  }}
+                >
+                  <Container flex="1" minWidth={0}>
+                    <Heading as="h3" size="lg" ellipsis>
+                      {primaryTitle}
+                    </Heading>
+                  </Container>
+                  <Flex align="center" flexShrink={0}>
+                    <IconOpen size="xs" variant="muted" />
+                  </Flex>
+                </TitleLink>
+              </Tooltip>
+            </Flex>
+            <IssueSeenTimes group={group} />
+          </Flex>
+          <EventMessage level={group.level} message={secondaryTitle} type={group.type} />
+        </Container>
+        <Flex justify="between" align="center" gap="md">
+          <Flex flex="1" minWidth={0}>
+            <GroupStatusSubtitle group={group} project={project} />
+          </Flex>
+          <Flex align="center" gap="xs" flexShrink={0} wrap="nowrap">
+            <EventUserCounts group={group} project={project} />
+          </Flex>
+        </Flex>
+      </Stack>
+    </Container>
   );
 }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -235,46 +235,47 @@ function IssuePreviewContent() {
           />
         </Flex>
       </Flex>
-      <Dividers>
-        {linkedPullRequests.isPending ? (
-          <Placeholder height="78px" />
-        ) : linkedPullRequests.data?.pullRequests.length ? (
-          <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
-            <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
-            <IssuePreviewSection.Content>
-              <LinkedPullRequests group={group} showEmptyState={false} />
-            </IssuePreviewSection.Content>
-          </IssuePreviewSection>
-        ) : null}
-        {previewSeer.isLoading ? (
-          <Placeholder height="120px" />
-        ) : previewSeer.hasAutofix ? (
-          <IssuePreviewSeerContent
-            key={group.id}
-            group={group}
-            project={project}
-            previewSeer={previewSeer}
-          />
-        ) : null}
-        <Container>
-          <ErrorBoundary mini>
-            <FoldSection
-              title={
-                <Heading as="h3" size="md">
-                  {t('Activity')}
-                </Heading>
-              }
-              sectionKey={SectionKey.ACTIVITY}
-            >
-              <ActivitySection
-                group={group}
-                variant="standalone"
-                placeholder={t('Add a comment. Tag users with @, or teams with #')}
-              />
-            </FoldSection>
-          </ErrorBoundary>
-        </Container>
-      </Dividers>
+      {/* Top sections load asynchronously, so block everything to avoid pop-in. */}
+      {previewSeer.isLoading || linkedPullRequests.isPending ? (
+        <LoadingIndicator />
+      ) : (
+        <Dividers>
+          {linkedPullRequests.data?.pullRequests.length ? (
+            <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
+              <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
+              <IssuePreviewSection.Content>
+                <LinkedPullRequests group={group} showEmptyState={false} />
+              </IssuePreviewSection.Content>
+            </IssuePreviewSection>
+          ) : null}
+          {previewSeer.hasAutofix && (
+            <IssuePreviewSeerContent
+              key={group.id}
+              group={group}
+              project={project}
+              previewSeer={previewSeer}
+            />
+          )}
+          <Container>
+            <ErrorBoundary mini>
+              <FoldSection
+                title={
+                  <Heading as="h3" size="md">
+                    {t('Activity')}
+                  </Heading>
+                }
+                sectionKey={SectionKey.ACTIVITY}
+              >
+                <ActivitySection
+                  group={group}
+                  variant="standalone"
+                  placeholder={t('Add a comment. Tag users with @, or teams with #')}
+                />
+              </FoldSection>
+            </ErrorBoundary>
+          </Container>
+        </Dividers>
+      )}
     </IssueDetailsContextProvider>
   );
 }

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -236,9 +236,7 @@ function IssuePreviewContent() {
         </Flex>
       </Flex>
       <Dividers>
-        {linkedPullRequests.isPending ? (
-          <Placeholder height="78px" />
-        ) : linkedPullRequests.data?.pullRequests.length ? (
+        {linkedPullRequests.data?.pullRequests.length ? (
           <IssuePreviewSection aria-label={t('Pull Requests')} defaultExpanded>
             <IssuePreviewSection.Title>{t('Pull Requests')}</IssuePreviewSection.Title>
             <IssuePreviewSection.Content>

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -54,6 +54,7 @@ import {IssueSeenTimes} from 'sentry/views/issueList/pages/issueSeenTimes';
 
 interface IssuePreviewProps {
   groupId: string;
+  initialGroup?: Group;
 }
 
 function useMarkPreviewedGroupSeen(group: Group | undefined) {
@@ -67,8 +68,9 @@ function useMarkPreviewedGroupSeen(group: Group | undefined) {
   }, [groupId, markGroupSeen]);
 }
 
-export function IssuePreview({groupId}: IssuePreviewProps) {
-  const {data: group, isPending, isError} = useGroup({groupId});
+export function IssuePreview({groupId, initialGroup}: IssuePreviewProps) {
+  const {data: fetchedGroup, isPending, isError} = useGroup({groupId});
+  const group = fetchedGroup ?? initialGroup;
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === group?.project.id) ?? group?.project;
@@ -114,8 +116,8 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
         overscrollBehavior="contain"
         padding="lg 2xl"
       >
-        {isPending && <LoadingIndicator />}
-        {isError && <LoadingError />}
+        {isPending && !group && <LoadingIndicator />}
+        {isError && !group && <LoadingError />}
         {group && project && (
           <GroupDataContextProvider group={group} project={project}>
             <ErrorBoundary mini>

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -15,7 +15,6 @@ import {
   useLinkedPullRequests,
 } from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {LoadingError} from 'sentry/components/loadingError';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -114,7 +113,7 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
         overscrollBehavior="contain"
         padding="lg 2xl"
       >
-        {isPending && <LoadingIndicator />}
+        {isPending && <IssuePreviewLoadingSkeleton />}
         {isError && <LoadingError />}
         {group && project && (
           <GroupDataContextProvider group={group} project={project}>
@@ -125,6 +124,33 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
         )}
       </Container>
     </AnalyticsArea>
+  );
+}
+
+function IssuePreviewLoadingSkeleton() {
+  return (
+    <Stack gap="md" aria-label={t('Loading issue preview')}>
+      <Stack gap="sm" paddingBottom="sm">
+        <Placeholder width="50%" height="22px" />
+        <Placeholder width="75%" height="18px" />
+        <Placeholder width="60%" height="18px" />
+      </Stack>
+      <Flex
+        paddingTop="sm"
+        paddingBottom="lg"
+        borderBottom="muted"
+        justify="between"
+        align="center"
+      >
+        <Placeholder width="120px" height="32px" />
+        <Placeholder width="80px" height="32px" />
+      </Flex>
+      <Stack gap="md">
+        <Placeholder height="78px" />
+        <Placeholder height="120px" />
+        <Placeholder height="160px" />
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -15,6 +15,7 @@ import {
   useLinkedPullRequests,
 } from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -113,7 +114,7 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
         overscrollBehavior="contain"
         padding="lg 2xl"
       >
-        {isPending && <IssuePreviewLoadingSkeleton />}
+        {isPending && <LoadingIndicator />}
         {isError && <LoadingError />}
         {group && project && (
           <GroupDataContextProvider group={group} project={project}>
@@ -124,33 +125,6 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
         )}
       </Container>
     </AnalyticsArea>
-  );
-}
-
-function IssuePreviewLoadingSkeleton() {
-  return (
-    <Stack gap="md" aria-label={t('Loading issue preview')}>
-      <Stack gap="sm" paddingBottom="sm">
-        <Placeholder width="50%" height="22px" />
-        <Placeholder width="75%" height="18px" />
-        <Placeholder width="60%" height="18px" />
-      </Stack>
-      <Flex
-        paddingTop="sm"
-        paddingBottom="lg"
-        borderBottom="muted"
-        justify="between"
-        align="center"
-      >
-        <Placeholder width="120px" height="32px" />
-        <Placeholder width="80px" height="32px" />
-      </Flex>
-      <Stack gap="md">
-        <Placeholder height="78px" />
-        <Placeholder height="120px" />
-        <Placeholder height="160px" />
-      </Stack>
-    </Stack>
   );
 }
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -13,6 +13,7 @@ import {PullRequestFixture} from 'sentry-fixture/pullRequest';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -152,6 +153,7 @@ describe('InboxPage', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
     localStorage.removeItem('inbox-split-size');
@@ -842,6 +844,8 @@ describe('InboxPage', () => {
   });
 
   it('prefetches independent preview details after an intentional hover', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
     mockSuccessfulSections();
     mockIssuePreview();
     const pendingRequest = new Promise(() => {});
@@ -869,14 +873,20 @@ describe('InboxPage', () => {
     const issueLink = await within(
       screen.getByRole('region', {name: 'Fix Proposed'})
     ).findByRole('link', {name: /Fix proposed issue/});
-    await userEvent.hover(issueLink);
+    await user.hover(issueLink);
 
-    await waitFor(() => {
-      expect(groupRequest).toHaveBeenCalledTimes(1);
-      expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
-      expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
-      expect(autofixRequest).toHaveBeenCalledTimes(1);
-    });
+    await act(() => jest.advanceTimersByTimeAsync(100));
+    expect(groupRequest).toHaveBeenCalledTimes(1);
+    expect(pullRequestsRequest).not.toHaveBeenCalled();
+    expect(autofixSetupRequest).not.toHaveBeenCalled();
+    expect(autofixRequest).not.toHaveBeenCalled();
+
+    await act(() => jest.advanceTimersByTimeAsync(200));
+    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+    expect(autofixRequest).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
 
     // Reads the warmed caches, which only hold if all query keys match.
     await userEvent.click(issueLink);

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -903,6 +903,47 @@ describe('InboxPage', () => {
     expect(autofixRequest).toHaveBeenCalledTimes(1);
   });
 
+  it('renders group information before preview details finish loading', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    const pendingRequest = new Promise(() => {});
+    const groupRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
+      asyncDelay: pendingRequest,
+    });
+    const pullRequestsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
+      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
+      asyncDelay: pendingRequest,
+    });
+    const autofixSetupRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/setup/`,
+      asyncDelay: pendingRequest,
+    });
+    const autofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
+      asyncDelay: pendingRequest,
+    });
+
+    render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
+
+    const issueLink = await within(
+      screen.getByRole('region', {name: 'Fix Proposed'})
+    ).findByRole('link', {name: /Fix proposed issue/});
+    await userEvent.click(issueLink);
+
+    const preview = screen.getByRole('complementary', {name: 'Issue preview'});
+    expect(
+      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
+    ).toBeInTheDocument();
+    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
+    expect(groupRequest).toHaveBeenCalledTimes(1);
+    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+    expect(autofixRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {
     mockSuccessfulSections();
     mockIssuePreview();

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -841,7 +841,7 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('prefetches preview details on hover so opening it needs no new request', async () => {
+  it('prefetches preview details immediately on hover so opening it needs no new request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     const groupRequest = MockApiClient.addMockResponse({
@@ -874,12 +874,10 @@ describe('InboxPage', () => {
     ).findByRole('link', {name: /Fix proposed issue/});
     await userEvent.hover(issueLink);
 
-    await waitFor(() => {
-      expect(groupRequest).toHaveBeenCalledTimes(1);
-      expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
-      expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
-      expect(autofixRequest).toHaveBeenCalledTimes(1);
-    });
+    expect(groupRequest).toHaveBeenCalledTimes(1);
+    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+    expect(autofixRequest).toHaveBeenCalledTimes(1);
 
     // Reads the warmed caches, which only hold if all query keys match.
     await userEvent.click(issueLink);
@@ -894,18 +892,21 @@ describe('InboxPage', () => {
     expect(autofixRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('renders available content while the Autofix prefetch is still loading', async () => {
+  it('renders group content while independent preview requests are still loading', async () => {
     mockSuccessfulSections();
-    mockIssuePreview();
+    const pendingRequest = new Promise(() => {});
+    mockIssuePreview({autofixSetupDelay: pendingRequest});
     const autofixRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
       match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
-      body: new Promise(() => {}),
+      body: ExplorerAutofixResponseFixture({autofix: null}),
+      asyncDelay: pendingRequest,
     });
     const pullRequestsRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
       match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
       body: {pullRequests: []},
+      asyncDelay: pendingRequest,
     });
 
     render(<InboxPage />, {
@@ -921,6 +922,10 @@ describe('InboxPage', () => {
     await userEvent.click(issueLink);
 
     const preview = screen.getByRole('complementary', {name: 'Issue preview'});
+    expect(
+      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
+    ).toBeInTheDocument();
+    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
     expect(
       await within(preview).findByRole('heading', {name: 'Activity'})
     ).toBeInTheDocument();

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -903,27 +903,29 @@ describe('InboxPage', () => {
     expect(autofixRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('renders group information before preview details finish loading', async () => {
+  it('renders inbox group information before the full preview group loads', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
-    const pendingRequest = new Promise(() => {});
+    const groupDelay = Promise.withResolvers<void>();
+    const pendingDetailsRequest = new Promise(() => {});
     const groupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
-      asyncDelay: pendingRequest,
+      body: fixProposedGroup,
+      asyncDelay: groupDelay.promise,
     });
     const pullRequestsRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
       match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
-      asyncDelay: pendingRequest,
+      asyncDelay: pendingDetailsRequest,
     });
     const autofixSetupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/setup/`,
-      asyncDelay: pendingRequest,
+      asyncDelay: pendingDetailsRequest,
     });
     const autofixRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
       match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
-      asyncDelay: pendingRequest,
+      asyncDelay: pendingDetailsRequest,
     });
 
     render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
@@ -939,9 +941,19 @@ describe('InboxPage', () => {
     ).toBeInTheDocument();
     expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalledTimes(1);
-    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+    expect(pullRequestsRequest).not.toHaveBeenCalled();
+    expect(autofixSetupRequest).not.toHaveBeenCalled();
+    expect(autofixRequest).not.toHaveBeenCalled();
+    expect(
+      within(preview).queryByText('There was a problem rendering this component')
+    ).not.toBeInTheDocument();
+
+    groupDelay.resolve();
+
+    await waitFor(() => expect(pullRequestsRequest).toHaveBeenCalledTimes(1));
     expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
     expect(autofixRequest).toHaveBeenCalledTimes(1);
+    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -212,12 +212,14 @@ describe('InboxPage', () => {
     }),
     autofixSetupDelay,
     group = fixProposedGroup,
+    groupDelay,
     markSeenResponse = {...fixProposedGroup, hasSeen: true},
     markSeenStatusCode = 200,
   }: {
     autofixSetup?: ReturnType<typeof AutofixSetupFixture>;
     autofixSetupDelay?: Promise<unknown>;
     group?: typeof fixProposedGroup;
+    groupDelay?: Promise<unknown>;
     markSeenResponse?: typeof fixProposedGroup;
     markSeenStatusCode?: number;
   } = {}) {
@@ -225,6 +227,7 @@ describe('InboxPage', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
       body: () => ({...group, hasSeen: previewHasSeen}),
+      ...(groupDelay === undefined ? {} : {asyncDelay: groupDelay}),
     });
     const markSeenRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
@@ -841,7 +844,7 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('prefetches preview details immediately on hover so opening it needs no new request', async () => {
+  it('prefetches preview details after an intentional hover so opening it needs no new request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     const groupRequest = MockApiClient.addMockResponse({
@@ -874,10 +877,12 @@ describe('InboxPage', () => {
     ).findByRole('link', {name: /Fix proposed issue/});
     await userEvent.hover(issueLink);
 
-    expect(groupRequest).toHaveBeenCalledTimes(1);
-    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
-    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
-    expect(autofixRequest).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(groupRequest).toHaveBeenCalledTimes(1);
+      expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+      expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+      expect(autofixRequest).toHaveBeenCalledTimes(1);
+    });
 
     // Reads the warmed caches, which only hold if all query keys match.
     await userEvent.click(issueLink);
@@ -930,6 +935,26 @@ describe('InboxPage', () => {
       await within(preview).findByRole('heading', {name: 'Activity'})
     ).toBeInTheDocument();
     expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a structured preview skeleton while the group is loading', async () => {
+    const groupDelay = Promise.withResolvers<void>();
+    mockSuccessfulSections();
+    mockIssuePreview({groupDelay: groupDelay.promise});
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    expect(within(preview).getByLabelText('Loading issue preview')).toBeInTheDocument();
+
+    groupDelay.resolve();
+
+    expect(
+      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
+    ).toBeInTheDocument();
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -852,22 +852,15 @@ describe('InboxPage', () => {
     const pullRequestsRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
       match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
-      body: {pullRequests: []},
       asyncDelay: pendingRequest,
     });
     const autofixSetupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/setup/`,
-      body: AutofixSetupFixture({
-        billing: {hasAutofixQuota: false},
-        integration: {ok: false, reason: null},
-        seerReposLinked: false,
-      }),
       asyncDelay: pendingRequest,
     });
     const autofixRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
       match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
-      body: ExplorerAutofixResponseFixture({autofix: null}),
       asyncDelay: pendingRequest,
     });
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -875,13 +875,14 @@ describe('InboxPage', () => {
     ).findByRole('link', {name: /Fix proposed issue/});
     await user.hover(issueLink);
 
-    await act(() => jest.advanceTimersByTimeAsync(100));
-    expect(groupRequest).toHaveBeenCalledTimes(1);
+    await act(() => jest.advanceTimersByTimeAsync(199));
+    expect(groupRequest).not.toHaveBeenCalled();
     expect(pullRequestsRequest).not.toHaveBeenCalled();
     expect(autofixSetupRequest).not.toHaveBeenCalled();
     expect(autofixRequest).not.toHaveBeenCalled();
 
-    await act(() => jest.advanceTimersByTimeAsync(200));
+    await act(() => jest.advanceTimersByTimeAsync(1));
+    expect(groupRequest).toHaveBeenCalledTimes(1);
     expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
     expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
     expect(autofixRequest).toHaveBeenCalledTimes(1);

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -212,14 +212,12 @@ describe('InboxPage', () => {
     }),
     autofixSetupDelay,
     group = fixProposedGroup,
-    groupDelay,
     markSeenResponse = {...fixProposedGroup, hasSeen: true},
     markSeenStatusCode = 200,
   }: {
     autofixSetup?: ReturnType<typeof AutofixSetupFixture>;
     autofixSetupDelay?: Promise<unknown>;
     group?: typeof fixProposedGroup;
-    groupDelay?: Promise<unknown>;
     markSeenResponse?: typeof fixProposedGroup;
     markSeenStatusCode?: number;
   } = {}) {
@@ -227,7 +225,6 @@ describe('InboxPage', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
       body: () => ({...group, hasSeen: previewHasSeen}),
-      ...(groupDelay === undefined ? {} : {asyncDelay: groupDelay}),
     });
     const markSeenRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
@@ -844,9 +841,10 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('prefetches preview details after an intentional hover so opening it needs no new request', async () => {
+  it('prefetches independent preview details after an intentional hover', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
+    const pendingRequest = new Promise(() => {});
     const groupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
       body: fixProposedGroup,
@@ -855,6 +853,7 @@ describe('InboxPage', () => {
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
       match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
       body: {pullRequests: []},
+      asyncDelay: pendingRequest,
     });
     const autofixSetupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/setup/`,
@@ -863,11 +862,13 @@ describe('InboxPage', () => {
         integration: {ok: false, reason: null},
         seerReposLinked: false,
       }),
+      asyncDelay: pendingRequest,
     });
     const autofixRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
       match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
       body: ExplorerAutofixResponseFixture({autofix: null}),
+      asyncDelay: pendingRequest,
     });
 
     render(<InboxPage />, {organization, initialRouterConfig});
@@ -889,72 +890,14 @@ describe('InboxPage', () => {
 
     const preview = screen.getByRole('complementary', {name: 'Issue preview'});
     expect(
-      await within(preview).findByRole('heading', {name: 'Activity'})
+      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
     ).toBeInTheDocument();
+    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
+    expect(within(preview).getByRole('heading', {name: 'Activity'})).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalledTimes(1);
     expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
     expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
     expect(autofixRequest).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders group content while independent preview requests are still loading', async () => {
-    mockSuccessfulSections();
-    const pendingRequest = new Promise(() => {});
-    mockIssuePreview({autofixSetupDelay: pendingRequest});
-    const autofixRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
-      match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
-      body: ExplorerAutofixResponseFixture({autofix: null}),
-      asyncDelay: pendingRequest,
-    });
-    const pullRequestsRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
-      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
-      body: {pullRequests: []},
-      asyncDelay: pendingRequest,
-    });
-
-    render(<InboxPage />, {
-      organization: seerOrganization,
-      initialRouterConfig,
-    });
-
-    const issueLink = await within(
-      screen.getByRole('region', {name: 'Fix Proposed'})
-    ).findByRole('link', {name: /Fix proposed issue/});
-    await userEvent.hover(issueLink);
-    await waitFor(() => expect(autofixRequest).toHaveBeenCalledTimes(1));
-    await userEvent.click(issueLink);
-
-    const preview = screen.getByRole('complementary', {name: 'Issue preview'});
-    expect(
-      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
-    ).toBeInTheDocument();
-    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
-    expect(
-      await within(preview).findByRole('heading', {name: 'Activity'})
-    ).toBeInTheDocument();
-    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows a structured preview skeleton while the group is loading', async () => {
-    const groupDelay = Promise.withResolvers<void>();
-    mockSuccessfulSections();
-    mockIssuePreview({groupDelay: groupDelay.promise});
-
-    render(<InboxPage />, {
-      organization: seerOrganization,
-      initialRouterConfig,
-    });
-
-    const preview = await openFixProposedPreview();
-    expect(within(preview).getByLabelText('Loading issue preview')).toBeInTheDocument();
-
-    groupDelay.resolve();
-
-    expect(
-      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
-    ).toBeInTheDocument();
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -896,64 +896,10 @@ describe('InboxPage', () => {
       await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
     ).toBeInTheDocument();
     expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
-    expect(within(preview).getByRole('heading', {name: 'Activity'})).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalledTimes(1);
     expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
     expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
     expect(autofixRequest).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders inbox group information before the full preview group loads', async () => {
-    mockSuccessfulSections();
-    mockIssuePreview();
-    const groupDelay = Promise.withResolvers<void>();
-    const pendingDetailsRequest = new Promise(() => {});
-    const groupRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
-      body: fixProposedGroup,
-      asyncDelay: groupDelay.promise,
-    });
-    const pullRequestsRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
-      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
-      asyncDelay: pendingDetailsRequest,
-    });
-    const autofixSetupRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/setup/`,
-      asyncDelay: pendingDetailsRequest,
-    });
-    const autofixRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
-      match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
-      asyncDelay: pendingDetailsRequest,
-    });
-
-    render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
-
-    const issueLink = await within(
-      screen.getByRole('region', {name: 'Fix Proposed'})
-    ).findByRole('link', {name: /Fix proposed issue/});
-    await userEvent.click(issueLink);
-
-    const preview = screen.getByRole('complementary', {name: 'Issue preview'});
-    expect(
-      await within(preview).findByRole('heading', {name: 'Fix proposed issue'})
-    ).toBeInTheDocument();
-    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
-    expect(groupRequest).toHaveBeenCalledTimes(1);
-    expect(pullRequestsRequest).not.toHaveBeenCalled();
-    expect(autofixSetupRequest).not.toHaveBeenCalled();
-    expect(autofixRequest).not.toHaveBeenCalled();
-    expect(
-      within(preview).queryByText('There was a problem rendering this component')
-    ).not.toBeInTheDocument();
-
-    groupDelay.resolve();
-
-    await waitFor(() => expect(pullRequestsRequest).toHaveBeenCalledTimes(1));
-    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
-    expect(autofixRequest).toHaveBeenCalledTimes(1);
-    expect(within(preview).getByText('Fix proposed message')).toBeInTheDocument();
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -868,6 +868,34 @@ describe('InboxPage', () => {
     expect(groupRequest).toHaveBeenCalledTimes(1);
   });
 
+  it('renders activity while the Autofix summary is loading', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    const autofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      match: [MockApiClient.matchQuery({mode: 'explorer'})],
+      body: new Promise(() => {}),
+    });
+    const pullRequestsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
+      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
+      body: {pullRequests: []},
+    });
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+
+    expect(
+      await within(preview).findByRole('heading', {name: 'Activity'})
+    ).toBeInTheDocument();
+    expect(autofixRequest).toHaveBeenCalledTimes(1);
+    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {
     mockSuccessfulSections();
     mockIssuePreview();

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -13,7 +13,6 @@ import {PullRequestFixture} from 'sentry-fixture/pullRequest';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
-  act,
   render,
   screen,
   userEvent,
@@ -153,7 +152,6 @@ describe('InboxPage', () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers();
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
     localStorage.removeItem('inbox-split-size');
@@ -844,8 +842,6 @@ describe('InboxPage', () => {
   });
 
   it('prefetches independent preview details after an intentional hover', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
     mockSuccessfulSections();
     mockIssuePreview();
     const pendingRequest = new Promise(() => {});
@@ -873,21 +869,14 @@ describe('InboxPage', () => {
     const issueLink = await within(
       screen.getByRole('region', {name: 'Fix Proposed'})
     ).findByRole('link', {name: /Fix proposed issue/});
-    await user.hover(issueLink);
+    await userEvent.hover(issueLink);
 
-    await act(() => jest.advanceTimersByTimeAsync(199));
-    expect(groupRequest).not.toHaveBeenCalled();
-    expect(pullRequestsRequest).not.toHaveBeenCalled();
-    expect(autofixSetupRequest).not.toHaveBeenCalled();
-    expect(autofixRequest).not.toHaveBeenCalled();
-
-    await act(() => jest.advanceTimersByTimeAsync(1));
-    expect(groupRequest).toHaveBeenCalledTimes(1);
-    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
-    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
-    expect(autofixRequest).toHaveBeenCalledTimes(1);
-
-    jest.useRealTimers();
+    await waitFor(() => {
+      expect(groupRequest).toHaveBeenCalledTimes(1);
+      expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+      expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+      expect(autofixRequest).toHaveBeenCalledTimes(1);
+    });
 
     // Reads the warmed caches, which only hold if all query keys match.
     await userEvent.click(issueLink);

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -841,12 +841,30 @@ describe('InboxPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('prefetches the preview on hover so opening it needs no new request', async () => {
+  it('prefetches preview details on hover so opening it needs no new request', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     const groupRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${fixProposedGroup.id}/`,
       body: fixProposedGroup,
+    });
+    const pullRequestsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
+      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
+      body: {pullRequests: []},
+    });
+    const autofixSetupRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/setup/`,
+      body: AutofixSetupFixture({
+        billing: {hasAutofixQuota: false},
+        integration: {ok: false, reason: null},
+        seerReposLinked: false,
+      }),
+    });
+    const autofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
+      body: ExplorerAutofixResponseFixture({autofix: null}),
     });
 
     render(<InboxPage />, {organization, initialRouterConfig});
@@ -856,9 +874,14 @@ describe('InboxPage', () => {
     ).findByRole('link', {name: /Fix proposed issue/});
     await userEvent.hover(issueLink);
 
-    await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(groupRequest).toHaveBeenCalledTimes(1);
+      expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+      expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+      expect(autofixRequest).toHaveBeenCalledTimes(1);
+    });
 
-    // Reads the warmed cache, which only holds if the query keys match.
+    // Reads the warmed caches, which only hold if all query keys match.
     await userEvent.click(issueLink);
 
     const preview = screen.getByRole('complementary', {name: 'Issue preview'});
@@ -866,34 +889,9 @@ describe('InboxPage', () => {
       await within(preview).findByRole('heading', {name: 'Activity'})
     ).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders activity while the Autofix summary is loading', async () => {
-    mockSuccessfulSections();
-    mockIssuePreview();
-    const autofixRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
-      match: [MockApiClient.matchQuery({mode: 'explorer'})],
-      body: new Promise(() => {}),
-    });
-    const pullRequestsRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
-      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
-      body: {pullRequests: []},
-    });
-
-    render(<InboxPage />, {
-      organization: seerOrganization,
-      initialRouterConfig,
-    });
-
-    const preview = await openFixProposedPreview();
-
-    expect(
-      await within(preview).findByRole('heading', {name: 'Activity'})
-    ).toBeInTheDocument();
-    expect(autofixRequest).toHaveBeenCalledTimes(1);
     expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+    expect(autofixSetupRequest).toHaveBeenCalledTimes(1);
+    expect(autofixRequest).toHaveBeenCalledTimes(1);
   });
 
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -894,6 +894,39 @@ describe('InboxPage', () => {
     expect(autofixRequest).toHaveBeenCalledTimes(1);
   });
 
+  it('renders available content while the Autofix prefetch is still loading', async () => {
+    mockSuccessfulSections();
+    mockIssuePreview();
+    const autofixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      match: [MockApiClient.matchQuery({mode: 'explorer', llmFormat: 'markdown'})],
+      body: new Promise(() => {}),
+    });
+    const pullRequestsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/pull-requests/`,
+      match: [MockApiClient.matchQuery({expand: 'checksAndReview'})],
+      body: {pullRequests: []},
+    });
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const issueLink = await within(
+      screen.getByRole('region', {name: 'Fix Proposed'})
+    ).findByRole('link', {name: /Fix proposed issue/});
+    await userEvent.hover(issueLink);
+    await waitFor(() => expect(autofixRequest).toHaveBeenCalledTimes(1));
+    await userEvent.click(issueLink);
+
+    const preview = screen.getByRole('complementary', {name: 'Issue preview'});
+    expect(
+      await within(preview).findByRole('heading', {name: 'Activity'})
+    ).toBeInTheDocument();
+    expect(pullRequestsRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('stores selection in the URL, renders the embedded preview, and clears it', async () => {
     mockSuccessfulSections();
     mockIssuePreview();

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -315,6 +315,7 @@ function InboxContent() {
     SELECTED_ISSUE_QUERY_PARAM,
     parseAsString.withOptions({history: 'replace'})
   );
+  const [selectedGroup, setSelectedGroup] = useState<Group>();
   const assignmentCounts = useAssignmentCounts();
   const sections = SECTIONS.filter(
     section => !section.hidden?.({assignmentFilter, hasSeer})
@@ -383,6 +384,7 @@ function InboxContent() {
                 section={section}
                 assignmentFilter={assignmentFilter}
                 selectedIssueId={selectedIssueId}
+                onSelectGroup={setSelectedGroup}
                 onInitialResult={handleInitialSectionResult}
               />
             ))}
@@ -432,7 +434,14 @@ function InboxContent() {
               </Button>
             </Container>
           )}
-          {selectedIssueId && <IssuePreview groupId={selectedIssueId} />}
+          {selectedIssueId && (
+            <IssuePreview
+              groupId={selectedIssueId}
+              initialGroup={
+                selectedGroup?.id === selectedIssueId ? selectedGroup : undefined
+              }
+            />
+          )}
           {!selectedIssueId && isInboxEmpty && (
             <InboxEmptyState assignmentFilter={assignmentFilter} />
           )}
@@ -460,6 +469,7 @@ function AssignmentCountBadge({count}: {count: number | undefined}) {
 interface InboxSectionProps {
   assignmentFilter: AssignmentFilter;
   onInitialResult: (sectionKey: string, firstIssueId: string | null) => void;
+  onSelectGroup: (group: Group) => void;
   section: InboxSectionConfig;
   selectedIssueId: string | null;
 }
@@ -467,6 +477,7 @@ interface InboxSectionProps {
 function InboxSection({
   assignmentFilter,
   onInitialResult,
+  onSelectGroup,
   section,
   selectedIssueId,
 }: InboxSectionProps) {
@@ -571,6 +582,7 @@ function InboxSection({
                 <InboxIssueCard
                   assignmentFilter={assignmentFilter}
                   group={group}
+                  onSelect={onSelectGroup}
                   progressLabel={section.label}
                   selected={selectedIssueId === group.id}
                   showPullRequests={
@@ -652,12 +664,14 @@ function InboxIssueCard({
   assignmentFilter,
   assignedUser,
   group,
+  onSelect,
   progressLabel,
   selected,
   showPullRequests,
 }: {
   assignmentFilter: AssignmentFilter;
   group: Group;
+  onSelect: (group: Group) => void;
   progressLabel: string;
   selected: boolean;
   showPullRequests: boolean;
@@ -680,15 +694,16 @@ function InboxIssueCard({
           pathname: location.pathname,
           query: {...location.query, [SELECTED_ISSUE_QUERY_PARAM]: group.id},
         }}
-        onClick={() =>
+        onClick={() => {
+          onSelect(group);
           trackAnalytics('issue_inbox.item_clicked', {
             organization,
             assignment_filter: assignmentFilter,
             group_id: group.id,
             progress: group.derivedData?.progress,
             last_progressed_at: group.derivedData?.lastProgressedAt ?? null,
-          })
-        }
+          });
+        }}
       >
         <InteractionStateLayer />
         <Grid columns="8px minmax(0, 1fr) max-content" gap="md" align="stretch">

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -667,7 +667,7 @@ function InboxIssueCard({
   const organization = useOrganization();
   const {title} = getTitle(group);
   const message = getMessage(group);
-  const prefetchHoverProps = useInboxPreviewPrefetch(group.id);
+  const prefetchHoverProps = useInboxPreviewPrefetch(group);
   const suggestedAssignees = useIssueSuggestedAssignees(group);
 
   return (

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -315,7 +315,6 @@ function InboxContent() {
     SELECTED_ISSUE_QUERY_PARAM,
     parseAsString.withOptions({history: 'replace'})
   );
-  const [selectedGroup, setSelectedGroup] = useState<Group>();
   const assignmentCounts = useAssignmentCounts();
   const sections = SECTIONS.filter(
     section => !section.hidden?.({assignmentFilter, hasSeer})
@@ -384,7 +383,6 @@ function InboxContent() {
                 section={section}
                 assignmentFilter={assignmentFilter}
                 selectedIssueId={selectedIssueId}
-                onSelectGroup={setSelectedGroup}
                 onInitialResult={handleInitialSectionResult}
               />
             ))}
@@ -434,14 +432,7 @@ function InboxContent() {
               </Button>
             </Container>
           )}
-          {selectedIssueId && (
-            <IssuePreview
-              groupId={selectedIssueId}
-              initialGroup={
-                selectedGroup?.id === selectedIssueId ? selectedGroup : undefined
-              }
-            />
-          )}
+          {selectedIssueId && <IssuePreview groupId={selectedIssueId} />}
           {!selectedIssueId && isInboxEmpty && (
             <InboxEmptyState assignmentFilter={assignmentFilter} />
           )}
@@ -469,7 +460,6 @@ function AssignmentCountBadge({count}: {count: number | undefined}) {
 interface InboxSectionProps {
   assignmentFilter: AssignmentFilter;
   onInitialResult: (sectionKey: string, firstIssueId: string | null) => void;
-  onSelectGroup: (group: Group) => void;
   section: InboxSectionConfig;
   selectedIssueId: string | null;
 }
@@ -477,7 +467,6 @@ interface InboxSectionProps {
 function InboxSection({
   assignmentFilter,
   onInitialResult,
-  onSelectGroup,
   section,
   selectedIssueId,
 }: InboxSectionProps) {
@@ -582,7 +571,6 @@ function InboxSection({
                 <InboxIssueCard
                   assignmentFilter={assignmentFilter}
                   group={group}
-                  onSelect={onSelectGroup}
                   progressLabel={section.label}
                   selected={selectedIssueId === group.id}
                   showPullRequests={
@@ -664,14 +652,12 @@ function InboxIssueCard({
   assignmentFilter,
   assignedUser,
   group,
-  onSelect,
   progressLabel,
   selected,
   showPullRequests,
 }: {
   assignmentFilter: AssignmentFilter;
   group: Group;
-  onSelect: (group: Group) => void;
   progressLabel: string;
   selected: boolean;
   showPullRequests: boolean;
@@ -694,16 +680,15 @@ function InboxIssueCard({
           pathname: location.pathname,
           query: {...location.query, [SELECTED_ISSUE_QUERY_PARAM]: group.id},
         }}
-        onClick={() => {
-          onSelect(group);
+        onClick={() =>
           trackAnalytics('issue_inbox.item_clicked', {
             organization,
             assignment_filter: assignmentFilter,
             group_id: group.id,
             progress: group.derivedData?.progress,
             last_progressed_at: group.derivedData?.lastProgressedAt ?? null,
-          });
-        }}
+          })
+        }
       >
         <InteractionStateLayer />
         <Grid columns="8px minmax(0, 1fr) max-content" gap="md" align="stretch">

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -2,6 +2,11 @@ import {useHover} from '@react-aria/interactions';
 import {useDebouncer} from '@tanstack/react-pacer';
 import {useQueryClient} from '@tanstack/react-query';
 
+import {autofixSetupApiOptions} from 'sentry/components/events/autofix/useAutofixSetup';
+import {explorerAutofixApiOptions} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {linkedPullRequestsApiOptions} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
+import type {Group} from 'sentry/types/group';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
@@ -9,23 +14,45 @@ import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 const PREFETCH_DELAY_MS = 300;
 
 /**
- * Warms the preview's request on hover so clicking renders from cache. Reuses
- * the preview's own options factory so the query key matches.
+ * Warms the preview's requests on hover so clicking renders from cache. Reuses
+ * the preview's own options factories so the query keys match.
  */
-export function useInboxPreviewPrefetch(groupId: string) {
+export function useInboxPreviewPrefetch(group: Group) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
   const environments = useEnvironmentsFromUrl();
+  const shouldPrefetchAutofix =
+    !organization.hideAiFeatures &&
+    organization.features.includes('gen-ai-features') &&
+    getConfigForIssueType(group, group.project).autofix;
   const prefetchDebouncer = useDebouncer(
     () => {
       void queryClient.prefetchQuery(
         groupApiOptions({
-          groupId,
+          groupId: group.id,
           organizationSlug: organization.slug,
           environments,
           expandDerivedData: organization.features.includes('issue-inbox'),
         })
       );
+      void queryClient.prefetchQuery(
+        linkedPullRequestsApiOptions({
+          groupId: group.id,
+          organizationSlug: organization.slug,
+        })
+      );
+      void queryClient.prefetchQuery(
+        autofixSetupApiOptions({
+          groupId: group.id,
+          organizationSlug: organization.slug,
+        })
+      );
+      if (shouldPrefetchAutofix) {
+        void queryClient.prefetchQuery({
+          ...explorerAutofixApiOptions(organization.slug, group.id),
+          retry: false,
+        });
+      }
     },
     {wait: PREFETCH_DELAY_MS}
   );

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,4 +1,5 @@
 import {useFocus, useHover} from '@react-aria/interactions';
+import {useDebouncer} from '@tanstack/react-pacer';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {autofixSetupApiOptions} from 'sentry/components/events/autofix/useAutofixSetup';
@@ -9,6 +10,8 @@ import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
+
+const PREFETCH_DELAY_MS = 100;
 
 /**
  * Warms each of the preview's independent requests as soon as a user shows
@@ -51,12 +54,16 @@ export function useInboxPreviewPrefetch(group: Group) {
       });
     }
   };
+  const hoverPrefetch = useDebouncer(prefetch, {wait: PREFETCH_DELAY_MS});
+  const focusPrefetch = useDebouncer(prefetch, {wait: PREFETCH_DELAY_MS});
 
   const {hoverProps} = useHover({
-    onHoverStart: prefetch,
+    onHoverStart: () => hoverPrefetch.maybeExecute(),
+    onHoverEnd: () => hoverPrefetch.cancel(),
   });
   const {focusProps} = useFocus({
-    onFocus: prefetch,
+    onFocus: () => focusPrefetch.maybeExecute(),
+    onBlur: () => focusPrefetch.cancel(),
   });
 
   return {

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,4 +1,4 @@
-import {useFocus, useHover} from '@react-aria/interactions';
+import {useHover} from '@react-aria/interactions';
 import {useDebouncer} from '@tanstack/react-pacer';
 import {useQueryClient} from '@tanstack/react-query';
 
@@ -26,48 +26,42 @@ export function useInboxPreviewPrefetch(group: Group) {
     !organization.hideAiFeatures &&
     organization.features.includes('gen-ai-features') &&
     getConfigForIssueType(group, group.project).autofix;
-  const prefetch = () => {
-    void queryClient.prefetchQuery(
-      groupApiOptions({
-        groupId: group.id,
-        organizationSlug: organization.slug,
-        environments,
-        expandDerivedData: organization.features.includes('issue-inbox'),
-      })
-    );
-    void queryClient.prefetchQuery(
-      linkedPullRequestsApiOptions({
-        groupId: group.id,
-        organizationSlug: organization.slug,
-      })
-    );
-    void queryClient.prefetchQuery(
-      autofixSetupApiOptions({
-        groupId: group.id,
-        organizationSlug: organization.slug,
-      })
-    );
-    if (shouldPrefetchAutofix) {
-      void queryClient.prefetchQuery({
-        ...explorerAutofixApiOptions(organization.slug, group.id),
-        retry: false,
-      });
-    }
-  };
-  const hoverPrefetch = useDebouncer(prefetch, {wait: PREFETCH_DELAY_MS});
-  const focusPrefetch = useDebouncer(prefetch, {wait: PREFETCH_DELAY_MS});
+  const prefetchDebouncer = useDebouncer(
+    () => {
+      void queryClient.prefetchQuery(
+        groupApiOptions({
+          groupId: group.id,
+          organizationSlug: organization.slug,
+          environments,
+          expandDerivedData: organization.features.includes('issue-inbox'),
+        })
+      );
+      void queryClient.prefetchQuery(
+        linkedPullRequestsApiOptions({
+          groupId: group.id,
+          organizationSlug: organization.slug,
+        })
+      );
+      void queryClient.prefetchQuery(
+        autofixSetupApiOptions({
+          groupId: group.id,
+          organizationSlug: organization.slug,
+        })
+      );
+      if (shouldPrefetchAutofix) {
+        void queryClient.prefetchQuery({
+          ...explorerAutofixApiOptions(organization.slug, group.id),
+          retry: false,
+        });
+      }
+    },
+    {wait: PREFETCH_DELAY_MS}
+  );
 
   const {hoverProps} = useHover({
-    onHoverStart: () => hoverPrefetch.maybeExecute(),
-    onHoverEnd: () => hoverPrefetch.cancel(),
-  });
-  const {focusProps} = useFocus({
-    onFocus: () => focusPrefetch.maybeExecute(),
-    onBlur: () => focusPrefetch.cancel(),
+    onHoverStart: () => prefetchDebouncer.maybeExecute(),
+    onHoverEnd: () => prefetchDebouncer.cancel(),
   });
 
-  return {
-    ...hoverProps,
-    ...focusProps,
-  };
+  return hoverProps;
 }

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -11,7 +11,8 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
-const PREFETCH_DELAY_MS = 100;
+const GROUP_PREFETCH_DELAY_MS = 100;
+const SECONDARY_PREFETCH_DELAY_MS = 300;
 
 /**
  * Warms each of the preview's independent requests as soon as a user shows
@@ -22,38 +23,56 @@ export function useInboxPreviewPrefetch(group: Group) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
   const environments = useEnvironmentsFromUrl();
-  const shouldPrefetchAutofix =
-    !organization.hideAiFeatures &&
-    organization.features.includes('gen-ai-features') &&
-    getConfigForIssueType(group, group.project).autofix;
-  const queryParams = {
+  const issueParams = {
     groupId: group.id,
     organizationSlug: organization.slug,
   };
-  const prefetchDebouncer = useDebouncer(
+  const groupPrefetchDebouncer = useDebouncer(
     () => {
       void queryClient.prefetchQuery(
         groupApiOptions({
-          ...queryParams,
+          ...issueParams,
           environments,
           expandDerivedData: organization.features.includes('issue-inbox'),
         })
       );
-      void queryClient.prefetchQuery(linkedPullRequestsApiOptions(queryParams));
-      void queryClient.prefetchQuery(autofixSetupApiOptions(queryParams));
+    },
+    {wait: GROUP_PREFETCH_DELAY_MS}
+  );
+  const secondaryPrefetchDebouncer = useDebouncer(
+    () => {
+      void queryClient.prefetchQuery({
+        ...linkedPullRequestsApiOptions(issueParams),
+        retry: false,
+      });
+
+      const shouldPrefetchAutofix =
+        !organization.hideAiFeatures &&
+        organization.features.includes('gen-ai-features') &&
+        getConfigForIssueType(group, group.project).autofix;
       if (shouldPrefetchAutofix) {
+        void queryClient.prefetchQuery({
+          ...autofixSetupApiOptions(issueParams),
+          retry: false,
+        });
         void queryClient.prefetchQuery({
           ...explorerAutofixApiOptions(organization.slug, group.id),
           retry: false,
         });
       }
     },
-    {wait: PREFETCH_DELAY_MS}
+    {wait: SECONDARY_PREFETCH_DELAY_MS}
   );
 
   const {hoverProps} = useHover({
-    onHoverStart: () => prefetchDebouncer.maybeExecute(),
-    onHoverEnd: () => prefetchDebouncer.cancel(),
+    onHoverStart: () => {
+      groupPrefetchDebouncer.maybeExecute();
+      secondaryPrefetchDebouncer.maybeExecute();
+    },
+    onHoverEnd: () => {
+      groupPrefetchDebouncer.cancel();
+      secondaryPrefetchDebouncer.cancel();
+    },
   });
 
   return hoverProps;

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -1,5 +1,4 @@
-import {useHover} from '@react-aria/interactions';
-import {useDebouncer} from '@tanstack/react-pacer';
+import {useFocus, useHover} from '@react-aria/interactions';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {autofixSetupApiOptions} from 'sentry/components/events/autofix/useAutofixSetup';
@@ -11,11 +10,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
-const PREFETCH_DELAY_MS = 300;
-
 /**
- * Warms the preview's requests on hover so clicking renders from cache. Reuses
- * the preview's own options factories so the query keys match.
+ * Warms each of the preview's independent requests as soon as a user shows
+ * intent to open an issue. Reuses the preview's own options factories so the
+ * query keys match.
  */
 export function useInboxPreviewPrefetch(group: Group) {
   const organization = useOrganization();
@@ -25,42 +23,44 @@ export function useInboxPreviewPrefetch(group: Group) {
     !organization.hideAiFeatures &&
     organization.features.includes('gen-ai-features') &&
     getConfigForIssueType(group, group.project).autofix;
-  const prefetchDebouncer = useDebouncer(
-    () => {
-      void queryClient.prefetchQuery(
-        groupApiOptions({
-          groupId: group.id,
-          organizationSlug: organization.slug,
-          environments,
-          expandDerivedData: organization.features.includes('issue-inbox'),
-        })
-      );
-      void queryClient.prefetchQuery(
-        linkedPullRequestsApiOptions({
-          groupId: group.id,
-          organizationSlug: organization.slug,
-        })
-      );
-      void queryClient.prefetchQuery(
-        autofixSetupApiOptions({
-          groupId: group.id,
-          organizationSlug: organization.slug,
-        })
-      );
-      if (shouldPrefetchAutofix) {
-        void queryClient.prefetchQuery({
-          ...explorerAutofixApiOptions(organization.slug, group.id),
-          retry: false,
-        });
-      }
-    },
-    {wait: PREFETCH_DELAY_MS}
-  );
+  const prefetch = () => {
+    void queryClient.prefetchQuery(
+      groupApiOptions({
+        groupId: group.id,
+        organizationSlug: organization.slug,
+        environments,
+        expandDerivedData: organization.features.includes('issue-inbox'),
+      })
+    );
+    void queryClient.prefetchQuery(
+      linkedPullRequestsApiOptions({
+        groupId: group.id,
+        organizationSlug: organization.slug,
+      })
+    );
+    void queryClient.prefetchQuery(
+      autofixSetupApiOptions({
+        groupId: group.id,
+        organizationSlug: organization.slug,
+      })
+    );
+    if (shouldPrefetchAutofix) {
+      void queryClient.prefetchQuery({
+        ...explorerAutofixApiOptions(organization.slug, group.id),
+        retry: false,
+      });
+    }
+  };
 
   const {hoverProps} = useHover({
-    onHoverStart: () => prefetchDebouncer.maybeExecute(),
-    onHoverEnd: () => prefetchDebouncer.cancel(),
+    onHoverStart: prefetch,
+  });
+  const {focusProps} = useFocus({
+    onFocus: prefetch,
   });
 
-  return hoverProps;
+  return {
+    ...hoverProps,
+    ...focusProps,
+  };
 }

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -11,8 +11,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
-const GROUP_PREFETCH_DELAY_MS = 100;
-const SECONDARY_PREFETCH_DELAY_MS = 300;
+const PREFETCH_DELAY_MS = 200;
 
 /**
  * Warms each of the preview's independent requests as soon as a user shows
@@ -27,7 +26,7 @@ export function useInboxPreviewPrefetch(group: Group) {
     groupId: group.id,
     organizationSlug: organization.slug,
   };
-  const groupPrefetchDebouncer = useDebouncer(
+  const prefetchDebouncer = useDebouncer(
     () => {
       void queryClient.prefetchQuery(
         groupApiOptions({
@@ -36,11 +35,6 @@ export function useInboxPreviewPrefetch(group: Group) {
           expandDerivedData: organization.features.includes('issue-inbox'),
         })
       );
-    },
-    {wait: GROUP_PREFETCH_DELAY_MS}
-  );
-  const secondaryPrefetchDebouncer = useDebouncer(
-    () => {
       void queryClient.prefetchQuery({
         ...linkedPullRequestsApiOptions(issueParams),
         retry: false,
@@ -61,18 +55,12 @@ export function useInboxPreviewPrefetch(group: Group) {
         });
       }
     },
-    {wait: SECONDARY_PREFETCH_DELAY_MS}
+    {wait: PREFETCH_DELAY_MS}
   );
 
   const {hoverProps} = useHover({
-    onHoverStart: () => {
-      groupPrefetchDebouncer.maybeExecute();
-      secondaryPrefetchDebouncer.maybeExecute();
-    },
-    onHoverEnd: () => {
-      groupPrefetchDebouncer.cancel();
-      secondaryPrefetchDebouncer.cancel();
-    },
+    onHoverStart: () => prefetchDebouncer.maybeExecute(),
+    onHoverEnd: () => prefetchDebouncer.cancel(),
   });
 
   return hoverProps;

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -26,28 +26,21 @@ export function useInboxPreviewPrefetch(group: Group) {
     !organization.hideAiFeatures &&
     organization.features.includes('gen-ai-features') &&
     getConfigForIssueType(group, group.project).autofix;
+  const queryParams = {
+    groupId: group.id,
+    organizationSlug: organization.slug,
+  };
   const prefetchDebouncer = useDebouncer(
     () => {
       void queryClient.prefetchQuery(
         groupApiOptions({
-          groupId: group.id,
-          organizationSlug: organization.slug,
+          ...queryParams,
           environments,
           expandDerivedData: organization.features.includes('issue-inbox'),
         })
       );
-      void queryClient.prefetchQuery(
-        linkedPullRequestsApiOptions({
-          groupId: group.id,
-          organizationSlug: organization.slug,
-        })
-      );
-      void queryClient.prefetchQuery(
-        autofixSetupApiOptions({
-          groupId: group.id,
-          organizationSlug: organization.slug,
-        })
-      );
+      void queryClient.prefetchQuery(linkedPullRequestsApiOptions(queryParams));
+      void queryClient.prefetchQuery(autofixSetupApiOptions(queryParams));
       if (shouldPrefetchAutofix) {
         void queryClient.prefetchQuery({
           ...explorerAutofixApiOptions(organization.slug, group.id),


### PR DESCRIPTION
Inbox hover prefetching now waits 200 ms, then warms the existing group query, linked Pull Requests, and Autofix setup and state for eligible issues at the same time. Speculative requests do not retry. The preview's existing rendering and selection behavior is unchanged.

The additional queries reuse the same option factories as their consumers. Autofix setup and state use a 30-second stale window so the warmed cache is consumed when the preview mounts; polling, explicit refetches, and mutation invalidation continue to refresh them.

Refs ISWF-3354
