### PR TITLE
feat(seer): Show the skeleton on an Autofix Overview sort change

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -792,23 +792,16 @@ describe('AutofixOverview', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('keeps the list up silently while a sort change reloads', async () => {
-    const {statusPollRequest} = mockOverview({
-      base: {autofix_root_cause: [rootCauseRun]},
-    });
+  it('shows the skeleton while a sort change reloads', async () => {
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
 
-    // The events sort returns a different run; hold its enrichment open to keep
-    // the reloading state on screen.
-    const eventsEnriched = deferEnriched();
+    // A sort change is a new scope, so previous data is dropped instead of held.
+    // Hold the events-sorted response open to keep the skeleton on screen.
+    const events = deferEnriched();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
-      match: [
-        MockApiClient.matchQuery({
-          sort: 'events',
-          expand: ['scmInfo', 'issueStats', 'status'],
-        }),
-      ],
-      asyncDelay: eventsEnriched.promise,
+      match: [MockApiClient.matchQuery({sort: 'events'})],
+      asyncDelay: events.promise,
       body: {runsByMilestone: {...emptyMilestones, autofix_solution: [solutionRun]}},
     });
 
@@ -817,29 +810,25 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(statusPollRequest).toHaveBeenCalledTimes(1);
 
     await userEvent.click(screen.getByRole('button', {name: /Sort/}));
     await userEvent.click(screen.getByRole('option', {name: 'Most events'}));
 
-    // The status poll refetches for the new sort, but the old list stays up
-    // silently (keepPreviousData) while the enriched request reloads — no spinner
-    // and no skeleton.
-    await waitFor(() => expect(statusPollRequest).toHaveBeenCalledTimes(2));
+    // The old list drops out and the skeleton shows while the reordered results
+    // load — matching a project or date change.
+    expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
+      0
+    );
     expect(
-      screen.getByRole('link', {name: 'TypeError in checkout cart'})
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
+    ).not.toBeInTheDocument();
 
-    eventsEnriched.resolve();
+    events.resolve();
 
     expect(
       await screen.findByRole('link', {name: 'KeyError in proxy handler'})
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
   });
 
   it('shows the skeleton again when the selected project changes', async () => {

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
@@ -166,13 +166,22 @@ describe('shouldRefetchEnriched', () => {
 describe('isSameScope', () => {
   const scope = {project: [2], statsPeriod: '14d'};
 
-  it('is true across a sort or expand change', () => {
+  it('is true across an expand change', () => {
     expect(
       isSameScope(
         {...scope, expand: ['status']},
-        {...scope, sort: 'events', expand: ['scmInfo', 'issueStats', 'status']}
+        {...scope, expand: ['scmInfo', 'issueStats', 'status']}
       )
     ).toBe(true);
+  });
+
+  it('is false when the sort changes', () => {
+    expect(
+      isSameScope(
+        {...scope, expand: ['status']},
+        {...scope, sort: 'events', expand: ['status']}
+      )
+    ).toBe(false);
   });
 
   it('is false when the projects change', () => {

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -112,7 +112,7 @@ export function shouldRefetchEnriched(
 
 type QueryParams = Record<string, unknown> | undefined;
 
-const SCOPE_FREE_PARAMS = ['sort', 'expand'];
+const SCOPE_FREE_PARAMS = ['expand'];
 
 export function isSameScope(previous: QueryParams, next: QueryParams): boolean {
   return isEqual(omit(previous, SCOPE_FREE_PARAMS), omit(next, SCOPE_FREE_PARAMS));


### PR DESCRIPTION
Changing the sort on the Autofix Overview refetches the query — sorting is a server-side reorder, not client-side. The current behavior treats `sort` as a "scope-free" param, so the previous list stays on screen silently while the reordered results load, giving the user no feedback that anything is happening.

This drops `sort` from `SCOPE_FREE_PARAMS` so a sort change is now a scope change: `placeholderData` discards the previous data, `resultsPending` flips true, and the existing `OverviewSkeleton` renders until the reordered results land — the same treatment as a project or date change.

This is deliberately reversing one of the "silent on sort" decisions from #122425. That PR held the list up silently on sort (via `keepPreviousData`, then via the scope-free classification). A codebase survey of how server-sorted lists handle sort found the opposite is the near-universal convention: the query key includes `sort`, sorting refetches, and the view drops its rows for a full loading state — a bare `LoadingIndicator` for everything on `GridEditable` / Explore's `DataTable` / the Replays `SimpleTable`, and a shaped placeholder skeleton for the issue stream (the closest analog to this page). The only "keep rows + light overlay" precedent is the Agents traces table, and it isn't wired to column sort. So the skeleton-on-sort behavior here matches the dominant pattern.

`expand` stays scope-free, so same-key refetches — the 10s status poll and the section-change enrichment — keep their results on screen silently as before. Only project/date/sort scope changes now show the skeleton.

Refs AIML-3358