### PR TITLE
feat(inbox): Link empty states to broader inboxes

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -1356,6 +1356,54 @@ describe('InboxPage', () => {
       expect(await screen.findByText('No Issues in your Inbox!')).toBeInTheDocument();
     });
 
+    it('links to the team inbox when the personal inbox is empty', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues-count/',
+        body: {
+          [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 0,
+          [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 2,
+          [`issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 3,
+        },
+      });
+
+      const {router} = render(<InboxPage />, {
+        organization: seerOrganization,
+        initialRouterConfig,
+      });
+
+      await userEvent.click(await screen.findByRole('button', {name: 'View team inbox'}));
+
+      expect(router.location.query.assignment).toBe('my_teams');
+    });
+
+    it('links to the all inbox when the team inbox is empty', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues-count/',
+        body: {
+          [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:me${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 0,
+          [`issue.progress:[fix_proposed,diagnosed,assigned,identified] is:unresolved assigned_or_suggested:[me,my_teams]${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 0,
+          [`issue.progress:[fix_proposed,diagnosed,assigned] is:unresolved${INBOX_AUTOFIX_CATEGORY_FILTER}`]: 3,
+        },
+      });
+
+      const {router} = render(<InboxPage />, {
+        organization: seerOrganization,
+        initialRouterConfig,
+      });
+
+      await userEvent.click(await screen.findByRole('button', {name: 'View all inbox'}));
+
+      expect(router.location.query.assignment).toBe('all');
+    });
+
     it('follows section order even when a later section resolves first', async () => {
       // Diagnosed resolves immediately, Fix Proposed only after a delay. Both
       // have issues, so taking whichever result arrives first would select the

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -308,6 +308,12 @@ function InboxContent() {
   const assignmentCounts = useAssignmentCounts();
   const sections = SECTIONS.filter(section => !section.hidden?.({hasSeer}));
   const isInboxEmpty = assignmentCounts?.[assignmentFilter] === 0;
+  const alternateInbox =
+    assignmentFilter === 'me' && assignmentCounts?.my_teams
+      ? {filter: 'my_teams' as const, label: t('View team inbox')}
+      : assignmentFilter !== 'all' && assignmentCounts?.all
+        ? {filter: 'all' as const, label: t('View all inbox')}
+        : null;
   const [storedSize, setStoredSize] = useSyncedLocalStorageState(
     INBOX_SPLIT_SIZE_STORAGE_KEY,
     INBOX_DEFAULT_SIZE
@@ -422,7 +428,23 @@ function InboxContent() {
           )}
           {selectedIssueId && <IssuePreview groupId={selectedIssueId} />}
           {!selectedIssueId && isInboxEmpty && (
-            <InboxEmptyState assignmentFilter={assignmentFilter} />
+            <InboxEmptyState
+              assignmentFilter={assignmentFilter}
+              alternateInbox={
+                alternateInbox
+                  ? {
+                      label: alternateInbox.label,
+                      onClick: () => {
+                        trackAnalytics('issue_inbox.assignment_filter_changed', {
+                          organization,
+                          assignment_filter: alternateInbox.filter,
+                        });
+                        void setAssignmentFilter(alternateInbox.filter);
+                      },
+                    }
+                  : undefined
+              }
+            />
           )}
         </Stack>
       </Grid>

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -73,6 +73,17 @@ const INBOX_MAX_SIZE = 640;
 const ASSIGNMENT_BADGE_WIDTH = '27px';
 type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
 
+interface AssignmentCounts {
+  all: number;
+  me: number;
+  my_teams: number;
+}
+
+interface AlternateInbox {
+  filter: Exclude<AssignmentFilter, 'me'>;
+  label: string;
+}
+
 const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
   me: ' assigned_or_suggested:me',
   my_teams: ' assigned_or_suggested:[me,my_teams]',
@@ -199,7 +210,7 @@ function useSelectFirstLoadedIssue({
 }
 
 // Fetch counts for the assignment filter tabs (my/my teams/all)
-function useAssignmentCounts() {
+function useAssignmentCounts(): AssignmentCounts | null {
   const organization = useOrganization();
   const meQuery = `${ASSIGNMENT_COUNT_QUERY}${ASSIGNMENT_QUERY_SUFFIXES.me}${INBOX_AUTOFIX_CATEGORY_FILTER}`;
   const myTeamsQuery = `${ASSIGNMENT_COUNT_QUERY}${ASSIGNMENT_QUERY_SUFFIXES.my_teams}${INBOX_AUTOFIX_CATEGORY_FILTER}`;
@@ -227,23 +238,29 @@ function useAssignmentCounts() {
   };
 }
 
+function getAlternateInbox(
+  assignmentFilter: AssignmentFilter,
+  assignmentCounts: AssignmentCounts | null
+): AlternateInbox | null {
+  if (assignmentFilter === 'me' && assignmentCounts?.my_teams) {
+    return {filter: 'my_teams', label: t('View team inbox')};
+  }
+
+  if (assignmentFilter !== 'all' && assignmentCounts?.all) {
+    return {filter: 'all', label: t('View all inbox')};
+  }
+
+  return null;
+}
+
 function AssignmentTabs({
   assignmentFilter,
-  setAssignmentFilter,
+  onChange,
 }: {
   assignmentFilter: AssignmentFilter;
-  setAssignmentFilter: (filter: AssignmentFilter) => void;
+  onChange: (filter: AssignmentFilter) => void;
 }) {
-  const organization = useOrganization();
   const assignmentCounts = useAssignmentCounts();
-
-  const handleAssignmentFilterChange = (filter: AssignmentFilter) => {
-    trackAnalytics('issue_inbox.assignment_filter_changed', {
-      organization,
-      assignment_filter: filter,
-    });
-    setAssignmentFilter(filter);
-  };
 
   useRouteAnalyticsParams(
     assignmentCounts
@@ -263,7 +280,7 @@ function AssignmentTabs({
       aria-label={t('Issue assignee')}
       size="xs"
       value={assignmentFilter}
-      onChange={handleAssignmentFilterChange}
+      onChange={onChange}
     >
       <SegmentedControl.Item key="me" textValue={t('Me')}>
         <Flex as="span" align="center" gap="sm">
@@ -308,12 +325,7 @@ function InboxContent() {
   const assignmentCounts = useAssignmentCounts();
   const sections = SECTIONS.filter(section => !section.hidden?.({hasSeer}));
   const isInboxEmpty = assignmentCounts?.[assignmentFilter] === 0;
-  const alternateInbox =
-    assignmentFilter === 'me' && assignmentCounts?.my_teams
-      ? {filter: 'my_teams' as const, label: t('View team inbox')}
-      : assignmentFilter !== 'all' && assignmentCounts?.all
-        ? {filter: 'all' as const, label: t('View all inbox')}
-        : null;
+  const alternateInbox = getAlternateInbox(assignmentFilter, assignmentCounts);
   const [storedSize, setStoredSize] = useSyncedLocalStorageState(
     INBOX_SPLIT_SIZE_STORAGE_KEY,
     INBOX_DEFAULT_SIZE
@@ -332,6 +344,21 @@ function InboxContent() {
     resetKey: assignmentFilter,
     sections,
   });
+
+  const handleAssignmentFilterChange = (filter: AssignmentFilter) => {
+    trackAnalytics('issue_inbox.assignment_filter_changed', {
+      organization,
+      assignment_filter: filter,
+    });
+    setAssignmentFilter(filter);
+  };
+
+  const alternateInboxAction = alternateInbox
+    ? {
+        label: alternateInbox.label,
+        onClick: () => handleAssignmentFilterChange(alternateInbox.filter),
+      }
+    : undefined;
 
   return (
     <Stack flex={1} minHeight={0} contain="size" overflow="hidden">
@@ -367,7 +394,7 @@ function InboxContent() {
             </Heading>
             <AssignmentTabs
               assignmentFilter={assignmentFilter}
-              setAssignmentFilter={setAssignmentFilter}
+              onChange={handleAssignmentFilterChange}
             />
           </Flex>
           <Stack flex={1} minHeight={0} overflowY="auto" overscrollBehavior="contain">
@@ -430,20 +457,7 @@ function InboxContent() {
           {!selectedIssueId && isInboxEmpty && (
             <InboxEmptyState
               assignmentFilter={assignmentFilter}
-              alternateInbox={
-                alternateInbox
-                  ? {
-                      label: alternateInbox.label,
-                      onClick: () => {
-                        trackAnalytics('issue_inbox.assignment_filter_changed', {
-                          organization,
-                          assignment_filter: alternateInbox.filter,
-                        });
-                        void setAssignmentFilter(alternateInbox.filter);
-                      },
-                    }
-                  : undefined
-              }
+              alternateInbox={alternateInboxAction}
             />
           )}
         </Stack>

--- a/static/app/views/issueList/pages/inboxEmptyState.tsx
+++ b/static/app/views/issueList/pages/inboxEmptyState.tsx
@@ -1,13 +1,24 @@
+import {Fragment} from 'react';
+
 import starryVoidImg from 'sentry-images/spot/starry-void.png';
 
-import {LinkButton} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {EmptyState} from '@sentry/scraps/emptyState';
 
 import {IconClock} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-export function InboxEmptyState({assignmentFilter}: {assignmentFilter: string}) {
+export function InboxEmptyState({
+  alternateInbox,
+  assignmentFilter,
+}: {
+  assignmentFilter: string;
+  alternateInbox?: {
+    label: string;
+    onClick: () => void;
+  };
+}) {
   const organization = useOrganization();
 
   return (
@@ -19,15 +30,20 @@ export function InboxEmptyState({assignmentFilter}: {assignmentFilter: string}) 
       )}
       illustration={<img src={starryVoidImg} alt="" />}
       action={
-        <LinkButton
-          to={`/organizations/${organization.slug}/issues/`}
-          icon={<IconClock />}
-          analyticsEventKey="issue_inbox.go_to_issue_feed_clicked"
-          analyticsEventName="Issue Inbox: Go to Issue Feed Clicked"
-          analyticsParams={{assignment_filter: assignmentFilter}}
-        >
-          {t('Go to Issue Feed')}
-        </LinkButton>
+        <Fragment>
+          <LinkButton
+            to={`/organizations/${organization.slug}/issues/`}
+            icon={<IconClock />}
+            analyticsEventKey="issue_inbox.go_to_issue_feed_clicked"
+            analyticsEventName="Issue Inbox: Go to Issue Feed Clicked"
+            analyticsParams={{assignment_filter: assignmentFilter}}
+          >
+            {t('Go to Issue Feed')}
+          </LinkButton>
+          {alternateInbox && (
+            <Button onClick={alternateInbox.onClick}>{alternateInbox.label}</Button>
+          )}
+        </Fragment>
       }
     />
   );


### PR DESCRIPTION
An empty personal inbox now offers a direct path to My Teams when it has issues, falling back to All when only the broader inbox has results. The existing Issue Feed action remains available, and filter switches keep the current inbox route and assignment-filter analytics.

Refs ISWF-3367
