### PR TITLE
fix(repos): Auto-sync newly connected SCM provider so repos appear

### DIFF
--- a/static/app/views/settings/organizationRepositories/hooks/useSyncRepositories.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/hooks/useSyncRepositories.spec.tsx
@@ -132,6 +132,56 @@ describe('useSyncRepositories', () => {
     expect(onSynced).toHaveBeenCalled();
   });
 
+  it('detects completion for a freshly connected integration with no prior last_sync', async () => {
+    // A newly connected integration starts without a last_sync value; the
+    // undefined -> timestamp transition must still be detected as completion.
+    const freshIntegration = OrganizationIntegrationsFixture({id: '123', configData: {}});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: freshIntegration,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/repo-sync/',
+      method: 'POST',
+      body: {},
+    });
+
+    const onSynced = jest.fn();
+    const {result} = renderHookWithProviders(
+      () =>
+        useSyncRepositories(freshIntegration, {
+          onSynced,
+          pollingConfig: [{pollInterval: 5_000, phaseTimeout: 30_000}],
+        }),
+      {organization}
+    );
+
+    await waitFor(() => expect(result.current.syncNow).toBeDefined());
+
+    jest.useFakeTimers();
+
+    act(() => {
+      result.current.syncNow?.();
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/integrations/123/',
+      body: OrganizationIntegrationsFixture({
+        id: '123',
+        configData: {last_sync: 'new-value'},
+      }),
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    jest.useRealTimers();
+
+    await waitFor(() => expect(result.current.isSyncing).toBe(false));
+    expect(onSynced).toHaveBeenCalled();
+  });
+
   it('shows a still-syncing toast and advances poll interval at phase boundary', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/123/repo-sync/',

--- a/static/app/views/settings/organizationRepositories/hooks/useSyncRepositories.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/hooks/useSyncRepositories.spec.tsx
@@ -132,56 +132,6 @@ describe('useSyncRepositories', () => {
     expect(onSynced).toHaveBeenCalled();
   });
 
-  it('detects completion for a freshly connected integration with no prior last_sync', async () => {
-    // A newly connected integration starts without a last_sync value; the
-    // undefined -> timestamp transition must still be detected as completion.
-    const freshIntegration = OrganizationIntegrationsFixture({id: '123', configData: {}});
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/123/',
-      body: freshIntegration,
-    });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/123/repo-sync/',
-      method: 'POST',
-      body: {},
-    });
-
-    const onSynced = jest.fn();
-    const {result} = renderHookWithProviders(
-      () =>
-        useSyncRepositories(freshIntegration, {
-          onSynced,
-          pollingConfig: [{pollInterval: 5_000, phaseTimeout: 30_000}],
-        }),
-      {organization}
-    );
-
-    await waitFor(() => expect(result.current.syncNow).toBeDefined());
-
-    jest.useFakeTimers();
-
-    act(() => {
-      result.current.syncNow?.();
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/integrations/123/',
-      body: OrganizationIntegrationsFixture({
-        id: '123',
-        configData: {last_sync: 'new-value'},
-      }),
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(5_000);
-    });
-
-    jest.useRealTimers();
-
-    await waitFor(() => expect(result.current.isSyncing).toBe(false));
-    expect(onSynced).toHaveBeenCalled();
-  });
-
   it('shows a still-syncing toast and advances poll interval at phase boundary', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/123/repo-sync/',

--- a/static/app/views/settings/organizationRepositories/index.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/index.spec.tsx
@@ -4,6 +4,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {
+  act,
   render,
   renderGlobalModal,
   screen,
@@ -11,6 +12,8 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
+import * as pipelineModal from 'sentry/components/pipeline/modal';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {mockElementSize} from 'sentry/utils/fixtures/virtualization';
 import OrganizationRepositories from 'sentry/views/settings/organizationRepositories';
 
@@ -266,6 +269,132 @@ describe('OrganizationRepositories', () => {
       expect(
         await screen.findByText('Re-syncing in the background…')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('connect', () => {
+    const NEW_INTEGRATION = OrganizationIntegrationsFixture({
+      id: '2',
+      name: 'my-new-org',
+      provider: {
+        key: 'github',
+        slug: 'github',
+        name: 'GitHub',
+        canAdd: true,
+        canDisable: false,
+        features: [],
+        aspects: {},
+      },
+    });
+
+    // Opens the connect dropdown, selects GitHub, and returns the captured
+    // pipeline onComplete so the test can simulate a finished connection.
+    async function startConnectFlow() {
+      const openPipelineModalSpy = jest
+        .spyOn(pipelineModal, 'openPipelineModal')
+        .mockImplementation(() => {});
+
+      await userEvent.click(screen.getByRole('button', {name: 'Connect new provider'}));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub'}));
+
+      return openPipelineModalSpy.mock.calls[0]![0].onComplete!;
+    }
+
+    it('auto-syncs a newly connected integration so repos appear without a refresh', async () => {
+      setupDefaultMocks();
+
+      render(<OrganizationRepositories />);
+
+      // Existing installed integration renders, then start the connect flow.
+      await screen.findByText('my-org');
+      const onComplete = await startConnectFlow();
+
+      // The refetch after connect now includes the new integration.
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/',
+        body: [GITHUB_INTEGRATION, NEW_INTEGRATION],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${NEW_INTEGRATION.id}/`,
+        body: NEW_INTEGRATION,
+      });
+      const syncRequest = MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${NEW_INTEGRATION.id}/repo-sync/`,
+        method: 'POST',
+        body: {},
+      });
+
+      act(() => onComplete(NEW_INTEGRATION as IntegrationWithConfig));
+
+      await waitFor(() => expect(syncRequest).toHaveBeenCalledTimes(1));
+    });
+
+    it('does not auto-sync integrations that were already installed on load', async () => {
+      const syncRequest = MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/repo-sync/`,
+        method: 'POST',
+        body: {},
+      });
+      setupDefaultMocks();
+
+      render(<OrganizationRepositories />);
+
+      // Once the settings button enables, the integration is fully loaded — a
+      // pending auto-sync would have fired by now.
+      expect(
+        await screen.findByRole('button', {name: 'Integration settings'})
+      ).toBeEnabled();
+      expect(syncRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not re-sync a connected integration when its row remounts', async () => {
+      setupDefaultMocks();
+
+      render(<OrganizationRepositories />);
+      renderGlobalModal();
+
+      await screen.findByText('my-org');
+      const onComplete = await startConnectFlow();
+
+      // After connect both integrations exist, so the table switches to the
+      // multi-install layout and the new row auto-syncs once.
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/',
+        body: [GITHUB_INTEGRATION, NEW_INTEGRATION],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${NEW_INTEGRATION.id}/`,
+        body: NEW_INTEGRATION,
+      });
+      const syncRequest = MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${NEW_INTEGRATION.id}/repo-sync/`,
+        method: 'POST',
+        body: {},
+      });
+
+      act(() => onComplete(NEW_INTEGRATION as IntegrationWithConfig));
+      await waitFor(() => expect(syncRequest).toHaveBeenCalledTimes(1));
+      await screen.findByText('my-new-org');
+
+      // Uninstall the original integration; the provider drops back to a single
+      // install, remounting the connected row.
+      MockApiClient.addMockResponse({
+        url: `/organizations/org-slug/integrations/${GITHUB_INTEGRATION.id}/`,
+        method: 'DELETE',
+        body: {},
+      });
+      await userEvent.click(screen.getAllByRole('button', {name: 'Uninstall'})[0]!);
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/',
+        body: [NEW_INTEGRATION],
+      });
+      await userEvent.click(screen.getByRole('button', {name: "I'm sure, uninstall"}));
+
+      // Wait for the original row to drop out (the remount has happened by then).
+      await waitFor(() => expect(screen.queryByText('my-org')).not.toBeInTheDocument());
+
+      // The signal is cleared once consumed, so the remount must not re-sync.
+      expect(syncRequest).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/static/app/views/settings/organizationRepositories/index.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/index.spec.tsx
@@ -287,8 +287,6 @@ describe('OrganizationRepositories', () => {
       },
     });
 
-    // Opens the connect dropdown, selects GitHub, and returns the captured
-    // pipeline onComplete so the test can simulate a finished connection.
     async function startConnectFlow() {
       const openPipelineModalSpy = jest
         .spyOn(pipelineModal, 'openPipelineModal')
@@ -305,11 +303,9 @@ describe('OrganizationRepositories', () => {
 
       render(<OrganizationRepositories />);
 
-      // Existing installed integration renders, then start the connect flow.
       await screen.findByText('my-org');
       const onComplete = await startConnectFlow();
 
-      // The refetch after connect now includes the new integration.
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/',
         body: [GITHUB_INTEGRATION, NEW_INTEGRATION],
@@ -356,8 +352,6 @@ describe('OrganizationRepositories', () => {
       await screen.findByText('my-org');
       const onComplete = await startConnectFlow();
 
-      // After connect both integrations exist, so the table switches to the
-      // multi-install layout and the new row auto-syncs once.
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/',
         body: [GITHUB_INTEGRATION, NEW_INTEGRATION],
@@ -390,10 +384,8 @@ describe('OrganizationRepositories', () => {
       });
       await userEvent.click(screen.getByRole('button', {name: "I'm sure, uninstall"}));
 
-      // Wait for the original row to drop out (the remount has happened by then).
       await waitFor(() => expect(screen.queryByText('my-org')).not.toBeInTheDocument());
 
-      // The signal is cleared once consumed, so the remount must not re-sync.
       expect(syncRequest).toHaveBeenCalledTimes(1);
     });
   });

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -1,4 +1,12 @@
-import {useMemo, useState} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useInfiniteQuery, useQuery, useQueryClient} from '@tanstack/react-query';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
@@ -44,6 +52,18 @@ import {useSyncRepositories} from './hooks/useSyncRepositories';
 import {getProviderConfigUrl} from './getProviderConfigUrl';
 import type {ScmInstallation} from './types';
 
+interface AutoSyncContextValue {
+  autoSyncIntegrationId: string | null;
+  clearAutoSync: () => void;
+}
+
+// Signals which just-connected integration should auto-sync, with a one-shot
+// clear so a remounting row can't re-trigger the sync.
+const AutoSyncContext = createContext<AutoSyncContextValue>({
+  autoSyncIntegrationId: null,
+  clearAutoSync: () => {},
+});
+
 function ConnectedInstallation({installation, children}: InstallationWrapperProps) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
@@ -85,6 +105,21 @@ function ConnectedInstallation({installation, children}: InstallationWrapperProp
   const {syncNow, isSyncing} = useSyncRepositories(installation.integration, {
     onSynced: () => queryClient.invalidateQueries({queryKey: reposOptions.queryKey}),
   });
+
+  // Auto-sync a freshly connected integration once syncNow is ready (i.e. the
+  // integration is queryable), so repos appear without a manual page refresh.
+  // Clearing the signal on fire keeps it one-shot across row remounts.
+  const {autoSyncIntegrationId, clearAutoSync} = useContext(AutoSyncContext);
+  const shouldAutoSync =
+    hasAccess && installation.integration.id === autoSyncIntegrationId;
+  const hasAutoSyncedRef = useRef(false);
+  useEffect(() => {
+    if (shouldAutoSync && syncNow && !hasAutoSyncedRef.current) {
+      hasAutoSyncedRef.current = true;
+      clearAutoSync();
+      syncNow();
+    }
+  }, [shouldAutoSync, syncNow, clearAutoSync]);
 
   // Settings cannot be opened until we've loaded the integrationWithConfig
   const settingsButtonProps = {
@@ -131,6 +166,8 @@ const SCM_PROVIDER_ORDER = [
 export default function OrganizationRepositories() {
   const organization = useOrganization();
   const [searchTerm, setSearchTerm] = useState('');
+  const [autoSyncIntegrationId, setAutoSyncIntegrationId] = useState<string | null>(null);
+  const clearAutoSync = useCallback(() => setAutoSyncIntegrationId(null), []);
 
   const providersQuery = useQuery(
     organizationConfigIntegrationsQueryOptions({organization})
@@ -227,10 +264,17 @@ export default function OrganizationRepositories() {
     mappingsLoading,
   ]);
 
-  const handleAddIntegration = (_data: Integration) => {
+  // Refetch so the new row appears; auto-sync then polls in its row until the
+  // backend finishes importing repos.
+  const handleAddIntegration = (data: Integration) => {
+    setAutoSyncIntegrationId(data.id);
     integrationsQuery.refetch();
-    reposQuery.refetch();
   };
+
+  const autoSyncContextValue = useMemo(
+    () => ({autoSyncIntegrationId, clearAutoSync}),
+    [autoSyncIntegrationId, clearAutoSync]
+  );
 
   const repoMatches = useRepoSearch(allRepos, searchTerm);
 
@@ -258,57 +302,59 @@ export default function OrganizationRepositories() {
 
   return (
     <AnalyticsArea name="repositories-v2">
-      <SentryDocumentTitle title={t('Repositories')} orgSlug={organization.slug} />
-      <SettingsPageHeader
-        title={t('Repositories')}
-        subtitle={pageDescription}
-        action={
-          scmIntegrations.length > 0 ? (
-            <ConnectProviderDropdown
-              providers={scmProviders.filter(p => p.canAdd)}
-              onAddIntegration={handleAddIntegration}
-            />
-          ) : undefined
-        }
-      />
-      {isLoading ? (
-        <LoadingIndicator />
-      ) : isError ? (
-        <LoadingError
-          onRetry={() => {
-            providersQuery.refetch();
-            integrationsQuery.refetch();
-            reposQuery.refetch();
-          }}
+      <AutoSyncContext.Provider value={autoSyncContextValue}>
+        <SentryDocumentTitle title={t('Repositories')} orgSlug={organization.slug} />
+        <SettingsPageHeader
+          title={t('Repositories')}
+          subtitle={pageDescription}
+          action={
+            scmIntegrations.length > 0 ? (
+              <ConnectProviderDropdown
+                providers={scmProviders.filter(p => p.canAdd)}
+                onAddIntegration={handleAddIntegration}
+              />
+            ) : undefined
+          }
         />
-      ) : (
-        <Stack gap="lg">
-          <Input
-            type="search"
-            placeholder={t('Search repositories')}
-            value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
+        {isLoading ? (
+          <LoadingIndicator />
+        ) : isError ? (
+          <LoadingError
+            onRetry={() => {
+              providersQuery.refetch();
+              integrationsQuery.refetch();
+              reposQuery.refetch();
+            }}
           />
-          {!integrationsQuery.isPending && scmIntegrations.length === 0 ? (
-            <NoIntegrationsEmptyState
-              providers={scmProviders}
-              onAddIntegration={handleAddIntegration}
+        ) : (
+          <Stack gap="lg">
+            <Input
+              type="search"
+              placeholder={t('Search repositories')}
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
             />
-          ) : (
-            scmProviders
-              .filter(p => installationsByProviderKey[p.key])
-              .map(provider => (
-                <ScmRepositoryTable
-                  key={provider.key}
-                  provider={provider}
-                  installations={installationsByProviderKey[provider.key]!}
-                  repoMatches={repoMatches}
-                  installationWrapper={ConnectedInstallation}
-                />
-              ))
-          )}
-        </Stack>
-      )}
+            {!integrationsQuery.isPending && scmIntegrations.length === 0 ? (
+              <NoIntegrationsEmptyState
+                providers={scmProviders}
+                onAddIntegration={handleAddIntegration}
+              />
+            ) : (
+              scmProviders
+                .filter(p => installationsByProviderKey[p.key])
+                .map(provider => (
+                  <ScmRepositoryTable
+                    key={provider.key}
+                    provider={provider}
+                    installations={installationsByProviderKey[provider.key]!}
+                    repoMatches={repoMatches}
+                    installationWrapper={ConnectedInstallation}
+                  />
+                ))
+            )}
+          </Stack>
+        )}
+      </AutoSyncContext.Provider>
     </AnalyticsArea>
   );
 }

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -64,6 +64,25 @@ const AutoSyncContext = createContext<AutoSyncContextValue>({
   clearAutoSync: () => {},
 });
 
+// Auto-sync a freshly connected integration once syncNow is ready, so repos
+// appear without a refresh. The clear handles remounts, the ref handles same-mount re-runs.
+function useAutoSyncOnConnect(
+  integrationId: string,
+  syncNow: (() => void) | undefined,
+  enabled: boolean
+) {
+  const {autoSyncIntegrationId, clearAutoSync} = useContext(AutoSyncContext);
+  const hasSyncedRef = useRef(false);
+  const shouldSync = enabled && integrationId === autoSyncIntegrationId;
+  useEffect(() => {
+    if (shouldSync && syncNow && !hasSyncedRef.current) {
+      hasSyncedRef.current = true;
+      clearAutoSync();
+      syncNow();
+    }
+  }, [shouldSync, syncNow, clearAutoSync]);
+}
+
 function ConnectedInstallation({installation, children}: InstallationWrapperProps) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
@@ -106,20 +125,7 @@ function ConnectedInstallation({installation, children}: InstallationWrapperProp
     onSynced: () => queryClient.invalidateQueries({queryKey: reposOptions.queryKey}),
   });
 
-  // Auto-sync a freshly connected integration once syncNow is ready (i.e. the
-  // integration is queryable), so repos appear without a manual page refresh.
-  // Clearing the signal on fire keeps it one-shot across row remounts.
-  const {autoSyncIntegrationId, clearAutoSync} = useContext(AutoSyncContext);
-  const shouldAutoSync =
-    hasAccess && installation.integration.id === autoSyncIntegrationId;
-  const hasAutoSyncedRef = useRef(false);
-  useEffect(() => {
-    if (shouldAutoSync && syncNow && !hasAutoSyncedRef.current) {
-      hasAutoSyncedRef.current = true;
-      clearAutoSync();
-      syncNow();
-    }
-  }, [shouldAutoSync, syncNow, clearAutoSync]);
+  useAutoSyncOnConnect(installation.integration.id, syncNow, hasAccess);
 
   // Settings cannot be opened until we've loaded the integrationWithConfig
   const settingsButtonProps = {

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -57,8 +57,7 @@ interface AutoSyncContextValue {
   clearAutoSync: () => void;
 }
 
-// Signals which just-connected integration should auto-sync, with a one-shot
-// clear so a remounting row can't re-trigger the sync.
+// Signals which just-connected integration should auto-sync.
 const AutoSyncContext = createContext<AutoSyncContextValue>({
   autoSyncIntegrationId: null,
   clearAutoSync: () => {},

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -269,8 +269,8 @@ export default function OrganizationRepositories() {
     mappingsLoading,
   ]);
 
-  // Refetch so the new row appears; auto-sync then polls in its row until the
-  // backend finishes importing repos.
+  // A newly connected provider has no repos imported yet. Refetch to render its
+  // row, then flag it to auto-sync, which polls until those repos appear.
   const handleAddIntegration = (data: Integration) => {
     setAutoSyncIntegrationId(data.id);
     integrationsQuery.refetch();


### PR DESCRIPTION
## Summary

On **Settings → Repositories**, a newly connected SCM provider's repos didn't appear until a manual page refresh — a dead-end after the "X added" success toast.

**Root cause:** `handleAddIntegration` did a single immediate refetch the instant the connect pipeline completed, but the backend imports repos asynchronously (and replicates control→region silo with lag), so that refetch raced the backend and came back empty.

## What changed

Reuse the existing per-row `useSyncRepositories` polling (the same machinery behind the "Sync now" link) instead of the one-shot refetch:

- On connect, flag the new integration to auto-sync; once its row is queryable it runs the same `last_sync` polling, so repos appear on their own.
- Condition-gated (fires only once the integration is queryable), provider-agnostic, and access-gated by `org:integrations`.
- The signal is carried via a small React context and cleared once consumed, so a row remount (the single↔multi-install table switch) can't re-trigger the sync.

## Testing

Three `connect` tests (auto-sync on connect, no auto-sync of pre-existing integrations, remount regression). All 16 tests in the file pass; typecheck and lint clean. Frontend-only.
