### PR TITLE
fix(seer): Limit Night Shift to recent issues

### DIFF
--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -44,6 +44,7 @@ NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER = 3
 # projects, so its per-project window stays well clear too.
 NIGHT_SHIFT_MAX_SEARCH_PAGES = 10
 FIXABILITY_SCORE_THRESHOLD = FixabilityScoreThresholds.MEDIUM.value
+NIGHT_SHIFT_OCCURRENCE_LOOKBACK = timedelta(days=14)
 
 
 @dataclass
@@ -227,10 +228,12 @@ def _fetch_and_score(
     """
     # Default types + LowValueSpan
     type_ids = sorted(group_types_from([]) | {LowValueSpanConfigurationType.type_id})
+    occurrence_cutoff = timezone.now() - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
     search_filters = [
         SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
+        SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
     ]
 
     scored: list[ScoredCandidate] = []
@@ -245,6 +248,7 @@ def _fetch_and_score(
             limit=fetch_limit,
             cursor=cursor,
             search_filters=search_filters,
+            date_from=occurrence_cutoff,
             referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
         )
 
@@ -312,11 +316,13 @@ def _fetch_and_score_agentic(
     # Exclude groups Seer ran on within the last 30 days (matching the
     # RecentDateCondition used by the recommended path's search filter).
     seer_recency_cutoff = timezone.now() - timedelta(days=30)
+    occurrence_cutoff = timezone.now() - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
     base_qs = (
         Group.objects.filter(
             project__in=projects,
             status=GroupStatus.UNRESOLVED,
             type__in=type_ids,
+            last_seen__gte=occurrence_cutoff,
         )
         .exclude(seer_explorer_autofix_last_triggered__gte=seer_recency_cutoff)
         .order_by("-last_seen")

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -233,6 +233,7 @@ def _fetch_and_score(
         SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
+        SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
     ]
 
     scored: list[ScoredCandidate] = []
@@ -247,7 +248,6 @@ def _fetch_and_score(
             limit=fetch_limit,
             cursor=cursor,
             search_filters=search_filters,
-            date_from=occurrence_cutoff,
             referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
         )
 

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -233,7 +233,6 @@ def _fetch_and_score(
         SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
-        SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
     ]
 
     scored: list[ScoredCandidate] = []

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -1378,7 +1378,7 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
         assert [candidate.group.id for candidate in result] == [recent.id]
 
-    def test_search_passes_fourteen_day_occurrence_window(self) -> None:
+    def test_search_filters_to_recent_issues(self) -> None:
         project = self.create_project()
 
         with (
@@ -1389,7 +1389,13 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
             fixability_score_strategy([project], max_candidates=10)
 
         expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
-        assert mock_query.call_args.kwargs["date_from"] == expected_cutoff
+        filters = {
+            search_filter.key.name: search_filter
+            for search_filter in mock_query.call_args.kwargs["search_filters"]
+        }
+        assert filters["last_seen"].operator == ">="
+        assert filters["last_seen"].value.raw_value == expected_cutoff
+        assert "date_from" not in mock_query.call_args.kwargs
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -36,6 +36,7 @@ from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.simple_triage import (
     NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
     NIGHT_SHIFT_MAX_SEARCH_PAGES,
+    NIGHT_SHIFT_OCCURRENCE_LOOKBACK,
     ScoredCandidate,
     fixability_score_strategy,
     fixability_score_strategy_per_project,
@@ -84,11 +85,11 @@ class NightShiftFixtures(Fixtures):
         project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
         return project
 
-    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
+    def _store_event_and_update_group(self, project, fingerprint, *, timestamp=None, **group_attrs):
         event = self.store_event(
             data={
                 "fingerprint": [fingerprint],
-                "timestamp": before_now(hours=1).isoformat(),
+                "timestamp": (timestamp or before_now(hours=1)).isoformat(),
                 "environment": "production",
             },
             project_id=project.id,
@@ -1349,6 +1350,52 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         assert null.id in result_ids
         # Low-scored issue (below threshold) is excluded entirely
         assert len(result) == 3
+
+    def test_requires_recent_occurrence(self) -> None:
+        project = self.create_project()
+        recent = self._store_event_and_update_group(project, "recent")
+        self._store_event_and_update_group(
+            project,
+            "old",
+            timestamp=before_now(days=15),
+        )
+
+        result = fixability_score_strategy([project], max_candidates=10)
+
+        assert [candidate.group.id for candidate in result] == [recent.id]
+
+    def test_agentic_search_requires_recent_occurrence(self) -> None:
+        project = self.create_project()
+        recent = self._store_event_and_update_group(project, "agentic-recent")
+        self._store_event_and_update_group(
+            project,
+            "agentic-old",
+            timestamp=before_now(days=15),
+        )
+
+        with self.feature({"organizations:agentic-triage-sort": True}):
+            result = fixability_score_strategy([project], max_candidates=10)
+
+        assert [candidate.group.id for candidate in result] == [recent.id]
+
+    def test_search_passes_fourteen_day_occurrence_window(self) -> None:
+        project = self.create_project()
+
+        with (
+            freeze_time("2026-08-24 12:00:00Z"),
+            patch("sentry.tasks.seer.night_shift.simple_triage.search.backend.query") as mock_query,
+        ):
+            mock_query.return_value = _cursor_result([])
+            fixability_score_strategy([project], max_candidates=10)
+
+        expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
+        assert mock_query.call_args.kwargs["date_from"] == expected_cutoff
+        filters = {
+            search_filter.key.name: search_filter
+            for search_filter in mock_query.call_args.kwargs["search_filters"]
+        }
+        assert filters["last_seen"].operator == ">="
+        assert filters["last_seen"].value.raw_value == expected_cutoff
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -36,7 +36,6 @@ from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.simple_triage import (
     NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
     NIGHT_SHIFT_MAX_SEARCH_PAGES,
-    NIGHT_SHIFT_OCCURRENCE_LOOKBACK,
     ScoredCandidate,
     fixability_score_strategy,
     fixability_score_strategy_per_project,
@@ -1353,7 +1352,9 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
     def test_requires_recent_occurrence(self) -> None:
         project = self.create_project()
-        recent = self._store_event_and_update_group(project, "recent")
+        recent = self._store_event_and_update_group(
+            project, "recent", timestamp=before_now(days=13)
+        )
         self._store_event_and_update_group(
             project,
             "old",
@@ -1366,7 +1367,9 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
     def test_agentic_search_requires_recent_occurrence(self) -> None:
         project = self.create_project()
-        recent = self._store_event_and_update_group(project, "agentic-recent")
+        recent = self._store_event_and_update_group(
+            project, "agentic-recent", timestamp=before_now(days=13)
+        )
         self._store_event_and_update_group(
             project,
             "agentic-old",
@@ -1377,25 +1380,6 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
             result = fixability_score_strategy([project], max_candidates=10)
 
         assert [candidate.group.id for candidate in result] == [recent.id]
-
-    def test_search_filters_to_recent_issues(self) -> None:
-        project = self.create_project()
-
-        with (
-            freeze_time("2026-08-24 12:00:00Z"),
-            patch("sentry.tasks.seer.night_shift.simple_triage.search.backend.query") as mock_query,
-        ):
-            mock_query.return_value = _cursor_result([])
-            fixability_score_strategy([project], max_candidates=10)
-
-        expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
-        filters = {
-            search_filter.key.name: search_filter
-            for search_filter in mock_query.call_args.kwargs["search_filters"]
-        }
-        assert filters["last_seen"].operator == ">="
-        assert filters["last_seen"].value.raw_value == expected_cutoff
-        assert "date_from" not in mock_query.call_args.kwargs
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -1390,12 +1390,6 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
         expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
         assert mock_query.call_args.kwargs["date_from"] == expected_cutoff
-        filters = {
-            search_filter.key.name: search_filter
-            for search_filter in mock_query.call_args.kwargs["search_filters"]
-        }
-        assert filters["last_seen"].operator == ">="
-        assert filters["last_seen"].value.raw_value == expected_cutoff
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()


### PR DESCRIPTION
Night Shift now requires candidate issues to have a `last_seen` value within the previous 14 days. The recommended path applies this as an issue search filter, while the agentic path applies the equivalent condition to its `Group` queryset.

This prevents stale issues from entering automated triage without changing the event window used for recommended scoring.
