### PR TITLE
feat(explore): Support array attributes in preprod search

### DIFF
--- a/static/app/components/preprod/preprodSearchBar.spec.tsx
+++ b/static/app/components/preprod/preprodSearchBar.spec.tsx
@@ -56,10 +56,18 @@ describe('PreprodSearchBar', () => {
     });
   });
 
-  it('surfaces no array attributes when none are returned', async () => {
+  it('gates out array attributes when the flag is disabled', async () => {
+    // Even if array attributes come back, the local flag guard drops them.
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
-      body: [{key: 'app.name', name: 'app.name', attributeType: 'string'}],
+      body: [
+        {key: 'app.name', name: 'app.name', attributeType: 'string'},
+        {
+          key: 'tags[app.features,array]',
+          name: 'app.features',
+          attributeType: 'array',
+        },
+      ],
     });
 
     render(<PreprodSearchBar initialQuery="" projects={[1]} />, {

--- a/static/app/components/preprod/preprodSearchBar.spec.tsx
+++ b/static/app/components/preprod/preprodSearchBar.spec.tsx
@@ -1,0 +1,84 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
+
+// Expose the attribute collections the builder receives so we can assert the
+// array attributes are threaded through.
+jest.mock('sentry/views/explore/components/traceItemSearchQueryBuilder', () => {
+  const actual = jest.requireActual(
+    'sentry/views/explore/components/traceItemSearchQueryBuilder'
+  );
+
+  return {
+    ...actual,
+    TraceItemSearchQueryBuilder: (props: {
+      arrayAttributes?: Record<string, unknown>;
+      stringAttributes?: Record<string, unknown>;
+    }) => (
+      <div
+        data-array-attributes={Object.keys(props.arrayAttributes ?? {}).join(',')}
+        data-string-attributes={Object.keys(props.stringAttributes ?? {}).join(',')}
+        data-test-id="preprod-search"
+      />
+    ),
+  };
+});
+
+describe('PreprodSearchBar', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('threads array attributes through to the search builder', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {key: 'app.name', name: 'app.name', attributeType: 'string'},
+        {
+          key: 'tags[app.features,array]',
+          name: 'app.features',
+          attributeType: 'array',
+        },
+      ],
+    });
+
+    render(<PreprodSearchBar initialQuery="" projects={[1]} />, {
+      organization: OrganizationFixture({
+        features: ['trace-item-array-query-support'],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preprod-search')).toHaveAttribute(
+        'data-array-attributes',
+        expect.stringContaining('tags[app.features,array]')
+      );
+    });
+  });
+
+  it('surfaces no array attributes when none are returned', async () => {
+    // With the flag off, the shared fetch drops the array type and the backend
+    // returns no array attributes.
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [{key: 'app.name', name: 'app.name', attributeType: 'string'}],
+    });
+
+    render(<PreprodSearchBar initialQuery="" projects={[1]} />, {
+      organization: OrganizationFixture(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preprod-search')).toHaveAttribute(
+        'data-string-attributes',
+        expect.stringContaining('app.name')
+      );
+    });
+    expect(screen.getByTestId('preprod-search')).toHaveAttribute(
+      'data-array-attributes',
+      ''
+    );
+  });
+});

--- a/static/app/components/preprod/preprodSearchBar.spec.tsx
+++ b/static/app/components/preprod/preprodSearchBar.spec.tsx
@@ -85,4 +85,38 @@ describe('PreprodSearchBar', () => {
       ''
     );
   });
+
+  it('keeps array attributes whose unwrapped name is in the allowlist', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {key: 'app_name', name: 'app_name', attributeType: 'string'},
+        {
+          key: 'tags[install_groups,array]',
+          name: 'install_groups',
+          attributeType: 'array',
+        },
+      ],
+    });
+
+    render(
+      <PreprodSearchBar
+        initialQuery=""
+        projects={[1]}
+        allowedKeys={['app_name', 'install_groups']}
+      />,
+      {
+        organization: OrganizationFixture({
+          features: ['trace-item-array-query-support'],
+        }),
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preprod-search')).toHaveAttribute(
+        'data-array-attributes',
+        expect.stringContaining('tags[install_groups,array]')
+      );
+    });
+  });
 });

