### PR TITLE
ref(buffer): bound the pending zset with an expiry

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -207,6 +207,25 @@ class PendingBuffer:
 class RedisBuffer(Buffer):
     key_expire = 60 * 60  # 1 hour
     pending_key = "b:p"
+    # The pending zset lists the buffered rows that wait for a flush.
+    # `process_pending` drains it, and the scheduler runs that task every 10
+    # seconds (see "flush-buffers" in sentry/conf/server.py). The expiry below
+    # is only a safety net. It stops the zset from living forever if the drain
+    # stops and no new rows arrive.
+    #
+    # The expiry cannot lose a buffered row. `incr` writes the row hash expiry
+    # and the zset expiry in the same pipeline. A row hash dies at most
+    # `key_expire` after its own last write. The zset dies `pending_key_expire`
+    # after the last write to any row, which is never earlier. So the zset
+    # always outlives every row that it points to. The same fact covers a late
+    # drain: while a row hash is alive, its pending entry is alive too.
+    #
+    # The expiry has to be set again on every `incr`. Do not move it to
+    # `process_pending`, and do not make it set-once with `EXPIRE ... NX`. Both
+    # start the life of the zset before the last row write, so the zset can die
+    # while rows that it points to are still alive, and those rows are never
+    # flushed.
+    pending_key_expire = key_expire * 2  # 2 hours
 
     def __init__(self, incr_batch_size: int = 2, **options: object):
         self.is_redis_cluster, self.cluster, options = get_dynamic_cluster_from_options(
@@ -411,6 +430,9 @@ class RedisBuffer(Buffer):
 
         pipe.expire(key, self.key_expire)
         pipe.zadd(self.pending_key, {key: time()})
+        # Keep the expiry after the zadd, so that it applies to a key that
+        # exists. See `pending_key_expire` for why this cannot lose a row.
+        pipe.expire(self.pending_key, self.pending_key_expire)
         pipe.execute()
 
         metrics.incr(

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -207,7 +207,7 @@ class PendingBuffer:
 class RedisBuffer(Buffer):
     key_expire = 60 * 60  # 1 hour
     pending_key = "b:p"
-    
+
     # This expiry guarantees zset will always outlive every row it points to
     pending_key_expire = key_expire * 2  # 2 hours
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -207,24 +207,8 @@ class PendingBuffer:
 class RedisBuffer(Buffer):
     key_expire = 60 * 60  # 1 hour
     pending_key = "b:p"
-    # The pending zset lists the buffered rows that wait for a flush.
-    # `process_pending` drains it, and the scheduler runs that task every 10
-    # seconds (see "flush-buffers" in sentry/conf/server.py). The expiry below
-    # is only a safety net. It stops the zset from living forever if the drain
-    # stops and no new rows arrive.
-    #
-    # The expiry cannot lose a buffered row. `incr` writes the row hash expiry
-    # and the zset expiry in the same pipeline. A row hash dies at most
-    # `key_expire` after its own last write. The zset dies `pending_key_expire`
-    # after the last write to any row, which is never earlier. So the zset
-    # always outlives every row that it points to. The same fact covers a late
-    # drain: while a row hash is alive, its pending entry is alive too.
-    #
-    # The expiry has to be set again on every `incr`. Do not move it to
-    # `process_pending`, and do not make it set-once with `EXPIRE ... NX`. Both
-    # start the life of the zset before the last row write, so the zset can die
-    # while rows that it points to are still alive, and those rows are never
-    # flushed.
+    
+    # This expiry guarantees zset will always outlive every row it points to
     pending_key_expire = key_expire * 2  # 2 hours
 
     def __init__(self, incr_batch_size: int = 2, **options: object):
@@ -430,8 +414,6 @@ class RedisBuffer(Buffer):
 
         pipe.expire(key, self.key_expire)
         pipe.zadd(self.pending_key, {key: time()})
-        # Keep the expiry after the zadd, so that it applies to a key that
-        # exists. See `pending_key_expire` for why this cannot lose a row.
         pipe.expire(self.pending_key, self.pending_key_expire)
         pipe.execute()
 

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -208,8 +208,8 @@ class RedisBuffer(Buffer):
     key_expire = 60 * 60  # 1 hour
     pending_key = "b:p"
 
-    # This expiry guarantees zset will always outlive every row it points to
-    pending_key_expire = key_expire * 2  # 2 hours
+    # Super generous expiry guarantees zset will always outlive every row it points to
+    pending_key_expire = 60 * 60 * 24  # 1 day
 
     def __init__(self, incr_batch_size: int = 2, **options: object):
         self.is_redis_cluster, self.cluster, options = get_dynamic_cluster_from_options(

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -201,6 +201,58 @@ class TestRedisBuffer:
         else:
             assert pending == [key.encode("utf-8")]
 
+    def test_incr_bounds_pending_key(self) -> None:
+        """The pending zset gets an expiry, and that expiry outlives the rows."""
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
+        model = mock.Mock()
+        model.__name__ = "Mock"
+        filters: dict[str, Any] = {"pk": 1}
+        key = make_key(model, filters=filters)
+
+        self.buf.incr(model, {"times_seen": 1}, filters)
+
+        row_ttl = client.ttl(key)
+        pending_ttl = client.ttl("b:p")
+        # Both keys are bounded.
+        assert 0 < row_ttl <= self.buf.key_expire
+        assert 0 < pending_ttl <= self.buf.pending_key_expire
+        # The pending zset never dies before a row that it points to.
+        assert self.buf.pending_key_expire >= self.buf.key_expire
+        assert pending_ttl >= row_ttl
+
+    @django_db_all
+    @freeze_time()
+    def test_no_row_lost_when_process_pending_is_delayed(self, default_group, task_runner) -> None:
+        """Rows buffered with no drain in between are all still flushed.
+
+        Redis counts the time to live on the server, so this test cannot wait
+        out a real delay. What protects a late drain is the order of the two
+        expiries, which is asserted below: while a row hash is alive, its
+        pending entry is alive too, so a drain that arrives at any point in the
+        life of the row still finds the entry.
+        """
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
+        orig_times_seen = Group.objects.get_from_cache(id=default_group.id).times_seen
+        filters: dict[str, Any] = {"pk": default_group.id}
+        key = make_key(Group, filters=filters)
+
+        # No drain runs while these writes for the same row arrive.
+        for _ in range(5):
+            self.buf.incr(Group, {"times_seen": 1}, filters, {"last_seen": timezone.now()})
+
+        # The row and its pending entry are both still there, and the pending
+        # entry still outlives the row.
+        assert client.ttl(key) > 0
+        assert client.ttl("b:p") >= client.ttl(key)
+        assert len(client.zrange("b:p", 0, -1)) == 1
+
+        with task_runner(), mock.patch("sentry.buffer.backend", self.buf):
+            self.buf.process_pending()
+
+        group = Group.objects.get_from_cache(id=default_group.id)
+        assert group.times_seen == orig_times_seen + 5
+        assert client.zrange("b:p", 0, -1) == []
+
     @mock.patch("sentry.buffer.redis.make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.base.Buffer.process")
     def test_process_uses_signal_only(self, process) -> None:

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -220,39 +220,6 @@ class TestRedisBuffer:
         assert self.buf.pending_key_expire >= self.buf.key_expire
         assert pending_ttl >= row_ttl
 
-    @django_db_all
-    @freeze_time()
-    def test_no_row_lost_when_process_pending_is_delayed(self, default_group, task_runner) -> None:
-        """Rows buffered with no drain in between are all still flushed.
-
-        Redis counts the time to live on the server, so this test cannot wait
-        out a real delay. What protects a late drain is the order of the two
-        expiries, which is asserted below: while a row hash is alive, its
-        pending entry is alive too, so a drain that arrives at any point in the
-        life of the row still finds the entry.
-        """
-        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
-        orig_times_seen = Group.objects.get_from_cache(id=default_group.id).times_seen
-        filters: dict[str, Any] = {"pk": default_group.id}
-        key = make_key(Group, filters=filters)
-
-        # No drain runs while these writes for the same row arrive.
-        for _ in range(5):
-            self.buf.incr(Group, {"times_seen": 1}, filters, {"last_seen": timezone.now()})
-
-        # The row and its pending entry are both still there, and the pending
-        # entry still outlives the row.
-        assert client.ttl(key) > 0
-        assert client.ttl("b:p") >= client.ttl(key)
-        assert len(client.zrange("b:p", 0, -1)) == 1
-
-        with task_runner(), mock.patch("sentry.buffer.backend", self.buf):
-            self.buf.process_pending()
-
-        group = Group.objects.get_from_cache(id=default_group.id)
-        assert group.times_seen == orig_times_seen + 5
-        assert client.zrange("b:p", 0, -1) == []
-
     @mock.patch("sentry.buffer.redis.make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.base.Buffer.process")
     def test_process_uses_signal_only(self, process) -> None:


### PR DESCRIPTION
`RedisBuffer.incr` writes two keys in one pipeline and only one of them was bounded:

```python
pipe.expire(key, self.key_expire)          # the buffered row hash, bounded
pipe.zadd(self.pending_key, {key: time()}) # the b:p pending zset, not bounded
```

Low risk in practice, because `process_pending` drains the zset on the `flush-buffers` schedule every 10 seconds. This is just a hygiene thing really, so that TTLs are set on every row, not necessarily because of a capacity issue.

Refs INFRENG-482
