### PR TITLE
ref(spans): Run process-segments as a task in devenv

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -157,8 +157,6 @@ x-sentry-service-config:
     # Spans and performance monitoring
     process-spans:
       description: Kafka consumer for processing spans data
-    process-segments:
-      description: Kafka consumer for processing performance segments
     # Metrics-related consumers
     ingest-metrics:
       description: Kafka consumer for processing metrics data
@@ -223,7 +221,6 @@ x-sentry-service-config:
         post-process-forwarder-issue-platform,
         process-spans,
         ingest-occurrences,
-        process-segments,
         taskbroker,
         taskbroker-sentry,
         taskworker,
@@ -359,7 +356,6 @@ x-sentry-service-config:
         post-process-forwarder-issue-platform,
         post-process-forwarder-transactions,
         postgres,
-        process-segments,
         process-spans,
         relay,
         symbolicator,
@@ -391,7 +387,6 @@ x-sentry-service-config:
         ingest-occurrences,
         objectstore,
         process-spans,
-        process-segments,
         ingest-metrics,
         ingest-generic-metrics,
         uptime-checker,
@@ -433,8 +428,6 @@ x-programs:
     command: sentry run consumer ingest-occurrences --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   process-spans:
     command: sentry run consumer process-spans --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  process-segments:
-    command: sentry run consumer process-segments --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   uptime-results:
     command: sentry run consumer uptime-results --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   ingest-metrics:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3305,7 +3305,7 @@ register(
 register(
     "spans.buffer.process-segments-task-rollout-rate",
     type=Float,
-    default=0.0,
+    default=1.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -334,7 +334,6 @@ def devserver(
                 if settings.SENTRY_USE_SPANS_BUFFER:
                     kafka_consumers.add("process-spans")
                     kafka_consumers.add("ingest-occurrences")
-                    kafka_consumers.add("process-segments")
 
             if occurrence_ingest:
                 kafka_consumers.add("ingest-occurrences")


### PR DESCRIPTION
Segments are already processed by the `process_segment` task in production.
This flips the default of `spans.buffer.process-segments-task-rollout-rate` to
1.0 and drops the dedicated `process-segments` Kafka consumer from devservices
and the devserver, so devenv matches production.

The flusher spawns the task directly, so no raw-mode taskbroker topic is
involved.

Self-hosted counterpart: https://github.com/getsentry/self-hosted/pull/4488

ref STREAM-1568