### PR TITLE
ref(pr-metrics): Deregister the five collapsed pr-metrics-* stage flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -216,16 +216,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Create issue activities for pull request lifecycle events
     manager.add("organizations:pr-lifecycle-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Write PullRequestActivity rows from GitHub PR lifecycle webhooks
-    manager.add("organizations:pr-metrics-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Fold PR activity into a single PullRequestActivityLog document instead of one row per event
-    manager.add("organizations:pr-metrics-activity-document", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Record PullRequestAttribution from webhook and seer.pr_created events
-    manager.add("organizations:pr-metrics-attribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Emit the BigQuery row on a tracked PR's close/merge (PR Merge Live Metrics rollout)
-    manager.add("organizations:pr-metrics-emit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Forward a terminal PR event that needs a judge to Seer (PR Merge Live Metrics judge path)
-    manager.add("organizations:pr-metrics-judge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod PR comments for size analysis


### PR DESCRIPTION
> [!WARNING]
> **Draft — blocked on [sentry-options-automator#9333](https://github.com/getsentry/sentry-options-automator/pull/9333) merging and its run going green.**
> That PR removes the flagpole values for these five flags. Deregistering them while the
> automator still sets a value makes it report an unregistered option and turn red on `main`
> for everyone. Ready to un-draft once #9333 has deployed clean.

### Problem

[#121939](https://github.com/getsentry/sentry/pull/121939) collapsed every read of the five
`organizations:pr-metrics-*` stage flags into the permanent `organizations:pr-metrics` gate.
The registrations stayed behind, so the manager now registers five flags that no call site
evaluates — and, because registering a FlagPole flag auto-registers a
`feature.<flag-name>` option, five options nothing reads either.

```
$ git grep -c 'organizations:pr-metrics-\(attribution\|activity\|activity-document\|emit\|judge\)'
src/sentry/features/temporary.py:5
```

That is the whole population: no other file in `src/`, `tests/`, or `static/` mentions them.

### What changed

The five `manager.add(...)` lines and their comments come out. `organizations:pr-metrics` in
[permanent.py](https://github.com/getsentry/sentry/blob/master/src/sentry/features/permanent.py)
is the surviving gate and is untouched, as is `organizations:pr-lifecycle-activity`, which is
issue_workflow's flag and sits directly above this block.

Nothing about flag evaluation changes: an unregistered flag and a registered-but-unread flag
are equally invisible to every caller, because there are no callers left.

### Ordering

Step 3 of the three-step removal from the `remove-option-or-flag` skill:

| # | Repo | Change | Status |
| --- | --- | --- | --- |
| 1 | sentry | Collapse every read to the permanent gate | ✅ [#121939](https://github.com/getsentry/sentry/pull/121939) merged |
| 2 | sentry-options-automator | Remove the flagpole values | [#9333](https://github.com/getsentry/sentry-options-automator/pull/9333), draft |
| 3 | **sentry** | **Remove the registrations — this PR** | blocked on 2 |

### Tests

`tests/sentry/features/` — 41 passed. `tests/sentry/pr_metrics/` — 656 passed.
`prek` clean on the changed file.

Refs CORE-298
