### PR TITLE
fix(derived data): Force constraint validation when trying to create GroupDerivedData

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -13,6 +13,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils import timezone
 
+from sentry.db.postgres.transactions import enforce_constraints
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.framework import Pipeline, State
 from sentry.issues.derived.store import GroupDerivedDataStore
@@ -97,7 +98,7 @@ def _ensure_derived(group_id: int, pipeline_hash: str) -> GroupDerivedData:
 
     try:
         # Contain a possible database error so an enclosing transaction remains usable.
-        with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
+        with enforce_constraints(transaction.atomic(using=router.db_for_write(GroupDerivedData))):
             derived, _created = GroupDerivedData.objects.get_or_create(
                 group_id=group_id,
                 defaults={

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -98,6 +98,10 @@ class ProcessGroupLogTest(TestCase):
         processing.PIPELINE = self._original_pipeline
         super().tearDown()
 
+    def test_missing_group_raises_does_not_exist(self) -> None:
+        with pytest.raises(Group.DoesNotExist):
+            process_group_log(9_999_999_999)
+
     def test_records_and_processes(self) -> None:
         group = self.create_group()
         user = self.user

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -99,8 +99,15 @@ class ProcessGroupLogTest(TestCase):
         super().tearDown()
 
     def test_missing_group_raises_does_not_exist(self) -> None:
-        with pytest.raises(Group.DoesNotExist):
-            process_group_log(9_999_999_999)
+        group = self.create_group()
+
+        with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
+            with pytest.raises(Group.DoesNotExist):
+                process_group_log(9_999_999_999)
+
+            # The failed insert rolls back to its savepoint without breaking this transaction.
+            derived = process_group_log(group.id)
+            assert derived.group_id == group.id
 
     def test_records_and_processes(self) -> None:
         group = self.create_group()


### PR DESCRIPTION
This ensure failures are immediate and localized when running in a surrounding transaction.

Fixes SENTRY-5T6W.