### PR TITLE
feat(pr-iter): run deferred consume when CI is complete

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -43,6 +43,7 @@ from sentry.seer.autofix.github_perms import (
     repos_with_failed_tool_calls,
 )
 from sentry.seer.autofix.pr_iteration.feedback import parse_feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTriggerSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
     GithubPrReviewCommentFeedbackSource,
@@ -875,6 +876,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             kwargs={
                 "run_id": run_id,
                 "organization_id": organization.id,
+                "trigger_source": ConsumeTriggerSource.FEEDBACK,
             }
         )
 

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -484,11 +484,7 @@ def inspect_check_suite_head(
         _skip("stale_head", {**resolved.log_extra, "head_sha": head_match.head_sha})
         return None
 
-    sweep = sweep_check_runs(
-        scm,
-        head_match.head_sha,
-        log_extra={**resolved.log_extra, "caller": "inspect_check_suite_head"},
-    )
+    sweep = sweep_check_runs(scm, head_match.head_sha, log_extra=resolved.log_extra)
     if sweep is None:
         _skip("sweep_failed", resolved.log_extra)
         return None

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -358,10 +358,23 @@ class GreenCheckSuiteContext:
     head_sha: str
 
 
+def pr_iteration_enabled(organization: Organization) -> bool:
+    """Whether any PR-iteration behaviour is enabled for this org."""
+    return (
+        features.has(REVIEW_REQUEST_FLAG, organization)
+        or features.has("organizations:autofix-pr-iteration", organization)
+        or features.has("organizations:autofix-pr-iteration-manual", organization)
+    )
+
+
 def resolve_green_check_suite(
     check_suite_event: CheckSuiteEvent,
 ) -> ResolvedGreenCheckSuite | None:
-    """Parse, flag-gate, and resolve the Autofix run (no SCM)."""
+    """Parse, flag-gate, and resolve the Autofix run (no SCM).
+
+    The gate here is only the coarse "does this org do PR iteration at all" one
+    (see ``pr_iteration_enabled``); callers gate their own side effects.
+    """
     try:
         raw = orjson.loads(check_suite_event.subscription_event["event"])
         event = GithubCheckSuiteEvent.parse_obj(raw)
@@ -379,8 +392,10 @@ def resolve_green_check_suite(
             except Organization.DoesNotExist:
                 continue
             organizations[repo.organization_id] = organization
-        if features.has(REVIEW_REQUEST_FLAG, organization):
+
+        if pr_iteration_enabled(organization):
             flagged_repos.append(repo)
+
     if not flagged_repos:
         return None
 
@@ -391,6 +406,7 @@ def resolve_green_check_suite(
     )
     if autofix_run is None:
         return None
+
     organization = organizations[autofix_run.repository.organization_id]
 
     log_extra: dict[str, Any] = {
@@ -425,10 +441,20 @@ def resolve_green_check_suite(
     )
 
 
-def confirm_green_check_suite(
+@dataclass(frozen=True)
+class InspectedCheckSuiteHead:
+    """Live PR head + check-run sweep. CI may still be red."""
+
+    scm: SourceCodeManager
+    pull_request: ActionResult[PullRequest]
+    head_sha: str
+    sweep: CheckRunsSweep
+
+
+def inspect_check_suite_head(
     resolved: ResolvedGreenCheckSuite,
-) -> GreenCheckSuiteContext | None:
-    """SCM live-head match + check-run sweep. Call only when a side effect is needed."""
+) -> InspectedCheckSuiteHead | None:
+    """SCM live-head match + check-run sweep. Does not require the tip to be green."""
     # Importing the SCM factory while the check-suite listener module is
     # initialized pulls in integration handlers before options init.
     from sentry.scm.factory import new as make_scm
@@ -458,17 +484,37 @@ def confirm_green_check_suite(
         _skip("stale_head", {**resolved.log_extra, "head_sha": head_match.head_sha})
         return None
 
-    sweep = sweep_check_runs(scm, head_match.head_sha, log_extra=resolved.log_extra)
+    sweep = sweep_check_runs(
+        scm,
+        head_match.head_sha,
+        log_extra={**resolved.log_extra, "caller": "inspect_check_suite_head"},
+    )
     if sweep is None:
         _skip("sweep_failed", resolved.log_extra)
         return None
-    if not sweep.is_green:
+
+    return InspectedCheckSuiteHead(
+        scm=scm,
+        pull_request=pull_request,
+        head_sha=head_match.head_sha,
+        sweep=sweep,
+    )
+
+
+def confirm_green_check_suite(
+    resolved: ResolvedGreenCheckSuite,
+) -> GreenCheckSuiteContext | None:
+    """SCM live-head match + check-run sweep. Call only when a side effect is needed."""
+    inspected = inspect_check_suite_head(resolved)
+    if inspected is None:
+        return None
+    if not inspected.sweep.is_green:
         _skip(
             "not_green",
             {
                 **resolved.log_extra,
-                "incomplete_count": sweep.incomplete,
-                "failed_count": sweep.failed,
+                "incomplete_count": inspected.sweep.incomplete,
+                "failed_count": inspected.sweep.failed,
             },
         )
         return None
@@ -476,10 +522,19 @@ def confirm_green_check_suite(
     metrics.incr("autofix.pr_iteration.green_check_suite.confirmed")
     return GreenCheckSuiteContext(
         resolved=resolved,
-        scm=scm,
-        pull_request=pull_request,
-        head_sha=head_match.head_sha,
+        scm=inspected.scm,
+        pull_request=inspected.pull_request,
+        head_sha=inspected.head_sha,
     )
+
+
+def green_review_side_effects_enabled(resolved: ResolvedGreenCheckSuite) -> bool:
+    """Whether undraft / request-review may run for this run's org."""
+    if features.has(REVIEW_REQUEST_FLAG, resolved.organization):
+        return True
+
+    _skip("review_request_disabled", resolved.log_extra)
+    return False
 
 
 def _skip(reason: str, log_extra: dict[str, Any]) -> None:

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -524,6 +524,42 @@ def confirm_green_check_suite(
     )
 
 
+def should_defer_pr_iteration(resolved: ResolvedGreenCheckSuite) -> bool:
+    """Whether a PR-iteration event on this head must leave a parked consume deferred.
+
+    A failing check suite parks its feedback and defers consume by an hour while
+    other checks are still running. A later event on the same head — today only a
+    green check suite — can pull that forward, but only once the head is actually
+    finished: one app going green says nothing about the other apps' suites.
+
+    Deferral holds unless the sweep ran and found nothing incomplete. Every
+    inconclusive outcome (SCM init failure, a provider that cannot list check
+    runs, a failed listing, a head the PR has already moved off) keeps the
+    existing 1h task as the only scheduler rather than starting an iteration
+    mid-CI. The automated-iteration hard cap defers for good.
+    """
+    # feedback.py imports the check-suite feedback source, which imports this
+    # module; deferred like ``make_scm`` below it.
+    from sentry.seer.autofix.pr_iteration.feedback import automated_iteration_cap_reached
+
+    if automated_iteration_cap_reached(resolved.autofix_run.run_state):
+        _skip("hard_cap_reached", resolved.log_extra)
+        return True
+
+    inspected = inspect_check_suite_head(resolved)
+    if inspected is None:
+        return True
+
+    if inspected.sweep.incomplete:
+        _skip(
+            "check_runs_incomplete",
+            {**resolved.log_extra, "incomplete_count": inspected.sweep.incomplete},
+        )
+        return True
+
+    return False
+
+
 def green_review_side_effects_enabled(resolved: ResolvedGreenCheckSuite) -> bool:
     """Whether undraft / request-review may run for this run's org."""
     if features.has(REVIEW_REQUEST_FLAG, resolved.organization):

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/base.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/base.py
@@ -35,6 +35,19 @@ ConsumeTask.Now = _ConsumeNow()
 ConsumeTask.Later = _ConsumeLater
 
 
+class ConsumeTriggerSource:
+    """Why ``consume_queued_autofix_feedback`` was scheduled.
+
+    Passed through Celery kwargs so consume can log early-vs-later impact:
+    feedback (webhook / UI / comment), a green check-suite pulling a parked
+    defer forward, or the original 1h time-limit defer firing.
+    """
+
+    FEEDBACK = "feedback"
+    GREEN_CHECK_SUITE_DEFER = "green_check_suite_defer"
+    TIME_LIMIT_DEFER = "time_limit_defer"
+
+
 class FeedbackSourceBase(BaseModel):
     class Config:
         extra = "ignore"

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -4,6 +4,7 @@ import orjson
 import sentry_sdk
 from pydantic import ValidationError
 
+from sentry.integrations.github.utils import is_github_rate_limit_sensitive
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -13,20 +14,90 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     GREEN_CONCLUSIONS,
     READY_FOR_REVIEW_EXTRA,
     REVIEW_REQUESTS_EXTRA,
+    ResolvedGreenCheckSuite,
     confirm_green_check_suite,
+    green_review_side_effects_enabled,
     resolve_green_check_suite,
 )
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
     MissingCheckSuiteAutofixRun,
 )
-from sentry.seer.autofix.pr_iteration.queue import try_enqueue_autofix_feedback
+from sentry.seer.autofix.pr_iteration.queue import (
+    peek_queued_autofix_feedback,
+    try_enqueue_autofix_feedback,
+)
 from sentry.seer.autofix.pr_iteration.ready_for_review import mark_ready_for_review
 from sentry.seer.autofix.pr_iteration.review_request import request_review_from_context
 from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
+
+
+def _retrigger_deferred_iteration(resolved: ResolvedGreenCheckSuite) -> None:
+    """Pull forward consume if this head has parked check-suite feedback.
+
+    A failing suite defers consume by an hour while other checks are still
+    running (``CheckSuiteFeedbackSource.should_trigger``). Bail on
+    rate-limit-sensitive orgs before the peek, since the sweep is the only
+    reason to look; otherwise peek first so there is no GitHub call unless the
+    queue already holds check-suite feedback on this head.
+    ``should_trigger`` then re-sweeps and answers Now vs Later; only Now
+    schedules, since the original deferred task already covers Later and
+    re-scheduling per green suite would pile up one consume per CI app.
+    ``should_consume`` drops items whose head no longer matches the run.
+    """
+    if is_github_rate_limit_sensitive(resolved.organization.slug):
+        metrics.incr(
+            "autofix.pr_iteration.green_check_suite.deferred_iteration",
+            tags={"outcome": "rate_limit_sensitive"},
+        )
+        return
+
+    run_id = resolved.autofix_run.run_state.run_id
+    head_sha = resolved.event.check_suite.head_sha
+    queued = peek_queued_autofix_feedback(run_id)
+    parked = next(
+        (
+            item
+            for item in queued
+            if item.feedback.source.type == "check-suite"
+            and item.feedback.source.event.check_suite.head_sha == head_sha
+        ),
+        None,
+    )
+    if parked is None:
+        metrics.incr(
+            "autofix.pr_iteration.green_check_suite.deferred_iteration",
+            tags={"outcome": "no_parked"},
+        )
+        return
+
+    run_state = resolved.autofix_run.run_state
+    task = parked.feedback.source.should_trigger(run_state)
+    if task is not ConsumeTask.Now:
+        metrics.incr(
+            "autofix.pr_iteration.green_check_suite.deferred_iteration",
+            tags={"outcome": "later" if task is not None else "skip"},
+        )
+        return
+
+    from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
+
+    metrics.incr(
+        "autofix.pr_iteration.green_check_suite.deferred_iteration",
+        tags={"outcome": "now"},
+    )
+    trigger_consume_pr_iteration_feedback(
+        run_id=run_id,
+        organization_id=resolved.organization.id,
+        feedback=parked.feedback,
+        run_state=run_state,
+        bypass=True,
+    )
 
 
 @scm_event_stream.listen_for(event_type="check_suite")
@@ -36,13 +107,29 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
 
     conclusion = check_suite_event.check_suite["conclusion"]
     if conclusion in GREEN_CONCLUSIONS:
+        resolved = resolve_green_check_suite(check_suite_event)
+        if resolved is None:
+            return None
+
+        # Peek the queue for parked check-suite feedback on this head, then
+        # ``should_trigger`` (GitHub sweep) only if something is waiting.
+        # Isolated so a failure cannot swallow undraft / review-request below.
+        try:
+            _retrigger_deferred_iteration(resolved)
+        except Exception:
+            logger.warning(
+                "autofix.pr_iteration.green_check_suite.retrigger_deferred_consume_failed",
+                extra=resolved.log_extra,
+                exc_info=True,
+            )
+
+        if not green_review_side_effects_enabled(resolved):
+            return None
+
         # Cheap resolve → read markers once → skip SCM if both done → confirm
         # green → run only the missing side effects. Undraft before
         # review-request: GitHub may CODEOWNERS-request after undraft; see TODO
         # on ``request_review_from_context``.
-        resolved = resolve_green_check_suite(check_suite_event)
-        if resolved is None:
-            return None
         ready_for_review_marker = get_run_marker(
             resolved.seer_run, READY_FOR_REVIEW_EXTRA, resolved.repo_name
         )

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -17,9 +17,9 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     confirm_green_check_suite,
     green_review_side_effects_enabled,
     resolve_green_check_suite,
+    should_defer_pr_iteration,
 )
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
-from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
     MissingCheckSuiteAutofixRun,
@@ -38,29 +38,27 @@ logger = logging.getLogger(__name__)
 def _retrigger_deferred_iteration(resolved: ResolvedGreenCheckSuite) -> None:
     """Pull forward consume if this head has parked check-suite feedback.
 
-    A failing suite defers consume by an hour while other checks are still
-    running (``CheckSuiteFeedbackSource.should_trigger``). Bail on
-    rate-limit-sensitive orgs before the peek, since the sweep is the only
-    reason to look; otherwise peek first so there is no GitHub call unless the
-    queue already holds check-suite feedback on this head.
-    ``should_trigger`` then re-sweeps and answers Now vs Later; only Now
-    schedules, since the original deferred task already covers Later and
-    re-scheduling per green suite would pile up one consume per CI app.
-    ``should_consume`` drops items whose head no longer matches the run.
+    Bail on rate-limit-sensitive orgs before the peek, since the sweep in
+    ``should_defer_pr_iteration`` is the only reason to look; otherwise peek
+    first so there is no GitHub call unless the queue already holds check-suite
+    feedback on this head. One parked item is enough to ask: the deferral is
+    per-head, not per-item, and re-scheduling per green suite would pile up one
+    consume per CI app. ``should_consume`` drops items whose head no longer
+    matches the run.
     """
     from sentry.integrations.github.utils import is_github_rate_limit_sensitive
 
     if is_github_rate_limit_sensitive(resolved.organization.slug):
         return
 
-    run_id = resolved.autofix_run.run_state.run_id
+    run_state = resolved.autofix_run.run_state
     head_sha = resolved.event.check_suite.head_sha
-    queued = peek_queued_autofix_feedback(run_id)
+
     parked = next(
         (
             item
-            for item in queued
-            if item.feedback.source.type == "check-suite"
+            for item in peek_queued_autofix_feedback(run_state.run_id)
+            if isinstance(item.feedback.source, CheckSuiteFeedbackSource)
             and item.feedback.source.event.check_suite.head_sha == head_sha
         ),
         None,
@@ -68,15 +66,13 @@ def _retrigger_deferred_iteration(resolved: ResolvedGreenCheckSuite) -> None:
     if parked is None:
         return
 
-    run_state = resolved.autofix_run.run_state
-    task = parked.feedback.source.should_trigger(run_state)
-    if task is not ConsumeTask.Now:
+    if should_defer_pr_iteration(resolved):
         return
 
     from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
 
     trigger_consume_pr_iteration_feedback(
-        run_id=run_id,
+        run_id=run_state.run_id,
         organization_id=resolved.organization.id,
         feedback=parked.feedback,
         run_state=run_state,
@@ -96,8 +92,9 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
             return None
 
         # Peek the queue for parked check-suite feedback on this head, then
-        # ``should_trigger`` (GitHub sweep) only if something is waiting.
-        # Isolated so a failure cannot swallow undraft / review-request below.
+        # ``should_defer_pr_iteration`` (GitHub sweep) only if something is
+        # waiting. Isolated so a failure cannot swallow undraft / review-request
+        # below.
         try:
             _retrigger_deferred_iteration(resolved)
         except Exception:

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -32,7 +32,6 @@ from sentry.seer.autofix.pr_iteration.queue import (
 from sentry.seer.autofix.pr_iteration.ready_for_review import mark_ready_for_review
 from sentry.seer.autofix.pr_iteration.review_request import request_review_from_context
 from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker
-from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -51,10 +50,6 @@ def _retrigger_deferred_iteration(resolved: ResolvedGreenCheckSuite) -> None:
     ``should_consume`` drops items whose head no longer matches the run.
     """
     if is_github_rate_limit_sensitive(resolved.organization.slug):
-        metrics.incr(
-            "autofix.pr_iteration.green_check_suite.deferred_iteration",
-            tags={"outcome": "rate_limit_sensitive"},
-        )
         return
 
     run_id = resolved.autofix_run.run_state.run_id
@@ -70,27 +65,15 @@ def _retrigger_deferred_iteration(resolved: ResolvedGreenCheckSuite) -> None:
         None,
     )
     if parked is None:
-        metrics.incr(
-            "autofix.pr_iteration.green_check_suite.deferred_iteration",
-            tags={"outcome": "no_parked"},
-        )
         return
 
     run_state = resolved.autofix_run.run_state
     task = parked.feedback.source.should_trigger(run_state)
     if task is not ConsumeTask.Now:
-        metrics.incr(
-            "autofix.pr_iteration.green_check_suite.deferred_iteration",
-            tags={"outcome": "later" if task is not None else "skip"},
-        )
         return
 
     from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
 
-    metrics.incr(
-        "autofix.pr_iteration.green_check_suite.deferred_iteration",
-        tags={"outcome": "now"},
-    )
     trigger_consume_pr_iteration_feedback(
         run_id=run_id,
         organization_id=resolved.organization.id,

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -4,7 +4,6 @@ import orjson
 import sentry_sdk
 from pydantic import ValidationError
 
-from sentry.integrations.github.utils import is_github_rate_limit_sensitive
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -49,6 +48,8 @@ def _retrigger_deferred_iteration(resolved: ResolvedGreenCheckSuite) -> None:
     re-scheduling per green suite would pile up one consume per CI app.
     ``should_consume`` drops items whose head no longer matches the run.
     """
+    from sentry.integrations.github.utils import is_github_rate_limit_sensitive
+
     if is_github_rate_limit_sensitive(resolved.organization.slug):
         return
 

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -64,6 +64,7 @@ from sentry.seer.autofix.github_perms import (
     get_out_of_date_github_permissions,
 )
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTriggerSource
 from sentry.seer.autofix.pr_iteration.queue import (
     peek_queued_autofix_feedback,
     try_enqueue_autofix_feedback,
@@ -415,6 +416,7 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
                     kwargs={
                         "run_id": resolved_run_id,
                         "organization_id": group.organization.id,
+                        "trigger_source": ConsumeTriggerSource.FEEDBACK,
                     }
                 )
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -59,7 +59,10 @@ from sentry.seer.autofix.commit_author import commit_author_for_feedback
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.constants import PR_ITERATION_PROVIDER
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, automated_iteration_cap_reached
-from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import (
+    ConsumeTask,
+    ConsumeTriggerSource,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
@@ -137,8 +140,14 @@ def trigger_consume_pr_iteration_feedback(
 
     if bypass:
         task: ConsumeTask | None = ConsumeTask.Now
+        trigger_source = ConsumeTriggerSource.GREEN_CHECK_SUITE_DEFER
     else:
         task = feedback.source.should_trigger(run_state)
+        trigger_source = (
+            ConsumeTriggerSource.TIME_LIMIT_DEFER
+            if isinstance(task, ConsumeTask.Later)
+            else ConsumeTriggerSource.FEEDBACK
+        )
 
     if task is None:
         return
@@ -148,6 +157,7 @@ def trigger_consume_pr_iteration_feedback(
         kwargs={
             "run_id": run_id,
             "organization_id": organization_id,
+            "trigger_source": trigger_source,
         },
         countdown=countdown,
     )
@@ -160,10 +170,15 @@ def trigger_consume_pr_iteration_feedback(
     retry=Retry(on=(UnableToAcquireLock,), times=3, delay=5),
 )
 def consume_queued_autofix_feedback(
-    run_id: int, organization_id: int, *args: Any, **kwargs: Any
+    run_id: int,
+    organization_id: int,
+    trigger_source: str | None = None,
+    *args: Any,
+    **kwargs: Any,
 ) -> None:
     # Accept unused *args/**kwargs so in-flight activations queued with retired
     # kwargs (e.g. group_id) still deserialize after the signature change.
+    # ``trigger_source`` is None for tasks queued before the kwarg existed.
     lock = locks.get(
         f"autofix:feedback:lock:{run_id}",
         duration=60,
@@ -287,6 +302,21 @@ def consume_queued_autofix_feedback(
                 "autofix.pr_iteration.consume_feedback.skipped",
                 extra={"run_id": run_id, "group_id": group.id, "error": str(error)},
             )
+            return
+
+        logger.info(
+            "autofix.pr_iteration.consume_feedback.triggered",
+            extra={
+                "run_id": run_id,
+                "organization_id": organization_id,
+                "group_id": group_id,
+                "trigger_source": trigger_source or "unknown",
+            },
+        )
+        metrics.incr(
+            "autofix.pr_iteration.consume_feedback.triggered",
+            tags={"trigger_source": trigger_source or "unknown"},
+        )
 
 
 def _github_commenter_has_repo_write_access(

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -7,10 +6,14 @@ from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.check_suites import (
+    CheckRunsSweep,
     CheckSuiteAutofixRun,
     GithubCheckSuiteEvent,
+    InspectedCheckSuiteHead,
+    ResolvedGreenCheckSuite,
     pr_iteration_enabled,
     resolve_check_suite_autofix_run,
+    should_defer_pr_iteration,
 )
 from sentry.seer.autofix.pr_iteration.constants import REVIEW_REQUEST_FLAG
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
@@ -24,6 +27,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeed
 from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
     pr_iteration_from_check_suite_listener,
 )
+from sentry.seer.autofix.pr_iteration.queue import QueuedAutofixFeedback
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 
@@ -45,6 +49,8 @@ def own_repo_pr(pr_id: int) -> dict:
 
 # Lazy-imported inside the listener (must not load at AppConfig.ready).
 TRIGGER_CONSUME_PATH = "sentry.tasks.seer.pr_iteration.trigger_consume_pr_iteration_feedback"
+DEFER_PATH = f"{CHECK_PATH}.should_defer_pr_iteration"
+INSPECT_PATH = f"{CHECK_SUITES_PATH}.inspect_check_suite_head"
 
 
 class PrIterationFromCheckSuiteListenerTest(TestCase):
@@ -507,17 +513,26 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
         resolved.log_extra = {"run_id": 67890}
         return resolved
 
-    def _parked_check_suite(
-        self, *, head_sha: str = "abc", task: object = ConsumeTask.Now
-    ) -> MagicMock:
-        source = MagicMock()
-        source.type = "check-suite"
-        source.event.check_suite.head_sha = head_sha
-        source.should_trigger.return_value = task
-        item = MagicMock()
-        item.feedback.source = source
-        return item
+    def _parked_check_suite(self, *, head_sha: str = "abc") -> QueuedAutofixFeedback:
+        source = CheckSuiteFeedbackSource(
+            event={
+                "check_suite": {
+                    "id": 1,
+                    "head_sha": head_sha,
+                    "check_runs_url": "https://github.com/owner/repo/check-runs",
+                    "app": {"name": "CI"},
+                },
+                "repository": {"html_url": "https://github.com/owner/repo"},
+            }
+        )
+        return QueuedAutofixFeedback(
+            organization_id=self.organization.id,
+            group_id=self.group.id,
+            feedback=Feedback(source=source),
+            referrer=AutofixReferrer.GITHUB_CHECK_SUITE,
+        )
 
+    @patch(DEFER_PATH, return_value=False)
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
     @patch(f"{CHECK_PATH}.confirm_green_check_suite")
@@ -532,6 +547,7 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
         mock_confirm: MagicMock,
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
+        mock_defer: MagicMock,
     ) -> None:
         resolved = self._resolved()
         parked = self._parked_check_suite()
@@ -547,9 +563,7 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
             run_state=resolved.autofix_run.run_state,
             bypass=True,
         )
-        parked.feedback.source.should_trigger.assert_called_once_with(
-            resolved.autofix_run.run_state
-        )
+        mock_defer.assert_called_once_with(resolved)
         mock_confirm.assert_not_called()
         mock_mark_ready.assert_not_called()
         mock_request_review.assert_not_called()
@@ -601,28 +615,30 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
 
         mock_trigger.assert_not_called()
 
+    @patch(DEFER_PATH, return_value=True)
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
-    def test_incomplete_sweep_leaves_the_existing_deferral_alone(
+    def test_unready_sweep_leaves_the_existing_deferral_alone(
         self,
         mock_resolve: MagicMock,
         mock_peek: MagicMock,
         mock_trigger: MagicMock,
+        mock_defer: MagicMock,
     ) -> None:
-        """Later means other checks are still running: the parked 1h task covers it.
+        """Checks still running, or a sweep that could not run, keeps the 1h defer.
 
         Re-scheduling here would queue one duplicate consume per CI app on the head.
         """
         mock_resolve.return_value = self._resolved()
-        parked = self._parked_check_suite(task=ConsumeTask.Later(timedelta(hours=1)))
-        mock_peek.return_value = [parked]
+        mock_peek.return_value = [self._parked_check_suite()]
 
         pr_iteration_from_check_suite_listener(self._event())
 
-        parked.feedback.source.should_trigger.assert_called_once()
+        mock_defer.assert_called_once()
         mock_trigger.assert_not_called()
 
+    @patch(DEFER_PATH, return_value=False)
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
     @patch(f"{CHECK_PATH}.resolve_green_check_suite")
@@ -631,19 +647,44 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
         mock_resolve: MagicMock,
         mock_peek: MagicMock,
         mock_trigger: MagicMock,
+        mock_defer: MagicMock,
     ) -> None:
         """The opt-out lands before the peek: the sweep is the only reason to look."""
         mock_resolve.return_value = self._resolved()
-        parked = self._parked_check_suite()
-        mock_peek.return_value = [parked]
+        mock_peek.return_value = [self._parked_check_suite()]
 
         with override_options({"github-app.rate-limit-sensitive-orgs": [self.organization.slug]}):
             pr_iteration_from_check_suite_listener(self._event())
 
         mock_peek.assert_not_called()
-        parked.feedback.source.should_trigger.assert_not_called()
+        mock_defer.assert_not_called()
         mock_trigger.assert_not_called()
 
+    @patch(INSPECT_PATH, return_value=None)
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_inconclusive_sweep_does_not_override_the_deferral(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+        mock_inspect: MagicMock,
+    ) -> None:
+        """End to end through the real ``should_defer_pr_iteration``.
+
+        An inspection that could not conclude says nothing about CI, so the
+        parked 1h task stays the only scheduler.
+        """
+        mock_resolve.return_value = self._resolved()
+        mock_peek.return_value = [self._parked_check_suite()]
+
+        pr_iteration_from_check_suite_listener(self._event())
+
+        mock_inspect.assert_called_once()
+        mock_trigger.assert_not_called()
+
+    @patch(DEFER_PATH, return_value=False)
     @patch(f"{CHECK_PATH}.get_run_marker", return_value={"marked": True})
     @patch(f"{CHECK_PATH}.confirm_green_check_suite")
     @patch(TRIGGER_CONSUME_PATH)
@@ -656,6 +697,7 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
         mock_trigger: MagicMock,
         mock_confirm: MagicMock,
         _mock_marker: MagicMock,
+        _mock_defer: MagicMock,
     ) -> None:
         mock_resolve.return_value = self._resolved()
         mock_peek.return_value = [self._parked_check_suite()]
@@ -666,6 +708,7 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
         mock_trigger.assert_called_once()
         mock_confirm.assert_not_called()
 
+    @patch(DEFER_PATH, return_value=False)
     @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
@@ -682,6 +725,7 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
         _mock_marker: MagicMock,
+        _mock_defer: MagicMock,
     ) -> None:
         mock_resolve.return_value = self._resolved()
         mock_peek.return_value = [self._parked_check_suite()]
@@ -693,6 +737,112 @@ class GreenCheckSuiteDeferredIterationTest(TestCase):
 
         mock_mark_ready.assert_called_once_with(ctx)
         mock_request_review.assert_called_once_with(ctx)
+
+
+class ShouldDeferPrIterationTest(TestCase):
+    """Parked feedback keeps its deferral unless the sweep proves the head is finished."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(
+            project=self.project, provider="integrations:github", name="owner/repo"
+        )
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=67890, user_id=self.user.id
+        )
+
+    def _resolved(self, *, blocks: list | None = None) -> ResolvedGreenCheckSuite:
+        run_state = SeerRunState(
+            run_id=67890,
+            blocks=blocks or [],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+            metadata={"group_id": 1},
+        )
+        event = GithubCheckSuiteEvent.parse_obj(
+            {
+                "check_suite": {
+                    "id": 1,
+                    "head_sha": "abc",
+                    "check_runs_url": "https://github.com/owner/repo/check-runs",
+                    "app": {"name": "CI"},
+                },
+                "repository": {
+                    "html_url": "https://github.com/owner/repo",
+                    "full_name": "owner/repo",
+                },
+            }
+        )
+        return ResolvedGreenCheckSuite(
+            event=event,
+            organization=self.organization,
+            autofix_run=CheckSuiteAutofixRun(
+                repository=self.repo, run_state=run_state, pr_id=1, group_id=1
+            ),
+            seer_run=self.seer_run,
+            repo_name="owner/repo",
+            pr_number=42,
+            log_extra={"run_id": 67890},
+        )
+
+    def _inspected(self, sweep: CheckRunsSweep) -> InspectedCheckSuiteHead:
+        return InspectedCheckSuiteHead(
+            scm=MagicMock(), pull_request=MagicMock(), head_sha="abc", sweep=sweep
+        )
+
+    @patch(INSPECT_PATH)
+    def test_false_when_every_check_run_completed(self, mock_inspect: MagicMock) -> None:
+        """Failed runs are expected — the parked feedback is a failed suite."""
+        mock_inspect.return_value = self._inspected(CheckRunsSweep(total=3, incomplete=0, failed=1))
+
+        assert should_defer_pr_iteration(self._resolved()) is False
+
+    @patch(INSPECT_PATH)
+    def test_true_when_a_check_run_is_incomplete(self, mock_inspect: MagicMock) -> None:
+        mock_inspect.return_value = self._inspected(CheckRunsSweep(total=3, incomplete=1, failed=1))
+
+        assert should_defer_pr_iteration(self._resolved()) is True
+
+    @patch(INSPECT_PATH, return_value=None)
+    def test_true_when_inspection_is_inconclusive(self, _mock_inspect: MagicMock) -> None:
+        """``inspect_check_suite_head`` folds SCM init, provider, PR-fetch, stale-head
+        and listing failures into ``None``. None of them mean CI finished."""
+        assert should_defer_pr_iteration(self._resolved()) is True
+
+    @patch(f"{CHECK_SUITES_PATH}.scm_actions.get_pull_request")
+    @patch("sentry.scm.factory.new", side_effect=Exception("boom"))
+    def test_true_when_scm_init_fails(self, _mock_new: MagicMock, mock_get_pr: MagicMock) -> None:
+        assert should_defer_pr_iteration(self._resolved()) is True
+        mock_get_pr.assert_not_called()
+
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", side_effect=Exception("boom"))
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.scm_actions.get_pull_request")
+    @patch("sentry.scm.factory.new")
+    def test_true_when_listing_check_runs_fails(
+        self,
+        mock_new: MagicMock,
+        mock_get_pr: MagicMock,
+        mock_pages: MagicMock,
+    ) -> None:
+        mock_new.return_value = MagicMock()
+        mock_get_pr.return_value = {"data": {"head": {"sha": "abc"}}}
+
+        assert should_defer_pr_iteration(self._resolved()) is True
+        mock_pages.assert_called_once()
+
+    @patch(INSPECT_PATH)
+    def test_true_when_hard_cap_reached(self, mock_inspect: MagicMock) -> None:
+        """A capped run must not iterate at all, so no sweep is worth paying for."""
+        cap = 3
+        blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap)]
+
+        with self.options({"autofix.pr-iteration.max-iterations": cap}):
+            assert should_defer_pr_iteration(self._resolved(blocks=blocks)) is True
+
+        mock_inspect.assert_not_called()
 
 
 class PrIterationEnabledTest(TestCase):

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -8,8 +9,10 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.check_suites import (
     CheckSuiteAutofixRun,
     GithubCheckSuiteEvent,
+    pr_iteration_enabled,
     resolve_check_suite_autofix_run,
 )
+from sentry.seer.autofix.pr_iteration.constants import REVIEW_REQUEST_FLAG
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
@@ -22,6 +25,7 @@ from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
     pr_iteration_from_check_suite_listener,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 
 CHECK_PATH = "sentry.seer.autofix.pr_iteration.listeners.check_suite"
 CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
@@ -106,6 +110,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         pr_iteration_from_check_suite_listener(self._event(conclusion="cancelled"))
         mock_get_state.assert_not_called()
 
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.green_review_side_effects_enabled", return_value=True)
     @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
@@ -120,6 +126,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
         _mock_marker: MagicMock,
+        _mock_flag: MagicMock,
+        _mock_peek: MagicMock,
     ) -> None:
         event = self._event(self._raw(), conclusion="success")
         resolved = MagicMock()
@@ -139,6 +147,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert call_order == ["ready", "review"]
         mock_get_state.assert_not_called()
 
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.green_review_side_effects_enabled", return_value=True)
     @patch(f"{CHECK_PATH}.get_run_marker")
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
@@ -153,6 +163,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
         mock_marker: MagicMock,
+        _mock_flag: MagicMock,
+        _mock_peek: MagicMock,
     ) -> None:
         from sentry.seer.autofix.pr_iteration.check_suites import (
             READY_FOR_REVIEW_EXTRA,
@@ -177,6 +189,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert mock_marker.call_args_list[1].args[1] == REVIEW_REQUESTS_EXTRA
         mock_get_state.assert_not_called()
 
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.green_review_side_effects_enabled", return_value=True)
     @patch(f"{CHECK_PATH}.get_run_marker", return_value={"marked": True})
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
@@ -191,6 +205,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
         _mock_marker: MagicMock,
+        _mock_flag: MagicMock,
+        _mock_peek: MagicMock,
     ) -> None:
         mock_resolve.return_value = MagicMock()
 
@@ -201,6 +217,35 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_request_review.assert_not_called()
         mock_get_state.assert_not_called()
 
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.green_review_side_effects_enabled", return_value=False)
+    @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
+    @patch(f"{CHECK_PATH}.request_review_from_context")
+    @patch(f"{CHECK_PATH}.mark_ready_for_review")
+    @patch(f"{CHECK_PATH}.confirm_green_check_suite")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_green_conclusion_skips_side_effects_when_review_request_disabled(
+        self,
+        mock_resolve: MagicMock,
+        mock_confirm: MagicMock,
+        mock_mark_ready: MagicMock,
+        mock_request_review: MagicMock,
+        mock_marker: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_peek: MagicMock,
+    ) -> None:
+        """The resolve no longer implies the review-request flag; the caller checks it."""
+        mock_resolve.return_value = MagicMock()
+
+        pr_iteration_from_check_suite_listener(self._event(self._raw(), conclusion="success"))
+
+        mock_marker.assert_not_called()
+        mock_confirm.assert_not_called()
+        mock_mark_ready.assert_not_called()
+        mock_request_review.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.green_review_side_effects_enabled", return_value=True)
     @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
     @patch(f"{CHECK_PATH}.request_review_from_context")
     @patch(f"{CHECK_PATH}.mark_ready_for_review")
@@ -215,6 +260,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_mark_ready: MagicMock,
         mock_request_review: MagicMock,
         _mock_marker: MagicMock,
+        _mock_flag: MagicMock,
+        _mock_peek: MagicMock,
     ) -> None:
         mock_resolve.return_value = MagicMock()
         pr_iteration_from_check_suite_listener(self._event(self._raw(), conclusion="success"))
