### PR TITLE
ref(attachments): Stop returning SHA1 in API

### DIFF
--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -24,7 +24,6 @@ class EventAttachmentSerializer(Serializer[EventAttachmentSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> EventAttachmentSerializerResponse:
         content_type = obj.content_type
         size = obj.size or 0
-        sha1 = obj.sha1
         headers = {"Content-Type": content_type}
 
         return {
@@ -38,7 +37,7 @@ class EventAttachmentSerializer(Serializer[EventAttachmentSerializerResponse]):
             # TODO: It would be nice to deprecate these two fields.
             # If not, we can at least define `headers` as `Content-Type: $mimetype`.
             "headers": headers,
-            "sha1": sha1,
+            "sha1": None,
         }
 
 

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -153,7 +153,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert response.data["id"] == str(self.attachment.id)
         assert response.data["event_id"] == self.event.event_id
         assert response.data["size"] == 0
-        assert response.data["sha1"] == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        assert response.data["sha1"] is None
 
         path = f"{path}?download"
 

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -52,7 +52,7 @@ class EventAttachmentsTest(APITestCase):
         assert response.data[0]["name"] == "hello.png"
         assert response.data[0]["mimetype"] == "image/png"
         assert response.data[0]["size"] == 18
-        assert response.data[0]["sha1"] == "d3f299af02d6abbe92dd8368bab781824a9702ed"
+        assert response.data[0]["sha1"] is None
         assert response.data[0]["headers"] == {"Content-Type": "image/png"}
 
         path = f"/api/0/projects/{event2.project.organization.slug}/{event2.project.slug}/events/{event2.event_id}/attachments/"
@@ -68,7 +68,7 @@ class EventAttachmentsTest(APITestCase):
         assert response.data[0]["name"] == "hello.png"
         assert response.data[0]["mimetype"] == "image/png"
         assert response.data[0]["size"] == 1234
-        assert response.data[0]["sha1"] == "1234"
+        assert response.data[0]["sha1"] is None
         assert response.data[0]["headers"] == {"Content-Type": "image/png"}
 
     def test_is_screenshot(self) -> None:


### PR DESCRIPTION
The SHA1 field has no longer been populated correctly since the move to
objectstore. The new platform does not offer automatic SHA1 checksums and
ingestion does not compute them. With the upcoming streaming upload API for
large attachments, there's no plans to support checksums at all.

As per schema documentation, the SHA1 field is nullable. We hence set it to
`null` statically.

At a later point, we might introduce checksums into the underlying platform.
These will likely be MD5 or other checksums, however. Until then, the field will
remain disabled.

Closes FS-327
Ref FS-491

