### PR TITLE
ref: Update sentry-protos to 0.64.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.2.6",
-  "sentry-protos>=0.63.1",
+  "sentry-protos>=0.64.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.28",
   "sentry-scm==1.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2361,7 +2361,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.2.6" },
-    { name = "sentry-protos", specifier = ">=0.63.1" },
+    { name = "sentry-protos", specifier = ">=0.64.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.28" },
     { name = "sentry-scm", specifier = "==1.5.0" },
@@ -2541,7 +2541,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.63.1"
+version = "0.64.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2549,7 +2549,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.63.1-py3-none-any.whl", hash = "sha256:7d7c710e0feaed11cdb016534f36bcd7b8a0c989755525fa51f53addaf12e8c4" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.64.0-py3-none-any.whl", hash = "sha256:8cf110aaa2cb8e8b43aa1f1f6bcaf3681de5fe2a2253fbd7d463ff252df647d6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update sentry-protos dependency from 0.63.1 to 0.64.0

## Release notes
https://github.com/getsentry/sentry-protos/releases/tag/0.64.0

Adds `CancelContractRequest`/`CancelContractResponse` for
`CheckoutService.cancel_contract` ([sentry-protos#409](https://github.com/getsentry/sentry-protos/pull/409)),
needed to unblock getsentry#21576 (contract cancellation on the billing
platform), which currently fails backend typing because the module doesn't
exist in the locked version.

## Test plan
- `uv lock` regenerated with the pinned CI uv version (0.9.28); diff is
  limited to the sentry-protos entry
- CI passes with the updated dependency