### PR TITLE
style(inbox): Reduce preview comment composer height

### DIFF
--- a/static/app/views/issueDetails/issuePreview/issuePreview.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.spec.tsx
@@ -94,6 +94,9 @@ describe('IssuePreview', () => {
       await screen.findByRole('button', {name: 'View example/repo-name#10'})
     ).toHaveAttribute('href', 'https://github.com/example/repo-name/pull/10');
     expect(screen.getByRole('button', {name: 'Find Root Cause'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Add a comment'})).toHaveStyle({
+      minHeight: '48px',
+    });
   });
 
   it('offers to restart Autofix after PR creation when the linked PR is closed', async () => {

--- a/static/app/views/issueDetails/issuePreview/issuePreview.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.spec.tsx
@@ -94,9 +94,6 @@ describe('IssuePreview', () => {
       await screen.findByRole('button', {name: 'View example/repo-name#10'})
     ).toHaveAttribute('href', 'https://github.com/example/repo-name/pull/10');
     expect(screen.getByRole('button', {name: 'Find Root Cause'})).toBeInTheDocument();
-    expect(screen.getByRole('textbox', {name: 'Add a comment'})).toHaveStyle({
-      minHeight: '40px',
-    });
   });
 
   it('offers to restart Autofix after PR creation when the linked PR is closed', async () => {

--- a/static/app/views/issueDetails/issuePreview/issuePreview.spec.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.spec.tsx
@@ -95,7 +95,7 @@ describe('IssuePreview', () => {
     ).toHaveAttribute('href', 'https://github.com/example/repo-name/pull/10');
     expect(screen.getByRole('button', {name: 'Find Root Cause'})).toBeInTheDocument();
     expect(screen.getByRole('textbox', {name: 'Add a comment'})).toHaveStyle({
-      minHeight: '48px',
+      minHeight: '40px',
     });
   });
 

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -268,6 +268,7 @@ function IssuePreviewContent() {
               >
                 <ActivitySection
                   group={group}
+                  minHeight={48}
                   variant="standalone"
                   placeholder={t('Add a comment. Tag users with @, or teams with #')}
                 />

--- a/static/app/views/issueDetails/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreview.tsx
@@ -268,7 +268,7 @@ function IssuePreviewContent() {
               >
                 <ActivitySection
                   group={group}
-                  minHeight={48}
+                  minHeight={40}
                   variant="standalone"
                   placeholder={t('Add a comment. Tag users with @, or teams with #')}
                 />


### PR DESCRIPTION
The inbox issue preview now uses a compact two-line comment composer with a
40px content height, roughly twice the height of the one-line issue-details
sidebar composer. This keeps more of the activity timeline visible without
changing the standalone editor's submission behavior.

Refs [ISWF-3217](https://linear.app/getsentry/issue/ISWF-3217/update-activity-comment-box-size).
