### PR TITLE
feat(tracemetrics): Add sum and count for gauge metrics

### DIFF
--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -202,6 +202,14 @@ export const OPTIONS_BY_TYPE: Record<string, Array<SelectOption<string>>> = {
       value: 'avg',
     },
     {
+      label: 'sum',
+      value: 'sum',
+    },
+    {
+      label: 'count',
+      value: 'count',
+    },
+    {
       label: 'per_second',
       value: 'per_second',
     },
@@ -271,6 +279,20 @@ export const GROUPED_OPTIONS_BY_TYPE: Record<string, Array<SelectSection<string>
           label: 'avg',
           value: 'avg',
           trailingItems: <Text size="xs">{t('Default')}</Text>,
+        },
+      ],
+    },
+    {
+      key: 'math',
+      label: t('Math'),
+      options: [
+        {
+          label: 'sum',
+          value: 'sum',
+        },
+        {
+          label: 'count',
+          value: 'count',
         },
       ],
     },

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -84,6 +84,14 @@ describe('MultiMetricsQueryParamsProvider', () => {
       }),
     ]);
 
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [new VisualizeFunction('p50(value,foo,counter,none)')],
+        })
+      )
+    );
+
     act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'gauge'}));
     expect(result.current).toEqual([
       expect.objectContaining({
@@ -110,19 +118,19 @@ describe('MultiMetricsQueryParamsProvider', () => {
       additionalWrapper: Wrapper,
     });
 
-    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'counter'}));
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'distribution'}));
     act(() =>
       result.current[0]!.setQueryParams(
         result.current[0]!.queryParams.replace({
-          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
+          aggregateFields: [new VisualizeFunction('p50(value,foo,distribution,none)')],
         })
       )
     );
     expect(result.current).toEqual([
       expect.objectContaining({
-        metric: {name: 'foo', type: 'counter'},
+        metric: {name: 'foo', type: 'distribution'},
         queryParams: expect.objectContaining({
-          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
+          aggregateFields: [new VisualizeFunction('p50(value,foo,distribution,none)')],
         }),
       }),
     ]);
@@ -185,6 +193,56 @@ describe('MultiMetricsQueryParamsProvider', () => {
         metric: {name: 'foo', type: 'counter'},
         queryParams: expect.objectContaining({
           aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
+        }),
+      }),
+    ]);
+  });
+
+  it('keeps sum when changing to a gauge metric', () => {
+    const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+      additionalWrapper: Wrapper,
+    });
+
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'counter'}));
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [new VisualizeFunction('sum(value,foo,counter,none)')],
+        })
+      )
+    );
+
+    act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'gauge'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'bar', type: 'gauge'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('sum(value,bar,gauge,none)')],
+        }),
+      }),
+    ]);
+  });
+
+  it('keeps count when changing to a gauge metric', () => {
+    const {result} = renderHookWithProviders(useMultiMetricsQueryParams, {
+      additionalWrapper: Wrapper,
+    });
+
+    act(() => result.current[0]!.setTraceMetric({name: 'foo', type: 'distribution'}));
+    act(() =>
+      result.current[0]!.setQueryParams(
+        result.current[0]!.queryParams.replace({
+          aggregateFields: [new VisualizeFunction('count(value,foo,distribution,none)')],
+        })
+      )
+    );
+
+    act(() => result.current[0]!.setTraceMetric({name: 'bar', type: 'gauge'}));
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        metric: {name: 'bar', type: 'gauge'},
+        queryParams: expect.objectContaining({
+          aggregateFields: [new VisualizeFunction('count(value,bar,gauge,none)')],
         }),
       }),
     ]);
@@ -335,7 +393,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                 query: '',
                 aggregateFields: [
                   new VisualizeFunction(
-                    'sum(value,metricA,distribution,none)'
+                    'p50(value,metricA,distribution,none)'
                   ).serialize(),
                 ],
                 aggregateSortBys: [],
@@ -368,7 +426,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                 query: '',
                 aggregateFields: [
                   new VisualizeEquation(
-                    'equation|sum(value,metricA,distribution,none) + sum(value,metricB,distribution,none)'
+                    'equation|p50(value,metricA,distribution,none) + sum(value,metricB,distribution,none)'
                   ).serialize(),
                 ],
                 aggregateSortBys: [],
@@ -379,7 +437,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
                 query: '',
                 aggregateFields: [
                   new VisualizeEquation(
-                    'equation|sum(value,metricA,distribution,none) - sum(value,metricC,distribution,none)'
+                    'equation|p50(value,metricA,distribution,none) - sum(value,metricC,distribution,none)'
                   ).serialize(),
                 ],
                 aggregateSortBys: [],


### PR DESCRIPTION
Adds `sum` and `count` to the aggregate options for gauge metrics.

Gauge was limited to `min`/`max`/`avg` plus the rate aggregates in the UI. That was a product decision rather than a technical constraint — the backend aggregate definitions already validate `gauge` for `sum` and `count`, so this only unhides them in the shared option lists (`OPTIONS_BY_TYPE` and `GROUPED_OPTIONS_BY_TYPE`), which cover the metrics aggregate dropdown, the dashboard widget builder, and the metric detector form.

One behaviour change falls out of this: switching a query from another metric type to a gauge metric now keeps a selected `sum` or `count` instead of falling back to the gauge default of `avg`, since both are valid gauge aggregates. That is covered by two new tests in `multiMetricsQueryParams.spec.tsx`. The existing aggregate compatibility tests keep their original assertions and now select a percentile, which gauge still does not support, so they continue to cover the fallback path.

Closes EXP-1152
Closes DAIN-1832