### PR TITLE
feat(autofix): Collapse changed-files list after 5 files

### DIFF
--- a/static/app/views/seerWorkflows/overview/changedFilesSection.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.spec.tsx
@@ -1,0 +1,61 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  ChangedFilesSection,
+  type RepoFileGroup,
+  useExpandedKeys,
+} from 'sentry/views/seerWorkflows/overview/changedFilesSection';
+
+function groupFixture(fileCount: number): RepoFileGroup {
+  return {
+    repoName: 'getsentry/sentry',
+    files: Array.from({length: fileCount}, (_, i) => ({
+      additions: 1,
+      deletions: 1,
+      path: `src/file-${i}.py`,
+      changeTag: null,
+      renderDiff: () => null,
+    })),
+  };
+}
+
+function Wrapper({group}: {group: RepoFileGroup}) {
+  const {expandedKeys, toggle} = useExpandedKeys();
+  return (
+    <ChangedFilesSection groups={[group]} expandedKeys={expandedKeys} onToggle={toggle} />
+  );
+}
+
+describe('ChangedFilesSection', () => {
+  it('renders every file without a toggle when there are 3 or fewer', () => {
+    render(<Wrapper group={groupFixture(3)} />);
+
+    expect(screen.getByText('src/file-0.py')).toBeInTheDocument();
+    expect(screen.getByText('src/file-2.py')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /more file/i})).not.toBeInTheDocument();
+  });
+
+  it('shows only the first 3 files and a toggle when there are more', () => {
+    render(<Wrapper group={groupFixture(5)} />);
+
+    expect(screen.getByText('src/file-0.py')).toBeInTheDocument();
+    expect(screen.getByText('src/file-2.py')).toBeInTheDocument();
+    expect(screen.queryByText('src/file-3.py')).not.toBeInTheDocument();
+    expect(screen.queryByText('src/file-4.py')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /show 2 more files/i})).toBeInTheDocument();
+  });
+
+  it('reveals the remaining files and flips the label when toggled', async () => {
+    render(<Wrapper group={groupFixture(5)} />);
+
+    await userEvent.click(screen.getByRole('button', {name: /show 2 more files/i}));
+
+    expect(screen.getByText('src/file-3.py')).toBeInTheDocument();
+    expect(screen.getByText('src/file-4.py')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /show fewer/i})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /show fewer/i}));
+
+    expect(screen.queryByText('src/file-3.py')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.spec.tsx
@@ -27,35 +27,35 @@ function Wrapper({group}: {group: RepoFileGroup}) {
 }
 
 describe('ChangedFilesSection', () => {
-  it('renders every file without a toggle when there are 3 or fewer', () => {
-    render(<Wrapper group={groupFixture(3)} />);
-
-    expect(screen.getByText('src/file-0.py')).toBeInTheDocument();
-    expect(screen.getByText('src/file-2.py')).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: /more file/i})).not.toBeInTheDocument();
-  });
-
-  it('shows only the first 3 files and a toggle when there are more', () => {
+  it('renders every file without a toggle when there are 5 or fewer', () => {
     render(<Wrapper group={groupFixture(5)} />);
 
     expect(screen.getByText('src/file-0.py')).toBeInTheDocument();
-    expect(screen.getByText('src/file-2.py')).toBeInTheDocument();
-    expect(screen.queryByText('src/file-3.py')).not.toBeInTheDocument();
-    expect(screen.queryByText('src/file-4.py')).not.toBeInTheDocument();
+    expect(screen.getByText('src/file-4.py')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /more file/i})).not.toBeInTheDocument();
+  });
+
+  it('shows only the first 5 files and a toggle when there are more', () => {
+    render(<Wrapper group={groupFixture(7)} />);
+
+    expect(screen.getByText('src/file-0.py')).toBeInTheDocument();
+    expect(screen.getByText('src/file-4.py')).toBeInTheDocument();
+    expect(screen.queryByText('src/file-5.py')).not.toBeInTheDocument();
+    expect(screen.queryByText('src/file-6.py')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: /show 2 more files/i})).toBeInTheDocument();
   });
 
   it('reveals the remaining files and flips the label when toggled', async () => {
-    render(<Wrapper group={groupFixture(5)} />);
+    render(<Wrapper group={groupFixture(7)} />);
 
     await userEvent.click(screen.getByRole('button', {name: /show 2 more files/i}));
 
-    expect(screen.getByText('src/file-3.py')).toBeInTheDocument();
-    expect(screen.getByText('src/file-4.py')).toBeInTheDocument();
+    expect(screen.getByText('src/file-5.py')).toBeInTheDocument();
+    expect(screen.getByText('src/file-6.py')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /show fewer/i})).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: /show fewer/i}));
 
