### PR TITLE
ref(hybridcloud): Baseline claim dispatch for webhook drains

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -22,7 +22,6 @@ from sentry.hybridcloud.models.webhookpayload import (
     WebhookPayload,
 )
 from sentry.hybridcloud.webhook_event_types import event_type_from_mailbox
-from sentry.options.rollout import in_rollout_group
 from sentry.shared_integrations.exceptions import (
     ApiConflictError,
     ApiConnectionResetError,
@@ -163,35 +162,13 @@ class DeliveryDropped(Exception):
 
 DRAIN_LOCK_TTL = 15
 """
-Seconds the claim guard survives without a refresh. Claim-mode dispatchers release
-it before returning, so this is crash cover for one that died mid-claim.
-"""
-
-
-LEASE_DRAIN_LOCK_TTL = 2 * CellSiloClient.timeout + DRAIN_LOCK_TTL
-"""
-Seconds a lease-mode drain's lock survives without a refresh.
-
-A lease drain refreshes once per record, right before delivering it, so the widest
-gap between refreshes is one delivery — bounded by the cell client's connect plus
-read timeout, plus the queue wait before the first refresh. Under that, the lock
-expires mid-drain and the scheduler dispatches a second drain over the same records.
+Seconds the claim guard survives without a refresh. Dispatchers release it before
+returning, so this is crash cover for one that died mid-claim.
 """
 
 
 def _drain_lock_key(mailbox_name: str) -> str:
     return f"wh:drain_active:{mailbox_name}"
-
-
-def _refresh_drain_lock(mailbox_name: str) -> None:
-    """Refresh the drain lock TTL to signal the drain task is still active.
-
-    Only lease-mode drains refresh.
-    """
-    try:
-        cache.set(_drain_lock_key(mailbox_name), 1, timeout=LEASE_DRAIN_LOCK_TTL)
-    except Exception:
-        pass
 
 
 def _release_drain_lock(mailbox_name: str) -> None:
@@ -200,25 +177,6 @@ def _release_drain_lock(mailbox_name: str) -> None:
         cache.delete(_drain_lock_key(mailbox_name))
     except Exception:
         pass
-
-
-def _claim_dispatch_active() -> bool:
-    """Whether any integration currently dispatches drains via batch claims."""
-    return options.get("hybridcloud.webhookpayload.claim_dispatch_rollout") > 0.0
-
-
-def _use_claim_dispatch(mailbox_name: str) -> bool:
-    """
-    Whether this mailbox dispatches drains via batch claims instead of the
-    drain-lock lease, per the claim_dispatch_rollout rate.
-
-    Keyed on the `provider:integration_id` prefix so all of an integration's
-    sub-mailboxes switch regimes together. Mixed regimes compose safely either
-    way: every dispatcher honors the lock, and a claimed head is not due for
-    any of them.
-    """
-    integration_prefix = ":".join(mailbox_name.split(":", 2)[:2])
-    return in_rollout_group("hybridcloud.webhookpayload.claim_dispatch_rollout", integration_prefix)
 
 
 def _is_due(schedule_for: datetime.datetime) -> bool:
@@ -231,17 +189,16 @@ def _is_due(schedule_for: datetime.datetime) -> bool:
     return schedule_for <= timezone.now()
 
 
-def _claim_mailbox_batch(head_id: int, mailbox_name: str, *, only_if_head_due: bool = False) -> int:
+def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> int:
     """
     Claim up to MAX_MAILBOX_DRAIN records at the head of the mailbox by scheduling
     them past the drain deadline, so no other dispatcher selects the mailbox for
     delivery until the drain that claimed them has had its full run.
 
-    With `only_if_head_due`, the whole claim is gated on the head still being due:
-    the check rides in the UPDATE's WHERE clause, so a head that another dispatcher
-    already claimed (or a drain already delivered) claims 0 rows in the same round
-    trip instead of needing a separate primary read. Lease-mode callers must not
-    gate — they claim unconditionally, matching the pre-claim-rollout behavior.
+    The whole claim is gated on the head still being due: the check rides in the
+    UPDATE's WHERE clause, so a head that another dispatcher already claimed (or a
+    drain already delivered) claims 0 rows in the same round trip instead of
+    needing a separate primary read.
 
     Returns the number of records claimed — also the depth signal that picks the
     drain mode.
@@ -251,11 +208,12 @@ def _claim_mailbox_batch(head_id: int, mailbox_name: str, *, only_if_head_due: b
         .order_by("id")
         .values("id")[:MAX_MAILBOX_DRAIN]
     )
-    batch = WebhookPayload.objects.filter(id__in=Subquery(mailbox_batch))
-    if only_if_head_due:
-        head_due = WebhookPayload.objects.filter(id=head_id, schedule_for__lte=timezone.now())
-        batch = batch.filter(Exists(head_due))
-    return batch.update(schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET)
+    head_due = WebhookPayload.objects.filter(id=head_id, schedule_for__lte=timezone.now())
+    return (
+        WebhookPayload.objects.filter(id__in=Subquery(mailbox_batch))
+        .filter(Exists(head_due))
+        .update(schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET)
+    )
 
 
 class DispatchOutcome(enum.StrEnum):
@@ -273,38 +231,22 @@ class Dispatcher(enum.StrEnum):
     SCHEDULER = "scheduler"
 
 
-class DispatchMode(enum.StrEnum):
-    """Which dispatch regime enqueued a drain; a metric tag and a drain task argument."""
-
-    LEASE = "lease"
-    CLAIM = "claim"
-
-
-def _dispatch_tags(dispatcher: str | None, mode: str | None) -> dict[str, str]:
+def _dispatch_tags(dispatcher: str | None) -> dict[str, str]:
     """
-    Attribute a drain's deliveries to the dispatcher and regime that enqueued it.
+    Attribute a drain's deliveries to the dispatcher that enqueued it.
 
-    Tagging `delivery` with `mode` is what makes a partial claim_dispatch_rollout
-    readable. The rollout selects whole integrations by hash, so at a low
-    percentage its effect on any global total is far smaller than the total's own
-    variance; segmenting by mode compares the claim cohort's outcome rates against
-    the lease cohort's instead, which stays valid at any rollout percentage.
-
-    `unknown` covers drains enqueued before these arguments deployed.
+    `unknown` covers drains enqueued before this argument deployed, and drains
+    invoked directly rather than through a dispatcher.
     """
-    return {
-        "dispatcher": dispatcher or "unknown",
-        "mode": mode or "unknown",
-    }
+    return {"dispatcher": dispatcher or "unknown"}
 
 
 def _record_dispatch(
     *,
     dispatcher: Dispatcher,
-    mode: DispatchMode,
     drain: DispatchOutcome,
     mailbox_name: str,
-    claimed: int = 0,
+    claimed: int,
 ) -> None:
     """
     Record a drain enqueue so push- and scheduler-dispatched work stay comparable.
@@ -312,18 +254,9 @@ def _record_dispatch(
     `dispatch` counts enqueues; `dispatch.claimed` carries the claim behind each
     one. A scheduler drain can claim up to MAX_MAILBOX_DRAIN records where a push
     drain typically claims one or two, so the two shares are different numbers.
-
-    Emitted unconditionally, including the zero a lease-mode push trigger claims:
-    a tag value with no samples yields no series at all rather than a line of
-    zeros, which blanks any formula comparing the two dispatchers. Zeros leave
-    `.sum` untouched, and `{mode:claim}` recovers a true claim depth from `.avg`.
-
-    `.sum` under-attributes push while lease mode is the majority — those drains
-    deliver webhooks no claim ever counted. It converges as the rollout ramps.
     """
     tags = {
         "dispatcher": dispatcher,
-        "mode": mode,
         "drain": drain,
         "provider": _provider_from_mailbox(mailbox_name),
     }
@@ -352,22 +285,17 @@ def _claim_and_dispatch(
     `dispatcher` tags this dispatch and is forwarded to the drain so its
     deliveries carry the same attribution; both callers claim identically.
     """
-    claimed = _claim_mailbox_batch(head_id, mailbox_name, only_if_head_due=True)
+    claimed = _claim_mailbox_batch(head_id, mailbox_name)
     if not claimed:
         return DispatchOutcome.NOT_DUE
     if claimed >= PARALLEL_DRAIN_THRESHOLD:
-        drain_mailbox_parallel.delay(
-            head_id, claimed_count=claimed, dispatcher=dispatcher, mode=DispatchMode.CLAIM
-        )
+        drain_mailbox_parallel.delay(head_id, claimed_count=claimed, dispatcher=dispatcher)
         outcome = DispatchOutcome.PARALLEL
     else:
-        drain_mailbox.delay(
-            head_id, claimed_count=claimed, dispatcher=dispatcher, mode=DispatchMode.CLAIM
-        )
+        drain_mailbox.delay(head_id, claimed_count=claimed, dispatcher=dispatcher)
         outcome = DispatchOutcome.SEQUENTIAL
     _record_dispatch(
         dispatcher=dispatcher,
-        mode=DispatchMode.CLAIM,
         drain=outcome,
         mailbox_name=mailbox_name,
         claimed=claimed,
@@ -375,21 +303,22 @@ def _claim_and_dispatch(
     return outcome
 
 
-def _maybe_trigger_drain_claim(mailbox_name: str) -> None:
-    """Claim-mode push trigger.
+def maybe_trigger_drain(mailbox_name: str) -> None:
+    """Trigger an immediate drain if the mailbox head is due for delivery.
 
     Claims the batch exactly like the scheduler, so the claim — not the lock —
     keeps other dispatchers off the mailbox. The lock only serializes the claim
     and is always released before returning, never held for the drain's run.
+
+    Falls back gracefully if the cache backend is unavailable — the scheduler handles delivery.
     """
+    if not options.get("hybridcloud.webhookpayload.push_drain_trigger"):
+        return
     trigger_tags = {"provider": _provider_from_mailbox(mailbox_name)}
     lock_acquired = False
     try:
         if not cache.add(_drain_lock_key(mailbox_name), 1, timeout=DRAIN_LOCK_TTL):
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.push_trigger.skipped",
-                tags={**trigger_tags, "mode": "claim"},
-            )
+            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.skipped", tags=trigger_tags)
             return
         lock_acquired = True
         # Only drain if the true mailbox head (lowest ID) is ready to deliver.
@@ -405,117 +334,25 @@ def _maybe_trigger_drain_claim(mailbox_name: str) -> None:
         if head is None or not _is_due(head[1]):
             # Mailbox is empty, drained by a claim already in flight, or in a retry
             # backoff — the scheduler covers it when schedule_for comes due.
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.push_trigger.backoff",
-                tags={**trigger_tags, "mode": "claim"},
-            )
+            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff", tags=trigger_tags)
             return
         outcome = _claim_and_dispatch(head[0], mailbox_name, dispatcher=Dispatcher.PUSH)
         if outcome is DispatchOutcome.NOT_DUE:
             # The head moved between our read and the claim; whoever moved it has
             # the mailbox covered.
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.push_trigger.backoff",
-                tags={**trigger_tags, "mode": "claim"},
-            )
+            metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff", tags=trigger_tags)
             return
         metrics.incr(
             "hybridcloud.deliver_webhooks.push_trigger.success",
-            tags={**trigger_tags, "mode": "claim", "drain": outcome},
+            tags={**trigger_tags, "drain": outcome},
         )
     except Exception:
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.push_trigger.error",
-            tags={**trigger_tags, "mode": "claim"},
-        )
+        metrics.incr("hybridcloud.deliver_webhooks.push_trigger.error", tags=trigger_tags)
     finally:
         # Only release the lock this caller acquired. Releasing unconditionally
         # would delete another dispatcher's claim guard.
         if lock_acquired:
             _release_drain_lock(mailbox_name)
-
-
-def _maybe_trigger_drain_lease(mailbox_name: str) -> None:
-    """Lease-mode push trigger (the legacy path).
-
-    The dispatched drain owns the lock for its whole run: it is passed
-    `mailbox_name`, refreshes the lock on every delivery, and releases it on
-    exit. The scheduler skips locked mailboxes, so the lease is the dedupe.
-    """
-    lock_key = _drain_lock_key(mailbox_name)
-    trigger_tags = {"provider": _provider_from_mailbox(mailbox_name)}
-    lock_acquired = False
-    try:
-        # The dispatched drain inherits this lock and only refreshes once picked up.
-        if cache.add(lock_key, 1, timeout=LEASE_DRAIN_LOCK_TTL):
-            lock_acquired = True
-            # Only drain if the true mailbox head (lowest ID) is ready to deliver.
-            # We must check the head specifically — filtering by schedule_for first
-            # would skip the head and return a later payload, breaking head-of-line
-            # ordering when the head is in a retry backoff window.
-            head = (
-                WebhookPayload.objects.filter(mailbox_name=mailbox_name)
-                .order_by("id")
-                .values_list("id", "schedule_for")
-                .first()
-            )
-            if head is None or not _is_due(head[1]):
-                # Mailbox is empty or head is in backoff — release the lock and let
-                # the scheduler handle it when schedule_for comes due.
-                _release_drain_lock(mailbox_name)
-                metrics.incr(
-                    "hybridcloud.deliver_webhooks.push_trigger.backoff",
-                    tags={**trigger_tags, "mode": "lease"},
-                )
-                return
-            head_id = head[0]
-            drain_mailbox.delay(
-                head_id,
-                mailbox_name=mailbox_name,
-                dispatcher=Dispatcher.PUSH,
-                mode=DispatchMode.LEASE,
-            )
-            _record_dispatch(
-                dispatcher=Dispatcher.PUSH,
-                mode=DispatchMode.LEASE,
-                drain=DispatchOutcome.SEQUENTIAL,
-                mailbox_name=mailbox_name,
-            )
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.push_trigger.success",
-                tags={**trigger_tags, "mode": "lease", "drain": "sequential"},
-            )
-        else:
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.push_trigger.skipped",
-                tags={**trigger_tags, "mode": "lease"},
-            )
-    except Exception:
-        # Only release the lock if this caller acquired it. Releasing unconditionally
-        # would delete another process's lock when cache.add returned False and a
-        # subsequent operation (e.g. metrics.incr) raised.
-        if lock_acquired:
-            _release_drain_lock(mailbox_name)
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.push_trigger.error",
-            tags={**trigger_tags, "mode": "lease"},
-        )
-
-
-def maybe_trigger_drain(mailbox_name: str) -> None:
-    """Trigger an immediate drain if the mailbox head is due for delivery.
-
-    While claim_dispatch_rollout ramps, `_use_claim_dispatch` picks between the
-    claim and lease trigger regimes (see the two helpers above).
-
-    Falls back gracefully if the cache backend is unavailable — the scheduler handles delivery.
-    """
-    if not options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-        return
-    if _use_claim_dispatch(mailbox_name):
-        _maybe_trigger_drain_claim(mailbox_name)
-    else:
-        _maybe_trigger_drain_lease(mailbox_name)
 
 
 @instrumented_task(
@@ -587,34 +424,6 @@ def schedule_webhook_delivery() -> None:
 
     for record in records:
         mailbox_name = record["mailbox_name"]
-        if not _use_claim_dispatch(mailbox_name):
-            # Lease-mode mailbox (the legacy path): skip anything a push-triggered
-            # drain currently holds, then claim and dispatch without the guard.
-            if options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-                try:
-                    if cache.get(_drain_lock_key(mailbox_name)):
-                        continue
-                except Exception:
-                    pass
-            claimed = _claim_mailbox_batch(record["id"], mailbox_name)
-            if claimed >= PARALLEL_DRAIN_THRESHOLD:
-                drain_mailbox_parallel.delay(
-                    record["id"], dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE
-                )
-                drain = DispatchOutcome.PARALLEL
-            else:
-                drain_mailbox.delay(
-                    record["id"], dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE
-                )
-                drain = DispatchOutcome.SEQUENTIAL
-            _record_dispatch(
-                dispatcher=Dispatcher.SCHEDULER,
-                mode=DispatchMode.LEASE,
-                drain=drain,
-                mailbox_name=mailbox_name,
-                claimed=claimed,
-            )
-            continue
         try:
             if not cache.add(_drain_lock_key(mailbox_name), 1, timeout=DRAIN_LOCK_TTL):
                 # Another dispatcher is mid-claim for this mailbox; it will dispatch.
@@ -639,8 +448,7 @@ def schedule_webhook_delivery() -> None:
 )
 def drain_mailbox(
     payload_id: int,
-    mailbox_name: str | None = None,
-    claimed_count: int | None = None,
+    claimed_count: int,
     dispatcher: str | None = None,
     mode: str | None = None,
 ) -> None:
@@ -651,20 +459,18 @@ def drain_mailbox(
     reached, or `claimed_count` records have been processed. Once messages have
     successfully been delivered or discarded, they are deleted.
 
-    `claimed_count` is sent by claim-mode dispatchers: this drain holds no lock
-    while it runs, so it must not deliver past the records its dispatcher claimed
-    — beyond them the mailbox head is due again and another dispatcher may have
-    started a drain of its own. `None` (lease drains, tasks enqueued before this
-    field deployed) keeps the legacy behavior of draining until empty.
+    This drain holds no lock while it runs, so it must not deliver past the
+    `claimed_count` records its dispatcher claimed — beyond them the mailbox head
+    is due again and another dispatcher may have started a drain of its own.
 
-    `mailbox_name` is sent by lease-mode push triggers (see `_use_claim_dispatch`),
-    which hand this drain ownership of the drain lock for its whole run: refreshed
-    on every delivery, released on exit. Claim-mode dispatchers never send it.
+    `dispatcher` carries the enqueueing dispatcher's attribution onto every
+    delivery outcome this drain records (see `_dispatch_tags`).
 
-    `dispatcher` and `mode` carry the enqueueing dispatcher's attribution onto
-    every delivery outcome this drain records (see `_dispatch_tags`).
+    `mode` is accepted but ignored: drains enqueued by the previous deploy still
+    carry it, and rejecting them would strand their claims until the horizon
+    passes. Removable once no such task can be in flight.
     """
-    dispatch_tags = _dispatch_tags(dispatcher, mode)
+    dispatch_tags = _dispatch_tags(dispatcher)
     try:
         payload = WebhookPayload.objects.get(id=payload_id)
     except WebhookPayload.DoesNotExist:
@@ -672,17 +478,10 @@ def drain_mailbox(
         # and let the other process continue, or a future process.
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={
-                **dispatch_tags,
-                "outcome": "race",
-                "provider": _provider_from_mailbox(mailbox_name),
-            },
+            # The row is gone, so nothing left in hand names the provider.
+            tags={**dispatch_tags, "outcome": "race", "provider": UNKNOWN_PROVIDER},
         )
         logger.info("deliver_webhook.potential_race", extra={"id": payload_id})
-        # Release the drain lock if we know the mailbox name. Otherwise the lock is
-        # held, blocking both push triggers and the scheduler for the full 15s TTL.
-        if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-            _release_drain_lock(mailbox_name)
         return
 
     _set_webhook_delivery_sentry_context(payload)
@@ -692,7 +491,7 @@ def drain_mailbox(
     )
     skip_on_failure = payload.provider in skip_on_failure_providers
 
-    deleter = _deleter_for(mailbox_name, claimed_count)
+    deleter = _deleter_for()
 
     delivered = 0
     failed = 0
@@ -727,17 +526,13 @@ def drain_mailbox(
                 id__gte=current_id, mailbox_name=payload.mailbox_name
             ).order_by("id")
 
-            slice_size = 100 if remaining is None else min(100, remaining)
+            slice_size = min(100, remaining)
             batch_count = 0
             for record in query[:slice_size]:
                 batch_count += 1
                 # Advance past this record regardless of outcome so that failed
                 # messages are not re-attempted in subsequent batches of this drain.
                 current_id = record.id + 1
-                # Keep the lease alive for lease-mode drains; their dedupe relies
-                # on the lock surviving the drain's run.
-                if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-                    _refresh_drain_lock(payload.mailbox_name)
                 try:
                     if deliver_message(record, deleter, dispatch_tags=dispatch_tags):
                         delivered += 1
@@ -781,30 +576,25 @@ def drain_mailbox(
                     )
                 return
 
-            if remaining is not None:
-                remaining -= batch_count
-                if remaining <= 0:
-                    # Claim exhausted. Rows past this point belong to whichever
-                    # dispatcher claims them next; delivering them here would race
-                    # a drain that dispatcher may have started.
-                    logger.debug(
-                        "deliver_webhook.claim_exhausted",
-                        extra={
-                            **payload.as_dict(),
-                            "delivered": delivered,
-                        },
-                    )
-                    metrics.incr(
-                        "hybridcloud.deliver_webhooks.delivery",
-                        tags={**dispatch_tags, "outcome": "claim_exhausted"},
-                    )
-                    return
+            remaining -= batch_count
+            if remaining <= 0:
+                # Claim exhausted. Rows past this point belong to whichever
+                # dispatcher claims them next; delivering them here would race
+                # a drain that dispatcher may have started.
+                logger.debug(
+                    "deliver_webhook.claim_exhausted",
+                    extra={
+                        **payload.as_dict(),
+                        "delivered": delivered,
+                    },
+                )
+                metrics.incr(
+                    "hybridcloud.deliver_webhooks.delivery",
+                    tags={**dispatch_tags, "outcome": "claim_exhausted"},
+                )
+                return
     finally:
         deleter.flush()
-        # Only lease-mode push drains own a lock to release here; claim-mode
-        # dispatchers release their guard themselves.
-        if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-            _release_drain_lock(mailbox_name)
 
 
 class _PayloadDeleter:
@@ -841,34 +631,17 @@ class _PayloadDeleter:
         self._pending.clear()
 
 
-def _deleter_for(mailbox_name: str | None, claimed_count: int | None) -> _PayloadDeleter:
+def _deleter_for() -> _PayloadDeleter:
     """
     Build the deleter for a drain.
 
-    Batching is only safe while a drain stays inside a claim it owns, so it takes
-    both a claim bound and no lease:
-
-    - `claimed_count` bounds the walk to claimed records. An unbounded drain
-      (the lease-mode scheduler path) runs on past its claim into rows that are
-      still due, and a finished-but-unflushed row there keeps the mailbox head
-      due — letting another dispatcher rediscover it and redeliver what this
-      drain already sent.
-    - `mailbox_name` means a lease drain, whose lock outlives a crash by only
-      LEASE_DRAIN_LOCK_TTL, after which unflushed rows would be handed to a
-      concurrent drain.
-
-    Inside a bound claim nothing else can touch a row between the drain
-    finishing with it and deleting it. A worker that dies before flushing
-    reprocesses at most one batch once the claim horizon passes — redelivering
-    its delivered rows and re-discarding the rest — the same window a
-    claim-then-crash already has.
+    Batching is safe because every drain is bounded to a claim its dispatcher
+    owns: nothing else can touch a row between the drain finishing with it and
+    deleting it. A worker that dies before flushing reprocesses at most one batch
+    once the claim horizon passes — redelivering its delivered rows and
+    re-discarding the rest — the same window a claim-then-crash already has.
     """
-    batched = (
-        mailbox_name is None
-        and claimed_count is not None
-        and options.get("hybridcloud.webhookpayload.drain_batch_deletes")
-    )
-    return _PayloadDeleter(batched=batched)
+    return _PayloadDeleter(batched=options.get("hybridcloud.webhookpayload.drain_batch_deletes"))
 
 
 def _discard_if_stale(
@@ -936,7 +709,7 @@ def _record_delivery_time_metrics(
     Measured from `date_added`, so this is queue wait plus retry backoff plus the
     request itself — the span dispatch is meant to shorten. It carries the same
     attribution as the outcome counter so latency can be compared per dispatcher
-    and per regime rather than only in aggregate.
+    rather than only in aggregate.
     """
     duration = timezone.now() - payload.date_added
     provider = _provider_tag(payload)
@@ -1091,8 +864,7 @@ def _run_parallel_delivery_batch(
 )
 def drain_mailbox_parallel(
     payload_id: int,
-    mailbox_name: str | None = None,
-    claimed_count: int | None = None,
+    claimed_count: int,
     dispatcher: str | None = None,
     mode: str | None = None,
 ) -> None:
@@ -1109,18 +881,12 @@ def drain_mailbox_parallel(
     `hybridcloud.webhookpayload.skip_on_failure_providers` (e.g. github) continue
     past retryable failures in the same way as sequential `drain_mailbox`.
 
-    `claimed_count` is sent by claim-mode dispatchers: this drain holds no lock
-    while it runs, so it must not deliver past the records its dispatcher claimed
-    — see `drain_mailbox`. `None` keeps the legacy drain-until-empty behavior.
+    This drain holds no lock while it runs, so it must not deliver past the
+    `claimed_count` records its dispatcher claimed — see `drain_mailbox`.
 
-    `mailbox_name` is accepted for symmetry with `drain_mailbox`; no current
-    dispatcher passes it (lease triggers only dispatch sequential drains), but a
-    caller that does owns the drain lock and gets it refreshed and released.
-
-    `dispatcher` and `mode` carry the enqueueing dispatcher's attribution onto
-    every delivery outcome this drain records (see `_dispatch_tags`).
+    `dispatcher` and `mode` behave as they do on `drain_mailbox`.
     """
-    dispatch_tags = _dispatch_tags(dispatcher, mode)
+    dispatch_tags = _dispatch_tags(dispatcher)
     try:
         payload = WebhookPayload.objects.get(id=payload_id)
     except WebhookPayload.DoesNotExist:
@@ -1128,15 +894,10 @@ def drain_mailbox_parallel(
         # and let the other process continue, or a future process.
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={
-                **dispatch_tags,
-                "outcome": "race",
-                "provider": _provider_from_mailbox(mailbox_name),
-            },
+            # The row is gone, so nothing left in hand names the provider.
+            tags={**dispatch_tags, "outcome": "race", "provider": UNKNOWN_PROVIDER},
         )
         logger.info("deliver_webhook_parallel.potential_race", extra={"id": payload_id})
-        if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-            _release_drain_lock(mailbox_name)
         return
 
     _set_webhook_delivery_sentry_context(payload)
@@ -1147,7 +908,7 @@ def drain_mailbox_parallel(
     skip_on_failure = payload.provider in skip_on_failure_providers
 
     worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
-    deleter = _deleter_for(mailbox_name, claimed_count)
+    deleter = _deleter_for()
     deadline = timezone.now() + BATCH_SCHEDULE_OFFSET
     delivered = 0
     remaining = claimed_count
@@ -1155,8 +916,6 @@ def drain_mailbox_parallel(
     extra = {**payload.as_dict(), "delivered": delivered}
     try:
         while True:
-            if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-                _refresh_drain_lock(payload.mailbox_name)
             if timezone.now() >= deadline:
                 logger.info("deliver_webhook_parallel.delivery_deadline", extra=extra)
                 metrics.incr(
@@ -1169,7 +928,7 @@ def drain_mailbox_parallel(
                 )
                 break
 
-            batch_size = worker_threads if remaining is None else min(worker_threads, remaining)
+            batch_size = min(worker_threads, remaining)
             attempted, delivered_batch, request_failed, next_id = _run_parallel_delivery_batch(
                 payload.mailbox_name,
                 current_id,
@@ -1188,18 +947,17 @@ def drain_mailbox_parallel(
             # schedule_for) are not immediately re-attempted when we continue.
             current_id = next_id
 
-            if remaining is not None:
-                remaining -= attempted
-                if remaining <= 0:
-                    # Claim exhausted. Rows past this point belong to whichever
-                    # dispatcher claims them next; delivering them here would race
-                    # a drain that dispatcher may have started.
-                    logger.debug("deliver_webhook_parallel.claim_exhausted", extra=extra)
-                    metrics.incr(
-                        "hybridcloud.deliver_webhooks.delivery",
-                        tags={**dispatch_tags, "outcome": "claim_exhausted"},
-                    )
-                    return
+            remaining -= attempted
+            if remaining <= 0:
+                # Claim exhausted. Rows past this point belong to whichever
+                # dispatcher claims them next; delivering them here would race
+                # a drain that dispatcher may have started.
+                logger.debug("deliver_webhook_parallel.claim_exhausted", extra=extra)
+                metrics.incr(
+                    "hybridcloud.deliver_webhooks.delivery",
+                    tags={**dispatch_tags, "outcome": "claim_exhausted"},
+                )
+                return
 
             if request_failed and not skip_on_failure:
                 # For providers that require stricter mailbox behavior, stop on
@@ -1208,10 +966,6 @@ def drain_mailbox_parallel(
                 return
     finally:
         deleter.flush()
-        # Only lease-mode push drains own a lock to release here; claim-mode
-        # dispatchers release their guard themselves.
-        if mailbox_name and options.get("hybridcloud.webhookpayload.push_drain_trigger"):
-            _release_drain_lock(mailbox_name)
 
 
 def deliver_message_parallel(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -21,15 +21,12 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
     Dispatcher,
-    DispatchMode,
     _claim_and_dispatch,
-    _use_claim_dispatch,
     drain_mailbox,
     drain_mailbox_parallel,
     maybe_trigger_drain,
     schedule_webhook_delivery,
 )
-from sentry.silo.client import CellSiloClient
 from sentry.testutils.cases import TestCase
 from sentry.testutils.cell import override_cells
 from sentry.testutils.factories import Factories
@@ -40,13 +37,10 @@ from sentry.types.cell import Cell, CellResolutionError
 cell_config = [Cell("us", 1, "http://us.testserver")]
 
 # Drains invoked directly carry no dispatcher attribution; `_dispatch_tags`
-# tags them rather than omitting the keys, so the tag stays queryable.
-UNATTRIBUTED = {"dispatcher": "unknown", "mode": "unknown"}
+# tags them rather than omitting the key, so the tag stays queryable.
+UNATTRIBUTED = {"dispatcher": "unknown"}
 
-CLAIM_MODE_OPTIONS = {
-    "hybridcloud.webhookpayload.push_drain_trigger": True,
-    "hybridcloud.webhookpayload.claim_dispatch_rollout": 1.0,
-}
+PUSH_TRIGGER_OPTIONS = {"hybridcloud.webhookpayload.push_drain_trigger": True}
 cell_config_with_gateway = [
     Cell(
         name="us",
@@ -93,7 +87,7 @@ class ScheduleWebhooksTest(TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id, dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE
+            webhook_one.id, claimed_count=2, dispatcher=Dispatcher.SCHEDULER
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -110,7 +104,7 @@ class ScheduleWebhooksTest(TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id, dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE
+            webhook_one.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -154,7 +148,7 @@ class ScheduleWebhooksTest(TestCase):
 
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id, dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE
+            webhook_one.id, claimed_count=2, dispatcher=Dispatcher.SCHEDULER
         )
 
     @responses.activate
@@ -250,7 +244,7 @@ class ScheduleWebhooksTest(TestCase):
 
         assert outcome == "sequential"
         mock_drain.delay.assert_called_once_with(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.CLAIM
+            webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
         )
         queries = [
             q["sql"]
@@ -389,7 +383,7 @@ def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list
     return created
 
 
-def assert_drain_skips_failed_message(drain: Callable[[int], None], provider: str) -> None:
+def assert_drain_skips_failed_message(drain: Callable[[int, int], None], provider: str) -> None:
     """
     Drain a 5 message mailbox where the second delivery fails.
 
@@ -408,7 +402,7 @@ def assert_drain_skips_failed_message(drain: Callable[[int], None], provider: st
     responses.add(responses.POST, url, status=200, body="")
     records = create_payloads(5, f"{provider}:123", provider=provider)
 
-    drain(records[0].id)
+    drain(records[0].id, MAX_MAILBOX_DRAIN)
 
     assert len(responses.calls) == 5
     assert WebhookPayload.objects.count() == 1
@@ -423,7 +417,7 @@ def assert_drain_skips_failed_message(drain: Callable[[int], None], provider: st
 class DrainMailboxTest(TestCase):
     @responses.activate
     def test_drain_missing_payload(self) -> None:
-        drain_mailbox(99)
+        drain_mailbox(99, claimed_count=MAX_MAILBOX_DRAIN)
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -433,7 +427,7 @@ class DrainMailboxTest(TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox(webhook_one.id)
+            drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -446,7 +440,7 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # github is in the skip-on-failure allowlist: failed messages are skipped
         # and processing continues. All 5 messages are attempted.
@@ -495,7 +489,7 @@ class DrainMailboxTest(TestCase):
 
         head = WebhookPayload.objects.order_by("id").first()
         assert head
-        drain_mailbox(head.id)
+        drain_mailbox(head.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Only the two fresh rows produce requests; everything is drained.
         assert len(responses.calls) == 2
@@ -509,7 +503,7 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox(records[0].id)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # jira is not in the allowlist: processing stops on the first failure
         # to preserve strict mailbox ordering.
@@ -636,55 +630,19 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
-    def test_drain_unbounded_keeps_per_row_deletes(self) -> None:
-        # The lease-mode scheduler dispatches without a claimed_count, so the
-        # drain runs on past its claim into rows that are still due. Holding a
-        # delivered row unflushed there keeps the mailbox head due, letting the
-        # next scheduler cycle rediscover it and redeliver what was already sent.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(3, "github:123", provider="github")
-
-        with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id)
-
-        assert len(responses.calls) == 3
-        assert WebhookPayload.objects.count() == 0
-        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
-        assert len(delete_queries) == 3
-
-    @responses.activate
-    @override_cells(cell_config)
     @override_options(
         {
             "hybridcloud.webhookpayload.drain_batch_deletes": True,
             "hybridcloud.webhookpayload.push_drain_trigger": True,
         }
     )
-    def test_drain_lease_mode_keeps_per_row_deletes(self) -> None:
-        # A lease drain's lock outlives a crash by only DRAIN_LOCK_TTL, after
-        # which another drain would redeliver any delivered-but-unflushed rows —
-        # so lease mode must not defer deletes even with the option enabled.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(3, "github:123", provider="github")
-
-        with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, mailbox_name="github:123")
-
-        assert len(responses.calls) == 3
-        assert WebhookPayload.objects.count() == 0
-        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
-        assert len(delete_queries) == 3
-
     @responses.activate
     @override_cells(cell_config)
     def test_drain_mailbox_multiple_consecutive_failures(self) -> None:
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # All 5 messages are attempted even though all fail.
         assert len(responses.calls) == 5
@@ -705,7 +663,7 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -725,7 +683,7 @@ class DrainMailboxTest(TestCase):
             "BATCH_SCHEDULE_OFFSET",
             new_callable=PropertyMock(return_value=timedelta(minutes=0)),
         ):
-            drain_mailbox(records[0].id)
+            drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Once start time + batch offset is in the past we stop delivery
         assert WebhookPayload.objects.count() == 1
@@ -738,7 +696,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -750,7 +708,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -768,7 +726,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox(webhook_one.id)
+            drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -787,7 +745,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -807,7 +765,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -824,7 +782,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -843,7 +801,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -862,7 +820,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 403
         assert hook is None
@@ -882,7 +840,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -899,7 +857,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -917,7 +875,7 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -927,7 +885,7 @@ class DrainMailboxTest(TestCase):
 class DrainMailboxParallelTest(TestCase):
     @responses.activate
     def test_drain_missing_payload(self) -> None:
-        drain_mailbox_parallel(99)
+        drain_mailbox_parallel(99, claimed_count=MAX_MAILBOX_DRAIN)
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -937,7 +895,7 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox_parallel(webhook_one.id)
+            drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1000,7 +958,7 @@ class DrainMailboxParallelTest(TestCase):
         )
         # provider=None is not in the skip-on-failure allowlist.
         records = create_payloads(5, "github:123")
-        drain_mailbox_parallel(records[0].id)
+        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
         # We'll attempt one thread batch, but the second+ will fail and stop the drain.
@@ -1025,7 +983,7 @@ class DrainMailboxParallelTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox_parallel(records[0].id)
+        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # github is in the skip-on-failure allowlist: failed messages are skipped
         # and processing continues across parallel batches.
@@ -1088,46 +1046,12 @@ class DrainMailboxParallelTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
-    def test_drain_unbounded_keeps_per_row_deletes(self) -> None:
-        # Mirrors DrainMailboxTest: without a claimed_count the drain walks past
-        # its claim, and parallel delivery never bumps schedule_for, so an
-        # unflushed delivered row stays due and rediscoverable.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(3, "github:123", provider="github")
-
-        with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox_parallel(records[0].id)
-
-        assert len(responses.calls) == 3
-        assert WebhookPayload.objects.count() == 0
-        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
-        assert len(delete_queries) == 3
-
-    @responses.activate
-    @override_cells(cell_config)
     @override_options(
         {
             "hybridcloud.webhookpayload.drain_batch_deletes": True,
             "hybridcloud.webhookpayload.push_drain_trigger": True,
         }
     )
-    def test_drain_lease_mode_keeps_per_row_deletes(self) -> None:
-        # Mirrors DrainMailboxTest: a lease drain's lock outlives a crash by only
-        # DRAIN_LOCK_TTL, so it must not defer deletes even with the option on.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(3, "github:123", provider="github")
-
-        with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox_parallel(records[0].id, mailbox_name="github:123")
-
-        assert len(responses.calls) == 3
-        assert WebhookPayload.objects.count() == 0
-        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
-        assert len(delete_queries) == 3
-
     @responses.activate
     @override_cells(cell_config)
     def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:
@@ -1135,7 +1059,7 @@ class DrainMailboxParallelTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox_parallel(records[0].id)
+        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
         # jira is not in the allowlist: processing stops after the first batch
@@ -1178,7 +1102,7 @@ class DrainMailboxParallelTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox_parallel(records[0].id)
+        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1198,7 +1122,7 @@ class DrainMailboxParallelTest(TestCase):
             "BATCH_SCHEDULE_OFFSET",
             new_callable=PropertyMock(return_value=timedelta(minutes=0)),
         ):
-            drain_mailbox_parallel(records[0].id)
+            drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Once start time + batch offset is in the past we stop delivery
         assert WebhookPayload.objects.count() == 1
@@ -1219,7 +1143,7 @@ class DrainMailboxParallelTest(TestCase):
             record.date_added = timezone.now() - timedelta(days=4)
             record.save()
 
-        drain_mailbox_parallel(records[0].id)
+        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1240,7 +1164,7 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1252,7 +1176,7 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1270,7 +1194,7 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox_parallel(webhook_one.id)
+            drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -1289,7 +1213,7 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -1309,7 +1233,7 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1326,7 +1250,7 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -1345,7 +1269,7 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -1365,7 +1289,7 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -1382,7 +1306,7 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id)
+        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -1417,7 +1341,7 @@ class SlowDeliveryLoggingTest(TestCase):
         expected_date_added = webhook.date_added.isoformat()
 
         with self.assertLogs("sentry.hybridcloud.tasks.deliver_webhooks", level="WARNING") as cm:
-            drain_mailbox(webhook.id)
+            drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         slow_log = next(r for r in cm.records if "deliver_webhook.slow_delivery" in r.msg)
         # extra dict from logger becomes attributes on LogRecord at runtime
@@ -1447,7 +1371,7 @@ class DeliveryTimeMetricsTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         delivery_time_ms_calls = [
             c
@@ -1460,10 +1384,9 @@ class DeliveryTimeMetricsTest(TestCase):
         # Rows predating the provider column still drain through here.
         assert tags.get("provider") == "unknown"
         assert tags.get("event_type") == "none"
-        # A drain with no dispatch arguments still emits the attribution keys; a
-        # tag missing from some series breaks grouping rather than showing a gap.
+        # A drain with no dispatcher still emits the attribution key; a tag
+        # missing from some series breaks grouping rather than showing a gap.
         assert tags.get("dispatcher") == "unknown"
-        assert tags.get("mode") == "unknown"
 
     @responses.activate
     @override_cells(cell_config)
@@ -1484,7 +1407,7 @@ class DeliveryTimeMetricsTest(TestCase):
             ).decode(),
             request_body=orjson.dumps({"action": "opened", "repository": {}}).decode(),
         )
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         delivery_time_ms_calls = [
             c
@@ -1518,7 +1441,7 @@ class DeliveryTimeMetricsTest(TestCase):
             ).decode(),
             request_body=orjson.dumps({"repository": {}}).decode(),
         )
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         delivery_time_ms_calls = [
             c
@@ -1546,7 +1469,7 @@ class DeliveryTimeMetricsTest(TestCase):
             cell_name="us",
             provider="stripe",
         )
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         delivery_time_ms_calls = [
             c
@@ -1578,7 +1501,7 @@ class DeliveryTimeMetricsTest(TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         delivery_time_ms_calls = [
             c
@@ -1624,7 +1547,7 @@ class DroppedDeliveryOutcomeTest(TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -1642,7 +1565,7 @@ class DroppedDeliveryOutcomeTest(TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -1660,7 +1583,7 @@ class DroppedDeliveryOutcomeTest(TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.delivery_outcomes(mock_metrics) == ["ok"]
         assert len(self.delivery_time_calls(mock_metrics)) == 1
@@ -1677,7 +1600,7 @@ class DroppedDeliveryOutcomeTest(TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox_parallel(webhook.id)
+        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -1695,7 +1618,7 @@ class DroppedDeliveryOutcomeTest(TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox_parallel(webhook.id)
+        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -1722,7 +1645,7 @@ class DroppedDeliveryOutcomeTest(TestCase):
         first = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         second = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(first.id)
+        drain_mailbox(first.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert not WebhookPayload.objects.filter(id=second.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "ok"]
@@ -1752,7 +1675,7 @@ class ProviderMetricTagTest(TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
@@ -1772,7 +1695,7 @@ class ProviderMetricTagTest(TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.failure") == [
             {"reason": "unauthorized", "destination_region": "us", "provider": "github"}
@@ -1794,7 +1717,7 @@ class ProviderMetricTagTest(TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
             {**UNATTRIBUTED, "outcome": "conflict", "provider": "github"}
@@ -1814,7 +1737,7 @@ class ProviderMetricTagTest(TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox_parallel(webhook.id)
+        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
             {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"}
@@ -1834,13 +1757,13 @@ class ProviderMetricTagTest(TestCase):
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         webhook.update(provider=None)
 
-        drain_mailbox(webhook.id)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "unknown"}
         ]
 
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    @override_options(PUSH_TRIGGER_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_push_trigger_provider_from_mailbox_name(
@@ -1852,23 +1775,7 @@ class ProviderMetricTagTest(TestCase):
         maybe_trigger_drain(webhook.mailbox_name)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.push_trigger.success") == [
-            {"provider": "github", "mode": "lease", "drain": "sequential"}
-        ]
-
-    @override_options(CLAIM_MODE_OPTIONS)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_claim_mode_provider_from_mailbox_name(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        # The claim regime must carry the provider tag too, or the metric loses its
-        # provider breakdown as claim_dispatch_rollout ramps.
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        maybe_trigger_drain(webhook.mailbox_name)
-
-        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.push_trigger.success") == [
-            {"provider": "github", "mode": "claim", "drain": "sequential"}
+            {"provider": "github", "drain": "sequential"}
         ]
 
     @responses.activate
@@ -1896,20 +1803,11 @@ class ProviderMetricTagTest(TestCase):
         legacy = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         legacy.update(provider=None)
 
-        drain_mailbox(head.id)
+        drain_mailbox(head.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"},
             {**UNATTRIBUTED, "outcome": "retry", "provider": "unknown"},
-        ]
-
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_race_provider_from_mailbox_name(self, mock_metrics: MagicMock) -> None:
-        drain_mailbox(999999, mailbox_name="gitlab:7")
-
-        assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.delivery") == [
-            {**UNATTRIBUTED, "outcome": "race", "provider": "gitlab"}
         ]
 
 
@@ -1934,10 +1832,10 @@ class DispatchMetricTest(TestCase):
             if c[0][0] == "hybridcloud.deliver_webhooks.dispatch.claimed"
         ]
 
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_claim_dispatch_attributed_to_push(
+    def test_push_dispatch_attributed_to_push(
         self, mock_drain: MagicMock, mock_metrics: MagicMock
     ) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
@@ -1945,97 +1843,17 @@ class DispatchMetricTest(TestCase):
         maybe_trigger_drain(webhook.mailbox_name)
 
         assert mock_drain.delay.call_args.kwargs["dispatcher"] == Dispatcher.PUSH
-        assert mock_drain.delay.call_args.kwargs["mode"] == DispatchMode.CLAIM
         assert self.dispatch_tags(mock_metrics) == [
-            {
-                "dispatcher": "push",
-                "mode": "claim",
-                "drain": "sequential",
-                "provider": "github",
-            }
+            {"dispatcher": "push", "drain": "sequential", "provider": "github"}
         ]
         assert self.claimed_calls(mock_metrics) == [
-            (
-                1,
-                {
-                    "dispatcher": "push",
-                    "mode": "claim",
-                    "drain": "sequential",
-                    "provider": "github",
-                },
-            )
+            (1, {"dispatcher": "push", "drain": "sequential", "provider": "github"})
         ]
 
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_lease_dispatch_claims_zero(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        # Lease mode runs no claim UPDATE, so zero is the true claim size. Skipping
-        # the emit instead would leave this dispatcher with no series at all while
-        # lease mode is the majority, blanking any push-vs-scheduler formula.
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        maybe_trigger_drain(webhook.mailbox_name)
-
-        assert mock_drain.delay.call_args.kwargs["dispatcher"] == Dispatcher.PUSH
-        assert mock_drain.delay.call_args.kwargs["mode"] == DispatchMode.LEASE
-        assert self.dispatch_tags(mock_metrics) == [
-            {
-                "dispatcher": "push",
-                "mode": "lease",
-                "drain": "sequential",
-                "provider": "github",
-            }
-        ]
-        assert self.claimed_calls(mock_metrics) == [
-            (
-                0,
-                {
-                    "dispatcher": "push",
-                    "mode": "lease",
-                    "drain": "sequential",
-                    "provider": "github",
-                },
-            )
-        ]
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_scheduler_lease_dispatch_attributed_to_scheduler(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        schedule_webhook_delivery()
-
-        assert mock_drain.delay.call_args.kwargs["dispatcher"] == Dispatcher.SCHEDULER
-        assert mock_drain.delay.call_args.kwargs["mode"] == DispatchMode.LEASE
-        assert self.dispatch_tags(mock_metrics) == [
-            {
-                "dispatcher": "scheduler",
-                "mode": "lease",
-                "drain": "sequential",
-                "provider": "github",
-            }
-        ]
-        assert self.claimed_calls(mock_metrics) == [
-            (
-                1,
-                {
-                    "dispatcher": "scheduler",
-                    "mode": "lease",
-                    "drain": "sequential",
-                    "provider": "github",
-                },
-            )
-        ]
-
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
-    def test_scheduler_claim_dispatch_reports_batch_depth(
+    def test_scheduler_dispatch_reports_batch_depth(
         self, mock_drain_parallel: MagicMock, mock_metrics: MagicMock
     ) -> None:
         # Deep on purpose: `claimed` must report the batch, not one per dispatch,
@@ -2046,24 +1864,13 @@ class DispatchMetricTest(TestCase):
         schedule_webhook_delivery()
 
         assert mock_drain_parallel.delay.call_args.kwargs["dispatcher"] == Dispatcher.SCHEDULER
-        assert mock_drain_parallel.delay.call_args.kwargs["mode"] == DispatchMode.CLAIM
         assert self.dispatch_tags(mock_metrics) == [
-            {
-                "dispatcher": "scheduler",
-                "mode": "claim",
-                "drain": "parallel",
-                "provider": "github",
-            }
+            {"dispatcher": "scheduler", "drain": "parallel", "provider": "github"}
         ]
         assert self.claimed_calls(mock_metrics) == [
             (
                 PARALLEL_DRAIN_THRESHOLD,
-                {
-                    "dispatcher": "scheduler",
-                    "mode": "claim",
-                    "drain": "parallel",
-                    "provider": "github",
-                },
+                {"dispatcher": "scheduler", "drain": "parallel", "provider": "github"},
             )
         ]
 
@@ -2071,9 +1878,9 @@ class DispatchMetricTest(TestCase):
 @control_silo_test
 class DeliveryDispatchTagTest(TestCase):
     """
-    Delivery outcomes carry the attribution of the drain that produced them.
-    Without it a partial claim rollout is only readable as a shift in a global
-    total, which that total's own variance swamps at low percentages.
+    Delivery outcomes carry the attribution of the drain that produced them, so
+    push- and scheduler-dispatched work stay separable rather than collapsing
+    into one global total.
     """
 
     def delivery_tags(self, mock_metrics: MagicMock) -> list[dict[str, str]]:
@@ -2104,31 +1911,21 @@ class DeliveryDispatchTagTest(TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(
-            webhook.id,
-            claimed_count=1,
-            dispatcher=Dispatcher.SCHEDULER,
-            mode=DispatchMode.CLAIM,
-        )
+        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
 
         # `claim_exhausted` has no provider tag, so it is the outcome most likely
         # to be missed when attribution is added; assert it alongside the delivery.
         assert self.delivery_tags(mock_metrics) == [
-            {
-                "dispatcher": "scheduler",
-                "mode": "claim",
-                "outcome": "ok",
-                "provider": "github",
-            },
-            {"dispatcher": "scheduler", "mode": "claim", "outcome": "claim_exhausted"},
+            {"dispatcher": "scheduler", "outcome": "ok", "provider": "github"},
+            {"dispatcher": "scheduler", "outcome": "claim_exhausted"},
         ]
 
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_delivery_time_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
-        # Latency is the quantity the claim regime is meant to move, so it needs
-        # the same attribution as the counter to be comparable between cohorts.
+        # Latency is what dispatch is meant to move, so it needs the same
+        # attribution as the counter to be comparable between dispatchers.
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2139,17 +1936,11 @@ class DeliveryDispatchTagTest(TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(
-            webhook.id,
-            claimed_count=1,
-            dispatcher=Dispatcher.SCHEDULER,
-            mode=DispatchMode.CLAIM,
-        )
+        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
 
         assert self.delivery_time_tags(mock_metrics) == [
             {
                 "dispatcher": "scheduler",
-                "mode": "claim",
                 "region_sent_to": "us",
                 "provider": "github",
                 # This fixture's mailbox carries no event-type suffix to read.
@@ -2173,16 +1964,10 @@ class DeliveryDispatchTagTest(TestCase):
         )
         records = create_payloads(2, "github:123", provider="github")
 
-        drain_mailbox_parallel(
-            records[0].id,
-            claimed_count=2,
-            dispatcher=Dispatcher.PUSH,
-            mode=DispatchMode.CLAIM,
-        )
+        drain_mailbox_parallel(records[0].id, claimed_count=2, dispatcher=Dispatcher.PUSH)
 
         expected = {
             "dispatcher": "push",
-            "mode": "claim",
             "region_sent_to": "us",
             "provider": "github",
             "event_type": "unknown",
@@ -2191,41 +1976,31 @@ class DeliveryDispatchTagTest(TestCase):
 
     @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_race_outcome_carries_mode(self, mock_metrics: MagicMock) -> None:
-        # Races are the rollout's primary benefit signal, so this is the outcome
-        # that most needs to be comparable between the claim and lease cohorts.
-        drain_mailbox(99, dispatcher=Dispatcher.PUSH, mode=DispatchMode.CLAIM)
+    def test_race_outcome_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
+        # A race means the row is already gone, so the outcome carries no provider
+        # and attribution is all that is left to tell the dispatchers apart.
+        drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH)
 
         assert self.delivery_tags(mock_metrics) == [
-            {
-                "dispatcher": "push",
-                "mode": "claim",
-                "outcome": "race",
-                "provider": "unknown",
-            }
+            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
         ]
 
     @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_parallel_drain_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
-        drain_mailbox_parallel(99, dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE)
+        drain_mailbox_parallel(99, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
 
         assert self.delivery_tags(mock_metrics) == [
-            {
-                "dispatcher": "scheduler",
-                "mode": "lease",
-                "outcome": "race",
-                "provider": "unknown",
-            }
+            {"dispatcher": "scheduler", "outcome": "race", "provider": "unknown"}
         ]
 
     @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_drain_enqueued_before_deploy_tags_unknown(self, mock_metrics: MagicMock) -> None:
-        # Tasks already queued when this deploys arrive without the arguments. The
-        # keys must still be emitted: a tag absent from some series breaks grouping
+        # Tasks already queued when this deploys arrive without a dispatcher. The
+        # key must still be emitted: a tag absent from some series breaks grouping
         # rather than showing a gap.
-        drain_mailbox(99)
+        drain_mailbox(99, claimed_count=1)
 
         assert self.delivery_tags(mock_metrics) == [
             {**UNATTRIBUTED, "outcome": "race", "provider": "unknown"}
@@ -2235,12 +2010,12 @@ class DeliveryDispatchTagTest(TestCase):
 @control_silo_test
 class PushTriggerTest(TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_enqueues_drain_for_idle_mailbox(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         maybe_trigger_drain(webhook.mailbox_name)
         mock_drain.delay.assert_called_once_with(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH, mode=DispatchMode.CLAIM
+            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH
         )
         # The batch is claimed before dispatch; the claim is what keeps other
         # dispatchers off the mailbox while the drain runs.
@@ -2248,7 +2023,7 @@ class PushTriggerTest(TestCase):
         assert webhook.schedule_for > timezone.now()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_claims_whole_batch(self, mock_drain: MagicMock) -> None:
         records = create_payloads(3, "github:123")
 
@@ -2259,7 +2034,7 @@ class PushTriggerTest(TestCase):
             assert record.schedule_for > timezone.now()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_deduplicates_concurrent_webhooks(self, mock_drain: MagicMock) -> None:
         webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         webhook_two = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
@@ -2271,7 +2046,7 @@ class PushTriggerTest(TestCase):
         assert mock_drain.delay.call_count == 1
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_drains_from_mailbox_head_not_new_payload(
         self, mock_drain: MagicMock
     ) -> None:
@@ -2282,11 +2057,11 @@ class PushTriggerTest(TestCase):
         maybe_trigger_drain(newer_webhook.mailbox_name)
         # Must drain from the head of the mailbox so the older payload is not skipped
         mock_drain.delay.assert_called_once_with(
-            older_webhook.id, claimed_count=2, dispatcher=Dispatcher.PUSH, mode=DispatchMode.CLAIM
+            older_webhook.id, claimed_count=2, dispatcher=Dispatcher.PUSH
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_allows_new_drain_after_claim_expires(self, mock_drain: MagicMock) -> None:
         webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
@@ -2310,20 +2085,8 @@ class PushTriggerTest(TestCase):
         mock_drain.delay.assert_not_called()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_graceful_on_redis_failure(self, mock_drain: MagicMock) -> None:
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        with patch(
-            "sentry.hybridcloud.tasks.deliver_webhooks.cache.add",
-            side_effect=Exception("Cache unavailable"),
-        ):
-            # Should not raise
-            maybe_trigger_drain(webhook.mailbox_name)
-        mock_drain.delay.assert_not_called()
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
-    def test_claim_trigger_graceful_on_redis_failure(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         with patch(
             "sentry.hybridcloud.tasks.deliver_webhooks.cache.add",
@@ -2337,8 +2100,8 @@ class PushTriggerTest(TestCase):
         assert webhook.schedule_for < timezone.now()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
-    def test_claim_trigger_releases_guard_when_enqueue_fails(self, mock_drain: MagicMock) -> None:
+    @override_options(PUSH_TRIGGER_OPTIONS)
+    def test_push_trigger_releases_guard_when_enqueue_fails(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         mock_drain.delay.side_effect = Exception("broker down")
 
@@ -2353,7 +2116,6 @@ class PushTriggerTest(TestCase):
         assert webhook.schedule_for > timezone.now()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
     def test_scheduler_skips_locked_mailboxes(self, mock_drain: MagicMock) -> None:
         webhook_a = self.create_webhook_payload(mailbox_name="github:111", cell_name="us")
         webhook_b = self.create_webhook_payload(mailbox_name="github:222", cell_name="us")
@@ -2364,12 +2126,11 @@ class PushTriggerTest(TestCase):
         schedule_webhook_delivery()
 
         # Only mailbox B should have been scheduled
-        assert mock_drain.delay.call_count == 1
         mock_drain.delay.assert_called_once_with(
-            webhook_b.id, dispatcher=Dispatcher.SCHEDULER, mode=DispatchMode.LEASE
+            webhook_b.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
         )
 
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_scheduler_releases_claim_guard(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
@@ -2381,7 +2142,7 @@ class PushTriggerTest(TestCase):
         # as soon as scheduling is done.
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
 
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_scheduler_claims_and_dispatches_when_cache_down(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
@@ -2401,7 +2162,7 @@ class PushTriggerTest(TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     @responses.activate
     @override_cells(cell_config)
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_fires_immediately_after_drain_completes(
         self, mock_drain: MagicMock
     ) -> None:
@@ -2412,32 +2173,18 @@ class PushTriggerTest(TestCase):
             body="",
         )
         webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        drain_mailbox(webhook_one.id)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
 
         # The drain emptied the mailbox; a new webhook arriving now must be able to
         # trigger a fresh drain right away.
         webhook_two = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         maybe_trigger_drain(webhook_two.mailbox_name)
         mock_drain.delay.assert_called_once_with(
-            webhook_two.id, claimed_count=1, dispatcher=Dispatcher.PUSH, mode=DispatchMode.CLAIM
+            webhook_two.id, claimed_count=1, dispatcher=Dispatcher.PUSH
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_push_trigger_lock_released_on_enqueue_failure(self, mock_drain: MagicMock) -> None:
-        from django.core.cache import cache
-
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        mock_drain.delay.side_effect = Exception("Celery broker unavailable")
-
-        # Should not raise — error is counted as a metric and swallowed
-        maybe_trigger_drain(webhook.mailbox_name)
-
-        # Lock must be released so the scheduler can still reach this mailbox
-        assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_skips_drain_when_head_is_in_backoff(self, mock_drain: MagicMock) -> None:
         from datetime import timedelta
 
@@ -2455,22 +2202,9 @@ class PushTriggerTest(TestCase):
         # Lock must also be released so the scheduler can pick it up when backoff expires
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
 
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_drain_releases_lock_on_doesnotexist_for_lease_drains(self) -> None:
-        mailbox = "github:123"
-        # Lease-mode triggers enqueue drains with mailbox_name and hand them the
-        # lock for the drain's whole run.
-        cache.add(f"wh:drain_active:{mailbox}", 1, timeout=15)
-
-        # The payload is gone — the drain lost a race to a concurrent drain and
-        # must still release the lease it owns.
-        drain_mailbox(999999, mailbox_name=mailbox)
-
-        assert cache.get(f"wh:drain_active:{mailbox}") is None
-
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_uses_parallel_drain_for_deep_mailbox(
         self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
     ) -> None:
@@ -2481,16 +2215,13 @@ class PushTriggerTest(TestCase):
         # A mailbox this deep is behind; the sequential drain would work it off at
         # one in-flight request for its whole run.
         mock_drain_parallel.delay.assert_called_once_with(
-            records[0].id,
-            claimed_count=PARALLEL_DRAIN_THRESHOLD,
-            dispatcher=Dispatcher.PUSH,
-            mode=DispatchMode.CLAIM,
+            records[0].id, claimed_count=PARALLEL_DRAIN_THRESHOLD, dispatcher=Dispatcher.PUSH
         )
         mock_drain.delay.assert_not_called()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_uses_sequential_drain_for_shallow_mailbox(
         self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
     ) -> None:
@@ -2500,16 +2231,13 @@ class PushTriggerTest(TestCase):
 
         # One record short of the threshold keeps strict ordering.
         mock_drain.delay.assert_called_once_with(
-            records[0].id,
-            claimed_count=PARALLEL_DRAIN_THRESHOLD - 1,
-            dispatcher=Dispatcher.PUSH,
-            mode=DispatchMode.CLAIM,
+            records[0].id, claimed_count=PARALLEL_DRAIN_THRESHOLD - 1, dispatcher=Dispatcher.PUSH
         )
         mock_drain_parallel.delay.assert_not_called()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_push_trigger_claim_keeps_scheduler_off(
         self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
     ) -> None:
@@ -2527,7 +2255,7 @@ class PushTriggerTest(TestCase):
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_scheduler_claim_blocks_push_trigger(
         self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
     ) -> None:
@@ -2544,76 +2272,25 @@ class PushTriggerTest(TestCase):
         assert mock_drain_parallel.delay.call_count == 0
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_lease_mode_trigger_hands_lock_to_drain(self, mock_drain: MagicMock) -> None:
-        # claim_dispatch_rollout defaults to 0.0 — lease mode.
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        maybe_trigger_drain(webhook.mailbox_name)
-
-        # The drain receives mailbox_name and owns the lock for its whole run;
-        # the trigger must not release it.
-        mock_drain.delay.assert_called_once_with(
-            webhook.id,
-            mailbox_name=webhook.mailbox_name,
-            dispatcher=Dispatcher.PUSH,
-            mode=DispatchMode.LEASE,
-        )
-        assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") == 1
-        # No claim in lease mode: the batch stays due for the scheduler's view.
-        webhook.refresh_from_db()
-        assert webhook.schedule_for < timezone.now()
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_lease_lock_outlives_a_single_delivery(self, mock_drain: MagicMock) -> None:
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        with patch.object(cache, "add", wraps=cache.add) as mock_add:
-            maybe_trigger_drain(webhook.mailbox_name)
-        trigger_ttl = mock_add.call_args.kwargs["timeout"]
-
-        with patch.object(cache, "set", wraps=cache.set) as mock_set:
-            deliver_webhooks._refresh_drain_lock(webhook.mailbox_name)
-        refresh_ttl = mock_set.call_args.kwargs["timeout"]
-
-        # Both the TTL the drain inherits and the one it writes must outlast a single
-        # delivery, or the lock expires mid-drain and the scheduler dispatches a
-        # second drain over the same records.
-        assert trigger_ttl > 2 * CellSiloClient.timeout
-        assert refresh_ttl > 2 * CellSiloClient.timeout
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
+    @override_options(PUSH_TRIGGER_OPTIONS)
     def test_claim_guard_keeps_the_short_ttl(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
         with patch.object(cache, "add", wraps=cache.add) as mock_add:
             maybe_trigger_drain(webhook.mailbox_name)
 
-        # Claim mode releases the lock before returning. Sizing its TTL for a delivery
+        # The trigger releases the lock before returning. Sizing its TTL for a delivery
         # would strand the mailbox that long whenever a dispatcher dies mid-claim.
         assert mock_add.call_args.kwargs["timeout"] == DRAIN_LOCK_TTL
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_lease_mode_deduplicates_via_lock(self, mock_drain: MagicMock) -> None:
-        webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        maybe_trigger_drain(webhook_one.mailbox_name)
-        maybe_trigger_drain(webhook_one.mailbox_name)
-
-        assert mock_drain.delay.call_count == 1
-
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(CLAIM_MODE_OPTIONS)
-    def test_claim_trigger_respects_lease_lock(
+    @override_options(PUSH_TRIGGER_OPTIONS)
+    def test_trigger_respects_held_lock(
         self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
     ) -> None:
-        # A lease-mode drain (e.g. dispatched before a rollout bump) still holds
-        # the lock; a claim-mode trigger must not dispatch over it.
+        # Another dispatcher is mid-claim and holds the lock; this trigger must
+        # not dispatch over it.
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         cache.add(f"wh:drain_active:{webhook.mailbox_name}", 1, timeout=15)
 
@@ -2623,10 +2300,10 @@ class PushTriggerTest(TestCase):
         mock_drain_parallel.delay.assert_not_called()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options({"hybridcloud.webhookpayload.push_drain_trigger": True})
-    def test_lease_trigger_respects_active_claim(self, mock_drain: MagicMock) -> None:
-        # A claim-mode dispatch (e.g. from before a rollout rollback) has the batch
-        # scheduled into the future; a lease-mode trigger sees the head as not due.
+    @override_options(PUSH_TRIGGER_OPTIONS)
+    def test_trigger_respects_active_claim(self, mock_drain: MagicMock) -> None:
+        # Another dispatcher's claim has the batch scheduled into the future, so
+        # this trigger sees the head as not due.
         webhook = self.create_webhook_payload(
             mailbox_name="github:123",
             cell_name="us",
@@ -2636,18 +2313,5 @@ class PushTriggerTest(TestCase):
         maybe_trigger_drain(webhook.mailbox_name)
 
         mock_drain.delay.assert_not_called()
-        # The lease trigger must release its lock so the mailbox stays reachable.
+        # The trigger must release its guard so the mailbox stays reachable.
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
-
-    def test_claim_rollout_buckets_by_integration(self) -> None:
-        with override_options({"hybridcloud.webhookpayload.claim_dispatch_rollout": 0.0}):
-            assert _use_claim_dispatch("github:123") is False
-        with override_options({"hybridcloud.webhookpayload.claim_dispatch_rollout": 1.0}):
-            assert _use_claim_dispatch("github:123") is True
-        with override_options({"hybridcloud.webhookpayload.claim_dispatch_rollout": 0.5}):
-            # Sub-mailboxes of one integration must land in the same regime as
-            # their base mailbox, deterministically across calls.
-            base = _use_claim_dispatch("github:123")
-            assert _use_claim_dispatch("github:123") is base
-            assert _use_claim_dispatch("github:123:93:check_run") is base
-            assert _use_claim_dispatch("github:123:5:push") is base

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -630,14 +630,6 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options(
-        {
-            "hybridcloud.webhookpayload.drain_batch_deletes": True,
-            "hybridcloud.webhookpayload.push_drain_trigger": True,
-        }
-    )
-    @responses.activate
-    @override_cells(cell_config)
     def test_drain_mailbox_multiple_consecutive_failures(self) -> None:
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
@@ -1044,14 +1036,6 @@ class DrainMailboxParallelTest(TestCase):
         delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
         assert len(delete_queries) == 1
 
-    @responses.activate
-    @override_cells(cell_config)
-    @override_options(
-        {
-            "hybridcloud.webhookpayload.drain_batch_deletes": True,
-            "hybridcloud.webhookpayload.push_drain_trigger": True,
-        }
-    )
     @responses.activate
     @override_cells(cell_config)
     def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:


### PR DESCRIPTION
`hybridcloud.webhookpayload.claim_dispatch_rollout` has sat at `1.0` since 2026-08-17 (options-automator #9178), and `in_rollout_group` at that rate returns `True` for every key — so no lease-mode drain has been dispatched in over a week. This collapses every read of the option to the outcome that won and deletes the regime it selected against.

## What goes away

- `_use_claim_dispatch` and the already-unreferenced `_claim_dispatch_active`
- `_maybe_trigger_drain_lease`, folded away so `maybe_trigger_drain` is one function instead of a dispatcher over two
- the scheduler's lease branch
- `LEASE_DRAIN_LOCK_TTL` and `_refresh_drain_lock` — only a lease drain refreshed
- the `mailbox_name` argument on both drain tasks, which existed to hand a drain ownership of the lock for its whole run

Two things the collapse orphaned, swept with it:

- **`claimed_count` is now required.** The `None` "drain until empty" walk was reachable only from the lease scheduler. `_deleter_for` loses both its arguments as a consequence: every drain is claim-bounded, so batching is safe whenever `drain_batch_deletes` is on rather than needing to prove it per call.
- **The `mode` tag comes off every series** — `dispatch`, `dispatch.claimed`, `delivery`, `delivery_time_ms`, `push_trigger.*`. It existed to make a partial rollout readable by comparing the claim and lease cohorts; with one regime left it is a constant carrying no information. `dispatcher` still separates push from scheduler work.

⚠️ **Dashboard note:** any query filtering `mode:claim` goes blank when this deploys. Worth updating those widgets before the deploy rather than after.

## What deliberately stays

Both drain tasks still *accept* a `mode` kwarg, ignored, with a comment saying why. Drains enqueued by the previous deploy carry `mode="claim"`; rejecting them would fail the task and strand its claim until the horizon passes. That argument comes out in a follow-up once none can be in flight. `mailbox_name` needed no such grace — nothing has passed it since the rollout hit 1.0.

## Ordering

Step 1 of the three-PR option removal. The other two are open as drafts and **must not merge before this one is deployed to every region**:

1. **this PR** — collapse the reads
2. https://github.com/getsentry/sentry-options-automator/pull/9345 — unset the value. Blocked on this deploying everywhere; the fallback is the registered default `0.0`, which is lease dispatch, so landing it early flips prod back to a regime this PR deletes.
3. https://github.com/getsentry/sentry/pull/122591 — remove the registration. Blocked on 2 deploying green; landing it early turns the automator red on `main` with `[ERROR] ... unregistered`.

## Verification

- `tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py` — 113 passed
- `tests/sentry/hybridcloud/` + `tests/sentry/middleware/integrations/` — 573 passed
- `prek run -q` clean, pre-push mypy clean