### PR TITLE
feat(onboarding): Create projects from SCM messaging

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -140,7 +140,15 @@ function ScmPlatformFeaturesTreatmentAdapter(props: StepProps) {
 }
 
 function ScmMessagingAdapter({genBackButton, onComplete}: StepProps) {
-  const {messagingSetup, selectedPlatform, setMessagingSetup} = useOnboardingContext();
+  const {
+    createdProjectSlug,
+    messagingSetup,
+    selectedFeatures,
+    selectedPlatform,
+    selectedRepository,
+    setCreatedProjectSlug,
+    setMessagingSetup,
+  } = useOnboardingContext();
 
   // Type-narrowing only. `isInvalidMessagingStep` below redirects away from
   // this step before it renders without a platform, so this is unreachable —
@@ -151,11 +159,15 @@ function ScmMessagingAdapter({genBackButton, onComplete}: StepProps) {
 
   return (
     <ScmMessaging
+      createdProjectSlug={createdProjectSlug}
       messagingSetup={messagingSetup}
       onMessagingSetupChange={setMessagingSetup}
-      selectedPlatform={selectedPlatform}
-      genBackButton={genBackButton}
+      onProjectCreated={setCreatedProjectSlug}
       onComplete={onComplete}
+      selectedFeatures={selectedFeatures}
+      selectedPlatform={selectedPlatform}
+      selectedRepository={selectedRepository}
+      genBackButton={genBackButton}
     />
   );
 }

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -1,7 +1,12 @@
 import {act, Fragment, useState} from 'react';
 import {QueryClientProvider} from '@tanstack/react-query';
+import {AutomationFixture} from 'sentry-fixture/automations';
+import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
 import {IntegrationProviderFixture} from 'sentry-fixture/integrationProvider';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {
@@ -13,12 +18,15 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   OnboardingContextProvider,
   useOnboardingContext,
 } from 'sentry/components/onboarding/onboardingContext';
 import type {ScmMessagingSetup} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import * as pipelineModal from 'sentry/components/pipeline/modal';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 
@@ -40,6 +48,14 @@ const selectedMessagingSetup: ScmMessagingSetup = {
   channelId: 'C123',
   channelName: '#alerts',
 };
+const selectedFeatures = [ProductSolution.ERROR_MONITORING];
+
+const organization = OrganizationFixture();
+const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
+const createdProject = ProjectFixture({
+  slug: selectedPlatform.key,
+  platform: selectedPlatform.key,
+});
 
 const slackIntegration = OrganizationIntegrationsFixture({
   id: 'slack-1',
@@ -124,25 +140,47 @@ function mockProviderQueries(integrations: OrganizationIntegration[] = []) {
 function renderMessaging(
   onMessagingSetupChange = jest.fn(),
   messagingSetup: ScmMessagingSetup = selectedMessagingSetup,
-  onComplete = jest.fn()
+  onComplete = jest.fn(),
+  onProjectCreated = jest.fn()
 ) {
   return render(
     <ScmMessaging
+      createdProjectSlug={undefined}
       messagingSetup={messagingSetup}
       onMessagingSetupChange={onMessagingSetupChange}
+      onProjectCreated={onProjectCreated}
+      selectedFeatures={selectedFeatures}
       selectedPlatform={selectedPlatform}
+      selectedRepository={undefined}
       onComplete={onComplete}
-    />
+    />,
+    {organization}
   );
 }
 
 describe('ScmMessaging', () => {
   beforeEach(() => {
+    TeamStore.loadInitialData([adminTeam]);
+    ProjectsStore.loadInitialData([]);
     mockProviderQueries();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [adminTeam],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
   });
 
   afterEach(() => {
     cleanup();
+    TeamStore.reset();
+    ProjectsStore.reset();
     MockApiClient.clearMockResponses();
     // Context-backed tests persist onboarding state to session storage, and
     // useSessionStorage prefers a stored value over initialValue.
@@ -205,9 +243,13 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
+          createdProjectSlug={undefined}
           messagingSetup={selectedMessagingSetup}
           onMessagingSetupChange={jest.fn()}
+          onProjectCreated={jest.fn()}
+          selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
+          selectedRepository={undefined}
           onComplete={jest.fn()}
         />
       </QueryClientProvider>
@@ -235,9 +277,13 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
+          createdProjectSlug={undefined}
           messagingSetup={selectedMessagingSetup}
           onMessagingSetupChange={jest.fn()}
+          onProjectCreated={jest.fn()}
+          selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
+          selectedRepository={undefined}
           onComplete={jest.fn()}
         />
       </QueryClientProvider>
@@ -279,9 +325,13 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
+          createdProjectSlug={undefined}
           messagingSetup={selectedMessagingSetup}
           onMessagingSetupChange={jest.fn()}
+          onProjectCreated={jest.fn()}
+          selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
+          selectedRepository={undefined}
           onComplete={jest.fn()}
         />
       </QueryClientProvider>
@@ -409,9 +459,13 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
+          createdProjectSlug={undefined}
           messagingSetup={selectedMessagingSetup}
           onMessagingSetupChange={onMessagingSetupChange}
+          onProjectCreated={jest.fn()}
+          selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
+          selectedRepository={undefined}
           onComplete={jest.fn()}
         />
       </QueryClientProvider>
@@ -441,9 +495,13 @@ describe('ScmMessaging', () => {
             Touch context
           </button>
           <ScmMessaging
+            createdProjectSlug={undefined}
             messagingSetup={messagingSetup}
             onMessagingSetupChange={setMessagingSetup}
+            onProjectCreated={jest.fn()}
+            selectedFeatures={selectedFeatures}
             selectedPlatform={selectedPlatform}
+            selectedRepository={undefined}
             onComplete={jest.fn()}
           />
         </Fragment>
@@ -477,9 +535,13 @@ describe('ScmMessaging', () => {
             New reference
           </button>
           <ScmMessaging
+            createdProjectSlug={undefined}
             messagingSetup={messagingSetup}
             onMessagingSetupChange={setMessagingSetup}
+            onProjectCreated={jest.fn()}
+            selectedFeatures={selectedFeatures}
             selectedPlatform={selectedPlatform}
+            selectedRepository={undefined}
             onComplete={jest.fn()}
           />
         </Fragment>
@@ -561,28 +623,209 @@ describe('ScmMessaging', () => {
     expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
   });
 
-  it('Continue calls onComplete', async () => {
+  it('Continue creates the project and messaging workflow before completing', async () => {
     mockIntegration();
     mockChannelValidate(true);
+    const createProjectRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      body: [IssueStreamDetectorFixture({projectId: createdProject.id})],
+    });
+    const createWorkflowRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: AutomationFixture({id: 'workflow-id'}),
+    });
     const onComplete = jest.fn();
-    renderMessaging(jest.fn(), selectedMessagingSetup, onComplete);
+    const onProjectCreated = jest.fn();
+    renderMessaging(jest.fn(), selectedMessagingSetup, onComplete, onProjectCreated);
 
     // Continue is visible immediately but disabled until revalidation succeeds.
     const continueButton = screen.getByRole('button', {name: 'Continue'});
     await waitFor(() => expect(continueButton).toBeEnabled());
 
     await userEvent.click(continueButton);
-    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
+        product: selectedFeatures,
+      })
+    );
+    expect(createProjectRequest).toHaveBeenCalledWith(
+      `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({
+          name: selectedPlatform.key,
+          platform: selectedPlatform.key,
+          // The selected destination is combined with email into one workflow
+          // below, replacing the server-created email-only default.
+          default_rules: false,
+        }),
+      })
+    );
+    expect(createWorkflowRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/workflows/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({
+          name: 'Send a notification for high priority issues',
+          actionFilters: [
+            expect.objectContaining({
+              actions: [
+                expect.objectContaining({type: 'email'}),
+                expect.objectContaining({
+                  type: 'slack',
+                  integrationId: selectedMessagingSetup.integrationId,
+                  config: expect.objectContaining({
+                    targetDisplay: selectedMessagingSetup.channelName,
+                  }),
+                }),
+              ],
+            }),
+          ],
+        }),
+      })
+    );
+    expect(onProjectCreated).toHaveBeenCalledWith(createdProject.slug);
+    expect(onProjectCreated.mock.invocationCallOrder[0]).toBeLessThan(
+      onComplete.mock.invocationCallOrder[0]!
+    );
   });
 
-  it('Set up later marks setup as skipped and calls onComplete', async () => {
+  it('Set up later creates the email-only project before completing', async () => {
+    const createProjectRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+    const createWorkflowRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: AutomationFixture(),
+    });
     const onMessagingSetupChange = jest.fn();
     const onComplete = jest.fn();
-    renderMessaging(onMessagingSetupChange, {mode: 'unconfigured'}, onComplete);
+    const onProjectCreated = jest.fn();
+    renderMessaging(
+      onMessagingSetupChange,
+      {mode: 'unconfigured'},
+      onComplete,
+      onProjectCreated
+    );
 
     await userEvent.click(screen.getByRole('button', {name: 'Set up later'}));
+
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
+        product: selectedFeatures,
+      })
+    );
     expect(onMessagingSetupChange).toHaveBeenCalledWith({mode: 'skipped'});
-    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(createProjectRequest).toHaveBeenCalledWith(
+      `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({default_rules: true}),
+      })
+    );
+    expect(createWorkflowRequest).not.toHaveBeenCalled();
+    expect(onProjectCreated).toHaveBeenCalledWith(createdProject.slug);
+  });
+
+  it('stays on the step with the destination staged when project creation fails', async () => {
+    mockIntegration();
+    mockChannelValidate(true);
+    const createProjectRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {},
+    });
+    const onMessagingSetupChange = jest.fn();
+    const onComplete = jest.fn();
+    const onProjectCreated = jest.fn();
+    renderMessaging(
+      onMessagingSetupChange,
+      selectedMessagingSetup,
+      onComplete,
+      onProjectCreated
+    );
+
+    const continueButton = await screen.findByRole('button', {name: 'Continue'});
+    await waitFor(() => expect(continueButton).toBeEnabled());
+    await userEvent.click(continueButton);
+
+    await waitFor(() => expect(createProjectRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(continueButton).toBeEnabled());
+    expect(onMessagingSetupChange).not.toHaveBeenCalled();
+    expect(onProjectCreated).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('Set up later keeps the staged destination when project creation fails', async () => {
+    mockIntegration();
+    mockChannelValidate(true);
+    const createProjectRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {},
+    });
+    const onMessagingSetupChange = jest.fn();
+    const onComplete = jest.fn();
+    renderMessaging(onMessagingSetupChange, selectedMessagingSetup, onComplete);
+
+    const setupLaterButton = screen.getByRole('button', {name: 'Set up later'});
+    await waitFor(() => expect(setupLaterButton).toBeEnabled());
+    await userEvent.click(setupLaterButton);
+
+    await waitFor(() => expect(createProjectRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(setupLaterButton).toBeEnabled());
+    // The skip is only recorded on success, so the staged destination (and
+    // with it the Continue button) survives the failure.
+    expect(onMessagingSetupChange).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the project and stays on the step when workflow creation fails', async () => {
+    mockIntegration();
+    mockChannelValidate(true);
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      body: [IssueStreamDetectorFixture({projectId: createdProject.id})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {},
+    });
+    const rollbackRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${createdProject.slug}/`,
+      method: 'DELETE',
+    });
+    const onComplete = jest.fn();
+    const onProjectCreated = jest.fn();
+    renderMessaging(jest.fn(), selectedMessagingSetup, onComplete, onProjectCreated);
+
+    const continueButton = await screen.findByRole('button', {name: 'Continue'});
+    await waitFor(() => expect(continueButton).toBeEnabled());
+    await userEvent.click(continueButton);
+
+    await waitFor(() => expect(rollbackRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(continueButton).toBeEnabled());
+    expect(onProjectCreated).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
   });
 
   it('clears an ineligible destination with an explanation', async () => {
@@ -640,14 +883,24 @@ describe('ScmMessaging', () => {
       });
     }
 
-    function StatefulMessaging({initial}: {initial: ScmMessagingSetup}) {
+    function StatefulMessaging({
+      initial,
+      onComplete = jest.fn(),
+    }: {
+      initial: ScmMessagingSetup;
+      onComplete?: () => void;
+    }) {
       const [setup, setSetup] = useState(initial);
       return (
         <ScmMessaging
+          createdProjectSlug={undefined}
           messagingSetup={setup}
           onMessagingSetupChange={setSetup}
+          onProjectCreated={jest.fn()}
+          selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
-          onComplete={jest.fn()}
+          selectedRepository={undefined}
+          onComplete={onComplete}
         />
       );
     }
@@ -699,7 +952,7 @@ describe('ScmMessaging', () => {
       );
     });
 
-    it('saving a destination from the picker keeps siblings hidden and restores the footer', async () => {
+    it('Confirm and continue keeps siblings hidden and restores the footer when creation fails', async () => {
       mockExclusiveSlackProviders();
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/slack-1/channels/',
@@ -707,8 +960,17 @@ describe('ScmMessaging', () => {
           results: [{id: 'C123', name: 'alerts', display: '#alerts', type: 'channel'}],
         },
       });
+      const createProjectRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        statusCode: 400,
+        body: {},
+      });
+      const onComplete = jest.fn();
 
-      render(<StatefulMessaging initial={{mode: 'unconfigured'}} />);
+      render(
+        <StatefulMessaging initial={{mode: 'unconfigured'}} onComplete={onComplete} />
+      );
 
       expect(await screen.findByText('discord')).toBeInTheDocument();
       await userEvent.click(
@@ -723,16 +985,19 @@ describe('ScmMessaging', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Confirm and continue'}));
 
       // activeRow clears after save; selected setup keeps siblings hidden and
-      // brings the footer back.
+      // brings the footer back. The requested continue fails, so the step
+      // stays with the destination staged and Continue enabled for a retry.
       expect(screen.queryByText('discord')).not.toBeInTheDocument();
       expect(screen.queryByText('msteams')).not.toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Set up later'})).toBeInTheDocument();
+      await waitFor(() => expect(createProjectRequest).toHaveBeenCalledTimes(1));
       await waitFor(() =>
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
       );
+      expect(onComplete).not.toHaveBeenCalled();
     });
 
-    it('Confirm and continue in the picker calls onComplete without a second click', async () => {
+    it('Confirm and continue in the picker creates the project and completes without a second click', async () => {
       mockExclusiveSlackProviders();
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/slack-1/channels/',
@@ -740,15 +1005,24 @@ describe('ScmMessaging', () => {
           results: [{id: 'C123', name: 'alerts', display: '#alerts', type: 'channel'}],
         },
       });
+      MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/`,
+        body: [IssueStreamDetectorFixture({projectId: createdProject.id})],
+      });
+      const createWorkflowRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/workflows/`,
+        method: 'POST',
+        body: AutomationFixture({id: 'workflow-id'}),
+      });
       const onComplete = jest.fn();
 
       render(
-        <ScmMessaging
-          messagingSetup={{mode: 'unconfigured'}}
-          onMessagingSetupChange={jest.fn()}
-          selectedPlatform={selectedPlatform}
-          onComplete={onComplete}
-        />
+        <StatefulMessaging initial={{mode: 'unconfigured'}} onComplete={onComplete} />
       );
 
       // Wait for provider rows to load before interacting.
@@ -760,7 +1034,33 @@ describe('ScmMessaging', () => {
       await selectEvent.select(screen.getByLabelText('channel'), '#alerts');
       await userEvent.click(screen.getByRole('button', {name: 'Confirm and continue'}));
 
+      await waitFor(() =>
+        expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
+          product: selectedFeatures,
+        })
+      );
       expect(onComplete).toHaveBeenCalledTimes(1);
+      // The workflow targets the destination confirmed in the picker, not the
+      // setup this render held when the picker asked to continue.
+      expect(createWorkflowRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/workflows/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            actionFilters: [
+              expect.objectContaining({
+                actions: [
+                  expect.objectContaining({type: 'email'}),
+                  expect.objectContaining({
+                    type: 'slack',
+                    integrationId: 'slack-1',
+                    config: expect.objectContaining({targetDisplay: '#alerts'}),
+                  }),
+                ],
+              }),
+            ],
+          }),
+        })
+      );
     });
 
     it('Cancel from removing keeps siblings hidden and restores the footer', async () => {
@@ -827,9 +1127,13 @@ describe('ScmMessaging', () => {
               Clear destination
             </button>
             <ScmMessaging
+              createdProjectSlug={undefined}
               messagingSetup={setup}
               onMessagingSetupChange={setSetup}
+              onProjectCreated={jest.fn()}
+              selectedFeatures={selectedFeatures}
               selectedPlatform={selectedPlatform}
+              selectedRepository={undefined}
               onComplete={jest.fn()}
             />
           </Fragment>

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useCallback, useEffect, useEffectEvent, useState} from 'react';
 import {AnimatePresence, LayoutGroup, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -7,22 +7,34 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {ScmMessagingProviderKey} from 'sentry/components/onboarding/scm/messagingProviders';
 import {ScmMessagingProviderRow} from 'sentry/components/onboarding/scm/scmMessagingProviderRow';
 import type {
   ScmMessagingActiveRow,
   ScmMessagingSetup,
 } from 'sentry/components/onboarding/scm/scmMessagingSetup';
+import {DEFAULT_SCM_FEATURES} from 'sentry/components/onboarding/scm/scmPlatformHelpers';
 import {useScmMessagingProviders} from 'sentry/components/onboarding/scm/useScmMessagingProviders';
 import {
   isEligibleForIssueAlerts,
   isIntegrationActive,
   useScmMessagingSetupValidation,
 } from 'sentry/components/onboarding/scm/useScmMessagingSetupValidation';
+import {useScmProjectCreation} from 'sentry/components/onboarding/scm/useScmProjectCreation';
 import {IconMail} from 'sentry/icons/iconMail';
 import {t} from 'sentry/locale';
+import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
+import {
+  buildIntegrationAction,
+  providerDetails,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import {
+  getRequestDataFragment,
+  type RequestDataFragment,
+} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import type {StepProps} from './types';
 
@@ -35,20 +47,38 @@ export const SCM_MESSAGING_TITLE = t('Get alerts where your team works');
 type MessagingProviderList = ReturnType<typeof useScmMessagingProviders>['providers'];
 
 interface ScmMessagingProps {
+  createdProjectSlug: string | undefined;
   messagingSetup: ScmMessagingSetup;
   onComplete: StepProps['onComplete'];
   onMessagingSetupChange: (messagingSetup: ScmMessagingSetup) => void;
+  onProjectCreated: (slug: string) => void;
+  selectedFeatures: ProductSolution[] | undefined;
   selectedPlatform: OnboardingSelectedSDK;
+  selectedRepository: Repository | undefined;
   genBackButton?: StepProps['genBackButton'];
 }
 
 export function ScmMessaging({
+  createdProjectSlug,
   genBackButton,
   messagingSetup,
   onMessagingSetupChange,
+  onProjectCreated,
   onComplete,
+  selectedFeatures,
   selectedPlatform,
+  selectedRepository,
 }: ScmMessagingProps) {
+  const {createOrReuseProject, isCreating, isDataPending} = useScmProjectCreation({
+    createdProjectSlug,
+    onProjectCreated,
+    selectedRepository,
+  });
+  const [submissionMode, setSubmissionMode] = useState<'continue' | 'setup-later'>();
+  // Confirm and continue in the picker saves the destination and asks to
+  // continue in the same tick, before this render has the new setup or its
+  // revalidation. The request waits until Continue itself would be enabled.
+  const [continueRequested, setContinueRequested] = useState(false);
   const validation = useScmMessagingSetupValidation({
     messagingSetup,
     onMessagingSetupChange,
@@ -67,18 +97,76 @@ export function ScmMessaging({
 
   const validatedActiveRow = validateActiveRow(activeRow, providers, messagingSetup);
   const visibleProviders = listedProviders(providers, validatedActiveRow, messagingSetup);
+  const getIntegrationAction = useCallback(
+    ({shouldCreateRule}: Partial<RequestDataFragment>) => {
+      if (!shouldCreateRule || messagingSetup.mode !== 'selected') {
+        return;
+      }
 
-  // Continue creates the project and alert rules. It renders as soon as a
-  // destination is selected so Set up later does not shift, but stays disabled
-  // until the destination is conclusively revalidated.
-  const canContinue = validation.isValid;
+      const channelTargetedBy =
+        providerDetails[messagingSetup.providerKey].channelTargetedBy;
+      return buildIntegrationAction({
+        provider: messagingSetup.providerKey,
+        integrationId: messagingSetup.integrationId,
+        channel: messagingSetup[channelTargetedBy],
+      });
+    },
+    [messagingSetup]
+  );
+
+  const isSubmitting = isCreating || submissionMode !== undefined;
+
+  // Continue creates the project and alert rules, so it must wait for a
+  // conclusively revalidated destination — not merely the absence of a
+  // problem, which is briefly true before the stale-check effect runs.
+  const canContinue = validation.isValid && !isDataPending && !isSubmitting;
   const showContinue = messagingSetup.mode === 'selected';
 
-  const handleContinue = () => onComplete();
+  const submitProject = async ({
+    includeMessagingRule,
+  }: {
+    includeMessagingRule: boolean;
+  }) => {
+    await createOrReuseProject({
+      platform: selectedPlatform,
+      alertRuleConfig: includeMessagingRule
+        ? getRequestDataFragment()
+        : {defaultRules: true},
+      getIntegrationAction: includeMessagingRule ? getIntegrationAction : undefined,
+      onSuccess: () => {
+        // Record the skip only on success: a failed creation keeps the staged
+        // destination (and the Continue button) intact on the step.
+        if (!includeMessagingRule) {
+          onMessagingSetupChange({mode: 'skipped'});
+        }
+        onComplete(selectedPlatform, {
+          product: selectedFeatures ?? DEFAULT_SCM_FEATURES,
+        });
+      },
+    });
+  };
 
-  const handleSetupLater = () => {
-    onMessagingSetupChange({mode: 'skipped'});
-    onComplete();
+  const handleContinue = async () => {
+    if (messagingSetup.mode !== 'selected' || !canContinue) {
+      return;
+    }
+
+    setSubmissionMode('continue');
+    try {
+      await submitProject({includeMessagingRule: true});
+    } finally {
+      setSubmissionMode(undefined);
+    }
+  };
+
+  const handleSetupLater = async () => {
+    setContinueRequested(false);
+    setSubmissionMode('setup-later');
+    try {
+      await submitProject({includeMessagingRule: false});
+    } finally {
+      setSubmissionMode(undefined);
+    }
   };
 
   const handleInstallComplete = async (providerKey: ScmMessagingProviderKey) => {
@@ -98,6 +186,37 @@ export function ScmMessaging({
   };
 
   const hasValidationAlert = !!validation.staleReason || validation.isError;
+
+  const requestContinue = useCallback(() => setContinueRequested(true), []);
+  const continueWhenReady = useEffectEvent(() => {
+    setContinueRequested(false);
+    handleContinue();
+  });
+
+  useEffect(() => {
+    if (!continueRequested) {
+      return;
+    }
+    if (messagingSetup.mode !== 'selected') {
+      setContinueRequested(false);
+      return;
+    }
+    if (canContinue) {
+      continueWhenReady();
+      return;
+    }
+    // Revalidation rejected the destination: keep the warning and the footer
+    // rather than continuing later with whatever is chosen next.
+    if (!validation.isPending && hasValidationAlert) {
+      setContinueRequested(false);
+    }
+  }, [
+    canContinue,
+    continueRequested,
+    hasValidationAlert,
+    messagingSetup.mode,
+    validation.isPending,
+  ]);
 
   return (
     // The onboarding flow has no page-level query container (project creation
@@ -211,7 +330,7 @@ export function ScmMessaging({
                     activeRow={validatedActiveRow}
                     onActiveRowChange={setActiveRow}
                     isRefetchingIntegrations={isRefetchingIntegrations}
-                    onContinue={handleContinue}
+                    onContinue={requestContinue}
                   />
                 ))}
               </MotionStack>
@@ -233,6 +352,8 @@ export function ScmMessaging({
                   variant="secondary"
                   analyticsEventKey="onboarding.scm_messaging_setup_later_clicked"
                   analyticsEventName="Onboarding: SCM Messaging Setup Later Clicked"
+                  busy={submissionMode === 'setup-later'}
+                  disabled={isDataPending || isSubmitting}
                   onClick={handleSetupLater}
                 >
                   {t('Set up later')}
@@ -241,9 +362,10 @@ export function ScmMessaging({
                   <Button
                     size="sm"
                     variant="primary"
-                    disabled={!canContinue}
                     analyticsEventKey="onboarding.scm_messaging_continue_clicked"
                     analyticsEventName="Onboarding: SCM Messaging Continue Clicked"
+                    busy={submissionMode === 'continue'}
+                    disabled={!canContinue}
                     onClick={handleContinue}
                   >
                     {t('Continue')}

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -16,6 +16,7 @@ import {
 import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
+  buildIntegrationAction,
   buildNotificationSelection,
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
@@ -23,6 +24,53 @@ import {
   useCreateNotificationAction,
   useScmNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+
+describe('buildIntegrationAction', () => {
+  it.each([
+    [
+      'slack',
+      '#alerts',
+      {
+        id: IssueAlertActionType.SLACK,
+        workspace: '15',
+        channel: '#alerts',
+      },
+    ],
+    [
+      'discord',
+      '123456789',
+      {
+        id: IssueAlertActionType.DISCORD,
+        server: '15',
+        channel_id: '123456789',
+      },
+    ],
+    [
+      'msteams',
+      '19:abc@thread.tacv2',
+      {
+        id: IssueAlertActionType.MS_TEAMS,
+        team: '15',
+        channel: '19:abc@thread.tacv2',
+      },
+    ],
+  ])('serializes a %s destination', (provider, channel, expectedAction) => {
+    expect(buildIntegrationAction({provider, integrationId: '15', channel})).toEqual(
+      expectedAction
+    );
+  });
+
+  it('returns undefined for an incomplete or unsupported selection', () => {
+    expect(buildIntegrationAction({provider: 'slack'})).toBeUndefined();
+    expect(
+      buildIntegrationAction({
+        provider: 'unsupported',
+        integrationId: '15',
+        channel: '#alerts',
+      })
+    ).toBeUndefined();
+  });
+});
 
 describe('MessagingIntegrationAlertRule', () => {
   const organization = OrganizationFixture();

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -339,7 +339,9 @@ function useNotificationPicker(resolveRestore: RestoreResolver) {
         // MS Teams is resolved by channel name on the backend, while the
         // picker keys it by id.
         channel:
-          provider === 'msteams' ? (channel?.channelName ?? channel?.value) : channel?.value,
+          provider === 'msteams'
+            ? (channel?.channelName ?? channel?.value)
+            : channel?.value,
       });
       if (!integrationAction) {
         return;

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -147,46 +147,49 @@ export type IssueAlertNotificationProps = {
   channel?: IntegrationChannel;
 };
 
-/**
- * Builds the serializable IntegrationAction for the current messaging
- * selection. Returns undefined if the provider is unrecognised or unset.
- */
-function buildIntegrationAction({
-  provider,
-  integration,
-  channel,
-}: Pick<IssueAlertNotificationProps, 'provider' | 'integration' | 'channel'>):
-  | IntegrationAction
-  | undefined {
-  switch (provider) {
-    case 'slack':
-      return {
-        id: IssueAlertActionType.SLACK,
-        workspace: integration?.id,
-        channel: channel?.value,
-      };
-    case 'discord':
-      return {
-        id: IssueAlertActionType.DISCORD,
-        server: integration?.id,
-        channel_id: channel?.value,
-      };
-    case 'msteams':
-      return {
-        id: IssueAlertActionType.MS_TEAMS,
-        team: integration?.id,
-        channel: channel?.channelName ?? channel?.value,
-      };
-    default:
-      return undefined;
-  }
-}
-
 export type NotificationSelection = {
   channel: string;
   integrationId: string;
   provider: string;
 };
+
+/**
+ * Builds the serializable IntegrationAction for a messaging selection.
+ * Returns undefined if any required selection field is absent or the provider
+ * is not recognized.
+ */
+export function buildIntegrationAction({
+  provider,
+  integrationId,
+  channel,
+}: Partial<NotificationSelection>): IntegrationAction | undefined {
+  if (!provider || !integrationId || !channel) {
+    return undefined;
+  }
+
+  switch (provider) {
+    case 'slack':
+      return {
+        id: IssueAlertActionType.SLACK,
+        workspace: integrationId,
+        channel,
+      };
+    case 'discord':
+      return {
+        id: IssueAlertActionType.DISCORD,
+        server: integrationId,
+        channel_id: channel,
+      };
+    case 'msteams':
+      return {
+        id: IssueAlertActionType.MS_TEAMS,
+        team: integrationId,
+        channel,
+      };
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Builds the raw {provider, integrationId, channel} snapshot of the current
@@ -330,7 +333,14 @@ function useNotificationPicker(resolveRestore: RestoreResolver) {
         return;
       }
 
-      const integrationAction = buildIntegrationAction({provider, integration, channel});
+      const integrationAction = buildIntegrationAction({
+        provider,
+        integrationId: integration?.id,
+        // MS Teams is resolved by channel name on the backend, while the
+        // picker keys it by id.
+        channel:
+          provider === 'msteams' ? (channel?.channelName ?? channel?.value) : channel?.value,
+      });
       if (!integrationAction) {
         return;
       }


### PR DESCRIPTION
The SCM messaging treatment now creates its project at the final Continue or Set up later boundary instead of the platform and feature step. Continue creates the project with a single high-priority workflow that notifies email and the selected Slack, Discord, or Microsoft Teams destination. Set up later creates the project with the server default email-only workflow. Both paths use the shared duplicate-submit guard, rollback on workflow failure, best-effort repository linking, project-slug persistence, and selected-product handoff to SDK setup.

Project creation moved from the deprecated /rules/ endpoint to the workflow engine in #123074. The messaging step supplies its destination through that PR's getIntegrationAction contract, so the combined email and destination workflow is built in one place.

Confirm and continue in the channel picker saves the destination and asks to continue in the same tick, before the step has the new setup or its revalidation. The step records the request and creates the project once Continue itself would be enabled. It drops the request when the destination leaves the selected state, when revalidation rejects it, or when Set up later is chosen instead.

Bottom of a five-PR stack. On a return to this step, project reuse checks only the platform, so a changed destination is dropped. #122802 records the destination the project was created for and creates a new project when it changes. #123602, #123621 and #123622 fix the Microsoft Teams channel target, channel list and channel picker.

VDY-145 will add permission checks before creation and user-visible recovery if workflow creation and project cleanup both fail.

Refs VDY-141
