### PR TITLE
fix(dashboards): Enforce widget minimum height on create

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -29,6 +29,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetTypes,
     DatasetSourcesTypes,
     get_max_widget_limit,
+    get_min_widget_height,
 )
 from sentry.models.project import Project
 from sentry.models.team import Team
@@ -182,11 +183,11 @@ DATASET_CONFIG: dict[int, DatasetConfig] = {
 }
 
 
-class WidgetLayoutSerializer(CamelSnakeSerializer[Dashboard]):
+class BaseWidgetLayoutSerializer(CamelSnakeSerializer[Dashboard]):
     """Widget grid layout position and dimensions.
 
-    The dashboard uses a 6-column grid. Required keys: x, y, w, h, minH.
-    Constraints: x (0-5), y (>= 0), w (1-6), h (>= 1), minH (>= 1), and x + w <= 6.
+    The dashboard uses a 6-column grid. Required keys: x, y, w, h.
+    Constraints: x (0-5), y (>= 0), w (1-6), h (>= 1), and x + w <= 6.
     """
 
     x = serializers.IntegerField(
@@ -197,12 +198,19 @@ class WidgetLayoutSerializer(CamelSnakeSerializer[Dashboard]):
         min_value=1, max_value=MAX_WIDGET_COLS, help_text="Width in grid columns (1-6)."
     )
     h = serializers.IntegerField(min_value=1, help_text="Height in grid rows.")
-    min_h = serializers.IntegerField(min_value=1, help_text="Minimum height in grid rows.")
 
     def validate(self, data):
         if data["x"] + data["w"] > MAX_WIDGET_COLS:
             raise serializers.ValidationError(f"x + w must not exceed {MAX_WIDGET_COLS}")
         return convert_dict_key_case(data, snake_to_camel_case)
+
+
+class WidgetLayoutSerializer(BaseWidgetLayoutSerializer):
+    min_h = serializers.IntegerField(min_value=1, help_text="Minimum height in grid rows.")
+
+
+class DashboardCreateWidgetLayoutSerializer(BaseWidgetLayoutSerializer):
+    pass
 
 
 class DashboardWidgetQueryOnDemandSerializer(CamelSnakeSerializer[Dashboard]):
@@ -1451,7 +1459,35 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         DashboardWidgetQuery.objects.filter(widget_id=widget_id).exclude(id__in=keep_ids).delete()
 
 
+class DashboardCreateWidgetSerializer(DashboardWidgetSerializer):
+    layout = DashboardCreateWidgetLayoutSerializer(required=False, allow_null=True)
+
+    def validate(self, data):
+        data = super().validate(data)
+        layout = data.get("layout")
+        display_type = data.get("display_type")
+        if layout is None or display_type is None:
+            return data
+
+        min_height = get_min_widget_height(display_type)
+        if layout["h"] < min_height:
+            display_type_name = DashboardWidgetDisplayTypes.get_type_name(display_type)
+            raise serializers.ValidationError(
+                {
+                    "layout": {
+                        "h": f"Height must be at least {min_height} for {display_type_name} widgets."
+                    }
+                }
+            )
+
+        layout["minH"] = min_height
+        return data
+
+
 class DashboardSerializer(DashboardDetailsSerializer):
+    widgets = DashboardCreateWidgetSerializer(
+        many=True, required=False, help_text="A json list of widgets saved in this dashboard."
+    )
     title = serializers.CharField(
         required=True, max_length=255, help_text="The user defined title for this dashboard."
     )

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -206,11 +206,21 @@ class BaseWidgetLayoutSerializer(CamelSnakeSerializer[Dashboard]):
 
 
 class WidgetLayoutSerializer(BaseWidgetLayoutSerializer):
+    """Widget grid layout position and dimensions.
+
+    The dashboard uses a 6-column grid. Required keys: x, y, w, h, minH.
+    Constraints: x (0-5), y (>= 0), w (1-6), h (>= 1), minH (>= 1), and x + w <= 6.
+    """
+
     min_h = serializers.IntegerField(min_value=1, help_text="Minimum height in grid rows.")
 
 
 class DashboardCreateWidgetLayoutSerializer(BaseWidgetLayoutSerializer):
-    pass
+    """Widget grid layout position and dimensions for dashboard creation.
+
+    The dashboard uses a 6-column grid. Required keys: x, y, w, h.
+    Constraints: x (0-5), y (>= 0), w (1-6), h (>= 1), and x + w <= 6.
+    """
 
 
 class DashboardWidgetQueryOnDemandSerializer(CamelSnakeSerializer[Dashboard]):
@@ -406,7 +416,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         choices=DashboardWidgetTypes.as_text_choices(), required=False, allow_null=True
     )
     limit = serializers.IntegerField(min_value=1, required=False, allow_null=True)
