### PR TITLE
fix(dashboards): Suggest refreshing when a save hits stale widget ids

### DIFF
--- a/static/app/actionCreators/dashboards.spec.tsx
+++ b/static/app/actionCreators/dashboards.spec.tsx
@@ -1,10 +1,14 @@
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 
 import {updateDashboard} from 'sentry/actionCreators/dashboards';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+
+jest.mock('sentry/actionCreators/indicator');
 
 describe('updateDashboard', () => {
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
   });
 
   it('does not include revisionSource in the request body by default', async () => {
@@ -43,5 +47,38 @@ describe('updateDashboard', () => {
         data: expect.objectContaining({revisionSource: 'edit-with-agent'}),
       })
     );
+  });
+
+  it.each([
+    'You cannot update widgets that are not part of this dashboard.',
+    'You cannot use a query not owned by this widget',
+  ])('suggests refreshing the page when the dashboard is stale: %s', async detail => {
+    const dashboard = DashboardFixture([]);
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/dashboards/${dashboard.id}/`,
+      method: 'PUT',
+      statusCode: 400,
+      body: [detail],
+    });
+
+    await expect(updateDashboard('org-slug', dashboard)).rejects.toBeDefined();
+
+    expect(addErrorMessage).toHaveBeenCalledWith(
+      'This dashboard may have been updated somewhere else. Refresh the page and try again.'
+    );
+  });
+
+  it('passes through other validation errors unchanged', async () => {
+    const dashboard = DashboardFixture([]);
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/dashboards/${dashboard.id}/`,
+      method: 'PUT',
+      statusCode: 400,
+      body: {title: ['This field may not be blank.']},
+    });
+
+    await expect(updateDashboard('org-slug', dashboard)).rejects.toBeDefined();
+
+    expect(addErrorMessage).toHaveBeenCalledWith('This field may not be blank.');
   });
 });

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -210,6 +210,17 @@ export function fetchDashboard(
   return promise;
 }
 
+// The backend rejects a save whose payload references widgets or queries that
+// are no longer on the dashboard. This happens when the dashboard changed after
+// this page loaded — a save from another tab, a Seer edit, or a restored
+// revision deletes the existing rows and recreates them with new ids, leaving
+// this page holding ids that no longer exist. The raw messages read like a
+// permissions problem and don't tell the user that reloading fixes it.
+const STALE_DASHBOARD_ERRORS = [
+  'You cannot update widgets that are not part of this dashboard.',
+  'You cannot use a query not owned by this widget',
+];
+
 export function updateDashboard(
   orgId: string,
   dashboard: DashboardDetails,
@@ -257,7 +268,14 @@ export function updateDashboard(
 
     if (errorResponse) {
       const errors = flattenErrors(errorResponse, {});
-      addErrorMessage(errors[Object.keys(errors)[0]!] as string);
+      const error = errors[Object.keys(errors)[0]!] as string;
+      addErrorMessage(
+        STALE_DASHBOARD_ERRORS.includes(error)
+          ? t(
+              'This dashboard may have been updated somewhere else. Refresh the page and try again.'
+            )
+          : error
+      );
     } else {
       addErrorMessage(t('Unable to update dashboard'));
     }


### PR DESCRIPTION
## Problem

Saving a dashboard fails with a bare `You cannot update widgets that are not part of this dashboard.` toast when the request references widget or query ids that are no longer on the dashboard.

This happens when the dashboard changed after the page loaded. A save from another tab, a Seer "edit with agent" apply, or a restored revision deletes the existing widget rows and recreates them with new ids, so the open page is left holding ids that no longer exist.

Two things make it worse than a one-off error:

- The message reads like a permissions problem. Nothing tells the user that reloading fixes it.
- The failed save leaves the editor in `EDIT` state with the same payload (the rejection handler in `detail.tsx` is a no-op), so clicking Save again reproduces the failure exactly.

The result is users retrying the identical request over and over. In the linked issue the same user fires the same failing `PUT` seconds apart, repeatedly, instead of reloading.

## Change

Frontend-only. `updateDashboard` maps the two stale-id messages to copy that tells the user what to do:

> This dashboard may have been updated somewhere else. Refresh the page and try again.

"may have been" rather than "was" — the client can't actually confirm what happened, only that its ids are stale. Every other validation error still passes through unchanged.

Both stale-id messages are covered, since they're the same failure mode with the same remedy:
- `You cannot update widgets that are not part of this dashboard.` (stale widget ids)
- `You cannot use a query not owned by this widget` (stale query ids)

## Why not change the backend message

`PUT` on this endpoint is `ApiPublishStatus.PUBLIC`, so "refresh the page" would be wrong advice for anyone driving the documented API from a script. Backend DRF strings also never go through `t()`, so the copy could never be localized.

The tradeoff is that this matches on the backend's English strings, and a reword there would silently break the mapping. The robust version is a stable machine-readable error code from the backend plus a frontend map — two PRs, since frontend and backend aren't atomically deployed. Happy to follow up with that if reviewers prefer it.

## Not addressed here

This improves the message, not the underlying cause. The widget ids go stale because the Seer artifact schema (`GeneratedWidget`) has no `id` field, so every agent edit returns id-less widgets and triggers a full delete-and-recreate. Restore strips ids deliberately for the same effect. Both are separate backend changes.

## Testing

- New cases in `dashboards.spec.tsx` assert the refresh copy for both stale-id messages and that other validation errors pass through untouched. Both new cases fail without the source change.
- `pnpm test-ci static/app/actionCreators/dashboards.spec.tsx` — 5 passed
- `pnpm run lint:js` on both files — clean