### PR TITLE
feat(auth): pre-fill email address in org invite registration

### DIFF
--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -88,6 +88,11 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
             "hasNewsletter": newsletter.backend.is_enabled(),
         }
 
+        invite_email = request.session.get("invite_email")
+        if invite_email:
+            context["inviteEmail"] = invite_email
+
+
         if "session_expired" in request.COOKIES:
             context["warning"] = WARN_SESSION_EXPIRED
 

--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -142,6 +142,7 @@ export type AuthConfig = {
   githubLoginLink: string;
   googleLoginLink: string;
   hasNewsletter: boolean;
+  inviteEmail?: string;
   serverHostname: string;
   vstsLoginLink: string;
 };

--- a/static/app/views/auth/registerForm.tsx
+++ b/static/app/views/auth/registerForm.tsx
@@ -18,7 +18,7 @@ type Props = {
 };
 
 export function RegisterForm({authConfig}: Props) {
-  const {hasNewsletter} = authConfig;
+  const {hasNewsletter, inviteEmail} = authConfig;
   const navigate = useNavigate();
 
   const [error, setError] = useState('');
@@ -27,7 +27,7 @@ export function RegisterForm({authConfig}: Props) {
     <Form
       apiMethod="POST"
       apiEndpoint="/auth/register/"
-      initialData={{subscribe: true}}
+      initialData={{subscribe: true, ...(inviteEmail ? {username: inviteEmail} : {})}}
       submitLabel={t('Continue')}
       onSubmitSuccess={response => {
         ConfigStore.set('user', response.user);


### PR DESCRIPTION
Resolves #121594 by properly passing \invite_email\ to the frontend context and pre-filling it on the registration form.