### PR TITLE
fix(autofix): Don't offer PR iteration after a failed PR create

### DIFF
--- a/static/app/components/events/autofix/getAutofixNextStep.ts
+++ b/static/app/components/events/autofix/getAutofixNextStep.ts
@@ -1,5 +1,8 @@
+import {isCreatedPullRequestState} from 'sentry/components/events/autofix/pullRequests';
 import {
+  getAutofixArtifactFromSection,
   isCodeChangesSection,
+  isPullRequestsArtifact,
   isPullRequestsSection,
   isRootCauseSection,
   isSolutionSection,
@@ -35,6 +38,10 @@ export function getAutofixNextStep({
   }
 
   if (isPullRequestsSection(section)) {
+    const artifact = getAutofixArtifactFromSection(section);
+    if (isPullRequestsArtifact(artifact) && !artifact.some(isCreatedPullRequestState)) {
+      return getAutofixNextStep({sections: sections.slice(0, -1)});
+    }
     return {action: 'pr_iteration', section};
   }
 

--- a/static/app/components/events/autofix/getAutofixNextStep.ts
+++ b/static/app/components/events/autofix/getAutofixNextStep.ts
@@ -40,7 +40,7 @@ export function getAutofixNextStep({
   if (isPullRequestsSection(section)) {
     const artifact = getAutofixArtifactFromSection(section);
     if (isPullRequestsArtifact(artifact) && !artifact.some(isCreatedPullRequestState)) {
-      return getAutofixNextStep({sections: sections.slice(0, -1)});
+      return null;
     }
     return {action: 'pr_iteration', section};
   }

--- a/static/app/components/events/autofix/pullRequests.spec.ts
+++ b/static/app/components/events/autofix/pullRequests.spec.ts
@@ -1,6 +1,8 @@
 import {
   getCodingAgentResultLink,
   getRepoPullRequestLink,
+  hasCreatedPullRequests,
+  isCreatedPullRequestState,
 } from 'sentry/components/events/autofix/pullRequests';
 import type {
   ExplorerCodingAgentState,
@@ -63,6 +65,46 @@ describe('getCodingAgentResultLink', () => {
 
   it('returns null when the agent reported no URL', () => {
     expect(getCodingAgentResultLink(makeResult())).toBeNull();
+  });
+});
+
+describe('isCreatedPullRequestState', () => {
+  it('is false for a failed create with no PR number', () => {
+    expect(
+      isCreatedPullRequestState(
+        makeRepoPRState({
+          pr_creation_status: 'error',
+          pr_number: null,
+          pr_url: null,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('is true for an errored push onto an already-open PR', () => {
+    expect(
+      isCreatedPullRequestState(makeRepoPRState({pr_creation_status: 'error'}))
+    ).toBe(true);
+  });
+
+  it('is true while creation is in flight', () => {
+    expect(
+      isCreatedPullRequestState(makeRepoPRState({pr_creation_status: 'creating'}))
+    ).toBe(true);
+  });
+});
+
+describe('hasCreatedPullRequests', () => {
+  it('ignores a failed create', () => {
+    expect(
+      hasCreatedPullRequests({
+        'org/repo': makeRepoPRState({
+          pr_creation_status: 'error',
+          pr_number: null,
+          pr_url: null,
+        }),
+      })
+    ).toBe(false);
   });
 });
 

--- a/static/app/components/events/autofix/pullRequests.ts
+++ b/static/app/components/events/autofix/pullRequests.ts
@@ -21,6 +21,24 @@ interface AutofixResultLink {
   url: string;
 }
 
+/**
+ * Whether this repo actually got a pull request onto GitHub.
+ *
+ * `repo_pr_states` also holds failed creates (error, no `pr_number`). Those
+ * are not PRs — treating them as such swaps "retry code changes" for the
+ * iteration form and 400s the submit. Matches
+ * `SeerRunState.get_created_pull_request_states`.
+ */
+export function isCreatedPullRequestState(state: RepoPRState): boolean {
+  return state.pr_creation_status !== 'error' || state.pr_number !== null;
+}
+
+export function hasCreatedPullRequests(
+  repoPrStates: Record<string, RepoPRState> | null | undefined
+): boolean {
+  return Object.values(repoPrStates ?? {}).some(isCreatedPullRequestState);
+}
+
 /** The PR Seer opened for this repo, or null if there isn't a finished one. */
 export function getRepoPullRequestLink(state: RepoPRState): AutofixResultLink | null {
   if (

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -748,6 +748,50 @@ describe('ArtifactCard', () => {
       });
     });
 
+    it('opens the code-changes reset prompt when PR creation failed', async () => {
+      const startStepMock = jest.fn();
+      const autofixWithFailedPR: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofixWithRunState,
+        startStep: startStepMock,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {
+            'org/repo': makePR({
+              pr_creation_status: 'error',
+              pr_number: null,
+              pr_url: null,
+            }),
+          },
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithFailedPR}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [],
+            [makeAssistantBlock('The relevant files are not in the connected repo.')]
+          )}
+        />,
+        {organization: manualPrIterationOrganization}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
+
+      expect(
+        screen.getByText('What additional context should Seer use?')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Anything else you want to see on your PR?')
+      ).not.toBeInTheDocument();
+    });
+
     it('ignores a requested context prompt when reset is ineligible', () => {
       const autofixWithPR: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofixWithRunState,

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -748,7 +748,7 @@ describe('ArtifactCard', () => {
       });
     });
 
-    it('opens the code-changes reset prompt when PR creation failed', async () => {
+    it('does not offer a code-changes reset when PR creation failed', () => {
       const startStepMock = jest.fn();
       const autofixWithFailedPR: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofixWithRunState,
@@ -782,11 +782,7 @@ describe('ArtifactCard', () => {
         {organization: manualPrIterationOrganization}
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Add context & retry'}));
-
-      expect(
-        screen.getByText('What additional context should Seer use?')
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Add context & retry'})).toBeDisabled();
       expect(
         screen.queryByText('Anything else you want to see on your PR?')
       ).not.toBeInTheDocument();

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -106,14 +106,18 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     [artifact]
   );
 
-  const hasPRs = hasCreatedPullRequests(autofix.runState?.repo_pr_states);
+  const hasPRs = Object.keys(autofix.runState?.repo_pr_states ?? {}).length > 0;
+  const hasFailedOnlyPRs =
+    hasPRs && !hasCreatedPullRequests(autofix.runState?.repo_pr_states);
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
   // Reset-after-PR is only reachable where reset opens the manual form.
-  const isResetEligible = hasManualPrIterationFeature
-    ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
-    : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
+  const isResetEligible =
+    !hasFailedOnlyPRs &&
+    (hasManualPrIterationFeature
+      ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
+      : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing');
 
   const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
     useResetAutofixStep({

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -7,6 +7,7 @@ import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
+import {hasCreatedPullRequests} from 'sentry/components/events/autofix/pullRequests';
 import {
   collectPatches,
   getAutofixArtifactFromSection,
@@ -105,7 +106,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     [artifact]
   );
 
-  const hasPRs = Object.keys(autofix.runState?.repo_pr_states ?? {}).length > 0;
+  const hasPRs = hasCreatedPullRequests(autofix.runState?.repo_pr_states);
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -930,11 +930,7 @@ describe('SeerDrawerNextStep', () => {
       jest.mocked(trackAnalytics).mockClear();
     });
 
-    it('does not show the feedback form when PR creation failed', async () => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/issues/1/autofix/repos/',
-        body: {repos: [{has_write_access: true}]},
-      });
+    it('does not show a next step when PR creation failed', () => {
       const autofix = makePrIterationAutofix({
         runState: {
           run_id: 1,
@@ -956,7 +952,7 @@ describe('SeerDrawerNextStep', () => {
           },
         } as any,
       });
-      render(
+      const {container} = render(
         <SeerDrawerNextStep
           group={GroupFixture()}
           sections={[makeSection('code_changes'), makeSection('pull_request')]}
@@ -964,12 +960,7 @@ describe('SeerDrawerNextStep', () => {
         />,
         {organization: prIterationOrganization}
       );
-      expect(
-        screen.queryByText('Anything else you want to see on your PR?')
-      ).not.toBeInTheDocument();
-      expect(
-        await screen.findByText('Are you happy with these code changes?')
-      ).toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
     });
 
     it('returns null when the run is not valid for PR iteration', () => {

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -930,6 +930,48 @@ describe('SeerDrawerNextStep', () => {
       jest.mocked(trackAnalytics).mockClear();
     });
 
+    it('does not show the feedback form when PR creation failed', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/1/autofix/repos/',
+        body: {repos: [{has_write_access: true}]},
+      });
+      const autofix = makePrIterationAutofix({
+        runState: {
+          run_id: 1,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {
+            'org/repo': {
+              repo_name: 'org/repo',
+              branch_name: null,
+              commit_sha: null,
+              pr_creation_error: 'Failed to create pull request',
+              pr_creation_status: 'error',
+              pr_id: null,
+              pr_number: null,
+              pr_url: null,
+              title: null,
+            },
+          },
+        } as any,
+      });
+      render(
+        <SeerDrawerNextStep
+          group={GroupFixture()}
+          sections={[makeSection('code_changes'), makeSection('pull_request')]}
+          autofix={autofix}
+        />,
+        {organization: prIterationOrganization}
+      );
+      expect(
+        screen.queryByText('Anything else you want to see on your PR?')
+      ).not.toBeInTheDocument();
+      expect(
+        await screen.findByText('Are you happy with these code changes?')
+      ).toBeInTheDocument();
+    });
+
     it('returns null when the run is not valid for PR iteration', () => {
       const autofix = makeAutofix({
         runState: {run_id: 1, blocks: []} as any,

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -9,6 +9,7 @@ import {TextArea} from '@sentry/scraps/textarea';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
+import {hasCreatedPullRequests} from 'sentry/components/events/autofix/pullRequests';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {
   type PermissionsTarget,
@@ -45,7 +46,17 @@ interface SeerDrawerNextStepProps {
 
 export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextStepProps) {
   const runId = getAutofixRunId(autofix.runState);
-  const section = sections[sections.length - 1];
+  const lastSection = sections[sections.length - 1];
+  const repoPrStates = autofix.runState?.repo_pr_states;
+  // A failed create still appends a pull_request section (Retry PR). That is
+  // not a PR — skip it so we don't offer iteration feedback.
+  const failedCreateOnly =
+    defined(lastSection) &&
+    isPullRequestsSection(lastSection) &&
+    defined(repoPrStates) &&
+    Object.keys(repoPrStates).length > 0 &&
+    !hasCreatedPullRequests(repoPrStates);
+  const section = failedCreateOnly ? sections[sections.length - 2] : lastSection;
   const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
   if (!defined(runId) || !defined(section)) {

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -46,20 +46,22 @@ interface SeerDrawerNextStepProps {
 
 export function SeerDrawerNextStep({sections, group, autofix}: SeerDrawerNextStepProps) {
   const runId = getAutofixRunId(autofix.runState);
-  const lastSection = sections[sections.length - 1];
-  const repoPrStates = autofix.runState?.repo_pr_states;
-  // A failed create still appends a pull_request section (Retry PR). That is
-  // not a PR — skip it so we don't offer iteration feedback.
-  const failedCreateOnly =
-    defined(lastSection) &&
-    isPullRequestsSection(lastSection) &&
-    defined(repoPrStates) &&
-    Object.keys(repoPrStates).length > 0 &&
-    !hasCreatedPullRequests(repoPrStates);
-  const section = failedCreateOnly ? sections[sections.length - 2] : lastSection;
+  const section = sections[sections.length - 1];
   const referrer = autofix.runState?.blocks?.[0]?.message?.metadata?.referrer;
 
   if (!defined(runId) || !defined(section)) {
+    return null;
+  }
+
+  // Failed create still renders the PR card (Retry PR). That is the next
+  // action — don't offer iteration feedback or "draft a PR" again.
+  const repoPrStates = autofix.runState?.repo_pr_states;
+  if (
+    isPullRequestsSection(section) &&
+    defined(repoPrStates) &&
+    Object.keys(repoPrStates).length > 0 &&
+    !hasCreatedPullRequests(repoPrStates)
+  ) {
     return null;
   }
 

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -107,7 +107,7 @@ describe('useResetAutofixStep', () => {
       expect(result.current.canReset).toBe(false);
     });
 
-    it('returns true when PR creation failed without opening a PR', () => {
+    it('returns false when a PR create failed without opening a PR', () => {
       const autofix = makeAutofix({
         runState: {
           run_id: 1,
@@ -135,7 +135,7 @@ describe('useResetAutofixStep', () => {
         useResetAutofixStep({autofix, section: makeSection(), step: 'code_changes'})
       );
 
-      expect(result.current.canReset).toBe(true);
+      expect(result.current.canReset).toBe(false);
     });
 
     it('uses the canReset override when provided', () => {

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -107,6 +107,37 @@ describe('useResetAutofixStep', () => {
       expect(result.current.canReset).toBe(false);
     });
 
+    it('returns true when PR creation failed without opening a PR', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+          repo_pr_states: {
+            'repo-1': {
+              repo_name: 'repo-1',
+              branch_name: null,
+              commit_sha: null,
+              pr_creation_error: 'Failed to create pull request',
+              pr_creation_status: 'error',
+              pr_id: null,
+              pr_number: null,
+              pr_url: null,
+              title: null,
+            },
+          },
+          coding_agents: {},
+        },
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'code_changes'})
+      );
+
+      expect(result.current.canReset).toBe(true);
+    });
+
     it('uses the canReset override when provided', () => {
       const autofix = makeAutofix({
         runState: {

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -2,6 +2,7 @@ import {useMemo, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
+import {hasCreatedPullRequests} from 'sentry/components/events/autofix/pullRequests';
 import {
   type AutofixExplorerStep,
   type AutofixSection,
@@ -29,7 +30,7 @@ export function useResetAutofixStep({
   const {runState, startStep} = autofix;
   const runId = getAutofixRunId(runState);
   const notProcessing = autofix.runState?.status !== 'processing';
-  const noPRs = Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0;
+  const noPRs = !hasCreatedPullRequests(autofix.runState?.repo_pr_states);
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
   const defaultCanReset = notProcessing && noPRs && noCodingAgents;

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -2,7 +2,6 @@ import {useMemo, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
-import {hasCreatedPullRequests} from 'sentry/components/events/autofix/pullRequests';
 import {
   type AutofixExplorerStep,
   type AutofixSection,
@@ -30,7 +29,7 @@ export function useResetAutofixStep({
   const {runState, startStep} = autofix;
   const runId = getAutofixRunId(runState);
   const notProcessing = autofix.runState?.status !== 'processing';
-  const noPRs = !hasCreatedPullRequests(autofix.runState?.repo_pr_states);
+  const noPRs = Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0;
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
   const defaultCanReset = notProcessing && noPRs && noCodingAgents;


### PR DESCRIPTION
When creating a PR fails, seer still records the attempt in `repo_pr_states`
with `pr_creation_status: "error"` and no `pr_number`. The UI counted that as
an existing PR, so the drawer offered the PR iteration form as the next step —
and submitting it 400s, because the API refuses to iterate before a PR exists
(`SeerRunState.get_created_pull_request_states`).
