### PR TITLE
chore(issues): Lower organization group index rate limits

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -277,7 +277,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
             "GET": {
                 RateLimitCategory.IP: RateLimit(limit=10, window=1),
                 RateLimitCategory.USER: RateLimit(limit=10, window=1),
-                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
             }
         }
     )

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -65,8 +65,10 @@ from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupinbox import GroupInbox
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.tracing import start_span
 from sentry.utils.validators import normalize_event_id
@@ -269,6 +271,16 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ISSUES
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True
+
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=1),
+                RateLimitCategory.USER: RateLimit(limit=10, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
+            }
+        }
+    )
 
     def _search(
         self,


### PR DESCRIPTION
These rates match issue stats which is called in parallel on the issue stream.

Previously these were lumped into the default rate limit which are much higher.