### PR TITLE
feat(seer): Drop 90-day option from Autofix overview activity filter

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -577,6 +577,21 @@ describe('AutofixOverview', () => {
     expect(screen.queryByRole('option', {name: 'Last 90 days'})).not.toBeInTheDocument();
   });
 
+  it('keeps a stale 90-day selection valid on the trigger', async () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({datetime: {period: '90d', start: null, end: null, utc: null}})
+    );
+    mockOverview({base: {}});
+
+    renderPage();
+
+    // A period no longer offered (here inherited from another page/URL) must
+    // still render on the trigger rather than showing "Invalid Period".
+    expect(
+      await screen.findByRole('button', {name: 'Autofix Activity 90D'})
+    ).toBeInTheDocument();
+  });
+
   it('renders card prose and links from the endpoint payload', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -581,12 +581,11 @@ describe('AutofixOverview', () => {
     PageFiltersStore.onInitializeUrlState(
       PageFiltersFixture({datetime: {period: '90d', start: null, end: null, utc: null}})
     );
+    setPageFiltersStorage(organization.slug, new Set(['datetime']));
     mockOverview({base: {}});
 
     renderPage();
 
-    // A period no longer offered (here inherited from another page/URL) must
-    // still render on the trigger rather than showing "Invalid Period".
     expect(
       await screen.findByRole('button', {name: 'Autofix Activity 90D'})
     ).toBeInTheDocument();

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -564,6 +564,19 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText('No issues')).not.toBeInTheDocument();
   });
 
+  it('offers activity periods up to 30 days but not 90 days', async () => {
+    mockOverview({base: {}});
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Autofix Activity 7D'})
+    );
+
+    expect(await screen.findByRole('option', {name: 'Last 30 days'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Last 90 days'})).not.toBeInTheDocument();
+  });
+
   it('renders card prose and links from the endpoint payload', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -65,10 +65,6 @@ const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
 
 const {'90d': _90d, ...ACTIVITY_RELATIVE_PERIODS} = DEFAULT_RELATIVE_PERIODS;
 
-// Drop the 90-day preset from the activity filter, but keep any
-// arbitrary/currently-selected period (e.g. a stale `90d` from the URL or a
-// custom range typed in search) so the trigger stays valid instead of
-// rendering "Invalid Period".
 const activityRelativeOptions = ({
   arbitraryOptions,
 }: {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -1,4 +1,4 @@
-import {type ComponentProps, Fragment, useMemo} from 'react';
+import {type ComponentProps, Fragment, type ReactNode, useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
@@ -64,6 +64,16 @@ const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
 ];
 
 const {'90d': _90d, ...ACTIVITY_RELATIVE_PERIODS} = DEFAULT_RELATIVE_PERIODS;
+
+// Drop the 90-day preset from the activity filter, but keep any
+// arbitrary/currently-selected period (e.g. a stale `90d` from the URL or a
+// custom range typed in search) so the trigger stays valid instead of
+// rendering "Invalid Period".
+const activityRelativeOptions = ({
+  arbitraryOptions,
+}: {
+  arbitraryOptions: Record<string, ReactNode>;
+}) => ({...ACTIVITY_RELATIVE_PERIODS, ...arbitraryOptions});
 
 // Buckets the assignee filter value (a raw `type:id` actor string) for
 // analytics, avoiding actor-id PII/cardinality. Null means the filter was
@@ -249,7 +259,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           <ProjectFilterSkeleton />
         )}
         <DatePageFilter
-          relativeOptions={ACTIVITY_RELATIVE_PERIODS}
+          relativeOptions={activityRelativeOptions}
           onChange={update =>
             trackFilterChanged('activity', update.relative ?? 'absolute')
           }

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -22,6 +22,7 @@ import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -61,6 +62,8 @@ const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
   {value: 'events', label: t('Most events')},
   {value: 'users', label: t('Most users')},
 ];
+
+const {'90d': _90d, ...ACTIVITY_RELATIVE_PERIODS} = DEFAULT_RELATIVE_PERIODS;
 
 // Buckets the assignee filter value (a raw `type:id` actor string) for
 // analytics, avoiding actor-id PII/cardinality. Null means the filter was
@@ -246,6 +249,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           <ProjectFilterSkeleton />
         )}
         <DatePageFilter
+          relativeOptions={ACTIVITY_RELATIVE_PERIODS}
           onChange={update =>
             trackFilterChanged('activity', update.relative ?? 'absolute')
           }


### PR DESCRIPTION
Removes "Last 90 days" from the activity date filter on the Autofix overview page (`/issues/autofix/overview/`).

The filter didn't define its own period options, so it fell through to the app-wide `DEFAULT_RELATIVE_PERIODS` constant, which includes `90d`. Editing that shared constant would drop the option everywhere, so instead this scopes a filtered option set (`DEFAULT_RELATIVE_PERIODS` minus `90d`) to just this page's `DatePageFilter`. The selector now goes up to "Last 30 days".

`WINDOW_LABELS` in `periods.ts` intentionally keeps its `90d` entry — it's typed off `DEFAULT_RELATIVE_PERIODS` and only supplies descriptive label text, so a stale `?statsPeriod=90d` in the URL still renders a sensible label rather than breaking.