### PR TITLE
ref(weekly-reports): add a TTL to the min_org_id progress key

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -76,10 +76,7 @@ class WeeklyReportProgressTracker:
 
     REPORT_REDIS_CLIENT_KEY: Final[str] = "weekly_reports_org_id_min"
 
-    # The progress marker only has to outlive a single run of
-    # `schedule_organizations`. The task has a 30 minute processing deadline and
-    # retries up to 5 times, so 3 days is well above the worst case and well
-    # below the weekly cadence of the task.
+    # 3 days to outlive all possible retries of a weekly report schedule run
     MIN_ORG_ID_TTL: Final[timedelta] = timedelta(days=3)
 
     def __init__(self, timestamp: float | None = None, duration: int | None = None):

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -76,6 +76,12 @@ class WeeklyReportProgressTracker:
 
     REPORT_REDIS_CLIENT_KEY: Final[str] = "weekly_reports_org_id_min"
 
+    # The progress marker only has to outlive a single run of
+    # `schedule_organizations`. The task has a 30 minute processing deadline and
+    # retries up to 5 times, so 3 days is well above the worst case and well
+    # below the weekly cadence of the task.
+    MIN_ORG_ID_TTL: Final[timedelta] = timedelta(days=3)
+
     def __init__(self, timestamp: float | None = None, duration: int | None = None):
         if timestamp is None:
             # The time that the report was generated
@@ -101,7 +107,7 @@ class WeeklyReportProgressTracker:
         return int(min_org_id_from_redis) if min_org_id_from_redis else None
 
     def set_last_processed_org_id(self, org_id: int) -> None:
-        self._redis_connection.set(self.min_org_id_redis_key, org_id)
+        self._redis_connection.set(self.min_org_id_redis_key, org_id, ex=self.MIN_ORG_ID_TTL)
 
     def delete_min_org_id(self) -> None:
         self._redis_connection.delete(self.min_org_id_redis_key)

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -39,6 +39,7 @@ from sentry.tasks.summaries.utils import (
 from sentry.tasks.summaries.weekly_reports import (
     CHART_PALETTE,
     OrganizationReportBatch,
+    WeeklyReportProgressTracker,
     _pct_change,
     date_format,
     group_status_to_color,
@@ -1597,6 +1598,48 @@ class WeeklyReportsTest(
 
             # Verify that the expected key was used
             assert expected_key in set_keys, f"Expected key {expected_key} not found in {set_keys}"
+
+    def test_set_last_processed_org_id_sets_a_ttl(self) -> None:
+        """The progress marker expires on its own, so an interrupted run cannot leak it."""
+        timestamp = self.timestamp
+        redis_cluster = redis.clusters.get("default").get_local_client_for_key(
+            "weekly_reports_org_id_min"
+        )
+        key = f"weekly_reports_org_id_min:{timestamp}"
+        redis_cluster.delete(key)
+
+        tracker = WeeklyReportProgressTracker(timestamp=timestamp)
+        tracker.set_last_processed_org_id(self.organization.id)
+
+        ttl = redis_cluster.ttl(key)
+        assert 0 < ttl <= WeeklyReportProgressTracker.MIN_ORG_ID_TTL.total_seconds()
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
+    def test_schedule_organizations_leaves_a_ttl_when_the_run_fails(
+        self, mock_prepare_organization_report: mock.MagicMock
+    ) -> None:
+        """A run that dies before delete_min_org_id must not leave a key without a TTL."""
+        timestamp = self.timestamp
+        redis_cluster = redis.clusters.get("default").get_local_client_for_key(
+            "weekly_reports_org_id_min"
+        )
+        key = f"weekly_reports_org_id_min:{timestamp}"
+        redis_cluster.delete(key)
+
+        assert self.organization is not None
+        self.create_organization(name="Another Org")
+        # Fail after the first organization is scheduled and recorded, so that the
+        # task raises with the progress marker already written.
+        mock_prepare_organization_report.delay.side_effect = [None, ValueError("boom")]
+
+        with pytest.raises(ValueError):
+            schedule_organizations(timestamp=timestamp)
+
+        assert mock_prepare_organization_report.delay.call_count == 2
+
+        assert redis_cluster.get(key) is not None
+        ttl = redis_cluster.ttl(key)
+        assert 0 < ttl <= WeeklyReportProgressTracker.MIN_ORG_ID_TTL.total_seconds()
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_organization_report")
     def test_schedule_organizations_starts_from_beginning_when_no_redis_key(


### PR DESCRIPTION
Problem: `schedule_organizations` uses a Redis key as a progress marker so an interrupted run can resume from the last org it scheduled. `weekly_reports_org_id_min:{beginning_of_day_timestamp}` is written with no expiry, and `delete_min_org_id` removes it at the end of the run. A run that dies before that delete leaks the key forever, because nothing else ever touches that timestamped key again.

Fix: pass `ex=` on the existing `set` rather than adding a separate `expire`. The key is rewritten for each org, so the expiry slides forward while the run makes progress, which is what you want for a progress marker.

Refs INFRENG-461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
