### PR TITLE
fix(forms): Have SelectField restores focus after selecting an option with the keyboard

### DIFF
--- a/static/app/components/core/form/field/selectField.spec.tsx
+++ b/static/app/components/core/form/field/selectField.spec.tsx
@@ -453,6 +453,22 @@ describe('SelectField auto-save', () => {
     expect(mutationFn).toHaveBeenCalledWith({fruit: 'banana'}, expect.anything());
   });
 
+  it('restores focus after selecting an option with the keyboard', async () => {
+    const mutationFn = jest.fn((data: {fruit: string}) => Promise.resolve(data));
+
+    render(<AutoSaveTestForm mutationFn={mutationFn} initialValue="apple" />);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.click(input);
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+
+    await waitFor(() => {
+      expect(mutationFn).toHaveBeenCalledWith({fruit: 'banana'}, expect.anything());
+    });
+    expect(await screen.findByTestId('icon-check-mark')).toBeInTheDocument();
+    expect(input).toHaveFocus();
+  });
+
   it('disables select while auto-save is pending', async () => {
     const mutationFn = jest.fn(() => new Promise<{fruit: string}>(() => {}));
 

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -135,6 +135,7 @@ export function SelectField<TValue>({
             multiple={multiple}
             value={value}
             inputRef={applyInputToRef(fieldRef)}
+            {...(autoSaveContext && {blurInputOnSelect: false})}
             components={
               {
                 ...props.components,
@@ -169,12 +170,18 @@ export function SelectField<TValue>({
                 if (!option) {
                   // Clearable single select - type system allows null via discriminated union
                   (onChange as (value: TValue | null) => void)(null);
+                  if (autoSaveContext) {
+                    fieldProps.onBlur();
+                  }
                   return;
                 }
                 // For single-select, option is a single value
                 (onChange as (value: TValue) => void)(
                   (option as SelectValue<TValue>).value
                 );
+                if (autoSaveContext) {
+                  fieldProps.onBlur();
+                }
               }
             }}
           />


### PR DESCRIPTION
found this during the v2 migration but turns out it’s not v2 related.

before: after submitting with the keyboard, the focus is nowhere

https://github.com/user-attachments/assets/2b4ec9dd-656e-4ec3-8ba2-70c16ea8a5aa

after: like with other fields, focus is restored to the current control

https://github.com/user-attachments/assets/580f4345-51a9-49fd-8dd7-e96bcc6d17be

