### PR TITLE
fix(attachments): Set content type on Objectstore attachment uploads

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -269,6 +269,7 @@ class EventAttachment(Model):
             session = get_attachments_session(organization_id, project_id)
             key = session.put(
                 data,
+                content_type=content_type,
                 filename=attachment.name,
                 expiration_policy=TimeToLive(timedelta(days=attachment.retention_days)),
             )

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -437,6 +437,7 @@ def _maybe_copy_attachment_into_cache(
         with attachment.getfile() as fp:
             stored_id = get_attachments_session(project.organization_id, project.id).put(
                 fp,
+                content_type=attachment.content_type,
                 filename=attachment.name,
                 expiration_policy=TimeToLive(timedelta(days=retention_days)),
             )

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -87,7 +87,7 @@ class EventAttachmentPutfileTest(TestCase):
             self.project.id,
             # Long enough that it cannot be stored inline.
             CachedAttachment(
-                name="one.log", content_type="application/octet-stream", data=b"x" * 200
+                name="one.txt", content_type="application/octet-stream", data=b"x" * 200
             ),
         )
 

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -71,6 +71,30 @@ class EventAttachmentPutfileTest(TestCase):
 
         assert result.blob_path == "v2/some-key"
         assert mock_get_session.return_value.put.call_args.kwargs["filename"] == "hello.png"
+        assert mock_get_session.return_value.put.call_args.kwargs["content_type"] == "image/png"
+
+    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
+    @override_options({"objectstore.enable_for.attachments": 1})
+    def test_objectstore_upload_stores_normalized_content_type(
+        self,
+        mock_get_org: mock.Mock,
+        mock_get_session: mock.Mock,
+    ) -> None:
+        mock_get_session.return_value.put.return_value = "some-key"
+
+        result = EventAttachment.putfile(
+            self.project.id,
+            # Long enough that it cannot be stored inline.
+            CachedAttachment(
+                name="one.log", content_type="application/octet-stream", data=b"x" * 200
+            ),
+        )
+
+        # The uninformative `application/octet-stream` is upgraded from the filename, and
+        # objectstore must record the same value as the `content_type` column.
+        assert result.content_type == "text/plain"
+        assert mock_get_session.return_value.put.call_args.kwargs["content_type"] == "text/plain"
 
 
 class NormalizeContentTypeTest(TestCase):

--- a/tests/sentry/test_reprocessing2.py
+++ b/tests/sentry/test_reprocessing2.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from sentry.models.eventattachment import EventAttachment
+from sentry.reprocessing2 import _maybe_copy_attachment_into_cache
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+
+
+class MaybeCopyAttachmentIntoCacheTest(TestCase):
+    def _create_inline_attachment(self) -> EventAttachment:
+        return EventAttachment.objects.create(
+            event_id="a" * 32,
+            project_id=self.project.id,
+            type="event.attachment",
+            name="one.log",
+            content_type="text/plain",
+            size=5,
+            blob_path=":hello",
+        )
+
+    @mock.patch("sentry.reprocessing2.get_attachments_session")
+    @override_options({"objectstore.enable_for.attachments": 1})
+    def test_objectstore_upload_stores_content_type(self, mock_get_session: mock.Mock) -> None:
+        mock_get_session.return_value.put.return_value = "some-key"
+        attachment = self._create_inline_attachment()
+
+        cached = _maybe_copy_attachment_into_cache(
+            self.project, 0, attachment, "cache-key", cache_timeout=3600
+        )
+
+        put_kwargs = mock_get_session.return_value.put.call_args.kwargs
+        assert put_kwargs["content_type"] == "text/plain"
+        assert put_kwargs["filename"] == "one.log"
+
+        assert cached.stored_id == "some-key"
+        attachment.refresh_from_db()
+        assert attachment.blob_path == "v2/some-key"


### PR DESCRIPTION
Attachments in objectstore are currently stored without a content type. Since getsentry/sentry#120958, Sentry redirects to Objectstore for downloads, and these are now missing the `content-type` header.

This PR now sets content-type in all attachment upload paths. Note that the primary upload path is in Relay (https://github.com/getsentry/relay/pull/6319).

Ref FS-491
Ref https://github.com/getsentry/sentry-mcp/issues/1267