### PR TITLE
fix(inbox): include identified issues in assigned section

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -551,7 +551,7 @@ describe('InboxPage', () => {
     mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]);
     mockSection('issue.progress:diagnosed is:unresolved', [diagnosedGroup]);
     const assignedAllRequest = mockSection(
-      'issue.progress:[assigned,identified] is:unresolved',
+      'issue.progress:[assigned,identified] is:unresolved !assigned_or_suggested:none',
       [assignedGroup]
     );
     mockSection('issue.progress:fix_applied is:unresolved', []);
@@ -675,7 +675,10 @@ describe('InboxPage', () => {
     const allRequests = [
       mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]),
       mockSection('issue.progress:diagnosed is:unresolved', [diagnosedGroup]),
-      mockSection('issue.progress:[assigned,identified] is:unresolved', [assignedGroup]),
+      mockSection(
+        'issue.progress:[assigned,identified] is:unresolved !assigned_or_suggested:none',
+        [assignedGroup]
+      ),
       mockSection('issue.progress:fix_applied is:unresolved', []),
     ];
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -529,7 +529,7 @@ describe('InboxPage', () => {
     expect(screen.getByText('Page Not Found')).toBeInTheDocument();
   });
 
-  it('includes identified issues in Assigned without a separate section', async () => {
+  it('includes identified issues in Assigned for scoped assignee tabs', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     mockSection(
@@ -550,10 +550,9 @@ describe('InboxPage', () => {
     );
     mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]);
     mockSection('issue.progress:diagnosed is:unresolved', [diagnosedGroup]);
-    const assignedAllRequest = mockSection(
-      'issue.progress:[assigned,identified] is:unresolved !assigned_or_suggested:none',
-      [assignedGroup]
-    );
+    const assignedAllRequest = mockSection('issue.progress:assigned is:unresolved', [
+      assignedGroup,
+    ]);
     mockSection('issue.progress:fix_applied is:unresolved', []);
 
     render(<InboxPage />, {
@@ -579,12 +578,12 @@ describe('InboxPage', () => {
   it('shows the total issue count for each assignee tab', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
-    MockApiClient.addMockResponse({
+    const countRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues-count/',
       body: {
         [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 10,
         [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 49,
-        [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 100,
+        [`issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 100,
       },
     });
 
@@ -593,6 +592,18 @@ describe('InboxPage', () => {
     expect(await screen.findByRole('radio', {name: 'Me 10'})).toBeInTheDocument();
     expect(screen.getByRole('radio', {name: 'My Teams 49'})).toBeInTheDocument();
     expect(screen.getByRole('radio', {name: 'All 99+'})).toBeInTheDocument();
+    expect(countRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          query: [
+            `issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+            `issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+            `issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+          ],
+        },
+      })
+    );
   });
 
   it('shows a plus sign when a section count reaches the API cap', async () => {
@@ -675,10 +686,7 @@ describe('InboxPage', () => {
     const allRequests = [
       mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]),
       mockSection('issue.progress:diagnosed is:unresolved', [diagnosedGroup]),
-      mockSection(
-        'issue.progress:[assigned,identified] is:unresolved !assigned_or_suggested:none',
-        [assignedGroup]
-      ),
+      mockSection('issue.progress:assigned is:unresolved', [assignedGroup]),
       mockSection('issue.progress:fix_applied is:unresolved', []),
     ];
 

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -191,12 +191,11 @@ describe('InboxPage', () => {
         2
       ),
       mockSection(
-        'issue.progress:assigned is:unresolved assigned_or_suggested:me',
+        'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:me',
         [assignedGroup],
         200,
         12
       ),
-      mockSection('issue.progress:identified is:unresolved assigned_or_suggested:me', []),
       mockSection(
         'issue.progress:fix_applied is:unresolved assigned_or_suggested:me',
         []
@@ -346,8 +345,7 @@ describe('InboxPage', () => {
     for (const [index, query] of [
       'issue.progress:fix_proposed is:unresolved assigned_or_suggested:me',
       'issue.progress:diagnosed is:unresolved assigned_or_suggested:me',
-      'issue.progress:assigned is:unresolved assigned_or_suggested:me',
-      'issue.progress:identified is:unresolved assigned_or_suggested:me',
+      'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:me',
       'issue.progress:fix_applied is:unresolved assigned_or_suggested:me',
     ].entries()) {
       await waitFor(() =>
@@ -490,8 +488,10 @@ describe('InboxPage', () => {
     mockSection('issue.progress:diagnosed is:unresolved assigned_or_suggested:me', [
       groupWithSuggestedOwner,
     ]);
-    mockSection('issue.progress:assigned is:unresolved assigned_or_suggested:me', []);
-    mockSection('issue.progress:identified is:unresolved assigned_or_suggested:me', []);
+    mockSection(
+      'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:me',
+      []
+    );
     mockSection('issue.progress:fix_applied is:unresolved assigned_or_suggested:me', []);
     const suggestedOwnerRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
@@ -529,7 +529,7 @@ describe('InboxPage', () => {
     expect(screen.getByText('Page Not Found')).toBeInTheDocument();
   });
 
-  it('hides the Identified section on the All assignee tab', async () => {
+  it('includes identified issues in Assigned without a separate section', async () => {
     mockSuccessfulSections();
     mockIssuePreview();
     mockSection(
@@ -540,13 +540,9 @@ describe('InboxPage', () => {
       'issue.progress:diagnosed is:unresolved assigned_or_suggested:[me,my_teams]',
       [diagnosedGroup]
     );
-    mockSection(
-      'issue.progress:assigned is:unresolved assigned_or_suggested:[me,my_teams]',
+    const assignedMyTeamsRequest = mockSection(
+      'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]',
       [assignedGroup]
-    );
-    const identifiedMyTeamsRequest = mockSection(
-      'issue.progress:identified is:unresolved assigned_or_suggested:[me,my_teams]',
-      []
     );
     mockSection(
       'issue.progress:fix_applied is:unresolved assigned_or_suggested:[me,my_teams]',
@@ -554,7 +550,10 @@ describe('InboxPage', () => {
     );
     mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]);
     mockSection('issue.progress:diagnosed is:unresolved', [diagnosedGroup]);
-    mockSection('issue.progress:assigned is:unresolved', [assignedGroup]);
+    const assignedAllRequest = mockSection(
+      'issue.progress:[assigned,identified] is:unresolved',
+      [assignedGroup]
+    );
     mockSection('issue.progress:fix_applied is:unresolved', []);
 
     render(<InboxPage />, {
@@ -562,19 +561,19 @@ describe('InboxPage', () => {
       initialRouterConfig,
     });
 
-    // Identified should be visible on the default "Me" tab
-    expect(screen.getByRole('region', {name: 'Identified'})).toBeInTheDocument();
+    expect(screen.queryByRole('region', {name: 'Identified'})).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('radio', {name: /^My Teams/}));
 
-    expect(screen.getByRole('region', {name: 'Identified'})).toBeInTheDocument();
-    await waitFor(() => expect(identifiedMyTeamsRequest).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('region', {name: 'Identified'})).not.toBeInTheDocument();
+    await waitFor(() => expect(assignedMyTeamsRequest).toHaveBeenCalledTimes(1));
 
     const allFilter = screen.getByRole('radio', {name: /^All/});
     await userEvent.click(allFilter);
 
     expect(allFilter).toBeChecked();
     expect(screen.queryByRole('region', {name: 'Identified'})).not.toBeInTheDocument();
+    await waitFor(() => expect(assignedAllRequest).toHaveBeenCalledTimes(1));
   });
 
   it('shows the total issue count for each assignee tab', async () => {
@@ -583,9 +582,9 @@ describe('InboxPage', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues-count/',
       body: {
-        [`issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 10,
-        [`issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved assigned_or_suggested:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 49,
-        [`issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 100,
+        [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 10,
+        [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 49,
+        [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 100,
       },
     });
 
@@ -611,10 +610,10 @@ describe('InboxPage', () => {
     mockSection('issue.progress:diagnosed is:unresolved assigned_or_suggested:me', [
       diagnosedGroup,
     ]);
-    mockSection('issue.progress:assigned is:unresolved assigned_or_suggested:me', [
-      assignedGroup,
-    ]);
-    mockSection('issue.progress:identified is:unresolved assigned_or_suggested:me', []);
+    mockSection(
+      'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:me',
+      [assignedGroup]
+    );
     mockSection('issue.progress:fix_applied is:unresolved assigned_or_suggested:me', []);
 
     render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
@@ -630,24 +629,26 @@ describe('InboxPage', () => {
     render(<InboxPage />, {organization: seerOrganization, initialRouterConfig});
 
     const fixProposedIssue = await screen.findByText('Fix proposed issue');
-    const identifiedEmptyMessage = await screen.findByText('No identified issues');
+    const fixAppliedEmptyMessage = await screen.findByText(
+      'No issues with an applied fix'
+    );
     const fixProposedButton = screen.getByRole('button', {
       name: 'Fix Proposed',
     });
-    const identifiedButton = screen.getByRole('button', {name: 'Identified'});
+    const fixAppliedButton = screen.getByRole('button', {name: 'Fix Applied'});
 
     expect(fixProposedButton).toHaveAttribute('aria-expanded', 'true');
     expect(fixProposedIssue).toBeVisible();
-    expect(identifiedButton).toHaveAttribute('aria-expanded', 'false');
-    expect(identifiedEmptyMessage).not.toBeVisible();
+    expect(fixAppliedButton).toHaveAttribute('aria-expanded', 'false');
+    expect(fixAppliedEmptyMessage).not.toBeVisible();
 
     await userEvent.click(fixProposedButton);
-    await userEvent.click(identifiedButton);
+    await userEvent.click(fixAppliedButton);
 
     expect(fixProposedButton).toHaveAttribute('aria-expanded', 'false');
     expect(fixProposedIssue).not.toBeVisible();
-    expect(identifiedButton).toHaveAttribute('aria-expanded', 'true');
-    expect(identifiedEmptyMessage).toBeVisible();
+    expect(fixAppliedButton).toHaveAttribute('aria-expanded', 'true');
+    expect(fixAppliedEmptyMessage).toBeVisible();
   });
 
   it('filters sections by the selected assignee', async () => {
@@ -663,12 +664,8 @@ describe('InboxPage', () => {
         [diagnosedGroup]
       ),
       mockSection(
-        'issue.progress:assigned is:unresolved assigned_or_suggested:[me,my_teams]',
+        'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]',
         [assignedGroup]
-      ),
-      mockSection(
-        'issue.progress:identified is:unresolved assigned_or_suggested:[me,my_teams]',
-        []
       ),
       mockSection(
         'issue.progress:fix_applied is:unresolved assigned_or_suggested:[me,my_teams]',
@@ -678,7 +675,7 @@ describe('InboxPage', () => {
     const allRequests = [
       mockSection('issue.progress:fix_proposed is:unresolved', [fixProposedGroup]),
       mockSection('issue.progress:diagnosed is:unresolved', [diagnosedGroup]),
-      mockSection('issue.progress:assigned is:unresolved', [assignedGroup]),
+      mockSection('issue.progress:[assigned,identified] is:unresolved', [assignedGroup]),
       mockSection('issue.progress:fix_applied is:unresolved', []),
     ];
 
@@ -815,10 +812,10 @@ describe('InboxPage', () => {
     mockSection('issue.progress:diagnosed is:unresolved assigned_or_suggested:me', [
       diagnosedGroup,
     ]);
-    mockSection('issue.progress:assigned is:unresolved assigned_or_suggested:me', [
-      assignedGroup,
-    ]);
-    mockSection('issue.progress:identified is:unresolved assigned_or_suggested:me', []);
+    mockSection(
+      'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:me',
+      [assignedGroup]
+    );
     mockSection('issue.progress:fix_applied is:unresolved assigned_or_suggested:me', []);
 
     render(<InboxPage />, {organization, initialRouterConfig});
@@ -1314,10 +1311,10 @@ describe('InboxPage', () => {
       mockSection('issue.progress:diagnosed is:unresolved assigned_or_suggested:me', [
         diagnosedGroup,
       ]);
-      mockSection('issue.progress:assigned is:unresolved assigned_or_suggested:me', [
-        assignedGroup,
-      ]);
-      mockSection('issue.progress:identified is:unresolved assigned_or_suggested:me', []);
+      mockSection(
+        'issue.progress:[assigned,identified] is:unresolved assigned_or_suggested:me',
+        [assignedGroup]
+      );
       mockSection(
         'issue.progress:fix_applied is:unresolved assigned_or_suggested:me',
         []

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -30,6 +30,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {Placeholder} from 'sentry/components/placeholder';
 import {QueryCount} from 'sentry/components/queryCount';
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {SuggestedAvatarStack} from 'sentry/components/suggestedAvatarStack';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconArrow, IconChevron, IconPullRequest} from 'sentry/icons';
@@ -116,10 +117,16 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     analyticsKey: 'num_assigned',
     key: 'assigned',
     label: t('Assigned'),
-    query: assignmentFilter =>
-      `issue.progress:[assigned,identified] is:unresolved${
-        assignmentFilter === 'all' ? ' !assigned_or_suggested:none' : ''
-      }`,
+    query: assignmentFilter => {
+      const search = new MutableSearch(
+        'issue.progress:[assigned,identified] is:unresolved'
+      );
+      // On the "All" tab, we want to show only issues which have a suggested assignee
+      if (assignmentFilter === 'all') {
+        search.addFilterValue('!assigned_or_suggested', 'none');
+      }
+      return search.formatString();
+    },
     emptyMessage: t('No assigned issues'),
     progress: ProgressState.ASSIGNED,
     hidden: ({hasSeer}) => !hasSeer,

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -78,6 +78,7 @@ const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
   my_teams: ' assigned_or_suggested:[me,my_teams]',
   all: '',
 };
+const ALL_ASSIGNED_QUERY_SUFFIX = ' !assigned_or_suggested:none';
 const ASSIGNMENT_COUNT_QUERY =
   'issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved';
 interface InboxSectionContext {
@@ -454,11 +455,15 @@ function InboxSection({
   selectedIssueId,
 }: InboxSectionProps) {
   const organization = useOrganization();
+  const assignmentQuerySuffix =
+    assignmentFilter === 'all' && section.progress === ProgressState.ASSIGNED
+      ? ALL_ASSIGNED_QUERY_SUFFIX
+      : ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter];
   const queryResult = useInfiniteQuery({
     ...apiOptions.asInfinite<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
       path: {organizationIdOrSlug: organization.slug},
       query: {
-        query: `${section.query}${ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter]}${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+        query: `${section.query}${assignmentQuerySuffix}${INBOX_AUTOFIX_CATEGORY_FILTER}`,
         sort: IssueSortOptions.PROGRESS,
         limit: ISSUE_LIMIT,
         collapse: ['stats', 'unhandled'],

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -30,7 +30,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {Placeholder} from 'sentry/components/placeholder';
 import {QueryCount} from 'sentry/components/queryCount';
-import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {SuggestedAvatarStack} from 'sentry/components/suggestedAvatarStack';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconArrow, IconChevron, IconPullRequest} from 'sentry/icons';
@@ -81,6 +80,8 @@ const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
 };
 const ASSIGNMENT_COUNT_QUERY =
   'issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved';
+const ALL_ASSIGNMENT_COUNT_QUERY =
+  'issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved';
 interface InboxSectionContext {
   hasSeer: boolean;
 }
@@ -117,16 +118,10 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     analyticsKey: 'num_assigned',
     key: 'assigned',
     label: t('Assigned'),
-    query: assignmentFilter => {
-      const search = new MutableSearch(
-        'issue.progress:[assigned,identified] is:unresolved'
-      );
-      // On the "All" tab, we want to show only issues which have a suggested assignee
-      if (assignmentFilter === 'all') {
-        search.addFilterValue('!assigned_or_suggested', 'none');
-      }
-      return search.formatString();
-    },
+    query: assignmentFilter =>
+      assignmentFilter === 'all'
+        ? 'issue.progress:assigned is:unresolved'
+        : 'issue.progress:[assigned,identified] is:unresolved',
     emptyMessage: t('No assigned issues'),
     progress: ProgressState.ASSIGNED,
     hidden: ({hasSeer}) => !hasSeer,
@@ -208,7 +203,7 @@ function useAssignmentCounts() {
   const organization = useOrganization();
   const meQuery = `${ASSIGNMENT_COUNT_QUERY}${ASSIGNMENT_QUERY_SUFFIXES.me}${INBOX_AUTOFIX_CATEGORY_FILTER}`;
   const myTeamsQuery = `${ASSIGNMENT_COUNT_QUERY}${ASSIGNMENT_QUERY_SUFFIXES.my_teams}${INBOX_AUTOFIX_CATEGORY_FILTER}`;
-  const allQuery = `${ASSIGNMENT_COUNT_QUERY}${ASSIGNMENT_QUERY_SUFFIXES.all}${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+  const allQuery = `${ALL_ASSIGNMENT_COUNT_QUERY}${INBOX_AUTOFIX_CATEGORY_FILTER}`;
 
   const {data} = useQuery({
     ...apiOptions.as<Record<string, number>>()(

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -78,7 +78,6 @@ const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
   my_teams: ' assigned_or_suggested:[me,my_teams]',
   all: '',
 };
-const ALL_ASSIGNED_QUERY_SUFFIX = ' !assigned_or_suggested:none';
 const ASSIGNMENT_COUNT_QUERY =
   'issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved';
 interface InboxSectionContext {
@@ -91,7 +90,7 @@ interface InboxSectionConfig {
   key: string;
   label: string;
   progress: ProgressState;
-  query: string;
+  query: string | ((assignmentFilter: AssignmentFilter) => string);
   hidden?: (context: InboxSectionContext) => boolean;
 }
 
@@ -117,7 +116,10 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     analyticsKey: 'num_assigned',
     key: 'assigned',
     label: t('Assigned'),
-    query: 'issue.progress:[assigned,identified] is:unresolved',
+    query: assignmentFilter =>
+      `issue.progress:[assigned,identified] is:unresolved${
+        assignmentFilter === 'all' ? ' !assigned_or_suggested:none' : ''
+      }`,
     emptyMessage: t('No assigned issues'),
     progress: ProgressState.ASSIGNED,
     hidden: ({hasSeer}) => !hasSeer,
@@ -455,15 +457,13 @@ function InboxSection({
   selectedIssueId,
 }: InboxSectionProps) {
   const organization = useOrganization();
-  const assignmentQuerySuffix =
-    assignmentFilter === 'all' && section.progress === ProgressState.ASSIGNED
-      ? ALL_ASSIGNED_QUERY_SUFFIX
-      : ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter];
+  const sectionQuery =
+    typeof section.query === 'function' ? section.query(assignmentFilter) : section.query;
   const queryResult = useInfiniteQuery({
     ...apiOptions.asInfinite<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
       path: {organizationIdOrSlug: organization.slug},
       query: {
-        query: `${section.query}${assignmentQuerySuffix}${INBOX_AUTOFIX_CATEGORY_FILTER}`,
+        query: `${sectionQuery}${ASSIGNMENT_QUERY_SUFFIXES[assignmentFilter]}${INBOX_AUTOFIX_CATEGORY_FILTER}`,
         sort: IssueSortOptions.PROGRESS,
         limit: ISSUE_LIMIT,
         collapse: ['stats', 'unhandled'],

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -79,19 +79,13 @@ const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
   all: '',
 };
 const ASSIGNMENT_COUNT_QUERY =
-  'issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved';
+  'issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved';
 interface InboxSectionContext {
-  assignmentFilter: AssignmentFilter;
   hasSeer: boolean;
 }
 
 interface InboxSectionConfig {
-  analyticsKey:
-    | 'num_fix_proposed'
-    | 'num_diagnosed'
-    | 'num_assigned'
-    | 'num_identified'
-    | 'num_fix_applied';
+  analyticsKey: 'num_fix_proposed' | 'num_diagnosed' | 'num_assigned' | 'num_fix_applied';
   emptyMessage: string;
   key: string;
   label: string;
@@ -122,19 +116,10 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
     analyticsKey: 'num_assigned',
     key: 'assigned',
     label: t('Assigned'),
-    query: 'issue.progress:assigned is:unresolved',
+    query: 'issue.progress:[assigned,identified] is:unresolved',
     emptyMessage: t('No assigned issues'),
     progress: ProgressState.ASSIGNED,
     hidden: ({hasSeer}) => !hasSeer,
-  },
-  {
-    analyticsKey: 'num_identified',
-    key: 'identified',
-    label: t('Identified'),
-    query: 'issue.progress:identified is:unresolved',
-    emptyMessage: t('No identified issues'),
-    progress: ProgressState.IDENTIFIED,
-    hidden: ({assignmentFilter, hasSeer}) => !hasSeer || assignmentFilter === 'all',
   },
   {
     analyticsKey: 'num_fix_applied',
@@ -316,9 +301,7 @@ function InboxContent() {
     parseAsString.withOptions({history: 'replace'})
   );
   const assignmentCounts = useAssignmentCounts();
-  const sections = SECTIONS.filter(
-    section => !section.hidden?.({assignmentFilter, hasSeer})
-  );
+  const sections = SECTIONS.filter(section => !section.hidden?.({hasSeer}));
   const isInboxEmpty = assignmentCounts?.[assignmentFilter] === 0;
   const [storedSize, setStoredSize] = useSyncedLocalStorageState(
     INBOX_SPLIT_SIZE_STORAGE_KEY,

--- a/static/app/views/issueList/queries/useInboxIssueCount.tsx
+++ b/static/app/views/issueList/queries/useInboxIssueCount.tsx
@@ -6,8 +6,8 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {INBOX_AUTOFIX_CATEGORY_FILTER} from './inbox';
 
-// Count all issues assigned or suggested to me which are assigned or further along
-const INBOX_COUNT_QUERY = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+// Count all issues assigned or suggested to me across the displayed progress sections
+const INBOX_COUNT_QUERY = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned,identified] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
 const INBOX_COUNT_QUERY_NO_SEER = `is:unresolved issue.progress:[fix_proposed] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
 
 export function useInboxIssueCount() {

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -7,7 +7,7 @@ import {IssuesSecondaryNavigation} from 'sentry/views/navigation/secondary/secti
 import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
 
 describe('IssuesSecondaryNavigation', () => {
-  const inboxCountQuery = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
+  const inboxCountQuery = `is:unresolved issue.progress:[fix_proposed,diagnosed,assigned,identified] assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`;
   const organization = OrganizationFixture({
     features: ['issue-inbox', 'gen-ai-features', 'seat-based-seer-enabled'],
   });
@@ -52,6 +52,7 @@ describe('IssuesSecondaryNavigation', () => {
     expect(query).toContain('fix_proposed');
     expect(query).toContain('diagnosed');
     expect(query).toContain('assigned');
+    expect(query).toContain('identified');
     expect(query).toContain('is:unresolved');
     expect(query).toContain('assigned_or_suggested:me');
   });


### PR DESCRIPTION
Resolves ISWF-3358

Merges the `identified` and `assigned` progress states into the same "assigned" section. This means that any issues assigned or suggested assigned to you/your teams will show up there.