### PR TITLE
feat(stacktrace): add astro file extension for syntax highlighting

### DIFF
--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -54,6 +54,7 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   mjs: 'javascript',
   jsbundle: 'javascript',
   bundle: 'javascript',
+  astro: 'javascript',
   vue: 'javascript',
   svelte: 'javascript',
   'js?': 'javascript',


### PR DESCRIPTION
<!-- Describe your PR here. -->
This MR adds the file extension `.astro` from the [Astro Framework](https://astro.build/) to be syntax-highlighted like Javascript.
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
