### PR TITLE
fix(admin): keep auth token last chars visible in narrow tables

### DIFF
--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -68,8 +68,6 @@ describe('ApiTokenRow', () => {
     renderRow(<ApiTokenRow onRemove={jest.fn()} token={token} />);
 
     expect(screen.getByText('Codespaces')).toBeInTheDocument();
-    expect(screen.getByLabelText('Token preview')).toHaveTextContent(
-      '************14e3'
-    );
+    expect(screen.getByLabelText('Token preview')).toHaveTextContent('************14e3');
   });
 });

--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -54,6 +54,22 @@ describe('ApiTokenRow', () => {
 
     const cb = jest.fn();
     renderRow(<ApiTokenRow onRemove={cb} token={token} canEdit />);
-    expect(screen.getByLabelText('Token preview')).toBeInTheDocument();
+    expect(screen.getByLabelText('Token preview')).toHaveTextContent(
+      '************a1b2c3d4'
+    );
+  });
+
+  it('keeps token name and last characters visible for long names', () => {
+    const token = ApiTokenFixture({
+      name: 'Codespaces',
+      tokenLastCharacters: '14e3',
+    });
+
+    renderRow(<ApiTokenRow onRemove={jest.fn()} token={token} />);
+
+    expect(screen.getByText('Codespaces')).toBeInTheDocument();
+    expect(screen.getByLabelText('Token preview')).toHaveTextContent(
+      '************14e3'
+    );
   });
 });

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -25,8 +25,8 @@ export function ApiTokenRow({
 }: Props) {
   return (
     <SimpleTable.Row>
-      <SimpleTable.RowCell>
-        {token.name}
+      <SimpleTable.RowCell direction="column" align="start">
+        <TokenName>{token.name}</TokenName>
         <TokenPreview aria-label={t('Token preview')}>
           {tokenPreview(token.tokenLastCharacters)}
         </TokenPreview>
@@ -66,6 +66,8 @@ const ScopeList = styled('div')`
   font-family: ${p => p.theme.font.family.mono};
   font-size: ${p => p.theme.font.size.sm};
   max-width: 400px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 `;
 
 const Actions = styled(SimpleTable.RowCell)`
@@ -73,6 +75,17 @@ const Actions = styled(SimpleTable.RowCell)`
   gap: ${p => p.theme.space.md};
 `;
 
+const TokenName = styled('div')`
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+`;
+
 const TokenPreview = styled('div')`
   color: ${p => p.theme.tokens.content.secondary};
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-all;
 `;

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -28,10 +28,10 @@ type Props = {
 };
 
 const USER_TOKEN_COLUMNS: TableColumnConfig[] = [
-  {key: 'token', width: 'auto'},
-  {key: 'created', width: 'auto'},
-  {key: 'scopes', width: 'auto'},
-  {key: 'actions', width: 'auto'},
+  {key: 'token'},
+  {key: 'created', width: 'min-content'},
+  {key: 'scopes'},
+  {key: 'actions', width: 'min-content'},
 ];
 
 function identityLabel(identity: UserIdentityConfig) {


### PR DESCRIPTION
Stack token name and preview in the token cell and allow wrapping so long names no longer clip trailing characters in the Auth Tokens section of _admin. Those trailing characters are often invisible and it's what is primarily used to identify tokens. 
