### PR TITLE
fix(dynamic-sampling): run recalibration only on EAP

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/calculations.py
+++ b/src/sentry/dynamic_sampling/per_org/calculations.py
@@ -46,9 +46,8 @@ def calculate_recalibration_factor(
     # to the effective sample rate of that org. An imbalance in the ratio can be introduced by many factors, including
     # biases that oversample or down sample irrespectively of the incoming volume.
     #
-    # The two sides of the volume come from different sources counting different populations,
-    # so the ratio can legitimately land above 1. That is not a sample rate, so treat it as
-    # fully sampled rather than scaling the factor down by however far the sources differed.
+    # Both sides come from the same EAP query, so the stored count cannot exceed the
+    # extrapolated total. The clamp keeps a rounded ratio from raising the factor.
     effective_sample_rate = min(1.0, data_volume.indexed / data_volume.total)
     new_factor = previous_factor * (target_sample_rate / effective_sample_rate)
     return new_factor

--- a/src/sentry/dynamic_sampling/per_org/comparisons.py
+++ b/src/sentry/dynamic_sampling/per_org/comparisons.py
@@ -255,16 +255,13 @@ def compare_rebalanced_transactions_with_cache(config: BaseDynamicSamplingConfig
 
 def compare_recalibration_factor_with_cache(config: BaseDynamicSamplingConfiguration) -> None:
     results = config.results
-    org_volume = results.recalibration_volume
+    org_volume = results.organization_volume
     calculated_factor = results.recalibration_factor
     cached_factor = get_cached_recalibration_factor(config.organization.id)
     legacy_volume = get_organization_volume(
         config.organization.id, time_interval=RECALIBRATION_TIME_INTERVAL
     )
     target_sample_rate = config.get_sample_rate()
-    eap_extrapolated_total = (
-        None if results.organization_volume is None else results.organization_volume.total
-    )
 
     def same_seed_factor(volume: OrganizationDataVolume | None) -> float | None:
         return calculate_recalibration_factor(volume, cached_factor, target_sample_rate)
@@ -295,12 +292,6 @@ def compare_recalibration_factor_with_cache(config: BaseDynamicSamplingConfigura
             "total_transactions": None if org_volume is None else org_volume.total,
             "stored_segments": None if org_volume is None else org_volume.indexed,
             "eap_effective_sample_rate": get_effective_sample_rate(org_volume),
-            "eap_extrapolated_total": eap_extrapolated_total,
-            "extrapolated_total_relative_deviation": (
-                None
-                if eap_extrapolated_total is None or org_volume is None
-                else get_relative_deviation(eap_extrapolated_total, org_volume.total)
-            ),
             "generic_metrics_total": None if legacy_volume is None else legacy_volume.total,
             "generic_metrics_indexed": None if legacy_volume is None else legacy_volume.indexed,
             "generic_metrics_effective_sample_rate": get_effective_sample_rate(legacy_volume),

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -33,7 +33,7 @@ from sentry.utils.snuba import raw_snql_query
 
 # The window recalibration measures an organization over. Shared with the comparison
 # logging, so that the legacy factor it reports is computed over the same window.
-RECALIBRATION_TIME_INTERVAL = timedelta(minutes=5)
+RECALIBRATION_TIME_INTERVAL = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL
 
 
 class OrganizationVolumeConfig(Protocol):
@@ -148,26 +148,6 @@ def get_eap_organization_volume(
     indexed = _get_aggregate_int(row, DynamicSamplingQueryFields.COUNT_SAMPLE)
 
     return OrganizationDataVolume(org_id=config.organization.id, total=total, indexed=indexed)
-
-
-def get_recalibration_organization_volume(
-    config: OrganizationVolumeConfig,
-    eap_volume: OrganizationDataVolume | None,
-    time_interval: timedelta = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
-    end: datetime | None = None,
-) -> OrganizationDataVolume | None:
-    if eap_volume is None or eap_volume.indexed is None:
-        return None
-
-    outcomes_volume = get_outcomes_organization_volume(config, time_interval=time_interval, end=end)
-    if outcomes_volume is None:
-        return None
-
-    return OrganizationDataVolume(
-        org_id=config.organization.id,
-        total=outcomes_volume.total,
-        indexed=eap_volume.indexed,
-    )
 
 
 def get_outcomes_organization_volume(

--- a/src/sentry/dynamic_sampling/per_org/results.py
+++ b/src/sentry/dynamic_sampling/per_org/results.py
@@ -26,6 +26,5 @@ class DynamicSamplingResults:
     rebalanced_projects: list[RebalancedItem] = field(default_factory=list)
     projects_to_balance: list[Project] = field(default_factory=list)
     rebalanced_transactions: TransactionSampleRates = field(default_factory=dict)
-    recalibration_volume: OrganizationDataVolume | None = None
     previous_recalibration_factor: float = 1.0
     recalibration_factor: float | None = None

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -28,7 +28,6 @@ from sentry.dynamic_sampling.per_org.queries import (
     get_eap_organization_volume,
     get_eap_project_volumes,
     get_eap_transaction_volumes,
-    get_recalibration_organization_volume,
 )
 from sentry.dynamic_sampling.per_org.telemetry import (
     SCHEDULER_BUCKET_ORG_STATUS_METRIC,
@@ -75,7 +74,9 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
     try:
         results = config.results
         org_volume_end = datetime.now(UTC).replace(second=0, microsecond=0)
-        results.organization_volume = get_eap_organization_volume(config, end=org_volume_end)
+        results.organization_volume = get_eap_organization_volume(
+            config, time_interval=RECALIBRATION_TIME_INTERVAL, end=org_volume_end
+        )
         if results.organization_volume is None:
             return DynamicSamplingStatus.NO_ORG_VOLUME
         results.project_volumes = get_eap_project_volumes(config)
@@ -103,13 +104,7 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
         )
 
         if is_org_in_recalibration_rollout(config.organization.id):
-            results.recalibration_volume = get_recalibration_organization_volume(
-                config,
-                results.organization_volume,
-                time_interval=RECALIBRATION_TIME_INTERVAL,
-                end=org_volume_end,
-            )
-            config.recalibrate(results.recalibration_volume)
+            config.recalibrate(results.organization_volume)
 
         return None
     finally:

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -20,13 +20,9 @@ from sentry.dynamic_sampling.per_org.queries import (
     get_eap_project_volumes,
     get_eap_transaction_volumes,
     get_outcomes_organization_volume,
-    get_recalibration_organization_volume,
     run_eap_spans_table_query_in_chunks,
 )
-from sentry.dynamic_sampling.tasks.common import (
-    ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
-    OrganizationDataVolume,
-)
+from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.models.organization import Organization
 from sentry.search.eap.constants import SAMPLING_MODE_HIGHEST_ACCURACY
 from sentry.search.eap.types import SearchResolverConfig
@@ -170,49 +166,6 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         assert org_volume is None
         run_table_query.assert_called_once()
         assert run_table_query.call_args.kwargs["params"].projects == []
-
-    def test_get_recalibration_organization_volume_combines_both_sources(self) -> None:
-        organization = self.create_organization()
-        self.create_project(organization=organization)
-        config = self.get_config(organization)
-        eap_volume = OrganizationDataVolume(org_id=organization.id, total=400, indexed=25)
-        window_end = before_now(minutes=5).replace(second=0, microsecond=0)
-
-        with patch(RUN_OUTCOMES_QUERY, return_value=[{"quantity": 100}]) as run_outcomes_query:
-            org_volume = get_recalibration_organization_volume(config, eap_volume, end=window_end)
-
-        # The total comes from the transaction outcomes and the stored count from EAP. The
-        # extrapolated EAP total is unused, so 75 segments were dropped, not 375.
-        assert org_volume == OrganizationDataVolume(org_id=organization.id, total=100, indexed=25)
-        # Both sides must cover the same window, or their ratio is not a sample rate. The
-        # outcomes query widens its window to whole intervals, so a 5-minute one asks for
-        # minute resolution rather than the hour it would otherwise cover.
-        query = run_outcomes_query.call_args.args[0]
-        assert query.end == window_end
-        assert query.start == window_end - ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL
-
-    def test_get_recalibration_organization_volume_without_stored_segments(self) -> None:
-        organization = self.create_organization()
-        self.create_project(organization=organization)
-        config = self.get_config(organization)
-        eap_volume = OrganizationDataVolume(org_id=organization.id, total=400, indexed=None)
-
-        with patch(RUN_OUTCOMES_QUERY, return_value=[{"quantity": 100}]) as run_outcomes_query:
-            assert get_recalibration_organization_volume(config, None) is None
-            assert get_recalibration_organization_volume(config, eap_volume) is None
-
-        run_outcomes_query.assert_not_called()
-
-    def test_get_recalibration_organization_volume_without_transaction_outcomes(self) -> None:
-        organization = self.create_organization()
-        self.create_project(organization=organization)
-        config = self.get_config(organization)
-        eap_volume = OrganizationDataVolume(org_id=organization.id, total=400, indexed=25)
-
-        with patch(RUN_OUTCOMES_QUERY, return_value=[]):
-            org_volume = get_recalibration_organization_volume(config, eap_volume)
-
-        assert org_volume is None
 
     def test_get_eap_project_volumes_existing_org(self) -> None:
         organization = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -33,7 +33,6 @@ PROJECT_VOLUMES = f"{SCHEDULER}.get_eap_project_volumes"
 TRANSACTION_VOLUMES = f"{SCHEDULER}.get_eap_transaction_volumes"
 PROJECT_BALANCING = f"{SCHEDULER}.run_project_balancing"
 TRANSACTION_BALANCING = f"{SCHEDULER}.run_transaction_balancing"
-RECALIBRATION_VOLUME = f"{SCHEDULER}.get_recalibration_organization_volume"
 EMIT_COMPARISONS = f"{SCHEDULER}.emit_comparisons"
 WRITE_CACHES = f"{SCHEDULER}.write_caches"
 
@@ -210,7 +209,6 @@ class RunCalculationsPerOrgTest(TestCase):
                 BLENDED_SAMPLE_RATE: 1.0,
                 ORG_VOLUME: None,
                 PROJECT_VOLUMES: DEFAULT,
-                RECALIBRATION_VOLUME: DEFAULT,
                 **END_OF_PASS,
             }
         ) as mocks:
@@ -220,7 +218,6 @@ class RunCalculationsPerOrgTest(TestCase):
         _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
         mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
         mocks[PROJECT_VOLUMES].assert_not_called()
-        mocks[RECALIBRATION_VOLUME].assert_not_called()
         # A pass that bails out still reaches both end-of-pass steps, which find an
         # untouched result and emit nothing.
         _assert_called_once_with_config(mocks[EMIT_COMPARISONS], org.id)
@@ -247,7 +244,6 @@ class RunCalculationsPerOrgTest(TestCase):
                 PROJECT_BALANCING: rebalanced_projects,
                 TRANSACTION_VOLUMES: DEFAULT,
                 TRANSACTION_BALANCING: DEFAULT,
-                RECALIBRATION_VOLUME: DEFAULT,
                 **END_OF_PASS,
             }
         ) as mocks:
@@ -261,7 +257,7 @@ class RunCalculationsPerOrgTest(TestCase):
         mocks[TRANSACTION_VOLUMES].assert_not_called()
         mocks[TRANSACTION_BALANCING].assert_not_called()
         # Recalibration is the last stage, so a full-sample-rate org returns before it runs.
-        mocks[RECALIBRATION_VOLUME].assert_not_called()
+        assert config.results.recalibration_factor is None
         # The project rates the pass did compute are still reported.
         assert config.results.rebalanced_projects == rebalanced_projects
         assert config.results.projects_to_balance == []
@@ -370,7 +366,6 @@ class RunCalculationsPerOrgTest(TestCase):
         project = self.create_project(organization=org)
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        recalibration_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [make_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         transaction_volumes = _transaction_volumes(org, project.id)
@@ -385,7 +380,6 @@ class RunCalculationsPerOrgTest(TestCase):
                     PROJECT_BALANCING: rebalanced_projects,
                     TRANSACTION_VOLUMES: transaction_volumes,
                     TRANSACTION_BALANCING: {},
-                    RECALIBRATION_VOLUME: recalibration_volume,
                     SET_FACTOR: DEFAULT,
                     EMIT_COMPARISONS: DEFAULT,
                 }
@@ -441,7 +435,6 @@ class RunCalculationsPerOrgTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        recalibration_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [make_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         transaction_volumes = _transaction_volumes(org, project.id)
@@ -454,7 +447,6 @@ class RunCalculationsPerOrgTest(TestCase):
                 PROJECT_BALANCING: rebalanced_projects,
                 TRANSACTION_VOLUMES: transaction_volumes,
                 TRANSACTION_BALANCING: {},
-                RECALIBRATION_VOLUME: recalibration_volume,
                 SET_FACTOR: DEFAULT,
                 EMIT_COMPARISONS: DEFAULT,
             }
@@ -474,10 +466,8 @@ class RunCalculationsPerOrgTest(TestCase):
         mocks[TRANSACTION_BALANCING].assert_called_once_with(
             config, project_volumes, transaction_volumes
         )
-        # The 5-minute organization volume is handed to the recalibration volume query, so its
-        # stored count is reused rather than fetched again.
-        assert mocks[RECALIBRATION_VOLUME].call_args.args[1] is org_volume
-        assert config.results.recalibration_volume is recalibration_volume
+        # Both sides of the effective sample rate come from the one EAP organization volume.
+        assert config.results.organization_volume is org_volume
         assert config.results.recalibration_factor == 4.0
         mocks[SET_FACTOR].assert_called_once_with(org.id, 4.0)
         # The comparison reads the same results, so it runs after the last stage.
@@ -489,12 +479,12 @@ class RunCalculationsPerOrgTest(TestCase):
             "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
         }
     )
