### PR TITLE
chore(deps): Bump `@sentry/conventions` to 0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@sentry-internal/rrweb-player": "2.41.0",
     "@sentry-internal/rrweb-snapshot": "2.41.0",
     "@sentry/browser": "10.69.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.69.0",
     "@sentry/node": "10.69.0",
     "@sentry/react": "10.69.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         specifier: 10.69.0
         version: 10.69.0
       '@sentry/conventions':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.20.0
+        version: 0.20.0
       '@sentry/core':
         specifier: 10.69.0
         version: 10.69.0
@@ -3120,8 +3120,8 @@ packages:
     resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
     engines: {node: '>=14'}
 
-  '@sentry/conventions@0.19.0':
-    resolution: {integrity: sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==}
+  '@sentry/conventions@0.20.0':
+    resolution: {integrity: sha512-nAL3tL+xgom6Dbuxq0NCEZZfBNIrUspjDJRcMMRl3WLiBCSeZzNCa7an48IpnrZoVMpAi2NQ2v9rFU+EQziKuQ==}
     engines: {node: '>=14'}
 
   '@sentry/core@10.69.0':
@@ -11623,7 +11623,7 @@ snapshots:
 
   '@sentry/conventions@0.16.0': {}
 
-  '@sentry/conventions@0.19.0': {}
+  '@sentry/conventions@0.20.0': {}
 
   '@sentry/core@10.69.0':
     dependencies:


### PR DESCRIPTION
probably should land after https://github.com/getsentry/sentry/pull/122471