### PR TITLE
feat(seer): Add failing check run URLs to autofix overview API

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -1239,7 +1239,7 @@ class GitHubBaseClient(
         if pull_request.include_files:
             cache_key_data["include_files"] = True
         cache_data = orjson.dumps(cache_key_data).decode()
-        return self.get_cache_key("/graphql/pull-request-status", "", cache_data)
+        return self.get_cache_key("/graphql/pull-request-status/v2", "", cache_data)
 
     def get_pull_request_statuses(
         self, pull_requests: Sequence[PullRequestStatusRequest]

--- a/src/sentry/integrations/github/pull_request_status.py
+++ b/src/sentry/integrations/github/pull_request_status.py
@@ -10,6 +10,7 @@ from sentry.integrations.source_code_management.status_check import (
     PullRequestFileSummary,
     PullRequestStatusRequest,
     PullRequestStatusResult,
+    http_url_or_none,
 )
 from sentry.utils.safe import get_path
 
@@ -188,8 +189,7 @@ def _extract_failed_checks(pull_request: Any) -> tuple[FailedCheck, ...]:
         else:
             continue
         if failing and isinstance(name, str):
-            # FailedCheck drops any non-http(s) url.
-            failed.append(FailedCheck(name=name, url=url))
+            failed.append(FailedCheck(name=name, url=http_url_or_none(url)))
     return tuple(failed)
 
 

--- a/src/sentry/integrations/github/pull_request_status.py
+++ b/src/sentry/integrations/github/pull_request_status.py
@@ -6,6 +6,7 @@ from typing import Any
 from sentry.integrations.source_code_management.status_check import (
     AggregateChecksStatus,
     AggregateReviewStatus,
+    FailedCheck,
     PullRequestFileSummary,
     PullRequestStatusRequest,
     PullRequestStatusResult,
@@ -26,10 +27,12 @@ fragment PullRequestStatusFields on PullRequest {
               ... on CheckRun {
                 name
                 conclusion
+                detailsUrl
               }
               ... on StatusContext {
                 context
                 state
+                targetUrl
               }
             }
           }
@@ -156,7 +159,7 @@ def _extract_files(pull_request: Any) -> tuple[PullRequestFileSummary, ...]:
     return tuple(files)
 
 
-def _extract_failed_checks(pull_request: Any) -> tuple[str, ...]:
+def _extract_failed_checks(pull_request: Any) -> tuple[FailedCheck, ...]:
     nodes = (
         get_path(
             pull_request,
@@ -170,20 +173,22 @@ def _extract_failed_checks(pull_request: Any) -> tuple[str, ...]:
         )
         or []
     )
-    failed: list[str] = []
+    failed: list[FailedCheck] = []
     for node in nodes:
         if not isinstance(node, Mapping):
             continue
         if node.get("__typename") == "CheckRun":
             name = node.get("name")
             failing = node.get("conclusion") in _FAILING_CHECK_RUN_CONCLUSIONS
+            url = node.get("detailsUrl")
         elif node.get("__typename") == "StatusContext":
             name = node.get("context")
             failing = node.get("state") in _FAILING_STATUS_CONTEXT_STATES
+            url = node.get("targetUrl")
         else:
             continue
         if failing and isinstance(name, str):
-            failed.append(name)
+            failed.append(FailedCheck(name=name, url=url if isinstance(url, str) else None))
     return tuple(failed)
 
 

--- a/src/sentry/integrations/github/pull_request_status.py
+++ b/src/sentry/integrations/github/pull_request_status.py
@@ -188,7 +188,8 @@ def _extract_failed_checks(pull_request: Any) -> tuple[FailedCheck, ...]:
         else:
             continue
         if failing and isinstance(name, str):
-            failed.append(FailedCheck(name=name, url=url if isinstance(url, str) else None))
+            # FailedCheck drops any non-http(s) url.
+            failed.append(FailedCheck(name=name, url=url))
     return tuple(failed)
 
 

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -6,7 +6,9 @@ from typing import Any
 from urllib.parse import urlparse
 
 
-def _http_url_or_none(value: object) -> str | None:
+def http_url_or_none(value: object) -> str | None:
+    """The value only if it is an http(s) URL, else None. Guards attacker-set
+    check URLs (e.g. javascript:) from reaching a rendered anchor href."""
     if not isinstance(value, str):
         return None
     try:
@@ -77,15 +79,12 @@ class PullRequestFileSummary:
 
 @dataclass(frozen=True)
 class FailedCheck:
-    """A failing check on a pull request, with a link to its run when the provider gives one."""
+    """A failing check on a pull request, with a link to its run when the provider gives one.
+
+    url must be sanitized with http_url_or_none by the caller before construction."""
 
     name: str
     url: str | None = None
-
-    def __post_init__(self) -> None:
-        # url is provider/CI-controlled; drop non-http(s) schemes so a javascript:
-        # link can never reach a rendered anchor href.
-        object.__setattr__(self, "url", _http_url_or_none(self.url))
 
 
 @dataclass(frozen=True)

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -65,13 +65,21 @@ class PullRequestFileSummary:
 
 
 @dataclass(frozen=True)
+class FailedCheck:
+    """A failing check on a pull request, with a link to its run when the provider gives one."""
+
+    name: str
+    url: str | None = None
+
+
+@dataclass(frozen=True)
 class PullRequestStatusResult:
     """A pull request's checks and review state, as far as the provider reports it."""
 
     checks: AggregateChecksStatus | None = None
     review: AggregateReviewStatus | None = None
     files: tuple[PullRequestFileSummary, ...] = ()
-    failed_checks: tuple[str, ...] = ()
+    failed_checks: tuple[FailedCheck, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/sentry/integrations/source_code_management/status_check.py
+++ b/src/sentry/integrations/source_code_management/status_check.py
@@ -3,6 +3,17 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
+
+
+def _http_url_or_none(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        scheme = urlparse(value).scheme
+    except ValueError:
+        return None
+    return value if scheme in ("http", "https") else None
 
 
 class StatusCheckStatus(str, enum.Enum):
@@ -70,6 +81,11 @@ class FailedCheck:
 
     name: str
     url: str | None = None
+
+    def __post_init__(self) -> None:
+        # url is provider/CI-controlled; drop non-http(s) schemes so a javascript:
+        # link can never reach a rendered anchor href.
+        object.__setattr__(self, "url", _http_url_or_none(self.url))
 
 
 @dataclass(frozen=True)

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -151,8 +151,6 @@ def _serialize_pull_request(
             }
             for file in checks_and_review.files
         ],
-        # failedChecks stays a name list for the deployed frontend; drop it once the
-        # frontend reads failedCheckDetails (name + run link) instead.
         "failedChecks": [check.name for check in checks_and_review.failed_checks],
         "failedCheckDetails": [
             {"name": check.name, "url": check.url} for check in checks_and_review.failed_checks

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -151,7 +151,12 @@ def _serialize_pull_request(
             }
             for file in checks_and_review.files
         ],
-        "failedChecks": list(checks_and_review.failed_checks),
+        # A plain name list for the currently-deployed frontend; failedCheckDetails
+        # carries the run links for the new frontend.
+        "failedChecks": [check.name for check in checks_and_review.failed_checks],
+        "failedCheckDetails": [
+            {"name": check.name, "url": check.url} for check in checks_and_review.failed_checks
+        ],
     }
 
 

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -151,8 +151,8 @@ def _serialize_pull_request(
             }
             for file in checks_and_review.files
         ],
-        # A plain name list for the currently-deployed frontend; failedCheckDetails
-        # carries the run links for the new frontend.
+        # failedChecks stays a name list for the deployed frontend; drop it once the
+        # frontend reads failedCheckDetails (name + run link) instead.
         "failedChecks": [check.name for check in checks_and_review.failed_checks],
         "failedCheckDetails": [
             {"name": check.name, "url": check.url} for check in checks_and_review.failed_checks

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -13,6 +13,11 @@ class PullRequestFilePayload(TypedDict):
     changeType: str
 
 
+class FailedCheckPayload(TypedDict):
+    name: str
+    url: str | None
+
+
 class PullRequestPayload(TypedDict):
     id: str
     number: int
@@ -23,6 +28,7 @@ class PullRequestPayload(TypedDict):
     repoName: str | None
     files: list[PullRequestFilePayload]
     failedChecks: list[str]
+    failedCheckDetails: list[FailedCheckPayload]
 
 
 class IssueProjectPayload(TypedDict):

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1259,9 +1259,21 @@ class GitHubApiClientTest(TestCase):
 
         status_only_key = self.github_client._get_pull_request_status_cache_key(status_only)
         assert status_only_key == self.github_client.get_cache_key(
-            "/graphql/pull-request-status", "", previous_cache_data
+            "/graphql/pull-request-status/v2", "", previous_cache_data
         )
         assert status_only_key != self.github_client._get_pull_request_status_cache_key(with_files)
+
+    def test_pull_request_status_cache_key_versions_the_result_shape(self) -> None:
+        # failed_checks changed shape (str -> FailedCheck), so the key must not
+        # collide with entries cached under the previous shape; otherwise the
+        # overview serializer reads stale bare strings and 500s just after deploy.
+        request = PullRequestStatusRequest(repo=self.repo.name, pull_number="45")
+        pre_version_key = self.github_client.get_cache_key(
+            "/graphql/pull-request-status",
+            "",
+            orjson.dumps({"repo": self.repo.name, "pull_number": "45"}).decode(),
+        )
+        assert self.github_client._get_pull_request_status_cache_key(request) != pre_version_key
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/github/test_pull_request_status.py
+++ b/tests/sentry/integrations/github/test_pull_request_status.py
@@ -212,6 +212,39 @@ def test_extract_failed_checks() -> None:
     )
 
 
+def test_extract_failed_checks_drops_non_http_urls() -> None:
+    # Check URLs come straight from provider/CI data; a javascript:/data: link must
+    # not survive to be rendered as an anchor href by a consumer.
+    result = extract_pull_request_status_from_response(
+        response(
+            {
+                "state": "FAILURE",
+                "contexts": {
+                    "nodes": [
+                        {
+                            "__typename": "CheckRun",
+                            "name": "xss",
+                            "conclusion": "FAILURE",
+                            "detailsUrl": "javascript:alert(document.cookie)",
+                        },
+                        {
+                            "__typename": "StatusContext",
+                            "context": "legacy-xss",
+                            "state": "FAILURE",
+                            "targetUrl": "data:text/html,<script>alert(1)</script>",
+                        },
+                    ]
+                },
+            }
+        )
+    )
+
+    assert result.failed_checks == (
+        FailedCheck(name="xss", url=None),
+        FailedCheck(name="legacy-xss", url=None),
+    )
+
+
 def test_extract_failed_checks_skips_partial_nodes() -> None:
     result = extract_pull_request_status_from_response(
         response(

--- a/tests/sentry/integrations/github/test_pull_request_status.py
+++ b/tests/sentry/integrations/github/test_pull_request_status.py
@@ -14,6 +14,7 @@ from sentry.integrations.github.pull_request_status import (
 from sentry.integrations.source_code_management.status_check import (
     AggregateChecksStatus,
     AggregateReviewStatus,
+    FailedCheck,
     PullRequestFileSummary,
     PullRequestStatusRequest,
     PullRequestStatusResult,
@@ -131,6 +132,12 @@ def test_query_reads_individual_check_contexts() -> None:
     assert "contexts(first: 100)" in PULL_REQUEST_STATUS_FRAGMENT
 
 
+def test_query_reads_check_run_urls() -> None:
+    # detailsUrl points at the external run for a CheckRun; targetUrl for a legacy status.
+    assert "detailsUrl" in PULL_REQUEST_STATUS_FRAGMENT
+    assert "targetUrl" in PULL_REQUEST_STATUS_FRAGMENT
+
+
 def test_extract_failed_checks() -> None:
     result = extract_pull_request_status_from_response(
         response(
@@ -142,25 +149,53 @@ def test_extract_failed_checks() -> None:
                             "__typename": "CheckRun",
                             "name": "build (3.12)",
                             "conclusion": "FAILURE",
+                            "detailsUrl": "https://github.com/getsentry/sentry/runs/1",
                         },
-                        {"__typename": "CheckRun", "name": "lint", "conclusion": "SUCCESS"},
-                        {"__typename": "CheckRun", "name": "deploy", "conclusion": "TIMED_OUT"},
+                        {
+                            "__typename": "CheckRun",
+                            "name": "lint",
+                            "conclusion": "SUCCESS",
+                            "detailsUrl": "https://github.com/getsentry/sentry/runs/2",
+                        },
+                        {
+                            "__typename": "CheckRun",
+                            "name": "deploy",
+                            "conclusion": "TIMED_OUT",
+                            "detailsUrl": "https://github.com/getsentry/sentry/runs/3",
+                        },
                         {
                             "__typename": "CheckRun",
                             "name": "setup",
                             "conclusion": "STARTUP_FAILURE",
+                            "detailsUrl": None,
                         },
                         {
                             "__typename": "CheckRun",
                             "name": "approval",
                             "conclusion": "ACTION_REQUIRED",
+                            "detailsUrl": "https://github.com/getsentry/sentry/runs/5",
                         },
                         # CANCELLED maps to neither pass nor fail, matching the rollup mapping.
                         {"__typename": "CheckRun", "name": "optional", "conclusion": "CANCELLED"},
                         {"__typename": "CheckRun", "name": "running", "conclusion": None},
-                        {"__typename": "StatusContext", "context": "ci/legacy", "state": "FAILURE"},
-                        {"__typename": "StatusContext", "context": "ci/error", "state": "ERROR"},
-                        {"__typename": "StatusContext", "context": "ci/ok", "state": "SUCCESS"},
+                        {
+                            "__typename": "StatusContext",
+                            "context": "ci/legacy",
+                            "state": "FAILURE",
+                            "targetUrl": "https://jenkins.example/legacy",
+                        },
+                        {
+                            "__typename": "StatusContext",
+                            "context": "ci/error",
+                            "state": "ERROR",
+                            "targetUrl": None,
+                        },
+                        {
+                            "__typename": "StatusContext",
+                            "context": "ci/ok",
+                            "state": "SUCCESS",
+                            "targetUrl": "https://jenkins.example/ok",
+                        },
                     ]
                 },
             }
@@ -168,12 +203,12 @@ def test_extract_failed_checks() -> None:
     )
 
     assert result.failed_checks == (
-        "build (3.12)",
-        "deploy",
-        "setup",
-        "approval",
-        "ci/legacy",
-        "ci/error",
+        FailedCheck(name="build (3.12)", url="https://github.com/getsentry/sentry/runs/1"),
+        FailedCheck(name="deploy", url="https://github.com/getsentry/sentry/runs/3"),
+        FailedCheck(name="setup", url=None),
+        FailedCheck(name="approval", url="https://github.com/getsentry/sentry/runs/5"),
+        FailedCheck(name="ci/legacy", url="https://jenkins.example/legacy"),
+        FailedCheck(name="ci/error", url=None),
     )
 
 
@@ -195,7 +230,7 @@ def test_extract_failed_checks_skips_partial_nodes() -> None:
         )
     )
 
