### PR TITLE
fix(tables): Forward overlays through Table.HeadCell

### DIFF
--- a/static/app/components/core/table/table.tsx
+++ b/static/app/components/core/table/table.tsx
@@ -8,6 +8,7 @@ import type {
 } from 'react';
 import {
   createContext,
+  Fragment,
   useCallback,
   useContext,
   useEffect,
@@ -272,6 +273,7 @@ interface HeadCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
    */
   columnIndex?: number;
   onSort?: () => void;
+  overlays?: ReactNode;
   sort?: SortDirection;
 }
 
@@ -280,6 +282,7 @@ function HeadCell({
   column,
   columnIndex,
   onSort,
+  overlays,
   sort,
   ...props
 }: HeadCellProps) {
@@ -310,11 +313,14 @@ function HeadCell({
       role="columnheader"
     >
       {sortable ? (
-        <SortableHeaderCell direction={sort} onSort={onSort}>
+        <SortableHeaderCell direction={sort} onSort={onSort} overlays={overlays}>
           {children}
         </SortableHeaderCell>
       ) : (
-        children
+        <Fragment>
+          {overlays}
+          {children}
+        </Fragment>
       )}
       {showResizer && (
         <TableResizer onContextMenu={event => event.preventDefault()}>


### PR DESCRIPTION
`Table.HeadCell` now accepts an `overlays` prop and renders it, forwarding it to `SortableHeaderCell` for sortable columns and placing it alongside the cell content otherwise.
