### PR TITLE
ref(onboarding): drop enableLogs from JS SDK onboardings

### DIFF
--- a/static/app/gettingStartedDocs/bun/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/bun/onboarding.spec.tsx
@@ -32,26 +32,6 @@ describe('bun onboarding docs', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/bun/onboarding.tsx
+++ b/static/app/gettingStartedDocs/bun/onboarding.tsx
@@ -13,12 +13,6 @@ import * as Sentry from "@sentry/bun";
 
 Sentry.init({
   dsn: "${params.dsn.public}",${
-    params.isLogsSelected
-      ? `
-  // Send structured logs to Sentry
-  enableLogs: true,`
-      : ''
-  }${
     params.isPerformanceSelected
       ? `
   // Tracing

--- a/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
@@ -106,26 +106,6 @@ describe('javascript-angular onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedOptions: {
-        configType: AngularConfigType.APP,
-      },
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-
-    // When logs are selected, import statement should appear in verify section too
-    expect(
-      screen.getAllByText(
-        textWithMarkupMatcher(/import \* as Sentry from "@sentry\/angular";/)
-      )
-    ).toHaveLength(3);
-  });
-
   it('shows Logging Integrations in next steps when logs is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedOptions: {

--- a/static/app/gettingStartedDocs/javascript-angular/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/utils.tsx
@@ -83,12 +83,6 @@ const getDynamicParts = (params: Params): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Enable sending logs to Sentry
-      enableLogs: true`);
-  }
-
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profileSessionSampleRate to 1.0 to profile during every session.

--- a/static/app/gettingStartedDocs/javascript-astro/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/onboarding.spec.tsx
@@ -88,17 +88,6 @@ describe('javascript-astro onboarding docs', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    // enableLogs appears in both client and server config
-    expect(screen.getAllByText(textWithMarkupMatcher(/enableLogs: true/))).toHaveLength(
-      2
-    );
-  });
-
   it('shows Logging Integrations in next steps when logs is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [

--- a/static/app/gettingStartedDocs/javascript-astro/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/onboarding.tsx
@@ -12,12 +12,6 @@ import {t, tct} from 'sentry/locale';
 import {installSnippetBlock} from './utils';
 
 function getServerConfigSnippet(params: DocsParams) {
-  const logsConfig = params.isLogsSelected
-    ? `
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`
-    : '';
-
   const performanceConfig = params.isPerformanceSelected
     ? `
   // Define how likely traces are sampled. Adjust this value in production,
@@ -35,18 +29,12 @@ Sentry.init({
     // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
-  },${logsConfig}${performanceConfig}
+  },${performanceConfig}
 });
 `;
 }
 
 function getClientConfigSnippet(params: DocsParams) {
-  const logsConfig = params.isLogsSelected
-    ? `
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`
-    : '';
-
   // Build integrations array based on selected features
   const integrations = [];
   if (params.isPerformanceSelected) {
@@ -89,7 +77,7 @@ Sentry.init({
     // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
-  },${integrationsConfig}${logsConfig}${performanceConfig}${replaySampleRates}
+  },${integrationsConfig}${performanceConfig}${replaySampleRates}
 });
 `;
 }

--- a/static/app/gettingStartedDocs/javascript-ember/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/onboarding.spec.tsx
@@ -88,16 +88,6 @@ describe('javascript-ember onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
   it('shows Configure Ember Options in next steps', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING],

--- a/static/app/gettingStartedDocs/javascript-ember/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/utils.tsx
@@ -33,12 +33,6 @@ const getIntegrations = (params: DocsParams): string[] => {
 const getDynamicParts = (params: DocsParams): string[] => {
   const dynamicParts: string[] = [];
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Enable sending logs to Sentry
-      enableLogs: true`);
-  }
-
   if (params.isReplaySelected) {
     dynamicParts.push(`
       // Session Replay

--- a/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
@@ -88,16 +88,6 @@ describe('javascript-gatsby onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
   it('shows Logging Integrations in next steps when logs is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [

--- a/static/app/gettingStartedDocs/javascript-gatsby/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/utils.tsx
@@ -39,12 +39,6 @@ const getIntegrations = (params: DocsParams): string[] => {
 const getDynamicParts = (params: DocsParams): string[] => {
   const dynamicParts: string[] = [];
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Enable sending logs to Sentry
-      enableLogs: true`);
-  }
-
   if (params.isReplaySelected) {
     dynamicParts.push(`
       // Session Replay

--- a/static/app/gettingStartedDocs/javascript-react-router/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/utils.tsx
@@ -8,12 +8,6 @@ export function getInstallSnippet({isSelfHosted, organization, project}: DocsPar
 }
 
 export function getClientSetupSnippet(params: DocsParams) {
-  const logsSnippet = params.isLogsSelected
-    ? `
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`
-    : '';
-
   const performanceSnippet = params.isPerformanceSelected
     ? `
   tracesSampleRate: 1.0, // Capture 100% of the transactions
@@ -71,7 +65,7 @@ Sentry.init({
     // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
-  },${integrationsCode}${logsSnippet}${performanceSnippet}${replaySnippet}
+  },${integrationsCode}${performanceSnippet}${replaySnippet}
 });
 
 startTransition(() => {

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.spec.tsx
@@ -86,16 +86,6 @@ describe('javascript-react onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
   it('includes metrics API calls in verify when metrics is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],

--- a/static/app/gettingStartedDocs/javascript-react/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/utils.tsx
@@ -24,12 +24,6 @@ const getDynamicParts = (params: DocsParams): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Enable logs to be sent to Sentry
-      enableLogs: true`);
-  }
-
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profileSessionSampleRate to 1.0 to profile during every session.

--- a/static/app/gettingStartedDocs/javascript-solid/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/onboarding.spec.tsx
@@ -86,16 +86,6 @@ describe('javascript-solid onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
   it('shows Logging Integrations in next steps when logs is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [

--- a/static/app/gettingStartedDocs/javascript-solid/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/utils.tsx
@@ -54,12 +54,6 @@ const getDynamicParts = (params: DocsParams): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Logs
-      enableLogs: true`);
-  }
-
   if (params.isProfilingSelected) {
     dynamicParts.push(`
         // Set profileSessionSampleRate to 1.0 to profile during every session.

--- a/static/app/gettingStartedDocs/javascript-svelte/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/onboarding.spec.tsx
@@ -88,16 +88,6 @@ describe('javascript-svelte onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
   it('shows Logging Integrations in next steps when logs is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [

--- a/static/app/gettingStartedDocs/javascript-svelte/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/utils.tsx
@@ -58,12 +58,6 @@ const getDynamicParts = (params: DocsParams): string[] => {
         profileSessionSampleRate: 1.0`);
   }
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Logs
-      enableLogs: true`);
-  }
-
   return dynamicParts;
 };
 

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.spec.tsx
@@ -83,6 +83,64 @@ describe('javascript-tanstackstart-react onboarding docs', () => {
     expect(screen.getAllByText(textWithMarkupMatcher(/Break the world/))).toHaveLength(2);
   });
 
+  it('includes logging code in verify snippet when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/Sentry\.logger\.info/))
+    ).toBeInTheDocument();
+  });
+
+  it('excludes logging code in verify snippet when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING],
+    });
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry\.logger\.info/))
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Logging Integrations in next steps when logs is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
+    });
+
+    expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
+  });
+
+  it('does not show Logging Integrations in next steps when logs is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING],
+    });
+
+    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+  });
+
+  it('shows TanStack Start Features in next steps', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(screen.getByText('TanStack Start Features')).toBeInTheDocument();
+  });
+
+  it('shows Application Metrics in next steps when metrics is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
+    });
+
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
+  });
+
+  it('does not show Application Metrics in next steps when metrics is not selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING],
+    });
+
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
+  });
+
   it('has metrics onboarding configuration', () => {
     expect(docs.metricsOnboarding).toBeDefined();
     expect(docs.metricsOnboarding?.install).toBeDefined();

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -102,13 +102,6 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,`
       : ''
-  }${
-    params.isLogsSelected
-      ? `
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`
-      : ''
   }
 });`,
             },
@@ -222,13 +215,6 @@ Sentry.init({
   // We recommend adjusting this value in production.
   // Learn more at https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
   tracesSampleRate: 1.0,`
