### PR TITLE
fix(jira): make a second call to fetch project details for saved config projects

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -259,6 +259,31 @@ class JiraIntegration(IssueSyncIntegration):
                     JiraProjectMapping(value=p["id"], label=p["name"])
                     for p in projects_response.get("values", [])
                 ]
+                fetched_ids = {project["value"] for project in projects}
+
+                # For saved config mappings we need to fetch the project name if it's not already in the list
+                saved_ids_to_fetch = [
+                    external_id
+                    for external_id in self._get_configured_external_ids()
+                    if external_id not in fetched_ids
+                ]
+                if saved_ids_to_fetch:
+                    try:
+                        supplemental = client.get_projects_paginated(
+                            params={"id": saved_ids_to_fetch, "maxResults": len(saved_ids_to_fetch)}
+                        )
+                        projects.extend(
+                            JiraProjectMapping(value=p["id"], label=p["name"])
+                            for p in supplemental.get("values", [])
+                        )
+                    except ApiError:
+                        logger.info(
+                            "jira.get-organization-config.supplemental-fetch-failed",
+                            extra={
+                                "org_id": self.organization_id,
+                                "integration_id": self.model.id,
+                            },
+                        )
             else:
                 projects = [
                     JiraProjectMapping(value=p["id"], label=p["name"])
@@ -284,6 +309,13 @@ class JiraIntegration(IssueSyncIntegration):
                 )
 
         return configuration
+
+    def _get_configured_external_ids(self) -> list[str]:
+        return list(
+            IntegrationExternalProject.objects.filter(
+                organization_integration_id=self.org_integration.id
+            ).values_list("external_id", flat=True)
+        )
 
     def _set_status_choices_in_organization_config(
         self, configuration: list[dict[str, Any]], jira_projects: list[JiraProjectMapping]
@@ -351,18 +383,15 @@ class JiraIntegration(IssueSyncIntegration):
         client = self.get_client()
 
         mapped_selectors: dict[str, Any] = {}
-        configured_projects = IntegrationExternalProject.objects.filter(
-            organization_integration_id=self.org_integration.id
-        )
-        for project in configured_projects:
+        for external_id in self._get_configured_external_ids():
             try:
-                project_statuses = client.get_project_statuses(
-                    project.external_id, paginate=True
-                ).get("values", [])
+                project_statuses = client.get_project_statuses(external_id, paginate=True).get(
+                    "values", []
+                )
             except ApiError:
                 continue
             statuses = [(c["id"], c["name"]) for c in project_statuses]
-            mapped_selectors[project.external_id] = {
+            mapped_selectors[external_id] = {
                 "on_resolve": {"choices": statuses},
                 "on_unresolve": {"choices": statuses},
             }

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -2036,6 +2036,201 @@ class JiraIntegrationTest(APITestCase):
         assert config[0]["disabled"] is True
         assert "Unable to communicate" in config[0]["disabledReason"]
 
+    def _create_paginated_jira_integration(self) -> Integration:
+        integration = self.create_provider_integration(
+            provider="jira",
+            name="Example Jira",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+        return integration
+
+    @responses.activate
+    def test_get_organization_config_includes_configured_project_beyond_first_page(self) -> None:
+        integration = self._create_paginated_jira_integration()
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="99999",
+            unresolved_status="in_progress",
+            resolved_status="done",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={
+                "values": [
+                    {"id": "10000", "name": "Project A"},
+                    {"id": "10001", "name": "Project B"},
+                ],
+                "maxResults": 50,
+                "total": 2,
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={"values": [{"id": "99999", "name": "Configured Project"}]},
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={"values": []},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_organization_config()
+
+        assert config[0]["addDropdown"]["items"] == [
+            {"value": "10000", "label": "Project A"},
+            {"value": "10001", "label": "Project B"},
+            {"value": "99999", "label": "Configured Project"},
+        ]
+        project_search_calls = [
+            call for call in responses.calls if "project/search" in call.request.url
+        ]
+        assert len(project_search_calls) == 2
+        assert "maxResults=50" in project_search_calls[0].request.url
+        assert "id=99999" not in project_search_calls[0].request.url
+        assert "id=99999" in project_search_calls[1].request.url
+
+    @responses.activate
+    def test_get_organization_config_no_configured_projects_skips_supplemental_fetch(self) -> None:
+        integration = self._create_paginated_jira_integration()
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={
+                "values": [
+                    {"id": "10000", "name": "Project A"},
+                    {"id": "10001", "name": "Project B"},
+                ],
+                "maxResults": 50,
+                "total": 2,
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={"values": []},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_organization_config()
+
+        assert config[0]["addDropdown"]["items"] == [
+            {"value": "10000", "label": "Project A"},
+            {"value": "10001", "label": "Project B"},
+        ]
+        project_search_calls = [
+            call for call in responses.calls if "project/search" in call.request.url
+        ]
+        assert len(project_search_calls) == 1
+        assert "id=" not in project_search_calls[0].request.url
+
+    @responses.activate
+    def test_get_organization_config_configured_project_in_first_page_not_duplicated(self) -> None:
+        integration = self._create_paginated_jira_integration()
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="10000",
+            unresolved_status="in_progress",
+            resolved_status="done",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={
+                "values": [
+                    {"id": "10000", "name": "Project A"},
+                    {"id": "10001", "name": "Project B"},
+                ],
+                "maxResults": 50,
+                "total": 2,
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={"values": []},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_organization_config()
+
+        assert config[0]["addDropdown"]["items"] == [
+            {"value": "10000", "label": "Project A"},
+            {"value": "10001", "label": "Project B"},
+        ]
+        project_search_calls = [
+            call for call in responses.calls if "project/search" in call.request.url
+        ]
+        assert len(project_search_calls) == 1
+        assert "id=" not in project_search_calls[0].request.url
+
+    @responses.activate
+    def test_get_organization_config_supplemental_fetch_failure_degrades_gracefully(self) -> None:
+        integration = self._create_paginated_jira_integration()
+        self.create_integration_external_project(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            external_id="99999",
+            unresolved_status="in_progress",
+            resolved_status="done",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={
+                "values": [
+                    {"id": "10000", "name": "Project A"},
+                    {"id": "10001", "name": "Project B"},
+                ],
+                "maxResults": 50,
+                "total": 2,
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project/search",
+            json={"errorMessages": ["Something went wrong"]},
+            status=500,
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/statuses/search",
+            json={"values": []},
+        )
+
+        installation = integration.get_installation(self.organization.id)
+        with self.feature("organizations:jira-paginated-project-config"):
+            config = installation.get_organization_config()
+
+        # The supplemental (name-resolving) fetch failing should not disable the whole config.
+        assert config[0].get("disabled") is not True
+        assert config[0]["addDropdown"]["items"] == [
+            {"value": "10000", "label": "Project A"},
+            {"value": "10001", "label": "Project B"},
+        ]
+        project_search_calls = [
+            call for call in responses.calls if "project/search" in call.request.url
+        ]
+        assert len(project_search_calls) == 2
+        assert "id=99999" in project_search_calls[1].request.url
+
     def _setup_jira_with_status_responses(
         self,
         projects: list[dict[str, str]] | None = None,


### PR DESCRIPTION
Paginated project flag was turned off as it causes project ids dissappearing in the left hand side next to status (this is when the project isn't loaded in the initial 50 proj GET. This PR slaps on the saved projects if they weren't in the initial load via a 2nd api call.