### PR TITLE
feat(explore): Support array attributes in logs and trace metrics search

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -62,15 +62,19 @@ export function OurlogsDrawer({
     useLogItemAttributes({}, 'number');
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean');
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useLogItemAttributes({}, 'array');
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery: logsSearch.formatString(),
     searchSource: 'ourlogs',
     onSearch: (query: string) => setLogsQuery(query),
+    arrayAttributes,
     booleanAttributes,
     numberAttributes,
     stringAttributes,
     itemType: TraceItemDataset.LOGS,
+    arraySecondaryAliases,
     booleanSecondaryAliases,
     numberSecondaryAliases,
     stringSecondaryAliases,

--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -21,6 +21,7 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {getShortEventId} from 'sentry/utils/events';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -53,6 +54,8 @@ export function OurlogsDrawer({
   embeddedOptions,
   additionalData: propAdditionalData,
 }: LogIssueDrawerProps) {
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const setLogsQuery = useSetQueryParamsQuery();
   const logsSearch = useQueryParamsSearch();
 
@@ -63,7 +66,7 @@ export function OurlogsDrawer({
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean');
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useLogItemAttributes({}, 'array');
+    useLogItemAttributes({enabled: supportsArrays}, 'array');
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery: logsSearch.formatString(),

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -93,9 +93,6 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     const localBooleanAttributes = {...spanBooleanAttributes};
     const localNumberAttributes = {...spanNumberAttributes};
     const localStringAttributes = {...spanStringAttributesWithSemver};
-    // Only expose array attributes when the feature is enabled, so nothing leaks
-    // through even if the fetch or the validate endpoint returns array-typed
-    // data while the flag is off.
     const localArrayAttributes = supportsArrays ? {...spansArrayAttributes} : {};
 
     if (props.validatedSearchQueryData?.query.fields.length) {

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -7,6 +7,7 @@ import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/typ
 import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind, type AggregationKey} from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {
   useTraceItemSearchQueryBuilderProps,
@@ -66,6 +67,10 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     useSpanItemAttributes({}, 'string');
   const {attributes: spansArrayAttributes, secondaryAliases: arraySecondaryAliases} =
     useSpanItemAttributes({}, 'array');
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
 
   const spanStringAttributesWithSemver = useMemo(() => {
     if (SpanFields.RELEASE in spanStringAttributes) {
@@ -88,7 +93,10 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     const localBooleanAttributes = {...spanBooleanAttributes};
     const localNumberAttributes = {...spanNumberAttributes};
     const localStringAttributes = {...spanStringAttributesWithSemver};
-    const localArrayAttributes = {...spansArrayAttributes};
+    // Only expose array attributes when the feature is enabled, so nothing leaks
+    // through even if the fetch or the validate endpoint returns array-typed
+    // data while the flag is off.
+    const localArrayAttributes = supportsArrays ? {...spansArrayAttributes} : {};
 
     if (props.validatedSearchQueryData?.query.fields.length) {
       for (const item of props.validatedSearchQueryData.query.fields) {
@@ -117,7 +125,7 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
             };
           }
 
-          if (item.attrType === 'array' && item.name) {
+          if (supportsArrays && item.attrType === 'array' && item.name) {
             localArrayAttributes[item.name] ??= {
               key: item.name,
               name: prettifyAttributeName(item.name),
@@ -147,6 +155,7 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
     spanNumberAttributes,
     spanStringAttributesWithSemver,
     spansArrayAttributes,
+    supportsArrays,
   ]);
 
   const spanSearchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps({

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -68,9 +68,7 @@ export function useSpanSearchQueryBuilderProps(props: UseSpanSearchQueryBuilderP
   const {attributes: spansArrayAttributes, secondaryAliases: arraySecondaryAliases} =
     useSpanItemAttributes({}, 'array');
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
 
   const spanStringAttributesWithSemver = useMemo(() => {
     if (SpanFields.RELEASE in spanStringAttributes) {

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -118,6 +118,9 @@ function LogsSearchBar({
   'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
 >) {
   const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   const {
     selection: {projects},
   } = usePageFilters();
@@ -134,11 +137,11 @@ function LogsSearchBar({
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       itemType={TraceItemDataset.LOGS}
-      arrayAttributes={arrayAttributes}
+      arrayAttributes={supportsArrays ? arrayAttributes : {}}
       booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
-      arraySecondaryAliases={arraySecondaryAliases}
+      arraySecondaryAliases={supportsArrays ? arraySecondaryAliases : {}}
       booleanSecondaryAliases={booleanSecondaryAliases}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
@@ -155,6 +158,9 @@ function LogsSearchBar({
 function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): SearchBarData {
   const {pageFilters, widgetQuery} = props;
   const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'string');
@@ -168,11 +174,11 @@ function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): Search
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.LOGS,
-      arrayAttributes,
+      arrayAttributes: supportsArrays ? arrayAttributes : {},
       booleanAttributes,
       numberAttributes,
       stringAttributes,
-      arraySecondaryAliases,
+      arraySecondaryAliases: supportsArrays ? arraySecondaryAliases : {},
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -118,9 +118,7 @@ function LogsSearchBar({
   'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
 >) {
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const {
     selection: {projects},
   } = usePageFilters();
@@ -158,9 +156,7 @@ function LogsSearchBar({
 function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): SearchBarData {
   const {pageFilters, widgetQuery} = props;
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'string');

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -129,7 +129,10 @@ function LogsSearchBar({
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'boolean');
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'array');
+    useLogItemAttributes(
+      {enabled: isLogsEnabled(organization) && supportsArrays},
+      'array'
+    );
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
@@ -165,7 +168,10 @@ function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): Search
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'boolean');
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'array');
+    useLogItemAttributes(
+      {enabled: isLogsEnabled(organization) && supportsArrays},
+      'array'
+    );
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -127,14 +127,18 @@ function LogsSearchBar({
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'number');
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'boolean');
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'array');
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       itemType={TraceItemDataset.LOGS}
+      arrayAttributes={arrayAttributes}
       booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
+      arraySecondaryAliases={arraySecondaryAliases}
       booleanSecondaryAliases={booleanSecondaryAliases}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
@@ -158,13 +162,17 @@ function useLogsSearchBarDataProvider(props: SearchBarDataProviderProps): Search
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'number');
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'boolean');
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useLogItemAttributes({enabled: isLogsEnabled(organization)}, 'array');
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.LOGS,
+      arrayAttributes,
       booleanAttributes,
       numberAttributes,
       stringAttributes,
+      arraySecondaryAliases,
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -87,9 +87,7 @@ function TraceMetricsSearchBar({
   'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
 >) {
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const {
     selection: {projects},
   } = usePageFilters();
@@ -165,9 +163,7 @@ function useTraceMetricsSearchBarDataProvider(
 ): SearchBarData {
   const {pageFilters, widgetQuery} = props;
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const {attributeQuery, traceMetrics} = useTraceMetricsSearchScope();
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -118,15 +118,26 @@ function TraceMetricsSearchBar({
       'boolean',
       HiddenTraceMetricSearchFields
     );
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useTraceMetricItemAttributes(
+      {
+        query: attributeQuery,
+        enabled: defined(traceMetrics[0]),
+      },
+      'array',
+      HiddenTraceMetricSearchFields
+    );
 
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       itemType={TraceItemDataset.TRACEMETRICS}
+      arrayAttributes={arrayAttributes}
       booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
+      arraySecondaryAliases={arraySecondaryAliases}
       booleanSecondaryAliases={booleanSecondaryAliases}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
@@ -168,13 +179,21 @@ function useTraceMetricsSearchBarDataProvider(
       'boolean',
       HiddenTraceMetricSearchFields
     );
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useTraceMetricItemAttributes(
+      {query: attributeQuery, enabled: defined(traceMetrics[0])},
+      'array',
+      HiddenTraceMetricSearchFields
+    );
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.TRACEMETRICS,
+      arrayAttributes,
       booleanAttributes,
       numberAttributes,
       stringAttributes,
+      arraySecondaryAliases,
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -18,6 +18,7 @@ import {
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   type DatasetConfig,
   type SearchBarData,
@@ -85,6 +86,10 @@ function TraceMetricsSearchBar({
   WidgetBuilderSearchBarProps,
   'widgetQuery' | 'onSearch' | 'portalTarget' | 'onClose'
 >) {
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   const {
     selection: {projects},
   } = usePageFilters();
@@ -133,11 +138,11 @@ function TraceMetricsSearchBar({
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       itemType={TraceItemDataset.TRACEMETRICS}
-      arrayAttributes={arrayAttributes}
+      arrayAttributes={supportsArrays ? arrayAttributes : {}}
       booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
-      arraySecondaryAliases={arraySecondaryAliases}
+      arraySecondaryAliases={supportsArrays ? arraySecondaryAliases : {}}
       booleanSecondaryAliases={booleanSecondaryAliases}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
@@ -159,6 +164,10 @@ function useTraceMetricsSearchBarDataProvider(
   props: SearchBarDataProviderProps
 ): SearchBarData {
   const {pageFilters, widgetQuery} = props;
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   const {attributeQuery, traceMetrics} = useTraceMetricsSearchScope();
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
@@ -189,11 +198,11 @@ function useTraceMetricsSearchBarDataProvider(
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({
       itemType: TraceItemDataset.TRACEMETRICS,
-      arrayAttributes,
+      arrayAttributes: supportsArrays ? arrayAttributes : {},
       booleanAttributes,
       numberAttributes,
       stringAttributes,
-      arraySecondaryAliases,
+      arraySecondaryAliases: supportsArrays ? arraySecondaryAliases : {},
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -125,7 +125,7 @@ function TraceMetricsSearchBar({
     useTraceMetricItemAttributes(
       {
         query: attributeQuery,
-        enabled: defined(traceMetrics[0]),
+        enabled: defined(traceMetrics[0]) && supportsArrays,
       },
       'array',
       HiddenTraceMetricSearchFields
@@ -186,7 +186,7 @@ function useTraceMetricsSearchBarDataProvider(
     );
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
     useTraceMetricItemAttributes(
-      {query: attributeQuery, enabled: defined(traceMetrics[0])},
+      {query: attributeQuery, enabled: defined(traceMetrics[0]) && supportsArrays},
       'array',
       HiddenTraceMetricSearchFields
     );

--- a/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
@@ -127,16 +127,26 @@ export function MetricsDetectorSearchBar({
     };
   }, [data?.booleanAttributes]);
 
+  const visibleArrayTags = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(data?.arrayAttributes ?? {}).filter(
+        ([key]) => !HiddenTraceMetricSearchFields.includes(key)
+      )
+    );
+  }, [data?.arrayAttributes]);
+
   return (
     <TraceItemSearchQueryBuilder
       key={traceMetric.name}
       itemType={TraceItemDataset.TRACEMETRICS}
       initialQuery={initialQuery}
       onSearch={onSearch}
+      arrayAttributes={visibleArrayTags ?? EMPTY_TAG_COLLECTION}
       booleanAttributes={visibleBooleanTags ?? EMPTY_TAG_COLLECTION}
       numberAttributes={visibleNumberTags ?? EMPTY_TAG_COLLECTION}
       numberSecondaryAliases={EMPTY_TAG_COLLECTION}
       stringAttributes={visibleStringTags ?? EMPTY_TAG_COLLECTION}
+      arraySecondaryAliases={EMPTY_TAG_COLLECTION}
       booleanSecondaryAliases={EMPTY_TAG_COLLECTION}
       stringSecondaryAliases={EMPTY_TAG_COLLECTION}
       searchSource="detectors-metrics"

--- a/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
@@ -40,6 +40,9 @@ export function MetricsDetectorSearchBar({
 }: DetectorSearchBarProps) {
   const {selection} = usePageFilters();
   const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   const aggregateFunction = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
   );
@@ -128,12 +131,15 @@ export function MetricsDetectorSearchBar({
   }, [data?.booleanAttributes]);
 
   const visibleArrayTags = useMemo(() => {
+    if (!supportsArrays) {
+      return EMPTY_TAG_COLLECTION;
+    }
     return Object.fromEntries(
       Object.entries(data?.arrayAttributes ?? {}).filter(
         ([key]) => !HiddenTraceMetricSearchFields.includes(key)
       )
     );
-  }, [data?.arrayAttributes]);
+  }, [data?.arrayAttributes, supportsArrays]);
 
   return (
     <TraceItemSearchQueryBuilder

--- a/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/metricsSearchBar.tsx
@@ -40,9 +40,7 @@ export function MetricsDetectorSearchBar({
 }: DetectorSearchBarProps) {
   const {selection} = usePageFilters();
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const aggregateFunction = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
   );

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -22,16 +22,20 @@ export function TraceSearchBar({
     useTraceItemDatasetAttributes(traceDataset, {projects: projectIds}, 'string');
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useTraceItemDatasetAttributes(traceDataset, {projects: projectIds}, 'boolean');
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useTraceItemDatasetAttributes(traceDataset, {projects: projectIds}, 'array');
 
   return (
     <TraceItemSearchQueryBuilder
       itemType={traceDataset}
       initialQuery={initialQuery}
       onSearch={onSearch}
+      arrayAttributes={arrayAttributes}
       booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       numberSecondaryAliases={numberSecondaryAliases}
       stringAttributes={stringAttributes}
+      arraySecondaryAliases={arraySecondaryAliases}
       booleanSecondaryAliases={booleanSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
       supportedAggregates={isLogs ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -15,9 +15,7 @@ export function TraceSearchBar({
   disabled,
 }: DetectorSearchBarProps) {
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const isLogs = dataset === DiscoverDatasets.OURLOGS;
   const traceDataset = isLogs ? TraceItemDataset.LOGS : TraceItemDataset.SPANS;
 

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -1,5 +1,6 @@
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DetectorSearchBarProps} from 'sentry/views/detectors/datasetConfig/base';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
@@ -13,6 +14,10 @@ export function TraceSearchBar({
   dataset,
   disabled,
 }: DetectorSearchBarProps) {
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   const isLogs = dataset === DiscoverDatasets.OURLOGS;
   const traceDataset = isLogs ? TraceItemDataset.LOGS : TraceItemDataset.SPANS;
 
@@ -30,12 +35,12 @@ export function TraceSearchBar({
       itemType={traceDataset}
       initialQuery={initialQuery}
       onSearch={onSearch}
-      arrayAttributes={arrayAttributes}
+      arrayAttributes={supportsArrays ? arrayAttributes : {}}
       booleanAttributes={booleanAttributes}
       numberAttributes={numberAttributes}
       numberSecondaryAliases={numberSecondaryAliases}
       stringAttributes={stringAttributes}
-      arraySecondaryAliases={arraySecondaryAliases}
+      arraySecondaryAliases={supportsArrays ? arraySecondaryAliases : {}}
       booleanSecondaryAliases={booleanSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
       supportedAggregates={isLogs ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -26,7 +26,11 @@ export function TraceSearchBar({
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useTraceItemDatasetAttributes(traceDataset, {projects: projectIds}, 'boolean');
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useTraceItemDatasetAttributes(traceDataset, {projects: projectIds}, 'array');
+    useTraceItemDatasetAttributes(
+      traceDataset,
+      {projects: projectIds, enabled: supportsArrays},
+      'array'
+    );
 
   return (
     <TraceItemSearchQueryBuilder

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -145,14 +145,18 @@ const LogsSearchSection = memo(function LogsSearchSectionImpl({
     useLogItemAttributes({}, 'number', HiddenLogSearchFields);
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useLogItemAttributes({}, 'array', HiddenLogSearchFields);
 
   const {data: validatedSearchQueryData} = useValidateLogsTab();
 
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
+      arrayAttributes,
       booleanAttributes,
       numberAttributes,
       stringAttributes,
+      arraySecondaryAliases,
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -139,6 +139,8 @@ const LogsSearchSection = memo(function LogsSearchSectionImpl({
     sortBys: aggregateSortBys,
   });
 
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
     useLogItemAttributes({}, 'string', HiddenLogSearchFields);
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
@@ -146,7 +148,7 @@ const LogsSearchSection = memo(function LogsSearchSectionImpl({
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useLogItemAttributes({}, 'array', HiddenLogSearchFields);
+    useLogItemAttributes({enabled: supportsArrays}, 'array', HiddenLogSearchFields);
 
   const {data: validatedSearchQueryData} = useValidateLogsTab();
 
@@ -163,7 +165,6 @@ const LogsSearchSection = memo(function LogsSearchSectionImpl({
       validatedSearchQueryData,
     });
 
-  const organization = useOrganization();
   const hasTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
@@ -173,9 +173,7 @@ describe('useLogsSearchQueryBuilderProps', () => {
     );
 
     expect(
-      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.[
-        'error.messages'
-      ]
+      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.['error.messages']
     ).toEqual(
       expect.objectContaining({
         kind: FieldKind.ARRAY,
@@ -200,12 +198,10 @@ describe('useLogsSearchQueryBuilderProps', () => {
     );
 
     expect(
-      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.[
-        'error.messages'
-      ]
+      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.['error.messages']
     ).toBeUndefined();
-    expect(
-      result.current.tracesItemSearchQueryBuilderProps.invalidFilterKeys
-    ).toEqual(['missing.key']);
+    expect(result.current.tracesItemSearchQueryBuilderProps.invalidFilterKeys).toEqual([
+      'missing.key',
+    ]);
   });
 });

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
@@ -35,12 +35,15 @@ const validationBody: EventValidationData = {
       {attrType: 'string', error: null, name: 'message.template', valid: true},
       {attrType: 'number', error: null, name: 'message.parameters.0', valid: true},
       {attrType: 'boolean', error: null, name: 'feature.enabled', valid: true},
+      {attrType: 'array', error: null, name: 'error.messages', valid: true},
       {attrType: null, error: 'unknown attribute', name: 'missing.key', valid: false},
     ],
     valid: false,
   },
   valid: false,
 };
+
+const arrayFeatures = {features: ['trace-item-array-query-support']};
 
 describe('useLogsSearchQueryBuilderProps', () => {
   beforeEach(() => {
@@ -107,5 +110,104 @@ describe('useLogsSearchQueryBuilderProps', () => {
     expect(result.current.tracesItemSearchQueryBuilderProps.invalidFilterKeys).toEqual([
       'missing.key',
     ]);
+  });
+
+  it('threads array attributes and aliases through to the builder props', () => {
+    const {result} = renderHookWithProviders(
+      () =>
+        useLogsSearchQueryBuilderProps({
+          arrayAttributes: {
+            'tags[error.messages,array]': {
+              key: 'tags[error.messages,array]',
+              name: 'error.messages',
+              kind: FieldKind.ARRAY,
+            },
+          },
+          arraySecondaryAliases: {
+            'error.messages': {
+              key: 'error.messages',
+              name: 'error.messages',
+              kind: FieldKind.ARRAY,
+            },
+          },
+          booleanAttributes: {},
+          booleanSecondaryAliases: {},
+          numberAttributes: {},
+          numberSecondaryAliases: {},
+          stringAttributes: {},
+          stringSecondaryAliases: {},
+        }),
+      {additionalWrapper: Wrapper, organization: arrayFeatures}
+    );
+
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.[
+        'tags[error.messages,array]'
+      ]
+    ).toEqual(
+      expect.objectContaining({
+        kind: FieldKind.ARRAY,
+        key: 'tags[error.messages,array]',
+      })
+    );
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.arraySecondaryAliases?.[
+        'error.messages'
+      ]
+    ).toEqual(expect.objectContaining({kind: FieldKind.ARRAY}));
+  });
+
+  it('merges validated array fields when the array flag is enabled', () => {
+    const {result} = renderHookWithProviders(
+      () =>
+        useLogsSearchQueryBuilderProps({
+          booleanAttributes: {},
+          booleanSecondaryAliases: {},
+          numberAttributes: {},
+          numberSecondaryAliases: {},
+          stringAttributes: {},
+          stringSecondaryAliases: {},
+          validatedSearchQueryData: validationBody,
+        }),
+      {additionalWrapper: Wrapper, organization: arrayFeatures}
+    );
+
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.[
+        'error.messages'
+      ]
+    ).toEqual(
+      expect.objectContaining({
+        kind: FieldKind.ARRAY,
+        key: 'error.messages',
+      })
+    );
+  });
+
+  it('does not merge validated array fields when the array flag is disabled', () => {
+    const {result} = renderHookWithProviders(
+      () =>
+        useLogsSearchQueryBuilderProps({
+          booleanAttributes: {},
+          booleanSecondaryAliases: {},
+          numberAttributes: {},
+          numberSecondaryAliases: {},
+          stringAttributes: {},
+          stringSecondaryAliases: {},
+          validatedSearchQueryData: validationBody,
+        }),
+      {additionalWrapper: Wrapper}
+    );
+
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.arrayAttributes?.[
+        'error.messages'
+      ]
+    ).toBeUndefined();
+    // The valid array field is neither merged nor flagged invalid when the
+    // feature is off; it simply isn't recognized as an array attribute.
+    expect(
+      result.current.tracesItemSearchQueryBuilderProps.invalidFilterKeys
+    ).toEqual(['missing.key']);
   });
 });

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.spec.tsx
@@ -204,8 +204,6 @@ describe('useLogsSearchQueryBuilderProps', () => {
         'error.messages'
       ]
     ).toBeUndefined();
-    // The valid array field is neither merged nor flagged invalid when the
-    // feature is off; it simply isn't recognized as an array attribute.
     expect(
       result.current.tracesItemSearchQueryBuilderProps.invalidFilterKeys
     ).toEqual(['missing.key']);

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -45,9 +45,7 @@ export function useLogsSearchQueryBuilderProps({
   validatedSearchQueryData?: EventValidationData;
 }) {
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const logsSearch = useQueryParamsSearch();
   const oldLogsSearch = usePrevious(logsSearch);
   const fields = useQueryParamsFields();

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -62,9 +62,6 @@ export function useLogsSearchQueryBuilderProps({
     invalidFilterKeys,
   } = useMemo(() => {
     const localInvalidFilterKeys: string[] = [];
-    // Only expose array attributes when the feature is enabled, so nothing
-    // leaks through even if the caller's fetch or the validate endpoint returns
-    // array-typed data while the flag is off.
     const localArrayAttributes = supportsArrays ? {...arrayAttributes} : {};
     const localBooleanAttributes = {...booleanAttributes};
     const localNumberAttributes = {...numberAttributes};

--- a/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
+++ b/static/app/views/explore/logs/useLogsSearchQueryBuilderProps.tsx
@@ -4,6 +4,7 @@ import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {
@@ -22,6 +23,8 @@ import type {EventValidationData} from 'sentry/views/explore/utils/validateEvent
 
 export function useLogsSearchQueryBuilderProps({
   attributeQuery,
+  arrayAttributes = {},
+  arraySecondaryAliases = {},
   booleanAttributes,
   booleanSecondaryAliases,
   numberAttributes,
@@ -36,9 +39,15 @@ export function useLogsSearchQueryBuilderProps({
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
+  arrayAttributes?: TagCollection;
+  arraySecondaryAliases?: TagCollection;
   attributeQuery?: string;
   validatedSearchQueryData?: EventValidationData;
 }) {
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   const logsSearch = useQueryParamsSearch();
   const oldLogsSearch = usePrevious(logsSearch);
   const fields = useQueryParamsFields();
@@ -46,12 +55,17 @@ export function useLogsSearchQueryBuilderProps({
   const [caseInsensitive, setCaseInsensitive] = useCaseInsensitivity();
 
   const {
+    validatedArrayAttributes,
     validatedBooleanAttributes,
     validatedNumberAttributes,
     validatedStringAttributes,
     invalidFilterKeys,
   } = useMemo(() => {
     const localInvalidFilterKeys: string[] = [];
+    // Only expose array attributes when the feature is enabled, so nothing
+    // leaks through even if the caller's fetch or the validate endpoint returns
+    // array-typed data while the flag is off.
+    const localArrayAttributes = supportsArrays ? {...arrayAttributes} : {};
     const localBooleanAttributes = {...booleanAttributes};
     const localNumberAttributes = {...numberAttributes};
     const localStringAttributes = {...stringAttributes};
@@ -83,6 +97,14 @@ export function useLogsSearchQueryBuilderProps({
             };
           }
 
+          if (supportsArrays && item.attrType === 'array' && item.name) {
+            localArrayAttributes[item.name] ??= {
+              key: item.name,
+              name: prettifyAttributeName(item.name),
+              kind: FieldKind.ARRAY,
+            };
+          }
+
           continue;
         }
 
@@ -93,15 +115,18 @@ export function useLogsSearchQueryBuilderProps({
     }
 
     return {
+      validatedArrayAttributes: localArrayAttributes,
       validatedBooleanAttributes: localBooleanAttributes,
       validatedNumberAttributes: localNumberAttributes,
       validatedStringAttributes: localStringAttributes,
       invalidFilterKeys: localInvalidFilterKeys,
     };
   }, [
+    arrayAttributes,
     booleanAttributes,
     numberAttributes,
     stringAttributes,
+    supportsArrays,
     validatedSearchQueryData?.query.fields,
   ]);
 
@@ -138,10 +163,12 @@ export function useLogsSearchQueryBuilderProps({
       initialQuery,
       searchSource: 'ourlogs',
       onSearch,
+      arrayAttributes: validatedArrayAttributes,
       booleanAttributes: validatedBooleanAttributes,
       numberAttributes: validatedNumberAttributes,
       stringAttributes: validatedStringAttributes,
       itemType: TraceItemDataset.LOGS,
+      arraySecondaryAliases,
       booleanSecondaryAliases,
       numberSecondaryAliases,
       stringSecondaryAliases,
@@ -154,6 +181,7 @@ export function useLogsSearchQueryBuilderProps({
       invalidFilterKeys,
     }),
     [
+      arraySecondaryAliases,
       attributeQuery,
       booleanSecondaryAliases,
       caseInsensitive,
@@ -163,6 +191,7 @@ export function useLogsSearchQueryBuilderProps({
       setCaseInsensitive,
       stringSecondaryAliases,
       invalidFilterKeys,
+      validatedArrayAttributes,
       validatedBooleanAttributes,
       validatedNumberAttributes,
       validatedStringAttributes,

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -85,9 +85,7 @@ export function Filter({
   const hasMetricsAISearch = organization.features.includes(
     'gen-ai-explore-metrics-search'
   );
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
   const attributeQuery = skipTraceMetricFilter ? undefined : traceMetricFilter;
@@ -321,7 +319,6 @@ export function Filter({
       key={traceMetric.name}
       {...searchQueryBuilderProviderProps}
       enableAISearch={hasTranslateEndpoint && hasMetricsAISearch}
-      aiSearchBadgeType="alpha"
     >
       <MetricsSearchBar
         tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -180,9 +180,6 @@ export function Filter({
     };
   }, [data?.booleanAttributes]);
 
-  // Array attributes are only ever custom (no static Sentry array tags), so this
-  // is just the fetched array attributes minus the hidden ones. Gated on the
-  // feature flag so arrays never surface while the flag is off.
   const visibleArrayTags = useMemo(() => {
     if (!supportsArrays) {
       return {};

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -85,6 +85,9 @@ export function Filter({
   const hasMetricsAISearch = organization.features.includes(
     'gen-ai-explore-metrics-search'
   );
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
   const attributeQuery = skipTraceMetricFilter ? undefined : traceMetricFilter;
@@ -177,12 +180,28 @@ export function Filter({
     };
   }, [data?.booleanAttributes]);
 
+  // Array attributes are only ever custom (no static Sentry array tags), so this
+  // is just the fetched array attributes minus the hidden ones. Gated on the
+  // feature flag so arrays never surface while the flag is off.
+  const visibleArrayTags = useMemo(() => {
+    if (!supportsArrays) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(data?.arrayAttributes ?? {}).filter(
+        ([key]) => !HiddenTraceMetricSearchFields.includes(key)
+      )
+    );
+  }, [data?.arrayAttributes, supportsArrays]);
+
   const {
+    validatedArrayTags,
     validatedNumberTags,
     validatedStringTags,
     validatedBooleanTags,
     invalidFilterKeys,
   } = useMemo(() => {
+    const localArrayTags: TagCollection = {...visibleArrayTags};
     const localBooleanTags: TagCollection = {...visibleBooleanTags};
     const localNumberTags: TagCollection = {...visibleNumberTags};
     const localStringTags: TagCollection = {...visibleStringTags};
@@ -218,6 +237,14 @@ export function Filter({
           };
         }
 
+        if (supportsArrays && item.attrType === 'array') {
+          localArrayTags[item.name] ??= {
+            key: item.name,
+            name: prettifyAttributeName(item.name),
+            kind: FieldKind.ARRAY,
+          };
+        }
+
         continue;
       }
 
@@ -225,13 +252,16 @@ export function Filter({
     }
 
     return {
+      validatedArrayTags: localArrayTags,
       validatedNumberTags: localNumberTags,
       validatedStringTags: localStringTags,
       validatedBooleanTags: localBooleanTags,
       invalidFilterKeys: localInvalidFilterKeys,
     };
   }, [
+    supportsArrays,
     validatedSearchQueryData?.query.fields,
+    visibleArrayTags,
     visibleBooleanTags,
     visibleNumberTags,
     visibleStringTags,
@@ -241,9 +271,11 @@ export function Filter({
     useMemo(() => {
       return {
         itemType: TraceItemDataset.TRACEMETRICS,
+        arrayAttributes: validatedArrayTags,
         booleanAttributes: validatedBooleanTags,
         numberAttributes: validatedNumberTags,
         stringAttributes: validatedStringTags,
+        arraySecondaryAliases: EMPTY_ALIASES,
         booleanSecondaryAliases: EMPTY_ALIASES,
         numberSecondaryAliases: EMPTY_ALIASES,
         stringSecondaryAliases: EMPTY_ALIASES,
@@ -275,6 +307,7 @@ export function Filter({
       setQuery,
       skipTraceMetricFilter,
       traceMetric.name,
+      validatedArrayTags,
       validatedBooleanTags,
       validatedNumberTags,
       validatedStringTags,

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -23,11 +23,13 @@ jest.mock('sentry/views/explore/components/traceItemSearchQueryBuilder', () => {
   return {
     ...actual,
     TraceItemSearchQueryBuilder: (props: {
+      arrayAttributes?: Record<string, unknown>;
       disabled?: boolean;
       invalidFilterKeys?: string[];
       numberAttributes?: Record<string, unknown>;
     }) => (
       <div
+        data-array-attributes={Object.keys(props.arrayAttributes ?? {}).join(',')}
         data-disabled={String(props.disabled ?? false)}
         data-invalid-filter-keys={props.invalidFilterKeys?.join(',') ?? ''}
         data-number-attributes={Object.keys(props.numberAttributes ?? {}).join(',')}
@@ -672,6 +674,68 @@ describe('Filter', () => {
     expect(screen.getByTestId('metrics-filter-search')).toHaveAttribute(
       'data-invalid-filter-keys',
       'missing.key'
+    );
+  });
+
+  it('surfaces array attributes when the array flag is enabled', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          key: 'tags[error.messages,array]',
+          name: 'error.messages',
+          attributeType: 'array',
+        },
+      ],
+    });
+
+    render(<Filter traceMetric={{name: 'test_metric', type: 'distribution'}} />, {
+      organization: OrganizationFixture({
+        features: ['tracemetrics-enabled', 'trace-item-array-query-support'],
+      }),
+      additionalWrapper: ({children}: {children: ReactNode}) => (
+        <Wrapper queryParams={queryParams}>{children}</Wrapper>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-filter-search')).toHaveAttribute(
+        'data-array-attributes',
+        expect.stringContaining('tags[error.messages,array]')
+      );
+    });
+  });
+
+  it('omits array attributes when the array flag is disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          key: 'tags[error.messages,array]',
+          name: 'error.messages',
+          attributeType: 'array',
+        },
+      ],
+    });
+
+    render(<Filter traceMetric={{name: 'test_metric', type: 'distribution'}} />, {
+      organization: OrganizationFixture({
+        features: ['tracemetrics-enabled'],
+      }),
+      additionalWrapper: ({children}: {children: ReactNode}) => (
+        <Wrapper queryParams={queryParams}>{children}</Wrapper>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-filter-search')).toHaveAttribute(
+        'data-disabled',
+        'false'
+      );
+    });
+    expect(screen.getByTestId('metrics-filter-search')).toHaveAttribute(
+      'data-array-attributes',
+      ''
     );
   });
 });

--- a/static/app/views/explore/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/index.tsx
@@ -11,6 +11,7 @@ import {defined} from 'sentry/utils/defined';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
 import {useCurrentHoverTime} from 'sentry/utils/replays/playback/providers/useCurrentHoverTime';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {
   LogsPageDataProvider,
@@ -77,6 +78,8 @@ interface OurLogsContentProps {
 }
 
 function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const replayAttributeFilter = MutableSearch.fromQueryObject({
     [`sentry._internal.cooccuring.replay_id.${replayId}`]: ['true'],
   }).formatString();
@@ -87,7 +90,10 @@ function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({query: replayAttributeFilter}, 'boolean');
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useLogItemAttributes({query: replayAttributeFilter}, 'array');
+    useLogItemAttributes(
+      {query: replayAttributeFilter, enabled: supportsArrays},
+      'array'
+    );
 
   const {currentTime, setCurrentTime} = useReplayContext();
   const [currentHoverTime] = useCurrentHoverTime();

--- a/static/app/views/explore/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/index.tsx
@@ -86,6 +86,8 @@ function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
     useLogItemAttributes({query: replayAttributeFilter}, 'number');
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({query: replayAttributeFilter}, 'boolean');
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useLogItemAttributes({query: replayAttributeFilter}, 'array');
 
   const {currentTime, setCurrentTime} = useReplayContext();
   const [currentHoverTime] = useCurrentHoverTime();
@@ -118,9 +120,11 @@ function OurLogsContent({replayId, startTimestampMs}: OurLogsContentProps) {
   const {tracesItemSearchQueryBuilderProps, searchQueryBuilderProviderProps} =
     useLogsSearchQueryBuilderProps({
       attributeQuery: replayAttributeFilter,
+      arrayAttributes,
       stringAttributes,
       numberAttributes,
       booleanAttributes,
+      arraySecondaryAliases,
       stringSecondaryAliases,
       numberSecondaryAliases,
       booleanSecondaryAliases,

--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -7,6 +7,7 @@ import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   type AggregationKey,
 } from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -40,6 +41,10 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
     const mode = useQueryParamsMode();
     const crossEvents = useQueryParamsCrossEvents();
     const setCrossEvents = useSetQueryParamsCrossEvents();
+    const organization = useOrganization();
+    const supportsArrays = organization.features.includes(
+      'trace-item-array-query-support'
+    );
 
     const metricFilter = useMemo(() => createTraceMetricFilter(metric), [metric]);
     const attributeOptions = useMemo(
@@ -121,7 +126,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
             : undefined,
         supportedAggregates:
           mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
-        arrayAttributes,
+        arrayAttributes: supportsArrays ? arrayAttributes : {},
         booleanAttributes,
         numberAttributes,
         stringAttributes,
@@ -129,7 +134,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
           {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
           {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
         ],
-        arraySecondaryAliases,
+        arraySecondaryAliases: supportsArrays ? arraySecondaryAliases : {},
         booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
@@ -156,6 +161,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
         setCrossEvents,
         stringAttributes,
         stringSecondaryAliases,
+        supportsArrays,
       ]
     );
 

--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -65,6 +65,12 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
         'boolean',
         HiddenTraceMetricSearchFields
       );
+    const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+      useTraceMetricItemAttributes(
+        attributeOptions,
+        'array',
+        HiddenTraceMetricSearchFields
+      );
 
     const onMetricChange = useCallback(
       (newMetric: TraceMetric) => {
@@ -115,6 +121,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
             : undefined,
         supportedAggregates:
           mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+        arrayAttributes,
         booleanAttributes,
         numberAttributes,
         stringAttributes,
@@ -122,6 +129,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
           {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
           {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
         ],
+        arraySecondaryAliases,
         booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
@@ -132,6 +140,8 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
         hiddenAttributeKeys: HiddenTraceMetricSearchFields,
       }),
       [
+        arrayAttributes,
+        arraySecondaryAliases,
         booleanAttributes,
         booleanSecondaryAliases,
         crossEvents,

--- a/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventMetricsSearchBar.tsx
@@ -72,7 +72,7 @@ export const SpansTabCrossEventMetricsSearchBar = memo(
       );
     const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
       useTraceMetricItemAttributes(
-        attributeOptions,
+        {...attributeOptions, enabled: supportsArrays},
         'array',
         HiddenTraceMetricSearchFields
       );

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
@@ -5,6 +5,7 @@ import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   type AggregationKey,
 } from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -34,6 +35,10 @@ export const SpansTabCrossEventSearchBar = memo(
     const mode = useQueryParamsMode();
     const crossEvents = useQueryParamsCrossEvents();
     const setCrossEvents = useSetQueryParamsCrossEvents();
+    const organization = useOrganization();
+    const supportsArrays = organization.features.includes(
+      'trace-item-array-query-support'
+    );
 
     const traceItemType =
       type === 'logs' ? TraceItemDataset.LOGS : TraceItemDataset.SPANS;
@@ -78,7 +83,7 @@ export const SpansTabCrossEventSearchBar = memo(
             : undefined,
         supportedAggregates:
           mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
-        arrayAttributes,
+        arrayAttributes: supportsArrays ? arrayAttributes : {},
         booleanAttributes,
         numberAttributes,
         stringAttributes,
@@ -86,7 +91,7 @@ export const SpansTabCrossEventSearchBar = memo(
           {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
           {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
         ],
-        arraySecondaryAliases,
+        arraySecondaryAliases: supportsArrays ? arraySecondaryAliases : {},
         booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
@@ -106,6 +111,7 @@ export const SpansTabCrossEventSearchBar = memo(
         setCrossEvents,
         stringSecondaryAliases,
         stringAttributes,
+        supportsArrays,
         type,
       ]
     );

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
@@ -44,6 +44,8 @@ export const SpansTabCrossEventSearchBar = memo(
       useTraceItemDatasetAttributes(traceItemType, {}, 'string');
     const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
       useTraceItemDatasetAttributes(traceItemType, {}, 'boolean');
+    const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+      useTraceItemDatasetAttributes(traceItemType, {}, 'array');
 
     const eapSpanSearchQueryBuilderProps = useMemo(
       () => ({
@@ -76,6 +78,7 @@ export const SpansTabCrossEventSearchBar = memo(
             : undefined,
         supportedAggregates:
           mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+        arrayAttributes,
         booleanAttributes,
         numberAttributes,
         stringAttributes,
@@ -83,12 +86,15 @@ export const SpansTabCrossEventSearchBar = memo(
           {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
           {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},
         ],
+        arraySecondaryAliases,
         booleanSecondaryAliases,
         numberSecondaryAliases,
         stringSecondaryAliases,
         replaceRawSearchKeys: type === 'logs' ? ['message'] : ['span.description'],
       }),
       [
+        arrayAttributes,
+        arraySecondaryAliases,
         booleanAttributes,
         booleanSecondaryAliases,
         crossEvents,

--- a/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
+++ b/static/app/views/explore/spans/crossEvents/crossEventSearchBar.tsx
@@ -50,7 +50,7 @@ export const SpansTabCrossEventSearchBar = memo(
     const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
       useTraceItemDatasetAttributes(traceItemType, {}, 'boolean');
     const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-      useTraceItemDatasetAttributes(traceItemType, {}, 'array');
+      useTraceItemDatasetAttributes(traceItemType, {enabled: supportsArrays}, 'array');
 
     const eapSpanSearchQueryBuilderProps = useMemo(
       () => ({

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -78,6 +78,7 @@ function LogsSectionContent({
   fallbackTimestampSeconds,
 }: Required<TraceViewLogsSectionProps>) {
   const organization = useOrganization();
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   const {selection} = usePageFilters();
   const traceIds = useLogsFrozenTraceIds();
 
@@ -93,7 +94,7 @@ function LogsSectionContent({
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
   const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
-    useLogItemAttributes({}, 'array', HiddenLogSearchFields);
+    useLogItemAttributes({enabled: supportsArrays}, 'array', HiddenLogSearchFields);
 
   const {tracesItemSearchQueryBuilderProps} = useLogsSearchQueryBuilderProps({
     arrayAttributes,

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -92,11 +92,15 @@ function LogsSectionContent({
     useLogItemAttributes({}, 'number', HiddenLogSearchFields);
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
     useLogItemAttributes({}, 'boolean', HiddenLogSearchFields);
+  const {attributes: arrayAttributes, secondaryAliases: arraySecondaryAliases} =
+    useLogItemAttributes({}, 'array', HiddenLogSearchFields);
 
   const {tracesItemSearchQueryBuilderProps} = useLogsSearchQueryBuilderProps({
+    arrayAttributes,
     booleanAttributes,
     numberAttributes,
     stringAttributes,
+    arraySecondaryAliases,
     booleanSecondaryAliases,
     numberSecondaryAliases,
     stringSecondaryAliases,


### PR DESCRIPTION
Array attribute support currently only surfaces in the **spans** search experience. This threads it into **every logs and trace-metrics filter surface** so array attributes appear in autocomplete, filter with the `[*]` membership operator, and work under `has:` — matching spans.

The shared plumbing (`useTraceItemAttributes`, `useGetTraceItemAttributeKeys`, `useTraceItemSearchQueryBuilderProps`, the array type badge) is already generic; these surfaces just never fetched/threaded the `array` collection.

