### PR TITLE
fix(autofix): Refresh repository write permissions

### DIFF
--- a/static/app/components/events/autofix/useAutofixCreatePrGate.ts
+++ b/static/app/components/events/autofix/useAutofixCreatePrGate.ts
@@ -1,3 +1,5 @@
+import {useCallback} from 'react';
+
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofixRepos';
 import type {Group} from 'sentry/types/group';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
@@ -19,10 +21,18 @@ export function useAutofixCreatePrGate({
 }: {
   group: Pick<Group, 'id'>;
   enabled?: boolean;
-}): {isPending: boolean; permissionsTarget: PermissionsTarget | null} {
-  const repos = useAutofixRepos({group, enabled});
+}): {
+  checkTargetWriteAccess: () => Promise<boolean>;
+  isPending: boolean;
+  permissionsTarget: PermissionsTarget | null;
+} {
+  const {
+    data: reposData,
+    isPending: isReposPending,
+    refetch: refetchRepos,
+  } = useAutofixRepos({group, enabled});
   const integrationIds =
-    repos.data?.repos
+    reposData?.repos
       ?.filter(repo => !repo.has_write_access)
       .map(repo => repo.integration_id) ?? [];
   const {integrations, isPending: isIntegrationsPending} = useIntegrations({
@@ -37,8 +47,28 @@ export function useAutofixCreatePrGate({
       })
       .find(Boolean) ?? null;
 
+  const targetIntegrationId = permissionsTarget?.integration.id;
+  const checkTargetWriteAccess = useCallback(async () => {
+    if (targetIntegrationId === undefined) {
+      return true;
+    }
+
+    const result = await refetchRepos();
+    if (result.isError) {
+      return false;
+    }
+
+    const matchingRepos =
+      result.data?.repos.filter(
+        repo => repo.integration_id === Number(targetIntegrationId)
+      ) ?? [];
+
+    return matchingRepos.length > 0 && matchingRepos.every(repo => repo.has_write_access);
+  }, [targetIntegrationId, refetchRepos]);
+
   return {
+    checkTargetWriteAccess,
+    isPending: enabled && (isReposPending || isIntegrationsPending),
     permissionsTarget,
-    isPending: enabled && (repos.isPending || isIntegrationsPending),
   };
 }

--- a/static/app/components/events/autofix/useAutofixCreatePrGate.ts
+++ b/static/app/components/events/autofix/useAutofixCreatePrGate.ts
@@ -6,7 +6,7 @@ import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {useIntegrations} from 'sentry/utils/integrations/useIntegrations';
 import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepositories/getProviderConfigUrl';
 
-interface PermissionsTarget {
+export interface PermissionsTarget {
   integration: OrganizationIntegration;
   url: string;
 }

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -1,7 +1,8 @@
+import {focusManager} from '@tanstack/react-query';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
 import type {
@@ -538,11 +539,52 @@ describe('SeerDrawerNextStep', () => {
   });
 
   describe('CodeChangesNextStep', () => {
+    const reposUrl = '/organizations/org-slug/issues/1/autofix/repos/';
+
+    function addRepoPermissionsResponse(
+      writeAccess: boolean | boolean[],
+      asyncDelay?: Promise<unknown>
+    ) {
+      const writeAccessByRepo = Array.isArray(writeAccess) ? writeAccess : [writeAccess];
+
+      return MockApiClient.addMockResponse({
+        url: reposUrl,
+        body: {
+          repos: writeAccessByRepo.map(hasWriteAccess => ({
+            has_write_access: hasWriteAccess,
+            has_read_access: true,
+            integration_id: 123,
+          })),
+        },
+        asyncDelay,
+      });
+    }
+
+    function addGithubIntegrationResponse({
+      providerKey = 'github',
+      providerName = 'GitHub',
+    } = {}) {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/123/',
+        body: {
+          id: '123',
+          externalId: '456',
+          accountType: 'Organization',
+          domainName: 'github.com/test-org',
+          provider: {key: providerKey, name: providerName},
+        },
+      });
+    }
+
     beforeEach(() => {
       MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/issues/1/autofix/repos/',
+        url: reposUrl,
         body: {repos: [{has_write_access: true}]},
       });
+    });
+
+    afterEach(() => {
+      focusManager.setFocused(undefined);
     });
 
     it('returns null when section has no artifacts', () => {
@@ -584,6 +626,215 @@ describe('SeerDrawerNextStep', () => {
       );
       await userEvent.click(await screen.findByRole('button', {name: 'Yes, draft a PR'}));
       expect(autofix.createPR).toHaveBeenCalledWith(1);
+    });
+
+    it('checks provider permissions on refocus and proceeds when access is granted', async () => {
+      addRepoPermissionsResponse(false);
+      addGithubIntegrationResponse({
+        providerKey: 'github_enterprise',
+        providerName: 'GitHub Enterprise',
+      });
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {
+          name: 'Yes, view GitHub Enterprise permissions',
+        })
+      );
+      act(() => focusManager.setFocused(false));
+
+      let resolvePermissionsRequest!: () => void;
+      const permissionsRequestDelay = new Promise<void>(resolve => {
+        resolvePermissionsRequest = resolve;
+      });
+      const permissionsRequest = addRepoPermissionsResponse(
+        true,
+        permissionsRequestDelay
+      );
+
+      act(() => focusManager.setFocused(true));
+
+      const checkingButton = screen.getByRole('button', {
+        name: 'Checking GitHub Enterprise permissions',
+      });
+      expect(checkingButton).toHaveAttribute('aria-busy', 'true');
+      expect(permissionsRequest).toHaveBeenCalledTimes(1);
+
+      resolvePermissionsRequest();
+
+      expect(
+        await screen.findByRole('button', {name: 'Yes, draft a PR'})
+      ).toBeInTheDocument();
+    });
+
+    it('offers a retry when the permission check fails', async () => {
+      addRepoPermissionsResponse(false);
+      addGithubIntegrationResponse();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={makeAutofix()}
+        />
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Yes, view GitHub permissions'})
+      );
+      act(() => focusManager.setFocused(false));
+      const permissionsRequest = MockApiClient.addMockResponse({
+        url: reposUrl,
+        statusCode: 500,
+        body: {detail: 'Internal Error'},
+      });
+
+      act(() => focusManager.setFocused(true));
+
+      await waitFor(() => expect(permissionsRequest).toHaveBeenCalledTimes(1));
+      expect(
+        await screen.findByRole('button', {name: 'Check access again'})
+      ).toBeInTheDocument();
+    });
+
+    it('requires write access to every repository in the integration', async () => {
+      addRepoPermissionsResponse([false, false]);
+      addGithubIntegrationResponse();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={makeAutofix()}
+        />
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Yes, view GitHub permissions'})
+      );
+      act(() => focusManager.setFocused(false));
+      const permissionsRequest = addRepoPermissionsResponse([true, false]);
+
+      act(() => focusManager.setFocused(true));
+
+      await waitFor(() => expect(permissionsRequest).toHaveBeenCalledTimes(1));
+      expect(
+        await screen.findByRole('button', {name: 'Check access again'})
+      ).toBeInTheDocument();
+    });
+
+    it('cancels the pending permission check when switching to feedback', async () => {
+      addRepoPermissionsResponse(false);
+      addGithubIntegrationResponse();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={makeAutofix()}
+        />
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Yes, view GitHub permissions'})
+      );
+      const permissionsRequest = addRepoPermissionsResponse(true);
+      act(() => focusManager.setFocused(true));
+      expect(permissionsRequest).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole('button', {name: 'No'}));
+      await userEvent.type(screen.getByRole('textbox'), 'Keep this feedback');
+
+      act(() => focusManager.setFocused(false));
+      act(() => focusManager.setFocused(true));
+
+      expect(permissionsRequest).not.toHaveBeenCalled();
+      expect(screen.getByRole('textbox')).toHaveValue('Keep this feedback');
+    });
+
+    it('preserves feedback when write access is granted', async () => {
+      addRepoPermissionsResponse(false);
+      addGithubIntegrationResponse();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={makeAutofix()}
+        />
+      );
+
+      await userEvent.click(await screen.findByRole('button', {name: 'No'}));
+      await userEvent.type(screen.getByRole('textbox'), 'Keep this feedback');
+      await userEvent.click(
+        screen.getByRole('button', {name: 'View GitHub permissions'})
+      );
+      act(() => focusManager.setFocused(false));
+      const permissionsRequest = addRepoPermissionsResponse(true);
+
+      act(() => focusManager.setFocused(true));
+
+      await waitFor(() => expect(permissionsRequest).toHaveBeenCalledTimes(1));
+      expect(
+        await screen.findByRole('button', {name: 'Nevermind, draft a PR'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('Keep this feedback');
+    });
+
+    it('rechecks after revisiting permissions and supports a manual retry', async () => {
+      addRepoPermissionsResponse(false);
+      addGithubIntegrationResponse();
+      const autofix = makeAutofix();
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes')]}
+          autofix={autofix}
+        />
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Yes, view GitHub permissions'})
+      );
+      act(() => focusManager.setFocused(false));
+      const refocusRequest = addRepoPermissionsResponse(false);
+
+      act(() => focusManager.setFocused(true));
+      await waitFor(() => expect(refocusRequest).toHaveBeenCalledTimes(1));
+      expect(
+        await screen.findByRole('button', {name: 'Check access again'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', {name: 'View GitHub permissions'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Yes, view GitHub permissions'})
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        focusManager.setFocused(false);
+        focusManager.setFocused(true);
+      });
+      expect(refocusRequest).toHaveBeenCalledTimes(1);
+
+      const retryLinkRequest = addRepoPermissionsResponse(false);
+      await userEvent.click(screen.getByRole('link', {name: 'View GitHub permissions'}));
+      act(() => focusManager.setFocused(false));
+      act(() => focusManager.setFocused(true));
+      await waitFor(() => expect(retryLinkRequest).toHaveBeenCalledTimes(1));
+
+      const retryRequest = addRepoPermissionsResponse(true);
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Check access again'})
+      );
+
+      expect(retryRequest).toHaveBeenCalledTimes(1);
+      expect(
+        await screen.findByRole('button', {name: 'Yes, draft a PR'})
+      ).toBeInTheDocument();
     });
 
     it('shows feedback UI on no click', async () => {

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -10,7 +10,10 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
-import {useAutofixCreatePrGate} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
+import {
+  type PermissionsTarget,
+  useAutofixCreatePrGate,
+} from 'sentry/components/events/autofix/useAutofixCreatePrGate';
 import {
   getAutofixArtifactFromSection,
   isCodeChangesSection,
@@ -300,13 +303,9 @@ function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextSte
   );
 }
 
-type CreatePrPermissionsTarget = ReturnType<
-  typeof useAutofixCreatePrGate
->['permissionsTarget'];
-
 interface CodeChangesNextStepContentProps extends NextStepProps {
   checkTargetWriteAccess: () => Promise<boolean>;
-  permissionsTarget: CreatePrPermissionsTarget;
+  permissionsTarget: PermissionsTarget | null;
 }
 
 function CodeChangesNextStepContent({

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,11 +1,10 @@
 import {useCallback, useMemo, useState, type ReactNode} from 'react';
 
-import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
+import {Button, ButtonBar} from '@sentry/scraps/button';
 import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
@@ -23,14 +22,13 @@ import {
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
+import {RepositoryWritePermissionButton} from 'sentry/components/events/autofix/v3/repositoryWritePermissionButton';
 import {useCodingAgents} from 'sentry/components/events/autofix/v3/useCodingAgents';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconChevron} from 'sentry/icons/iconChevron';
-import {IconOpen} from 'sentry/icons/iconOpen';
 import {PluginIcon} from 'sentry/icons/pluginIcon';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -276,7 +274,7 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
 function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextStepProps) {
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
 
-  const {permissionsTarget, isPending} = useAutofixCreatePrGate({
+  const {permissionsTarget, isPending, checkTargetWriteAccess} = useAutofixCreatePrGate({
     group,
     enabled: defined(artifact),
   });
@@ -289,119 +287,37 @@ function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextSte
     return null;
   }
 
-  if (permissionsTarget) {
-    return (
-      <CodeChangesNextStepWithoutWritePermissions
-        group={group}
-        autofix={autofix}
-        runId={runId}
-        section={section}
-        referrer={referrer}
-        integration={permissionsTarget.integration}
-        permissionsUrl={permissionsTarget.url}
-      />
-    );
-  }
-
   return (
-    <CodeChangesNextStepWithWritePermissions
+    <CodeChangesNextStepContent
       group={group}
       autofix={autofix}
       runId={runId}
       section={section}
       referrer={referrer}
+      permissionsTarget={permissionsTarget}
+      checkTargetWriteAccess={checkTargetWriteAccess}
     />
   );
 }
 
-interface CodeChangesNextStepWithoutWritePermissionsProps extends NextStepProps {
-  integration: OrganizationIntegration;
-  permissionsUrl: string;
+type CreatePrPermissionsTarget = ReturnType<
+  typeof useAutofixCreatePrGate
+>['permissionsTarget'];
+
+interface CodeChangesNextStepContentProps extends NextStepProps {
+  checkTargetWriteAccess: () => Promise<boolean>;
+  permissionsTarget: CreatePrPermissionsTarget;
 }
 
-function CodeChangesNextStepWithoutWritePermissions({
+function CodeChangesNextStepContent({
   autofix,
   group,
   runId,
   section,
   referrer,
-  integration,
-  permissionsUrl,
-}: CodeChangesNextStepWithoutWritePermissionsProps) {
-  const organization = useOrganization();
-  const {isPolling, startStep} = autofix;
-
-  const handleNoClick = useCallback(
-    (userContext: string) => {
-      startStep('code_changes', {runId, userContext, insertIndex: section.index});
-      trackAnalytics('autofix.code_changes.re_run', {
-        organization,
-        group_id: group.id,
-        mode: 'explorer',
-        referrer,
-      });
-    },
-    [organization, group, startStep, runId, referrer, section.index]
-  );
-
-  return (
-    <NextStepTemplate
-      isProcessing={isPolling}
-      prompt={t('Are you happy with these code changes?')}
-      labelNo={t('No')}
-      onClickNo={handleNoClick}
-      yesButton={
-        <Tooltip
-          title={t(
-            'You need to grant write permissions for your %s integration',
-            integration.provider.name
-          )}
-        >
-          <LinkButton
-            external
-            openInNewTab
-            variant="primary"
-            disabled={isPolling}
-            to={permissionsUrl}
-            icon={<IconOpen />}
-          >
-            {t('Yes, view %s permissions', integration.provider.name)}
-          </LinkButton>
-        </Tooltip>
-      }
-      nevermindButton={
-        <Tooltip
-          title={t(
-            'You need to grant write permissions for your %s integration',
-            integration.provider.name
-          )}
-        >
-          <LinkButton
-            external
-            openInNewTab
-            variant="primary"
-            disabled={isPolling}
-            to={permissionsUrl}
-            icon={<IconOpen />}
-          >
-            {t('Nevermind, view %s permissions', integration.provider.name)}
-          </LinkButton>
-        </Tooltip>
-      }
-      placeholderPrompt={t('Give seer additional context to improve this code change.')}
-      rethinkPrompt={t('How can this code change be improved?')}
-      labelRethink={t('Rethink code changes')}
-    />
-  );
-}
-
-function CodeChangesNextStepWithWritePermissions({
-  autofix,
-  group,
-  runId,
-  section,
-  referrer,
-}: NextStepProps) {
+  checkTargetWriteAccess,
+  permissionsTarget,
+}: CodeChangesNextStepContentProps) {
   const organization = useOrganization();
   const {isPolling, createPR, startStep} = autofix;
 
@@ -428,22 +344,45 @@ function CodeChangesNextStepWithWritePermissions({
     [organization, group, startStep, runId, referrer, section.index]
   );
 
+  const renderActionButton = (
+    getPermissionsLabel: (providerName: string) => string,
+    readyLabel: string
+  ) => {
+    if (permissionsTarget) {
+      const providerName = permissionsTarget.integration.provider.name;
+      return (
+        <RepositoryWritePermissionButton
+          key={permissionsTarget.integration.id}
+          checkTargetWriteAccess={checkTargetWriteAccess}
+          disabled={isPolling}
+          label={getPermissionsLabel(providerName)}
+          permissionsUrl={permissionsTarget.url}
+          providerName={providerName}
+        />
+      );
+    }
+
+    return (
+      <Button variant="primary" disabled={isPolling} onClick={handleYesClick}>
+        {readyLabel}
+      </Button>
+    );
+  };
+
   return (
     <NextStepTemplate
       isProcessing={isPolling}
       prompt={t('Are you happy with these code changes?')}
       labelNo={t('No')}
       onClickNo={handleNoClick}
-      yesButton={
-        <Button variant="primary" disabled={isPolling} onClick={handleYesClick}>
-          {t('Yes, draft a PR')}
-        </Button>
-      }
-      nevermindButton={
-        <Button variant="primary" disabled={isPolling} onClick={handleYesClick}>
-          {t('Nevermind, draft a PR')}
-        </Button>
-      }
+      yesButton={renderActionButton(
+        providerName => t('Yes, view %s permissions', providerName),
+        t('Yes, draft a PR')
+      )}
+      nevermindButton={renderActionButton(
+        providerName => t('View %s permissions', providerName),
+        t('Nevermind, draft a PR')
+      )}
       placeholderPrompt={t('Give seer additional context to improve this code change.')}
       rethinkPrompt={t('How can this code change be improved?')}
       labelRethink={t('Rethink code changes')}

--- a/static/app/components/events/autofix/v3/repositoryWritePermissionButton.tsx
+++ b/static/app/components/events/autofix/v3/repositoryWritePermissionButton.tsx
@@ -1,0 +1,113 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {focusManager} from '@tanstack/react-query';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {t} from 'sentry/locale';
+
+type RepositoryPermissionCheckPhase = 'ready' | 'checking' | 'retry_available';
+type PermissionFocusCheckPhase = 'idle' | 'awaiting_hidden' | 'awaiting_visible';
+
+interface RepositoryWritePermissionButtonProps {
+  checkTargetWriteAccess: () => Promise<boolean>;
+  label: string;
+  permissionsUrl: string;
+  providerName: string;
+  disabled?: boolean;
+}
+
+export function RepositoryWritePermissionButton({
+  checkTargetWriteAccess,
+  disabled,
+  label,
+  permissionsUrl,
+  providerName,
+}: RepositoryWritePermissionButtonProps) {
+  const [phase, setPhase] = useState<RepositoryPermissionCheckPhase>('ready');
+  const focusCheckPhase = useRef<PermissionFocusCheckPhase>('idle');
+
+  const runCheck = useCallback(async () => {
+    focusCheckPhase.current = 'idle';
+    setPhase('checking');
+
+    const hasWriteAccess = await checkTargetWriteAccess();
+    setPhase(hasWriteAccess ? 'ready' : 'retry_available');
+  }, [checkTargetWriteAccess]);
+
+  useEffect(() => {
+    return focusManager.subscribe(isFocused => {
+      if (!isFocused && focusCheckPhase.current === 'awaiting_hidden') {
+        focusCheckPhase.current = 'awaiting_visible';
+        return;
+      }
+
+      if (isFocused && focusCheckPhase.current === 'awaiting_visible') {
+        void runCheck();
+      }
+    });
+  }, [runCheck]);
+
+  const checkAfterReturning = () => {
+    focusCheckPhase.current = 'awaiting_hidden';
+  };
+
+  switch (phase) {
+    case 'checking':
+      return (
+        <Button variant="primary" busy disabled>
+          {t('Checking %s permissions', providerName)}
+        </Button>
+      );
+    case 'retry_available': {
+      const viewPermissionsLabel = t('View %s permissions', providerName);
+
+      return (
+        <Flex gap="md" align="center">
+          <Button
+            variant="primary"
+            tooltipProps={{
+              title: t(
+                "We couldn't confirm write access. Check your %s permissions, then try again.",
+                providerName
+              ),
+            }}
+            onClick={() => void runCheck()}
+          >
+            {t('Check access again')}
+          </Button>
+          <ExternalLink href={permissionsUrl} onClick={checkAfterReturning}>
+            <Flex as="span" display="inline-flex" gap="xs" align="center">
+              <Text as="span" variant="inherit">
+                {viewPermissionsLabel}
+              </Text>
+              <IconOpen size="xs" />
+            </Flex>
+          </ExternalLink>
+        </Flex>
+      );
+    }
+    case 'ready':
+      return (
+        <LinkButton
+          external
+          variant="primary"
+          disabled={disabled}
+          href={permissionsUrl}
+          icon={<IconOpen />}
+          tooltipProps={{
+            title: t(
+              'You need to grant write permissions for your %s integration',
+              providerName
+            ),
+          }}
+          onClick={checkAfterReturning}
+        >
+          {label}
+        </LinkButton>
+      );
+  }
+}


### PR DESCRIPTION
Autofix now rechecks repository write access when a user returns from their provider's permissions page. If access still cannot be confirmed, the action presents a manual retry and a link back to the provider settings instead of leaving the user stuck on stale permission data.

The shared create-PR gate owns refreshing and interpreting repository access, while the drawer-specific button owns focus and retry presentation. The check remains conservative for integrations containing multiple repositories: every matching repository must have write access before Autofix proceeds.

Refs AIML-3365

---

Here's a simulated flow showing the idea if you were to go to the GH app permissions page, then return and we didn't see the updated permissions yet, and then you had to manually refresh once to get them to be visible:

https://github.com/user-attachments/assets/911f26ec-61ce-42b7-91fe-15ecc8a95215


