### PR TITLE
feat(seer): Link failing checks to their runs on autofix overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -72,7 +72,6 @@ describe('AutofixOverview', () => {
       checksStatus: null,
       reviewStatus: null,
       files: [],
-      failedChecks: [],
     };
   }
 
@@ -937,7 +936,6 @@ describe('AutofixOverview', () => {
       reviewStatus: null,
       repoName: 'getsentry/sentry',
       files: [],
-      failedChecks: [],
     };
 
     const enriched = deferEnriched();
@@ -996,7 +994,6 @@ describe('AutofixOverview', () => {
       checksStatus: null,
       reviewStatus: null,
       repoName: null,
-      failedChecks: [],
       files: [
         {path: 'src/sentry/foo.py', additions: 1, deletions: 1, changeType: 'MODIFIED'},
         {path: 'src/sentry/bar.py', additions: 2, deletions: 0, changeType: 'ADDED'},
@@ -1022,7 +1019,6 @@ describe('AutofixOverview', () => {
       checksStatus: null,
       reviewStatus: null,
       files: [],
-      failedChecks: [],
     };
     // The endpoint enriches open/draft links only, so the actionable PR is the
     // one carrying badges and files.
@@ -1041,7 +1037,6 @@ describe('AutofixOverview', () => {
           changeType: 'MODIFIED',
         },
       ],
-      failedChecks: [],
     };
     mockOverview({
       base: {
@@ -1077,7 +1072,10 @@ describe('AutofixOverview', () => {
       ...pullRequestFixture({number: 3, status: 'open'}),
       checksStatus: 'failure',
       reviewStatus: 'changes_requested',
-      failedChecks: ['build (3.12)', 'mypy'],
+      failedCheckDetails: [
+        {name: 'build (3.12)', url: null},
+        {name: 'mypy', url: null},
+      ],
     };
     const pendingPullRequest: OverviewPullRequest = {
       ...pullRequestFixture({number: 4, status: 'open'}),
@@ -1120,6 +1118,30 @@ describe('AutofixOverview', () => {
     expect(screen.getByText('mypy')).toBeInTheDocument();
   });
 
+  it('links a failing check to its run and leaves url-less checks as plain text', async () => {
+    const failingPullRequest: OverviewPullRequest = {
+      ...pullRequestFixture({number: 3, status: 'open'}),
+      checksStatus: 'failure',
+      failedCheckDetails: [
+        {name: 'build (3.12)', url: 'https://github.com/getsentry/sentry/runs/1'},
+        {name: 'flaky', url: null},
+      ],
+    };
+    mockOverview({
+      base: {has_pull_request: [{...rootCauseRun, pullRequests: [failingPullRequest]}]},
+    });
+
+    renderPage();
+
+    await userEvent.hover(await screen.findByText('2 Checks Failing'));
+
+    const runLink = await screen.findByRole('link', {name: 'build (3.12)'});
+    expect(runLink).toHaveAttribute('href', 'https://github.com/getsentry/sentry/runs/1');
+    // A check with no run url stays plain text, not a link.
+    expect(screen.getByText('flaky')).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'flaky'})).not.toBeInTheDocument();
+  });
+
   it('uses the singular label for a single failed check', async () => {
     mockOverview({
       base: {
@@ -1130,7 +1152,7 @@ describe('AutofixOverview', () => {
               {
                 ...pullRequestFixture({number: 3, status: 'open'}),
                 checksStatus: 'failure',
-                failedChecks: ['mypy'],
+                failedCheckDetails: [{name: 'mypy', url: null}],
               },
             ],
           },
@@ -1143,16 +1165,16 @@ describe('AutofixOverview', () => {
     expect(await screen.findByText('1 Check Failing')).toBeInTheDocument();
   });
 
-  it('falls back to the plain failing label when a failing PR omits failedChecks', async () => {
-    // The field is absent until the backend deploys; the failing tag must fall
-    // back to the plain label rather than reading .length of undefined.
-    const {failedChecks: _omitted, ...withoutFailedChecks} = {
+  it('shows the plain failing label when a failing PR has no check details', async () => {
+    // A failing PR with no per-check details must show the plain label rather
+    // than reading .length of undefined.
+    const failingWithoutDetails: OverviewPullRequest = {
       ...pullRequestFixture({number: 3, status: 'open'}),
-      checksStatus: 'failure' as const,
+      checksStatus: 'failure',
     };
     mockOverview({
       base: {
-        has_pull_request: [{...rootCauseRun, pullRequests: [withoutFailedChecks]}],
+        has_pull_request: [{...rootCauseRun, pullRequests: [failingWithoutDetails]}],
       },
     });
 
@@ -1248,7 +1270,6 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
-                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/new.py',
@@ -1315,7 +1336,6 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
-                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/mystery.py',
@@ -1356,7 +1376,6 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
-                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/foo.py',
@@ -1412,7 +1431,6 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
-                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/foo.py',
@@ -1472,7 +1490,6 @@ describe('AutofixOverview', () => {
                 status: 'open',
                 checksStatus: null,
                 reviewStatus: null,
-                failedChecks: [],
                 files: [
                   {
                     path: 'src/sentry/gone.py',

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -7,7 +7,7 @@ import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Markdown, type MarkdownProps} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -211,7 +211,7 @@ function OverviewAction({
       : null;
     const failedChecks =
       reviewPullRequest.checksStatus === 'failure'
-        ? (reviewPullRequest.failedChecks ?? [])
+        ? (reviewPullRequest.failedCheckDetails ?? [])
         : [];
 
     return (
@@ -250,13 +250,17 @@ function OverviewAction({
                       {t('Failing checks:')}
                     </Text>
                     <Stack gap="2xs" align="start">
-                      {failedChecks.map((name, index) => (
-                        <Flex key={`${name}-${index}`} gap="xs" align="start">
+                      {failedChecks.map((check, index) => (
+                        <Flex key={`${check.name}-${index}`} gap="xs" align="start">
                           <Text size="sm" variant="muted">
                             •
                           </Text>
                           <Text size="sm" align="left">
-                            {name}
+                            {check.url ? (
+                              <ExternalLink href={check.url}>{check.name}</ExternalLink>
+                            ) : (
+                              check.name
+                            )}
                           </Text>
                         </Flex>
                       ))}

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -146,6 +146,11 @@ export interface OverviewPullRequestFile {
   path: string;
 }
 
+interface FailedCheckDetail {
+  name: string;
+  url: string | null;
+}
+
 export interface OverviewPullRequest {
   checksStatus: PullRequestChecksStatus | null;
   files: OverviewPullRequestFile[];
@@ -154,7 +159,7 @@ export interface OverviewPullRequest {
   reviewStatus: PullRequestReviewStatus | null;
   status: PullRequestStatus | null;
   url: string | null;
-  failedChecks?: string[];
+  failedCheckDetails?: FailedCheckDetail[];
   repoName?: string | null;
 }
 


### PR DESCRIPTION
> [!WARNING]
> **Blocked on #122486 (backend) — do not merge until that PR is deployed.**
> This reads the `failedCheckDetails` API field added by #122486. Per the split-deploy rule (`AGENTS.md`), the backend must land and deploy first. Opened as a draft for early review.

## Summary

The Autofix Overview's "N Checks Failing" tooltip lists each failing PR check by name as dead text. This makes each check name a link to its CI run, so a user can jump straight from a failing check to the run that failed.

## What changed

- `types.ts`: adds `FailedCheckDetail { name, url }` and an optional `failedCheckDetails` field on `OverviewPullRequest`.
- `issueCard.tsx`: the failing-checks tooltip renders each check name as an `ExternalLink` to its run URL when one is present; checks without a URL stay plain text. The tooltip is already hoverable by default, so the links are clickable.

## Deploy dependency

Reads only `failedCheckDetails` (no name-only fallback), so it hard-depends on #122486 being deployed first — which is the required merge order anyway. A failing check whose provider gives no run URL renders as plain text.

Note: the backend validates that each `url` is http(s)-only (see #122486), preventing a `javascript:`/`data:` scheme from reaching the anchor `href`.

## Follow-up cleanup

The redundant `failedChecks` names field is removed from the backend in the stacked cleanup PR #122490 (merges after this deploys).

## Tests

Extends `index.spec.tsx`: a failing check with a run URL renders an anchor to that URL; a check with `url: null` stays plain text; a failing PR with no check details shows the plain "Checks Failing" label.
