### PR TITLE
fix(ui): Stop reserving a scrollbar gutter on scrollable tables

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -80,7 +80,7 @@ export const Grid = styled(Table, {
     p.scrollable &&
     css`
       overflow-x: auto;
-      overflow-y: scroll;
+      overflow-y: auto;
     `}
 
   /* Pin the header to a definite track height in both layouts; a content-based


### PR DESCRIPTION
- Set `overflow-y: auto` instead of `scroll` on GridEditable tables, which reserves an ~11px scrollbar gutter even when the rows fit. The header band and the row dividers stop short of the panel border and leave a white strip on the right.
- Affects every `scrollable` GridEditable: dashboard table widgets, explore tables, multi-query table, releases drawer tables, agents traces table, and the feature flags log table.
- Verified locally by looking at different tables in different product surfaces - doesn't seem to have any adverse effects AFAICT

Contributes to DAIN-1794
