### PR TITLE
feat(seer): register organizations:seer-xray feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -343,6 +343,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-disable-coding-setting", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GitLab as a supported SCM provider for Seer
     manager.add("organizations:seer-gitlab-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable the Seer XRay Mode overlay (cmd+k), which inspects the LLM context tree on the page
+    manager.add("organizations:seer-xray", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Append a "text" summary to SentryApp webhooks sent to Claude Code routine fire URLs
     manager.add("organizations:sentry-apps-claude-routine-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable prefill templates on the internal integration creation page


### PR DESCRIPTION
## Summary
- Registers the `organizations:seer-xray` FlagPole feature flag, extracted out of #122143 per the frontend/backend split policy in AGENTS.md.
- This flag gates the Seer XRay Mode overlay (cmd+k), whose frontend implementation lives entirely in #122143.
- Isolated, forward/backward compatible: the frontend checks `organization.features.includes('seer-xray')` and treats an unregistered/absent flag as `false` (feature hidden), so this can land independently in either order relative to #122143.
- Rollout config (sentry orgs + sentry employees only) is being defined separately in a companion `sentry-options-automator` PR.

## Test plan
- [x] No behavior change until the corresponding options-automator rollout PR enables the segment — `manager.add(...)` alone doesn't turn anything on.
- [x] Frontend consumer PR: #122143
