### PR TITLE
ref(ai-monitoring): Move conversation details endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -477,7 +477,6 @@ module = [
     "sentry.api.endpoints.internal.*",
     "sentry.api.endpoints.oauth_userinfo",
     "sentry.api.endpoints.organization_access_request_details",
-    "sentry.api.endpoints.organization_ai_conversation_details",
     "sentry.api.endpoints.organization_ai_conversations",
     "sentry.api.endpoints.organization_api_key_details",
     "sentry.api.endpoints.organization_api_key_index",

--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -28,6 +28,8 @@ from sentry.utils.tracing import trace
 
 logger = logging.getLogger(__name__)
 
+type SpanRow = dict[str, Any]
+
 MAX_RETENTION_DAYS = 30
 
 _WIDENING_STEPS = [timedelta(days=7), timedelta(days=14), timedelta(days=MAX_RETENTION_DAYS)]
@@ -120,12 +122,12 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                     snuba_params, request.GET.get("statsPeriod"), now, conversation_id
                 )
 
-            def data_fn(offset: int, limit: int) -> list:
+            def data_fn(offset: int, limit: int) -> list[SpanRow]:
                 spans = self._fetch_spans(resolved_params, conversation_id, offset, limit)
                 self._annotate_issues(spans, resolved_params, organization)
                 return spans
 
-            def on_results(spans: list[dict[str, Any]]) -> AIConversationDetailsResponse:
+            def on_results(spans: list[SpanRow]) -> AIConversationDetailsResponse:
                 return {
                     "conversationId": conversation_id,
                     "title": self._resolve_title(conversation_id, spans, organization),
@@ -205,7 +207,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     @trace
     def _annotate_issues(
         self,
-        spans: list[dict],
+        spans: list[SpanRow],
         snuba_params: SnubaParams,
         organization: Organization,
     ) -> None:
@@ -268,7 +270,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         conversation_id: str,
         offset: int,
         limit: int,
-    ) -> list:
+    ) -> list[SpanRow]:
         result = Spans.run_table_query(
             params=snuba_params,
             query_string=build_escaped_term_filter("gen_ai.conversation.id", [conversation_id]),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
-from sentry.api.endpoints.dsn_lookup import DsnLookupEndpoint
-from sentry.api.endpoints.organization_ai_conversation_details import (
+from sentry.ai_monitoring.endpoints.organization_ai_conversation_details import (
     OrganizationAIConversationDetailsEndpoint,
 )
+from sentry.api.endpoints.dsn_lookup import DsnLookupEndpoint
 from sentry.api.endpoints.organization_ai_conversations import OrganizationAIConversationsEndpoint
 from sentry.api.endpoints.organization_auth_token_details import (
     OrganizationAuthTokenDetailsEndpoint,

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -945,7 +945,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert len(response.data["spans"]) == 1
 
     @patch(
-        "sentry.api.endpoints.organization_ai_conversation_details.fetch_conversation_title",
+        "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.fetch_conversation_title",
         side_effect=Exception("metadata unavailable"),
     )
     def test_survives_a_failing_title_lookup(


### PR DESCRIPTION
AI conversation details now belongs to the AI Monitoring package, which starts consolidating backend ownership around that domain. API paths, route names, response shape, and runtime behavior remain unchanged.

Follow-up PRs will move the conversation list, utilities, title tasks, and model metadata task in separate reviewable steps.