### PR TITLE
feat(seer-infra-telemetry): Show read-only config on GCP integration configure page

### DIFF
--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping
 from typing import Any, TypedDict, cast
 
 from django.http.request import HttpRequest
@@ -143,11 +143,47 @@ class GcpIntegration(IntegrationInstallation):
         if sa_email:
             delete_sentry_sa(sa_email, self.organization_id)
 
-    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
-        pass
+    def get_organization_config(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "sentry_sa_email",
+                "type": "string",
+                "label": _("Sentry Service Account"),
+                "help": _(
+                    "Auto-generated service account in the sentry-connectors project. "
+                    "Your customer SA must grant this account the "
+                    "roles/iam.serviceAccountTokenCreator role."
+                ),
+                "readonly": True,
+            },
+            {
+                "name": "customer_sa_email",
+                "type": "string",
+                "label": _("Customer Service Account"),
+                "help": _(
+                    "Your GCP service account that the Sentry SA impersonates. "
+                    "It must have viewer roles on the configured projects."
+                ),
+                "readonly": True,
+            },
+            {
+                "name": "projects",
+                "type": "string",
+                "label": _("GCP Project IDs"),
+                "help": _("To update, uninstall and re-install the integration."),
+                "readonly": True,
+            },
+        ]
 
-    def get_organization_config(self) -> Sequence[Any]:
-        return []
+    def get_config_data(self) -> Mapping[str, Any]:
+        config = self.gcp_config
+        if not config:
+            return {}
+        return {
+            "sentry_sa_email": config.get("sentry_sa_email", ""),
+            "customer_sa_email": config.get("customer_sa_email", ""),
+            "projects": ", ".join(config.get("projects", [])),
+        }
 
     def get_client(self) -> Any:
         raise NotImplementedError

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any, TypedDict, cast
 
 from django.http.request import HttpRequest
@@ -154,7 +154,8 @@ class GcpIntegration(IntegrationInstallation):
                     "Your customer SA must grant this account the "
                     "roles/iam.serviceAccountTokenCreator role."
                 ),
-                "readonly": True,
+                "disabled": True,
+                "disabledReason": _("Managed by Sentry"),
             },
             {
                 "name": "customer_sa_email",
@@ -164,14 +165,16 @@ class GcpIntegration(IntegrationInstallation):
                     "Your GCP service account that the Sentry SA impersonates. "
                     "It must have viewer roles on the configured projects."
                 ),
-                "readonly": True,
+                "disabled": True,
+                "disabledReason": _("To update, uninstall and re-install the integration."),
             },
             {
                 "name": "projects",
                 "type": "string",
                 "label": _("GCP Project IDs"),
-                "help": _("To update, uninstall and re-install the integration."),
-                "readonly": True,
+                "help": _("Comma-separated list of GCP project IDs."),
+                "disabled": True,
+                "disabledReason": _("To update, uninstall and re-install the integration."),
             },
         ]
 
@@ -184,6 +187,9 @@ class GcpIntegration(IntegrationInstallation):
             "customer_sa_email": config.get("customer_sa_email", ""),
             "projects": ", ".join(config.get("projects", [])),
         }
+
+    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+        pass
 
     def get_client(self) -> Any:
         raise NotImplementedError

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -259,13 +259,42 @@ class GcpIntegrationTest(TestCase):
 
     def test_update_organization_config_is_noop(self) -> None:
         installation = self._create_installed_integration()
-        original_config = installation.gcp_config
-        assert original_config is not None
 
         installation.update_organization_config({"sentry_sa_email": "evil@attacker.com"})
 
         oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
-        assert oi.config == original_config
+        assert oi.config["sentry_sa_email"] == _SA_EMAIL
+        assert oi.config["customer_sa_email"] == _CUSTOMER_SA
+        assert oi.config["projects"] == ["my-gcp-project"]
+
+    def test_get_organization_config_returns_disabled_fields(self) -> None:
+        installation = self._create_installed_integration()
+        fields = installation.get_organization_config()
+
+        assert len(fields) == 3
+        names = [f["name"] for f in fields]
+        assert names == ["sentry_sa_email", "customer_sa_email", "projects"]
+        for field in fields:
+            assert field["disabled"] is True
+
+    def test_get_config_data_flattens_projects(self) -> None:
+        installation = self._create_installed_integration(
+            projects=["project-a", "project-b", "project-c"]
+        )
+        data = installation.get_config_data()
+
+        assert data["sentry_sa_email"] == _SA_EMAIL
+        assert data["customer_sa_email"] == _CUSTOMER_SA
+        assert data["projects"] == "project-a, project-b, project-c"
+
+    def test_get_config_data_empty_without_config(self) -> None:
+        installation = self._create_installed_integration()
+        oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
+        oi.update(config={})
+
+        installation = oi.integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, GcpIntegration)
+        assert installation.get_config_data() == {}
 
     # -- Uninstall: SA deletion --
 

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -288,13 +288,13 @@ class GcpIntegrationTest(TestCase):
         assert data["projects"] == "project-a, project-b, project-c"
 
     def test_get_config_data_empty_without_config(self) -> None:
-        installation = self._create_installed_integration()
+        self._create_installed_integration()
         oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
         oi.update(config={})
 
-        installation = oi.integration.get_installation(organization_id=self.organization.id)
-        assert isinstance(installation, GcpIntegration)
-        assert installation.get_config_data() == {}
+        reinstalled = oi.integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(reinstalled, GcpIntegration)
+        assert reinstalled.get_config_data() == {}
 
     # -- Uninstall: SA deletion --
 


### PR DESCRIPTION
The GCP integration configure page (`/settings/integrations/gcp/{id}/)`) was blank because `get_organization_config()` returned `[]`. This is now implemented so that three read-only fields are returned: Sentry SA email, customer SA email, and GCP project IDs. In the future, these fields can be made editable, in which case we also have to rerun the install pipeline's validation. Currently, to reconfigure, users uninstall and re-install.