### PR TITLE
feat(seer): Add dashboard and replay embeds

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -65,6 +65,36 @@
     ]
   },
   {
+    "name": "dashboard",
+    "description": "The ONLY way to reference a saved Sentry dashboard. Use the dashboard ID exactly as returned by the dashboard API. Include the API-provided title when available. Inline: renders a compact link. Block: renders a standalone dashboard reference. Never use a markdown link for dashboard references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Dashboard",
+        "data": {
+          "id": "123",
+          "title": "Application health"
+        }
+      }
+    ]
+  },
+  {
     "name": "dsn",
     "description": "Display a copyable Sentry DSN (Data Source Name) string. Use this whenever presenting a DSN to the user — never output it as bare text.",
     "level": ["block"],
@@ -182,6 +212,37 @@
         "label": "Block",
         "data": {
           "ids": ["JAVASCRIPT-22SP", "JAVASCRIPT-39HX", "JAVASCRIPT-39ZF"]
+        }
+      }
+    ]
+  },
+  {
+    "name": "replay",
+    "description": "The ONLY way to reference a Sentry Session Replay. Use the replay ID, not the legacy project-slug:replay-id form. Provide eventTimestamp when the replay should open around a relevant event. Inline: renders a compact link. Block: renders a standalone replay reference. Never use a markdown link for replay references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "eventTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Replay",
+        "data": {
+          "id": "4c1f2e3d1234567890",
+          "eventTimestamp": "2026-08-25T16:37:12Z"
         }
       }
     ]

--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -218,7 +218,7 @@
   },
   {
     "name": "replay",
-    "description": "The ONLY way to reference a Sentry Session Replay. Use the replay ID, not the legacy project-slug:replay-id form. Provide eventTimestamp when the replay should open around a relevant event. Inline: renders a compact link. Block: renders a standalone replay reference. Never use a markdown link for replay references.",
+    "description": "The ONLY way to reference a Sentry Session Replay. Use the replay ID, not the legacy project-slug:replay-id form. Provide eventTimestamp as an ISO 8601 timestamp with a timezone offset (for example, Z or +00:00) when the replay should open around a relevant event. Inline: renders a compact link. Block: renders a standalone replay reference. Never use a markdown link for replay references.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -231,7 +231,8 @@
         "eventTimestamp": {
           "type": "string",
           "format": "date-time",
-          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+          "description": "ISO 8601 timestamp with a timezone offset (for example, Z or +00:00)"
         }
       },
       "required": ["id"],

