### PR TITLE
fix(grouping): Filter out invalid bases in `EnhancementsConfig` objects

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -85,6 +85,8 @@ def _merge_rust_enhancements(
     This will merge the parsed enhancements together with the `bases`.
     It pretty much concatenates all the rules in `bases` (in order) together
     with all the rules in the incoming `rust_enhancements`.
+
+    Note: Assumes all of the passed bases are valid.
     """
     merged_rust_enhancements = RustEnhancements.empty()
     for base_id in bases:

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -403,7 +403,8 @@ class EnhancementsConfig:
         self.id = id
         self.rules = rules
         self.version = version or DEFAULT_ENHANCEMENTS_VERSION
-        self.bases = bases or []
+        # To be safe, filter out invalid base ids (shouldn't ever happen in practice, though)
+        self.bases = [base_id for base_id in (bases or []) if base_id in ENHANCEMENT_BASES]
 
         classifier_config, contributes_config = split_enhancement_configs or _split_rules(rules)
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -88,14 +88,13 @@ def _merge_rust_enhancements(
     """
     merged_rust_enhancements = RustEnhancements.empty()
     for base_id in bases:
-        base = ENHANCEMENT_BASES.get(base_id)
-        if base:
-            base_rust_enhancements = (
-                base.classifier_rust_enhancements
-                if type == "classifier"
-                else base.contributes_rust_enhancements
-            )
-            merged_rust_enhancements.extend_from(base_rust_enhancements)
+        base = ENHANCEMENT_BASES[base_id]
+        base_rust_enhancements = (
+            base.classifier_rust_enhancements
+            if type == "classifier"
+            else base.contributes_rust_enhancements
+        )
+        merged_rust_enhancements.extend_from(base_rust_enhancements)
     merged_rust_enhancements.extend_from(rust_enhancements)
     return merged_rust_enhancements
 

--- a/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing/3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing/3.pysnap
@@ -2,7 +2,7 @@
 source: tests/sentry/grouping/test_enhancer.py::test_basic_parsing
 ---
 bases:
-- common:v1
+- all-platforms:2026-01-20
 classifier_rules:
 - actions:
   - flag: true

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -75,7 +75,7 @@ def test_basic_parsing(insta_snapshot: InstaSnapshotter, version: int) -> None:
             family:native                                   max-frames=3
             error.value:"*something*"                       max-frames=12
         """,
-        bases=["common:v1"],
+        bases=[DEFAULT_ENHANCEMENTS_BASE],
         version=version,
     )
 


### PR DESCRIPTION
This is a small fix to an issue I came across during hackweek, where we theoretically allow `EnhancementsConfig` objects to be instantiated with invalid `base` values. Though this never happens in practice, given earlier checks in the grouping-config-loading pipeline, it still requires us to include "does this base actually exist?" checks later on in our code for typesafety.

Given an upcoming fix which will otherwise need to add another such only-theoretically-necessary base-existence check, this removes all possibility of things going wrong by only using bases we've confirmed exist when creating `EnhancementsConfig` objects, which in turn allows the existing check to be simplified. This PR also updates a snapshot test with an now-outdated `base` value to always use the default one, since that's what actually happens in prod.