### PR TITLE
ref(issue detectors): Use helper to get numbers from spans

### DIFF
--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -9,8 +9,8 @@ from sentry.issue_detection.base import DetectorType, PerformanceDetector
 from sentry.issue_detection.detectors.utils import (
     does_overlap_previous_span,
     get_notification_attachment_body,
+    get_numeric_value_from_span,
     get_span_evidence_value,
-    log_invalid_span_data,
     safer_urlparse,
     span_has_obfuscated_hostname,
 )
@@ -69,36 +69,15 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         url = span_data.get("url", "")
         span_start = span.get("start_timestamp", 0) * 1000
-        request_start = span_data.get("http.request.request_start", 0)
+        request_start = get_numeric_value_from_span(
+            span,
+            keys=["http.request.request_start"],
+            detector="http_overhead",
+            number_type=float,
+        )
 
         if not url or not span_start or not request_start:
             return
-
-        if isinstance(request_start, str):
-            try:
-                # Calling `float` on NaN won't actually raise an error, so we have to fake it, since
-                # even if it's technically a valid float, it's not valid for our purposes
-                if request_start == "NaN":
-                    # We log a custom error below, so all we need is something to get us into the
-                    # `except` block
-                    raise ValueError()
-
-                request_start = float(request_start)
-            except (ValueError, OverflowError) as err:
-                # Smooth over the difference between real errors and the faked NaN case above by
-                # setting a custom error message for both
-                err.args = (
-                    f"could not convert string to `request_start` value: '{request_start}'",
-                )
-                # Track instances of this happening so we know if it's a widespread problem
-                log_invalid_span_data(
-                    span,
-                    detector="http_overhead",
-                    key="http.request.request_start",
-                    value=request_start,
-                    error=err,
-                )
-                return
 
         request_start *= 1000
 

--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -11,9 +11,9 @@ from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
     fingerprint_http_spans,
     get_notification_attachment_body,
+    get_numeric_value_from_span,
     get_span_duration,
     get_span_evidence_value,
-    log_invalid_span_data,
 )
 from ..performance_problem import PerformanceProblem
 from ..types import Span
@@ -46,29 +46,16 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         if not self._is_span_eligible(span):
             return
 
-        data = span.get("data", None)
-        if not data:
-            return
-
-        encoded_body_size = data.get("http.response_content_length", None)
+        encoded_body_size = get_numeric_value_from_span(
+            span,
+            keys=["http.response_content_length"],
+            detector="large_http_payload",
+            number_type=int,
+        )
         if not encoded_body_size:
             return
 
         payload_size_threshold = self.settings["payload_size_threshold"]
-
-        if isinstance(encoded_body_size, str):
-            try:
-                encoded_body_size = int(encoded_body_size)
-            except (ValueError, OverflowError) as err:
-                # Track instances of this happening so we know if it's a widespread problem
-                log_invalid_span_data(
-                    span,
-                    detector="large_http_payload",
-                    key="http.response_content_length",
-                    value=encoded_body_size,
-                    error=err,
-                )
-                return
 
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)

--- a/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
@@ -11,6 +11,7 @@ from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
     fingerprint_resource_span,
     get_notification_attachment_body,
+    get_numeric_value_from_span,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -133,12 +134,19 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         if span_end_timestamp >= fcp_timestamp:
             return False
 
-        minimum_size_bytes = self.settings.get("minimum_size_bytes")
-        encoded_body_size = data.get("http.response_content_length", 0)
+        encoded_body_size = get_numeric_value_from_span(
+            span,
+            keys=["http.response_content_length"],
+            detector="render_blocking_asset",
+            number_type=int,
+        )
 
-        if encoded_body_size < minimum_size_bytes or encoded_body_size > self.settings.get(
-            "maximum_size_bytes"
-        ):
+        if not encoded_body_size:
+            return False
+
+        minimum_size_bytes = self.settings["minimum_size_bytes"]
+        maximum_size_bytes = self.settings["maximum_size_bytes"]
+        if encoded_body_size < minimum_size_bytes or encoded_body_size > maximum_size_bytes:
             return False
 
         span_duration = get_span_duration(span)

--- a/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
@@ -12,6 +12,7 @@ from ..base import DetectorType, PerformanceDetector
 from ..detectors.utils import (
     fingerprint_resource_span,
     get_notification_attachment_body,
+    get_numeric_value_from_span,
     get_span_duration,
     get_span_evidence_value,
 )
@@ -52,18 +53,25 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
         if op not in allowed_span_ops:
             return
 
-        data = span.get("data", None)
         # TODO(nar): The sentence-style keys can be removed once SDK adoption has increased and
         # we are receiving snake_case keys consistently, likely beyond October 2023
