### PR TITLE
ref(hybridcloud): Deregister claim_dispatch_rollout

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -450,7 +450,6 @@ def drain_mailbox(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
-    mode: str | None = None,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of.
@@ -465,10 +464,6 @@ def drain_mailbox(
 
     `dispatcher` carries the enqueueing dispatcher's attribution onto every
     delivery outcome this drain records (see `_dispatch_tags`).
-
-    `mode` is accepted but ignored: drains enqueued by the previous deploy still
-    carry it, and rejecting them would strand their claims until the horizon
-    passes. Removable once no such task can be in flight.
     """
     dispatch_tags = _dispatch_tags(dispatcher)
     try:
@@ -866,7 +861,6 @@ def drain_mailbox_parallel(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
-    mode: str | None = None,
 ) -> None:
     """
     Deliver messages from a mailbox in small parallel batches.
@@ -884,7 +878,7 @@ def drain_mailbox_parallel(
     This drain holds no lock while it runs, so it must not deliver past the
     `claimed_count` records its dispatcher claimed — see `drain_mailbox`.
 
-    `dispatcher` and `mode` behave as they do on `drain_mailbox`.
+    `dispatcher` behaves as it does on `drain_mailbox`.
     """
     dispatch_tags = _dispatch_tags(dispatcher)
     try:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2522,15 +2522,6 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Fraction of integrations (bucketed by the provider:integration_id prefix of
-# mailbox_name, so all of an integration's mailboxes switch together) whose
-# drains are dispatched via batch claims instead of the drain-lock lease.
-register(
-    "hybridcloud.webhookpayload.claim_dispatch_rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Remove the rows a claim-bounded drain finishes with — delivered, attempts
 # exhausted, or stale — in batches instead of one DELETE per row. Such a drain
 # stays inside a claim reserved for its whole run, so deferring deletes cannot


### PR DESCRIPTION
Stacked on https://github.com/getsentry/sentry/pull/122590. Steps 3 and the `mode` cleanup of the option removal — **draft on purpose**, see Ordering.

Two post-deploy cleanups that share a gate:

1. **Deregister the option.** Removes the `register(...)` for `hybridcloud.webhookpayload.claim_dispatch_rollout` from `defaults.py`. Nothing reads it once #122590 lands, and the automator will no longer set a value, so the registration is the last thing keeping it alive.
2. **Drop the ignored `mode` argument** from `drain_mailbox` and `drain_mailbox_parallel`. #122590 kept it accepted-and-ignored purely so drains enqueued by the deploy *before* it would not be rejected. Nothing passes it any more, and no metric reads it.

## Ordering

Merge only after **both** of these have deployed, not merely merged:

1. https://github.com/getsentry/sentry/pull/122590 — collapse the call sites (this PR's base)
2. https://github.com/getsentry/sentry-options-automator/pull/9345 — unset the value, and its run is green in `#feed-options-automator`

That gate is now load-bearing for two separate reasons:

- **Deregistering early** fails the automator run with `[ERROR] ... unregistered` and leaves `options-drift` red on `main` for everyone. Worse, `configoptions sync` only iterates *registered* `FLAG_AUTOMATOR_MODIFIABLE` options, so once the registration is gone nothing can ever delete the `sentry_option` row — recovering means re-registering, letting the automator unset it, then removing the registration again.
- **Dropping `mode` early**, while any region still runs pre-#122590 code, makes every in-flight drain carrying `mode="claim"` raise `TypeError`. Each failure strands its claim until the horizon passes, so those mailboxes stall for up to `BACKOFF_INTERVAL` minutes.

Neither can happen once #122590 has been out everywhere for a deploy cycle, which the automator step already guarantees.

## Verification

- `tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py` + `tests/sentry/options/` — 211 passed
- `prek run -q` and pre-push mypy clean. No test passed `mode=`, so removing it needed no test changes. `FLAG_MODIFIABLE_RATE` and `Float` are still used by other registrations, so no imports are orphaned.