### PR TITLE
ref(autofix): Make the GitHub App permissions warning CI-specific

### DIFF
--- a/static/app/components/events/autofix/v3/drawer.spec.tsx
+++ b/static/app/components/events/autofix/v3/drawer.spec.tsx
@@ -26,7 +26,7 @@ describe('AutofixWarnings', () => {
     );
 
     expect(screen.getAllByText('getsentry/sentry')).toHaveLength(1);
-    expect(screen.getByText(/The configured GitHub App for/)).toBeInTheDocument();
+    expect(screen.getByText(/Seer can't fix the failing CI/)).toBeInTheDocument();
   });
 
   it('renders fallback copy when repo names are missing', () => {
@@ -44,9 +44,9 @@ describe('AutofixWarnings', () => {
 
     expect(
       screen.getByText(
-        'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
+        "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app."
       )
     ).toBeInTheDocument();
-    expect(screen.queryByText(/The configured GitHub App for/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/on your pull request in/)).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/v3/drawer.spec.tsx
+++ b/static/app/components/events/autofix/v3/drawer.spec.tsx
@@ -26,7 +26,7 @@ describe('AutofixWarnings', () => {
     );
 
     expect(screen.getAllByText('getsentry/sentry')).toHaveLength(1);
-    expect(screen.getByText(/The configured GitHub App for/)).toBeInTheDocument();
+    expect(screen.getByText(/Seer can't fix the failing CI/)).toBeInTheDocument();
   });
 
   it('renders fallback copy when repo names are missing', () => {
@@ -44,9 +44,9 @@ describe('AutofixWarnings', () => {
 
     expect(
       screen.getByText(
-        'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
+        "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app and ask Seer to retry."
       )
     ).toBeInTheDocument();
-    expect(screen.queryByText(/The configured GitHub App for/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/on your pull request in/)).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -260,13 +260,13 @@ export function AutofixWarnings({
       >
         {repoNames.length
           ? tct(
-              'The configured GitHub App for [repoNames] is missing permissions. Update the app and ask Seer to retry.',
+              "Seer can't fix the failing CI on your pull request because the configured GitHub App for [repoNames] is missing permissions. Update the app.",
               {
                 repoNames: repoNamesNode,
               }
             )
           : t(
-              'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
+              "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app."
             )}
       </Alert>
     </Stack>

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -260,13 +260,13 @@ export function AutofixWarnings({
       >
         {repoNames.length
           ? tct(
-              'The configured GitHub App for [repoNames] is missing permissions. Update the app and ask Seer to retry.',
+              "Seer can't fix the failing CI on your pull request because the configured GitHub App for [repoNames] is missing permissions. Update the app and ask Seer to retry.",
               {
                 repoNames: repoNamesNode,
               }
             )
           : t(
-              'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
+              "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app and ask Seer to retry."
             )}
       </Alert>
     </Stack>


### PR DESCRIPTION
The Autofix drawer's GitHub App permissions warning currently reads:

> The configured GitHub App for `owner/repo` is missing permissions. Update the app and ask Seer to retry.

That copy predates the warning having a specific trigger. In the backend change that follows this one, the warning is only returned when Seer had CI feedback queued for an open PR and refused to iterate because the installation was missing a required scope — so the alert can say what actually happened:

> Seer can't fix the failing CI on your pull request because the configured GitHub App for `owner/repo` is missing permissions. Update the app and ask Seer to retry.

Plain and direct rather than in Sentry voice, per the [Content & Voice](https://develop.sentry.dev/frontend/sentry-voice/) guidance — alerts are on the "don't use Sentry voice" list, and anyone reading this is already stuck on something.

Frontend-only, so it ships separately from the backend work. There's no ordering dependency: the response shape is unchanged and this needs no new API field. Landing it before the backend just means the sharper wording shows up on the existing (broader) trigger for a while.