### PR TITLE
fix(inbox): Align Autofix action icons

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreviewActions.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewActions.tsx
@@ -18,9 +18,13 @@ import {useLinkedPullRequests} from 'sentry/components/group/externalIssuesList/
 import {Placeholder} from 'sentry/components/placeholder';
 import {
   IconAdd,
+  IconBug,
   IconChevron,
+  IconCode,
   IconGithub,
+  IconList,
   IconOpen,
+  IconPullRequest,
   IconRefresh,
   IconSeer,
 } from 'sentry/icons';
@@ -87,7 +91,7 @@ function StartAutofixAction({
   codingAgentStep,
   disabled,
   group,
-  icon = <IconSeer />,
+  icon,
   label,
   onContinueInSeer,
   tooltip,
@@ -97,10 +101,10 @@ function StartAutofixAction({
   analyticsAction: string;
   analyticsEventKey: string;
   analyticsEventName: string;
+  icon: ReactNode;
   label: string;
   analyticsParams?: ButtonProps['analyticsParams'];
   codingAgentStep?: 'root_cause' | 'solution';
-  icon?: ReactNode;
   tooltip?: string | null;
   variant?: 'primary' | 'secondary';
   waiting?: boolean;
@@ -234,6 +238,7 @@ function NextAutofixStepButton({
         autofix={autofix}
         disabled={disabled}
         group={group}
+        icon={<IconBug data-test-id="autofix-root-cause-icon" />}
         label={t('Find Root Cause')}
         onContinueInSeer={onContinueInSeer}
         variant={variant}
@@ -350,12 +355,21 @@ function NextAutofixStepButton({
 
   const nextStep = getAutofixNextStep({sections});
   if (autofix.isProcessing) {
-    const label =
+    const {icon, label} =
       nextStep?.action === 'solution'
-        ? t('Make a Plan')
+        ? {
+            icon: <IconList data-test-id="autofix-plan-icon" />,
+            label: t('Make a Plan'),
+          }
         : nextStep?.action === 'code_changes'
-          ? t('Write a Code Fix')
-          : t('Find Root Cause');
+          ? {
+              icon: <IconCode data-test-id="autofix-code-changes-icon" />,
+              label: t('Write a Code Fix'),
+            }
+          : {
+              icon: <IconBug data-test-id="autofix-root-cause-icon" />,
+              label: t('Find Root Cause'),
+            };
 
     return (
       <StartAutofixAction
@@ -366,6 +380,7 @@ function NextAutofixStepButton({
         autofix={autofix}
         disabled
         group={group}
+        icon={icon}
         label={label}
         onContinueInSeer={onContinueInSeer}
         variant={variant}
@@ -386,6 +401,7 @@ function NextAutofixStepButton({
           autofix={autofix}
           disabled={disabled}
           group={group}
+          icon={<IconPullRequest data-test-id="autofix-pull-request-icon" />}
           label={t('Create PR')}
           onContinueInSeer={onContinueInSeer}
           variant={variant}
@@ -402,6 +418,7 @@ function NextAutofixStepButton({
           disabled={disabled}
           group={group}
           codingAgentStep="solution"
+          icon={<IconCode data-test-id="autofix-code-changes-icon" />}
           label={t('Write a Code Fix')}
           onContinueInSeer={onContinueInSeer}
           variant={variant}
@@ -418,6 +435,7 @@ function NextAutofixStepButton({
           disabled={disabled}
           group={group}
           codingAgentStep="root_cause"
+          icon={<IconList data-test-id="autofix-plan-icon" />}
           label={t('Make a Plan')}
           onContinueInSeer={onContinueInSeer}
           variant={variant}

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -931,6 +931,7 @@ describe('InboxPage', () => {
     const seerButton = await within(preview).findByRole('button', {
       name: 'Find Root Cause',
     });
+    expect(within(seerButton).getByTestId('autofix-root-cause-icon')).toBeVisible();
     await userEvent.click(seerButton);
 
     expect(within(preview).queryByRole('tab', {name: 'Autofix'})).not.toBeInTheDocument();
@@ -1071,6 +1072,9 @@ describe('InboxPage', () => {
 
     const preview = await openFixProposedPreview();
     await within(preview).findByRole('button', {name: 'Make a Plan'});
+    await waitFor(() =>
+      expect(within(preview).getByTestId('autofix-plan-icon')).toBeVisible()
+    );
 
     // After starting the step, the refetch will see a processing state
     mockAutofixResponse(
@@ -1097,9 +1101,52 @@ describe('InboxPage', () => {
     );
   });
 
-  it('offers to create a PR when code changes are complete', async () => {
+  it('uses action-specific icons from code changes through PR creation', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
+    mockAutofixResponse(
+      ExplorerAutofixResponseFixture({
+        autofix: ExplorerAutofixStateFixture({
+          blocks: [
+            ExplorerAutofixBlockFixture(),
+            ExplorerAutofixBlockFixture({
+              id: 'solution',
+              message: {
+                content: 'Plan complete',
+                metadata: {step: 'solution'},
+                role: 'assistant',
+              },
+            }),
+          ],
+        }),
+      })
+    );
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/coding-agents/',
+      body: {integrations: []},
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/seer/repos/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/issues/${fixProposedGroup.id}/autofix/`,
+      method: 'POST',
+      body: {run_id: 42},
+    });
+
+    render(<InboxPage />, {
+      organization: seerOrganization,
+      initialRouterConfig,
+    });
+
+    const preview = await openFixProposedPreview();
+    await within(preview).findByRole('button', {name: 'Write a Code Fix'});
+    await waitFor(() =>
+      expect(within(preview).getByTestId('autofix-code-changes-icon')).toBeVisible()
+    );
+
+    // After starting the step, the refetch will see completed code changes.
     mockAutofixResponse(
       ExplorerAutofixResponseFixture({
         autofix: ExplorerAutofixStateFixture({
@@ -1116,15 +1163,16 @@ describe('InboxPage', () => {
       })
     );
 
-    render(<InboxPage />, {
-      organization: seerOrganization,
-      initialRouterConfig,
-    });
+    await userEvent.click(
+      within(preview).getByRole('button', {name: 'Write a Code Fix'})
+    );
 
-    const preview = await openFixProposedPreview();
+    const createPullRequestButton = await within(preview).findByRole('button', {
+      name: 'Create PR',
+    });
     expect(
-      await within(preview).findByRole('button', {name: 'Create PR'})
-    ).toBeInTheDocument();
+      within(createPullRequestButton).getByTestId('autofix-pull-request-icon')
+    ).toBeVisible();
   });
 
   it('labels a coding agent pull request like a Seer one', async () => {


### PR DESCRIPTION
The Inbox issue stream now replaces the generic Seer icon on Root Cause, Plan, Code Changes, and Create PR buttons with action-specific Autofix icons, including while steps are processing. Existing GitHub, external-link, retry, and Continue in Seer icons remain unchanged.

Fixes ISWF-3259
