### PR TITLE
Add PostgreSQL ILIKE lookup for trigram index support

### DIFF
--- a/src/sentry/db/models/__init__.py
+++ b/src/sentry/db/models/__init__.py
@@ -1,2 +1,3 @@
 from .base import *  # NOQA
 from .fields import *  # NOQA
+from . import lookups as _lookups  # noqa: F401  -- registers custom ORM lookups

--- a/src/sentry/db/models/lookups.py
+++ b/src/sentry/db/models/lookups.py
@@ -1,0 +1,31 @@
+from django.db.models import CharField, TextField
+from django.db.models.lookups import Lookup
+
+
+class ILike(Lookup):
+    """
+    PostgreSQL-native ILIKE lookup that generates ``col ILIKE %s``
+    instead of Django's default ``UPPER(col) LIKE UPPER(%s)`` from icontains.
+
+    This allows PostgreSQL GIN trigram indexes (pg_trgm) to be used.
+    """
+
+    lookup_name = "ilike"
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        if rhs_params:
+            value = rhs_params[0]
+            # Escape LIKE-special characters so they match literally
+            value = value.replace("\\", "\\\\")
+            value = value.replace("%", "\\%")
+            value = value.replace("_", "\\_")
+            params = [f"%{value}%"]
+        else:
+            params = rhs_params
+        return f"{lhs} ILIKE %s", params
+
+
+CharField.register_lookup(ILike)
+TextField.register_lookup(ILike)

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -452,7 +452,7 @@ def get_artifact_bundles_containing_url(
                 ArtifactBundleIndex.objects.filter(
                     artifact_bundle_id=OuterRef("pk"),
                     organization_id=project.organization.id,
-                    url__icontains=url,
+                    url__ilike=url,
                 )
             ),
             Exists(


### PR DESCRIPTION
## Description

This PR introduces a custom Django ORM lookup `ilike` that generates PostgreSQL's native `ILIKE` operator instead of Django's default `UPPER(col) LIKE UPPER(%s)` pattern used by `icontains`.

The native `ILIKE` operator allows PostgreSQL GIN trigram indexes (pg_trgm) to be utilized for case-insensitive substring searches, which can significantly improve query performance on large text columns.

## Changes

- **New file**: `src/sentry/db/models/lookups.py`
  - Implements `ILike` lookup class that generates `col ILIKE %s` SQL
  - Properly escapes LIKE-special characters (`\`, `%`, `_`) to ensure literal matching
  - Registers the lookup on `CharField` and `TextField`

- **Modified**: `src/sentry/db/models/__init__.py`
  - Imports the lookups module to ensure custom lookups are registered on Django startup

- **Modified**: `src/sentry/debug_files/artifact_bundles.py`
  - Updates `get_artifact_bundles_containing_url()` to use `url__ilike=url` instead of `url__icontains=url`
  - This enables the use of trigram indexes for improved query performance

## Test Plan

Existing tests should pass. The lookup is a drop-in replacement for `icontains` with identical semantics but better performance characteristics when trigram indexes are available.

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

https://claude.ai/code/session_01TBJUhe292JiFpqbMSWY2zv