-    layout = WidgetLayoutSerializer(required=False, allow_null=True)
+    layout: BaseWidgetLayoutSerializer = WidgetLayoutSerializer(required=False, allow_null=True)
     axis_range = serializers.ChoiceField(
         choices=[("auto", "auto"), ("dataMin", "dataMin")],
         required=False,
@@ -1460,7 +1470,9 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
 
 class DashboardCreateWidgetSerializer(DashboardWidgetSerializer):
-    layout = DashboardCreateWidgetLayoutSerializer(required=False, allow_null=True)
+    layout: BaseWidgetLayoutSerializer = DashboardCreateWidgetLayoutSerializer(
+        required=False, allow_null=True
+    )
 
     def validate(self, data):
         data = super().validate(data)

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -9,6 +9,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetDisplayTypes,
     DashboardWidgetTypes,
     get_max_widget_limit,
+    get_min_widget_height,
 )
 
 GRID_WIDTH = 6
@@ -275,6 +276,22 @@ class GeneratedWidget(BaseModel):
             raise ValueError(
                 f"limit={limit} exceeds the maximum of {max_limit} for display_type '{display_type}'"
             )
+        return values
+
+    @root_validator
+    def check_height_by_display_type(cls, values: dict[str, Any]) -> dict[str, Any]:
+        display_type = values.get("display_type")
+        layout = values.get("layout")
+        if display_type is None or layout is None:
+            return values
+
+        min_height = get_min_widget_height(
+            DashboardWidgetDisplayTypes.get_id_for_type_name(display_type)
+        )
+        if layout.h < min_height:
+            raise ValueError(f"Height must be at least {min_height} for {display_type} widgets.")
+
+        layout.min_h = min_height
         return values
 
     @root_validator

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -206,6 +206,20 @@ class DashboardWidgetDisplayTypes(TypesClass):
     TYPE_NAMES = [t[1] for t in TYPES]
 
 
+SHORT_WIDGET_DISPLAY_TYPES = frozenset(
+    {
+        DashboardWidgetDisplayTypes.BIG_NUMBER,
+        DashboardWidgetDisplayTypes.DETAILS,
+        DashboardWidgetDisplayTypes.TEXT,
+    }
+)
+DEFAULT_WIDGET_MIN_HEIGHT = 2
+
+
+def get_min_widget_height(display_type_id: int) -> int:
+    return 1 if display_type_id in SHORT_WIDGET_DISPLAY_TYPES else DEFAULT_WIDGET_MIN_HEIGHT
+
+
 DEFAULT_MAX_WIDGET_LIMIT = 10
 MAX_WIDGET_LIMIT_BY_DISPLAY_TYPE: dict[int, int] = {
     DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART: 25,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -2268,6 +2268,18 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         for widget in widgets:
             assert widget["layout"] == layouts[int(widget["id"])]
 
+    def test_update_widget_layout_allows_height_below_minimum(self) -> None:
+        layout = {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 2}
+
+        response = self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={"widgets": [{"id": self.widget_1.id, "layout": layout}]},
+        )
+
+        assert response.status_code == 200, response.data
+        assert response.data["widgets"][0]["layout"] == layout
+
     def test_update_layout_with_invalid_data_fails(self) -> None:
         response = self.do_request(
             "put",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -1068,7 +1068,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                             "conditions": "event.type:transaction",
                         }
                     ],
-                    "layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2},
+                    "layout": {"x": 0, "y": 0, "w": 1, "h": 2, "minH": 2},
                 },
                 {
                     "displayType": "bar",
@@ -1083,7 +1083,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                             "conditions": "event.type:error",
                         }
                     ],
-                    "layout": {"x": 1, "y": 0, "w": 1, "h": 1, "minH": 2},
+                    "layout": {"x": 1, "y": 0, "w": 1, "h": 2, "minH": 2},
                 },
             ],
         }
@@ -1105,6 +1105,123 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             queries = actual_widget.dashboardwidgetquery_set.all()
             for expected_query, actual_query in zip(expected_widget["queries"], queries):
                 self.assert_serialized_widget_query(expected_query, actual_query)
