### PR TITLE
feat(autofix): Move truncated-runs notice into the assignee menu

### DIFF
--- a/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
+++ b/static/app/views/seerWorkflows/overview/assigneeFilter.tsx
@@ -3,9 +3,12 @@ import {useMemo} from 'react';
 import {ActorAvatar} from '@sentry/scraps/avatar';
 import {Badge} from '@sentry/scraps/badge';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Actor} from 'sentry/types/core';
 
@@ -26,11 +29,13 @@ export function AssigneeFilter({
   value,
   onChange,
   loading,
+  truncated,
 }: {
   onChange: (value: string | null) => void;
   runs: OverviewRun[];
   value: string | null;
   loading?: boolean;
+  truncated?: boolean;
 }) {
   const options = useMemo(() => {
     const byValue = new Map<string, {actor: Actor | null; count: number}>();
@@ -73,6 +78,16 @@ export function AssigneeFilter({
       loading={loading}
       disabled={false}
       menuTitle={loading ? t('Assignee') : undefined}
+      menuBody={
+        truncated && options.length > 0 ? (
+          <Flex gap="xs" align="center" padding="xs md">
+            <IconWarning size="xs" variant="warning" />
+            <Text size="sm" variant="muted">
+              {t('Assignee counts may be incomplete')}
+            </Text>
+          </Flex>
+        ) : undefined
+      }
       options={options}
       value={value ?? undefined}
       onChange={selected => onChange(selected?.value ?? null)}

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1678,7 +1678,7 @@ describe('AutofixOverview', () => {
       expect(screen.queryByRole('tab', {name: /All Runs/})).not.toBeInTheDocument();
     });
 
-    it('shows a truncation notice when the backend caps a section', async () => {
+    it('shows a truncation notice in the assignee menu when the backend caps a section', async () => {
       mockOverview({
         base: {autofix_root_cause: [assignedRun]},
         truncated: ['autofix_root_cause'],
@@ -1686,11 +1686,35 @@ describe('AutofixOverview', () => {
 
       renderPage();
 
+      await userEvent.click(await screen.findByRole('button', {name: /Assignee/}));
+
       expect(
-        await screen.findByText(
-          'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
-        )
+        await screen.findByText('Assignee counts may be incomplete')
       ).toBeInTheDocument();
+    });
+
+    it('omits the truncation notice when nothing is capped', async () => {
+      mockOverview({base: {autofix_root_cause: [assignedRun]}});
+
+      renderPage();
+
+      await userEvent.click(await screen.findByRole('button', {name: /Assignee/}));
+
+      expect(
+        screen.queryByText('Assignee counts may be incomplete')
+      ).not.toBeInTheDocument();
+    });
+
+    it('omits the truncation notice when the menu has no assignee options', async () => {
+      mockOverview({base: {}, truncated: ['autofix_root_cause']});
+
+      renderPage();
+
+      await userEvent.click(await screen.findByRole('button', {name: /Assignee/}));
+
+      expect(
+        screen.queryByText('Assignee counts may be incomplete')
+      ).not.toBeInTheDocument();
     });
 
     it('formats team assignees with a # prefix', async () => {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -261,6 +261,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             setQueryParam('assignee', next ?? undefined);
           }}
           loading={isPending}
+          truncated={(data?.truncatedMilestones?.length ?? 0) > 0}
         />
         <CompactSelect
           value={sort}
@@ -273,13 +274,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
         />
-        {(data?.truncatedMilestones?.length ?? 0) > 0 && (
-          <Text size="sm" variant="muted">
-            {t(
-              'Some sections show only their most recent runs, so assignee options and counts may be incomplete.'
-            )}
-          </Text>
-        )}
         <Flex marginLeft="auto">
           <Button
             onClick={toggleAllGroups}


### PR DESCRIPTION
The Autofix overview showed an inline notice in the filter bar whenever a milestone section was capped by the backend, warning that assignee options and counts could be incomplete. It competed with the filters for horizontal space and was only loosely tied to the control it actually qualifies.

This moves the notice into the assignee picker's menu (rendered above the options via `menuBody`), where it sits with the counts it describes, and shortens the copy to "Assignee counts may be incomplete". It only renders when the picker actually has options to qualify, so it never shows over an empty menu.

Frontend-only, scoped to the Seer workflows overview view — no shared/core component changes.

<img width="696" height="1126" alt="CleanShot 2026-08-25 at 14 30 04@2x" src="https://github.com/user-attachments/assets/d6edbb15-2b95-4cbd-8163-492e576744e6" />
