### PR TITLE
ref(crons): Make monitors.checkin.result one increment per message

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -271,10 +271,6 @@ def transform_checkin_uuid(
         pass
 
     if check_in_guid is None:
-        metrics.incr(
-            "monitors.checkin.result",
-            tags={**metric_kwargs, "status": "failed_guid_validation"},
-        )
         set_span_tag(span, "result", "failed_guid_validation")
         logger.info(
             "monitors.consumer.guid_validation_failed",
@@ -352,9 +348,6 @@ def update_existing_check_in(
     )
 
     if already_user_complete and not updated_duration_only and not is_out_of_order_in_progress:
-        if updated_status == CheckInStatus.IN_PROGRESS:
-            return
-
         finished_error: CheckinFinished = {
             "type": ProcessingErrorType.CHECKIN_FINISHED,
         }
@@ -420,6 +413,10 @@ def update_existing_check_in(
     if is_out_of_order_in_progress:
         updated_checkin["date_in_progress"] = start_time
         existing_check_in.update(**updated_checkin)
+        metrics.incr(
+            "monitors.checkin.result",
+            tags={**metric_kwargs, "status": "out_of_order_in_progress"},
+        )
         return
 
     updated_checkin["status"] = updated_status
@@ -1000,11 +997,6 @@ def _process_checkin(item: CheckinItem, span: Transaction | Span | StreamedSpan)
             # XXX: We are ONLY recording this metric for completed check-ins.
             delay = datetime.now() - item.ts
             metrics.timing("monitors.checkin.completion_time", delay.total_seconds())
-
-            metrics.incr(
-                "monitors.checkin.result",
-                tags={**metric_kwargs, "status": "complete"},
-            )
     except Exception as e:
         if isinstance(e, ProcessingErrorsException):
             raise


### PR DESCRIPTION
This fixes cron ingest stats:
- Complete was just basically double counting all the rows for no reason
- out_of_order_in_progress is added to make sure we cover all paths
- `failed_guid_validation` was double counts

We can still get a small number of double counts due to processing errors, but this should be much more accurate.