### PR TITLE
ref(derived): Move status consistency checking into sentry/issues

### DIFF
--- a/src/sentry/issues/derived/check.py
+++ b/src/sentry/issues/derived/check.py
@@ -4,12 +4,42 @@ from datetime import datetime, timedelta
 from typing import Any, NamedTuple, TypedDict
 from uuid import uuid4
 
+from sentry.issues.derived.features import STATUS, IssueStatus
 from sentry.issues.derived.framework import Feature, Pipeline
 from sentry.issues.derived.processing import DEFAULT_BATCH_SIZE
 from sentry.issues.derived.store import GroupDerivedDataStore
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
+from sentry.models.group import Group, GroupStatus
 from sentry.workflow_engine.caches.mapping import CacheMapping
+
+_GROUP_STATUS_TO_DERIVED_STATUS = {
+    GroupStatus.UNRESOLVED: IssueStatus.OPEN,
+    GroupStatus.RESOLVED: IssueStatus.CLOSED,
+    GroupStatus.IGNORED: IssueStatus.CLOSED,
+}
+# Lifecycle-only statuses such as pending deletion and reprocessing have no
+# equivalent in the derived OPEN/CLOSED model and are intentionally omitted.
+
+
+@dataclass(frozen=True)
+class StatusInconsistency:
+    derived: IssueStatus
+    actual: IssueStatus
+
+
+def check_status_consistency(group: Group, derived: GroupDerivedData) -> StatusInconsistency | None:
+    """Compare a group's source-of-truth status with its derived status."""
+    actual_status = _GROUP_STATUS_TO_DERIVED_STATUS.get(group.status)
+    if actual_status is None:
+        return None
+
+    raw = derived.data.get(STATUS.name)
+    derived_status = STATUS.from_json(raw) if raw is not None else STATUS.initial_value()
+    if derived_status == actual_status:
+        return None
+
+    return StatusInconsistency(derived=derived_status, actual=actual_status)
 
 
 @dataclass(frozen=True)

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -53,7 +53,7 @@ from sentry.issues.constants import (
     cache_key_for_issue_view,
     get_issue_tsdb_group_model,
 )
-from sentry.issues.derived.features import STATUS, IssueStatus
+from sentry.issues.derived.check import check_status_consistency
 from sentry.issues.derived.gate import derived_should_be_correct
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
@@ -61,7 +61,7 @@ from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
-from sentry.models.group import Group, GroupStatus
+from sentry.models.group import Group
 from sentry.models.groupinbox import get_inbox_details
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import get_owner_details
@@ -86,13 +86,6 @@ logger = logging.getLogger(__name__)
 def get_group_global_count(group: Group) -> str:
     fetch_buffered_group_stats(group)
     return str(group.times_seen_with_pending)
-
-
-_GROUP_STATUS_TO_DERIVED_STATUS = {
-    GroupStatus.UNRESOLVED: IssueStatus.OPEN,
-    GroupStatus.RESOLVED: IssueStatus.CLOSED,
-    GroupStatus.IGNORED: IssueStatus.CLOSED,
-}
 
 
 @extend_schema(tags=["Events"])
@@ -129,13 +122,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
         seen_by = list(GroupSeen.objects.filter(group=group).order_by("-last_seen"))
         return [seen for seen in serialize(seen_by, request.user) if seen is not None]
 
-    def _reconcile_status(self, request: Request, group: Group) -> None:
-        """Detect divergence between the Group model status (source of truth) and
-        the action-log-derived status and publish a ReconcileStatusAction to fix it.
-
-        This is a best-effort, non-essential side effect on a read path; callers
-        must ensure a failure here never breaks the group view.
-        """
+    def _report_status_inconsistency(self, group: Group) -> None:
         if options.get("issues.derived_data.read_path_checks.killswitch"):
             return
 
@@ -145,40 +132,29 @@ class GroupDetailsEndpoint(GroupEndpoint):
         ):
             return
 
-        expected_status = _GROUP_STATUS_TO_DERIVED_STATUS.get(group.status)
-        if expected_status is None:
-            # XXX: some statuses like pending deletion, merge, etc. are skipped
-            # as they don't map to a derived status
-            return
-
         derived = GroupDerivedData.objects.filter(group_id=group.id).first()
         if derived is None:
-            # nothing to reconcile against
             return
 
-        raw = derived.data.get(STATUS.name)
-        derived_status = STATUS.from_json(raw) if raw is not None else STATUS.initial_value()
-        if derived_status == expected_status:
+        inconsistency = check_status_consistency(group, derived)
+        if inconsistency is None:
             return
 
         metrics.incr(
             "issues.status_reconciliation.diverged",
             sample_rate=1.0,
             tags={
-                "derived_status": derived_status.value,
-                "expected_status": expected_status.value,
+                "derived_status": inconsistency.derived.value,
+                "actual_status": inconsistency.actual.value,
             },
         )
-        # Status reconciliation is disabled for now; log divergences so we can
-        # find and investigate these cases automatically instead of publishing a
-        # ReconcileStatusAction.
         logger.info(
             "issues.status_reconciliation.diverged",
             extra={
                 "group_id": group.id,
                 "project_id": group.project_id,
-                "derived_status": derived_status.value,
-                "expected_status": expected_status.value,
+                "derived_status": inconsistency.derived.value,
+                "actual_status": inconsistency.actual.value,
             },
         )
 
