### PR TITLE
style(inbox): Hide closed pull request badges

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -421,6 +421,17 @@ describe('InboxPage', () => {
         pullRequests: [
           {
             ...PullRequestFixture({
+              id: '12',
+              externalUrl: 'https://github.com/org/repository/pull/12',
+            }),
+            attribution: null,
+            checksStatus: null,
+            dateLinked: '2026-07-20T12:00:00Z',
+            reviewStatus: null,
+            status: 'closed',
+          },
+          {
+            ...PullRequestFixture({
               id: '10',
               externalUrl: 'https://github.com/org/repository/pull/10',
             }),
@@ -440,17 +451,6 @@ describe('InboxPage', () => {
             dateLinked: '2026-07-20T12:00:00Z',
             reviewStatus: null,
             status: 'merged',
-          },
-          {
-            ...PullRequestFixture({
-              id: '12',
-              externalUrl: 'https://github.com/org/repository/pull/12',
-            }),
-            attribution: null,
-            checksStatus: null,
-            dateLinked: '2026-07-20T12:00:00Z',
-            reviewStatus: null,
-            status: 'closed',
           },
         ],
       },

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -749,8 +749,11 @@ const PULL_REQUEST_BADGE_VARIANTS = {
 
 function InboxPullRequestBadges({group}: {group: Group}) {
   const {data} = useLinkedPullRequests({group, includeChecksAndReview: false});
+  const pullRequests = data?.pullRequests.filter(
+    pullRequest => pullRequest.status !== 'closed'
+  );
 
-  if (!data?.pullRequests.length) {
+  if (!pullRequests?.length) {
     return null;
   }
 
@@ -759,26 +762,23 @@ function InboxPullRequestBadges({group}: {group: Group}) {
       <Grid columns="8px minmax(0, 1fr) max-content" gap="md">
         <span />
         <Flex align="center" gap="xs">
-          {data.pullRequests
-            .filter(pullRequest => pullRequest.status !== 'closed')
-            .slice(0, 2)
-            .map(pullRequest => (
-              <PullRequestBadgeLink
-                key={`${pullRequest.repository.id}:${pullRequest.id}`}
-                aria-label={t(
-                  'Pull request #%s, %s',
-                  pullRequest.id,
-                  getPullRequestStatusLabel(pullRequest.status)
-                )}
-                href={pullRequest.externalUrl}
-              >
-                <Badge variant={PULL_REQUEST_BADGE_VARIANTS[pullRequest.status]}>
-                  <Flex as="span" align="center" gap="2xs">
-                    <IconPullRequest aria-hidden size="xs" />#{pullRequest.id}
-                  </Flex>
-                </Badge>
-              </PullRequestBadgeLink>
-            ))}
+          {pullRequests.slice(0, 2).map(pullRequest => (
+            <PullRequestBadgeLink
+              key={`${pullRequest.repository.id}:${pullRequest.id}`}
+              aria-label={t(
+                'Pull request #%s, %s',
+                pullRequest.id,
+                getPullRequestStatusLabel(pullRequest.status)
+              )}
+              href={pullRequest.externalUrl}
+            >
+              <Badge variant={PULL_REQUEST_BADGE_VARIANTS[pullRequest.status]}>
+                <Flex as="span" align="center" gap="2xs">
+                  <IconPullRequest aria-hidden size="xs" />#{pullRequest.id}
+                </Flex>
+              </Badge>
+            </PullRequestBadgeLink>
+          ))}
         </Flex>
         <span />
       </Grid>

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -759,23 +759,26 @@ function InboxPullRequestBadges({group}: {group: Group}) {
       <Grid columns="8px minmax(0, 1fr) max-content" gap="md">
         <span />
         <Flex align="center" gap="xs">
-          {data.pullRequests.slice(0, 2).map(pullRequest => (
-            <PullRequestBadgeLink
-              key={`${pullRequest.repository.id}:${pullRequest.id}`}
-              aria-label={t(
-                'Pull request #%s, %s',
-                pullRequest.id,
-                getPullRequestStatusLabel(pullRequest.status)
-              )}
-              href={pullRequest.externalUrl}
-            >
-              <Badge variant={PULL_REQUEST_BADGE_VARIANTS[pullRequest.status]}>
-                <Flex as="span" align="center" gap="2xs">
-                  <IconPullRequest aria-hidden size="xs" />#{pullRequest.id}
-                </Flex>
-              </Badge>
-            </PullRequestBadgeLink>
-          ))}
+          {data.pullRequests
+            .filter(pullRequest => pullRequest.status !== 'closed')
+            .slice(0, 2)
+            .map(pullRequest => (
+              <PullRequestBadgeLink
+                key={`${pullRequest.repository.id}:${pullRequest.id}`}
+                aria-label={t(
+                  'Pull request #%s, %s',
+                  pullRequest.id,
+                  getPullRequestStatusLabel(pullRequest.status)
+                )}
+                href={pullRequest.externalUrl}
+              >
+                <Badge variant={PULL_REQUEST_BADGE_VARIANTS[pullRequest.status]}>
+                  <Flex as="span" align="center" gap="2xs">
+                    <IconPullRequest aria-hidden size="xs" />#{pullRequest.id}
+                  </Flex>
+                </Badge>
+              </PullRequestBadgeLink>
+            ))}
         </Flex>
         <span />
       </Grid>


### PR DESCRIPTION
Inbox pull request badges now exclude closed pull requests before applying the two-badge limit, preserving space for open and merged work that still matters in the issue workflow.

Refs ISWF-3368
