### PR TITLE
feat(crons): Log a sample of over-quota and rate limited check-in drops

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -91,7 +91,7 @@ logger = logging.getLogger(__name__)
 
 MONITOR_CODEC: Codec[IngestMonitorMessage] = get_topic_codec(Topic.INGEST_MONITORS)
 
-OVER_QUOTA_LOG_SAMPLE_RATE = 0.01
+DROP_LOG_SAMPLE_RATE = 0.01
 
 
 def _ensure_monitor_with_config(
@@ -521,6 +521,16 @@ def _process_checkin(item: CheckinItem, span: Transaction | Span | StreamedSpan)
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "monitor_environment_ratelimited"},
         )
+        if random.random() < DROP_LOG_SAMPLE_RATE:
+            logger.info(
+                "monitors.consumer.monitor_environment_ratelimited",
+                extra={
+                    "organization_id": project.organization_id,
+                    "project": project.id,
+                    "slug": monitor_slug,
+                    "environment": environment,
+                },
+            )
         track_outcome(
             org_id=project.organization_id,
             project_id=project.id,
@@ -545,7 +555,7 @@ def _process_checkin(item: CheckinItem, span: Transaction | Span | StreamedSpan)
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "monitor_over_quota"},
         )
-        if random.random() < OVER_QUOTA_LOG_SAMPLE_RATE:
+        if random.random() < DROP_LOG_SAMPLE_RATE:
             logger.info(
                 "monitors.consumer.monitor_over_quota",
                 extra={

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import uuid
 from collections import defaultdict
 from collections.abc import Mapping
@@ -89,6 +90,8 @@ from sentry.utils.tracing import set_span_tag, start_span
 logger = logging.getLogger(__name__)
 
 MONITOR_CODEC: Codec[IngestMonitorMessage] = get_topic_codec(Topic.INGEST_MONITORS)
+
+OVER_QUOTA_LOG_SAMPLE_RATE = 0.01
 
 
 def _ensure_monitor_with_config(
@@ -542,6 +545,16 @@ def _process_checkin(item: CheckinItem, span: Transaction | Span | StreamedSpan)
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "monitor_over_quota"},
         )
+        if random.random() < OVER_QUOTA_LOG_SAMPLE_RATE:
+            logger.info(
+                "monitors.consumer.monitor_over_quota",
+                extra={
+                    "organization_id": project.organization_id,
+                    "project": project.id,
+                    "slug": monitor_slug,
+                    "environment": environment,
+                },
+            )
         track_outcome(
             org_id=project.organization_id,
             project_id=project.id,


### PR DESCRIPTION
I want to understand how many unique projects/monitors/monitor envs are actually seen in over quota messages. I suspect it's a relatively small number.

If my suspicion is correct, then we could potentially keep these over quota monitors cached in relay so that we can avoid seeing them at all in our consumer. This would massively cut the number of messages we need to process and just drop.

<!-- Describe your PR here. -->