### PR TITLE
fix(dashboards): table widget stories collapsing

### DIFF
--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -68,11 +68,11 @@ export default Storybook.story('TableWidgetVisualization', story => {
           <code>TabularData</code>. This is a mandatory prop. If the <code>data</code>{' '}
           field is empty, such as
         </p>
-        <CodeBlock language="json">
+        <StyledCodeBlock language="json">
           {`
 ${JSON.stringify(tableWithEmptyData)}
           `}
-        </CodeBlock>
+        </StyledCodeBlock>
         <p>Then the table renders empty like this:</p>
         <TableWidgetVisualization tableData={tableWithEmptyData} />
         <p>
@@ -86,11 +86,11 @@ ${JSON.stringify(tableWithEmptyData)}
           tableData={sampleHTTPRequestTableData}
           columns={customColumns}
         />
-        <CodeBlock language="json">
+        <StyledCodeBlock language="json">
           {`
 ${JSON.stringify(customColumns)}
           `}
-        </CodeBlock>
+        </StyledCodeBlock>
         <p>
           To pass custom names for a column header, provide the prop <code>aliases</code>{' '}
           which maps column key to the alias. In some cases you may have both field
@@ -106,11 +106,11 @@ ${JSON.stringify(customColumns)}
           tableData={sampleHTTPRequestTableData}
           aliases={aliases}
         />
-        <CodeBlock language="json">
+        <StyledCodeBlock language="json">
           {`
 ${JSON.stringify(aliases)}
           `}
-        </CodeBlock>
+        </StyledCodeBlock>
       </Fragment>
     );
   });
@@ -152,7 +152,7 @@ ${JSON.stringify(aliases)}
           <code>columns</code> prop with the field <code>sortable</code> set to true.
           e.g.,
         </p>
-        <CodeBlock language="tsx">
+        <StyledCodeBlock language="tsx">
           {`
 columns={[{
   key: 'count(span.duration)',
@@ -166,7 +166,7 @@ columns={[{
   type: 'string',
 }]}
           `}
-        </CodeBlock>
+        </StyledCodeBlock>
         <p>
           This table <b>does not</b> sort entries. Almost all tables in Sentry rely on the{' '}
           <code>sort</code> URL query parameter as a reference for sorting, which is why
@@ -232,7 +232,7 @@ columns={[{
           sort={sort}
           onChangeSort={(newSort: Sort) => onChangeSort(newSort)}
         />
-        <CodeBlock language="tsx">
+        <StyledCodeBlock language="tsx">
           {`
 const [data, setData] = useState<TabularData>(...);
 const [sort, setSort] = useState<Sort>();
@@ -256,7 +256,7 @@ function onChangeSort(newSort: Sort) {
   setData({data: sortedData, meta: data.meta});
 }
         `}
-        </CodeBlock>
+        </StyledCodeBlock>
       </Fragment>
     );
   });
@@ -378,7 +378,7 @@ function onChangeSort(newSort: Sort) {
             }
           }}
         />
-        <CodeBlock language="tsx">
+        <StyledCodeBlock language="tsx">
           {`
 const [filter, setFilter] = useState<Array<string | number>>([]);
 
@@ -390,10 +390,12 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
     case Actions.EXCLUDE:
       setFilter(filter.filter(_value => _value !== value));
       break;
+    default:
+      break;
   }
 }
         `}
-        </CodeBlock>
+        </StyledCodeBlock>
         <p>
           To customize actions per cell, use <code>allowedCellActions</code> as a
           function. This function receives the full cell info, including the column type.
@@ -410,7 +412,7 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
             return [Actions.ADD, Actions.EXCLUDE];
           }}
         />
-        <CodeBlock language="tsx">
+        <StyledCodeBlock language="tsx">
           {`
 <TableWidgetVisualization
   tableData={sampleHTTPRequestTableData}
@@ -423,7 +425,7 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
   }}
 />
           `}
-        </CodeBlock>
+        </StyledCodeBlock>
       </Fragment>
     );
   });
@@ -472,7 +474,7 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
           tableData={sampleHTTPRequestTableData}
           getRenderer={getRenderer}
         />
-        <CodeBlock language="tsx">
+        <StyledCodeBlock language="tsx">
           {`
 function getRenderer(fieldName: string) {
   if (fieldName === 'http.request_method') {
@@ -488,7 +490,7 @@ function getRenderer(fieldName: string) {
   );
 }
           `}
-        </CodeBlock>
+        </StyledCodeBlock>
       </Fragment>
     );
   });
@@ -520,4 +522,8 @@ const ButtonContainer = styled('div')`
   display: flex;
   justify-content: center;
   margin: 20px;
+`;
+
+const StyledCodeBlock = styled(CodeBlock)`
+  height: fit-content;
 `;


### PR DESCRIPTION
When investigating another bug, saw that the table widget stories were a little broken:
<img width="859" height="365" alt="Screenshot 2026-08-25 at 10 52 34 AM" src="https://github.com/user-attachments/assets/ad80b47b-3025-4d53-932b-97203b0a8f8a" />

Now they should be fixed:
<img width="834" height="736" alt="Screenshot 2026-08-25 at 10 53 09 AM" src="https://github.com/user-attachments/assets/e260e341-59b4-4a3c-aeaa-6a2fe795d1a5" />