@@ -424,7 +400,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             )
 
             try:
-                self._reconcile_status(request, group)
+                self._report_status_inconsistency(group)
             except Exception:
                 logger.exception("group.details.get.reconcile_status_failed")
 

--- a/tests/sentry/issues/derived/test_check.py
+++ b/tests/sentry/issues/derived/test_check.py
@@ -1,0 +1,36 @@
+from sentry.issues.derived.check import StatusInconsistency, check_status_consistency
+from sentry.issues.derived.features import IssueStatus
+from sentry.models.group import GroupStatus
+from sentry.testutils.cases import TestCase
+
+
+class CheckStatusConsistencyTest(TestCase):
+    def test_expected_closed_but_derived_open(self) -> None:
+        group = self.create_group(status=GroupStatus.IGNORED)
+        derived = self.create_group_derived_data(group=group, data={"status": "open"})
+
+        assert check_status_consistency(group, derived) == StatusInconsistency(
+            derived=IssueStatus.OPEN,
+            actual=IssueStatus.CLOSED,
+        )
+
+    def test_expected_open_but_derived_closed(self) -> None:
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        derived = self.create_group_derived_data(group=group, data={"status": "closed"})
+
+        assert check_status_consistency(group, derived) == StatusInconsistency(
+            derived=IssueStatus.CLOSED,
+            actual=IssueStatus.OPEN,
+        )
+
+    def test_consistent(self) -> None:
+        group = self.create_group(status=GroupStatus.RESOLVED)
+        derived = self.create_group_derived_data(group=group, data={"status": "closed"})
+
+        assert check_status_consistency(group, derived) is None
+
+    def test_status_without_derived_equivalent(self) -> None:
+        group = self.create_group(status=GroupStatus.PENDING_DELETION)
+        derived = self.create_group_derived_data(group=group, data={"status": "open"})
+
+        assert check_status_consistency(group, derived) is None

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -11,15 +11,10 @@ from sentry.analytics.events.issue_viewed import IssueViewedEvent
 from sentry.buffer.redis import RedisBuffer
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.issues.action_log import action_context_scope
-from sentry.issues.action_log.types import (
-    ActionSource,
-    GroupActionActor,
-    ReconcileStatusAction,
-)
+from sentry.issues.action_log.types import ActionSource, GroupActionActor, ReconcileStatusAction
 from sentry.issues.constants import cache_key_for_issue_view
 from sentry.issues.derived.gate import GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
-from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
 from sentry.models.auditlogentry import AuditLogEntry
@@ -420,7 +415,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
     @mock.patch("sentry.issues.endpoints.group_details.logger")
     def test_diverged_closed_logs_and_skips_action(self, mock_logger: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.IGNORED, substatus=GroupSubStatus.FOREVER)
-        GroupDerivedData.objects.create(group=group, data={"status": "open"})
+        self.create_group_derived_data(group=group, data={"status": "open"})
 
         with capture_action_log() as log:
             self._get(group)
@@ -432,7 +427,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "group_id": group.id,
                 "project_id": group.project_id,
                 "derived_status": "open",
-                "expected_status": "closed",
+                "actual_status": "closed",
             },
         )
 
@@ -440,7 +435,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
     @mock.patch("sentry.issues.endpoints.group_details.logger")
     def test_diverged_open_logs_and_skips_action(self, mock_logger: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
-        GroupDerivedData.objects.create(group=group, data={"status": "closed"})
+        self.create_group_derived_data(group=group, data={"status": "closed"})
 
         with capture_action_log() as log:
             self._get(group)
@@ -452,14 +447,14 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "group_id": group.id,
                 "project_id": group.project_id,
                 "derived_status": "closed",
-                "expected_status": "open",
+                "actual_status": "open",
             },
         )
 
     @with_feature("projects:issue-status-reconciliation")
     def test_aligned_status_skips(self) -> None:
         group = self.create_group(status=GroupStatus.RESOLVED, substatus=None)
-        GroupDerivedData.objects.create(group=group, data={"status": "closed"})
+        self.create_group_derived_data(group=group, data={"status": "closed"})
 
         with capture_action_log() as log:
             self._get(group)
@@ -483,7 +478,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
     )
     def test_feature_flags_off_skip(self) -> None:
         group = self.create_group(status=GroupStatus.IGNORED, substatus=GroupSubStatus.FOREVER)
-        GroupDerivedData.objects.create(group=group, data={"status": "open"})
+        self.create_group_derived_data(group=group, data={"status": "open"})
 
         with capture_action_log() as log:
             self._get(group)
@@ -502,7 +497,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
     ) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
         group.project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
-        GroupDerivedData.objects.create(group=group, data={"status": "closed"})
+        self.create_group_derived_data(group=group, data={"status": "closed"})
 
         self._get(group)
 
@@ -512,7 +507,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "group_id": group.id,
                 "project_id": group.project_id,
                 "derived_status": "closed",
-                "expected_status": "open",
+                "actual_status": "open",
             },
         )
 
@@ -521,7 +516,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
     @mock.patch("sentry.issues.endpoints.group_details.logger")
     def test_read_path_checks_killswitch(self, mock_logger: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
-        GroupDerivedData.objects.create(group=group, data={"status": "closed"})
+        self.create_group_derived_data(group=group, data={"status": "closed"})
 
         self._get(group)
 


### PR DESCRIPTION
We're going to be doing more validation, so it's helpful to have our validation code centralized.