-        transfer_size = data and (
-            data.get("http.response_transfer_size", None) or data.get("Transfer Size", None)
+        transfer_size = get_numeric_value_from_span(
+            span,
+            keys=["http.response_transfer_size", "Transfer Size"],
+            detector="uncompressed_asset",
+            number_type=int,
         )
-        encoded_body_size = data and (
-            data.get("http.response_content_length", None) or data.get("Encoded Body Size", None)
+        encoded_body_size = get_numeric_value_from_span(
+            span,
+            keys=["http.response_content_length", "Encoded Body Size"],
+            detector="uncompressed_asset",
+            number_type=int,
         )
-        decoded_body_size = data and (
-            data.get("http.decoded_response_content_length", None)
-            or data.get("Decoded Body Size", None)
+        decoded_body_size = get_numeric_value_from_span(
+            span,
+            keys=["http.decoded_response_content_length", "Decoded Body Size"],
+            detector="uncompressed_asset",
+            number_type=int,
         )
         if not (encoded_body_size and decoded_body_size and transfer_size):
             return

--- a/tests/sentry/issue_detection/test_http_overhead_detector.py
+++ b/tests/sentry/issue_detection/test_http_overhead_detector.py
@@ -324,7 +324,11 @@ class HTTPOverheadDetectorTest(TestCase):
         span["organization_id"] = self.project.organization.id
         event["spans"] = [span]
 
-        for invalid_value in ["dogs are great", "NaN", "[Filtered]"]:
+        for invalid_value, expected_description in [
+            ("NaN", "non_number_float"),
+            ("[Filtered]", "non_number_string"),
+            ("dogs are great", "non_number_string"),
+        ]:
             event["spans"][0]["data"]["http.request.request_start"] = invalid_value
 
             assert self.find_problems(event) == []
@@ -338,7 +342,10 @@ class HTTPOverheadDetectorTest(TestCase):
                     "org_id": span["organization_id"],
                     "key": "http.request.request_start",
                     "value": invalid_value,
-                    "error": f"ValueError(\"could not convert string to `request_start` value: '{invalid_value}'\")",
+                    "error": (
+                        f"ValueError(\"Couldn't convert <{expected_description}> to <float>. "
+                        + f'Invalid value: {invalid_value}")'
+                    ),
                 },
             )
 

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -287,13 +287,18 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         ]
 
     @patch("sentry.issue_detection.detectors.utils.logger.warning")
-    def test_handles_invalid_string_payload_size(self, mock_logger_warning: MagicMock) -> None:
+    def test_handles_invalid_payload_size_values(self, mock_logger_warning: MagicMock) -> None:
         span = create_span("http.client", 1000, "GET /api/0/organizations/endpoint1", "hash2")
         span["project_id"] = self.project.id
         span["organization_id"] = self.project.organization.id
         event = create_event([span])
 
-        for invalid_value in ["NaN", "[Filtered]", "dogs are great"]:
+        for invalid_value, expected_description in [
+            (12.31, "non_integer_float"),
+            ("NaN", "non_number_float"),
+            ("[Filtered]", "non_number_string"),
+            ("dogs are great", "non_number_string"),
+        ]:
             event["spans"][0]["data"] = {"http.response_content_length": invalid_value}
 
             assert self.find_problems(event) == []  # No problem found, but also no crash
@@ -307,7 +312,10 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                     "org_id": span["organization_id"],
                     "key": "http.response_content_length",
                     "value": invalid_value,
-                    "error": f"ValueError(\"invalid literal for int() with base 10: '{invalid_value}'\")",
+                    "error": (
+                        f"ValueError(\"Couldn't convert <{expected_description}> to <int>. "
+                        + f'Invalid value: {invalid_value}")'
+                    ),
                 },
             )
 

--- a/tests/sentry/issue_detection/test_render_blocking_asset_detector.py
+++ b/tests/sentry/issue_detection/test_render_blocking_asset_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -193,6 +194,62 @@ class RenderBlockingAssetDetectorTest(TestCase):
             span["data"]["resource.render_blocking_status"] = "non-blocking"
 
         assert self.find_problems(event) == []