-    assert result.failed_checks == ("mypy",)
+    assert result.failed_checks == (FailedCheck(name="mypy", url=None),)
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -10,6 +10,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.source_code_management.status_check import (
     AggregateChecksStatus,
     AggregateReviewStatus,
+    FailedCheck,
     PullRequestFileSummary,
     PullRequestStatusClient,
     PullRequestStatusRequest,
@@ -741,6 +742,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
                 "repoName": "getsentry/sentry",
                 "files": [],
                 "failedChecks": [],
+                "failedCheckDetails": [],
             }
         ]
 
@@ -808,6 +810,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         assert pull_requests[0]["checksStatus"] == "success"
         assert pull_requests[0]["reviewStatus"] == "approved"
         assert pull_requests[0]["failedChecks"] == []
+        assert pull_requests[0]["failedCheckDetails"] == []
         assert client.requested_keys == ["123"]
 
     @mock.patch(_INTEGRATION_SERVICE)
@@ -821,7 +824,13 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
                 {
                     "123": PullRequestStatusResult(
                         checks=AggregateChecksStatus.FAILURE,
-                        failed_checks=("build (3.12)", "mypy"),
+                        failed_checks=(
+                            FailedCheck(
+                                name="build (3.12)",
+                                url="https://github.com/getsentry/sentry/runs/1",
+                            ),
+                            FailedCheck(name="mypy", url=None),
+                        ),
                     )
                 }
             ),
