### PR TITLE
feat(autofix): Stop PR iteration from an `@sentry` comment

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1010,7 +1010,9 @@ def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
 
     if features.has("organizations:autofix-pr-iteration-manual", group.organization):
         lines.append(
-            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes.</sub>"
+            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes. "
+            "Comment `@sentry stop iterating` on this PR (not in a review) to stop this "
+            "Autofix run from iterating.</sub>"
         )
 
     seer_run = SeerRun.objects.filter(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1010,8 +1010,8 @@ def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
 
     if features.has("organizations:autofix-pr-iteration-manual", group.organization):
         lines.append(
-            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes.</sub>"
-            "\n\n<sub>Comment `@sentry stop iterating` on this PR to stop this Autofix run from "
+            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the "
+            "changes, or comment `@sentry stop iterating` to stop this Autofix run from "
             "iterating.</sub>"
         )
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1010,9 +1010,10 @@ def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
 
     if features.has("organizations:autofix-pr-iteration-manual", group.organization):
         lines.append(
-            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the "
-            "changes, or comment `@sentry stop iterating` to stop this Autofix run from "
-            "iterating.</sub>"
+            # One command per line, and one `<sub>` tag per line: a blank line
+            # would close the tag and leave the next line full size.
+            "\n<sub>`@sentry <feedback>` — Autofix iterates on these changes</sub>"
+            "\n<sub>`@sentry stop iterating` — Autofix stops iterating on this run</sub>"
         )
 
     seer_run = SeerRun.objects.filter(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1010,8 +1010,8 @@ def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
 
     if features.has("organizations:autofix-pr-iteration-manual", group.organization):
         lines.append(
-            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes."
-            "\n\nComment `@sentry stop iterating` on this PR to stop this Autofix run from "
+            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes.</sub>"
+            "\n\n<sub>Comment `@sentry stop iterating` on this PR to stop this Autofix run from "
             "iterating.</sub>"
         )
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1010,9 +1010,9 @@ def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
 
     if features.has("organizations:autofix-pr-iteration-manual", group.organization):
         lines.append(
-            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes. "
-            "Comment `@sentry stop iterating` on this PR (not in a review) to stop this "
-            "Autofix run from iterating.</sub>"
+            "\n<sub>Comment `@sentry <feedback>` on this PR to have Autofix iterate on the changes."
+            "\n\nComment `@sentry stop iterating` on this PR to stop this Autofix run from "
+            "iterating.</sub>"
         )
 
     seer_run = SeerRun.objects.filter(

--- a/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
+++ b/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
@@ -105,7 +105,9 @@ def _status_comment_body(github_login: str) -> str:
         "fix attempts, so Seer has stopped iterating on this pull request. It needs a human "
         "decision — you can:\n\n"
         "- push a fix to this branch yourself,\n"
-        "- comment `@sentry <guidance>` to send Seer back for another attempt, or\n"
+        "- comment `@sentry <guidance>` to send Seer back for another attempt,\n"
+        "- comment `@sentry stop iterating` on this PR (not in a review) to stop this "
+        "Autofix run from iterating, or\n"
         "- close this pull request if it is not worth pursuing."
     )
 

--- a/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
+++ b/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
@@ -106,8 +106,7 @@ def _status_comment_body(github_login: str) -> str:
         "decision — you can:\n\n"
         "- push a fix to this branch yourself,\n"
         "- comment `@sentry <guidance>` to send Seer back for another attempt,\n"
-        "- comment `@sentry stop iterating` on this PR (not in a review) to stop this "
-        "Autofix run from iterating, or\n"
+        "- comment `@sentry stop iterating` to stop this Autofix run from iterating, or\n"
         "- close this pull request if it is not worth pursuing."
     )
 

--- a/src/sentry/seer/autofix/pr_iteration/mention.py
+++ b/src/sentry/seer/autofix/pr_iteration/mention.py
@@ -1,17 +1,8 @@
-"""
-Trigger an Autofix PR iteration from a top-level GitHub PR comment mention.
-
-When a user comments ``@sentry iterate <feedback>`` on a pull request that
-Autofix created, we kick off a ``PR_ITERATION`` run that revises the existing
-PR using the comment as feedback. The commenter must have write access to the
-repository so that random GitHub users can't drive Autofix runs (which cost
-quota and rewrite the PR).
-
-This covers only top-level PR comments (``issue_comment``). Inline review
-comments arrive via the ``pull_request_review`` SCM listener (see
-``listeners/review.py``),
-which acts on the whole submitted review without requiring an ``@sentry`` command
-but still gates human review authors on repo write access.
+"""Start or stop an Autofix PR iteration from a top-level GitHub PR comment.
+``@sentry <feedback>`` starts an iteration on an Autofix pull request.
+``@sentry stop iterating`` stops iteration for that Autofix run.
+The commenter must have write access to the repository.
+Inline review comments arrive through ``listeners/review.py`` instead.
 """
 
 from __future__ import annotations
@@ -31,7 +22,11 @@ from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
 )
-from sentry.tasks.seer.pr_iteration import trigger_pr_iteration_from_comment
+from sentry.seer.webhooks import SentryStopCommand, sentry_command
+from sentry.tasks.seer.pr_iteration import (
+    pause_pr_iteration_from_comment,
+    trigger_pr_iteration_from_comment,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +59,55 @@ def _created_comment_context(
     return CreatedCommentContext(comment=comment, log_extra=log_extra)
 
 
+class CommentDispatchTarget(NamedTuple):
+    integration: RpcIntegration
+    pr_number: int
+
+
+def _resolve_comment_dispatch(
+    *,
+    comment: Mapping[str, Any],
+    pr_number: int | None,
+    organization: Organization,
+    integration: RpcIntegration | None,
+    log_extra: Mapping[str, Any],
+    log_prefix: str,
+) -> CommentDispatchTarget | None:
+    """Run the gates that every ``@sentry`` command on a pull request shares.
+
+    Each caller passes its own ``log_prefix`` so the two commands stay separate
+    in the logs.
+    """
+    if not features.has("organizations:autofix-pr-iteration-manual", organization):
+        logger.info("%s.feature_disabled", log_prefix, extra=log_extra)
+        return None
+
+    if integration is None:
+        logger.info("%s.no_integration", log_prefix, extra=log_extra)
+        return None
+
+    # GitHub Enterprise inherits this processor (see
+    # ``GitHubEnterpriseIssueCommentEventWebhook``) and sends the same
+    # ``issue_comment`` events, so it is turned away here rather than a task hop
+    # later. See ``PR_ITERATION_PROVIDER``.
+    if integration.provider != PR_ITERATION_PROVIDER_SLUG:
+        logger.info(
+            "%s.unsupported_provider",
+            log_prefix,
+            extra={**log_extra, "provider": integration.provider},
+        )
+        return None
+
+    if pr_number is None:
+        logger.info("%s.no_pr_number", log_prefix, extra=log_extra)
+        return None
+
+    if not comment.get("html_url"):
+        raise ValueError("GitHub PR comment is missing html_url")
+
+    return CommentDispatchTarget(integration=integration, pr_number=pr_number)
+
+
 def _dispatch_autofix_iteration_from_comment(
     *,
     comment: Mapping[str, Any],
@@ -82,43 +126,67 @@ def _dispatch_autofix_iteration_from_comment(
         return None
 
     log_extra = {**log_extra, "pr_number": pr_number}
-    # Past this point we have a genuine ``@sentry`` iterate command on a PR, so
-    # log at info to make any silent drop debuggable.
+    # From here the comment is a real ``@sentry`` iterate command on a pull request.
     logger.info("autofix.pr_iteration.comment_trigger.received", extra=log_extra)
 
-    if not features.has("organizations:autofix-pr-iteration-manual", organization):
-        logger.info("autofix.pr_iteration.comment_trigger.feature_disabled", extra=log_extra)
+    target = _resolve_comment_dispatch(
+        comment=comment,
+        pr_number=pr_number,
+        organization=organization,
+        integration=integration,
+        log_extra=log_extra,
+        log_prefix="autofix.pr_iteration.comment_trigger",
+    )
+    if target is None:
         return None
-
-    if integration is None:
-        logger.info("autofix.pr_iteration.comment_trigger.no_integration", extra=log_extra)
-        return None
-
-    # GitHub Enterprise inherits this processor (see
-    # ``GitHubEnterpriseIssueCommentEventWebhook``) and sends the same
-    # ``issue_comment`` events, so it is turned away here rather than a task hop
-    # later. See ``PR_ITERATION_PROVIDER``.
-    if integration.provider != PR_ITERATION_PROVIDER_SLUG:
-        logger.info(
-            "autofix.pr_iteration.comment_trigger.unsupported_provider",
-            extra={**log_extra, "provider": integration.provider},
-        )
-        return None
-
-    if pr_number is None:
-        logger.info("autofix.pr_iteration.comment_trigger.no_pr_number", extra=log_extra)
-        return None
-
-    if not comment.get("html_url"):
-        raise ValueError("GitHub PR comment is missing html_url")
 
     logger.info("autofix.pr_iteration.comment_trigger.scheduled", extra=log_extra)
     trigger_pr_iteration_from_comment.delay(
         organization_id=organization.id,
         repo_id=repo.id,
-        integration_id=integration.id,
-        pr_number=pr_number,
+        integration_id=target.integration.id,
+        pr_number=target.pr_number,
         feedback=feedback.json(),
+    )
+    return None
+
+
+def _dispatch_pause_from_comment(
+    *,
+    comment: Mapping[str, Any],
+    pr_number: int | None,
+    organization: Organization,
+    repo: Repository,
+    integration: RpcIntegration | None,
+    log_extra: Mapping[str, Any],
+) -> None:
+    log_extra = {**log_extra, "pr_number": pr_number}
+    logger.info("autofix.pr_iteration.stop_command.received", extra=log_extra)
+
+    target = _resolve_comment_dispatch(
+        comment=comment,
+        pr_number=pr_number,
+        organization=organization,
+        integration=integration,
+        log_extra=log_extra,
+        log_prefix="autofix.pr_iteration.stop_command",
+    )
+    if target is None:
+        return None
+
+    github_username = (comment.get("user") or {}).get("login")
+    if not github_username:
+        logger.info("autofix.pr_iteration.stop_command.no_github_username", extra=log_extra)
+        return None
+
+    logger.info("autofix.pr_iteration.stop_command.scheduled", extra=log_extra)
+    pause_pr_iteration_from_comment.delay(
+        organization_id=organization.id,
+        repo_id=repo.id,
+        integration_id=target.integration.id,
+        pr_number=target.pr_number,
+        comment_id=comment.get("id"),
+        github_username=github_username,
     )
     return None
 
@@ -132,8 +200,8 @@ def handle_issue_comment_for_autofix_iteration(
     **kwargs: Any,
 ) -> None:
     """
-    Webhook processor for ``issue_comment`` events that triggers an Autofix PR
-    iteration when a user comments ``@sentry``.
+    Webhook processor for ``issue_comment`` events that starts or stops an
+    Autofix PR iteration when a user comments ``@sentry``.
     """
     context = _created_comment_context(event=event, organization=organization)
     if context is None:
@@ -144,6 +212,17 @@ def handle_issue_comment_for_autofix_iteration(
     issue = event.get("issue", {})
     if not issue.get("pull_request"):
         logger.debug("autofix.pr_iteration.comment_trigger.skipped_not_pr", extra=context.log_extra)
+        return None
+
+    if isinstance(sentry_command(context.comment.get("body")), SentryStopCommand):
+        _dispatch_pause_from_comment(
+            comment=context.comment,
+            pr_number=issue.get("number"),
+            organization=organization,
+            repo=repo,
+            integration=integration,
+            log_extra=context.log_extra,
+        )
         return None
 
     _dispatch_autofix_iteration_from_comment(

--- a/src/sentry/seer/autofix/pr_iteration/mention.py
+++ b/src/sentry/seer/autofix/pr_iteration/mention.py
@@ -71,19 +71,21 @@ def _resolve_comment_dispatch(
     organization: Organization,
     integration: RpcIntegration | None,
     log_extra: Mapping[str, Any],
-    log_prefix: str,
+    command: str,
 ) -> CommentDispatchTarget | None:
     """Run the gates that every ``@sentry`` command on a pull request shares.
 
-    Each caller passes its own ``log_prefix`` so the two commands stay separate
-    in the logs.
+    These logs are shared, so each caller names itself with a ``command`` tag
+    rather than a message of its own.
     """
+    log_extra = {**log_extra, "command": command}
+
     if not features.has("organizations:autofix-pr-iteration-manual", organization):
-        logger.info("%s.feature_disabled", log_prefix, extra=log_extra)
+        logger.info("autofix.pr_iteration.comment_trigger.feature_disabled", extra=log_extra)
         return None
 
     if integration is None:
-        logger.info("%s.no_integration", log_prefix, extra=log_extra)
+        logger.info("autofix.pr_iteration.comment_trigger.no_integration", extra=log_extra)
         return None
 
     # GitHub Enterprise inherits this processor (see
@@ -92,14 +94,13 @@ def _resolve_comment_dispatch(
     # later. See ``PR_ITERATION_PROVIDER``.
     if integration.provider != PR_ITERATION_PROVIDER_SLUG:
         logger.info(
-            "%s.unsupported_provider",
-            log_prefix,
+            "autofix.pr_iteration.comment_trigger.unsupported_provider",
             extra={**log_extra, "provider": integration.provider},
         )
         return None
 
     if pr_number is None:
-        logger.info("%s.no_pr_number", log_prefix, extra=log_extra)
+        logger.info("autofix.pr_iteration.comment_trigger.no_pr_number", extra=log_extra)
         return None
 
     if not comment.get("html_url"):
@@ -135,7 +136,7 @@ def _dispatch_autofix_iteration_from_comment(
         organization=organization,
         integration=integration,
         log_extra=log_extra,
-        log_prefix="autofix.pr_iteration.comment_trigger",
+        command="iterate",
     )
     if target is None:
         return None
@@ -169,7 +170,7 @@ def _dispatch_pause_from_comment(
         organization=organization,
         integration=integration,
         log_extra=log_extra,
-        log_prefix="autofix.pr_iteration.stop_command",
+        command="stop",
     )
     if target is None:
         return None

--- a/src/sentry/seer/webhooks.py
+++ b/src/sentry/seer/webhooks.py
@@ -7,12 +7,16 @@ REVIEW_COMMAND = f"{MARKER} review"
 # Shared patterns for bounded @sentry mentions (whitespace or string edges only).
 MARKER_PATTERN = re.compile(r"(?:^|\s)@sentry(?=\s|$)", re.IGNORECASE)
 REVIEW_PATTERN = re.compile(r"(?:^|\s)@sentry review(?=\s|$)", re.IGNORECASE)
+STOP_PATTERN = re.compile(r"(?:^|\s)@sentry stop iterating(?=\s|$)", re.IGNORECASE)
 
 
 class SentryCommand: ...
 
 
 class SentryReviewCommand(SentryCommand): ...
+
+
+class SentryStopCommand(SentryCommand): ...
 
 
 @dataclass
@@ -37,6 +41,9 @@ def sentry_command(comment_body: str | None) -> SentryCommand | None:
 
     if REVIEW_PATTERN.search(comment_body):
         return SentryReviewCommand()
+
+    if STOP_PATTERN.search(comment_body):
+        return SentryStopCommand()
 
     feedback = " ".join(_remove_bounded_sentry_mentions(comment_body).split())
     if not feedback:

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -557,7 +557,7 @@ def _ack_pr_command(
     source_type: GithubPrCommentFeedbackType,
     reaction: Reaction,
     body: str,
-    log_prefix: str,
+    command: str,
 ) -> None:
     """Answer an ``@sentry`` command with a reaction on it and a reply on the PR.
 
@@ -580,9 +580,12 @@ def _ack_pr_command(
         scm_actions.create_pull_request_comment(scm, str(pr_number), body)
     except Exception:
         logger.warning(
-            "%s.comment_failed",
-            log_prefix,
-            extra={"organization_id": organization_id, "pr_number": pr_number},
+            "autofix.pr_iteration.comment_trigger.comment_failed",
+            extra={
+                "organization_id": organization_id,
+                "pr_number": pr_number,
+                "command": command,
+            },
             exc_info=True,
         )
 
@@ -650,14 +653,14 @@ def _resolve_run_for_pr_comment(
     github_username: str,
     comment_id: int | None,
     source_type: GithubPrCommentFeedbackType,
-    log_prefix: str,
+    command: str,
     explain_ineligible: bool,
     external_id: str | int | None = None,
 ) -> ResolvedPrCommentRun | PrCommentRunOutcome:
     """Resolve the Autofix run behind a PR comment and gate on repo write access.
 
-    The iterate command and the stop command share this gate. Each caller passes
-    its own ``log_prefix`` so that the two commands stay separate in the logs.
+    The iterate command and the stop command share this gate, so these logs name
+    the caller with a ``command`` tag rather than a message of their own.
 
     ``explain_ineligible`` decides whether an ineligible run is answered on the PR
     at all. A cell can only see its own Seer, so it cannot tell "no Autofix
@@ -668,9 +671,8 @@ def _resolve_run_for_pr_comment(
     repo = Repository.objects.filter(id=repo_id, organization_id=organization_id).first()
     if repo is None:
         logger.info(
-            "%s.missing_repo",
-            log_prefix,
-            extra={"organization_id": organization_id, "repo_id": repo_id},
+            "autofix.pr_iteration.comment_trigger.missing_repo",
+            extra={"organization_id": organization_id, "repo_id": repo_id, "command": command},
         )
         return PrCommentRunOutcome.MISSING_REPO
 
@@ -681,12 +683,12 @@ def _resolve_run_for_pr_comment(
         # disagreement between that gate and this task rather than ordinary
         # traffic — hence warning, and hence the provider in `extra`.
         logger.warning(
-            "%s.unsupported_provider",
-            log_prefix,
+            "autofix.pr_iteration.comment_trigger.unsupported_provider",
             extra={
                 "organization_id": organization_id,
                 "repo_id": repo.id,
                 "provider": repo.provider,
+                "command": command,
             },
         )
         return PrCommentRunOutcome.UNSUPPORTED_PROVIDER
@@ -695,18 +697,16 @@ def _resolve_run_for_pr_comment(
         scm = make_scm(organization_id, repo_id, referrer="seer")
     except Exception:
         logger.warning(
-            "%s.scm_init_failed",
-            log_prefix,
-            extra={"organization_id": organization_id, "repo_id": repo_id},
+            "autofix.pr_iteration.comment_trigger.scm_init_failed",
+            extra={"organization_id": organization_id, "repo_id": repo_id, "command": command},
             exc_info=True,
         )
         return PrCommentRunOutcome.SCM_INIT_FAILED
 
     if not isinstance(scm, GetPullRequestProtocol):
         logger.warning(
-            "%s.unsupported_provider",
-            log_prefix,
-            extra={"organization_id": organization_id, "repo_id": repo_id},
+            "autofix.pr_iteration.comment_trigger.unsupported_provider",
+            extra={"organization_id": organization_id, "repo_id": repo_id, "command": command},
         )
         return PrCommentRunOutcome.UNSUPPORTED_PROVIDER
 
@@ -723,9 +723,8 @@ def _resolve_run_for_pr_comment(
         )
     except SCMError:
         logger.warning(
-            "%s.get_pull_request_failed",
-            log_prefix,
-            extra={"organization_id": organization_id, "pr_number": pr_number},
+            "autofix.pr_iteration.comment_trigger.get_pull_request_failed",
+            extra={"organization_id": organization_id, "pr_number": pr_number, "command": command},
             exc_info=True,
         )
         return PrCommentRunOutcome.PR_FETCH_FAILED
@@ -739,9 +738,8 @@ def _resolve_run_for_pr_comment(
         # ineligible — that would false-positive against the region that does
         # own the Autofix run and is iterating successfully.
         logger.info(
-            "%s.no_run",
-            log_prefix,
-            extra={"organization_id": organization_id, "pr_id": pr_id},
+            "autofix.pr_iteration.comment_trigger.no_run",
+            extra={"organization_id": organization_id, "pr_id": pr_id, "command": command},
         )
         return PrCommentRunOutcome.NO_RUN
 
@@ -749,12 +747,12 @@ def _resolve_run_for_pr_comment(
         # Found a Seer run for this PR, but it wasn't created by Autofix
         # (coding-agent handoff is the main case).
         logger.info(
-            "%s.ineligible_run",
-            log_prefix,
+            "autofix.pr_iteration.comment_trigger.ineligible_run",
             extra={
                 "organization_id": organization_id,
                 "pr_id": pr_id,
                 "run_id": agent_state.run_id,
+                "command": command,
             },
         )
         if explain_ineligible:
@@ -771,11 +769,11 @@ def _resolve_run_for_pr_comment(
 
     if not _github_commenter_has_repo_write_access(scm, github_username):
         logger.info(
-            "%s.unauthorized",
-            log_prefix,
+            "autofix.pr_iteration.comment_trigger.unauthorized",
             extra={
                 "organization_id": organization_id,
                 "github_username": github_username,
+                "command": command,
             },
         )
         return PrCommentRunOutcome.UNAUTHORIZED
@@ -839,7 +837,7 @@ def trigger_pr_iteration_from_comment(
         github_username=github_username,
         comment_id=comment.id,
         source_type=source.type,
-        log_prefix="autofix.pr_iteration.comment_trigger",
+        command="iterate",
         explain_ineligible=True,
         external_id=comment.user.id if comment.user else None,
     )
@@ -938,7 +936,7 @@ def pause_pr_iteration_from_comment(
         # An ineligible run means no cell-local Autofix PR, which is also what a
         # non-owning cell sees for a perfectly healthy run. Writing nothing keeps
         # this command's ack coming from one cell.
-        log_prefix="autofix.pr_iteration.stop_command",
+        command="stop",
         explain_ineligible=False,
     )
     if isinstance(resolved, PrCommentRunOutcome):
@@ -960,7 +958,7 @@ def pause_pr_iteration_from_comment(
             source_type="github-pr-comment",
             reaction="+1",
             body=ALREADY_PAUSED_PR_ITERATION_COMMENT,
-            log_prefix="autofix.pr_iteration.stop_command",
+            command="stop",
         )
         return None
 
@@ -994,7 +992,7 @@ def pause_pr_iteration_from_comment(
         source_type="github-pr-comment",
         reaction=reaction,
         body=body,
-        log_prefix="autofix.pr_iteration.stop_command",
+        command="stop",
     )
 
     return None

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -107,6 +107,8 @@ STOP_PR_ITERATION_FAILED_COMMENT = (
     "Seer could not stop iteration on this Autofix run. Close this pull request to stop the work."
 )
 
+# Answers a repeat `@sentry stop iterating`. Feedback that lands on a stopped run
+# gets no reply at all — the stop asked Seer to go quiet, not to keep talking.
 ALREADY_PAUSED_PR_ITERATION_COMMENT = "Iteration was already paused."
 
 # One explanatory comment per PR; further pings still get a :confused: reaction.
@@ -849,23 +851,13 @@ def trigger_pr_iteration_from_comment(
     agent_state = resolved.agent_state
     if is_pr_iteration_paused(run_id=agent_state.run_id, organization_id=organization_id):
         # `@sentry stop iterating` already stopped this run, and nothing restarts
-        # it, so consume would drop whatever we queued here. Say that outright
-        # instead of reacting :eyes: — an ack of work that will never run reads
-        # as a promise to do it.
+        # it, so consume would drop whatever we queued here. Write nothing at all:
+        # a reaction on feedback that will never be read is an ack of work that
+        # won't happen, and the stop asked Seer to go quiet on this PR.
         record_pause_blocked("comment_trigger")
         logger.info(
             "autofix.pr_iteration.comment_trigger.paused",
             extra={"organization_id": organization_id, "run_id": agent_state.run_id},
-        )
-        _ack_pr_command(
-            resolved.scm,
-            organization_id=organization_id,
-            pr_number=pr_number,
-            comment_id=comment.id,
-            source_type=source.type,
-            reaction="+1",
-            body=ALREADY_PAUSED_PR_ITERATION_COMMENT,
-            log_prefix="autofix.pr_iteration.comment_trigger",
         )
         return None
 
@@ -953,8 +945,27 @@ def pause_pr_iteration_from_comment(
         metrics.incr("autofix.pr_iteration.stop_command", tags={"outcome": resolved.value})
         return None
 
+    run_id = resolved.agent_state.run_id
+    if is_pr_iteration_paused(run_id=run_id, organization_id=organization_id):
+        # `pause_pr_iteration` is idempotent and reports success either way, so
+        # ask first — repeating the stop confirmation would credit this comment
+        # with a stop it didn't perform. Nothing resumes a run, so a paused run
+        # stays paused and this is not a race worth locking.
+        metrics.incr("autofix.pr_iteration.stop_command", tags={"outcome": "already_paused"})
+        _ack_pr_command(
+            resolved.scm,
+            organization_id=organization_id,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            source_type="github-pr-comment",
+            reaction="+1",
+            body=ALREADY_PAUSED_PR_ITERATION_COMMENT,
+            log_prefix="autofix.pr_iteration.stop_command",
+        )
+        return None
+
     paused = pause_pr_iteration(
-        run_id=resolved.agent_state.run_id,
+        run_id=run_id,
         organization_id=organization_id,
         actor_user_id=resolved.actor_user.id if resolved.actor_user else None,
     )
@@ -966,7 +977,7 @@ def pause_pr_iteration_from_comment(
         # The run predates SeerRun mirroring, so the stop marker has no row to land on.
         logger.warning(
             "autofix.pr_iteration.stop_command.pause_failed",
-            extra={"organization_id": organization_id, "run_id": resolved.agent_state.run_id},
+            extra={"organization_id": organization_id, "run_id": run_id},
         )
         metrics.incr(
             "autofix.pr_iteration.stop_command",

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -972,8 +972,11 @@ def pause_pr_iteration_from_comment(
     if paused:
         metrics.incr("autofix.pr_iteration.stop_command", tags={"outcome": "success"})
     else:
-        # The run predates SeerRun mirroring, so the stop marker has no row to land on.
-        logger.warning(
+        # The run has no SeerRun row for the stop marker to land on, so it
+        # predates mirroring or was deleted mid-command. Logged at error to
+        # raise it in Sentry: the comment below is the user's way out, not a
+        # state we intend to keep serving.
+        logger.error(
             "autofix.pr_iteration.stop_command.pause_failed",
             extra={"organization_id": organization_id, "run_id": run_id},
         )

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -107,6 +107,8 @@ STOP_PR_ITERATION_FAILED_COMMENT = (
     "Seer could not stop iteration on this Autofix run. Close this pull request to stop the work."
 )
 
+ALREADY_PAUSED_PR_ITERATION_COMMENT = "Iteration was already paused."
+
 # One explanatory comment per PR; further pings still get a :confused: reaction.
 _INELIGIBLE_COMMENT_CACHE_TTL = int(timedelta(days=7).total_seconds())
 
@@ -544,6 +546,45 @@ def _comment_pr_iteration_ineligible(
         pass
 
 
+def _ack_pr_command(
+    scm: SourceCodeManager,
+    *,
+    organization_id: int,
+    pr_number: int,
+    comment_id: int | None,
+    source_type: GithubPrCommentFeedbackType,
+    reaction: Reaction,
+    body: str,
+    log_prefix: str,
+) -> None:
+    """Answer an ``@sentry`` command with a reaction on it and a reply on the PR.
+
+    The reply is best-effort: a command whose work already landed shouldn't fail
+    on the acknowledgement of it.
+    """
+    if comment_id is not None:
+        _add_comment_reaction(
+            scm,
+            source_type=source_type,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            reaction=reaction,
+        )
+
+    if not isinstance(scm, CreatePullRequestCommentProtocol):
+        return
+
+    try:
+        scm_actions.create_pull_request_comment(scm, str(pr_number), body)
+    except Exception:
+        logger.warning(
+            "%s.comment_failed",
+            log_prefix,
+            extra={"organization_id": organization_id, "pr_number": pr_number},
+            exc_info=True,
+        )
+
+
 def _fetch_pr_id(scm: GetPullRequestProtocol, pr_number: int) -> int | None:
     """Recover a PR's provider-global id from its repo-scoped number.
 
@@ -608,12 +649,19 @@ def _resolve_run_for_pr_comment(
     comment_id: int | None,
     source_type: GithubPrCommentFeedbackType,
     log_prefix: str,
+    explain_ineligible: bool,
     external_id: str | int | None = None,
 ) -> ResolvedPrCommentRun | PrCommentRunOutcome:
     """Resolve the Autofix run behind a PR comment and gate on repo write access.
 
     The iterate command and the stop command share this gate. Each caller passes
     its own ``log_prefix`` so that the two commands stay separate in the logs.
+
+    ``explain_ineligible`` decides whether an ineligible run is answered on the PR
+    at all. A cell can only see its own Seer, so it cannot tell "no Autofix
+    created this PR" from "none did *here*" — and one GitHub delivery reaches
+    every cell holding an org on the installation. The stop command therefore
+    stays silent and leaves the answer to the cell that owns the run.
     """
     repo = Repository.objects.filter(id=repo_id, organization_id=organization_id).first()
     if repo is None:
@@ -697,7 +745,7 @@ def _resolve_run_for_pr_comment(
 
     if not agent_state.repo_pr_states:
         # Found a Seer run for this PR, but it wasn't created by Autofix
-        # (coding-agent handoff is the main case). Explain ineligibility.
+        # (coding-agent handoff is the main case).
         logger.info(
             "%s.ineligible_run",
             log_prefix,
@@ -707,15 +755,16 @@ def _resolve_run_for_pr_comment(
                 "run_id": agent_state.run_id,
             },
         )
-        _comment_pr_iteration_ineligible(
-            scm,
-            organization_id=organization_id,
-            repo_id=repo.id,
-            pr_number=pr_number,
-            github_username=github_username,
-            source_type=source_type,
-            comment_id=comment_id,
-        )
+        if explain_ineligible:
+            _comment_pr_iteration_ineligible(
+                scm,
+                organization_id=organization_id,
+                repo_id=repo.id,
+                pr_number=pr_number,
+                github_username=github_username,
+                source_type=source_type,
+                comment_id=comment_id,
+            )
         return PrCommentRunOutcome.INELIGIBLE_RUN
 
     if not _github_commenter_has_repo_write_access(scm, github_username):
@@ -789,6 +838,7 @@ def trigger_pr_iteration_from_comment(
         comment_id=comment.id,
         source_type=source.type,
         log_prefix="autofix.pr_iteration.comment_trigger",
+        explain_ineligible=True,
         external_id=comment.user.id if comment.user else None,
     )
     if isinstance(resolved, PrCommentRunOutcome):
@@ -797,6 +847,28 @@ def trigger_pr_iteration_from_comment(
         return None
 
     agent_state = resolved.agent_state
+    if is_pr_iteration_paused(run_id=agent_state.run_id, organization_id=organization_id):
+        # `@sentry stop iterating` already stopped this run, and nothing restarts
+        # it, so consume would drop whatever we queued here. Say that outright
+        # instead of reacting :eyes: — an ack of work that will never run reads
+        # as a promise to do it.
+        record_pause_blocked("comment_trigger")
+        logger.info(
+            "autofix.pr_iteration.comment_trigger.paused",
+            extra={"organization_id": organization_id, "run_id": agent_state.run_id},
+        )
+        _ack_pr_command(
+            resolved.scm,
+            organization_id=organization_id,
+            pr_number=pr_number,
+            comment_id=comment.id,
+            source_type=source.type,
+            reaction="+1",
+            body=ALREADY_PAUSED_PR_ITERATION_COMMENT,
+            log_prefix="autofix.pr_iteration.comment_trigger",
+        )
+        return None
+
     group_id = agent_state.metadata.get("group_id") if agent_state.metadata else None
     if group_id is None:
         raise ValueError(f"Missing group id in agent run {agent_state.run_id}")
@@ -871,7 +943,11 @@ def pause_pr_iteration_from_comment(
         github_username=github_username,
         comment_id=comment_id,
         source_type="github-pr-comment",
+        # An ineligible run means no cell-local Autofix PR, which is also what a
+        # non-owning cell sees for a perfectly healthy run. Writing nothing keeps
+        # this command's ack coming from one cell.
         log_prefix="autofix.pr_iteration.stop_command",
+        explain_ineligible=False,
     )
     if isinstance(resolved, PrCommentRunOutcome):
         metrics.incr("autofix.pr_iteration.stop_command", tags={"outcome": resolved.value})
@@ -899,24 +975,16 @@ def pause_pr_iteration_from_comment(
         reaction = "confused"
         body = STOP_PR_ITERATION_FAILED_COMMENT
 
-    if comment_id is not None:
-        _add_comment_reaction(
-            resolved.scm,
-            source_type="github-pr-comment",
-            pr_number=pr_number,
-            comment_id=comment_id,
-            reaction=reaction,
-        )
-
-    if isinstance(resolved.scm, CreatePullRequestCommentProtocol):
-        try:
-            scm_actions.create_pull_request_comment(resolved.scm, str(pr_number), body)
-        except Exception:
-            logger.warning(
-                "autofix.pr_iteration.stop_command.comment_failed",
-                extra={"organization_id": organization_id, "pr_number": pr_number},
-                exc_info=True,
-            )
+    _ack_pr_command(
+        resolved.scm,
+        organization_id=organization_id,
+        pr_number=pr_number,
+        comment_id=comment_id,
+        source_type="github-pr-comment",
+        reaction=reaction,
+        body=body,
+        log_prefix="autofix.pr_iteration.stop_command",
+    )
 
     return None
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -101,11 +101,7 @@ INELIGIBLE_PR_ITERATION_COMMENT = (
     "created by the Coding Agent handoff and unrelated human PRs."
 )
 
-STOPPED_PR_ITERATION_COMMENT = (
-    "Seer stopped iterating on this Autofix run. Queued feedback was discarded.\n"
-    "New comments will not start another iteration. This cannot be undone. Start a new "
-    "Autofix run to iterate again."
-)
+STOPPED_PR_ITERATION_COMMENT = "Seer stopped iterating on this Autofix run."
 
 STOP_PR_ITERATION_FAILED_COMMENT = (
     "Seer could not stop iteration on this Autofix run. Close this pull request to stop the work."

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -4,7 +4,8 @@ import logging
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from enum import StrEnum
+from typing import Any, NamedTuple
 
 import sentry_sdk
 from scm import actions as scm_actions
@@ -69,7 +70,11 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
     GithubPullRequestReviewComment,
 )
-from sentry.seer.autofix.pr_iteration.pause import is_pr_iteration_paused, record_pause_blocked
+from sentry.seer.autofix.pr_iteration.pause import (
+    is_pr_iteration_paused,
+    pause_pr_iteration,
+    record_pause_blocked,
+)
 from sentry.seer.autofix.pr_iteration.queue import (
     QueuedAutofixFeedback,
     clear_queued_autofix_feedback,
@@ -94,6 +99,16 @@ INELIGIBLE_PR_ITERATION_COMMENT = (
     "PR iteration only works on pull requests created by Seer's Autofix agent. "
     "PRs that the Autofix Agent didn't create aren't eligible. This includes PRs "
     "created by the Coding Agent handoff and unrelated human PRs."
+)
+
+STOPPED_PR_ITERATION_COMMENT = (
+    "Seer stopped iterating on this Autofix run. Queued feedback was discarded.\n"
+    "New comments will not start another iteration. This cannot be undone. Start a new "
+    "Autofix run to iterate again."
+)
+
+STOP_PR_ITERATION_FAILED_COMMENT = (
+    "Seer could not stop iteration on this Autofix run. Close this pull request to stop the work."
 )
 
 # One explanatory comment per PR; further pings still get a :confused: reaction.
@@ -560,6 +575,173 @@ def _fetch_pr_id(scm: GetPullRequestProtocol, pr_number: int) -> int | None:
         return None
 
 
+class PrCommentRunOutcome(StrEnum):
+    MISSING_REPO = "missing_repo"
+    UNSUPPORTED_PROVIDER = "unsupported_provider"
+    PR_FETCH_FAILED = "pr_fetch_failed"
+    NO_RUN = "no_run"
+    INELIGIBLE_RUN = "ineligible_run"
+    SCM_INIT_FAILED = "scm_init_failed"
+    UNAUTHORIZED = "unauthorized"
+    PAUSE_FAILED = "pause_failed"
+
+
+# The iterate task counts these three outcomes only.
+_COMMENT_TRIGGER_COUNTED_OUTCOMES = frozenset(
+    {
+        PrCommentRunOutcome.NO_RUN,
+        PrCommentRunOutcome.INELIGIBLE_RUN,
+        PrCommentRunOutcome.UNAUTHORIZED,
+    }
+)
+
+
+class ResolvedPrCommentRun(NamedTuple):
+    agent_state: SeerRunState
+    scm: SourceCodeManager
+    actor_user: RpcUser | None
+
+
+def _resolve_run_for_pr_comment(
+    *,
+    organization_id: int,
+    repo_id: int,
+    integration_id: int,
+    pr_number: int,
+    github_username: str,
+    comment_id: int | None,
+    source_type: GithubPrCommentFeedbackType,
+    log_prefix: str,
+    external_id: str | int | None = None,
+) -> ResolvedPrCommentRun | PrCommentRunOutcome:
+    """Resolve the Autofix run behind a PR comment and gate on repo write access.
+
+    The iterate command and the stop command share this gate. Each caller passes
+    its own ``log_prefix`` so that the two commands stay separate in the logs.
+    """
+    repo = Repository.objects.filter(id=repo_id, organization_id=organization_id).first()
+    if repo is None:
+        logger.info(
+            "%s.missing_repo",
+            log_prefix,
+            extra={"organization_id": organization_id, "repo_id": repo_id},
+        )
+        return PrCommentRunOutcome.MISSING_REPO
+
+    if repo.provider != PR_ITERATION_PROVIDER:
+        # Everything below reads the provider off the constant rather than the
+        # repo, so this is where the two are held to be the same thing. The entry
+        # point already rejects anything else, which makes reaching this a
+        # disagreement between that gate and this task rather than ordinary
+        # traffic — hence warning, and hence the provider in `extra`.
+        logger.warning(
+            "%s.unsupported_provider",
+            log_prefix,
+            extra={
+                "organization_id": organization_id,
+                "repo_id": repo.id,
+                "provider": repo.provider,
+            },
+        )
+        return PrCommentRunOutcome.UNSUPPORTED_PROVIDER
+
+    try:
+        scm = make_scm(organization_id, repo_id, referrer="seer")
+    except Exception:
+        logger.warning(
+            "%s.scm_init_failed",
+            log_prefix,
+            extra={"organization_id": organization_id, "repo_id": repo_id},
+            exc_info=True,
+        )
+        return PrCommentRunOutcome.SCM_INIT_FAILED
+
+    if not isinstance(scm, GetPullRequestProtocol):
+        logger.warning(
+            "%s.unsupported_provider",
+            log_prefix,
+            extra={"organization_id": organization_id, "repo_id": repo_id},
+        )
+        return PrCommentRunOutcome.UNSUPPORTED_PROVIDER
+
+    try:
+        # The issue_comment payload behind an `@sentry` mention carries only the
+        # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
+        # The mapping lives on ``PullRequest.external_id``; the provider call
+        # runs only when no webhook (or earlier write-back) has stored it yet.
+        pr_id = PullRequest.objects.get_or_fetch_external_id(
+            organization_id=organization_id,
+            repository_id=repo.id,
+            key=str(pr_number),
+            fetch=lambda: _fetch_pr_id(scm, pr_number),
+        )
+    except SCMError:
+        logger.warning(
+            "%s.get_pull_request_failed",
+            log_prefix,
+            extra={"organization_id": organization_id, "pr_number": pr_number},
+            exc_info=True,
+        )
+        return PrCommentRunOutcome.PR_FETCH_FAILED
+    if pr_id is None:
+        return PrCommentRunOutcome.PR_FETCH_FAILED
+
+    agent_state = get_agent_state_from_pr_id(organization_id, PR_ITERATION_PROVIDER, pr_id)
+    if agent_state is None:
+        # No-op: missing runs are expected on regions that don't own the session
+        # when webhooks are fanned out everywhere. Do not react/comment as
+        # ineligible — that would false-positive against the region that does
+        # own the Autofix run and is iterating successfully.
+        logger.info(
+            "%s.no_run",
+            log_prefix,
+            extra={"organization_id": organization_id, "pr_id": pr_id},
+        )
+        return PrCommentRunOutcome.NO_RUN
+
+    if not agent_state.repo_pr_states:
+        # Found a Seer run for this PR, but it wasn't created by Autofix
+        # (coding-agent handoff is the main case). Explain ineligibility.
+        logger.info(
+            "%s.ineligible_run",
+            log_prefix,
+            extra={
+                "organization_id": organization_id,
+                "pr_id": pr_id,
+                "run_id": agent_state.run_id,
+            },
+        )
+        _comment_pr_iteration_ineligible(
+            scm,
+            organization_id=organization_id,
+            repo_id=repo.id,
+            pr_number=pr_number,
+            github_username=github_username,
+            source_type=source_type,
+            comment_id=comment_id,
+        )
+        return PrCommentRunOutcome.INELIGIBLE_RUN
+
+    if not _github_commenter_has_repo_write_access(scm, github_username):
+        logger.info(
+            "%s.unauthorized",
+            log_prefix,
+            extra={
+                "organization_id": organization_id,
+                "github_username": github_username,
+            },
+        )
+        return PrCommentRunOutcome.UNAUTHORIZED
+
+    actor_user = find_user_for_scm_actor(
+        organization_id=organization_id,
+        integration_id=integration_id,
+        username=github_username,
+        external_id=external_id,
+    )
+    return ResolvedPrCommentRun(agent_state=agent_state, scm=scm, actor_user=actor_user)
+
+
 @instrumented_task(
     name="sentry.tasks.autofix.trigger_pr_iteration_from_comment",
     namespace=seer_tasks,
@@ -602,121 +784,23 @@ def trigger_pr_iteration_from_comment(
         )
         return None
 
-    repo = Repository.objects.filter(id=repo_id, organization_id=organization_id).first()
-    if repo is None:
-        logger.info(
-            "autofix.pr_iteration.comment_trigger.missing_repo",
-            extra={"organization_id": organization_id, "repo_id": repo_id},
-        )
-        return None
-
-    if repo.provider != PR_ITERATION_PROVIDER:
-        # Everything below reads the provider off the constant rather than the
-        # repo, so this is where the two are held to be the same thing. The entry
-        # point already rejects anything else, which makes reaching this a
-        # disagreement between that gate and this task rather than ordinary
-        # traffic — hence warning, and hence the provider in `extra`.
-        logger.warning(
-            "autofix.pr_iteration.comment_trigger.unsupported_provider",
-            extra={
-                "organization_id": organization_id,
-                "repo_id": repo.id,
-                "provider": repo.provider,
-            },
-        )
-        return None
-
-    try:
-        scm = make_scm(organization_id, repo_id, referrer="seer")
-    except Exception:
-        logger.warning(
-            "autofix.pr_iteration.comment_trigger.scm_init_failed",
-            extra={"organization_id": organization_id, "repo_id": repo_id},
-            exc_info=True,
-        )
-        return None
-
-    if not isinstance(scm, GetPullRequestProtocol):
-        logger.warning(
-            "autofix.pr_iteration.comment_trigger.unsupported_provider",
-            extra={"organization_id": organization_id, "repo_id": repo_id},
-        )
-        return None
-
-    try:
-        # The issue_comment payload behind an `@sentry` mention carries only the
-        # PR number, but Seer's run lookup is keyed on GitHub's numeric PR id.
-        # The mapping lives on ``PullRequest.external_id``; the provider call
-        # runs only when no webhook (or earlier write-back) has stored it yet.
-        pr_id = PullRequest.objects.get_or_fetch_external_id(
-            organization_id=organization_id,
-            repository_id=repo.id,
-            key=str(pr_number),
-            fetch=lambda: _fetch_pr_id(scm, pr_number),
-        )
-    except SCMError:
-        logger.warning(
-            "autofix.pr_iteration.comment_trigger.get_pull_request_failed",
-            extra={"organization_id": organization_id, "pr_number": pr_number},
-            exc_info=True,
-        )
-        return None
-    if pr_id is None:
-        return None
-
-    agent_state = get_agent_state_from_pr_id(organization_id, PR_ITERATION_PROVIDER, pr_id)
-    if agent_state is None:
-        # No-op: missing runs are expected on regions that don't own the session
-        # when webhooks are fanned out everywhere. Do not react/comment as
-        # ineligible — that would false-positive against the region that does
-        # own the Autofix run and is iterating successfully.
-        metrics.incr("autofix.pr_iteration.comment_trigger.no_run")
-        logger.info(
-            "autofix.pr_iteration.comment_trigger.no_run",
-            extra={"organization_id": organization_id, "pr_id": pr_id},
-        )
-        return None
-
-    if not agent_state.repo_pr_states:
-        # Found a Seer run for this PR, but it wasn't created by Autofix
-        # (coding-agent handoff is the main case). Explain ineligibility.
-        metrics.incr("autofix.pr_iteration.comment_trigger.ineligible_run")
-        logger.info(
-            "autofix.pr_iteration.comment_trigger.ineligible_run",
-            extra={
-                "organization_id": organization_id,
-                "pr_id": pr_id,
-                "run_id": agent_state.run_id,
-            },
-        )
-        _comment_pr_iteration_ineligible(
-            scm,
-            organization_id=organization_id,
-            repo_id=repo.id,
-            pr_number=pr_number,
-            github_username=github_username,
-            source_type=source.type,
-            comment_id=comment.id,
-        )
-        return None
-
-    if not _github_commenter_has_repo_write_access(scm, github_username):
-        metrics.incr("autofix.pr_iteration.comment_trigger.unauthorized")
-        logger.info(
-            "autofix.pr_iteration.comment_trigger.unauthorized",
-            extra={
-                "organization_id": organization_id,
-                "github_username": github_username,
-            },
-        )
-        return None
-
-    actor_user = find_user_for_scm_actor(
+    resolved = _resolve_run_for_pr_comment(
         organization_id=organization_id,
+        repo_id=repo_id,
         integration_id=integration_id,
-        username=github_username,
+        pr_number=pr_number,
+        github_username=github_username,
+        comment_id=comment.id,
+        source_type=source.type,
+        log_prefix="autofix.pr_iteration.comment_trigger",
         external_id=comment.user.id if comment.user else None,
     )
+    if isinstance(resolved, PrCommentRunOutcome):
+        if resolved in _COMMENT_TRIGGER_COUNTED_OUTCOMES:
+            metrics.incr(f"autofix.pr_iteration.comment_trigger.{resolved.value}")
+        return None
+
+    agent_state = resolved.agent_state
     group_id = agent_state.metadata.get("group_id") if agent_state.metadata else None
     if group_id is None:
         raise ValueError(f"Missing group id in agent run {agent_state.run_id}")
@@ -728,7 +812,7 @@ def trigger_pr_iteration_from_comment(
         feedback=feedback_obj,
         referrer=AutofixReferrer.GITHUB_PR_COMMENT,
         run_state=agent_state,
-        actor_user_id=actor_user.id if actor_user else None,
+        actor_user_id=resolved.actor_user.id if resolved.actor_user else None,
     )
     trigger_consume_pr_iteration_feedback(
         run_id=agent_state.run_id,
@@ -744,7 +828,7 @@ def trigger_pr_iteration_from_comment(
         return None
 
     _add_comment_reaction(
-        scm,
+        resolved.scm,
         source_type=source.type,
         pr_number=pr_number,
         comment_id=comment_id,
@@ -758,6 +842,85 @@ def trigger_pr_iteration_from_comment(
             "repo_id": repo_id,
         },
     )
+
+    return None
+
+
+@instrumented_task(
+    name="sentry.tasks.autofix.pause_pr_iteration_from_comment",
+    namespace=seer_tasks,
+    processing_deadline_duration=65,
+    retry=Retry(times=1),
+)
+def pause_pr_iteration_from_comment(
+    *,
+    organization_id: int,
+    repo_id: int,
+    integration_id: int,
+    pr_number: int,
+    comment_id: int | None,
+    github_username: str,
+) -> None:
+    """
+    Resolve the Autofix run behind ``pr_number`` and stop its PR iteration.
+
+    Gates the commenter on repo write access, then acknowledges the stop with a
+    reaction and a comment on the pull request.
+    """
+    resolved = _resolve_run_for_pr_comment(
+        organization_id=organization_id,
+        repo_id=repo_id,
+        integration_id=integration_id,
+        pr_number=pr_number,
+        github_username=github_username,
+        comment_id=comment_id,
+        source_type="github-pr-comment",
+        log_prefix="autofix.pr_iteration.stop_command",
+    )
+    if isinstance(resolved, PrCommentRunOutcome):
+        metrics.incr("autofix.pr_iteration.stop_command", tags={"outcome": resolved.value})
+        return None
+
+    paused = pause_pr_iteration(
+        run_id=resolved.agent_state.run_id,
+        organization_id=organization_id,
+        actor_user_id=resolved.actor_user.id if resolved.actor_user else None,
+    )
+    reaction: Reaction = "+1"
+    body = STOPPED_PR_ITERATION_COMMENT
+    if paused:
+        metrics.incr("autofix.pr_iteration.stop_command", tags={"outcome": "success"})
+    else:
+        # The run predates SeerRun mirroring, so the stop marker has no row to land on.
+        logger.warning(
+            "autofix.pr_iteration.stop_command.pause_failed",
+            extra={"organization_id": organization_id, "run_id": resolved.agent_state.run_id},
+        )
+        metrics.incr(
+            "autofix.pr_iteration.stop_command",
+            tags={"outcome": PrCommentRunOutcome.PAUSE_FAILED.value},
+        )
+        reaction = "confused"
+        body = STOP_PR_ITERATION_FAILED_COMMENT
+
+    if comment_id is not None:
+        _add_comment_reaction(
+            resolved.scm,
+            source_type="github-pr-comment",
+            pr_number=pr_number,
+            comment_id=comment_id,
+            reaction=reaction,
+        )
+
+    if isinstance(resolved.scm, CreatePullRequestCommentProtocol):
+        try:
+            scm_actions.create_pull_request_comment(resolved.scm, str(pr_number), body)
+        except Exception:
+            logger.warning(
+                "autofix.pr_iteration.stop_command.comment_failed",
+                extra={"organization_id": organization_id, "pr_number": pr_number},
+                exc_info=True,
+            )
 
     return None
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -212,8 +212,11 @@ class StopCommandEndToEndTest(TestCase):
 
         assert is_pr_iteration_paused(run_id=STOP_RUN_ID, organization_id=self.organization.id)
         mock_consume.assert_not_called()
+        # The stop is enforced at the trigger task, before the feedback is
+        # queued — the later `trigger_consume` and `consume` gates never see it.
+        assert peek_queued_autofix_feedback(STOP_RUN_ID) == []
         mock_metrics.incr.assert_any_call(
-            "autofix.pr_iteration.paused.blocked", tags={"gate": "trigger_consume"}
+            "autofix.pr_iteration.paused.blocked", tags={"gate": "comment_trigger"}
         )
 
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from sentry.seer.agent.client_models import RepoPRState, SeerRunState
@@ -8,6 +9,8 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
+from sentry.seer.autofix.pr_iteration.mention import handle_issue_comment_for_autofix_iteration
+from sentry.seer.autofix.pr_iteration.pause import is_pr_iteration_paused
 from sentry.seer.autofix.pr_iteration.queue import (
     _parse_queued_item,
     peek_queued_autofix_feedback,
@@ -17,6 +20,17 @@ from sentry.testutils.cases import TestCase
 from sentry.utils import json
 
 CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
+PAUSE_PATH = "sentry.seer.autofix.pr_iteration.pause"
+TASK_PATH = "sentry.tasks.seer.pr_iteration"
+STOP_RUN_ID = 4646
+
+
+class _CommentScmStub:
+    """Spec that lets the mock SCM pass the task's protocol checks."""
+
+    def get_pull_request(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def create_pull_request_comment(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 def _run_state(*, repo_pr_states=None) -> SeerRunState:
@@ -129,6 +143,78 @@ class TryEnqueueAutofixFeedbackTest(TestCase):
         assert queued[0].feedback.source._autofix_run is None
         assert "autofix_run" not in queued[0].feedback.source.dict()
         mock_resolve.assert_not_called()
+
+
+class StopCommandEndToEndTest(TestCase):
+    """Drive the webhook processor so the parser and both tasks run for real."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="123",
+            name="owner/repo",
+        )
+        self.create_seer_run(
+            organization=self.organization, seer_run_state_id=STOP_RUN_ID, user_id=self.user.id
+        )
+        self.group = self.create_group(project=self.project)
+
+    def _event(self, body: str) -> dict:
+        return {
+            "action": "created",
+            "comment": {
+                "id": 999,
+                "body": body,
+                "user": {"login": "octocat"},
+                "html_url": "https://github.com/owner/repo/pull/7#issuecomment-999",
+            },
+            "issue": {"number": 7, "pull_request": {"url": "https://example.com/pulls/7"}},
+        }
+
+    def _agent_state(self) -> SeerRunState:
+        return SeerRunState(
+            run_id=STOP_RUN_ID,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                "owner/repo": RepoPRState(
+                    repo_name="owner/repo", pr_url="https://example.com/pull/7"
+                )
+            },
+            metadata={"group_id": self.group.id},
+        )
+
+    def _handle(self, body: str) -> None:
+        with self.feature("organizations:autofix-pr-iteration-manual"), self.tasks():
+            handle_issue_comment_for_autofix_iteration(
+                event=self._event(body),
+                organization=self.organization,
+                repo=self.repo,
+                integration=MagicMock(id=42, provider="github"),
+            )
+
+    def test_iterate_comment_after_stop_comment_does_not_consume(self) -> None:
+        with (
+            patch(f"{TASK_PATH}.get_agent_state_from_pr_id", return_value=self._agent_state()),
+            patch(f"{TASK_PATH}.make_scm", return_value=MagicMock(spec=_CommentScmStub)),
+            patch(f"{TASK_PATH}.scm_actions") as mock_actions,
+            patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True),
+            patch(f"{TASK_PATH}._add_comment_reaction"),
+            patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async") as mock_consume,
+            patch(f"{PAUSE_PATH}.metrics") as mock_metrics,
+        ):
+            mock_actions.get_pull_request.return_value = {"data": {"internal_id": "555"}}
+            self._handle("@sentry stop iterating")
+            self._handle("@sentry fix the lint error")
+
+        assert is_pr_iteration_paused(run_id=STOP_RUN_ID, organization_id=self.organization.id)
+        mock_consume.assert_not_called()
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.paused.blocked", tags={"gate": "trigger_consume"}
+        )
 
 
 class ParseQueuedItemTest(TestCase):

--- a/tests/sentry/seer/autofix/pr_iteration/test_mention.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_mention.py
@@ -120,3 +120,59 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
         with self.feature("organizations:autofix-pr-iteration-manual"):
             self._call(self._event(body="contact email@sentry.io for help"))
         mock_delay.assert_not_called()
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    @patch(f"{MENTION_PATH}.pause_pr_iteration_from_comment.delay")
+    def test_schedules_pause_task_for_stop_command(
+        self, mock_pause_delay: MagicMock, mock_trigger_delay: MagicMock
+    ) -> None:
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            self._call(self._event(body="@sentry stop iterating"))
+
+        mock_trigger_delay.assert_not_called()
+        mock_pause_delay.assert_called_once_with(
+            organization_id=self.organization.id,
+            repo_id=self.repo.id,
+            integration_id=self.integration.id,
+            pr_number=7,
+            comment_id=999,
+            github_username="octocat",
+        )
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    @patch(f"{MENTION_PATH}.pause_pr_iteration_from_comment.delay")
+    def test_skips_stop_command_when_manual_feature_disabled(
+        self, mock_pause_delay: MagicMock, mock_trigger_delay: MagicMock
+    ) -> None:
+        with self.feature("organizations:autofix-pr-iteration"):
+            self._call(self._event(body="@sentry stop iterating"))
+
+        mock_pause_delay.assert_not_called()
+        mock_trigger_delay.assert_not_called()
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    @patch(f"{MENTION_PATH}.pause_pr_iteration_from_comment.delay")
+    def test_skips_stop_command_for_github_enterprise(
+        self, mock_pause_delay: MagicMock, mock_trigger_delay: MagicMock
+    ) -> None:
+        self.integration = MagicMock(id=42, provider="github_enterprise")
+
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            self._call(self._event(body="@sentry stop iterating"))
+
+        mock_pause_delay.assert_not_called()
+        mock_trigger_delay.assert_not_called()
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    @patch(f"{MENTION_PATH}.pause_pr_iteration_from_comment.delay")
+    def test_skips_stop_command_when_not_pr_comment(
+        self, mock_pause_delay: MagicMock, mock_trigger_delay: MagicMock
+    ) -> None:
+        event = self._event(body="@sentry stop iterating")
+        event["issue"].pop("pull_request")
+
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            self._call(event)
+
+        mock_pause_delay.assert_not_called()
+        mock_trigger_delay.assert_not_called()

--- a/tests/sentry/seer/test_webhooks.py
+++ b/tests/sentry/seer/test_webhooks.py
@@ -3,6 +3,7 @@ import pytest
 from sentry.seer.webhooks import (
     SentryIterateCommand,
     SentryReviewCommand,
+    SentryStopCommand,
     sentry_command,
 )
 
@@ -34,6 +35,19 @@ class TestSentryCommand:
         assert not isinstance(sentry_command(body), SentryReviewCommand)
 
     @pytest.mark.parametrize(
+        "body",
+        [
+            "@sentry stop iterating",
+            "  @sentry stop iterating  ",
+            "@Sentry STOP ITERATING",
+            "@sentry stop iterating on the tests",
+            "please @sentry stop iterating",
+        ],
+    )
+    def test_stop_command(self, body: str) -> None:
+        assert isinstance(sentry_command(body), SentryStopCommand)
+
+    @pytest.mark.parametrize(
         "body, expected_feedback",
         [
             ("@sentry fix the typo", "fix the typo"),
@@ -46,6 +60,13 @@ class TestSentryCommand:
             ("@sentry  review", "review"),
             ("@sentry fix docs@sentry.io", "fix docs@sentry.io"),
             ("@sentry fix @sentry-cursor-agent", "fix @sentry-cursor-agent"),
+            (
+                "@sentry stop putting long comments in the diff",
+                "stop putting long comments in the diff",
+            ),
+            ("@sentry stop", "stop"),
+            ("@sentry stop iterations", "stop iterations"),
+            ("@sentry stopiterating", "stopiterating"),
         ],
     )
     def test_iterate_command(self, body: str, expected_feedback: str) -> None:

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -38,6 +38,7 @@ from sentry.seer.autofix.pr_iteration.run_markers import record_run_extras
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun
 from sentry.tasks.seer.pr_iteration import (
+    ALREADY_PAUSED_PR_ITERATION_COMMENT,
     STOP_PR_ITERATION_FAILED_COMMENT,
     STOPPED_PR_ITERATION_COMMENT,
     UnsupportedProviderError,
@@ -431,6 +432,45 @@ class TriggerPrIterationFromCommentTest(TestCase):
             reaction="eyes",
         )
 
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_does_not_queue_or_ack_feedback_on_a_stopped_run(
+        self,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+    ) -> None:
+        # `@sentry stop iterating` already stopped this run, so consume would
+        # drop anything queued here. The comment is answered with the stop rather
+        # than the :eyes: that promises an iteration.
+        self.create_seer_run(
+            organization=self.organization, seer_run_state_id=67890, user_id=self.user.id
+        )
+        pause_pr_iteration(run_id=67890, organization_id=self.organization.id)
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+
+        mock_enqueue.assert_not_called()
+        mock_trigger_consume.assert_not_called()
+        mock_reaction.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="+1",
+        )
+        self.mock_actions.create_pull_request_comment.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            "7",
+            ALREADY_PAUSED_PR_ITERATION_COMMENT,
+        )
+
     @patch(f"{TASK_PATH}.metrics")
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm", side_effect=ValueError("boom"))
@@ -640,37 +680,28 @@ class PausePrIterationFromCommentTest(TestCase):
 
     @patch(f"{TASK_PATH}.metrics")
     @patch(f"{TASK_PATH}._add_comment_reaction")
-    @patch(f"{TASK_PATH}.default_cache")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
-    def test_comments_ineligible_when_run_has_no_repo_pr_states(
+    def test_writes_nothing_when_run_has_no_repo_pr_states(
         self,
         mock_get_state: MagicMock,
         mock_has_access: MagicMock,
-        mock_cache: MagicMock,
         mock_reaction: MagicMock,
         mock_metrics: MagicMock,
     ) -> None:
+        # A cell sees only its own Seer, so an ineligible run here is
+        # indistinguishable from a healthy run owned by another cell — and the
+        # webhook reached every cell on the installation. Only the owning cell
+        # answers a stop; this one records the outcome and writes nothing.
         mock_get_state.return_value = self._agent_state(repo_pr_states={})
-        mock_cache.get.return_value = None
 
         self._call()
 
         assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is False
         mock_has_access.assert_not_called()
-        mock_reaction.assert_called_once_with(
-            self.mock_make_scm.return_value,
-            source_type="github-pr-comment",
-            pr_number=7,
-            comment_id=999,
-            reaction="confused",
-        )
-        self.mock_actions.create_pull_request_comment.assert_called_once_with(
-            self.mock_make_scm.return_value,
-            "7",
-            _ineligible_pr_iteration_comment_body("octocat"),
-        )
-        mock_metrics.incr.assert_any_call(
+        mock_reaction.assert_not_called()
+        self.mock_actions.create_pull_request_comment.assert_not_called()
+        mock_metrics.incr.assert_called_once_with(
             "autofix.pr_iteration.stop_command", tags={"outcome": "ineligible_run"}
         )
 

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -446,8 +446,8 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_reaction: MagicMock,
     ) -> None:
         # `@sentry stop iterating` already stopped this run, so consume would
-        # drop anything queued here. The comment is answered with the stop rather
-        # than the :eyes: that promises an iteration.
+        # drop anything queued here. Nothing is queued and nothing is written to
+        # the PR: an :eyes: would promise an iteration that never comes.
         self.create_seer_run(
             organization=self.organization, seer_run_state_id=67890, user_id=self.user.id
         )
@@ -458,18 +458,8 @@ class TriggerPrIterationFromCommentTest(TestCase):
 
         mock_enqueue.assert_not_called()
         mock_trigger_consume.assert_not_called()
-        mock_reaction.assert_called_once_with(
-            self.mock_make_scm.return_value,
-            source_type="github-pr-comment",
-            pr_number=7,
-            comment_id=999,
-            reaction="+1",
-        )
-        self.mock_actions.create_pull_request_comment.assert_called_once_with(
-            self.mock_make_scm.return_value,
-            "7",
-            ALREADY_PAUSED_PR_ITERATION_COMMENT,
-        )
+        mock_reaction.assert_not_called()
+        self.mock_actions.create_pull_request_comment.assert_not_called()
 
     @patch(f"{TASK_PATH}.metrics")
     @patch(f"{TASK_PATH}._add_comment_reaction")
@@ -618,13 +608,15 @@ class PausePrIterationFromCommentTest(TestCase):
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
-    def test_second_stop_comment_pauses_again(
+    def test_second_stop_comment_reports_already_paused(
         self,
         mock_get_state: MagicMock,
         mock_has_access: MagicMock,
         mock_reaction: MagicMock,
         mock_metrics: MagicMock,
     ) -> None:
+        # The stop is idempotent, so the second comment is acknowledged — but as
+        # the state it found, not as a stop it performed.
         mock_get_state.return_value = self._agent_state()
 
         self._call()
@@ -632,6 +624,13 @@ class PausePrIterationFromCommentTest(TestCase):
 
         assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is True
         assert mock_reaction.call_count == 2
+        bodies = [
+            call.args[2] for call in self.mock_actions.create_pull_request_comment.call_args_list
+        ]
+        assert bodies == [STOPPED_PR_ITERATION_COMMENT, ALREADY_PAUSED_PR_ITERATION_COMMENT]
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "already_paused"}
+        )
 
     @patch(f"{TASK_PATH}.metrics")
     @patch(f"{TASK_PATH}._add_comment_reaction")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -268,6 +268,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         self.mock_actions.get_pull_request.assert_not_called()
         assert not PullRequest.objects.filter(repository_id=self.repo.id, key="7").exists()
 
+    @patch(f"{TASK_PATH}.metrics")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=False)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
@@ -278,6 +279,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
         mock_has_access: MagicMock,
+        mock_metrics: MagicMock,
     ) -> None:
         mock_get_state.return_value = self._agent_state()
 
@@ -286,6 +288,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_has_access.assert_called_once_with(self.mock_make_scm.return_value, "octocat")
         mock_enqueue.assert_not_called()
         mock_trigger_consume.assert_not_called()
+        mock_metrics.incr.assert_any_call("autofix.pr_iteration.comment_trigger.unauthorized")
 
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.default_cache")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -24,7 +24,11 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
-from sentry.seer.autofix.pr_iteration.pause import PAUSED_EXTRA, pause_pr_iteration
+from sentry.seer.autofix.pr_iteration.pause import (
+    PAUSED_EXTRA,
+    is_pr_iteration_paused,
+    pause_pr_iteration,
+)
 from sentry.seer.autofix.pr_iteration.queue import (
     QueuedAutofixFeedback,
     peek_queued_autofix_feedback,
@@ -34,12 +38,15 @@ from sentry.seer.autofix.pr_iteration.run_markers import record_run_extras
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun
 from sentry.tasks.seer.pr_iteration import (
+    STOP_PR_ITERATION_FAILED_COMMENT,
+    STOPPED_PR_ITERATION_COMMENT,
     UnsupportedProviderError,
     _build_review_feedback,
     _delete_own_comment_eyes_reaction,
     _ineligible_pr_iteration_comment_body,
     _resolve_review_comment_threads,
     consume_queued_autofix_feedback,
+    pause_pr_iteration_from_comment,
     trigger_consume_pr_iteration_feedback,
     trigger_pr_iteration_from_comment,
 )
@@ -421,6 +428,34 @@ class TriggerPrIterationFromCommentTest(TestCase):
             reaction="eyes",
         )
 
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm", side_effect=ValueError("boom"))
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_emits_no_metric_when_scm_init_fails(
+        self,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        # An SCM init failure is neither a permission denial nor a missing run.
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+
+        mock_has_access.assert_not_called()
+        mock_enqueue.assert_not_called()
+        mock_trigger_consume.assert_not_called()
+        mock_reaction.assert_not_called()
+        mock_metrics.incr.assert_not_called()
+
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
@@ -446,6 +481,281 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue.assert_called_once()
         mock_trigger_consume.assert_called_once()
         mock_reaction.assert_called_once()
+
+
+class PausePrIterationFromCommentTest(TestCase):
+    mock_make_scm: MagicMock
+    mock_actions: MagicMock
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+        self.repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="123",
+            name="owner/repo",
+        )
+        self.create_seer_run(
+            organization=self.organization, seer_run_state_id=67890, user_id=self.user.id
+        )
+
+        for attr, target in (
+            ("mock_make_scm", "make_scm"),
+            ("mock_actions", "scm_actions"),
+        ):
+            patcher = patch(f"{TASK_PATH}.{target}")
+            setattr(self, attr, patcher.start())
+            self.addCleanup(patcher.stop)
+
+        self.mock_make_scm.return_value = MagicMock(spec=_CommentScmStub)
+        self.mock_actions.get_pull_request.return_value = {"data": {"internal_id": "555"}}
+
+    def _agent_state(self, *, repo_pr_states: dict[str, RepoPRState] | None = None) -> SeerRunState:
+        return SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states=(
+                {
+                    "owner/repo": RepoPRState(
+                        repo_name="owner/repo", pr_url="https://example.com/pull/7"
+                    )
+                }
+                if repo_pr_states is None
+                else repo_pr_states
+            ),
+            metadata={"group_id": self.group.id},
+        )
+
+    def _call(self, *, comment_id: int | None = 999) -> None:
+        pause_pr_iteration_from_comment(
+            organization_id=self.organization.id,
+            repo_id=self.repo.id,
+            integration_id=42,
+            pr_number=7,
+            comment_id=comment_id,
+            github_username="octocat",
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_pauses_run_and_acknowledges(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is True
+        mock_reaction.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="+1",
+        )
+        self.mock_actions.create_pull_request_comment.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            "7",
+            STOPPED_PR_ITERATION_COMMENT,
+        )
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "success"}
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_second_stop_comment_pauses_again(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+        self._call()
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is True
+        assert mock_reaction.call_count == 2
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=False)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_skips_when_no_write_access(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is False
+        mock_reaction.assert_not_called()
+        self.mock_actions.create_pull_request_comment.assert_not_called()
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "unauthorized"}
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_skips_when_no_agent_state(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = None
+
+        self._call()
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is False
+        mock_has_access.assert_not_called()
+        mock_reaction.assert_not_called()
+        self.mock_actions.create_pull_request_comment.assert_not_called()
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "no_run"}
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.default_cache")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_comments_ineligible_when_run_has_no_repo_pr_states(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_cache: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state(repo_pr_states={})
+        mock_cache.get.return_value = None
+
+        self._call()
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is False
+        mock_has_access.assert_not_called()
+        mock_reaction.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="confused",
+        )
+        self.mock_actions.create_pull_request_comment.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            "7",
+            _ineligible_pr_iteration_comment_body("octocat"),
+        )
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "ineligible_run"}
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm", side_effect=ValueError("boom"))
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_tags_scm_init_failure(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is False
+        mock_has_access.assert_not_called()
+        mock_reaction.assert_not_called()
+        self.mock_actions.create_pull_request_comment.assert_not_called()
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "scm_init_failed"}
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_reports_failure_when_pause_does_not_apply(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        # A legacy run has no SeerRun row, so the stop marker has nowhere to go.
+        SeerRun.objects.filter(
+            seer_run_state_id=67890, organization_id=self.organization.id
+        ).delete()
+        mock_get_state.return_value = self._agent_state()
+
+        self._call()
+
+        mock_reaction.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="confused",
+        )
+        self.mock_actions.create_pull_request_comment.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            "7",
+            STOP_PR_ITERATION_FAILED_COMMENT,
+        )
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "pause_failed"}
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_pauses_run_without_a_comment_id(
+        self,
+        mock_get_state: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state()
+
+        self._call(comment_id=None)
+
+        assert is_pr_iteration_paused(run_id=67890, organization_id=self.organization.id) is True
+        mock_reaction.assert_not_called()
+        self.mock_actions.create_pull_request_comment.assert_called_once_with(
+            self.mock_make_scm.return_value,
+            "7",
+            STOPPED_PR_ITERATION_COMMENT,
+        )
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.stop_command", tags={"outcome": "success"}
+        )
 
 
 class ConsumeQueuedAutofixFeedbackTest(TestCase):


### PR DESCRIPTION
Adds an `@sentry stop iterating` command on top-level pull request comments. It calls the existing `pause_pr_iteration`, which had no production caller until now.

Two words, not one: `@sentry stop putting long comments in the diff` is real feedback and still iterates.

The command runs the same gates as an iteration — feature flag, GitHub provider, repo write access. It acknowledges with a :+1: and a comment, and reports a failure with a :confused: when the run has no `SeerRun` row to mark.

Stacked on #122086.

you can see an example of pr iteration being paused in https://github.com/alexsohn1126/sentry-test-tools/pull/22

CW-1709