### PR TITLE
feat(tasks): Log GAL coordinator phases

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from datetime import datetime
 
 from django.utils import timezone
@@ -602,6 +603,14 @@ def backfill_group_action_log_for_all_projects(
     """Dispatch project backfills in batches for projects explicitly marked with a false backfill option."""
     task_state = current_task()
     activation_id = task_state.id if task_state else None
+    logger.info(
+        "backfill_group_action_log.coordinator.started",
+        extra={
+            "activation_id": activation_id,
+            "last_project_option_id": last_project_option_id,
+            "project_reset": project_reset,
+        },
+    )
     if activation_id and already_spawned(_COORDINATOR_TASK_KEY, activation_id):
         logger.info(
             "backfill_group_action_log.coordinator.duplicate_redelivery.skipped",
@@ -626,6 +635,14 @@ def backfill_group_action_log_for_all_projects(
         )
         return
 
+    logger.info(
+        "backfill_group_action_log.coordinator.query_started",
+        extra={
+            "batch_size": batch_size,
+            "last_project_option_id": last_project_option_id,
+        },
+    )
+    query_started_at = time.monotonic()
     project_options = list(
         ProjectOption.objects.filter(
             key=GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION,
@@ -633,6 +650,15 @@ def backfill_group_action_log_for_all_projects(
         )
         .order_by("id")
         .values_list("id", "project_id", "value")[:batch_size]
+    )
+    incomplete_option_count = sum(value is False for _, _, value in project_options)
+    logger.info(
+        "backfill_group_action_log.coordinator.query_completed",
+        extra={
+            "duration_ms": (time.monotonic() - query_started_at) * 1000,
+            "incomplete_option_count": incomplete_option_count,
+            "option_count": len(project_options),
+        },
     )
 
     if not project_options:
@@ -642,6 +668,11 @@ def backfill_group_action_log_for_all_projects(
         )
         return
 
+    logger.info(
+        "backfill_group_action_log.coordinator.dispatch_started",
+        extra={"project_count": incomplete_option_count},
+    )
+    dispatched_project_count = 0
     for _, project_id, value in project_options:
         if value is not False:
             continue
@@ -653,6 +684,7 @@ def backfill_group_action_log_for_all_projects(
             },
             headers={"sentry-propagate-traces": False},
         )
+        dispatched_project_count += 1
 
     logger.info(
         "backfill_group_action_log.coordinator.batch_dispatched",
@@ -661,6 +693,7 @@ def backfill_group_action_log_for_all_projects(
             "first_project_option_id": project_options[0][0],
             "last_project_option_id": project_options[-1][0],
             "project_reset": project_reset,
+            "project_count": dispatched_project_count,
         },
     )
 
@@ -672,6 +705,10 @@ def backfill_group_action_log_for_all_projects(
             },
             countdown=inter_batch_delay_s,
             headers={"sentry-propagate-traces": False},
+        )
+        logger.info(
+            "backfill_group_action_log.coordinator.self_chain_scheduled",
+            extra={"last_project_option_id": project_options[-1][0]},
         )
         if activation_id:
             mark_spawned(_COORDINATOR_TASK_KEY, activation_id)

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -770,6 +770,30 @@ class BackfillGroupActionLogForAllProjectsTest(TestCase):
             complete_option_2.id
         )
 
+    def test_logs_coordinator_phases(self) -> None:
+        project = self.create_project(organization=self.organization)
+        self._set_backfill_complete(project, False)
+
+        with (
+            self.assertLogs("sentry.tasks.backfill_group_action_log", level="INFO") as logs,
+            patch.object(backfill_group_action_log_for_project, "apply_async"),
+        ):
+            backfill_group_action_log_for_all_projects()
+
+        events = [record.getMessage() for record in logs.records]
+        assert events == [
+            "backfill_group_action_log.coordinator.started",
+            "backfill_group_action_log.coordinator.query_started",
+            "backfill_group_action_log.coordinator.query_completed",
+            "backfill_group_action_log.coordinator.dispatch_started",
+            "backfill_group_action_log.coordinator.batch_dispatched",
+            "backfill_group_action_log.coordinator.completed",
+        ]
+        query_completed = logs.records[2]
+        assert query_completed.__dict__["duration_ms"] >= 0
+        assert query_completed.__dict__["incomplete_option_count"] == 1
+        assert query_completed.__dict__["option_count"] == 1
+
     def test_self_chains_when_more_projects_remain(self) -> None:
         for _ in range(3):
             project = self.create_project(organization=self.organization)


### PR DESCRIPTION
The group action log coordinator now emits structured phase events at task entry, around its `ProjectOption` query, before and after project dispatch, and after scheduling its next coordinator activation. Query completion records duration and option counts, while batch completion records the number of projects actually dispatched.

These boundaries make a stalled activation diagnosable from the last emitted event without adding per-project log volume.