-    def test_run_calculations_per_org_skips_the_factor_without_a_recalibration_volume(
+    def test_run_calculations_per_org_skips_the_factor_without_stored_segments(
         self,
     ) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
+        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=0)
         project_volumes = [make_project_volume(project.id)]
 
         with patch_configuration(
@@ -505,7 +495,6 @@ class RunCalculationsPerOrgTest(TestCase):
                 PROJECT_BALANCING: [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)],
                 TRANSACTION_VOLUMES: _transaction_volumes(org, project.id),
                 TRANSACTION_BALANCING: {},
-                RECALIBRATION_VOLUME: None,
                 SET_FACTOR: DEFAULT,
                 EMIT_COMPARISONS: DEFAULT,
             }
@@ -514,7 +503,7 @@ class RunCalculationsPerOrgTest(TestCase):
 
         assert result is None
         config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        # One missing source leaves no effective sample rate, so there is no factor.
+        # An org that stored nothing has no effective sample rate, so there is no factor.
         assert config.results.recalibration_factor is None
         mocks[SET_FACTOR].assert_not_called()
         # The comparison still runs, so the legacy factor is reported next to no EAP factor.
@@ -540,7 +529,6 @@ class RunCalculationsPerOrgTest(TestCase):
                 PROJECT_BALANCING: [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)],
                 TRANSACTION_VOLUMES: _transaction_volumes(org, project.id),
                 TRANSACTION_BALANCING: {},
-                RECALIBRATION_VOLUME: DEFAULT,
                 **END_OF_PASS,
             }
         ) as mocks:
@@ -549,7 +537,6 @@ class RunCalculationsPerOrgTest(TestCase):
         assert result is None
         config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
         assert config.results.recalibration_factor is None
-        mocks[RECALIBRATION_VOLUME].assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_still_reports_when_a_stage_raises(self) -> None:


### PR DESCRIPTION
- We currently use a combination of EAP and outcomes. We don't achieve the accuracy we need using just transaction outcomes and the segment spans in EAP.
- To solve this, use only EAP for the recalibration by using the number of samples and the extrapolated volume directly
- We logged all of the values needed and it looks like we get very close to the right values, so let's try this and see if results converge

Contributes to TET-2815