-      : ''
-  }${
-    params.isLogsSelected
-      ? `
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,`
       : ''
   }
 });`,
@@ -560,6 +546,14 @@ const route = createRoute({
               code: `<button
   type="button"
   onClick={() => {${
+    params.isLogsSelected
+      ? `
+    // Send a log before throwing the error
+    Sentry.logger.info('User triggered test error', {
+      action: 'test_error_button_click',
+    });`
+      : ''
+  }${
     params.isMetricsSelected
       ? `
     // Send a test metric before throwing the error
@@ -695,4 +689,40 @@ export const Route = createFileRoute("/api/sentry-example")({
       ],
     },
   ],
+  nextSteps: params => {
+    const steps = [
+      {
+        id: 'tanstackstart-features',
+        name: t('TanStack Start Features'),
+        description: t(
+          'Learn about our first class integration with the TanStack Start framework.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/features/',
+      },
+    ];
+
+    if (params.isLogsSelected) {
+      steps.push({
+        id: 'logs',
+        name: t('Logging Integrations'),
+        description: t(
+          'Add logging integrations to automatically capture logs from your application.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/logs/#integrations',
+      });
+    }
+
+    if (params.isMetricsSelected) {
+      steps.push({
+        id: 'metrics',
+        name: t('Application Metrics'),
+        description: t(
+          'Learn how to track custom metrics to monitor your application performance and business KPIs.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/metrics/',
+      });
+    }
+
+    return steps;
+  },
 };

--- a/static/app/gettingStartedDocs/javascript-vue/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/onboarding.spec.tsx
@@ -86,16 +86,6 @@ describe('javascript-vue onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
   it('shows Logging Integrations in next steps when logs is selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [

--- a/static/app/gettingStartedDocs/javascript-vue/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/utils.tsx
@@ -79,12 +79,6 @@ const getDynamicParts = (params: Params): string[] => {
       replaysOnErrorSampleRate: 1.0 // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`);
   }
 
-  if (params.isLogsSelected) {
-    dynamicParts.push(`
-      // Logs
-      enableLogs: true`);
-  }
-
   if (params.isProfilingSelected) {
     dynamicParts.push(`
       // Profiling

--- a/static/app/gettingStartedDocs/javascript/logs.tsx
+++ b/static/app/gettingStartedDocs/javascript/logs.tsx
@@ -56,7 +56,7 @@ export const logs = <PlatformOptions extends BasePlatformOptions = BasePlatformO
         {
           type: 'text',
           text: tct(
-            'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
+            'Logs are enabled by default. To also capture your [code:console] logs, add the [code:consoleLoggingIntegration] to your [code:Sentry.init()] configuration.',
             {code: <code />}
           ),
         },
@@ -72,8 +72,6 @@ Sentry.init({
     // send console.log, console.warn, and console.error calls as logs to Sentry
     Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 });
 `,
         },
@@ -204,7 +202,7 @@ export const logsFullStack = <
         {
           type: 'text',
           text: tct(
-            'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
+            'Logs are enabled by default. To also capture your [code:console] logs, add the [code:consoleLoggingIntegration] to your [code:Sentry.init()] configuration.',
             {code: <code />}
           ),
         },
@@ -220,8 +218,6 @@ Sentry.init({
     // send console.log, console.warn, and console.error calls as logs to Sentry
     Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 });
 `,
         },

--- a/static/app/gettingStartedDocs/node-azurefunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-azurefunctions/onboarding.spec.tsx
@@ -45,26 +45,6 @@ describe('express onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-cloudflare-pages/logs.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-pages/logs.tsx
@@ -16,8 +16,6 @@ export const onRequest = [
       // send console.log, console.warn, and console.error calls as logs to Sentry
       Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
     ],
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
   })),
   // Add more middlewares here
 ];`,

--- a/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.spec.tsx
@@ -40,26 +40,6 @@ describe('cloudflare-pages onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-pages/onboarding.tsx
@@ -37,13 +37,6 @@ export const onRequest = [
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,`
         : ''
-    }${
-      params.isLogsSelected
-        ? `
-
-    // Send structured logs to Sentry
-    enableLogs: true,`
-        : ''
     }
 
     dataCollection: {

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/logs.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/logs.tsx
@@ -15,8 +15,6 @@ export default Sentry.withSentry(
       // send console.log, console.warn, and console.error calls as logs to Sentry
       Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
     ],
-    // Enable logs to be sent to Sentry
-    enableLogs: true,
   }),
   {
     async fetch(request, env, ctx) {

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.spec.tsx
@@ -40,26 +40,6 @@ describe('cloudflare-workers onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-cloudflare-workers/onboarding.tsx
@@ -35,13 +35,6 @@ export default Sentry.withSentry(
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,`
         : ''
-    }${
-      params.isLogsSelected
-        ? `
-
-    // Send structured logs to Sentry
-    enableLogs: true,`
-        : ''
     }
 
     dataCollection: {

--- a/static/app/gettingStartedDocs/node-connect/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-connect/onboarding.spec.tsx
@@ -53,26 +53,6 @@ describe('connect onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
@@ -54,26 +54,6 @@ describe('express onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-fastify/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-fastify/onboarding.spec.tsx
@@ -54,26 +54,6 @@ describe('fastify onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-gcpfunctions/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-gcpfunctions/onboarding.spec.tsx
@@ -46,26 +46,6 @@ describe('gcpfunctions onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
@@ -54,26 +54,6 @@ describe('hapi onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.spec.tsx
@@ -50,26 +50,6 @@ describe('hono onboarding docs', () => {
       ).toBeInTheDocument();
     });
 
-    it('enables logs by setting enableLogs to true', () => {
-      renderWithOnboardingLayout(docs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-      });
-
-      expect(
-        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-      ).toBeInTheDocument();
-    });
-
-    it('does not enable logs when not selected', () => {
-      renderWithOnboardingLayout(docs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING],
-      });
-
-      expect(
-        screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-      ).not.toBeInTheDocument();
-    });
-
     it('shows profiling info alert when profiling is selected', () => {
       renderWithOnboardingLayout(docs, {
         selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
@@ -194,26 +174,6 @@ describe('hono onboarding docs', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('enables logs by setting enableLogs to true', () => {
-      renderWithOnboardingLayout(nodeDocs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-      });
-
-      expect(
-        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-      ).toBeInTheDocument();
-    });
-
-    it('does not enable logs when not selected', () => {
-      renderWithOnboardingLayout(nodeDocs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING],
-      });
-
-      expect(
-        screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-      ).not.toBeInTheDocument();
-    });
-
     it('does not show profiling alert when profiling is selected', () => {
       renderWithOnboardingLayout(nodeDocs, {
         selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.PROFILING],
@@ -275,16 +235,6 @@ describe('hono onboarding docs', () => {
 
       expect(
         screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-      ).toBeInTheDocument();
-    });
-
-    it('enables logs by setting enableLogs to true', () => {
-      renderWithOnboardingLayout(bunDocs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-      });
-
-      expect(
-        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
       ).toBeInTheDocument();
     });
 
@@ -352,16 +302,6 @@ describe('hono onboarding docs', () => {
 
       expect(
         screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
-      ).toBeInTheDocument();
-    });
-
-    it('enables logs by setting enableLogs to true', () => {
-      renderWithOnboardingLayout(denoDocs, {
-        selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-      });
-
-      expect(
-        screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
       ).toBeInTheDocument();
     });
 

--- a/static/app/gettingStartedDocs/node-hono/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-hono/onboarding.tsx
@@ -71,11 +71,6 @@ Sentry.init({
   profileSessionSampleRate: 1.0,
   profileLifecycle: 'trace',`
       : ''
-  }${
-    params.isLogsSelected
-      ? `
-  enableLogs: true,`
-      : ''
   }
   dataCollection: {
     // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -117,11 +112,6 @@ app.use(
         ? `
     tracesSampleRate: 1.0,`
         : ''
-    }${
-      params.isLogsSelected
-        ? `
-    enableLogs: true,`
-        : ''
     }
     dataCollection: {
       // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
@@ -152,11 +142,6 @@ app.use(
       params.isPerformanceSelected
         ? `
     tracesSampleRate: 1.0,`
-        : ''
-    }${
-      params.isLogsSelected
-        ? `
-    enableLogs: true,`
         : ''
     }
     dataCollection: {

--- a/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
@@ -54,26 +54,6 @@ describe('koa onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node-nestjs/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-nestjs/onboarding.spec.tsx
@@ -119,26 +119,6 @@ describe('Nest.js onboarding docs', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.spec.tsx
@@ -111,26 +111,6 @@ describe('node onboarding docs', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('enables logs by setting enableLogs to true', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
-    });
-
-    expect(
-      screen.getByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).toBeInTheDocument();
-  });
-
-  it('does not enable logs when not selected', () => {
-    renderWithOnboardingLayout(docs, {
-      selectedProducts: [ProductSolution.ERROR_MONITORING],
-    });
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher(/enableLogs: true/))
-    ).not.toBeInTheDocument();
-  });
-
   it('displays logs integration next step when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -475,8 +475,6 @@ Sentry.init({
   // send console.log, console.warn, and console.error calls as logs to Sentry
   Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
   ],
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
 });`,
   };
 }
@@ -534,7 +532,7 @@ export const getNodeLogsOnboarding = <
           {
             type: 'text',
             text: tct(
-              'Enable Sentry logs by adding [code:enableLogs: true] to your [code:Sentry.init()] configuration.',
+              'Logs are enabled by default. To also capture your [code:console] logs, add the [code:consoleLoggingIntegration] to your [code:Sentry.init()] configuration.',
               {code: <code />}
             ),
           },
@@ -593,13 +591,6 @@ Sentry.init({
       ? `integrations: [
     nodeProfilingIntegration(),
   ],`
-      : ''
-  }${
-    params.isLogsSelected
-      ? `
-
-  // Send structured logs to Sentry
-  enableLogs: true,`
       : ''
   }${
     params.isPerformanceSelected


### PR DESCRIPTION
Logs are enabled by default as of JS SDK `10.71.0`, so the in-product onboardings should no longer set `enableLogs: true`. This mirrors the docs change in https://github.com/getsentry/sentry-docs/pull/19080.

Also noticed that the `tanstackstart-react` setup was missing next-steps and verify sections for logs/metrics so added these.