--- a/static/app/components/seer/markdown/embeds/components/dashboard.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboard.tsx
@@ -1,0 +1,29 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconDashboard} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+function DashboardLink({id, title}: EmbedOutput<'dashboard'>) {
+  const organization = useOrganization();
+  const href = normalizeUrl(`/organizations/${organization.slug}/dashboard/${id}/`);
+
+  return (
+    <ResourceLink
+      icon={IconDashboard}
+      href={href}
+      title={title ?? t('Dashboard %s', id)}
+    />
+  );
+}
+
+export const Dashboard = defineSeerEmbed({
+  name: 'dashboard',
+  render(props) {
+    return <DashboardLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/replay.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replay.tsx
@@ -1,0 +1,35 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {getShortEventId} from 'sentry/utils/events';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+
+function ReplayLink({id, eventTimestamp}: EmbedOutput<'replay'>) {
+  const organization = useOrganization();
+  const pathname = makeReplaysPathname({path: `/${id}/`, organization});
+  const href = eventTimestamp
+    ? queryString.stringifyUrl({url: pathname, query: {event_t: eventTimestamp}})
+    : pathname;
+
+  return (
+    <ResourceLink
+      icon={IconPlay}
+      href={href}
+      title={t('Replay %s', getShortEventId(id))}
+    />
+  );
+}
+
+export const Replay = defineSeerEmbed({
+  name: 'replay',
+  render(props) {
+    return <ReplayLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -1,0 +1,71 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {ConfigStore} from 'sentry/stores/configStore';
+import type {Config} from 'sentry/types/system';
+
+function renderEmbed(name: string, data: Record<string, unknown>) {
+  const raw = `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
+  return render(<SeerMarkdown raw={raw} />);
+}
+
+describe('Seer resource embeds', () => {
+  let initialConfig: Config;
+
+  beforeEach(() => {
+    initialConfig = ConfigStore.getState();
+  });
+
+  afterEach(() => {
+    ConfigStore.loadInitialData(initialConfig);
+  });
+
+  it('links a dashboard title to the dashboard in the current organization', async () => {
+    const {router} = renderEmbed('dashboard', {
+      id: '123',
+      title: 'Application health',
+    });
+
+    await userEvent.click(screen.getByRole('link', {name: 'Application health'}));
+
+    expect(router.location.pathname).toBe('/organizations/org-slug/dashboard/123/');
+  });
+
+  it('uses a dashboard fallback label and normalizes customer-domain links', () => {
+    ConfigStore.set('customerDomain', {
+      subdomain: 'org-slug',
+      organizationUrl: 'https://org-slug.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
+
+    renderEmbed('dashboard', {id: '456'});
+
+    expect(screen.getByRole('link', {name: 'Dashboard 456'})).toHaveAttribute(
+      'href',
+      '/dashboard/456/'
+    );
+  });
+
+  it('links a replay to the relevant event timestamp', async () => {
+    const {router} = renderEmbed('replay', {
+      id: '4c1f2e3d1234567890',
+      eventTimestamp: '2026-08-25T16:37:12Z',
+    });
+
+    await userEvent.click(screen.getByRole('link', {name: 'Replay 4c1f2e3d'}));
+
+    expect(router.location.pathname).toBe(
+      '/organizations/org-slug/explore/replays/4c1f2e3d1234567890/'
+    );
+    expect(router.location.query.event_t).toBe('2026-08-25T16:37:12Z');
+  });
+
+  it('links a replay without a timestamp to the beginning', () => {
+    renderEmbed('replay', {id: 'abcdef1234567890'});
+
+    expect(screen.getByRole('link', {name: 'Replay abcdef12'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/replays/abcdef1234567890/'
+    );
+  });
+});

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -1,9 +1,11 @@
 import {AgentWriteApprovalEmbed} from './components/agentWriteApproval';
 import {Autofix} from './components/autofix';
 import {Chart} from './components/chart';
+import {Dashboard} from './components/dashboard';
 import {Docs} from './components/docs';
 import {Dsn} from './components/dsn';
 import {Issue, Issues} from './components/issue';
+import {Replay} from './components/replay';
 import {Timestamp} from './components/timestamp';
 import {User} from './components/user';
 import {SeerEmbedRegistry} from './registry';
@@ -12,10 +14,12 @@ const embeds = [
   AgentWriteApprovalEmbed,
   Autofix,
   Chart,
+  Dashboard,
   Docs,
   Dsn,
   Issue,
   Issues,
+  Replay,
   Timestamp,
   User,
 ];

--- a/static/app/components/seer/markdown/embeds/schemas.spec.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.spec.ts
@@ -1,0 +1,18 @@
+import {seerEmbedsToJsonSchemas} from './schemas';
+
+describe('seerEmbedsToJsonSchemas', () => {
+  it('documents the replay timestamp offset requirement in the agent contract', () => {
+    const replay = seerEmbedsToJsonSchemas().find(widget => widget.name === 'replay');
+
+    expect(replay).toMatchObject({
+      description: expect.stringContaining('timezone offset'),
+      body: {
+        properties: {
+          eventTimestamp: {
+            description: expect.stringContaining('timezone offset'),
+          },
+        },
+      },
+    });
+  });
+});

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -157,14 +157,17 @@ export const SEER_EMBED_SCHEMAS = {
     description:
       'The ONLY way to reference a Sentry Session Replay. ' +
       'Use the replay ID, not the legacy project-slug:replay-id form. ' +
-      'Provide eventTimestamp when the replay should open around a relevant event. ' +
+      'Provide eventTimestamp as an ISO 8601 timestamp with a timezone offset ' +
+      '(for example, Z or +00:00) when the replay should open around a relevant event. ' +
       'Inline: renders a compact link. ' +
       'Block: renders a standalone replay reference. ' +
       'Never use a markdown link for replay references.',
     level: ['inline', 'block'],
     schema: z.object({
       id: z.string().min(1),
-      eventTimestamp: isoTimestampSchema.optional(),
+      eventTimestamp: isoTimestampSchema
+        .describe('ISO 8601 timestamp with a timezone offset (for example, Z or +00:00)')
+        .optional(),
     }),
     examples: [
       {

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -69,6 +69,26 @@ export const SEER_EMBED_SCHEMAS = {
       },
     ],
   },
+  dashboard: {
+    description:
+      'The ONLY way to reference a saved Sentry dashboard. ' +
+      'Use the dashboard ID exactly as returned by the dashboard API. ' +
+      'Include the API-provided title when available. ' +
+      'Inline: renders a compact link. ' +
+      'Block: renders a standalone dashboard reference. ' +
+      'Never use a markdown link for dashboard references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      id: z.string().min(1),
+      title: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Dashboard',
+        data: {id: '123', title: 'Application health'},
+      },
+    ],
+  },
   dsn: {
     description:
       'Display a copyable Sentry DSN (Data Source Name) string. ' +
@@ -130,6 +150,29 @@ export const SEER_EMBED_SCHEMAS = {
         label: 'Block',
         level: 'block',
         data: {ids: ['JAVASCRIPT-22SP', 'JAVASCRIPT-39HX', 'JAVASCRIPT-39ZF']},
+      },
+    ],
+  },
+  replay: {
+    description:
+      'The ONLY way to reference a Sentry Session Replay. ' +
+      'Use the replay ID, not the legacy project-slug:replay-id form. ' +
+      'Provide eventTimestamp when the replay should open around a relevant event. ' +
+      'Inline: renders a compact link. ' +
+      'Block: renders a standalone replay reference. ' +
+      'Never use a markdown link for replay references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      id: z.string().min(1),
+      eventTimestamp: isoTimestampSchema.optional(),
+    }),
+    examples: [
+      {
+        label: 'Replay',
+        data: {
+          id: '4c1f2e3d1234567890',
+          eventTimestamp: '2026-08-25T16:37:12Z',
+        },
       },
     ],
   },


### PR DESCRIPTION
### Why?

Seer responses can reference issues with purpose-built embeds, but dashboard and Session Replay references currently fall back to plain links. Adding typed embeds gives these resources consistent in-chat navigation and leaves room for richer previews later.

### How?

Adds typed dashboard and replay schemas and registers link-first renderers that build organization-aware destinations. Replay references optionally preserve an event timestamp, and the generated embed widget contract is updated.

<sub>Generated with Codex</sub>