### PR TITLE
ref(featureadoption): add a 90 day TTL to the adoption cache

### DIFF
--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from typing import ClassVar, cast
 
 import rb
@@ -23,6 +24,7 @@ from sentry.utils.services import build_instance_from_options
 logger = logging.getLogger(__name__)
 
 FEATURE_ADOPTION_REDIS_KEY = "organization-feature-adoption:{}"
+FEATURE_ADOPTION_CACHE_TTL = int(timedelta(days=90).total_seconds())
 
 # Languages
 manager.add(0, "python", "Python", "language")
@@ -149,7 +151,10 @@ class FeatureAdoptionRedisBackend:
             return False
 
         org_key = self.key_tpl.format(organization_id)
-        self.get_client(org_key).sadd(org_key, *args)
+        pipe = self.get_client(org_key).pipeline()
+        pipe.sadd(org_key, *args)
+        pipe.expire(org_key, FEATURE_ADOPTION_CACHE_TTL)
+        pipe.execute()
         return True
 
 
@@ -212,13 +217,9 @@ class FeatureAdoptionManager(BaseManager["FeatureAdoption"]):
 
         try:
             with transaction.atomic(router.db_for_write(FeatureAdoption)):
-                self.bulk_create(features)
+                # Skip existing rows and keep the new ones
+                self.bulk_create(features, ignore_conflicts=True)
         except IntegrityError:
-            # This can occur if redis somehow loses the set of complete features and
-            # we attempt to insert duplicate (org_id, feature_id) rows
-            # This also will happen if we get parallel processes running `bulk_record` and
-            # `get_all_cache` returns in the second process before the first process
-            # can `bulk_set_cache`.
             pass
 
         return self.bulk_set_cache(organization_id, *incomplete_feature_ids)

--- a/tests/sentry/models/test_featureadoption.py
+++ b/tests/sentry/models/test_featureadoption.py
@@ -18,6 +18,11 @@ class TestFeatureAdoptionRedisCache(TestCase):
         self.cache.bulk_set_cache(self.org_id, *fids)
         assert self.cache.get_all_cache(self.org_id) == fids
 
+    def test_bulk_set_cache_sets_ttl(self) -> None:
+        self.cache.bulk_set_cache(self.org_id, 90)
+        org_key = self.cache.key_tpl.format(self.org_id)
+        assert self.cache.get_client(org_key).ttl(org_key) > 0
+
 
 class TestFeatureAdoptionRedisClusterCache(TestFeatureAdoptionRedisCache):
     def setUp(self) -> None:

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -583,3 +583,19 @@ class FeatureAdoptionTest(TestCase, SnubaTestCase):
             organization=self.organization, slug="delete_and_discard"
         )
         assert feature_complete
+
+    def test_bulk_record_keeps_new_features_after_cache_loss(self) -> None:
+        org_id = self.organization.id
+        FeatureAdoption.objects.record(org_id, "python")
+
+        # The redis set expires on its own TTL, so a cold cache is a normal state.
+        key = FeatureAdoption.objects.cache_backend.key_tpl.format(org_id)
+        FeatureAdoption.objects.cache_backend.get_client(key).delete(key)
+
+        # This batch mixes a feature that is already in the database with a new one.
+        FeatureAdoption.objects.bulk_record(org_id, ["python", "source_maps"])
+
+        source_maps = FeatureAdoption.objects.get_by_slug(
+            organization=self.organization, slug="source_maps"
+        )
+        assert source_maps


### PR DESCRIPTION
The feature adoption cache writes one redis set per organization and never expires it, so the key count grows forever. This PR includes a TTL of 90 days. The set itself is tiny (52 registered features). One bug had to be fixed to make the cold path actually ok - if we tried inserting a duplicate row, the whole statement would fail, things would get rolled back (new rows included), but the cache still marked them as complete. That's been fixed here.

Fixes INFRENG-459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
