### PR TITLE
fix(seer): Require in-app frames for Night Shift

### DIFF
--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -44,6 +44,7 @@ NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER = 3
 # projects, so its per-project window stays well clear too.
 NIGHT_SHIFT_MAX_SEARCH_PAGES = 10
 FIXABILITY_SCORE_THRESHOLD = FixabilityScoreThresholds.MEDIUM.value
+NIGHT_SHIFT_OCCURRENCE_LOOKBACK = timedelta(days=14)
 
 
 @dataclass
@@ -227,10 +228,12 @@ def _fetch_and_score(
     """
     # Default types + LowValueSpan
     type_ids = sorted(group_types_from([]) | {LowValueSpanConfigurationType.type_id})
+    occurrence_cutoff = timezone.now() - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
     search_filters = [
         SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
+        SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
     ]
 
     scored: list[ScoredCandidate] = []
@@ -245,6 +248,7 @@ def _fetch_and_score(
             limit=fetch_limit,
             cursor=cursor,
             search_filters=search_filters,
+            date_from=occurrence_cutoff,
             referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
         )
 
@@ -312,11 +316,13 @@ def _fetch_and_score_agentic(
     # Exclude groups Seer ran on within the last 30 days (matching the
     # RecentDateCondition used by the recommended path's search filter).
     seer_recency_cutoff = timezone.now() - timedelta(days=30)
+    occurrence_cutoff = timezone.now() - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
     base_qs = (
         Group.objects.filter(
             project__in=projects,
             status=GroupStatus.UNRESOLVED,
             type__in=type_ids,
+            last_seen__gte=occurrence_cutoff,
         )
         .exclude(seer_explorer_autofix_last_triggered__gte=seer_recency_cutoff)
         .order_by("-last_seen")

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -233,6 +233,7 @@ def _fetch_and_score(
         SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
+        SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
     ]
 
     scored: list[ScoredCandidate] = []
@@ -247,7 +248,6 @@ def _fetch_and_score(
             limit=fetch_limit,
             cursor=cursor,
             search_filters=search_filters,
-            date_from=occurrence_cutoff,
             referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
         )
 

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -266,7 +266,6 @@ def _fetch_and_score(
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
         SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
-        SearchFilter(SearchKey("stack.in_app"), "=", SearchValue(1.0)),
     ]
 
     scored: list[ScoredCandidate] = []
@@ -281,7 +280,6 @@ def _fetch_and_score(
             limit=fetch_limit,
             cursor=cursor,
             search_filters=search_filters,
-            date_from=occurrence_cutoff,
             referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
         )
 
@@ -321,6 +319,16 @@ def _fetch_and_score(
             break
 
         cursor = result.next
+
+    # Mixed issue search treats stack.in_app as a tag for issue-platform rows.
+    # Query Events directly and post-filter by group id instead.
+    in_app_group_ids = _groups_with_recent_in_app_frame(
+        [c.group.id for c in scored + unscored],
+        [project.id for project in projects],
+        projects[0].organization_id,
+    )
+    scored = [c for c in scored if c.group.id in in_app_group_ids]
+    unscored = [c for c in unscored if c.group.id in in_app_group_ids]
 
     scored.sort(key=lambda c: c.fixability or 0.0, reverse=True)
     selected = (scored + unscored)[:max_candidates]

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -56,6 +56,38 @@ class ScoredCandidate(TriageResult):
     action: TriageAction = TriageAction.AUTOFIX
 
 
+def _groups_with_recent_in_app_frame(
+    group_ids: Sequence[int], project_ids: Sequence[int], organization_id: int
+) -> set[int]:
+    if not group_ids:
+        return set()
+
+    now = timezone.now()
+    query = Query(
+        match=Entity("events"),
+        select=[Column("group_id")],
+        where=[
+            Condition(Column("group_id"), Op.IN, list(group_ids)),
+            Condition(Column("project_id"), Op.IN, list(project_ids)),
+            Condition(Column("timestamp"), Op.GTE, now - NIGHT_SHIFT_OCCURRENCE_LOOKBACK),
+            Condition(Column("timestamp"), Op.LT, now),
+            Condition(Column("exception_frames.in_app"), Op.EQ, 1),
+        ],
+        groupby=[Column("group_id")],
+        limit=Limit(len(group_ids)),
+    )
+    request = Request(
+        dataset=Dataset.Events.value,
+        app_id="night_shift",
+        query=query,
+        tenant_ids={"organization_id": organization_id},
+    )
+    rows = raw_snql_query(
+        request, referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value
+    )["data"]
+    return {row["group_id"] for row in rows}
+
+
 def fixability_score_strategy(
     projects: Sequence[Project],
     max_candidates: int,
@@ -234,6 +266,7 @@ def _fetch_and_score(
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
         SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
+        SearchFilter(SearchKey("stack.in_app"), "=", SearchValue(1.0)),
     ]
 
     scored: list[ScoredCandidate] = []
@@ -350,6 +383,13 @@ def _fetch_and_score_agentic(
         if len(candidates) >= fetch_limit:
             break
 
+    in_app_group_ids = _groups_with_recent_in_app_frame(
+        [group.id for group in candidates],
+        [project.id for project in projects],
+        projects[0].organization_id,
+    )
+    candidates = [group for group in candidates if group.id in in_app_group_ids]
+
     logger.info(
         "night_shift.agentic_search_results",
         extra={
@@ -366,9 +406,8 @@ def _fetch_and_score_agentic(
     project_ids = [p.id for p in projects]
     factors = _agentic_triage_snuba_factors(group_ids, project_ids, projects[0].organization_id)
 
-    # Step 3: Only score groups that got Snuba results. Non-error types
-    # (issue-platform) won't have rows in the events entity — append them
-    # after scored groups so they don't distort min-max normalization.
+    # Step 3: Append groups whose in-app occurrence falls outside the shorter
+    # scoring lookback after groups with scoring data.
     with_data = [g for g in candidates if g.id in factors]
     without_data = [g for g in candidates if g.id not in factors]
     scores = _agentic_triage_score([g.id for g in with_data], factors)

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -233,7 +233,6 @@ def _fetch_and_score(
         SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
         SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
         SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
-        SearchFilter(SearchKey("last_seen"), ">=", SearchValue(occurrence_cutoff)),
     ]
 
     scored: list[ScoredCandidate] = []

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -56,6 +56,37 @@ class ScoredCandidate(TriageResult):
     action: TriageAction = TriageAction.AUTOFIX
 
 
+def fixability_score_strategy(
+    projects: Sequence[Project],
+    max_candidates: int,
+) -> list[ScoredCandidate]:
+    """Scores candidates across all projects combined — a busy project can eat
+    the whole max_candidates budget. See fixability_score_strategy_per_project."""
+    if features.has(
+        "organizations:agentic-triage-sort", projects[0].organization
+    ):  # Assume all projects are in the same org
+        return _fetch_and_score_agentic(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
+    return _fetch_and_score(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
+
+
+def fixability_score_strategy_per_project(
+    projects: Sequence[Project],
+    max_candidates: int,
+) -> list[ScoredCandidate]:
+    """Like fixability_score_strategy, but scores each project independently so
+    no project can crowd out the others' share of max_candidates."""
+    fetch_limit = min(
+        NIGHT_SHIFT_ISSUE_FETCH_LIMIT, max_candidates * NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER
+    )
+    selected: list[ScoredCandidate] = []
+    for project in projects:
+        if features.has("organizations:agentic-triage-sort", project.organization):
+            selected.extend(_fetch_and_score_agentic([project], max_candidates, fetch_limit))
+        else:
+            selected.extend(_fetch_and_score([project], max_candidates, fetch_limit))
+    return selected
+
+
 def _groups_with_recent_in_app_frame(
     group_ids: Sequence[int], project_ids: Sequence[int], organization_id: int
 ) -> set[int]:
@@ -86,37 +117,6 @@ def _groups_with_recent_in_app_frame(
         request, referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value
     )["data"]
     return {row["group_id"] for row in rows}
-
-
-def fixability_score_strategy(
-    projects: Sequence[Project],
-    max_candidates: int,
-) -> list[ScoredCandidate]:
-    """Scores candidates across all projects combined — a busy project can eat
-    the whole max_candidates budget. See fixability_score_strategy_per_project."""
-    if features.has(
-        "organizations:agentic-triage-sort", projects[0].organization
-    ):  # Assume all projects are in the same org
-        return _fetch_and_score_agentic(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
-    return _fetch_and_score(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
-
-
-def fixability_score_strategy_per_project(
-    projects: Sequence[Project],
-    max_candidates: int,
-) -> list[ScoredCandidate]:
-    """Like fixability_score_strategy, but scores each project independently so
-    no project can crowd out the others' share of max_candidates."""
-    fetch_limit = min(
-        NIGHT_SHIFT_ISSUE_FETCH_LIMIT, max_candidates * NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER
-    )
-    selected: list[ScoredCandidate] = []
-    for project in projects:
-        if features.has("organizations:agentic-triage-sort", project.organization):
-            selected.extend(_fetch_and_score_agentic([project], max_candidates, fetch_limit))
-        else:
-            selected.extend(_fetch_and_score([project], max_candidates, fetch_limit))
-    return selected
 
 
 def _agentic_triage_snuba_factors(

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -1378,7 +1378,7 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
         assert [candidate.group.id for candidate in result] == [recent.id]
 
-    def test_search_passes_fourteen_day_occurrence_window(self) -> None:
+    def test_search_filters_to_recent_issues(self) -> None:
         project = self.create_project()
 
         with (
@@ -1389,7 +1389,13 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
             fixability_score_strategy([project], max_candidates=10)
 
         expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
-        assert mock_query.call_args.kwargs["date_from"] == expected_cutoff
+        filters = {
+            search_filter.key.name: search_filter
+            for search_filter in mock_query.call_args.kwargs["search_filters"]
+        }
+        assert filters["last_seen"].operator == ">="
+        assert filters["last_seen"].value.raw_value == expected_cutoff
+        assert "date_from" not in mock_query.call_args.kwargs
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -36,6 +36,7 @@ from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.simple_triage import (
     NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
     NIGHT_SHIFT_MAX_SEARCH_PAGES,
+    NIGHT_SHIFT_OCCURRENCE_LOOKBACK,
     ScoredCandidate,
     fixability_score_strategy,
     fixability_score_strategy_per_project,
@@ -84,11 +85,11 @@ class NightShiftFixtures(Fixtures):
         project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
         return project
 
-    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
+    def _store_event_and_update_group(self, project, fingerprint, *, timestamp=None, **group_attrs):
         event = self.store_event(
             data={
                 "fingerprint": [fingerprint],
-                "timestamp": before_now(hours=1).isoformat(),
+                "timestamp": (timestamp or before_now(hours=1)).isoformat(),
                 "environment": "production",
             },
             project_id=project.id,
@@ -1349,6 +1350,52 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         assert null.id in result_ids
         # Low-scored issue (below threshold) is excluded entirely
         assert len(result) == 3
+
+    def test_requires_recent_occurrence(self) -> None:
+        project = self.create_project()
+        recent = self._store_event_and_update_group(project, "recent")
+        self._store_event_and_update_group(
+            project,
+            "old",
+            timestamp=before_now(days=15),
+        )
+
+        result = fixability_score_strategy([project], max_candidates=10)
+
+        assert [candidate.group.id for candidate in result] == [recent.id]
+
+    def test_agentic_search_requires_recent_occurrence(self) -> None:
+        project = self.create_project()
+        recent = self._store_event_and_update_group(project, "agentic-recent")
+        self._store_event_and_update_group(
+            project,
+            "agentic-old",
+            timestamp=before_now(days=15),
+        )
+
+        with self.feature({"organizations:agentic-triage-sort": True}):
+            result = fixability_score_strategy([project], max_candidates=10)
+
+        assert [candidate.group.id for candidate in result] == [recent.id]
+
+    def test_search_passes_fourteen_day_occurrence_window(self) -> None:
+        project = self.create_project()
+
+        with (
+            freeze_time("2026-08-24 12:00:00Z"),
+            patch("sentry.tasks.seer.night_shift.simple_triage.search.backend.query") as mock_query,
+        ):
+            mock_query.return_value = _cursor_result([])
+            fixability_score_strategy([project], max_candidates=10)
+
+        expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
+        assert mock_query.call_args.kwargs["date_from"] == expected_cutoff
+        filters = {
+            search_filter.key.name: search_filter
+            for search_filter in mock_query.call_args.kwargs["search_filters"]
+        }
+        assert filters["last_seen"].operator == ">="
+        assert filters["last_seen"].value.raw_value == expected_cutoff
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -36,7 +36,6 @@ from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.simple_triage import (
     NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
     NIGHT_SHIFT_MAX_SEARCH_PAGES,
-    NIGHT_SHIFT_OCCURRENCE_LOOKBACK,
     ScoredCandidate,
     fixability_score_strategy,
     fixability_score_strategy_per_project,
@@ -1353,7 +1352,9 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
     def test_requires_recent_occurrence(self) -> None:
         project = self.create_project()
-        recent = self._store_event_and_update_group(project, "recent")
+        recent = self._store_event_and_update_group(
+            project, "recent", timestamp=before_now(days=13)
+        )
         self._store_event_and_update_group(
             project,
             "old",
@@ -1366,7 +1367,9 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
     def test_agentic_search_requires_recent_occurrence(self) -> None:
         project = self.create_project()
-        recent = self._store_event_and_update_group(project, "agentic-recent")
+        recent = self._store_event_and_update_group(
+            project, "agentic-recent", timestamp=before_now(days=13)
+        )
         self._store_event_and_update_group(
             project,
             "agentic-old",
@@ -1377,25 +1380,6 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
             result = fixability_score_strategy([project], max_candidates=10)
 
         assert [candidate.group.id for candidate in result] == [recent.id]
-
-    def test_search_filters_to_recent_issues(self) -> None:
-        project = self.create_project()
-
-        with (
-            freeze_time("2026-08-24 12:00:00Z"),
-            patch("sentry.tasks.seer.night_shift.simple_triage.search.backend.query") as mock_query,
-        ):
-            mock_query.return_value = _cursor_result([])
-            fixability_score_strategy([project], max_candidates=10)
-
-        expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
-        filters = {
-            search_filter.key.name: search_filter
-            for search_filter in mock_query.call_args.kwargs["search_filters"]
-        }
-        assert filters["last_seen"].operator == ">="
-        assert filters["last_seen"].value.raw_value == expected_cutoff
-        assert "date_from" not in mock_query.call_args.kwargs
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -1390,12 +1390,6 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
         expected_cutoff = datetime(2026, 8, 24, 12, tzinfo=UTC) - NIGHT_SHIFT_OCCURRENCE_LOOKBACK
         assert mock_query.call_args.kwargs["date_from"] == expected_cutoff
-        filters = {
-            search_filter.key.name: search_filter
-            for search_filter in mock_query.call_args.kwargs["search_filters"]
-        }
-        assert filters["last_seen"].operator == ">="
-        assert filters["last_seen"].value.raw_value == expected_cutoff
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -85,9 +85,34 @@ class NightShiftFixtures(Fixtures):
         project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
         return project
 
-    def _store_event_and_update_group(self, project, fingerprint, *, timestamp=None, **group_attrs):
+    def _store_event_and_update_group(
+        self,
+        project,
+        fingerprint,
+        *,
+        timestamp=None,
+        in_app=True,
+        **group_attrs,
+    ):
         event = self.store_event(
             data={
+                "exception": {
+                    "values": [
+                        {
+                            "type": "ValueError",
+                            "value": fingerprint,
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "filename": "app.py",
+                                        "function": "main",
+                                        "in_app": in_app,
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
                 "fingerprint": [fingerprint],
                 "timestamp": (timestamp or before_now(hours=1)).isoformat(),
                 "environment": "production",
@@ -1378,6 +1403,25 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
         assert [candidate.group.id for candidate in result] == [recent.id]
 
+    def test_requires_in_app_frame(self) -> None:
+        project = self.create_project()
+        in_app = self._store_event_and_update_group(project, "in-app")
+        self._store_event_and_update_group(project, "not-in-app", in_app=False)
+
+        result = fixability_score_strategy([project], max_candidates=10)
+
+        assert [candidate.group.id for candidate in result] == [in_app.id]
+
+    def test_agentic_search_requires_in_app_frame(self) -> None:
+        project = self.create_project()
+        in_app = self._store_event_and_update_group(project, "agentic-in-app")
+        self._store_event_and_update_group(project, "agentic-not-in-app", in_app=False)
+
+        with self.feature({"organizations:agentic-triage-sort": True}):
+            result = fixability_score_strategy([project], max_candidates=10)
+
+        assert [candidate.group.id for candidate in result] == [in_app.id]
+
     def test_search_passes_fourteen_day_occurrence_window(self) -> None:
         project = self.create_project()
 
@@ -1396,6 +1440,7 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         }
         assert filters["last_seen"].operator == ">="
         assert filters["last_seen"].value.raw_value == expected_cutoff
+        assert filters["stack.in_app"].value.raw_value == 1.0
 
     def test_includes_low_value_span_issues_in_search(self) -> None:
         project = self.create_project()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -6,7 +6,6 @@ from taskbroker_client.scheduler.config import crontab
 
 from sentry.hybridcloud.models.outbox import CellOutbox
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.issues.search import group_types_from
 from sentry.models.group import Group
 from sentry.models.organization import OrganizationStatus
 from sentry.models.project import Project
@@ -1429,30 +1428,18 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
 
         assert [candidate.group.id for candidate in result] == [recent_in_app.id]
 
-    def test_includes_low_value_span_issues_in_search(self) -> None:
+    def test_excludes_issue_platform_without_in_app_frame(self) -> None:
         project = self.create_project()
-        error_group = self.create_group(project=project)
-        lvs_group = self.create_group(project=project, type=LowValueSpanConfigurationType.type_id)
+        recent_in_app = self._store_event_and_update_group(project, "recent-in-app-error")
+        self.create_group(
+            project=project,
+            type=LowValueSpanConfigurationType.type_id,
+            last_seen=before_now(hours=1),
+        )
 
-        with patch(
-            "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
-        ) as mock_query:
-            mock_query.return_value = _cursor_result([error_group, lvs_group])
-            result = fixability_score_strategy([project], max_candidates=10)
+        result = fixability_score_strategy([project], max_candidates=10)
 
-        assert {c.group.id for c in result} == {error_group.id, lvs_group.id}
-
-        mock_query.assert_called_once()
-        type_filters = [
-            sf
-            for sf in mock_query.call_args.kwargs["search_filters"]
-            if sf.key.name == "issue.type"
-        ]
-        assert len(type_filters) == 1
-        # The default type set is widened to include low-value-span, not replaced by it.
-        assert set(type_filters[0].value.raw_value) == group_types_from([]) | {
-            LowValueSpanConfigurationType.type_id
-        }
+        assert [candidate.group.id for candidate in result] == [recent_in_app.id]
 
     def test_per_project_fetch_limit_scales_with_max_candidates(self) -> None:
         project = self.create_project()


### PR DESCRIPTION
Night Shift candidates now require at least one occurrence with an in-app exception frame during the 14-day window. Both candidate-selection paths use the same batched Events query and post-filter candidate group IDs before final selection.

This avoids applying `stack.in_app` through mixed issue search, where issue-platform rows can resolve it as a numeric tag condition and fail query validation. It stacks on #122518, which independently filters issues by `last_seen`.
