### PR TITLE
fix(web): Serve Scraps without redirecting

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -506,6 +506,11 @@ urlpatterns += [
     ),
     # Story book
     re_path(
+        r"^scraps/",
+        react_page_view,
+        name="scraps",
+    ),
+    re_path(
         r"^stories/",
         react_page_view,
         name="stories",
@@ -532,11 +537,6 @@ urlpatterns += [
         r"^docs/api/?$",
         RedirectView.as_view(url="https://docs.sentry.io/api/", permanent=False),
         name="sentry-api-docs-redirect",
-    ),
-    re_path(
-        r"^scraps/?$",
-        RedirectView.as_view(pattern_name="stories", permanent=False),
-        name="sentry-scraps-redirect",
     ),
     re_path(
         r"^api/$",

--- a/tests/sentry/web/test_urls.py
+++ b/tests/sentry/web/test_urls.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
 
 
 class DocsRedirectTest(TestCase):
@@ -19,13 +20,16 @@ class ApiDocsRedirectTest(TestCase):
         assert resp.status_code == 302, resp.status_code
 
 
+@control_silo_test
 class StorybookRoutesTest(TestCase):
     def test_scraps_response(self) -> None:
+        self.login_as(self.user)
         path = reverse("scraps")
         resp = self.client.get(path)
         assert resp.status_code == 200, resp.status_code
 
     def test_legacy_stories_response(self) -> None:
+        self.login_as(self.user)
         path = reverse("stories")
         resp = self.client.get(path)
         assert resp.status_code == 200, resp.status_code

--- a/tests/sentry/web/test_urls.py
+++ b/tests/sentry/web/test_urls.py
@@ -23,13 +23,17 @@ class ApiDocsRedirectTest(TestCase):
 @control_silo_test
 class StorybookRoutesTest(TestCase):
     def test_scraps_response(self) -> None:
-        self.login_as(self.user)
+        user = self.create_user("scraps@example.com")
+        self.create_organization(owner=user)
+        self.login_as(user)
         path = reverse("scraps")
         resp = self.client.get(path)
         assert resp.status_code == 200, resp.status_code
 
     def test_legacy_stories_response(self) -> None:
-        self.login_as(self.user)
+        user = self.create_user("stories@example.com")
+        self.create_organization(owner=user)
+        self.login_as(user)
         path = reverse("stories")
         resp = self.client.get(path)
         assert resp.status_code == 200, resp.status_code

--- a/tests/sentry/web/test_urls.py
+++ b/tests/sentry/web/test_urls.py
@@ -22,18 +22,18 @@ class ApiDocsRedirectTest(TestCase):
 
 @control_silo_test
 class StorybookRoutesTest(TestCase):
-    def test_scraps_response(self) -> None:
-        user = self.create_user("scraps@example.com")
+    def setUp(self) -> None:
+        super().setUp()
+        user = self.create_user("user@example.com")
         self.create_organization(owner=user)
         self.login_as(user)
+
+    def test_scraps_response(self) -> None:
         path = reverse("scraps")
         resp = self.client.get(path)
         assert resp.status_code == 200, resp.status_code
 
     def test_legacy_stories_response(self) -> None:
-        user = self.create_user("stories@example.com")
-        self.create_organization(owner=user)
-        self.login_as(user)
         path = reverse("stories")
         resp = self.client.get(path)
         assert resp.status_code == 200, resp.status_code

--- a/tests/sentry/web/test_urls.py
+++ b/tests/sentry/web/test_urls.py
@@ -19,9 +19,13 @@ class ApiDocsRedirectTest(TestCase):
         assert resp.status_code == 302, resp.status_code
 
 
-class ScrapsRedirectTest(TestCase):
-    def test_response(self) -> None:
-        path = reverse("sentry-scraps-redirect")
+class StorybookRoutesTest(TestCase):
+    def test_scraps_response(self) -> None:
+        path = reverse("scraps")
         resp = self.client.get(path)
-        assert resp["Location"] == reverse("stories")
-        assert resp.status_code == 302, resp.status_code
+        assert resp.status_code == 200, resp.status_code
+
+    def test_legacy_stories_response(self) -> None:
+        path = reverse("stories")
+        resp = self.client.get(path)
+        assert resp.status_code == 200, resp.status_code


### PR DESCRIPTION
The backend now serves the React app at both `/scraps/*` and `/stories/*` instead of redirecting `/scraps` to `/stories`. This must land before #122556 so the frontend can make `/scraps` canonical without creating a redirect loop during separate deployments.
