### PR TITLE
fix(autofix): clarify GitHub App permissions alert message

### DIFF
--- a/static/app/components/events/autofix/v3/drawer.spec.tsx
+++ b/static/app/components/events/autofix/v3/drawer.spec.tsx
@@ -26,7 +26,7 @@ describe('AutofixWarnings', () => {
     );
 
     expect(screen.getAllByText('getsentry/sentry')).toHaveLength(1);
-    expect(screen.getByText(/The configured GitHub App for/)).toBeInTheDocument();
+    expect(screen.getByText(/Seer can't fix the failing CI/)).toBeInTheDocument();
   });
 
   it('renders fallback copy when repo names are missing', () => {
@@ -44,9 +44,9 @@ describe('AutofixWarnings', () => {
 
     expect(
       screen.getByText(
-        'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
+        "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app."
       )
     ).toBeInTheDocument();
-    expect(screen.queryByText(/The configured GitHub App for/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/on your pull request in/)).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -260,13 +260,13 @@ export function AutofixWarnings({
       >
         {repoNames.length
           ? tct(
-              'The configured GitHub App for [repoNames] is missing permissions. Update the app and ask Seer to retry.',
+              "Seer can't fix the failing CI on your pull request because the configured GitHub App for [repoNames] is missing permissions. Update the app.",
               {
                 repoNames: repoNamesNode,
               }
             )
           : t(
-              'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
+              "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app."
             )}
       </Alert>
     </Stack>


### PR DESCRIPTION
Update the missing permissions alert copy to explain that Seer
cannot fix failing CI on the pull request due to the GitHub App
permission issue.