### PR TITLE
fix(project-creation): Preserve SCM details on platform change

### DIFF
--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
@@ -74,7 +74,6 @@ function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
     selectedPlatform: pythonPlatform,
     onPlatformChange: jest.fn(),
     onFeaturesChange: jest.fn(),
-    onClearProjectDetailsForm: jest.fn(),
     ...overrides,
   };
 }
@@ -239,13 +238,11 @@ describe('ScmPlatformFeaturesCore', () => {
   it('clears the selected platform from the manual picker', async () => {
     const onPlatformChange = jest.fn();
     const onFeaturesChange = jest.fn();
-    const onClearProjectDetailsForm = jest.fn();
     render(
       <ScmPlatformFeaturesCore
         {...defaultProps({
           onPlatformChange,
           onFeaturesChange,
-          onClearProjectDetailsForm,
         })}
       />,
       {organization}
@@ -255,7 +252,6 @@ describe('ScmPlatformFeaturesCore', () => {
 
     expect(onPlatformChange).toHaveBeenCalledWith(undefined);
     expect(onFeaturesChange).toHaveBeenCalledWith(undefined);
-    expect(onClearProjectDetailsForm).toHaveBeenCalled();
   });
 
   it('does not offer a clear button when a platform was auto-detected', async () => {
@@ -289,7 +285,6 @@ describe('ScmPlatformFeaturesCore', () => {
 
   it('keeps a non-default detected selection when returning to the recommended view', async () => {
     const onFeaturesChange = jest.fn();
-    const onClearProjectDetailsForm = jest.fn();
     const repository = RepositoryFixture({
       id: '123',
       provider: {id: 'integrations:github', name: 'GitHub'},
@@ -317,7 +312,6 @@ describe('ScmPlatformFeaturesCore', () => {
           selectedPlatform={platform}
           onPlatformChange={setPlatform}
           onFeaturesChange={onFeaturesChange}
-          onClearProjectDetailsForm={onClearProjectDetailsForm}
         />
       );
     }
@@ -332,7 +326,6 @@ describe('ScmPlatformFeaturesCore', () => {
       screen.getByRole('button', {name: "Doesn't look right? Change platform"})
     );
     onFeaturesChange.mockClear();
-    onClearProjectDetailsForm.mockClear();
 
     // Returning keeps the chosen detected platform: it is already detected, so
     // nothing is reset and the card stays selected.
@@ -344,12 +337,10 @@ describe('ScmPlatformFeaturesCore', () => {
       await screen.findByRole('radio', {name: 'Browser JavaScript Language'})
     ).toBeChecked();
     expect(onFeaturesChange).not.toHaveBeenCalled();
-    expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
   });
 
   it('does not reset state when returning without a change', async () => {
     const onFeaturesChange = jest.fn();
-    const onClearProjectDetailsForm = jest.fn();
     const repository = RepositoryFixture({
       id: '123',
       provider: {id: 'integrations:github', name: 'GitHub'},
@@ -366,7 +357,6 @@ describe('ScmPlatformFeaturesCore', () => {
           selectedRepository: repository,
           selectedPlatform: pythonPlatform,
           onFeaturesChange,
-          onClearProjectDetailsForm,
         })}
       />,
       {organization}
@@ -382,14 +372,12 @@ describe('ScmPlatformFeaturesCore', () => {
     );
 
     expect(onFeaturesChange).not.toHaveBeenCalled();
-    expect(onClearProjectDetailsForm).not.toHaveBeenCalled();
   });
 
   it('reverts a manual pick to the detected platform on return, recording it', async () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const onPlatformChange = jest.fn();
     const onFeaturesChange = jest.fn();
-    const onClearProjectDetailsForm = jest.fn();
     const repository = RepositoryFixture({
       id: '123',
       provider: {id: 'integrations:github', name: 'GitHub'},
@@ -408,7 +396,6 @@ describe('ScmPlatformFeaturesCore', () => {
           selectedPlatform: javascriptPlatform,
           onPlatformChange,
           onFeaturesChange,
-          onClearProjectDetailsForm,
         })}
       />,
       {organization}

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -62,7 +62,6 @@ interface ScmPlatformFeaturesCoreProps {
   onPlatformChange: (platform: OnboardingSelectedSDK | undefined) => void;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
-  onClearProjectDetailsForm?: () => void;
 }
 
 /**
@@ -80,7 +79,6 @@ interface ScmPlatformFeaturesCoreProps {
  */
 export function ScmPlatformFeaturesCore({
   analyticsFlow,
-  onClearProjectDetailsForm,
   onFeaturesChange,
   onPlatformChange,
   selectedPlatform,
@@ -175,11 +173,9 @@ export function ScmPlatformFeaturesCore({
   const applyPlatformSelection = (sdk: OnboardingSelectedSDK) => {
     onPlatformChange(sdk);
     onFeaturesChange(DEFAULT_SCM_FEATURES);
-    onClearProjectDetailsForm?.();
   };
 
-  // Inverse of a platform selection: drop the platform and everything derived
-  // from it (the default features and the platform-seeded project name).
+  // Inverse of a platform selection: drop the platform and default features.
   // Mirrors the repo selector's clearable Select. Only offered when there is no
   // detected platform to fall back to (see the Select's clearable below):
   // otherwise currentPlatformKey would keep showing the detected key while the
@@ -194,7 +190,6 @@ export function ScmPlatformFeaturesCore({
     autoDetectionTrackedRef.current = true;
     onPlatformChange(undefined);
     onFeaturesChange(undefined);
-    onClearProjectDetailsForm?.();
   };
 
   const handleManualPlatformSelect = async (option: {value: string}) => {
@@ -254,7 +249,6 @@ export function ScmPlatformFeaturesCore({
 
     setPlatform(platformKey);
     onFeaturesChange(DEFAULT_SCM_FEATURES);
-    onClearProjectDetailsForm?.();
 
     trackScmPlatformSelected(analyticsFlow, organization, platformKey, 'manual');
   };
@@ -265,7 +259,6 @@ export function ScmPlatformFeaturesCore({
     }
     setPlatform(platformKey);
     onFeaturesChange(DEFAULT_SCM_FEATURES);
-    onClearProjectDetailsForm?.();
 
     trackScmPlatformSelected(analyticsFlow, organization, platformKey, 'detected');
   };
@@ -292,7 +285,7 @@ export function ScmPlatformFeaturesCore({
     // If the host already has a detected platform committed, just reopen the
     // cards view with it still selected. The user may have committed a non-top
     // detection (or the auto-adopted default), so forcing the top detection here
-    // would clear a valid selection and wipe the derived features/form for no
+    // would clear a valid selection and reset the derived features for no
     // reason. Check selectedPlatform, not currentPlatformKey: the latter falls
     // back to the top detection even when nothing is committed, so using it here
     // would skip the commit below and strand Create behind an empty
@@ -305,7 +298,6 @@ export function ScmPlatformFeaturesCore({
     }
     setPlatform(detectedPlatformKey);
     onFeaturesChange(DEFAULT_SCM_FEATURES);
-    onClearProjectDetailsForm?.();
     // Leaving a manual pick for the detected platform is itself a platform
     // selection, so record it as the detected source (mirrors the auto-adopt
     // path and handleSelectDetectedPlatform, which were the only detected-source

--- a/static/app/components/onboarding/scm/scmProjectDetailsTypes.ts
+++ b/static/app/components/onboarding/scm/scmProjectDetailsTypes.ts
@@ -6,4 +6,5 @@ export interface ProjectDetailsFormState {
   notificationSelection?: NotificationSelection;
   projectName?: string;
   teamSlug?: string;
+  wasNameManuallyModified?: boolean;
 }

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -30,6 +30,16 @@ import {
   RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
+export function isProjectNameManuallyModified(
+  projectDetailsForm: ProjectDetailsFormState | undefined
+): boolean {
+  // Sessions stored before this flag existed contain an explicit project name.
+  return (
+    projectDetailsForm?.wasNameManuallyModified ??
+    projectDetailsForm?.projectName !== undefined
+  );
+}
+
 export function getSubmitTooltipText({
   platform,
   projectName,
@@ -353,7 +363,7 @@ export function useScmProjectDetails({
       teamSlug: teamSlugResolved,
       alertRuleConfig,
       notificationSelection,
-      wasNameManuallyModified: projectDetailsForm?.wasNameManuallyModified ?? false,
+      wasNameManuallyModified: isProjectNameManuallyModified(projectDetailsForm),
     };
     // Mirror the legacy project_creation_page.created `issue_alert` breakdown
     // (see createProject.tsx): Custom > Default > No Rule, derived from the
@@ -455,7 +465,7 @@ export function useScmProjectDetails({
     notificationProps,
     onComplete,
     organization,
-    projectDetailsForm?.wasNameManuallyModified,
+    projectDetailsForm,
     projectNameResolved,
     selectedPlatform,
     selectedRepository,

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -33,11 +33,14 @@ import {
 export function isProjectNameManuallyModified(
   projectDetailsForm: ProjectDetailsFormState | undefined
 ): boolean {
+  if (!projectDetailsForm) {
+    return false;
+  }
+  if (projectDetailsForm.wasNameManuallyModified !== undefined) {
+    return projectDetailsForm.wasNameManuallyModified;
+  }
   // Sessions stored before this flag existed contain an explicit project name.
-  return (
-    projectDetailsForm?.wasNameManuallyModified ??
-    projectDetailsForm?.projectName !== undefined
-  );
+  return projectDetailsForm.projectName !== undefined;
 }
 
 export function getSubmitTooltipText({

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -174,7 +174,7 @@ export function useScmProjectDetails({
   const defaultName = slugify(selectedPlatform?.key ?? '');
 
   // Fields absent from the host-owned form fall back to derived defaults, so
-  // a host clearing the form (e.g. on a platform change) re-derives them.
+  // a host resetting a field (e.g. the name on a platform change) re-derives it.
   const projectNameResolved = projectDetailsForm?.projectName ?? defaultName;
   const teamSlugResolved = projectDetailsForm?.teamSlug ?? firstAdminTeam?.slug ?? '';
   const alertRuleConfig =

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -80,7 +80,7 @@ interface UseScmProjectDetailsOptions {
   /**
    * Live form state, owned by the host. Fields absent from the form derive
    * their defaults (platform-based name, first admin team, default alert
-   * config), so the host clearing the form makes the fields re-derive.
+   * config).
    */
   onProjectDetailsFormChange: (form: ProjectDetailsFormState) => void;
   projectDetailsForm: ProjectDetailsFormState | undefined;
@@ -177,7 +177,12 @@ export function useScmProjectDetails({
 
   const onProjectNameChange = useCallback(
     (value: string) => {
-      onProjectDetailsFormChange({...projectDetailsForm, projectName: slugify(value)});
+      const projectName = slugify(value);
+      onProjectDetailsFormChange({
+        ...projectDetailsForm,
+        projectName,
+        wasNameManuallyModified: projectName.length > 0,
+      });
     },
     [onProjectDetailsFormChange, projectDetailsForm]
   );
@@ -348,6 +353,7 @@ export function useScmProjectDetails({
       teamSlug: teamSlugResolved,
       alertRuleConfig,
       notificationSelection,
+      wasNameManuallyModified: projectDetailsForm?.wasNameManuallyModified ?? false,
     };
     // Mirror the legacy project_creation_page.created `issue_alert` breakdown
     // (see createProject.tsx): Custom > Default > No Rule, derived from the
@@ -449,6 +455,7 @@ export function useScmProjectDetails({
     notificationProps,
     onComplete,
     organization,
+    projectDetailsForm?.wasNameManuallyModified,
     projectNameResolved,
     selectedPlatform,
     selectedRepository,

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -334,20 +334,17 @@ describe('ScmCreateProject', () => {
     expect(projectName).toHaveValue('javascript');
     expect(screen.getByText('#selected-team')).toBeInTheDocument();
 
-    // Deliberately retype the current default: manual detection must come from
-    // the edit itself (wasNameManuallyModified), not from comparing the value
-    // to the platform default, so a name matching the default still counts.
     await userEvent.clear(projectName);
-    await userEvent.type(projectName, 'javascript');
+    await userEvent.type(projectName, 'my-app');
 
     await userEvent.click(screen.getByText('Browser JavaScript'));
     await userEvent.keyboard('Python');
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Python'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
 
-    // The manual name survives the switch back: 'javascript' on a Python
-    // platform, where a reset would have re-derived 'python'.
-    expect(projectName).toHaveValue('javascript');
+    // The manual name survives the switch back to Python, where a reset would
+    // have re-derived 'python'.
+    expect(projectName).toHaveValue('my-app');
     expect(screen.getByText('#selected-team')).toBeInTheDocument();
   });
 

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -561,6 +561,10 @@ describe('ScmCreateProject', () => {
       expect(router.location.pathname).toContain('/python/getting-started/');
     });
     expect(createRequest).not.toHaveBeenCalled();
+    expect(
+      JSON.parse(window.sessionStorage.getItem(WIZARD_KEY)!).projectDetailsForm
+        .wasNameManuallyModified
+    ).toBe(true);
   });
 
   it('creates from fresh manual selections and persists the completed state', async () => {

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -373,6 +373,38 @@ describe('ScmCreateProject', () => {
     expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
   });
 
+  it('re-derives a restored untouched name on a platform change', async () => {
+    // A completed session stores the resolved name with the manual-edit flag;
+    // false marks it as platform-derived, so it must follow a new platform
+    // instead of sticking to the old default (the explicit-name fallback alone
+    // would wrongly preserve it).
+    persistWizardSession({
+      projectDetailsForm: {
+        projectName: 'python',
+        teamSlug: adminTeam.slug,
+        wasNameManuallyModified: false,
+      },
+    });
+    renderGlobalModal();
+    render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: returningRouterConfig,
+    });
+
+    const projectName = await screen.findByPlaceholderText('project-name');
+    expect(projectName).toHaveValue('python');
+
+    await userEvent.click(screen.getByText('Python'));
+    await userEvent.keyboard('JavaScript');
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Browser JavaScript'})
+    );
+    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+
+    expect(projectName).toHaveValue('javascript');
+    expect(screen.getByText(`#${adminTeam.slug}`)).toBeInTheDocument();
+  });
+
   it('restores the wizard when the return params arrive after mount', async () => {
     const projectDetailsForm: ProjectDetailsFormState = {
       projectName: 'my-restored-name',

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -329,9 +329,14 @@ describe('ScmCreateProject', () => {
     );
     await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
 
+    // The name was never touched, so it re-derives from the new platform
+    // ('python' -> 'javascript') while the team selection survives.
     expect(projectName).toHaveValue('javascript');
     expect(screen.getByText('#selected-team')).toBeInTheDocument();
 
+    // Deliberately retype the current default: manual detection must come from
+    // the edit itself (wasNameManuallyModified), not from comparing the value
+    // to the platform default, so a name matching the default still counts.
     await userEvent.clear(projectName);
     await userEvent.type(projectName, 'javascript');
 
@@ -340,6 +345,8 @@ describe('ScmCreateProject', () => {
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Python'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
 
+    // The manual name survives the switch back: 'javascript' on a Python
+    // platform, where a reset would have re-derived 'python'.
     expect(projectName).toHaveValue('javascript');
     expect(screen.getByText('#selected-team')).toBeInTheDocument();
   });

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -65,6 +65,11 @@ const pythonPlatform: OnboardingSelectedSDK = {
 describe('ScmCreateProject', () => {
   const organization = OrganizationFixture({features: ['performance-view']});
   const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
+  const selectedTeam = TeamFixture({
+    id: '2',
+    slug: 'selected-team',
+    access: ['team:admin'],
+  });
   const githubIntegration = OrganizationIntegrationsFixture({
     id: '1',
     name: 'getsentry',
@@ -297,6 +302,46 @@ describe('ScmCreateProject', () => {
     expect(
       await screen.findByText('Please fill out all the required fields')
     ).toBeInTheDocument();
+  });
+
+  it('updates the default name and preserves edited project details', async () => {
+    TeamStore.loadInitialData([adminTeam, selectedTeam]);
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/user-teams/`,
+      body: [adminTeam, selectedTeam],
+    });
+    renderGlobalModal();
+    render(<ScmCreateProject />, {organization});
+
+    await userEvent.click(await screen.findByText('Search SDKs...'));
+    await userEvent.keyboard('Python');
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Python'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+
+    const projectName = screen.getByPlaceholderText('project-name');
+    await userEvent.type(screen.getByLabelText('Select a Team'), '{keyDown}');
+    await userEvent.click(await screen.findByText('#selected-team'));
+
+    await userEvent.click(screen.getByText('Python'));
+    await userEvent.keyboard('JavaScript');
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Browser JavaScript'})
+    );
+    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+
+    expect(projectName).toHaveValue('javascript');
+    expect(screen.getByText('#selected-team')).toBeInTheDocument();
+
+    await userEvent.clear(projectName);
+    await userEvent.type(projectName, 'javascript');
+
+    await userEvent.click(screen.getByText('Browser JavaScript'));
+    await userEvent.keyboard('Python');
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Python'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+
+    expect(projectName).toHaveValue('javascript');
+    expect(screen.getByText('#selected-team')).toBeInTheDocument();
   });
 
   it('drops a persisted wizard on a fresh visit (no return from getting-started)', async () => {

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -44,8 +44,8 @@ jest.mock('sentry/data/platforms', () => {
   const actual = jest.requireActual('sentry/data/platforms');
   return {
     ...actual,
-    platforms: actual.platforms.filter(
-      (p: {id: string}) => p.id === 'python' || p.id === 'javascript'
+    platforms: actual.platforms.filter((p: {id: string}) =>
+      ['python', 'javascript', 'python-django', 'javascript-react'].includes(p.id)
     ),
   };
 });
@@ -310,40 +310,37 @@ describe('ScmCreateProject', () => {
       url: `/organizations/${organization.slug}/user-teams/`,
       body: [adminTeam, selectedTeam],
     });
-    renderGlobalModal();
     render(<ScmCreateProject />, {organization});
 
+    // Framework SDKs commit straight from the picker; a base language (plain
+    // Python) would detour through the framework-suggestion modal.
     await userEvent.click(await screen.findByText('Search SDKs...'));
-    await userEvent.keyboard('Python');
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Python'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+    await userEvent.keyboard('Django');
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Django'}));
 
     const projectName = screen.getByPlaceholderText('project-name');
+    expect(projectName).toHaveValue('python-django');
     await userEvent.type(screen.getByLabelText('Select a Team'), '{keyDown}');
     await userEvent.click(await screen.findByText('#selected-team'));
 
-    await userEvent.click(screen.getByText('Python'));
-    await userEvent.keyboard('JavaScript');
-    await userEvent.click(
-      await screen.findByRole('menuitemradio', {name: 'Browser JavaScript'})
-    );
-    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+    await userEvent.click(screen.getByText('Django'));
+    await userEvent.keyboard('React');
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'React'}));
 
     // The name was never touched, so it re-derives from the new platform
-    // ('python' -> 'javascript') while the team selection survives.
-    expect(projectName).toHaveValue('javascript');
+    // while the team selection survives.
+    expect(projectName).toHaveValue('javascript-react');
     expect(screen.getByText('#selected-team')).toBeInTheDocument();
 
     await userEvent.clear(projectName);
     await userEvent.type(projectName, 'my-app');
 
-    await userEvent.click(screen.getByText('Browser JavaScript'));
-    await userEvent.keyboard('Python');
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Python'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Configure SDK'}));
+    await userEvent.click(screen.getByText('React'));
+    await userEvent.keyboard('Django');
+    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Django'}));
 
-    // The manual name survives the switch back to Python, where a reset would
-    // have re-derived 'python'.
+    // The manual name survives the switch back to Django, where a reset would
+    // have re-derived 'python-django'.
     expect(projectName).toHaveValue('my-app');
     expect(screen.getByText('#selected-team')).toBeInTheDocument();
   });

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -21,6 +21,7 @@ import {ScmProjectDetailsCore} from 'sentry/components/onboarding/scm/scmProject
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/scm/scmProjectDetailsTypes';
 import {useScmPlatformDetection} from 'sentry/components/onboarding/scm/useScmPlatformDetection';
 import {
+  isProjectNameManuallyModified,
   type ScmProjectDetailsCompletion,
   useScmProjectDetails,
 } from 'sentry/components/onboarding/scm/useScmProjectDetails';
@@ -154,15 +155,13 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
     (platform: OnboardingSelectedSDK | undefined) => {
       setState(s => {
         const currentProjectDetailsForm = s.projectDetailsForm;
-        const wasNameManuallyModified =
-          currentProjectDetailsForm?.wasNameManuallyModified ??
-          currentProjectDetailsForm?.projectName !== undefined;
 
         return {
           ...s,
           selectedPlatform: platform,
           projectDetailsForm:
-            !currentProjectDetailsForm || wasNameManuallyModified
+            !currentProjectDetailsForm ||
+            isProjectNameManuallyModified(currentProjectDetailsForm)
               ? currentProjectDetailsForm
               : {...currentProjectDetailsForm, projectName: undefined},
         };

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -152,7 +152,21 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
 
   const handlePlatformChange = useCallback(
     (platform: OnboardingSelectedSDK | undefined) => {
-      setState(s => ({...s, selectedPlatform: platform}));
+      setState(s => {
+        const currentProjectDetailsForm = s.projectDetailsForm;
+        const wasNameManuallyModified =
+          currentProjectDetailsForm?.wasNameManuallyModified ??
+          currentProjectDetailsForm?.projectName !== undefined;
+
+        return {
+          ...s,
+          selectedPlatform: platform,
+          projectDetailsForm:
+            !currentProjectDetailsForm || wasNameManuallyModified
+              ? currentProjectDetailsForm
+              : {...currentProjectDetailsForm, projectName: undefined},
+        };
+      });
     },
     [setState]
   );
@@ -174,13 +188,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
       selectedFeatures: undefined,
       projectDetailsForm: undefined,
     }));
-  }, [setState]);
-
-  // Clear the project-details form when the platform changes, since the
-  // project name defaults from the platform key; the hook re-derives cleared
-  // fields.
-  const handleClearProjectDetailsForm = useCallback(() => {
-    setState(s => ({...s, projectDetailsForm: undefined}));
   }, [setState]);
 
   const handleProjectDetailsFormChange = useCallback(
@@ -303,7 +310,6 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                   selectedPlatform={selectedPlatform}
                   onPlatformChange={handlePlatformChange}
                   onFeaturesChange={handleFeaturesChange}
-                  onClearProjectDetailsForm={handleClearProjectDetailsForm}
                 />
               </MotionContainer>
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -154,16 +154,15 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
   const handlePlatformChange = useCallback(
     (platform: OnboardingSelectedSDK | undefined) => {
       setState(s => {
-        const currentProjectDetailsForm = s.projectDetailsForm;
+        const form = s.projectDetailsForm;
+        // A manual name survives a platform change; an untouched name tracks
+        // the platform default, so drop it and let the hook re-derive it.
+        const shouldResetName = !!form && !isProjectNameManuallyModified(form);
 
         return {
           ...s,
           selectedPlatform: platform,
-          projectDetailsForm:
-            !currentProjectDetailsForm ||
-            isProjectNameManuallyModified(currentProjectDetailsForm)
-              ? currentProjectDetailsForm
-              : {...currentProjectDetailsForm, projectName: undefined},
+          projectDetailsForm: shouldResetName ? {...form, projectName: undefined} : form,
         };
       });
     },


### PR DESCRIPTION
## TLDR

Keep SCM project names and team selections when users change platforms. Untouched project names still follow the selected platform default.

## Details

`ScmPlatformFeaturesCore` previously cleared the entire project-details form on every platform selection. The project creation host now resets only an unmodified platform-derived name and preserves the selected team, alert settings, and manual names. It also persists whether the name was manually edited so the behavior remains stable after returning from getting-started.

Fixes VDY-183
