### PR TITLE
fix(codeowners): repair two dead owner references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -675,7 +675,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/search/events/builder/errors.py                 @getsentry/issues-feed @getsentry/issue-workflow
 /src/sentry/search/snuba/                                   @getsentry/issues-feed @getsentry/issue-workflow
 /src/sentry/seer/similarity/                                @getsentry/issue-detection-backend
-/src/sentry/seer/supergroups/                               @getsentry/supergroups @getsentry/issue-detection-backend
+/src/sentry/seer/supergroups/                               @getsentry/issue-detection-backend
 /src/sentry/similarity/                                     @getsentry/issue-detection-backend
 /src/sentry/tasks/auto_ongoing_issues.py                    @getsentry/issue-detection-backend
 /src/sentry/tasks/auto_remove_inbox.py                      @getsentry/issues-feed @getsentry/issue-detection-backend
@@ -697,11 +697,11 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/llm_issue_detection/                      @getsentry/issue-detection-backend
 /static/app/components/issues/                              @getsentry/issues-feed @getsentry/issue-workflow
 /static/app/components/stackTrace/                          @getsentry/issue-details @getsentry/issue-workflow
-/static/app/components/stream/supergroups/                  @getsentry/supergroups @getsentry/issue-detection-frontend
+/static/app/components/stream/supergroups/                  @getsentry/issue-detection-frontend
 /static/app/views/issueList/                                @getsentry/issues-feed @getsentry/issue-workflow
 /static/app/views/issueList/issueListSeerComboBox.tsx       @getsentry/issues-feed @getsentry/issue-workflow @getsentry/machine-learning-ai
-/static/app/views/issueList/pages/supergroups.tsx           @getsentry/supergroups @getsentry/issue-detection-frontend
-/static/app/views/issueList/supergroups/                    @getsentry/supergroups @getsentry/issue-detection-frontend
+/static/app/views/issueList/pages/supergroups.tsx           @getsentry/issue-detection-frontend
+/static/app/views/issueList/supergroups/                    @getsentry/issue-detection-frontend
 /static/app/views/issueDetails/                             @getsentry/issue-details @getsentry/issue-workflow
 /static/app/views/nav/secondary/sections/issues/            @getsentry/issues-feed @getsentry/issue-workflow
 /static/app/views/sharedGroupDetails/                       @getsentry/issues-feed @getsentry/issue-details @getsentry/issue-workflow
@@ -720,10 +720,10 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/processing_errors/                            @getsentry/issue-detection-backend
 /tests/sentry/search/                                       @getsentry/issues-feed @getsentry/issue-workflow
 /tests/sentry/seer/similarity/                              @getsentry/issue-detection-backend
-/tests/sentry/seer/supergroups/                             @getsentry/supergroups @getsentry/issue-detection-backend
+/tests/sentry/seer/supergroups/                             @getsentry/issue-detection-backend
 /tests/sentry/similarity/                                   @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_auto_ongoing_issues.py             @getsentry/issue-detection-backend
-/tests/sentry/tasks/test_auto_remove_inbox.py               @getnsentry/issues-feed @getsentry/issue-detection-backend
+/tests/sentry/tasks/test_auto_remove_inbox.py               @getsentry/issues-feed @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_auto_resolve_issues.py             @getsentry/issue-detection-backend
 /tests/sentry/tasks/seer/test_delete_seer_grouping_records.py @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_console_platform_cleanup.py        @getsentry/gdx


### PR DESCRIPTION
Two owner references in `.github/CODEOWNERS` point at teams that do not exist, so the rules naming them assign ownership to nobody and never generate review requests.

### 1. Typo — `@getnsentry/issues-feed` (line 726)

```diff
-/tests/sentry/tasks/test_auto_remove_inbox.py   @getnsentry/issues-feed @getsentry/issue-detection-backend
+/tests/sentry/tasks/test_auto_remove_inbox.py   @getsentry/issues-feed @getsentry/issue-detection-backend
```

`getnsentry` is not a GitHub org. `@getsentry/issues-feed` is a real team (id 19078876, 1 member), so this restores the intended owner.

### 2. Non-existent team — `@getsentry/supergroups` (5 rules)

`gh api orgs/getsentry/teams/supergroups` returns 404 — the team does not exist. Removed from:

- `/src/sentry/seer/supergroups/`
- `/static/app/components/stream/supergroups/`
- `/static/app/views/issueList/pages/supergroups.tsx`
- `/static/app/views/issueList/supergroups/`
- `/tests/sentry/seer/supergroups/`

Every one of those rules already carries `@getsentry/issue-detection-backend` or `@getsentry/issue-detection-frontend` as a co-owner, so **no path loses ownership** — each simply drops a reference that resolved to nothing.

If `supergroups` is meant to be a real team, the alternative fix is to create it in [`getsentry/security-as-code`](https://github.com/getsentry/security-as-code/tree/main/rbac/env/prod-github/team) and revert this half. Happy to do that instead.

---

Found while reconciling CODEOWNERS across the org against the GitHub teams defined in `getsentry/security-as-code`. Same sweep found `@getsentry/ml-autofix` in `getsentry/seer` — fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)