--- a/static/app/components/preprod/preprodSearchBar.spec.tsx
+++ b/static/app/components/preprod/preprodSearchBar.spec.tsx
@@ -12,11 +12,15 @@ jest.mock('sentry/views/explore/components/traceItemSearchQueryBuilder', () => {
   return {
     ...actual,
     TraceItemSearchQueryBuilder: (props: {
-      arrayAttributes?: Record<string, unknown>;
+      arrayAttributes?: Record<string, {predefined?: boolean}>;
       stringAttributes?: Record<string, unknown>;
     }) => (
       <div
         data-array-attributes={Object.keys(props.arrayAttributes ?? {}).join(',')}
+        data-array-predefined={Object.entries(props.arrayAttributes ?? {})
+          .filter(([, tag]) => tag?.predefined)
+          .map(([key]) => key)
+          .join(',')}
         data-string-attributes={Object.keys(props.stringAttributes ?? {}).join(',')}
         data-test-id="preprod-search"
       />
@@ -115,6 +119,40 @@ describe('PreprodSearchBar', () => {
     await waitFor(() => {
       expect(screen.getByTestId('preprod-search')).toHaveAttribute(
         'data-array-attributes',
+        expect.stringContaining('tags[install_groups,array]')
+      );
+    });
+  });
+
+  it('marks a freeform array attribute as predefined', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {
+          key: 'tags[install_groups,array]',
+          name: 'install_groups',
+          attributeType: 'array',
+        },
+      ],
+    });
+
+    render(
+      <PreprodSearchBar
+        initialQuery=""
+        projects={[1]}
+        allowedKeys={['install_groups']}
+        freeformKeys={['install_groups']}
+      />,
+      {
+        organization: OrganizationFixture({
+          features: ['trace-item-array-query-support'],
+        }),
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preprod-search')).toHaveAttribute(
+        'data-array-predefined',
         expect.stringContaining('tags[install_groups,array]')
       );
     });

--- a/static/app/components/preprod/preprodSearchBar.spec.tsx
+++ b/static/app/components/preprod/preprodSearchBar.spec.tsx
@@ -4,8 +4,6 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 
-// Expose the attribute collections the builder receives so we can assert the
-// array attributes are threaded through.
 jest.mock('sentry/views/explore/components/traceItemSearchQueryBuilder', () => {
   const actual = jest.requireActual(
     'sentry/views/explore/components/traceItemSearchQueryBuilder'
@@ -59,8 +57,6 @@ describe('PreprodSearchBar', () => {
   });
 
   it('surfaces no array attributes when none are returned', async () => {
-    // With the flag off, the shared fetch drops the array type and the backend
-    // returns no array attributes.
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [{key: 'app.name', name: 'app.name', attributeType: 'string'}],

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -153,10 +153,6 @@ export function PreprodSearchBar({
     [allowedKeys, rawBooleanSecondaryAliases]
   );
 
-  // Array attributes filter by membership (`[*]`), so they don't participate in
-  // the freeform-value handling; only the allowlist filter applies. The fetch is
-  // already gated on organizations:trace-item-array-query-support, so these are
-  // empty when the flag is off.
   const arrayAttributes = useMemo(
     () =>
       allowedKeys

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {usePreprodItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
@@ -89,6 +90,10 @@ export function PreprodSearchBar({
   disallowLogicalOperators,
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
+  const organization = useOrganization();
+  const supportsArrays = organization.features.includes(
+    'trace-item-array-query-support'
+  );
   // When using allowedKeys, we fetch all attributes then filter to the allowlist.
   // Otherwise, we use HIDDEN_PREPROD_ATTRIBUTES to hide internal fields.
   const hiddenKeys = allowedKeys ? undefined : HIDDEN_PREPROD_ATTRIBUTES;
@@ -153,21 +158,23 @@ export function PreprodSearchBar({
     [allowedKeys, rawBooleanSecondaryAliases]
   );
 
-  const arrayAttributes = useMemo(
-    () =>
-      allowedKeys
-        ? filterToAllowedKeys(rawArrayAttributes, allowedKeys)
-        : rawArrayAttributes,
-    [allowedKeys, rawArrayAttributes]
-  );
+  const arrayAttributes = useMemo(() => {
+    if (!supportsArrays) {
+      return {};
+    }
+    return allowedKeys
+      ? filterToAllowedKeys(rawArrayAttributes, allowedKeys)
+      : rawArrayAttributes;
+  }, [allowedKeys, rawArrayAttributes, supportsArrays]);
 
-  const arraySecondaryAliases = useMemo(
-    () =>
-      allowedKeys
-        ? filterToAllowedKeys(rawArraySecondaryAliases, allowedKeys)
-        : rawArraySecondaryAliases,
-    [allowedKeys, rawArraySecondaryAliases]
-  );
+  const arraySecondaryAliases = useMemo(() => {
+    if (!supportsArrays) {
+      return {};
+    }
+    return allowedKeys
+      ? filterToAllowedKeys(rawArraySecondaryAliases, allowedKeys)
+      : rawArraySecondaryAliases;
+  }, [allowedKeys, rawArraySecondaryAliases, supportsArrays]);
 
   return (
     <TraceItemSearchQueryBuilder

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -113,7 +113,7 @@ export function PreprodSearchBar({
   const {attributes: rawBooleanAttributes, secondaryAliases: rawBooleanSecondaryAliases} =
     usePreprodItemAttributes({}, 'boolean', hiddenKeys);
   const {attributes: rawArrayAttributes, secondaryAliases: rawArraySecondaryAliases} =
-    usePreprodItemAttributes({}, 'array', hiddenKeys);
+    usePreprodItemAttributes({enabled: supportsArrays}, 'array', hiddenKeys);
 
   const stringAttributes = useMemo(
     () =>

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
@@ -47,8 +48,17 @@ function filterToAllowedKeys(
   const allowedSet = new Set(allowedKeys);
   const result: TagCollection = {};
   for (const key in attributes) {
-    if (allowedSet.has(key) && attributes[key]) {
-      result[key] = attributes[key];
+    const tag = attributes[key];
+    if (!tag) {
+      continue;
+    }
+    // Array attributes are keyed by their wrapped backend form
+    // (`tags[name,array]`), so match them on the unwrapped `name` the allowlist
+    // uses instead of the key.
+    const matches =
+      allowedSet.has(key) || (tag.kind === FieldKind.ARRAY && allowedSet.has(tag.name));
+    if (matches) {
+      result[key] = tag;
     }
   }
   return result;

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -91,9 +91,7 @@ export function PreprodSearchBar({
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
   const organization = useOrganization();
-  const supportsArrays = organization.features.includes(
-    'trace-item-array-query-support'
-  );
+  const supportsArrays = organization.features.includes('trace-item-array-query-support');
   // When using allowedKeys, we fetch all attributes then filter to the allowlist.
   // Otherwise, we use HIDDEN_PREPROD_ATTRIBUTES to hide internal fields.
   const hiddenKeys = allowedKeys ? undefined : HIDDEN_PREPROD_ATTRIBUTES;

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
@@ -41,6 +41,12 @@ interface PreprodSearchBarProps {
   searchSource?: string;
 }
 
+// Array attributes are keyed by their wrapped backend form (`tags[name,array]`),
+// so also match the unwrapped `name` that the allowlist / freeform lists use.
+function matchesKeyOrArrayName(tag: Tag, key: string, names: Set<string>): boolean {
+  return names.has(key) || (tag.kind === FieldKind.ARRAY && names.has(tag.name));
+}
+
 function filterToAllowedKeys(
   attributes: TagCollection,
   allowedKeys: string[]
@@ -49,15 +55,7 @@ function filterToAllowedKeys(
   const result: TagCollection = {};
   for (const key in attributes) {
     const tag = attributes[key];
-    if (!tag) {
-      continue;
-    }
-    // Array attributes are keyed by their wrapped backend form
-    // (`tags[name,array]`), so match them on the unwrapped `name` the allowlist
-    // uses instead of the key.
-    const matches =
-      allowedSet.has(key) || (tag.kind === FieldKind.ARRAY && allowedSet.has(tag.name));
-    if (matches) {
+    if (tag && matchesKeyOrArrayName(tag, key, allowedSet)) {
       result[key] = tag;
     }
   }
@@ -75,7 +73,9 @@ function markFreeformKeys(
     if (!tag) {
       continue;
     }
-    result[key] = freeformKeySet.has(key) ? {...tag, predefined: true} : tag;
+    result[key] = matchesKeyOrArrayName(tag, key, freeformKeySet)
+      ? {...tag, predefined: true}
+      : tag;
   }
   return result;
 }
@@ -170,10 +170,13 @@ export function PreprodSearchBar({
     if (!supportsArrays) {
       return {};
     }
-    return allowedKeys
-      ? filterToAllowedKeys(rawArrayAttributes, allowedKeys)
-      : rawArrayAttributes;
-  }, [allowedKeys, rawArrayAttributes, supportsArrays]);
+    return markFreeformKeys(
+      allowedKeys
+        ? filterToAllowedKeys(rawArrayAttributes, allowedKeys)
+        : rawArrayAttributes,
+      freeformKeys
+    );
+  }, [allowedKeys, freeformKeys, rawArrayAttributes, supportsArrays]);
 
   const arraySecondaryAliases = useMemo(() => {
     if (!supportsArrays) {

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -99,6 +99,8 @@ export function PreprodSearchBar({
     usePreprodItemAttributes({}, 'number', hiddenKeys);
   const {attributes: rawBooleanAttributes, secondaryAliases: rawBooleanSecondaryAliases} =
     usePreprodItemAttributes({}, 'boolean', hiddenKeys);
+  const {attributes: rawArrayAttributes, secondaryAliases: rawArraySecondaryAliases} =
+    usePreprodItemAttributes({}, 'array', hiddenKeys);
 
   const stringAttributes = useMemo(
     () =>
@@ -151,6 +153,26 @@ export function PreprodSearchBar({
     [allowedKeys, rawBooleanSecondaryAliases]
   );
 
+  // Array attributes filter by membership (`[*]`), so they don't participate in
+  // the freeform-value handling; only the allowlist filter applies. The fetch is
+  // already gated on organizations:trace-item-array-query-support, so these are
+  // empty when the flag is off.
+  const arrayAttributes = useMemo(
+    () =>
+      allowedKeys
+        ? filterToAllowedKeys(rawArrayAttributes, allowedKeys)
+        : rawArrayAttributes,
+    [allowedKeys, rawArrayAttributes]
+  );
+
+  const arraySecondaryAliases = useMemo(
+    () =>
+      allowedKeys
+        ? filterToAllowedKeys(rawArraySecondaryAliases, allowedKeys)
+        : rawArraySecondaryAliases,
+    [allowedKeys, rawArraySecondaryAliases]
+  );
+
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={initialQuery}
@@ -159,8 +181,10 @@ export function PreprodSearchBar({
       itemType={TraceItemDataset.PREPROD}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
+      arrayAttributes={arrayAttributes}
       numberSecondaryAliases={numberSecondaryAliases}
       stringSecondaryAliases={stringSecondaryAliases}
+      arraySecondaryAliases={arraySecondaryAliases}
       booleanAttributes={booleanAttributes}
       booleanSecondaryAliases={booleanSecondaryAliases}
       searchSource={searchSource}


### PR DESCRIPTION
Array attribute support currently only surfaces in the **spans** search experience. This threads it into the **preprod** (mobile build) search surface so array attributes appear in autocomplete, filter with the `[*]` membership operator, and work under `has:` — matching spans.

