### PR TITLE
ref(autofix): Pass on_completion_hook to rca-in-seer

### DIFF
--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -54,6 +54,7 @@ def deliver_autofix_rca_result(
             "group_id": agent_run.group_id,
         }
         extras = dict(agent_run.extras or {})
+        completion_hook_managed_by_seer = extras.get("completion_hook_managed_by_seer") is True
 
         if extras.get("status") == "completed":
             sentry_sdk.metrics.count(
@@ -89,7 +90,8 @@ def deliver_autofix_rca_result(
         logger.warning("autofix_rca.delivery.cannot_surface", extra=log_extra)
         return
 
-    AutofixOnCompletionHook.execute(organization, run_state_id)
+    if not completion_hook_managed_by_seer:
+        AutofixOnCompletionHook.execute(organization, run_state_id)
 
     sentry_sdk.metrics.count("autofix_rca.delivery_completed", 1)
     logger.info("autofix_rca.delivery.completed", extra=log_extra)

--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -8,7 +8,6 @@ import sentry_sdk
 from django.db import router, transaction
 
 from sentry.seer.agent.types import FeatureRunStatus
-from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.autofix_rca.models import FEATURE_ID, LEGACY_FEATURE_ID
 from sentry.seer.models.run import SeerAgentRun
 
@@ -54,7 +53,6 @@ def deliver_autofix_rca_result(
             "group_id": agent_run.group_id,
         }
         extras = dict(agent_run.extras or {})
-        completion_hook_managed_by_seer = extras.get("completion_hook_managed_by_seer") is True
 
         if extras.get("status") == "completed":
             sentry_sdk.metrics.count(
@@ -84,14 +82,10 @@ def deliver_autofix_rca_result(
         )
 
         group_id = agent_run.group_id
-        organization = agent_run.run.organization
 
     if group_id is None or run_state_id is None:
         logger.warning("autofix_rca.delivery.cannot_surface", extra=log_extra)
         return
-
-    if not completion_hook_managed_by_seer:
-        AutofixOnCompletionHook.execute(organization, run_state_id)
 
     sentry_sdk.metrics.count("autofix_rca.delivery_completed", 1)
     logger.info("autofix_rca.delivery.completed", extra=log_extra)

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -63,7 +63,6 @@ def trigger_autofix_rca_feature(
     # Store the stopping point here for delivery to use when advancing steps.
     extras: dict[str, Any] = {
         "referrer": referrer.value,
-        "completion_hook_managed_by_seer": True,
     }
     if stopping_point is not None:
         extras["stopping_point"] = stopping_point.value

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from sentry import quotas
 from sentry.constants import DataCategory
+from sentry.models.group import Group
 from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.on_completion_hook import extract_hook_definition
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
-from sentry.seer.autofix.utils import is_free_cohort_org
+from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+from sentry.seer.autofix.utils import AutofixStoppingPoint, is_free_cohort_org
 from sentry.seer.autofix_rca.models import FEATURE_ID, AutofixRCAPayload, AutofixRCATweaks
+from sentry.seer.models.run import SeerRun
 from sentry.utils import metrics
-
-if TYPE_CHECKING:
-    from sentry.models.group import Group
-    from sentry.seer.autofix.constants import AutofixReferrer
-    from sentry.seer.autofix.utils import AutofixStoppingPoint
-    from sentry.seer.models.run import SeerRun
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +46,7 @@ def trigger_autofix_rca_feature(
         short_id=group.qualified_short_id or str(group.id),
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",
+        on_completion_hook=extract_hook_definition(AutofixOnCompletionHook),
         tweaks=AutofixRCATweaks(
             intelligence_level=intelligence_level,
             reasoning_effort=reasoning_effort,
@@ -54,7 +54,6 @@ def trigger_autofix_rca_feature(
         ),
     )
 
-    # category_key is set by Seer; unused client-side for feature runs.
     client = SeerAgentClient(
         organization=group.organization,
         project=group.project,
@@ -62,7 +61,10 @@ def trigger_autofix_rca_feature(
     )
 
     # Store the stopping point here for delivery to use when advancing steps.
-    extras: dict[str, Any] = {"referrer": referrer.value}
+    extras: dict[str, Any] = {
+        "referrer": referrer.value,
+        "completion_hook_managed_by_seer": True,
+    }
     if stopping_point is not None:
         extras["stopping_point"] = stopping_point.value
 

--- a/src/sentry/seer/autofix_rca/models.py
+++ b/src/sentry/seer/autofix_rca/models.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from sentry.seer.agent.on_completion_hook import OnCompletionHookDefinition
+
 # Keep models in sync with src/seer/automation/features/autofix/models.py in Seer
 
 FEATURE_ID = "autofix"
@@ -29,4 +31,5 @@ class AutofixRCAPayload(BaseModel):
     short_id: str
     title: str
     culprit: str
+    on_completion_hook: OnCompletionHookDefinition
     tweaks: AutofixRCATweaks = Field(default_factory=AutofixRCATweaks)

--- a/tests/sentry/seer/autofix_rca/test_delivery.py
+++ b/tests/sentry/seer/autofix_rca/test_delivery.py
@@ -149,7 +149,6 @@ class TestDeliverAutofixRCAResult(TestCase):
     def test_seer_managed_run_only_persists_result(self, mock_execute: MagicMock) -> None:
         self.agent_run.extras = {
             **self.agent_run.extras,
-            "completion_hook_managed_by_seer": True,
             "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
         }
         self.agent_run.save(update_fields=["extras"])

--- a/tests/sentry/seer/autofix_rca/test_delivery.py
+++ b/tests/sentry/seer/autofix_rca/test_delivery.py
@@ -1,20 +1,13 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import UUID
 
 from django.db import connections, router
 from django.test.utils import CaptureQueriesContext
 
-from sentry.analytics.events.autofix_events import (
-    AiAutofixIntrospectionEvent,
-    AiAutofixRootCauseCompletedEvent,
-)
-from sentry.seer.agent.client_models import Artifact, MemoryBlock, Message, SeerRunState
-from sentry.seer.autofix.autofix_agent import AutofixStep
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.autofix_rca.delivery import deliver_autofix_rca_result
 from sentry.seer.models.run import SeerAgentRun
-from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -46,38 +39,6 @@ class TestDeliverAutofixRCAResult(TestCase):
             extras={"referrer": AutofixReferrer.WEB.value},
         )
 
-    def _run_state(
-        self,
-        run_id: int = 123,
-        result: dict[str, object] | None = None,
-        referrer: AutofixReferrer | None = None,
-    ) -> SeerRunState:
-        """The state Seer reports back for a completed feature run: a root_cause
-        block carrying the artifact, and no pipeline metadata of its own."""
-        message_metadata = {"step": "root_cause"}
-        if referrer is not None:
-            message_metadata["referrer"] = referrer.value
-
-        return SeerRunState(
-            run_id=run_id,
-            blocks=[
-                MemoryBlock(
-                    id="block-root-cause",
-                    message=Message(
-                        role="assistant",
-                        content="message root cause",
-                        metadata=message_metadata,
-                    ),
-                    timestamp="2026-02-10T00:00:00Z",
-                    artifacts=[
-                        Artifact(key="root_cause", data=result or VALID_RESULT, reason="explorer"),
-                    ],
-                )
-            ],
-            status="completed",
-            updated_at="2026-02-10T00:00:00Z",
-        )
-
     def test_missing_run_logs_warning(self) -> None:
         with patch("sentry.seer.autofix_rca.delivery.logger") as mock_logger:
             deliver_autofix_rca_result(
@@ -91,62 +52,7 @@ class TestDeliverAutofixRCAResult(TestCase):
         mock_logger.warning.assert_called_once()
         assert "autofix_rca.delivery.missing_run" in mock_logger.warning.call_args.args[0]
 
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_completed_result_hooks_back_into_flow(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock
-    ) -> None:
-        agent_run = self.agent_run
-        mock_fetch.return_value = self._run_state()
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        # Persisted for evaluation.
-        agent_run.refresh_from_db()
-        assert agent_run.extras["status"] == "completed"
-        assert agent_run.extras["result"]["one_line_description"] == "null deref in handler"
-        assert agent_run.extras["result"]["fixability"]["assessment"] == "fixable"
-
-        # Group marked triggered by the hook.
-        self.group.refresh_from_db()
-        assert self.group.seer_explorer_autofix_last_triggered is not None
-
-        # ROOT_CAUSE_COMPLETED webhook fired with the root cause payload.
-        mock_broadcast.assert_called_once()
-        kwargs = mock_broadcast.call_args.kwargs
-        assert kwargs["event_name"] == SeerActionType.ROOT_CAUSE_COMPLETED.value
-        assert kwargs["payload"]["run_id"] == 123
-        assert kwargs["payload"]["root_cause"]["one_line_description"] == "null deref in handler"
-
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_completed_result_matches_run_with_autofix_source(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock
-    ) -> None:
-        # Runs dispatched after the feature rename persist source="autofix".
-        self.agent_run.source = "autofix"
-        self.agent_run.save()
-        mock_fetch.return_value = self._run_state()
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=self.agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        self.agent_run.refresh_from_db()
-        assert self.agent_run.extras["status"] == "completed"
-
-    @patch("sentry.seer.autofix_rca.delivery.AutofixOnCompletionHook.execute")
-    def test_seer_managed_run_only_persists_result(self, mock_execute: MagicMock) -> None:
+    def test_completed_result_is_persisted(self) -> None:
         self.agent_run.extras = {
             **self.agent_run.extras,
             "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
@@ -166,15 +72,27 @@ class TestDeliverAutofixRCAResult(TestCase):
         assert self.agent_run.extras["result"] == VALID_RESULT
         assert self.agent_run.extras["referrer"] == AutofixReferrer.WEB.value
         assert self.agent_run.extras["stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
-        mock_execute.assert_not_called()
+
+    def test_completed_result_matches_run_with_autofix_source(self) -> None:
+        self.agent_run.source = "autofix"
+        self.agent_run.save(update_fields=["source"])
+
+        deliver_autofix_rca_result(
+            organization_id=self.organization.id,
+            run_uuid=self.agent_run.run.uuid,
+            status="completed",
+            result=VALID_RESULT,
+            error=None,
+        )
+
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "completed"
 
     def test_error_status_recorded(self) -> None:
-        agent_run = self.agent_run
-
         with patch("sentry.seer.autofix_rca.delivery.logger") as mock_logger:
             deliver_autofix_rca_result(
                 organization_id=self.organization.id,
-                run_uuid=agent_run.run.uuid,
+                run_uuid=self.agent_run.run.uuid,
                 status="error",
                 result=None,
                 error="seer exploded",
@@ -183,98 +101,26 @@ class TestDeliverAutofixRCAResult(TestCase):
         mock_logger.warning.assert_called()
         assert "autofix_rca.delivery.no_result" in mock_logger.warning.call_args.args[0]
 
-        agent_run.refresh_from_db()
-        assert agent_run.extras["status"] == "error"
-        assert agent_run.extras["error_message"] == "seer exploded"
-        assert "result" not in agent_run.extras
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "error"
+        assert self.agent_run.extras["error_message"] == "seer exploded"
+        assert "result" not in self.agent_run.extras
 
-    @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_artifact_off_schema_still_delivers_without_fixability(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock, mock_record: MagicMock
-    ) -> None:
-        """An off-schema fixability value must not block the completed webhook."""
-        agent_run = self.agent_run
-        off_schema: dict[str, object] = {
-            **VALID_RESULT,
-            "fixability": {"fixability": "fixable", "reason": "wrong key"},
-        }
-        mock_fetch.return_value = self._run_state(result=off_schema)
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=off_schema,
-            error=None,
-        )
-
-        assert not any(
-            isinstance(call.args[0], AiAutofixIntrospectionEvent)
-            for call in mock_record.call_args_list
-        )
-        mock_broadcast.assert_called_once()
-        kwargs = mock_broadcast.call_args.kwargs
-        assert kwargs["event_name"] == SeerActionType.ROOT_CAUSE_COMPLETED.value
-        assert kwargs["payload"]["root_cause"]["one_line_description"] == "null deref in handler"
-
-    @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_fixability_records_introspection_event(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock, mock_record: MagicMock
-    ) -> None:
-        agent_run = self.agent_run
-        mock_fetch.return_value = self._run_state()
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        events = [
-            call.args[0]
-            for call in mock_record.call_args_list
-            if isinstance(call.args[0], AiAutofixIntrospectionEvent)
-        ]
-        assert len(events) == 1
-        assert events[0].action == "fixable"
-        assert events[0].step == "root_cause"
-        assert events[0].run_id == 123
-        assert events[0].referrer == AutofixReferrer.WEB.value
-        assert events[0].reached_stopping_point is True
-        completed_events = [
-            call.args[0]
-            for call in mock_record.call_args_list
-            if isinstance(call.args[0], AiAutofixRootCauseCompletedEvent)
-        ]
-        assert len(completed_events) == 1
-        assert completed_events[0].referrer == AutofixReferrer.WEB.value
-
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_redelivery_does_not_run_the_hook_twice(self, mock_fetch: MagicMock) -> None:
-        """Seer's result push is not idempotent per run, so a redelivery must not
-        re-fire the webhook or continue the pipeline a second time."""
-        agent_run = self.agent_run
-        mock_fetch.return_value = self._run_state()
-
+    def test_redelivery_is_idempotent(self) -> None:
         for _ in range(2):
             deliver_autofix_rca_result(
                 organization_id=self.organization.id,
-                run_uuid=agent_run.run.uuid,
+                run_uuid=self.agent_run.run.uuid,
                 status="completed",
                 result=VALID_RESULT,
                 error=None,
             )
 
-        assert mock_fetch.call_count == 1
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "completed"
+        assert self.agent_run.extras["result"] == VALID_RESULT
 
-    @patch("sentry.seer.autofix_rca.delivery.AutofixOnCompletionHook.execute")
-    def test_delivery_claim_uses_row_lock(self, mock_execute: MagicMock) -> None:
+    def test_delivery_claim_uses_row_lock(self) -> None:
         using = router.db_for_write(SeerAgentRun)
 
         with CaptureQueriesContext(connections[using]) as queries:
@@ -287,178 +133,49 @@ class TestDeliverAutofixRCAResult(TestCase):
             )
 
         assert any("FOR UPDATE" in query["sql"] for query in queries)
-        mock_execute.assert_called_once()
 
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_completed_status_is_not_overwritten_by_late_error(self, mock_fetch: MagicMock) -> None:
-        agent_run = self.agent_run
-        mock_fetch.return_value = self._run_state()
-
+    def test_completed_status_is_not_overwritten_by_late_error(self) -> None:
         deliver_autofix_rca_result(
             organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
+            run_uuid=self.agent_run.run.uuid,
             status="completed",
             result=VALID_RESULT,
             error=None,
         )
         deliver_autofix_rca_result(
             organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
+            run_uuid=self.agent_run.run.uuid,
             status="error",
             result=None,
             error="late error",
         )
 
-        agent_run.refresh_from_db()
-        assert agent_run.extras["status"] == "completed"
-        assert "error_message" not in agent_run.extras
-        assert mock_fetch.call_count == 1
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "completed"
+        assert "error_message" not in self.agent_run.extras
 
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_success_after_error_clears_error_message(self, mock_fetch: MagicMock) -> None:
-        agent_run = self.agent_run
-        mock_fetch.return_value = self._run_state()
-
+    def test_success_after_error_clears_error_message(self) -> None:
         deliver_autofix_rca_result(
             organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
+            run_uuid=self.agent_run.run.uuid,
             status="error",
             result=None,
             error="temporary error",
         )
         deliver_autofix_rca_result(
             organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
+            run_uuid=self.agent_run.run.uuid,
             status="completed",
             result=VALID_RESULT,
             error=None,
         )
 
-        agent_run.refresh_from_db()
-        assert agent_run.extras["status"] == "completed"
-        assert "error_message" not in agent_run.extras
-        assert agent_run.extras["result"] == VALID_RESULT
-        assert mock_fetch.call_count == 1
-
-    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_stops_when_stopping_point_is_root_cause(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock, mock_trigger: MagicMock
-    ) -> None:
-        seer_run = self.create_seer_run(
-            organization=self.organization,
-            type="feature_run",
-            seer_run_state_id=124,
-        )
-        agent_run = self.create_seer_agent_run(
-            run=seer_run,
-            source="autofix_rca",
-            group=self.group,
-            project=self.project,
-            extras={
-                **self.agent_run.extras,
-                "stopping_point": AutofixStoppingPoint.ROOT_CAUSE.value,
-            },
-        )
-        mock_fetch.return_value = self._run_state(run_id=124)
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        mock_trigger.assert_not_called()
-
-    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_continues_to_solution_when_stopping_point_is_later(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock, mock_trigger: MagicMock
-    ) -> None:
-        """A feature run started with a later stopping point continues the pipeline,
-        matching a run the autofix pipeline started itself. The stopping point is
-        read off SeerAgentRun.extras since Seer's feature runs carry no metadata."""
-        seer_run = self.create_seer_run(
-            organization=self.organization,
-            type="feature_run",
-            seer_run_state_id=124,
-        )
-        agent_run = self.create_seer_agent_run(
-            run=seer_run,
-            source="autofix_rca",
-            group=self.group,
-            project=self.project,
-            extras={
-                **self.agent_run.extras,
-                "stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
-            },
-        )
-        mock_fetch.return_value = self._run_state(run_id=124)
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        mock_trigger.assert_called_once()
-        call_kwargs = mock_trigger.call_args.kwargs
-        assert call_kwargs["step"] == AutofixStep.SOLUTION
-        assert call_kwargs["run_id"] == 124
-        assert call_kwargs["group"].id == self.group.id
-        assert call_kwargs["referrer"] == AutofixReferrer.WEB
-
-    @patch("sentry.seer.autofix.on_completion_hook.trigger_autofix_agent")
-    @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_no_stopping_point_recorded_does_not_continue(
-        self, mock_fetch: MagicMock, mock_broadcast: MagicMock, mock_trigger: MagicMock
-    ) -> None:
-        agent_run = self.agent_run
-        mock_fetch.return_value = self._run_state()
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        mock_trigger.assert_not_called()
-
-    @patch("sentry.seer.autofix.on_completion_hook.logger")
-    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
-    def test_stale_group_stops_without_raising(
-        self, mock_fetch: MagicMock, mock_logger: MagicMock
-    ) -> None:
-        agent_run = self.agent_run
-        agent_run.group_id = 999_999_999
-        agent_run.save(update_fields=["group_id"])
-        mock_fetch.return_value = self._run_state()
-
-        deliver_autofix_rca_result(
-            organization_id=self.organization.id,
-            run_uuid=agent_run.run.uuid,
-            status="completed",
-            result=VALID_RESULT,
-            error=None,
-        )
-
-        assert any(
-            call.args[0] == "autofix.on_completion_hook.group_not_found"
-            for call in mock_logger.warning.call_args_list
-        )
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "completed"
+        assert "error_message" not in self.agent_run.extras
+        assert self.agent_run.extras["result"] == VALID_RESULT
 
     def test_night_shift_run_is_not_matched(self) -> None:
-        """Only autofix_rca-sourced runs are handled; a night_shift run with the
-        same uuid is ignored (dispatched by feature_id upstream, but be safe)."""
         seer_run = self.create_seer_run(organization=self.organization, type="feature_run")
         self.create_seer_agent_run(run=seer_run, source="night_shift", group=self.group)
 

--- a/tests/sentry/seer/autofix_rca/test_delivery.py
+++ b/tests/sentry/seer/autofix_rca/test_delivery.py
@@ -145,6 +145,30 @@ class TestDeliverAutofixRCAResult(TestCase):
         self.agent_run.refresh_from_db()
         assert self.agent_run.extras["status"] == "completed"
 
+    @patch("sentry.seer.autofix_rca.delivery.AutofixOnCompletionHook.execute")
+    def test_seer_managed_run_only_persists_result(self, mock_execute: MagicMock) -> None:
+        self.agent_run.extras = {
+            **self.agent_run.extras,
+            "completion_hook_managed_by_seer": True,
+            "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+        }
+        self.agent_run.save(update_fields=["extras"])
+
+        deliver_autofix_rca_result(
+            organization_id=self.organization.id,
+            run_uuid=self.agent_run.run.uuid,
+            status="completed",
+            result=VALID_RESULT,
+            error=None,
+        )
+
+        self.agent_run.refresh_from_db()
+        assert self.agent_run.extras["status"] == "completed"
+        assert self.agent_run.extras["result"] == VALID_RESULT
+        assert self.agent_run.extras["referrer"] == AutofixReferrer.WEB.value
+        assert self.agent_run.extras["stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
+        mock_execute.assert_not_called()
+
     def test_error_status_recorded(self) -> None:
         agent_run = self.agent_run
 

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -4,6 +4,8 @@ import pytest
 
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.autofix_rca.dispatch import trigger_autofix_rca_feature
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -30,6 +32,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
                 self.group,
                 referrer=AutofixReferrer.NIGHT_SHIFT,
                 user_context="an upstream triage summary",
+                stopping_point=AutofixStoppingPoint.OPEN_PR,
             )
 
         assert run is fake_run
@@ -49,7 +52,16 @@ class TestTriggerAutofixRCAFeature(TestCase):
         assert payload["short_id"] == (self.group.qualified_short_id or str(self.group.id))
         assert payload["title"] == self.group.title
         assert payload["tweaks"]["user_context"] == "an upstream triage summary"
-        assert run_kwargs["extras"] == {"referrer": AutofixReferrer.NIGHT_SHIFT.value}
+        # Seer persists this hook on the Explorer run so later PR iteration
+        # completions continue through the Autofix completion flow.
+        assert payload["on_completion_hook"] == {
+            "module_path": AutofixOnCompletionHook.get_module_path()
+        }
+        assert run_kwargs["extras"] == {
+            "referrer": AutofixReferrer.NIGHT_SHIFT.value,
+            "completion_hook_managed_by_seer": True,
+            "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+        }
         assert run_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT.value
 
         # A new run consumes Seer autofix budget.

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -59,7 +59,6 @@ class TestTriggerAutofixRCAFeature(TestCase):
         }
         assert run_kwargs["extras"] == {
             "referrer": AutofixReferrer.NIGHT_SHIFT.value,
-            "completion_hook_managed_by_seer": True,
             "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
         }
         assert run_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT.value


### PR DESCRIPTION
Passes the on_completion_hook through to RCA in Seer which will allow autofix to automatically proceed upon completion using the hook. Allows us to remove explicit invoking on the delivery side of the autofix feature and properly supports PR iteration features.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>