### PR TITLE
ref(seer): Drop transitional failedChecks names field from overview API

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -151,7 +151,6 @@ def _serialize_pull_request(
             }
             for file in checks_and_review.files
         ],
-        "failedChecks": [check.name for check in checks_and_review.failed_checks],
         "failedCheckDetails": [
             {"name": check.name, "url": check.url} for check in checks_and_review.failed_checks
         ],

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -27,7 +27,6 @@ class PullRequestPayload(TypedDict):
     reviewStatus: str | None
     repoName: str | None
     files: list[PullRequestFilePayload]
-    failedChecks: list[str]
     failedCheckDetails: list[FailedCheckPayload]
 
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -741,7 +741,6 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
                 "reviewStatus": None,
                 "repoName": "getsentry/sentry",
                 "files": [],
-                "failedChecks": [],
                 "failedCheckDetails": [],
             }
         ]
@@ -809,7 +808,6 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
 
         assert pull_requests[0]["checksStatus"] == "success"
         assert pull_requests[0]["reviewStatus"] == "approved"
-        assert pull_requests[0]["failedChecks"] == []
         assert pull_requests[0]["failedCheckDetails"] == []
         assert client.requested_keys == ["123"]
 
@@ -839,8 +837,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
         pull_requests = self._pull_requests(expand="scmInfo")
 
         assert pull_requests[0]["checksStatus"] == "failure"
-        # failedChecks stays a plain name list for the currently-deployed frontend.
-        assert pull_requests[0]["failedChecks"] == ["build (3.12)", "mypy"]
+        assert "failedChecks" not in pull_requests[0]
         assert pull_requests[0]["failedCheckDetails"] == [
             {"name": "build (3.12)", "url": "https://github.com/getsentry/sentry/runs/1"},
             {"name": "mypy", "url": None},


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until the frontend (#122489) is deployed.**
> This removes the `failedChecks` field that the currently-deployed frontend still reads. It is only safe once #122489 (which reads `failedCheckDetails`) has shipped everywhere.

## Summary

Follow-up cleanup for the failing-check run-links work (#122486, now merged). The overview API temporarily carried **both** `failedChecks` (names only) and `failedCheckDetails` (name + run link); `failedChecks` existed solely to keep the pre-links frontend working across the non-atomic deploy. Now that the frontend reads `failedCheckDetails`, this drops the redundant field and its `PullRequestPayload` TypedDict entry, leaving one representation of failing checks.

## Deploy order

1. ~~#122486 (backend, adds `failedCheckDetails`)~~ — **merged**
2. **#122489** (frontend, reads `failedCheckDetails`) — merge + deploy
3. **this PR** — merge + deploy

## Tests

Updates the overview endpoint tests to assert `failedChecks` is no longer in the payload and only `failedCheckDetails` is present.
