### PR TITLE
perf(api): Skip release stats in project event details

### DIFF
--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -169,7 +169,6 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
             request_user=request.user,
             event=event,
             environments=list(environments),
-            include_full_release_data=True,
             start=start,
             end=end,
         )


### PR DESCRIPTION
Use the lightweight release representation already declared by the endpoint response schema. This avoids running an unrelated Snuba aggregation while fetching an event, which seems to be causing timeouts.

This was originally added by https://github.com/getsentry/sentry/pull/93293, but looking at the PR, I'm like 90% sure it was unintentional to use the full release serializer rather than the lightweight one.