### PR TITLE
feat(trace): Recalculate time compression after viewport interactions

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1452,6 +1452,53 @@ describe('trace view', () => {
         }
       });
 
+      it('cancels a pending compression update when trace space changes', async () => {
+        mockTracePreferences({compressed_timeline: true});
+        const organization = OrganizationFixture({
+          features: ['trace-waterfall-time-compression'],
+        });
+        const compressionSpy = jest.spyOn(TraceTimeCompression, 'FromVisibleItems');
+        const setCompressionSpy = jest.spyOn(
+          VirtualizedViewManager.prototype,
+          'setTimeCompression'
+        );
+
+        try {
+          await completeTestSetup({organization});
+          const manager = setCompressionSpy.mock.contexts.at(-1) as
+            | VirtualizedViewManager
+            | undefined;
+          if (!manager) {
+            throw new Error('Expected trace view manager to receive time compression');
+          }
+
+          compressionSpy.mockClear();
+          jest.useFakeTimers();
+
+          const traceStart = manager.view.to_origin;
+          const traceDuration = manager.view.trace_space.width;
+          act(() => {
+            manager.scheduler.dispatch('set trace view', {
+              x: traceDuration * 0.25,
+              width: traceDuration * 0.5,
+            });
+            manager.scheduler.dispatch('initialize trace space', [
+              traceStart,
+              0,
+              traceDuration,
+              1,
+            ]);
+          });
+
+          act(() => jest.advanceTimersByTime(250));
+          expect(compressionSpy).not.toHaveBeenCalled();
+        } finally {
+          jest.useRealTimers();
+          compressionSpy.mockRestore();
+          setCompressionSpy.mockRestore();
+        }
+      });
+
       it('waits for an active wheel zoom to end before recomputing compression', async () => {
         mockTracePreferences({compressed_timeline: true});
         const organization = OrganizationFixture({

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -5,6 +5,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -1384,6 +1385,134 @@ describe('trace view', () => {
           );
         } finally {
           compressionSpy.mockRestore();
+        }
+      });
+
+      it('recomputes compressed timeline once after trace view changes settle', async () => {
+        mockTracePreferences({compressed_timeline: true});
+        const organization = OrganizationFixture({
+          features: ['trace-waterfall-time-compression'],
+        });
+        const compressionSpy = jest.spyOn(TraceTimeCompression, 'FromVisibleItems');
+        const setCompressionSpy = jest.spyOn(
+          VirtualizedViewManager.prototype,
+          'setTimeCompression'
+        );
+
+        try {
+          await completeTestSetup({organization});
+          const manager = setCompressionSpy.mock.contexts.at(-1) as
+            | VirtualizedViewManager
+            | undefined;
+          if (!manager) {
+            throw new Error('Expected trace view manager to receive time compression');
+          }
+
+          compressionSpy.mockClear();
+          setCompressionSpy.mockClear();
+          jest.useFakeTimers();
+
+          const initialWidth = manager.view.trace_view.width;
+          act(() => {
+            manager.scheduler.dispatch('set trace view', {
+              x: 0,
+              width: initialWidth * 0.9,
+            });
+            manager.scheduler.dispatch('set trace view', {
+              x: initialWidth * 0.1,
+              width: initialWidth * 0.8,
+            });
+            manager.scheduler.dispatch('set trace view', {
+              x: initialWidth * 0.2,
+              width: initialWidth * 0.7,
+            });
+          });
+
+          const expectedViewSpace = [
+            manager.view.to_origin + manager.view.trace_view.x,
+            manager.view.trace_view.width,
+          ];
+
+          act(() => jest.advanceTimersByTime(249));
+          expect(compressionSpy).not.toHaveBeenCalled();
+
+          act(() => jest.advanceTimersByTime(1));
+          expect(compressionSpy).toHaveBeenCalledTimes(1);
+          expect(compressionSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({viewSpace: expectedViewSpace})
+          );
+          expect(setCompressionSpy).toHaveBeenCalledTimes(1);
+          expect(setCompressionSpy).toHaveBeenLastCalledWith(
+            compressionSpy.mock.results[0]!.value
+          );
+        } finally {
+          jest.useRealTimers();
+          compressionSpy.mockRestore();
+          setCompressionSpy.mockRestore();
+        }
+      });
+
+      it('waits for an active wheel zoom to end before recomputing compression', async () => {
+        mockTracePreferences({compressed_timeline: true});
+        const organization = OrganizationFixture({
+          features: ['trace-waterfall-time-compression'],
+        });
+        const compressionSpy = jest.spyOn(TraceTimeCompression, 'FromVisibleItems');
+        const setCompressionSpy = jest.spyOn(
+          VirtualizedViewManager.prototype,
+          'setTimeCompression'
+        );
+
+        try {
+          await completeTestSetup({organization});
+          const manager = setCompressionSpy.mock.contexts.at(-1) as
+            | VirtualizedViewManager
+            | undefined;
+          if (!manager) {
+            throw new Error('Expected trace view manager to receive time compression');
+          }
+
+          compressionSpy.mockClear();
+          jest.useFakeTimers();
+          let interactionEndAt: number | null = null;
+          const onInteractionEnd = () => {
+            interactionEndAt = performance.now();
+          };
+          manager.scheduler.on('trace view interaction end', onInteractionEnd);
+
+          for (let i = 0; i < 5; i++) {
+            const wheelEvent = new WheelEvent('wheel', {
+              cancelable: true,
+              clientX: 250,
+              ctrlKey: true,
+              deltaY: -1,
+            });
+            Object.defineProperty(wheelEvent, 'offsetX', {value: 250});
+
+            act(() => manager.onWheel(wheelEvent));
+            if (i < 4) {
+              act(() => jest.advanceTimersByTime(75));
+            }
+          }
+
+          expect(compressionSpy).not.toHaveBeenCalled();
+
+          act(() => jest.advanceTimersByTime(250));
+          expect(interactionEndAt).not.toBeNull();
+          expect(compressionSpy).not.toHaveBeenCalled();
+
+          const elapsedSinceInteractionEnd = performance.now() - interactionEndAt!;
+          act(() => jest.advanceTimersByTime(250 - elapsedSinceInteractionEnd - 1));
+          expect(compressionSpy).not.toHaveBeenCalled();
+
+          act(() => jest.advanceTimersByTime(1));
+          expect(compressionSpy).toHaveBeenCalledTimes(1);
+
+          manager.scheduler.off('trace view interaction end', onInteractionEnd);
+        } finally {
+          jest.useRealTimers();
+          compressionSpy.mockRestore();
+          setCompressionSpy.mockRestore();
         }
       });
     });

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -294,6 +294,7 @@ export function Trace({
       ]);
       if (!hasMeasuredPhysicalWidthRef.current && viewport.physicalWidth > 0) {
         hasMeasuredPhysicalWidthRef.current = true;
+        timeCompressionViewportDebouncer.cancel();
         setTimeCompressionViewport(viewport);
       } else {
         timeCompressionViewportDebouncer.maybeExecute(viewport);
@@ -303,6 +304,7 @@ export function Trace({
       manager.draw();
     };
     const onTraceSpaceChange: TraceEvents['initialize trace space'] = () => {
+      timeCompressionViewportDebouncer.cancel();
       setTimeCompressionViewport(
         snapshotTimeCompressionViewport(manager, trace_id, [traceStart, traceDuration])
       );

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {useDebouncer} from '@tanstack/react-pacer';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -43,10 +44,7 @@ import {
   useVirtualizedList,
   type VirtualizedRow,
 } from './traceRenderers/traceVirtualizedList';
-import type {
-  TraceTimeCompressionManagerOptions,
-  VirtualizedViewManager,
-} from './traceRenderers/virtualizedViewManager';
+import type {VirtualizedViewManager} from './traceRenderers/virtualizedViewManager';
 import {TraceLoadingRow} from './traceRow/traceLoadingRow';
 import {
   TRACE_CHILDREN_COUNT_WRAPPER_CLASSNAME,
@@ -115,6 +113,31 @@ function computeNextIndexFromAction(
 
 function snapshotVisibleTraceItems(nodes: BaseNode[], _version: number): BaseNode[] {
   return nodes.slice();
+}
+
+const TIME_COMPRESSION_SETTLE_MS = 250;
+
+type TimeCompressionViewport = {
+  physicalWidth: number;
+  traceId: string | undefined;
+  viewSpace: [start: number, duration: number];
+};
+
+function snapshotTimeCompressionViewport(
+  manager: VirtualizedViewManager,
+  traceId: string | undefined,
+  traceSpace: [start: number, duration: number]
+): TimeCompressionViewport {
+  const viewDuration = manager.view.trace_view.width;
+
+  return {
+    physicalWidth: manager.view.trace_physical_space.width,
+    traceId,
+    viewSpace:
+      viewDuration > 0
+        ? [manager.view.to_origin + manager.view.trace_view.x, viewDuration]
+        : traceSpace,
+  };
 }
 
 interface TraceProps {
@@ -186,50 +209,66 @@ export function Trace({
     () => snapshotVisibleTraceItems(trace.list, forceRerender),
     [trace.list, forceRerender]
   );
-
-  const timeCompressionOptions = useMemo((): TraceTimeCompressionManagerOptions => {
-    const traceSpace: [start: number, duration: number] = [traceStart, traceDuration];
-    return {
-      enabled:
-        hasCompressedTimelineFeature &&
-        traceState.preferences.compressed_timeline &&
-        trace.type === 'trace',
-      traceSpace,
-      nodes: visibleTraceItems,
-      indicators: trace.indicators,
-    };
-  }, [
-    trace.indicators,
-    traceDuration,
-    traceStart,
-    trace.type,
-    hasCompressedTimelineFeature,
-    traceState.preferences.compressed_timeline,
-    visibleTraceItems,
-  ]);
-
-  const [physicalWidth, setPhysicalWidth] = useState(
-    () => manager.view.trace_physical_space.width
+  const [timeCompressionViewport, setTimeCompressionViewport] =
+    useState<TimeCompressionViewport>(() =>
+      snapshotTimeCompressionViewport(manager, trace_id, [traceStart, traceDuration])
+    );
+  const timeCompressionViewStart =
+    timeCompressionViewport.traceId === trace_id
+      ? timeCompressionViewport.viewSpace[0]
+      : traceStart;
+  const timeCompressionViewDuration =
+    timeCompressionViewport.traceId === trace_id
+      ? timeCompressionViewport.viewSpace[1]
+      : traceDuration;
+  const timeCompressionViewportDebouncer = useDebouncer(
+    (viewport: TimeCompressionViewport) => {
+      if (!manager.isTraceViewInteractionActive()) {
+        setTimeCompressionViewport(viewport);
+      }
+    },
+    {wait: TIME_COMPRESSION_SETTLE_MS}
   );
+  const hasMeasuredPhysicalWidthRef = useRef(timeCompressionViewport.physicalWidth > 0);
 
   const timeCompression = useMemo(
     () =>
       TraceTimeCompression.FromVisibleItems({
-        ...timeCompressionOptions,
-        physicalWidth,
+        enabled:
+          hasCompressedTimelineFeature &&
+          traceState.preferences.compressed_timeline &&
+          trace.type === 'trace',
+        traceSpace: [traceStart, traceDuration],
+        viewSpace: [timeCompressionViewStart, timeCompressionViewDuration],
+        physicalWidth: timeCompressionViewport.physicalWidth,
+        nodes: visibleTraceItems,
+        indicators: trace.indicators,
       }),
-    [physicalWidth, timeCompressionOptions]
+    [
+      hasCompressedTimelineFeature,
+      timeCompressionViewDuration,
+      timeCompressionViewStart,
+      timeCompressionViewport.physicalWidth,
+      trace.indicators,
+      trace.type,
+      traceDuration,
+      traceStart,
+      traceState.preferences.compressed_timeline,
+      visibleTraceItems,
+    ]
   );
-  const timeCompressionOptionsRef = useRef(timeCompressionOptions);
-  timeCompressionOptionsRef.current = timeCompressionOptions;
 
   useLayoutEffect(() => {
-    manager.timeCompressionOptions = timeCompressionOptions;
-    manager.recomputeTimeCompression(timeCompressionOptions);
+    manager.setTimeCompression(timeCompression);
     manager.recomputeTimelineIntervals();
     manager.recomputeSpanToPXMatrix();
     manager.draw();
-  }, [manager, physicalWidth, timeCompressionOptions]);
+  }, [manager, timeCompression]);
+
+  useEffect(
+    () => () => timeCompressionViewportDebouncer.cancel(),
+    [timeCompressionViewportDebouncer, trace_id]
+  );
 
   const traceStatePreferencesRef = useRef<
     Pick<TraceReducerState['preferences'], 'autogroup' | 'missing_instrumentation'>
@@ -242,17 +281,31 @@ export function Trace({
       manager.recomputeSpanToPXMatrix();
       manager.syncResetZoomButton();
       manager.draw();
+      if (!manager.isTraceViewInteractionActive()) {
+        timeCompressionViewportDebouncer.maybeExecute(
+          snapshotTimeCompressionViewport(manager, trace_id, [traceStart, traceDuration])
+        );
+      }
     };
     const onPhysicalSpaceChange: TraceEvents['set container physical space'] = () => {
-      const nextPhysicalWidth = manager.view.trace_physical_space.width;
-      setPhysicalWidth(nextPhysicalWidth);
-      manager.recomputeTimeCompression(timeCompressionOptionsRef.current);
+      const viewport = snapshotTimeCompressionViewport(manager, trace_id, [
+        traceStart,
+        traceDuration,
+      ]);
+      if (!hasMeasuredPhysicalWidthRef.current && viewport.physicalWidth > 0) {
+        hasMeasuredPhysicalWidthRef.current = true;
+        setTimeCompressionViewport(viewport);
+      } else {
+        timeCompressionViewportDebouncer.maybeExecute(viewport);
+      }
       manager.recomputeTimelineIntervals();
       manager.recomputeSpanToPXMatrix();
       manager.draw();
     };
     const onTraceSpaceChange: TraceEvents['initialize trace space'] = () => {
-      manager.recomputeTimeCompression(timeCompressionOptionsRef.current);
+      setTimeCompressionViewport(
+        snapshotTimeCompressionViewport(manager, trace_id, [traceStart, traceDuration])
+      );
       manager.recomputeTimelineIntervals();
       manager.recomputeSpanToPXMatrix();
       manager.draw();
@@ -263,8 +316,14 @@ export function Trace({
       manager.draw(view);
     };
     const onDividerResizeEnd: TraceEvents['divider resize end'] = () => {
-      const nextPhysicalWidth = manager.view.trace_physical_space.width;
-      setPhysicalWidth(nextPhysicalWidth);
+      timeCompressionViewportDebouncer.maybeExecute(
+        snapshotTimeCompressionViewport(manager, trace_id, [traceStart, traceDuration])
+      );
+    };
+    const onTraceViewInteractionEnd = () => {
+      timeCompressionViewportDebouncer.maybeExecute(
+        snapshotTimeCompressionViewport(manager, trace_id, [traceStart, traceDuration])
+      );
     };
 
     scheduler.on('set trace view', onTraceViewChange);
@@ -273,6 +332,7 @@ export function Trace({
     scheduler.on('initialize trace space', onTraceSpaceChange);
     scheduler.on('divider resize', onDividerResize);
     scheduler.on('divider resize end', onDividerResizeEnd);
+    scheduler.on('trace view interaction end', onTraceViewInteractionEnd);
 
     return () => {
       scheduler.off('set trace view', onTraceViewChange);
@@ -281,8 +341,16 @@ export function Trace({
       scheduler.off('initialize trace space', onTraceSpaceChange);
       scheduler.off('divider resize', onDividerResize);
       scheduler.off('divider resize end', onDividerResizeEnd);
+      scheduler.off('trace view interaction end', onTraceViewInteractionEnd);
     };
-  }, [manager, scheduler]);
+  }, [
+    manager,
+    scheduler,
+    timeCompressionViewportDebouncer,
+    traceDuration,
+    traceStart,
+    trace_id,
+  ]);
 
   const onNodeZoomIn = useCallback(
     (event: React.MouseEvent | React.KeyboardEvent, node: BaseNode, value: boolean) => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceScheduler.tsx
@@ -23,6 +23,7 @@ export interface TraceEvents {
     space: [x: number, y: number, width: number, height: number]
   ) => void;
   ['set trace view']: (view: {width?: number; x?: number}) => void;
+  ['trace view interaction end']: () => void;
 }
 
 export class TraceScheduler {
@@ -42,6 +43,9 @@ export class TraceScheduler {
     >(),
     'divider resize': new Array<[TraceEventPriority, TraceEvents['divider resize']]>(),
     'set trace view': new Array<[TraceEventPriority, TraceEvents['set trace view']]>(),
+    'trace view interaction end': new Array<
+      [TraceEventPriority, TraceEvents['trace view interaction end']]
+    >(),
     draw: new Array<[TraceEventPriority, TraceEvents['draw']]>(),
   };
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.spec.tsx
@@ -5,10 +5,11 @@ function node(type: string, space: [number, number]) {
 }
 
 describe('TraceTimeCompression', () => {
-  it('collapses gaps at least 5% of the trace duration', () => {
+  it('collapses gaps at least twice the collapsed marker width', () => {
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: true,
       traceSpace: [0, 1000],
+      viewSpace: [0, 1000],
       physicalWidth: 1000,
       nodes: [
         node('trace', [0, 1000]),
@@ -28,6 +29,7 @@ describe('TraceTimeCompression', () => {
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: true,
       traceSpace: [0, 10_000],
+      viewSpace: [0, 10_000],
       physicalWidth: 1000,
       nodes: [node('span', [2000, 1000]), node('span', [7000, 1000])],
       indicators: [],
@@ -44,6 +46,7 @@ describe('TraceTimeCompression', () => {
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: true,
       traceSpace: [0, 1000],
+      viewSpace: [0, 1000],
       physicalWidth: 1000,
       nodes: [
         node('transaction', [0, 1000]),
@@ -62,6 +65,7 @@ describe('TraceTimeCompression', () => {
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: true,
       traceSpace: [0, 3_600_000],
+      viewSpace: [0, 3_600_000],
       physicalWidth,
       nodes: [
         node('span', [0, 600_000]),
@@ -85,6 +89,7 @@ describe('TraceTimeCompression', () => {
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: true,
       traceSpace: [0, 1000],
+      viewSpace: [0, 1000],
       physicalWidth: 1000,
       nodes: [node('transaction', [0, 100]), node('span', [500, 100])],
       indicators: [],
@@ -101,6 +106,7 @@ describe('TraceTimeCompression', () => {
     const compression = TraceTimeCompression.FromVisibleItems({
       enabled: false,
       traceSpace: [0, 1000],
+      viewSpace: [0, 1000],
       physicalWidth: 1000,
       nodes: [node('transaction', [0, 100]), node('span', [500, 100])],
       indicators: [],
@@ -108,5 +114,108 @@ describe('TraceTimeCompression', () => {
 
     expect(compression.enabled).toBe(false);
     expect(compression.toCompressedOffset(500)).toBe(500);
+  });
+
+  it('uses the uncompressed viewport to qualify gaps at 56px', () => {
+    const options = {
+      enabled: true,
+      traceSpace: [0, 1000] as [number, number],
+      viewSpace: [0, 1000] as [number, number],
+      nodes: [node('span', [0, 100]), node('span', [500, 500])],
+      indicators: [],
+    };
+
+    expect(
+      TraceTimeCompression.FromVisibleItems({...options, physicalWidth: 379}).enabled
+    ).toBe(false);
+    expect(
+      TraceTimeCompression.FromVisibleItems({...options, physicalWidth: 380}).enabled
+    ).toBe(true);
+  });
+
+  it('discovers gaps that become wide enough in a zoomed viewport', () => {
+    const options = {
+      enabled: true,
+      traceSpace: [0, 1000] as [number, number],
+      physicalWidth: 1000,
+      nodes: [node('span', [0, 100]), node('span', [160, 840])],
+      indicators: [],
+    };
+
+    expect(
+      TraceTimeCompression.FromVisibleItems({
+        ...options,
+        viewSpace: [0, 1000],
+      }).enabled
+    ).toBe(false);
+    expect(
+      TraceTimeCompression.FromVisibleItems({
+        ...options,
+        viewSpace: [100, 100],
+      }).enabled
+    ).toBe(true);
+  });
+
+  it('does not collapse empty viewport edges when zoomed into spans', () => {
+    const compression = TraceTimeCompression.FromVisibleItems({
+      enabled: true,
+      traceSpace: [0, 1000],
+      viewSpace: [200, 600],
+      physicalWidth: 1000,
+      nodes: [node('span', [300, 300])],
+      indicators: [],
+    });
+
+    expect(compression.enabled).toBe(false);
+    expect(compression.gaps).toHaveLength(0);
+  });
+
+  it('renders fully visible gaps at the collapsed marker width', () => {
+    const physicalWidth = 1000;
+    const viewSpace: [number, number] = [0, 1000];
+    const compression = TraceTimeCompression.FromVisibleItems({
+      enabled: true,
+      traceSpace: [0, 1000],
+      viewSpace,
+      physicalWidth,
+      nodes: [node('span', [0, 100]), node('span', [500, 100])],
+      indicators: [],
+    });
+    const compressedViewDuration =
+      compression.toCompressedOffset(viewSpace[0] + viewSpace[1]) -
+      compression.toCompressedOffset(viewSpace[0]);
+
+    for (const gap of compression.gaps) {
+      expect((gap.retainedDuration / compressedViewDuration) * physicalWidth).toBeCloseTo(
+        COLLAPSED_GAP_WIDTH_PX
+      );
+    }
+  });
+
+  it('does not collapse a gap crossing a zoomed viewport edge', () => {
+    const compression = TraceTimeCompression.FromVisibleItems({
+      enabled: true,
+      traceSpace: [0, 1000],
+      viewSpace: [300, 300],
+      physicalWidth: 1000,
+      nodes: [node('span', [0, 100]), node('span', [500, 500])],
+      indicators: [],
+    });
+
+    expect(compression.enabled).toBe(false);
+    expect(compression.gaps).toHaveLength(0);
+  });
+
+  it('disables compression when the viewport contains only inactive time', () => {
+    const compression = TraceTimeCompression.FromVisibleItems({
+      enabled: true,
+      traceSpace: [0, 1000],
+      viewSpace: [400, 100],
+      physicalWidth: 1000,
+      nodes: [node('span', [0, 100]), node('span', [900, 100])],
+      indicators: [],
+    });
+
+    expect(compression.enabled).toBe(false);
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
@@ -2,10 +2,11 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import {isZeroDurationNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/utils';
 
-const COLLAPSE_THRESHOLD_RATIO = 0.05;
 export const COLLAPSED_GAP_WIDTH_PX = 28;
+const MIN_COLLAPSIBLE_GAP_WIDTH_PX = COLLAPSED_GAP_WIDTH_PX * 2;
+const COMPARISON_EPSILON = 1e-9;
 const DURATION_LABEL_BUFFER_PX = 48;
-const MARKER_PADDING_RATIO = 0.01;
+const MARKER_PADDING_PX = 10;
 const MARKER_PADDING_MAX_MS = 500;
 
 type Interval = [start: number, end: number];
@@ -25,6 +26,7 @@ type TraceTimeCompressionOptions = {
   nodes: BaseNode[];
   physicalWidth: number;
   traceSpace: [start: number, duration: number];
+  viewSpace?: [start: number, duration: number];
 };
 
 export class TraceTimeCompression {
@@ -60,44 +62,68 @@ export class TraceTimeCompression {
 
   static FromVisibleItems(options: TraceTimeCompressionOptions): TraceTimeCompression {
     const [traceStart, traceDuration] = options.traceSpace;
+    const [viewStart, viewDuration] = options.viewSpace ?? options.traceSpace;
 
-    if (!options.enabled || traceDuration <= 0 || options.physicalWidth <= 0) {
+    if (
+      !options.enabled ||
+      traceDuration <= 0 ||
+      viewDuration <= 0 ||
+      options.physicalWidth <= 0
+    ) {
       return TraceTimeCompression.Disabled(options.traceSpace);
     }
 
     const intervals = collectVisibleIntervals(options);
     const mergedIntervals = mergeIntervals(intervals);
-    const collapsibleGaps = collectCollapsibleGaps(
-      mergedIntervals,
-      traceStart,
-      traceDuration
+    const traceEnd = traceStart + traceDuration;
+    const viewEnd = viewStart + viewDuration;
+    const timestampComparisonEpsilon = Math.max(
+      traceDuration * COMPARISON_EPSILON,
+      Number.EPSILON
     );
+    const isZoomedView =
+      viewStart > traceStart + timestampComparisonEpsilon ||
+      viewEnd < traceEnd - timestampComparisonEpsilon;
+    const collapsibleGaps = collectGaps(mergedIntervals, traceStart, traceDuration)
+      .map(gap => ({
+        gap,
+        visibleDuration: getIntersectionDuration(gap, viewStart, viewEnd),
+      }))
+      .filter(
+        ({gap: [gapStart, gapEnd], visibleDuration}) =>
+          (visibleDuration / viewDuration) * options.physicalWidth >=
+            MIN_COLLAPSIBLE_GAP_WIDTH_PX - COMPARISON_EPSILON &&
+          (!isZoomedView ||
+            (gapStart > viewStart + timestampComparisonEpsilon &&
+              gapEnd < viewEnd - timestampComparisonEpsilon))
+      );
 
     if (collapsibleGaps.length === 0) {
       return TraceTimeCompression.Disabled(options.traceSpace);
     }
 
-    const collapsedGapPx = Math.min(
-      COLLAPSED_GAP_WIDTH_PX,
-      options.physicalWidth / (collapsibleGaps.length + 1)
-    );
-    const collapsedGapWidthRatio = collapsedGapPx / options.physicalWidth;
-    const collapsedDuration = collapsibleGaps.reduce(
-      (sum, gap) => sum + (gap[1] - gap[0]),
+    const collapsedVisibleDuration = collapsibleGaps.reduce(
+      (sum, {visibleDuration}) => sum + visibleDuration,
       0
     );
-    const activeDuration = traceDuration - collapsedDuration;
-    const denominator = 1 - collapsedGapWidthRatio * collapsibleGaps.length;
+    const activeVisibleDuration = viewDuration - collapsedVisibleDuration;
+    const collapsedGapWidthRatio = COLLAPSED_GAP_WIDTH_PX / options.physicalWidth;
+    const visibleGapFractionSum = collapsibleGaps.reduce(
+      (sum, {gap, visibleDuration}) =>
+        sum + visibleDuration / Math.max(gap[1] - gap[0], Number.EPSILON),
+      0
+    );
+    const denominator = 1 - collapsedGapWidthRatio * visibleGapFractionSum;
 
-    if (denominator <= 0 || activeDuration <= 0) {
+    if (denominator <= 0 || activeVisibleDuration <= 0) {
       return TraceTimeCompression.Disabled(options.traceSpace);
     }
 
-    const compressedDuration = activeDuration / denominator;
-    const retainedDuration = compressedDuration * collapsedGapWidthRatio;
+    const compressedViewDuration = activeVisibleDuration / denominator;
+    const retainedDuration = compressedViewDuration * collapsedGapWidthRatio;
     let removedBefore = 0;
 
-    const gaps = collapsibleGaps.map(([start, end]) => {
+    const gaps = collapsibleGaps.map(({gap: [start, end]}) => {
       const duration = end - start;
       const compressedStart = start - traceStart - removedBefore;
       const compressedEnd = compressedStart + retainedDuration;
@@ -112,6 +138,9 @@ export class TraceTimeCompression {
         compressedEnd,
       };
     });
+    const compressedDuration =
+      traceDuration -
+      gaps.reduce((sum, gap) => sum + gap.duration - gap.retainedDuration, 0);
 
     return new TraceTimeCompression({
       start: traceStart,
@@ -174,19 +203,17 @@ export class TraceTimeCompression {
 
 function collectVisibleIntervals(options: TraceTimeCompressionOptions): Interval[] {
   const [traceStart, traceDuration] = options.traceSpace;
+  const [, viewDuration] = options.viewSpace ?? options.traceSpace;
   const traceEnd = traceStart + traceDuration;
+  const durationPerPixel = viewDuration / options.physicalWidth;
   const markerPadding = Math.min(
-    traceDuration * MARKER_PADDING_RATIO,
+    durationPerPixel * MARKER_PADDING_PX,
     MARKER_PADDING_MAX_MS
   );
   const durationLabelBuffer =
-    options.physicalWidth > 0
-      ? (traceDuration / options.physicalWidth) * DURATION_LABEL_BUFFER_PX
-      : 0;
+    options.physicalWidth > 0 ? durationPerPixel * DURATION_LABEL_BUFFER_PX : 0;
   const zeroDurationBuffer =
-    options.physicalWidth > 0
-      ? (traceDuration / options.physicalWidth) * COLLAPSED_GAP_WIDTH_PX
-      : 0;
+    options.physicalWidth > 0 ? durationPerPixel * COLLAPSED_GAP_WIDTH_PX : 0;
   const intervals: Interval[] = [];
 
   for (const node of options.nodes) {
@@ -246,28 +273,31 @@ function mergeIntervals(intervals: Interval[]): Interval[] {
   return merged;
 }
 
-function collectCollapsibleGaps(
+function collectGaps(
   intervals: Interval[],
   traceStart: number,
   traceDuration: number
 ): Interval[] {
   const traceEnd = traceStart + traceDuration;
-  const threshold = traceDuration * COLLAPSE_THRESHOLD_RATIO;
   const gaps: Interval[] = [];
   let previousEnd = traceStart;
 
   for (const [start, end] of intervals) {
-    if (start - previousEnd >= threshold) {
+    if (start > previousEnd) {
       gaps.push([previousEnd, start]);
     }
     previousEnd = Math.max(previousEnd, end);
   }
 
-  if (traceEnd - previousEnd >= threshold) {
+  if (traceEnd > previousEnd) {
     gaps.push([previousEnd, traceEnd]);
   }
 
   return gaps;
+}
+
+function getIntersectionDuration(interval: Interval, start: number, end: number): number {
+  return Math.max(0, Math.min(interval[1], end) - Math.max(interval[0], start));
 }
 
 function clampTimestamp(timestamp: number, min: number, max: number): number {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTimeCompression.tsx
@@ -26,7 +26,7 @@ type TraceTimeCompressionOptions = {
   nodes: BaseNode[];
   physicalWidth: number;
   traceSpace: [start: number, duration: number];
-  viewSpace?: [start: number, duration: number];
+  viewSpace: [start: number, duration: number];
 };
 
 export class TraceTimeCompression {
@@ -62,7 +62,7 @@ export class TraceTimeCompression {
 
   static FromVisibleItems(options: TraceTimeCompressionOptions): TraceTimeCompression {
     const [traceStart, traceDuration] = options.traceSpace;
-    const [viewStart, viewDuration] = options.viewSpace ?? options.traceSpace;
+    const [viewStart, viewDuration] = options.viewSpace;
 
     if (
       !options.enabled ||
@@ -203,7 +203,7 @@ export class TraceTimeCompression {
 
 function collectVisibleIntervals(options: TraceTimeCompressionOptions): Interval[] {
   const [traceStart, traceDuration] = options.traceSpace;
-  const [, viewDuration] = options.viewSpace ?? options.traceSpace;
+  const [, viewDuration] = options.viewSpace;
   const traceEnd = traceStart + traceDuration;
   const durationPerPixel = viewDuration / options.physicalWidth;
   const markerPadding = Math.min(

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceViewCalculations.spec.tsx
@@ -54,6 +54,7 @@ function makeCompressedContext(): TraceViewCalculationContext {
     timeCompression: TraceTimeCompression.FromVisibleItems({
       enabled: true,
       traceSpace: [0, 1000],
+      viewSpace: [0, 1000],
       physicalWidth: 1000,
       nodes: [
         {type: 'transaction', space: [0, 100]} as unknown as BaseNode,

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -1,7 +1,6 @@
 import {ThemeFixture} from 'sentry-fixture/theme';
 
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import {TraceScheduler} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceScheduler';
 import {TraceTimeCompression} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
 import {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
@@ -42,66 +41,6 @@ describe('VirtualizedViewManger', () => {
       0, 0, 1000, 1,
     ]);
     expect(manager.view.trace_physical_space.serialize()).toEqual([0, 0, 500, 1]);
-  });
-
-  it('recomputes time compression before redrawing during divider resize', () => {
-    const scheduler = new TraceScheduler();
-    const manager = new VirtualizedViewManager(
-      {
-        list: {width: 0.5},
-        span_list: {width: 0.5},
-      },
-      scheduler,
-      new TraceView(),
-      ThemeFixture()
-    );
-
-    manager.view.setTraceSpace([0, 0, 1000, 1]);
-    manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
-    manager.divider = document.createElement('div');
-    manager.dividerStartVec = [0, 0];
-    manager.previousDividerClientVec = [0, 0];
-
-    const recomputeSpy = jest.spyOn(manager, 'recomputeTimeCompression');
-    const dispatchSpy = jest.spyOn(scheduler, 'dispatch');
-
-    manager.onDividerMouseMove(new MouseEvent('mousemove', {clientX: 100, clientY: 0}));
-
-    expect(manager.view.trace_physical_space.width).toBe(400);
-    expect(recomputeSpy).toHaveBeenCalledTimes(1);
-    expect(recomputeSpy.mock.invocationCallOrder[0]).toBeLessThan(
-      dispatchSpy.mock.invocationCallOrder[0]!
-    );
-  });
-
-  it('uses explicit time compression options over previously stored options', () => {
-    const manager = new VirtualizedViewManager(
-      {
-        list: {width: 0.5},
-        span_list: {width: 0.5},
-      },
-      new TraceScheduler(),
-      new TraceView(),
-      ThemeFixture()
-    );
-
-    manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
-    manager.timeCompressionOptions = {
-      enabled: true,
-      traceSpace: [0, 1000],
-      nodes: [{type: 'span', space: [100, 10]} as BaseNode],
-      indicators: [],
-    };
-
-    manager.recomputeTimeCompression({
-      enabled: true,
-      traceSpace: [10_000, 2000],
-      nodes: [{type: 'span', space: [10_500, 10]} as BaseNode],
-      indicators: [],
-    });
-
-    expect(manager.time_compression.start).toBe(10_000);
-    expect(manager.time_compression.duration).toBe(2000);
   });
 
   it('re-dispatches the container content box when scrollbar width changes', () => {
@@ -430,11 +369,12 @@ describe('VirtualizedViewManger', () => {
       );
 
       manager.view.setTraceSpace([0, 0, 1000, 1]);
-      manager.view.setTracePhysicalSpace([0, 0, 100, 1], [0, 0, 100, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
       manager.time_compression = TraceTimeCompression.FromVisibleItems({
         enabled: true,
         traceSpace: [0, 1000],
-        physicalWidth: 100,
+        viewSpace: [0, 1000],
+        physicalWidth: 1000,
         nodes: [
           {type: 'span', space: [100, 0]},
           {type: 'span', space: [900, 0]},
@@ -443,7 +383,9 @@ describe('VirtualizedViewManger', () => {
       });
       manager.recomputeSpanToPXMatrix();
 
-      const gap = manager.time_compression.gaps[0]!;
+      const gap = manager.time_compression.gaps.find(
+        candidate => candidate.start > 0 && candidate.end < 1000
+      )!;
       const markerRef = document.createElement('div');
       Object.defineProperty(markerRef, 'offsetWidth', {value: 40});
       manager.collapsed_gap_markers[0] = {gap, ref: markerRef};
@@ -459,6 +401,39 @@ describe('VirtualizedViewManger', () => {
       );
 
       expect(markerLeft).toBeCloseTo(placement + actualGapWidth / 2 - 20);
+    });
+
+    it('keeps full-trace edge-gap markers inside the viewport', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.time_compression = TraceTimeCompression.FromVisibleItems({
+        enabled: true,
+        traceSpace: [0, 1000],
+        viewSpace: [0, 1000],
+        physicalWidth: 1000,
+        nodes: [{type: 'span', space: [500, 500]}] as any,
+        indicators: [],
+      });
+      manager.recomputeSpanToPXMatrix();
+
+      const gap = manager.time_compression.gaps[0]!;
+      const markerRef = document.createElement('div');
+      Object.defineProperty(markerRef, 'offsetWidth', {value: 40});
+      manager.collapsed_gap_markers[0] = {gap, ref: markerRef};
+
+      manager.drawCollapsedGapMarkers();
+
+      expect(markerRef).toHaveStyle({opacity: '1', transform: 'translateX(0px)'});
     });
 
     it('treats nearby timeline labels as overlapping collapsed gap markers', () => {
@@ -477,6 +452,7 @@ describe('VirtualizedViewManger', () => {
       manager.time_compression = TraceTimeCompression.FromVisibleItems({
         enabled: true,
         traceSpace: [0, 1000],
+        viewSpace: [0, 1000],
         physicalWidth: 1000,
         nodes: [
           {type: 'span', space: [100, 0]},
@@ -578,6 +554,7 @@ describe('VirtualizedViewManger', () => {
       manager.time_compression = TraceTimeCompression.FromVisibleItems({
         enabled: true,
         traceSpace: [0, 1000],
+        viewSpace: [0, 1000],
         physicalWidth: 1000,
         nodes: [
           {type: 'span', space: [0, 10]},
@@ -619,6 +596,7 @@ describe('VirtualizedViewManger', () => {
         manager.time_compression = TraceTimeCompression.FromVisibleItems({
           enabled: true,
           traceSpace: [0, 1000],
+          viewSpace: [0, 1000],
           physicalWidth: 1000,
           nodes: [
             {type: 'transaction', space: [0, 100]},
@@ -1313,6 +1291,7 @@ describe('VirtualizedViewManger', () => {
       manager.time_compression = TraceTimeCompression.FromVisibleItems({
         enabled: true,
         traceSpace: [0, 1000],
+        viewSpace: [0, 1000],
         physicalWidth: 1000,
         nodes: [
           {type: 'span', space: [0, 100]},

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -19,10 +19,7 @@ import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/tr
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import {TraceRowWidthMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer';
 import {TraceTextMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer';
-import {
-  COLLAPSED_GAP_WIDTH_PX,
-  TraceTimeCompression,
-} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
+import {TraceTimeCompression} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
 import type {TraceTimeCompressionGap} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTimeCompression';
 import type {TraceView} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceView';
 import {
@@ -39,13 +36,6 @@ import type {TraceScheduler} from './traceScheduler';
 
 const DIVIDER_WIDTH = 6;
 const COLLAPSED_GAP_MARKER_CLEARANCE_PX = 8;
-
-export type TraceTimeCompressionManagerOptions = {
-  enabled: boolean;
-  indicators: TraceTree['indicators'];
-  nodes: BaseNode[];
-  traceSpace: [start: number, duration: number];
-};
 
 interface TraceIconPlacement {
   anchorTimestamp: number;
@@ -175,7 +165,6 @@ export class VirtualizedViewManager {
   scheduler: TraceScheduler;
   view: TraceView;
   time_compression = TraceTimeCompression.Disabled();
-  timeCompressionOptions: TraceTimeCompressionManagerOptions | null = null;
 
   constructor(
     columns: {
@@ -224,19 +213,12 @@ export class VirtualizedViewManager {
     this.time_compression = compression;
   }
 
-  recomputeTimeCompression(options = this.timeCompressionOptions) {
-    if (!options) {
-      this.time_compression = TraceTimeCompression.Disabled([
-        this.view.to_origin,
-        this.view.trace_space.width,
-      ]);
-      return;
-    }
-
-    this.time_compression = TraceTimeCompression.FromVisibleItems({
-      ...options,
-      physicalWidth: this.view.trace_physical_space.width,
-    });
+  isTraceViewInteractionActive(): boolean {
+    return (
+      this.dividerStartVec !== null ||
+      this.timers.onWheelEnd !== null ||
+      this.timers.onZoomIntoSpace !== null
+    );
   }
 
   dividerStartVec: [number, number] | null = null;
@@ -306,7 +288,6 @@ export class VirtualizedViewManager {
 
     this.view.trace_physical_space.width =
       span_list * (this.view.trace_container_physical_space.width - this.scrollbar_width);
-    this.recomputeTimeCompression();
 
     this.scheduler.dispatch('set trace view', {
       x: this.view.trace_view.x,
@@ -781,6 +762,8 @@ export class VirtualizedViewManager {
         indicator.ref.style.pointerEvents = 'auto';
       }
     }
+
+    this.scheduler.dispatch('trace view interaction end');
   }
 
   maybeInitializeTraceViewFromQS(fov: string): void {
@@ -1906,17 +1889,26 @@ export class VirtualizedViewManager {
     );
   }
 
-  private getCollapsedGapWidthPx(
+  private getCollapsedGapMarkerPosition(
     gap: TraceTimeCompressionGap,
-    placement = this.transformXFromTimestamp(gap.start)
-  ): number {
-    const gapWidth = this.transformXFromTimestamp(gap.end) - placement;
+    markerWidth: number
+  ): {left: number; placement: number} {
+    const viewStart = this.view.to_origin + this.view.trace_view.x;
+    const viewEnd = viewStart + this.view.trace_view.width;
+    const visibleGapStart = Math.max(gap.start, viewStart);
+    const visibleGapEnd = Math.min(gap.end, viewEnd);
+    const placement = this.transformXFromTimestamp(visibleGapStart);
+    const visibleGapWidth = this.transformXFromTimestamp(visibleGapEnd) - placement;
+    const centeredLeft = placement + visibleGapWidth / 2 - markerWidth / 2;
 
-    if (!Number.isFinite(gapWidth) || gapWidth < 0) {
-      return COLLAPSED_GAP_WIDTH_PX;
-    }
-
-    return gapWidth;
+    return {
+      left: clamp(
+        centeredLeft,
+        0,
+        Math.max(this.view.trace_physical_space.width - markerWidth, 0)
+      ),
+      placement,
+    };
   }
 
   drawTimelineIntervals() {
@@ -1965,11 +1957,11 @@ export class VirtualizedViewManager {
         continue;
       }
 
-      const placement = this.transformXFromTimestamp(marker.gap.start);
-      const gapWidth = this.getCollapsedGapWidthPx(marker.gap, placement);
       const markerWidth = widths[i] ?? 0;
-      const halfWidth = markerWidth / 2;
-      const left = placement + gapWidth / 2 - halfWidth;
+      const {left, placement} = this.getCollapsedGapMarkerPosition(
+        marker.gap,
+        markerWidth
+      );
 
       marker.ref.style.opacity = '1';
       marker.ref.style.transform = `translateX(${left}px)`;
@@ -1998,11 +1990,9 @@ export class VirtualizedViewManager {
       return;
     }
 
-    const placement = this.transformXFromTimestamp(marker.gap.start);
-    const gapWidth = this.getCollapsedGapWidthPx(marker.gap, placement);
-    const halfWidth = marker.ref.offsetWidth / 2;
+    const {left} = this.getCollapsedGapMarkerPosition(marker.gap, marker.ref.offsetWidth);
     marker.ref.style.opacity = '1';
-    marker.ref.style.transform = `translateX(${placement + gapWidth / 2 - halfWidth}px)`;
+    marker.ref.style.transform = `translateX(${left}px)`;
   }
 
   // Special case for when the timeline is empty - we want to show the first and last


### PR DESCRIPTION
## Summary

- make trace time compression eligibility and retained gap widths relative to the settled viewport
- only compress zoomed gaps that are fully bounded by visible span activity
- defer viewport recomputation until zoom, pan, and resize interactions settle using TanStack Pacer
- keep a single React-owned compression mapping shared with the virtualized view manager
- keep collapsed gap markers within the visible viewport