+
+    def test_handles_valid_string_encoded_body_size(self) -> None:
+        event = _valid_render_blocking_asset_event("https://example.com/a.js")
+        event["spans"][0]["data"]["http.response_content_length"] = "1200000"
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1004-ba43281143a88ba902029356cb543dd0bff8f41c",
+                op="resource.script",
+                desc="https://example.com/a.js",
+                type=PerformanceRenderBlockingAssetSpanGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "op": "resource.script",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                },
+                evidence_display=[],
+            )
+        ]
+
+    @patch("sentry.issue_detection.detectors.utils.logger.warning")
+    def test_handles_invalid_encoded_body_size_values(self, mock_logger_warning: MagicMock) -> None:
+        event = _valid_render_blocking_asset_event("https://example.com/a.js")
+        span = event["spans"][0]
+        span["project_id"] = self.project.id
+        span["organization_id"] = self.project.organization.id
+
+        for invalid_value, expected_description in [
+            (12.31, "non_integer_float"),
+            ("NaN", "non_number_float"),
+            ("[Filtered]", "non_number_string"),
+            ("dogs are great", "non_number_string"),
+        ]:
+            span["data"] = {"http.response_content_length": invalid_value}
+
+            assert self.find_problems(event) == []  # No problem found, but also no crash
+            mock_logger_warning.assert_called_with(
+                "issue_detectors.invalid_data",
+                extra={
+                    "detector": "render_blocking_asset",
+                    "span_id": span["span_id"],
+                    "trace_id": span["trace_id"],
+                    "project_id": span["project_id"],
+                    "org_id": span["organization_id"],
+                    "key": "http.response_content_length",
+                    "value": invalid_value,
+                    "error": (
+                        f"ValueError(\"Couldn't convert <{expected_description}> to <int>. "
+                        + f'Invalid value: {invalid_value}")'
+                    ),
+                },
+            )
 
 
 @pytest.mark.django_db

--- a/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
+++ b/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -444,3 +445,95 @@ class UncompressedAssetsDetectorTest(TestCase):
         )
 
         assert not detector.is_creation_allowed()
+
+    def test_handles_valid_string_values(self) -> None:
+        event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "tags": [["browser.name", "chrome"]],
+            "spans": [
+                create_asset_span(
+                    duration=1000.0,
+                    data={
+                        # These should really be ints
+                        "http.response_transfer_size": "1_000_000",
+                        "http.response_content_length": "1_000_000",
+                        "http.decoded_response_content_length": "1_000_000",
+                    },
+                ),
+                create_compressed_asset_span(),
+            ],
+        }
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1012-6893fb5a8a875d692da96590f40dc6bddd6fcabc",
+                op="resource.script",
+                desc="https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+                type=PerformanceUncompressedAssetsGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"],
+                evidence_data={
+                    "op": "resource.script",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"],
+                },
+                evidence_display=[],
+            )
+        ]
+
+    @patch("sentry.issue_detection.detectors.utils.logger.warning")
+    def test_handles_invalid_encoded_body_size_values(self, mock_logger_warning: MagicMock) -> None:
+        valid_data = {
+            "http.response_transfer_size": 1_000_000,
+            "http.response_content_length": 1_000_000,
+            "http.decoded_response_content_length": 1_000_000,
+        }
+        event: dict[str, Any] = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "tags": [["browser.name", "chrome"]],
+            "spans": [
+                create_asset_span(duration=1000.0, data=valid_data),
+                create_compressed_asset_span(),
+            ],
+        }
+
+        span = event["spans"][0]
+        span["project_id"] = self.project.id
+        span["organization_id"] = self.project.organization.id
+
+        for invalid_value, expected_description in [
+            (12.31, "non_integer_float"),
+            ("NaN", "non_number_float"),
+            ("[Filtered]", "non_number_string"),
+            ("dogs are great", "non_number_string"),
+        ]:
+            for key in [
+                "http.response_transfer_size",
+                "http.response_content_length",
+                "http.decoded_response_content_length",
+            ]:
+                # Only check one invalid value per loop iteration
+                span["data"] = {**valid_data, key: invalid_value}
+
+                assert self.find_problems(event) == []  # No problem found, but also no crash
+
+                mock_logger_warning.assert_called_with(
+                    "issue_detectors.invalid_data",
+                    extra={
+                        "detector": "uncompressed_asset",
+                        "span_id": span["span_id"],
+                        "trace_id": span["trace_id"],
+                        "project_id": span["project_id"],
+                        "org_id": span["organization_id"],
+                        "key": key,
+                        "value": invalid_value,
+                        "error": (
+                            f"ValueError(\"Couldn't convert <{expected_description}> to <int>. "
+                            + f'Invalid value: {invalid_value}")'
+                        ),
+                    },
+                )


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/122016, which added a helper function to safely extract numerical data from spans, actually using the helper in our detectors. In addition to centralizing the logic for handling missing and invalid values, this also fixes two places where we currently crash when confronted with data we don't expect.

Fixes https://sentry.sentry.io/issues/7652716145
Fixes https://sentry.sentry.io/issues/7653388366