### PR TITLE
style(inbox): Match feedback count badges

### DIFF
--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -516,9 +516,9 @@ function InboxSection({
         <Container width="100%" padding="sm" background="secondary" radius="sm">
           <Disclosure.Title
             trailingItems={
-              <CountBadge variant="muted">
+              <Badge variant="muted">
                 <QueryCount count={count} max={maxCount} hideIfEmpty={false} hideParens />
-              </CountBadge>
+              </Badge>
             }
           >
             <Flex align="center" gap="sm">
@@ -850,12 +850,8 @@ const IssueCardLink = styled(Link)`
   }
 `;
 
-const CountBadge = styled(Badge)`
+const AssignmentBadge = styled(Badge)`
   padding: 0 ${p => p.theme.space.xs};
-`;
-
-const AssignmentBadge = styled(CountBadge)`
-  min-width: ${ASSIGNMENT_BADGE_WIDTH};
   height: 16px;
   font-size: ${p => p.theme.font.size.xs};
   justify-content: center;

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -516,9 +516,9 @@ function InboxSection({
         <Container width="100%" padding="sm" background="secondary" radius="sm">
           <Disclosure.Title
             trailingItems={
-              <Badge variant="muted">
+              <CountBadge variant="muted">
                 <QueryCount count={count} max={maxCount} hideIfEmpty={false} hideParens />
-              </Badge>
+              </CountBadge>
             }
           >
             <Flex align="center" gap="sm">
@@ -850,7 +850,11 @@ const IssueCardLink = styled(Link)`
   }
 `;
 
-const AssignmentBadge = styled(Badge)`
+const CountBadge = styled(Badge)`
+  padding: 0 ${p => p.theme.space.xs};
+`;
+
+const AssignmentBadge = styled(CountBadge)`
   min-width: ${ASSIGNMENT_BADGE_WIDTH};
   height: 16px;
   font-size: ${p => p.theme.font.size.xs};

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -431,7 +431,7 @@ function InboxContent() {
 
 function AssignmentCountBadge({count}: {count: number | undefined}) {
   if (count === undefined) {
-    return null;
+    return <Placeholder width="24px" height="20px" />;
   }
 
   return (

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -70,7 +70,6 @@ const INBOX_SPLIT_SIZE_STORAGE_KEY = 'inbox-split-size';
 const INBOX_DEFAULT_SIZE = 480;
 const INBOX_MIN_SIZE = 320;
 const INBOX_MAX_SIZE = 640;
-const ASSIGNMENT_BADGE_WIDTH = '27px';
 type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
 
 const ASSIGNMENT_QUERY_SUFFIXES: Record<AssignmentFilter, string> = {
@@ -430,18 +429,15 @@ function InboxContent() {
   );
 }
 
-// To avoid pop-in we ensure that the badge has the same width (which is enough to contain 99+)
 function AssignmentCountBadge({count}: {count: number | undefined}) {
+  if (count === undefined) {
+    return null;
+  }
+
   return (
-    <Flex as="span" width={ASSIGNMENT_BADGE_WIDTH} justify="end" align="center">
-      {count === undefined ? (
-        <Placeholder width={ASSIGNMENT_BADGE_WIDTH} height="16px" />
-      ) : (
-        <AssignmentBadge variant="muted">
-          <QueryCount count={count} max={99} hideIfEmpty={false} hideParens />
-        </AssignmentBadge>
-      )}
-    </Flex>
+    <Badge variant="muted">
+      <QueryCount count={count} max={99} hideIfEmpty={false} hideParens />
+    </Badge>
   );
 }
 
@@ -848,11 +844,4 @@ const IssueCardLink = styled(Link)`
     border-color: ${p => p.theme.tokens.border.transparent.accent.muted};
     color: ${p => p.theme.tokens.content.primary};
   }
-`;
-
-const AssignmentBadge = styled(Badge)`
-  padding: 0 ${p => p.theme.space.xs};
-  height: 16px;
-  font-size: ${p => p.theme.font.size.xs};
-  justify-content: center;
 `;


### PR DESCRIPTION
Assignment-filter counts now use the same standard muted badge treatment as the User Feedback mailbox toggle. Removing the fixed-width slot and custom size overrides makes loaded pills inherit the shared padding, height, typography, and content-based width while preserving the existing `0` and `99+` display behavior. Compact badge-height placeholders remain visible while counts load.

Refs ISWF-3369