-    expect(screen.queryByText('src/file-3.py')).not.toBeInTheDocument();
+    expect(screen.queryByText('src/file-5.py')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.spec.tsx
@@ -14,7 +14,7 @@ function groupFixture(fileCount: number): RepoFileGroup {
       deletions: 1,
       path: `src/file-${i}.py`,
       changeTag: null,
-      renderDiff: () => null,
+      renderDiff: () => <div>{`diff-${i}`}</div>,
     })),
   };
 }
@@ -57,5 +57,19 @@ describe('ChangedFilesSection', () => {
     await userEvent.click(screen.getByRole('button', {name: /show fewer/i}));
 
     expect(screen.queryByText('src/file-5.py')).not.toBeInTheDocument();
+  });
+
+  it('collapses an expanded diff when its file is hidden and re-revealed', async () => {
+    render(<Wrapper group={groupFixture(7)} />);
+
+    await userEvent.click(screen.getByRole('button', {name: /show 2 more files/i}));
+    await userEvent.click(screen.getByRole('button', {name: /src\/file-6\.py/}));
+    expect(screen.getByText('diff-6')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /show fewer/i}));
+    await userEvent.click(screen.getByRole('button', {name: /show 2 more files/i}));
+
+    expect(screen.getByText('src/file-6.py')).toBeInTheDocument();
+    expect(screen.queryByText('diff-6')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -9,7 +9,7 @@ import {t, tn} from 'sentry/locale';
 
 import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
 
-const COLLAPSED_FILE_COUNT = 3;
+const COLLAPSED_FILE_COUNT = 5;
 
 interface ChangedFile {
   additions: number;

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -1,13 +1,16 @@
 import {Fragment, type ReactNode, useState} from 'react';
 
 import {Tag} from '@sentry/scraps/badge';
+import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconCode} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {IconChevron, IconCode} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
 
 import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
+
+const COLLAPSED_FILE_COUNT = 3;
 
 interface ChangedFile {
   additions: number;
@@ -37,6 +40,84 @@ export function useExpandedKeys() {
   return {expandedKeys, toggle};
 }
 
+function RepoGroup({
+  group,
+  groupIndex,
+  expandedKeys,
+  onToggle,
+}: {
+  expandedKeys: Set<string>;
+  group: RepoFileGroup;
+  groupIndex: number;
+  onToggle: (key: string, expanded: boolean) => void;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const hiddenCount = group.files.length - COLLAPSED_FILE_COUNT;
+  const visibleFiles =
+    showAll || hiddenCount <= 0
+      ? group.files
+      : group.files.slice(0, COLLAPSED_FILE_COUNT);
+
+  return (
+    <Fragment>
+      <Flex
+        gap="md"
+        align="center"
+        padding="md"
+        borderBottom="primary"
+        borderTop={groupIndex > 0 ? 'primary' : undefined}
+      >
+        {group.repoName ? (
+          <Fragment>
+            <Tag variant="muted">{group.files.length}</Tag>
+            <Text size="sm" bold variant="secondary" ellipsis>
+              {group.repoName}
+            </Text>
+          </Fragment>
+        ) : (
+          <Text size="sm" variant="muted">
+            {group.files.length === 1
+              ? t('1 file changed')
+              : t('%s files changed', group.files.length.toLocaleString())}
+          </Text>
+        )}
+      </Flex>
+      {visibleFiles.map(file => {
+        const key = JSON.stringify([group.repoName, file.path]);
+        const isExpanded = expandedKeys.has(key);
+        return (
+          <ChangedFileRow
+            key={key}
+            additions={file.additions}
+            deletions={file.deletions}
+            path={file.path}
+            changeTag={file.changeTag}
+            expanded={isExpanded}
+            onExpandedChange={next => onToggle(key, next)}
+          >
+            {isExpanded ? file.renderDiff() : null}
+          </ChangedFileRow>
+        );
+      })}
+      {hiddenCount > 0 ? (
+        <Flex borderTop="primary" padding="0 xs">
+          <Button
+            size="sm"
+            variant="transparent"
+            aria-expanded={showAll}
+            icon={<IconChevron direction={showAll ? 'up' : 'down'} />}
+            onClick={() => setShowAll(prev => !prev)}
+          >
+            {showAll
+              ? t('Show fewer')
+              : tn('Show %s more file', 'Show %s more files', hiddenCount)}
+          </Button>
+        </Flex>
+      ) : null}
+    </Fragment>
+  );
+}
+
 export function ChangedFilesSection({
   groups,
   expandedKeys,
@@ -58,47 +139,13 @@ export function ChangedFilesSection({
       </Flex>
       <Container border="primary" radius="md" overflow="hidden" background="secondary">
         {groups.map((group, groupIndex) => (
-          <Fragment key={JSON.stringify([group.repoName])}>
-            <Flex
-              gap="md"
-              align="center"
-              padding="md"
-              borderBottom="primary"
-              borderTop={groupIndex > 0 ? 'primary' : undefined}
-            >
-              {group.repoName ? (
-                <Fragment>
-                  <Tag variant="muted">{group.files.length}</Tag>
-                  <Text size="sm" bold variant="secondary" ellipsis>
-                    {group.repoName}
-                  </Text>
-                </Fragment>
-              ) : (
-                <Text size="sm" variant="muted">
-                  {group.files.length === 1
-                    ? t('1 file changed')
-                    : t('%s files changed', group.files.length.toLocaleString())}
-                </Text>
-              )}
-            </Flex>
-            {group.files.map(file => {
-              const key = JSON.stringify([group.repoName, file.path]);
-              const isExpanded = expandedKeys.has(key);
-              return (
-                <ChangedFileRow
-                  key={key}
-                  additions={file.additions}
-                  deletions={file.deletions}
-                  path={file.path}
-                  changeTag={file.changeTag}
-                  expanded={isExpanded}
-                  onExpandedChange={next => onToggle(key, next)}
-                >
-                  {isExpanded ? file.renderDiff() : null}
-                </ChangedFileRow>
-              );
-            })}
-          </Fragment>
+          <RepoGroup
+            key={JSON.stringify([group.repoName])}
+            group={group}
+            groupIndex={groupIndex}
+            expandedKeys={expandedKeys}
+            onToggle={onToggle}
+          />
         ))}
       </Container>
     </Stack>

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -4,7 +4,7 @@ import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconCode} from 'sentry/icons';
+import {IconChevron, IconCode} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 
 import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
@@ -108,11 +108,12 @@ function RepoGroup({
         );
       })}
       {hiddenCount > 0 ? (
-        <Flex justify="center" borderTop="primary" padding="xs">
+        <Flex justify="center" borderTop="primary" background="primary" padding="xs">
           <Button
-            size="sm"
+            size="xs"
             variant="transparent"
             aria-expanded={showAll}
+            icon={<IconChevron isDouble direction={showAll ? 'up' : 'down'} />}
             onClick={toggleShowAll}
           >
             <Text size="sm" variant="muted">

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -96,16 +96,18 @@ function RepoGroup({
         );
       })}
       {hiddenCount > 0 ? (
-        <Flex borderTop="primary" padding="0 xs">
+        <Flex justify="center" borderTop="primary" padding="xs">
           <Button
             size="sm"
-            variant="link"
+            variant="transparent"
             aria-expanded={showAll}
             onClick={() => setShowAll(prev => !prev)}
           >
-            {showAll
-              ? t('Show fewer')
-              : tn('Show %s more file', 'Show %s more files', hiddenCount)}
+            <Text size="sm" variant="muted">
+              {showAll
+                ? t('Show fewer')
+                : tn('Show %s more file', 'Show %s more files', hiddenCount)}
+            </Text>
           </Button>
         </Flex>
       ) : null}

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -1,11 +1,10 @@
 import {Fragment, type ReactNode, useState} from 'react';
 
-import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {IconChevron, IconCode} from 'sentry/icons';
+import {IconCode} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 
 import {ChangedFileRow, type FileChangeTag} from './changedFileRow';
@@ -68,12 +67,9 @@ function RepoGroup({
         borderTop={groupIndex > 0 ? 'primary' : undefined}
       >
         {group.repoName ? (
-          <Fragment>
-            <Tag variant="muted">{group.files.length}</Tag>
-            <Text size="sm" bold variant="secondary" ellipsis>
-              {group.repoName}
-            </Text>
-          </Fragment>
+          <Text size="sm" bold variant="secondary" ellipsis>
+            {group.repoName}
+          </Text>
         ) : (
           <Text size="sm" variant="muted">
             {group.files.length === 1
@@ -103,9 +99,8 @@ function RepoGroup({
         <Flex borderTop="primary" padding="0 xs">
           <Button
             size="sm"
-            variant="transparent"
+            variant="link"
             aria-expanded={showAll}
-            icon={<IconChevron direction={showAll ? 'up' : 'down'} />}
             onClick={() => setShowAll(prev => !prev)}
           >
             {showAll

--- a/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFilesSection.tsx
@@ -57,6 +57,18 @@ function RepoGroup({
       ? group.files
       : group.files.slice(0, COLLAPSED_FILE_COUNT);
 
+  const fileKey = (path: string) => JSON.stringify([group.repoName, path]);
+
+  const toggleShowAll = () => {
+    if (showAll) {
+      // Collapsing: forget expanded diffs for files about to be hidden.
+      group.files
+        .slice(COLLAPSED_FILE_COUNT)
+        .forEach(file => onToggle(fileKey(file.path), false));
+    }
+    setShowAll(prev => !prev);
+  };
+
   return (
     <Fragment>
       <Flex
@@ -79,7 +91,7 @@ function RepoGroup({
         )}
       </Flex>
       {visibleFiles.map(file => {
-        const key = JSON.stringify([group.repoName, file.path]);
+        const key = fileKey(file.path);
         const isExpanded = expandedKeys.has(key);
         return (
           <ChangedFileRow
@@ -101,7 +113,7 @@ function RepoGroup({
             size="sm"
             variant="transparent"
             aria-expanded={showAll}
-            onClick={() => setShowAll(prev => !prev)}
+            onClick={toggleShowAll}
           >
             <Text size="sm" variant="muted">
               {showAll

--- a/static/app/views/seerWorkflows/overview/codeChanges.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/codeChanges.spec.tsx
@@ -77,9 +77,6 @@ describe('CodeChanges', () => {
 
     expect(screen.getByText('getsentry/sentry')).toBeInTheDocument();
     expect(screen.getByText('getsentry/getsentry')).toBeInTheDocument();
-    // Each repo header carries its own file count.
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
     expect(screen.getByText('src/a.py')).toBeInTheDocument();
     expect(screen.getByText('src/b.py')).toBeInTheDocument();
     expect(screen.getByText('src/c.py')).toBeInTheDocument();

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1282,9 +1282,16 @@ describe('AutofixOverview', () => {
       },
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/pull-requests/42/files/`,
+      body: {files: []},
+    });
+
     renderPage();
 
     expect(await screen.findByText('src/sentry/new.py')).toBeInTheDocument();
+    // The renamed file is the 4th, hidden behind the collapse toggle by default.
+    await userEvent.click(screen.getByRole('button', {name: /show 1 more file/i}));
     expect(screen.getByText('Added')).toBeInTheDocument();
     expect(screen.getByText('Deleted')).toBeInTheDocument();
     expect(screen.getByText('Renamed')).toBeInTheDocument();

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1282,16 +1282,9 @@ describe('AutofixOverview', () => {
       },
     });
 
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/pull-requests/42/files/`,
-      body: {files: []},
-    });
-
     renderPage();
 
     expect(await screen.findByText('src/sentry/new.py')).toBeInTheDocument();
-    // The renamed file is the 4th, hidden behind the collapse toggle by default.
-    await userEvent.click(screen.getByRole('button', {name: /show 1 more file/i}));
     expect(screen.getByText('Added')).toBeInTheDocument();
     expect(screen.getByText('Deleted')).toBeInTheDocument();
     expect(screen.getByText('Renamed')).toBeInTheDocument();


### PR DESCRIPTION
On the Autofix Overview page, the "Review Open PRs" cards list every file changed by a PR under **Code Changes**. For PRs touching many files this produces a long, noisy list that dominates the card.

This collapses each repo group's file list to the first 3 files by default, with an inline toggle to reveal the rest:

- **≤ 5 files** — unchanged, all rendered.
- **> 5 files** — shows the first 5, then a `Show N more files` / `Show fewer` toggle that expands and collapses inline (no navigation, no extra fetch).
- The repo header badge still reflects the **total** file count.

The logic lives in the shared `ChangedFilesSection`, so both the PR file list (`PullRequestFiles`) and the generated `Code Changes` list get the same behavior. Per-group `showAll` state is owned by an extracted `RepoGroup` component; the existing expand-to-diff / prefetch flow is unchanged. The toggle carries `aria-expanded` for screen-reader semantics.