+
+    def test_post_derives_widget_min_height(self) -> None:
+        data = {
+            "title": "Dashboard with derived minimum heights",
+            "widgets": [
+                {
+                    "displayType": "line",
+                    "interval": "5m",
+                    "title": "Minimum height omitted",
+                    "queries": [
+                        {
+                            "name": "Transactions",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:transaction",
+                        }
+                    ],
+                    "layout": {"x": 0, "y": 0, "w": 3, "h": 2},
+                },
+                {
+                    "displayType": "bar",
+                    "interval": "5m",
+                    "title": "Caller minimum height ignored",
+                    "queries": [
+                        {
+                            "name": "Errors",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:error",
+                        }
+                    ],
+                    "layout": {"x": 3, "y": 0, "w": 3, "h": 2, "minH": 5},
+                },
+            ],
+        }
+
+        response = self.do_request("post", self.url, data=data)
+
+        assert response.status_code == 201, response.data
+        assert response.data["widgets"][0]["layout"] == {
+            "x": 0,
+            "y": 0,
+            "w": 3,
+            "h": 2,
+            "minH": 2,
+        }
+        assert response.data["widgets"][1]["layout"] == {
+            "x": 3,
+            "y": 0,
+            "w": 3,
+            "h": 2,
+            "minH": 2,
+        }
+
+    def test_post_rejects_widget_height_below_minimum(self) -> None:
+        data = {
+            "title": "Dashboard with short widget",
+            "widgets": [
+                {
+                    "displayType": "line",
+                    "interval": "5m",
+                    "title": "Short line chart",
+                    "queries": [
+                        {
+                            "name": "Transactions",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:transaction",
+                        }
+                    ],
+                    "layout": {"x": 0, "y": 0, "w": 3, "h": 1, "minH": 1},
+                }
+            ],
+        }
+
+        response = self.do_request("post", self.url, data=data)
+
+        assert response.status_code == 400, response.data
+        assert str(response.data["widgets"][0]["layout"]["h"]) == (
+            "Height must be at least 2 for line widgets."
+        )
+
+    def test_post_allows_short_widget_display_type_at_height_one(self) -> None:
+        data = {
+            "title": "Dashboard with big number",
+            "widgets": [
+                {
+                    "displayType": "big_number",
+                    "interval": "5m",
+                    "title": "Transaction count()",
+                    "queries": [
+                        {
+                            "name": "Transactions",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:transaction",
+                        }
+                    ],
+                    "layout": {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 2},
+                }
+            ],
+        }
+
+        response = self.do_request("post", self.url, data=data)
+
+        assert response.status_code == 201, response.data
+        assert response.data["widgets"][0]["layout"] == {
+            "x": 0,
+            "y": 0,
+            "w": 2,
+            "h": 1,
+            "minH": 1,
+        }
 
     def test_post_widget_with_camel_case_layout_keys_returns_camel_case(self) -> None:
         data = {
@@ -1217,7 +1334,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                     "conditions": "event.type:transaction",
                 }
             ],
-            "layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2},
+            "layout": {"x": 0, "y": 0, "w": 1, "h": 2, "minH": 2},
         }
         data: dict[str, Any] = {
             "title": "Dashboard from Post",
@@ -1659,7 +1776,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                             "conditions": "event.type:transaction",
                         }
                     ],
-                    "layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2},
+                    "layout": {"x": 0, "y": 0, "w": 1, "h": 2, "minH": 2},
                 },
             ],
         }
@@ -1697,7 +1814,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                             "conditions": "event.type:transaction",
                         }
                     ],
-                    "layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2},
+                    "layout": {"x": 0, "y": 0, "w": 1, "h": 2, "minH": 2},
                 }
                 for i in range(Dashboard.MAX_WIDGETS + 1)
             ],
@@ -2025,7 +2142,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                             "conditions": "is:unresolved",
                         }
                     ],
-                    "layout": {"x": 0, "y": 0, "w": 1, "h": 1, "minH": 2},
+                    "layout": {"x": 0, "y": 0, "w": 1, "h": 2, "minH": 2},
                     "widgetType": "error-events",
                 },
             ],

--- a/tests/sentry/dashboards/test_on_completion_hook.py
+++ b/tests/sentry/dashboards/test_on_completion_hook.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+from pydantic import ValidationError
+
 from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashboard
 from sentry.dashboards.on_completion_hook import (
     FIX_PROMPT,
@@ -109,6 +112,20 @@ def _make_artifact(**widget_overrides: Any) -> GeneratedDashboard:
         **widget_overrides,
     }
     return GeneratedDashboard(title="Dashboard", widgets=[widget])
+
+
+def test_generated_widget_rejects_height_below_display_type_minimum() -> None:
+    with pytest.raises(ValidationError, match="Height must be at least 2 for line widgets"):
+        _make_artifact(layout={"x": 0, "y": 0, "w": 3, "h": 1, "min_h": 1})
+
+
+def test_generated_widget_derives_min_height_from_display_type() -> None:
+    artifact = _make_artifact(
+        display_type="big_number",
+        layout={"x": 0, "y": 0, "w": 2, "h": 1, "min_h": 2},
+    )
+
+    assert artifact.widgets[0].layout.min_h == 1
 
 
 class TestFormatSerializerErrors(TestCase):


### PR DESCRIPTION
Dashboard creation now derives each widget's `minH` from its display type and rejects layouts whose `h` is below that minimum. The create request schema no longer exposes `minH`, so callers cannot override the server-owned constraint. Generated dashboard artifacts apply the same rule before serializer validation so invalid layouts receive actionable retry feedback.

The frontend duplicate/import normalization must deploy before this change so legacy invalid dashboards are repaired before being POSTed. PUT compatibility is handled separately in #122748, which allows existing invalid layouts to round-trip but rejects newly invalid state.

Fixes DAIN-1842
