### PR TITLE
fix(metrics): restore MetricInfoTabs additionalActions prop

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -19,10 +19,15 @@ import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
 
 interface MetricInfoTabsProps {
   traceMetric: TraceMetric;
+  additionalActions?: React.ReactNode;
   isMetricOptionsEmpty?: boolean;
 }
 
-export function MetricInfoTabs({traceMetric, isMetricOptionsEmpty}: MetricInfoTabsProps) {
+export function MetricInfoTabs({
+  traceMetric,
+  additionalActions,
+  isMetricOptionsEmpty,
+}: MetricInfoTabsProps) {
   const visualize = useMetricVisualize();
   const queryParamsMode = useQueryParamsMode();
   const setAggregatesMode = useSetQueryParamsMode();
@@ -54,6 +59,7 @@ export function MetricInfoTabs({traceMetric, isMetricOptionsEmpty}: MetricInfoTa
                 <TabList.Item key={Mode.AGGREGATE}>{t('Aggregates')}</TabList.Item>
               </TabList>
             </TabListWrapper>
+            {additionalActions}
           </Flex>
         ) : null}
         {visualize.visible ? (


### PR DESCRIPTION
Master is failing typecheck:

```
static/app/views/explore/metrics/metricPanel/index.tsx(347,25): error TS2322: Type '{ traceMetric: TraceMetric; isMetricOptionsEmpty: boolean; additionalActions: Element; }' is not assignable to type 'IntrinsicAttributes & MetricInfoTabsProps'.
```

Semantic conflict between two PRs (from me 😬) that landed close together:

- #122234 (unused-props cleanup) removed `additionalActions` from `MetricInfoTabsProps`, since nothing passed it at the time.
- #122041 (metrics export button) started passing `additionalActions` to `MetricInfoTabs`.

Each was correct against its own base. Together, master doesn't typecheck and the export button never renders.

This restores the `additionalActions` prop and renders it in the tab bar row, matching how it worked before #122234. 