### PR TITLE
ref(clusterer): add a TTL to the transaction clusterer rules hash

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -67,6 +67,9 @@ class RedisRuleStore:
             p.delete(key)
             if len(rules) > 0:
                 p.hmset(name=key, mapping=rules)
+                # The cache gets the same lifetime as the rules it holds. With an
+                # empty rule set there is no key, so there is nothing to expire.
+                p.expire(key, TRANSACTION_NAME_RULE_TTL_SECS)
             p.execute()
 
     def update_rule(self, project: Project, rule: str, last_used: int) -> None:
@@ -79,7 +82,12 @@ class RedisRuleStore:
         # There is no atomic "overwrite if exists" for hashes, so fetch keys first:
         existing_rules = client.hkeys(key)
         if rule in existing_rules:
-            client.hset(key, rule, last_used)
+            # This runs on the per-event path, so send the write and the expiry
+            # refresh in one round trip.
+            with client.pipeline() as p:
+                p.hset(key, rule, last_used)
+                p.expire(key, TRANSACTION_NAME_RULE_TTL_SECS)
+                p.execute()
 
 
 class ProjectOptionRuleStore:

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -67,8 +67,6 @@ class RedisRuleStore:
             p.delete(key)
             if len(rules) > 0:
                 p.hmset(name=key, mapping=rules)
-                # The cache gets the same lifetime as the rules it holds. With an
-                # empty rule set there is no key, so there is nothing to expire.
                 p.expire(key, TRANSACTION_NAME_RULE_TTL_SECS)
             p.execute()
 
@@ -82,8 +80,6 @@ class RedisRuleStore:
         # There is no atomic "overwrite if exists" for hashes, so fetch keys first:
         existing_rules = client.hkeys(key)
         if rule in existing_rules:
-            # This runs on the per-event path, so send the write and the expiry
-            # refresh in one round trip.
             with client.pipeline() as p:
                 p.hset(key, rule, last_used)
                 p.expire(key, TRANSACTION_NAME_RULE_TTL_SECS)

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -17,6 +17,7 @@ from sentry.ingest.transaction_clusterer.datasource.redis import (
 )
 from sentry.ingest.transaction_clusterer.meta import get_clusterer_meta
 from sentry.ingest.transaction_clusterer.rules import (
+    TRANSACTION_NAME_RULE_TTL_SECS,
     ProjectOptionRuleStore,
     RedisRuleStore,
     _sort,
@@ -593,6 +594,71 @@ def test_bump_last_used() -> None:
         "foo": 1,
         "bar": 946688400,
     }
+
+
+# `ClustererNamespace` has a single member today, but each member has its own key
+# prefix, so the redis tests run for every namespace that exists.
+@pytest.mark.parametrize("namespace", list(ClustererNamespace))
+def test_write_sets_ttl(namespace: ClustererNamespace) -> None:
+    """The rules hash expires with the same lifetime as the rules it holds."""
+    project = Project(id=1231, name="ttl-write")
+    store = RedisRuleStore(namespace=namespace)
+    store.write(project, {ReplacementRule("foo"): 1, ReplacementRule("bar"): 2})
+
+    client = get_redis_client()
+    key = store._get_rules_key(project)
+    ttl = client.ttl(key)
+    assert 0 < ttl <= TRANSACTION_NAME_RULE_TTL_SECS
+    assert ttl > TRANSACTION_NAME_RULE_TTL_SECS - 60
+
+
+@pytest.mark.parametrize("namespace", list(ClustererNamespace))
+def test_write_empty_rules_leaves_no_key(namespace: ClustererNamespace) -> None:
+    """An empty rule set deletes the key. It must not be re-created by the expiry."""
+    project = Project(id=1232, name="ttl-empty")
+    store = RedisRuleStore(namespace=namespace)
+    store.write(project, {ReplacementRule("foo"): 1})
+    store.write(project, {})
+
+    client = get_redis_client()
+    key = store._get_rules_key(project)
+    assert client.exists(key) == 0
+    # -2 is the redis answer for "no such key", not "key without expiry" (-1).
+    assert client.ttl(key) == -2
+    assert store.read(project) == {}
+
+
+@pytest.mark.parametrize("namespace", list(ClustererNamespace))
+def test_update_rule_refreshes_ttl(namespace: ClustererNamespace) -> None:
+    """A bump of last_used pushes the expiry back to the full lifetime."""
+    project = Project(id=1233, name="ttl-update")
+    store = RedisRuleStore(namespace=namespace)
+    store.write(project, {ReplacementRule("foo"): 1, ReplacementRule("bar"): 2})
+
+    client = get_redis_client()
+    key = store._get_rules_key(project)
+    # Simulate a key that is close to the end of its lifetime.
+    client.expire(key, 10)
+    assert client.ttl(key) <= 10
+
+    store.update_rule(project, "bar", 946688400)
+
+    ttl = client.ttl(key)
+    assert ttl > TRANSACTION_NAME_RULE_TTL_SECS - 60
+    assert store.read(project) == {"foo": 1, "bar": 946688400}
+
+
+@pytest.mark.parametrize("namespace", list(ClustererNamespace))
+def test_update_rule_missing_rule_does_not_create_key(namespace: ClustererNamespace) -> None:
+    """An unknown rule writes nothing, so no key and no expiry are created."""
+    project = Project(id=1234, name="ttl-missing")
+    store = RedisRuleStore(namespace=namespace)
+    store.write(project, {})
+
+    store.update_rule(project, "not-a-stored-rule", 946688400)
+
+    client = get_redis_client()
+    assert client.exists(store._get_rules_key(project)) == 0
 
 
 @django_db_all


### PR DESCRIPTION
`RedisRuleStore` keeps a per-project hash of transaction name rules. Neither writes nor updates set an expiry, so a project that stops sending transactions keeps its key forever.

The module already defines `TRANSACTION_NAME_RULE_TTL_SECS`  at 90 days, and `CompositeRuleStore._trim_rules` already drops rules whose `last_seen` is older than that. So 90 days was already the rule lifetime, we're just honoring it in Redis now.

Refs INFRENG-462