@@ -400,6 +447,271 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         _, kwargs = mock_enqueue.call_args
         assert kwargs["organization_id"] == self.organization.id
         mock_trigger_consume.assert_called_once()
+
+
+class GreenCheckSuiteDeferredIterationTest(TestCase):
+    """Green suite retriggers consume only if parked check-suite feedback matches this head."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+
+    def _event(self) -> CheckSuiteEvent:
+        return CheckSuiteEvent(
+            action="completed",
+            check_suite={
+                "id": "1",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "",
+                "pull_request_ids": [],
+            },
+            subscription_event={
+                "event": orjson.dumps(
+                    {
+                        "check_suite": {
+                            "id": 1,
+                            "head_sha": "abc",
+                            "check_runs_url": "https://github.com/owner/repo/check-runs",
+                            "app": {"name": "CI"},
+                            "updated_at": "2024-01-01T00:00:00Z",
+                            "pull_requests": [],
+                        },
+                        "repository": {"html_url": "https://github.com/owner/repo"},
+                    }
+                ).decode(),
+                "event_type_hint": "check_suite",
+                "extra": {},
+                "received_at": 0,
+                "sentry_meta": None,
+                "type": "github",
+            },
+        )
+
+    def _run_state(self) -> SeerRunState:
+        return SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+            metadata={"group_id": self.group.id},
+        )
+
+    def _resolved(self) -> MagicMock:
+        resolved = MagicMock()
+        resolved.organization = self.organization
+        resolved.event.check_suite.head_sha = "abc"
+        resolved.autofix_run.run_state = self._run_state()
+        resolved.autofix_run.group_id = self.group.id
+        resolved.log_extra = {"run_id": 67890}
+        return resolved
+
+    def _parked_check_suite(
+        self, *, head_sha: str = "abc", task: object = ConsumeTask.Now
+    ) -> MagicMock:
+        source = MagicMock()
+        source.type = "check-suite"
+        source.event.check_suite.head_sha = head_sha
+        source.should_trigger.return_value = task
+        item = MagicMock()
+        item.feedback.source = source
+        return item
+
+    @patch(f"{CHECK_PATH}.request_review_from_context")
+    @patch(f"{CHECK_PATH}.mark_ready_for_review")
+    @patch(f"{CHECK_PATH}.confirm_green_check_suite")
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_parked_check_suite_on_this_head_triggers_consume(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+        mock_confirm: MagicMock,
+        mock_mark_ready: MagicMock,
+        mock_request_review: MagicMock,
+    ) -> None:
+        resolved = self._resolved()
+        parked = self._parked_check_suite()
+        mock_resolve.return_value = resolved
+        mock_peek.return_value = [parked]
+
+        pr_iteration_from_check_suite_listener(self._event())
+
+        mock_trigger.assert_called_once_with(
+            run_id=67890,
+            organization_id=self.organization.id,
+            feedback=parked.feedback,
+            run_state=resolved.autofix_run.run_state,
+            bypass=True,
+        )
+        parked.feedback.source.should_trigger.assert_called_once_with(
+            resolved.autofix_run.run_state
+        )
+        mock_confirm.assert_not_called()
+        mock_mark_ready.assert_not_called()
+        mock_request_review.assert_not_called()
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_empty_queue_does_not_trigger_consume(
+        self,
+        mock_resolve: MagicMock,
+        _mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+
+        pr_iteration_from_check_suite_listener(self._event())
+
+        mock_trigger.assert_not_called()
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_other_feedback_does_not_trigger_consume(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_peek.return_value = [MagicMock()]
+
+        pr_iteration_from_check_suite_listener(self._event())
+
+        mock_trigger.assert_not_called()
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_check_suite_on_other_head_does_not_trigger_consume(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_peek.return_value = [self._parked_check_suite(head_sha="old")]
+
+        pr_iteration_from_check_suite_listener(self._event())
+
+        mock_trigger.assert_not_called()
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_incomplete_sweep_leaves_the_existing_deferral_alone(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        """Later means other checks are still running: the parked 1h task covers it.
+
+        Re-scheduling here would queue one duplicate consume per CI app on the head.
+        """
+        mock_resolve.return_value = self._resolved()
+        parked = self._parked_check_suite(task=ConsumeTask.Later(timedelta(hours=1)))
+        mock_peek.return_value = [parked]
+
+        pr_iteration_from_check_suite_listener(self._event())
+
+        parked.feedback.source.should_trigger.assert_called_once()
+        mock_trigger.assert_not_called()
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_rate_limit_sensitive_org_skips_the_sweep_entirely(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        """The opt-out lands before the peek: the sweep is the only reason to look."""
+        mock_resolve.return_value = self._resolved()
+        parked = self._parked_check_suite()
+        mock_peek.return_value = [parked]
+
+        with override_options({"github-app.rate-limit-sensitive-orgs": [self.organization.slug]}):
+            pr_iteration_from_check_suite_listener(self._event())
+
+        mock_peek.assert_not_called()
+        parked.feedback.source.should_trigger.assert_not_called()
+        mock_trigger.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.get_run_marker", return_value={"marked": True})
+    @patch(f"{CHECK_PATH}.confirm_green_check_suite")
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_triggers_consume_even_when_both_markers_set(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        mock_trigger: MagicMock,
+        mock_confirm: MagicMock,
+        _mock_marker: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_peek.return_value = [self._parked_check_suite()]
+
+        with self.feature(REVIEW_REQUEST_FLAG):
+            pr_iteration_from_check_suite_listener(self._event())
+
+        mock_trigger.assert_called_once()
+        mock_confirm.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.get_run_marker", return_value=None)
+    @patch(f"{CHECK_PATH}.request_review_from_context")
+    @patch(f"{CHECK_PATH}.mark_ready_for_review")
+    @patch(f"{CHECK_PATH}.confirm_green_check_suite")
+    @patch(TRIGGER_CONSUME_PATH, side_effect=ValueError("broker down"))
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback")
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_failing_consume_schedule_still_runs_review_side_effects(
+        self,
+        mock_resolve: MagicMock,
+        mock_peek: MagicMock,
+        _mock_trigger: MagicMock,
+        mock_confirm: MagicMock,
+        mock_mark_ready: MagicMock,
+        mock_request_review: MagicMock,
+        _mock_marker: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_peek.return_value = [self._parked_check_suite()]
+        ctx = MagicMock()
+        mock_confirm.return_value = ctx
+
+        with self.feature(REVIEW_REQUEST_FLAG):
+            pr_iteration_from_check_suite_listener(self._event())
+
+        mock_mark_ready.assert_called_once_with(ctx)
+        mock_request_review.assert_called_once_with(ctx)
+
+
+class PrIterationEnabledTest(TestCase):
+    """The coarse gate on the green resolve: any PR-iteration behaviour admits."""
+
+    def test_disabled_without_any_flag(self) -> None:
+        assert not pr_iteration_enabled(self.organization)
+
+    def test_enabled_by_review_request_flag(self) -> None:
+        with self.feature(REVIEW_REQUEST_FLAG):
+            assert pr_iteration_enabled(self.organization)
+
+    def test_enabled_by_automated_iteration_flag(self) -> None:
+        with self.feature("organizations:autofix-pr-iteration"):
+            assert pr_iteration_enabled(self.organization)
+
+    def test_enabled_by_manual_iteration_flag(self) -> None:
+        with self.feature("organizations:autofix-pr-iteration-manual"):
+            assert pr_iteration_enabled(self.organization)
 
 
 class ResolveCheckSuiteAutofixRunTest(TestCase):

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -9,6 +9,7 @@ from scm.types import (
 from sentry.seer.agent.client_models import RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTriggerSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
     GithubPrCommentFeedbackType,
@@ -239,6 +240,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             kwargs={
                 "run_id": 67890,
                 "organization_id": self.organization.id,
+                "trigger_source": ConsumeTriggerSource.FEEDBACK,
             },
             countdown=None,
         )

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -14,7 +14,10 @@ from sentry.seer.autofix.autofix_agent import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.check_suites import CheckSuiteAutofixRun
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
-from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import (
+    ConsumeTask,
+    ConsumeTriggerSource,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
 )
@@ -570,6 +573,39 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         assert kwargs["group"].id == self.group.id
         assert [f.text for f in kwargs["feedback"]] == ["fix it"]
 
+    @patch(f"{TASK_PATH}.logger")
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_logs_trigger_source_on_consume(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state()
+        mock_pop.return_value = [
+            self._queued(Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it")))
+        ]
+
+        consume_queued_autofix_feedback(
+            run_id=67890,
+            organization_id=self.organization.id,
+            trigger_source=ConsumeTriggerSource.GREEN_CHECK_SUITE_DEFER,
+        )
+
+        mock_trigger.assert_called_once()
+        mock_logger.info.assert_any_call(
+            "autofix.pr_iteration.consume_feedback.triggered",
+            extra={
+                "run_id": 67890,
+                "organization_id": self.organization.id,
+                "group_id": self.group.id,
+                "trigger_source": ConsumeTriggerSource.GREEN_CHECK_SUITE_DEFER,
+            },
+        )
+
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
     @patch(f"{TASK_PATH}.fetch_run_status")
@@ -918,6 +954,7 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         mock_trigger.assert_called_once()
         assert len(mock_trigger.call_args.kwargs["feedback"]) == 2
 
+    @patch(f"{TASK_PATH}.logger")
     @patch(f"{TASK_PATH}.trigger_autofix_agent", side_effect=PrIterationNoPullRequestException())
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
     @patch(f"{TASK_PATH}.fetch_run_status")
@@ -926,6 +963,7 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         mock_fetch: MagicMock,
         mock_pop: MagicMock,
         _mock_trigger: MagicMock,
+        mock_logger: MagicMock,
     ) -> None:
         mock_fetch.return_value = self._state()
         mock_pop.return_value = [
@@ -933,6 +971,11 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         ]
 
         self._call()
+
+        assert not any(
+            call.args and call.args[0] == "autofix.pr_iteration.consume_feedback.triggered"
+            for call in mock_logger.info.call_args_list
+        )
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
@@ -1098,7 +1141,11 @@ class TriggerConsumePrIterationFeedbackTest(TestCase):
         )
 
         mock_apply.assert_called_once_with(
-            kwargs={"run_id": 67890, "organization_id": self.organization.id},
+            kwargs={
+                "run_id": 67890,
+                "organization_id": self.organization.id,
+                "trigger_source": ConsumeTriggerSource.FEEDBACK,
+            },
             countdown=None,
         )
 
@@ -1131,7 +1178,11 @@ class TriggerConsumePrIterationFeedbackTest(TestCase):
             )
 
         mock_apply.assert_called_once_with(
-            kwargs={"run_id": 67890, "organization_id": self.organization.id},
+            kwargs={
+                "run_id": 67890,
+                "organization_id": self.organization.id,
+                "trigger_source": ConsumeTriggerSource.TIME_LIMIT_DEFER,
+            },
             countdown=3600,
         )
 
@@ -1147,7 +1198,14 @@ class TriggerConsumePrIterationFeedbackTest(TestCase):
                 bypass=True,
             )
 
-        mock_apply.assert_called_once()
+        mock_apply.assert_called_once_with(
+            kwargs={
+                "run_id": 67890,
+                "organization_id": self.organization.id,
+                "trigger_source": ConsumeTriggerSource.GREEN_CHECK_SUITE_DEFER,
+            },
+            countdown=None,
+        )
 
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
     def test_passes_delay_as_countdown(self, mock_apply: MagicMock) -> None:


### PR DESCRIPTION
### Why
gist is that the desired logic for deciding when to run iteration on CI is:

- if we have failures and CI is done

our code says:

- if we get a red check suite and CI is done, trigger
- if we get a red check suite and CI is not done, enqueue it (and trigger a "fallback" task to run in an hour in case CI doesn't finish in a timely way)

but we aren't detecting when CI is actually done so we're always using the fall back task

this degrades UX so i'm adding the "detection" for when CI is done and we have CI feedback in the queue

### What

- Refactored check-suite gating logic so that a green check suite for a run with queued feedback triggers a sweep of check runs on the associated PR
- Always resolve the autofix run on incoming check suites for orgs with PR iteration enabled, then check the feedback queue for that run
- Sweep check runs only when the queue contains check-suite-based feedback, tracking the added GitHub API cost
- Trigger consumption of queued feedback once the sweep confirms CI is complete
- Added `ConsumeTriggerSource` logging when scheduling the `consume_queued_autofix_feedback` task, to indicate the cause of consumption (new feedback, check suite defer, or time limit defer)