@@ -830,7 +839,12 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         pull_requests = self._pull_requests(expand="scmInfo")
 
         assert pull_requests[0]["checksStatus"] == "failure"
+        # failedChecks stays a plain name list for the currently-deployed frontend.
         assert pull_requests[0]["failedChecks"] == ["build (3.12)", "mypy"]
+        assert pull_requests[0]["failedCheckDetails"] == [
+            {"name": "build (3.12)", "url": "https://github.com/getsentry/sentry/runs/1"},
+            {"name": "mypy", "url": None},
+        ]
 
     @mock.patch(_INTEGRATION_SERVICE)
     def test_merged_pull_request_skips_provider_fetch(self, mock_get_integration):


### PR DESCRIPTION
## Summary

The Autofix Overview page shows a "N Checks Failing" pill whose tooltip lists each failing PR check by name. Those names are dead text — there's no way to jump from a failing check to its CI run.

This backend change captures each failing check's run URL from GitHub and exposes it on the autofix-overview API so a follow-up frontend PR can link each check to its run.

## What changed

- **GitHub GraphQL** (`pull_request_status.py`): fetch `detailsUrl` on `CheckRun` nodes (the external run page) and `targetUrl` on legacy `StatusContext` nodes.
- **`PullRequestStatusResult.failed_checks`**: now a tuple of a new `FailedCheck(name, url)` dataclass instead of bare strings. URL is `None` when the provider doesn't give one.
- **API payload**: adds a new `failedCheckDetails: [{name, url}]` field on `PullRequestPayload`.

## Deploy safety

Frontend and backend don't deploy atomically. Rather than change the shape of the existing `failedChecks: string[]` field (which would make the currently-deployed frontend try to render objects as text and crash the tooltip during the deploy window), this **adds** `failedCheckDetails` and leaves `failedChecks` untouched. The follow-up frontend PR reads the new field; a later cleanup PR can drop `failedChecks` once the frontend is out.

## Tests

- Extraction unit tests cover check-run `detailsUrl`, status-context `targetUrl`, and null URLs.
- Serializer tests assert both `failedChecks` (names, unchanged) and the new `failedCheckDetails`.

All affected backend suites pass; prek + mypy clean.

## Security

The check `url` is provider/CI-controlled (`StatusContext.targetUrl` is set by third-party CI apps), and Sentry's frontend link primitives don't sanitize the URL scheme. To prevent a `javascript:`/`data:` link from becoming a DOM-XSS sink once the frontend renders it as an anchor, `FailedCheck` enforces an http(s)-only invariant at construction — any other scheme (or a non-string) becomes `None`.
