### PR TITLE
feat(seer): Add resource link embeds for Sentry entities and queries

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -444,5 +444,706 @@
       }
     ],
     "featureFlag": "organizations:seer-agent-autofix"
+  },
+  {
+    "name": "alert",
+    "description": "The ONLY way to reference a Sentry alert. Use `id` exactly as the alerts API returns it, and set `kind` to match: \"metric\" for a metric alert, \"issue\" for an issue alert, \"uptime\" for an uptime alert, \"cron\" for a cron alert. Include the API-provided name when available. Never use a markdown link for alert references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["metric", "issue", "uptime", "cron"]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["id", "kind"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Metric alert",
+        "data": {
+          "id": "4521",
+          "kind": "metric",
+          "name": "Checkout p95 latency"
+        }
+      },
+      {
+        "label": "Issue alert",
+        "data": {
+          "id": "881",
+          "kind": "issue"
+        }
+      }
+    ]
+  },
+  {
+    "name": "monitor",
+    "description": "The ONLY way to reference a Sentry monitor (cron, uptime, or metric detector). Use the detector ID exactly as the monitors API returns it. Include the API-provided name when available. Never use a markdown link for monitor references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Monitor",
+        "data": {
+          "id": "9931",
+          "name": "nightly-billing-sync"
+        }
+      }
+    ]
+  },
+  {
+    "name": "savedIssueView",
+    "description": "The ONLY way to reference a saved Sentry issue view. Use the view ID exactly as the issue-views API returns it. Include the API-provided name when available. Never use a markdown link for issue view references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Saved issue view",
+        "data": {
+          "id": "77",
+          "name": "Unresolved in checkout"
+        }
+      }
+    ]
+  },
+  {
+    "name": "savedQuery",
+    "description": "The ONLY way to reference a saved Explore query. Use the saved query ID exactly as the API returns it and set `dataset` to the dataset it was saved against. Include the API-provided name when available. Never use a markdown link for saved query references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dataset": {
+          "type": "string",
+          "enum": ["spans", "logs", "metrics", "replays"]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["id", "dataset"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Saved query",
+        "data": {
+          "id": "312",
+          "dataset": "spans",
+          "name": "Slow checkout spans"
+        }
+      }
+    ]
+  },
+  {
+    "name": "trace",
+    "description": "The ONLY way to reference a Sentry trace (the trace waterfall view). Use the 32-character trace ID. Provide `timestamp` when known so the waterfall opens on the right time range, and `spanId` to focus a span. Never use a markdown link for trace references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "traceId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "spanId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["traceId"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Trace",
+        "data": {
+          "traceId": "a1b2c3d4e5f678901234567890abcdef",
+          "timestamp": "2026-08-25T16:37:12Z"
+        }
+      }
+    ]
+  },
+  {
+    "name": "profile",
+    "description": "The ONLY way to reference a Sentry profile (the flamegraph view). Requires both the profile ID and the slug of the project it belongs to. Never use a markdown link for profile references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projectSlug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "profileId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["projectSlug", "profileId"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Profile",
+        "data": {
+          "projectSlug": "javascript",
+          "profileId": "7f3c2b1a9d8e4f60"
+        }
+      }
+    ]
+  },
+  {
+    "name": "issuesQuery",
+    "description": "Link to the issue stream filtered by a search query. Use this when pointing the user at a SET of issues defined by a search rather than specific known issues — if you already have the short IDs, use the `issue` or `issues` embed instead. `query` uses issue search syntax, e.g. \"is:unresolved level:error\".",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projects": {
+          "description": "Project IDs. Omit for the \"My Projects\" selection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statsPeriod": {
+          "description": "Relative time range, e.g. \"24h\" or \"7d\". Mutually exclusive with start/end.",
+          "type": "string",
+          "pattern": "^\\d+[smhdw]$"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "sort": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Unresolved errors",
+        "data": {
+          "query": "is:unresolved level:error",
+          "statsPeriod": "7d",
+          "title": "Unresolved errors"
+        }
+      }
+    ]
+  },
+  {
+    "name": "errorsQuery",
+    "description": "Link to an errors (Discover) query results page. Use this for tabular error exploration across events. `query` uses event search syntax and `fields` are the table columns. Provide `yAxes` to chart aggregates alongside the table.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projects": {
+          "description": "Project IDs. Omit for the \"My Projects\" selection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statsPeriod": {
+          "description": "Relative time range, e.g. \"24h\" or \"7d\". Mutually exclusive with start/end.",
+          "type": "string",
+          "pattern": "^\\d+[smhdw]$"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "yAxes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Errors by URL",
+        "data": {
+          "query": "event.type:error",
+          "fields": ["title", "count()", "url"],
+          "statsPeriod": "24h",
+          "title": "Checkout errors"
+        }
+      }
+    ]
+  },
+  {
+    "name": "spansQuery",
+    "description": "Link to an Explore > Traces (spans) query. Use mode \"samples\" to show individual spans and \"aggregate\" to group and chart them. In aggregate mode supply `groupBy` and `yAxes`. `query` uses span search syntax, e.g. \"span.op:http.client\".",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projects": {
+          "description": "Project IDs. Omit for the \"My Projects\" selection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statsPeriod": {
+          "description": "Relative time range, e.g. \"24h\" or \"7d\". Mutually exclusive with start/end.",
+          "type": "string",
+          "pattern": "^\\d+[smhdw]$"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "mode": {
+          "default": "samples",
+          "type": "string",
+          "enum": ["samples", "aggregate"]
+        },
+        "groupBy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "yAxes": {
+          "description": "Aggregate functions to chart, e.g. \"count()\" or \"p95(span.duration)\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["query", "mode"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Slow HTTP spans",
+        "data": {
+          "query": "span.op:http.client",
+          "mode": "samples",
+          "sort": "-span.duration",
+          "statsPeriod": "24h"
+        }
+      },
+      {
+        "label": "p95 by span op",
+        "data": {
+          "query": "",
+          "mode": "aggregate",
+          "groupBy": ["span.op"],
+          "yAxes": ["p95(span.duration)"],
+          "statsPeriod": "7d"
+        }
+      }
+    ]
+  },
+  {
+    "name": "logsQuery",
+    "description": "Link to an Explore > Logs query. Use mode \"samples\" to show individual log rows and \"aggregate\" to group and chart them. In aggregate mode supply `groupBy` and `yAxes`. `query` uses log search syntax, e.g. \"severity:error\".",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projects": {
+          "description": "Project IDs. Omit for the \"My Projects\" selection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statsPeriod": {
+          "description": "Relative time range, e.g. \"24h\" or \"7d\". Mutually exclusive with start/end.",
+          "type": "string",
+          "pattern": "^\\d+[smhdw]$"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "mode": {
+          "default": "samples",
+          "type": "string",
+          "enum": ["samples", "aggregate"]
+        },
+        "groupBy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "yAxes": {
+          "description": "Aggregate functions to chart, e.g. \"count()\" or \"p95(span.duration)\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["query", "mode"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Error logs",
+        "data": {
+          "query": "severity:error",
+          "mode": "samples",
+          "statsPeriod": "24h"
+        }
+      },
+      {
+        "label": "Log volume by severity",
+        "data": {
+          "query": "",
+          "mode": "aggregate",
+          "groupBy": ["severity"],
+          "yAxes": ["count(message)"],
+          "statsPeriod": "7d"
+        }
+      }
+    ]
+  },
+  {
+    "name": "replaysQuery",
+    "description": "Link to the Session Replay list filtered by a search query. Use this when pointing the user at a SET of replays — if you have a specific replay ID, use the `replay` embed instead. `query` uses replay search syntax, e.g. \"user.email:user@example.com\".",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projects": {
+          "description": "Project IDs. Omit for the \"My Projects\" selection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statsPeriod": {
+          "description": "Relative time range, e.g. \"24h\" or \"7d\". Mutually exclusive with start/end.",
+          "type": "string",
+          "pattern": "^\\d+[smhdw]$"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "sort": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Replays with rage clicks",
+        "data": {
+          "query": "count_rage_clicks:>0",
+          "statsPeriod": "7d"
+        }
+      }
+    ]
+  },
+  {
+    "name": "metricsQuery",
+    "description": "Link to an Explore > Metrics query for a single trace metric. Requires the metric `name` and `type` exactly as the metrics API returns them. Use mode \"aggregate\" with `groupBy`/`yAxes` to chart the metric, or \"samples\" to list raw points.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "projects": {
+          "description": "Project IDs. Omit for the \"My Projects\" selection.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statsPeriod": {
+          "description": "Relative time range, e.g. \"24h\" or \"7d\". Mutually exclusive with start/end.",
+          "type": "string",
+          "pattern": "^\\d+[smhdw]$"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "query": {
+          "default": "",
+          "type": "string"
+        },
+        "mode": {
+          "default": "samples",
+          "type": "string",
+          "enum": ["samples", "aggregate"]
+        },
+        "groupBy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "yAxes": {
+          "description": "Aggregate functions to chart, e.g. \"count()\" or \"p95(span.duration)\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["query", "mode", "name", "type"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Checkout latency metric",
+        "data": {
+          "name": "checkout.latency",
+          "type": "distribution",
+          "unit": "millisecond",
+          "mode": "aggregate",
+          "yAxes": ["p95(value)"],
+          "statsPeriod": "24h"
+        }
+      }
+    ]
   }
 ]

--- a/static/app/components/seer/markdown/embeds/components/alert.tsx
+++ b/static/app/components/seer/markdown/embeds/components/alert.tsx
@@ -1,0 +1,30 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconSiren} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
+
+function AlertLink({id, kind, name}: EmbedOutput<'alert'>) {
+  const organization = useOrganization();
+
+  // Under the workflow engine an issue alert is an automation, while metric,
+  // uptime and cron alerts are all detectors.
+  const href =
+    kind === 'issue'
+      ? makeAutomationDetailsPathname(organization.slug, id)
+      : makeMonitorDetailsPathname(organization.slug, id);
+
+  return <ResourceLink icon={IconSiren} href={href} title={name ?? t('Alert %s', id)} />;
+}
+
+export const Alert = defineSeerEmbed({
+  name: 'alert',
+  render(props) {
+    return <AlertLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/errorsQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/errorsQuery.tsx
@@ -1,0 +1,64 @@
+import * as qs from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconSearch} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {EventView} from 'sentry/utils/discover/eventView';
+import {SavedQueryDatasets} from 'sentry/utils/discover/types';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+const DEFAULT_FIELDS = ['title', 'event.type', 'project', 'user.display', 'timestamp'];
+
+function ErrorsQueryLink({
+  query,
+  fields,
+  yAxes,
+  sort,
+  title,
+  projects,
+  environments,
+  statsPeriod,
+  start,
+  end,
+}: EmbedOutput<'errorsQuery'>) {
+  const organization = useOrganization();
+
+  // Discover encodes a lot of interdependent state (columns, sorts, chart
+  // aggregates), so round-trip through EventView rather than hand-rolling it.
+  const eventView = EventView.fromSavedQuery({
+    version: 2,
+    name: title ?? t('Errors'),
+    query,
+    fields: fields ?? DEFAULT_FIELDS,
+    orderby: sort ?? '-timestamp',
+    projects: projects?.map(Number),
+    environment: environments,
+    range: statsPeriod,
+    start,
+    end,
+    yAxis: yAxes,
+    queryDataset: SavedQueryDatasets.ERRORS,
+  });
+
+  const target = eventView.getResultsViewUrlTarget(
+    organization,
+    false,
+    SavedQueryDatasets.ERRORS
+  );
+  const href = `${target.pathname}?${qs.stringify(target.query, {skipNull: true})}`;
+
+  return (
+    <ResourceLink icon={IconSearch} href={href} title={title ?? t('Error search')} />
+  );
+}
+
+export const ErrorsQuery = defineSeerEmbed({
+  name: 'errorsQuery',
+  render(props) {
+    return <ErrorsQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/issuesQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/issuesQuery.tsx
@@ -1,0 +1,47 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconIssues} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+function IssuesQueryLink({
+  query,
+  sort,
+  title,
+  projects,
+  environments,
+  statsPeriod,
+  start,
+  end,
+}: EmbedOutput<'issuesQuery'>) {
+  const organization = useOrganization();
+  const href = queryString.stringifyUrl({
+    url: normalizeUrl(`/organizations/${organization.slug}/issues/`),
+    query: {
+      query,
+      sort,
+      project: projects,
+      environment: environments,
+      statsPeriod,
+      start,
+      end,
+    },
+  });
+
+  return (
+    <ResourceLink icon={IconIssues} href={href} title={title ?? t('Issue search')} />
+  );
+}
+
+export const IssuesQuery = defineSeerEmbed({
+  name: 'issuesQuery',
+  render(props) {
+    return <IssuesQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/logsQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/logsQuery.tsx
@@ -1,0 +1,38 @@
+import {
+  toAggregateFields,
+  toMode,
+  toPageFilters,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconList} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getLogsUrl} from 'sentry/views/explore/logs/utils';
+
+function LogsQueryLink(props: EmbedOutput<'logsQuery'>) {
+  const organization = useOrganization();
+  const {query, mode, sort, fields, groupBy, yAxes, title} = props;
+
+  const href = getLogsUrl({
+    organization,
+    selection: toPageFilters(props),
+    query,
+    mode: toMode(mode),
+    field: fields,
+    sortBy: sort,
+    aggregateFields: toAggregateFields({groupBy, yAxes}),
+  });
+
+  return <ResourceLink icon={IconList} href={href} title={title ?? t('Log search')} />;
+}
+
+export const LogsQuery = defineSeerEmbed({
+  name: 'logsQuery',
+  render(props) {
+    return <LogsQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/metricsQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/metricsQuery.tsx
@@ -1,0 +1,58 @@
+import * as qs from 'query-string';
+
+import {
+  toAggregateFields,
+  toPageFilters,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconGraph} from 'sentry/icons';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
+
+/**
+ * Metrics refuses to decode a query that charts nothing, so fall back to the
+ * same aggregate the metrics UI opens with.
+ */
+const DEFAULT_Y_AXES = ['sum(value)'];
+
+function MetricsQueryLink(props: EmbedOutput<'metricsQuery'>) {
+  const organization = useOrganization();
+  const {name, type, unit, query, mode, sort, groupBy, yAxes, title} = props;
+  const {projects, environments, datetime} = toPageFilters(props);
+
+  const metric = JSON.stringify({
+    metric: {name, type, unit},
+    query,
+    aggregateFields: toAggregateFields({
+      groupBy,
+      yAxes: yAxes?.length ? yAxes : DEFAULT_Y_AXES,
+    }),
+    aggregateSortBys: sort ? [sort] : undefined,
+    mode,
+  });
+
+  const href = `${makeMetricsPathname({organizationSlug: organization.slug, path: '/'})}?${qs.stringify(
+    {
+      project: projects.length === 0 ? '' : projects,
+      environment: environments,
+      statsPeriod: datetime.period,
+      start: datetime.start,
+      end: datetime.end,
+      metric,
+    },
+    {skipNull: true}
+  )}`;
+
+  return <ResourceLink icon={IconGraph} href={href} title={title ?? name} />;
+}
+
+export const MetricsQuery = defineSeerEmbed({
+  name: 'metricsQuery',
+  render(props) {
+    return <MetricsQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/monitor.tsx
+++ b/static/app/components/seer/markdown/embeds/components/monitor.tsx
@@ -1,0 +1,25 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconTimer} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
+
+function MonitorLink({id, name}: EmbedOutput<'monitor'>) {
+  const organization = useOrganization();
+  const href = makeMonitorDetailsPathname(organization.slug, id);
+
+  return (
+    <ResourceLink icon={IconTimer} href={href} title={name ?? t('Monitor %s', id)} />
+  );
+}
+
+export const Monitor = defineSeerEmbed({
+  name: 'monitor',
+  render(props) {
+    return <MonitorLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/profile.tsx
+++ b/static/app/components/seer/markdown/embeds/components/profile.tsx
@@ -1,0 +1,33 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconProfiling} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {getShortEventId} from 'sentry/utils/events';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+function ProfileLink({projectSlug, profileId}: EmbedOutput<'profile'>) {
+  const organization = useOrganization();
+  const href = normalizeUrl(
+    generateProfileFlamechartRoute({organization, projectSlug, profileId})
+  );
+
+  return (
+    <ResourceLink
+      icon={IconProfiling}
+      href={href}
+      title={t('Profile %s', getShortEventId(profileId))}
+    />
+  );
+}
+
+export const Profile = defineSeerEmbed({
+  name: 'profile',
+  render(props) {
+    return <ProfileLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/queryEmbedParams.ts
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbedParams.ts
@@ -1,0 +1,57 @@
+import type {PageFilters} from 'sentry/types/core';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+
+interface PageFilterParams {
+  end?: string;
+  environments?: string[];
+  projects?: string[];
+  start?: string;
+  statsPeriod?: string;
+}
+
+/**
+ * Seer reports project IDs as strings, but the URL builders take the numeric
+ * `PageFilters` shape. An empty project list is meaningful rather than absent:
+ * the builders encode it as the "My Projects" selection.
+ */
+export function toPageFilters({
+  projects,
+  environments,
+  statsPeriod,
+  start,
+  end,
+}: PageFilterParams): PageFilters {
+  return {
+    projects: projects?.map(Number).filter(Number.isInteger) ?? [],
+    environments: environments ?? [],
+    datetime: {
+      period: statsPeriod ?? null,
+      start: start ?? null,
+      end: end ?? null,
+      utc: null,
+    },
+  };
+}
+
+export function toMode(mode: 'samples' | 'aggregate'): Mode {
+  return mode === 'aggregate' ? Mode.AGGREGATE : Mode.SAMPLES;
+}
+
+/**
+ * Explore flattens group-bys and chart aggregates into a single ordered
+ * `aggregateField` list. The object literals structurally match the `GroupBy`
+ * and `BaseVisualize` types each Explore surface declares for itself.
+ */
+export function toAggregateFields({
+  groupBy,
+  yAxes,
+}: {
+  groupBy?: string[];
+  yAxes?: string[];
+}): Array<{groupBy: string} | {yAxes: string[]}> | undefined {
+  const fields = [
+    ...(groupBy ?? []).map(field => ({groupBy: field})),
+    ...(yAxes?.length ? [{yAxes}] : []),
+  ];
+  return fields.length > 0 ? fields : undefined;
+}

--- a/static/app/components/seer/markdown/embeds/components/replaysQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replaysQuery.tsx
@@ -1,0 +1,45 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+
+function ReplaysQueryLink({
+  query,
+  sort,
+  title,
+  projects,
+  environments,
+  statsPeriod,
+  start,
+  end,
+}: EmbedOutput<'replaysQuery'>) {
+  const organization = useOrganization();
+  const href = queryString.stringifyUrl({
+    url: makeReplaysPathname({organization, path: '/'}),
+    query: {
+      query,
+      sort,
+      project: projects,
+      environment: environments,
+      statsPeriod,
+      start,
+      end,
+    },
+  });
+
+  return <ResourceLink icon={IconPlay} href={href} title={title ?? t('Replay search')} />;
+}
+
+export const ReplaysQuery = defineSeerEmbed({
+  name: 'replaysQuery',
+  render(props) {
+    return <ReplaysQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -9,6 +9,11 @@ function renderEmbed(name: string, data: Record<string, unknown>) {
   return render(<SeerMarkdown raw={raw} />);
 }
 
+function hrefFor(name: string, label: string, data: Record<string, unknown>) {
+  renderEmbed(name, data);
+  return screen.getByRole('link', {name: label}).getAttribute('href') ?? '';
+}
+
 describe('Seer resource embeds', () => {
   let initialConfig: Config;
 
@@ -67,5 +72,215 @@ describe('Seer resource embeds', () => {
       'href',
       '/organizations/org-slug/explore/replays/abcdef1234567890/'
     );
+  });
+
+  describe('alert', () => {
+    it('points a metric alert at its detector', () => {
+      expect(
+        hrefFor('alert', 'Checkout latency', {
+          id: '4521',
+          kind: 'metric',
+          name: 'Checkout latency',
+        })
+      ).toBe('/organizations/org-slug/monitors/4521/');
+    });
+
+    it('points an issue alert at its automation', () => {
+      expect(hrefFor('alert', 'Alert 881', {id: '881', kind: 'issue'})).toBe(
+        '/organizations/org-slug/monitors/alerts/881/'
+      );
+    });
+
+    it('falls back to an id-based label when the API name is missing', () => {
+      renderEmbed('alert', {id: '4521', kind: 'metric'});
+      expect(screen.getByRole('link', {name: 'Alert 4521'})).toBeInTheDocument();
+    });
+  });
+
+  it('links a monitor to its detector detail page', () => {
+    expect(hrefFor('monitor', 'nightly-sync', {id: '9931', name: 'nightly-sync'})).toBe(
+      '/organizations/org-slug/monitors/9931/'
+    );
+  });
+
+  it('links a saved issue view to the view route', () => {
+    expect(hrefFor('savedIssueView', 'Unresolved', {id: '77', name: 'Unresolved'})).toBe(
+      '/organizations/org-slug/issues/views/77/'
+    );
+  });
+
+  it.each([
+    ['spans', '/organizations/org-slug/explore/traces/?id=312'],
+    ['logs', '/organizations/org-slug/explore/logs/?id=312'],
+    ['metrics', '/organizations/org-slug/explore/metrics/?id=312'],
+    ['replays', '/organizations/org-slug/explore/replays/?id=312'],
+  ])('opens a saved %s query on its own explore surface', (dataset, expected) => {
+    expect(hrefFor('savedQuery', 'Saved query 312', {id: '312', dataset})).toBe(expected);
+  });
+
+  describe('trace', () => {
+    const traceId = 'a1b2c3d4e5f678901234567890abcdef';
+
+    it('converts the ISO timestamp to unix seconds for the waterfall', () => {
+      const href = hrefFor('trace', 'Trace a1b2c3d4', {
+        traceId,
+        timestamp: '2026-08-25T16:37:12Z',
+      });
+
+      expect(href).toContain(`/explore/traces/trace/${traceId}/`);
+      expect(href).toContain(`timestamp=${Date.parse('2026-08-25T16:37:12Z') / 1000}`);
+    });
+
+    it('focuses a span when one is given', () => {
+      expect(hrefFor('trace', 'Trace a1b2c3d4', {traceId, spanId: 'abc123'})).toContain(
+        'node=span-abc123'
+      );
+    });
+
+    it('omits trace query params that were not provided', () => {
+      expect(hrefFor('trace', 'Trace a1b2c3d4', {traceId})).toBe(
+        `/organizations/org-slug/explore/traces/trace/${traceId}/`
+      );
+    });
+  });
+
+  it('links a profile to its flamegraph', () => {
+    expect(
+      hrefFor('profile', 'Profile 7f3c2b1a', {
+        projectSlug: 'javascript',
+        profileId: '7f3c2b1a9d8e4f60',
+      })
+    ).toBe(
+      '/organizations/org-slug/explore/profiles/profile/javascript/7f3c2b1a9d8e4f60/flamegraph/'
+    );
+  });
+
+  describe('issuesQuery', () => {
+    it('carries the search string and page filters into the issue stream', () => {
+      const href = hrefFor('issuesQuery', 'Unresolved errors', {
+        query: 'is:unresolved level:error',
+        statsPeriod: '7d',
+        projects: ['1', '2'],
+        title: 'Unresolved errors',
+      });
+
+      expect(href).toContain('/organizations/org-slug/issues/');
+      expect(href).toContain('query=is%3Aunresolved%20level%3Aerror');
+      expect(href).toContain('statsPeriod=7d');
+      expect(href).toContain('project=1');
+      expect(href).toContain('project=2');
+    });
+
+    it('uses a generic label when Seer supplies no title', () => {
+      renderEmbed('issuesQuery', {query: 'is:unresolved'});
+      expect(screen.getByRole('link', {name: 'Issue search'})).toBeInTheDocument();
+    });
+  });
+
+  it('builds an errors query with columns and a sort', () => {
+    const href = hrefFor('errorsQuery', 'Checkout errors', {
+      query: 'event.type:error',
+      fields: ['title', 'count()'],
+      sort: '-count',
+      statsPeriod: '24h',
+      title: 'Checkout errors',
+    });
+
+    expect(href).toContain('/explore/discover/results/');
+    expect(href).toContain('query=event.type%3Aerror');
+    expect(href).toContain('field=title');
+    expect(href).toContain('field=count%28%29');
+    expect(href).toContain('sort=-count');
+  });
+
+  describe('spansQuery', () => {
+    it('builds a samples-mode query', () => {
+      const href = hrefFor('spansQuery', 'Span search', {
+        query: 'span.op:http.client',
+        mode: 'samples',
+        sort: '-span.duration',
+        statsPeriod: '24h',
+      });
+
+      expect(href).toContain('/organizations/org-slug/explore/traces/');
+      expect(href).toContain('mode=samples');
+      expect(href).toContain('query=span.op%3Ahttp.client');
+      expect(href).toContain('sort=-span.duration');
+    });
+
+    it('encodes group-bys and aggregates for aggregate mode', () => {
+      const href = hrefFor('spansQuery', 'p95 by op', {
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        yAxes: ['p95(span.duration)'],
+        title: 'p95 by op',
+      });
+
+      expect(href).toContain('mode=aggregate');
+
+      const params = new URL(href, 'https://sentry.io').searchParams;
+      expect(params.getAll('aggregateField').map(field => JSON.parse(field))).toEqual([
+        {groupBy: 'span.op'},
+        {yAxes: ['p95(span.duration)']},
+      ]);
+    });
+  });
+
+  it('builds a logs query using the logs-prefixed params', () => {
+    const href = hrefFor('logsQuery', 'Error logs', {
+      query: 'severity:error',
+      mode: 'samples',
+      statsPeriod: '24h',
+      title: 'Error logs',
+    });
+
+    expect(href).toContain('/organizations/org-slug/explore/logs/');
+    expect(href).toContain('logsQuery=severity%3Aerror');
+    expect(href).toContain('mode=samples');
+  });
+
+  it('builds a replays query', () => {
+    const href = hrefFor('replaysQuery', 'Replay search', {
+      query: 'count_rage_clicks:>0',
+      statsPeriod: '7d',
+    });
+
+    expect(href).toContain('/organizations/org-slug/explore/replays/');
+    expect(href).toContain('query=count_rage_clicks%3A%3E0');
+    expect(href).toContain('statsPeriod=7d');
+  });
+
+  describe('metricsQuery', () => {
+    it('encodes the metric as a single JSON param', () => {
+      const href = hrefFor('metricsQuery', 'checkout.latency', {
+        name: 'checkout.latency',
+        type: 'distribution',
+        unit: 'millisecond',
+        mode: 'aggregate',
+        yAxes: ['p95(value)'],
+      });
+
+      expect(href).toContain('/organizations/org-slug/explore/metrics/');
+
+      const metric = new URL(href, 'https://sentry.io').searchParams.get('metric');
+      expect(JSON.parse(metric ?? '{}')).toEqual({
+        metric: {name: 'checkout.latency', type: 'distribution', unit: 'millisecond'},
+        query: '',
+        aggregateFields: [{yAxes: ['p95(value)']}],
+        mode: 'aggregate',
+      });
+    });
+
+    it('charts a default aggregate so the query stays decodable', () => {
+      const href = hrefFor('metricsQuery', 'checkout.latency', {
+        name: 'checkout.latency',
+        type: 'distribution',
+      });
+
+      const metric = new URL(href, 'https://sentry.io').searchParams.get('metric');
+      expect(JSON.parse(metric ?? '{}').aggregateFields).toEqual([
+        {yAxes: ['sum(value)']},
+      ]);
+    });
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/savedIssueView.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueView.tsx
@@ -1,0 +1,25 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+function SavedIssueViewLink({id, name}: EmbedOutput<'savedIssueView'>) {
+  const organization = useOrganization();
+  const href = normalizeUrl(`/organizations/${organization.slug}/issues/views/${id}/`);
+
+  return (
+    <ResourceLink icon={IconStar} href={href} title={name ?? t('Issue view %s', id)} />
+  );
+}
+
+export const SavedIssueView = defineSeerEmbed({
+  name: 'savedIssueView',
+  render(props) {
+    return <SavedIssueViewLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/savedQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQuery.tsx
@@ -1,0 +1,56 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeLogsPathname} from 'sentry/views/explore/logs/utils';
+import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
+import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+
+type Dataset = EmbedOutput<'savedQuery'>['dataset'];
+
+/**
+ * Explore has no saved-query detail route. Opening one means loading the
+ * dataset's own explore surface with the saved query's `id`.
+ */
+function datasetPathname(dataset: Dataset, organization: Organization): string {
+  switch (dataset) {
+    case 'logs':
+      return makeLogsPathname({organizationSlug: organization.slug, path: '/'});
+    case 'metrics':
+      return makeMetricsPathname({organizationSlug: organization.slug, path: '/'});
+    case 'replays':
+      return makeReplaysPathname({organization, path: '/'});
+    case 'spans':
+      return makeTracesPathname({organization, path: '/'});
+    default:
+      dataset satisfies never;
+      return makeTracesPathname({organization, path: '/'});
+  }
+}
+
+function SavedQueryLink({id, dataset, name}: EmbedOutput<'savedQuery'>) {
+  const organization = useOrganization();
+  const href = queryString.stringifyUrl({
+    url: datasetPathname(dataset, organization),
+    query: {id},
+  });
+
+  return (
+    <ResourceLink icon={IconStar} href={href} title={name ?? t('Saved query %s', id)} />
+  );
+}
+
+export const SavedQuery = defineSeerEmbed({
+  name: 'savedQuery',
+  render(props) {
+    return <SavedQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.tsx
@@ -1,0 +1,38 @@
+import {
+  toAggregateFields,
+  toMode,
+  toPageFilters,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+function SpansQueryLink(props: EmbedOutput<'spansQuery'>) {
+  const organization = useOrganization();
+  const {query, mode, sort, fields, groupBy, yAxes, title} = props;
+
+  const href = getExploreUrl({
+    organization,
+    selection: toPageFilters(props),
+    query,
+    mode: toMode(mode),
+    field: fields,
+    sort,
+    aggregateField: toAggregateFields({groupBy, yAxes}),
+  });
+
+  return <ResourceLink icon={IconSpan} href={href} title={title ?? t('Span search')} />;
+}
+
+export const SpansQuery = defineSeerEmbed({
+  name: 'spansQuery',
+  render(props) {
+    return <SpansQueryLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/trace.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.tsx
@@ -1,0 +1,47 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
+import {getShortEventId} from 'sentry/utils/events';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+
+function TraceLink({traceId, timestamp, spanId}: EmbedOutput<'trace'>) {
+  const organization = useOrganization();
+  const pathname = makeTracesPathname({
+    organization,
+    path: `/trace/${traceId}/`,
+  });
+
+  // Seer reports ISO timestamps but the waterfall reads unix seconds. Without
+  // one it falls back to scanning a default window, so pass it through whenever
+  // Seer knows when the trace happened.
+  const href = queryString.stringifyUrl({
+    url: pathname,
+    query: {
+      timestamp: getTimeStampFromTableDateField(timestamp),
+      node: spanId ? `span-${spanId}` : undefined,
+    },
+  });
+
+  return (
+    <ResourceLink
+      icon={IconSpan}
+      href={href}
+      title={t('Trace %s', getShortEventId(traceId))}
+    />
+  );
+}
+
+export const Trace = defineSeerEmbed({
+  name: 'trace',
+  render(props) {
+    return <TraceLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -1,26 +1,50 @@
 import {AgentWriteApprovalEmbed} from './components/agentWriteApproval';
+import {Alert} from './components/alert';
 import {Autofix} from './components/autofix';
 import {Chart} from './components/chart';
 import {Dashboard} from './components/dashboard';
 import {Docs} from './components/docs';
 import {Dsn} from './components/dsn';
+import {ErrorsQuery} from './components/errorsQuery';
 import {Issue, Issues} from './components/issue';
+import {IssuesQuery} from './components/issuesQuery';
+import {LogsQuery} from './components/logsQuery';
+import {MetricsQuery} from './components/metricsQuery';
+import {Monitor} from './components/monitor';
+import {Profile} from './components/profile';
 import {Replay} from './components/replay';
+import {ReplaysQuery} from './components/replaysQuery';
+import {SavedIssueView} from './components/savedIssueView';
+import {SavedQuery} from './components/savedQuery';
+import {SpansQuery} from './components/spansQuery';
 import {Timestamp} from './components/timestamp';
+import {Trace} from './components/trace';
 import {User} from './components/user';
 import {SeerEmbedRegistry} from './registry';
 
 const embeds = [
   AgentWriteApprovalEmbed,
+  Alert,
   Autofix,
   Chart,
   Dashboard,
   Docs,
   Dsn,
+  ErrorsQuery,
   Issue,
   Issues,
+  IssuesQuery,
+  LogsQuery,
+  MetricsQuery,
+  Monitor,
+  Profile,
   Replay,
+  ReplaysQuery,
+  SavedIssueView,
+  SavedQuery,
+  SpansQuery,
   Timestamp,
+  Trace,
   User,
 ];
 for (const embed of embeds) {

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -25,6 +25,47 @@ const chartSeriesSchema = z.union([
   }),
 ]);
 
+/**
+ * Page filters shared by every query embed. Seer supplies these separately from
+ * the search string so the frontend can hand them to the canonical URL builders
+ * rather than parsing them back out of a pre-built querystring.
+ */
+const pageFilterFields = {
+  projects: z
+    .array(z.string())
+    .optional()
+    .describe('Project IDs. Omit for the "My Projects" selection.'),
+  environments: z.array(z.string()).optional(),
+  statsPeriod: z
+    .string()
+    .regex(/^\d+[smhdw]$/)
+    .optional()
+    .describe(
+      'Relative time range, e.g. "24h" or "7d". Mutually exclusive with start/end.'
+    ),
+  start: isoTimestampSchema.optional(),
+  end: isoTimestampSchema.optional(),
+};
+
+/**
+ * Explore surfaces (spans, logs, metrics) share a samples/aggregate mode. In
+ * aggregate mode `groupBy` and `yAxes` drive the chart and table; in samples
+ * mode they are ignored in favour of `fields`.
+ */
+const exploreQueryFields = {
+  ...pageFilterFields,
+  query: z.string().default(''),
+  mode: z.enum(['samples', 'aggregate']).default('samples'),
+  groupBy: z.array(z.string()).optional(),
+  yAxes: z
+    .array(z.string())
+    .optional()
+    .describe('Aggregate functions to chart, e.g. "count()" or "p95(span.duration)".'),
+  sort: z.string().optional(),
+  fields: z.array(z.string()).optional(),
+  title: z.string().min(1).optional(),
+};
+
 type SeerEmbedLevel = 'inline' | 'block';
 
 export interface SeerEmbedExample {
@@ -282,6 +323,269 @@ export const SEER_EMBED_SCHEMAS = {
           result:
             'The root cause of the issue is that the code is not working correctly.',
           step: 'root_cause' as const,
+        },
+      },
+    ],
+  },
+  alert: {
+    description:
+      'The ONLY way to reference a Sentry alert. ' +
+      'Use `id` exactly as the alerts API returns it, and set `kind` to match: ' +
+      '"metric" for a metric alert, "issue" for an issue alert, "uptime" for an ' +
+      'uptime alert, "cron" for a cron alert. ' +
+      'Include the API-provided name when available. ' +
+      'Never use a markdown link for alert references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      id: z.string().min(1),
+      kind: z.enum(['metric', 'issue', 'uptime', 'cron']),
+      name: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Metric alert',
+        data: {id: '4521', kind: 'metric', name: 'Checkout p95 latency'},
+      },
+      {label: 'Issue alert', data: {id: '881', kind: 'issue'}},
+    ],
+  },
+  monitor: {
+    description:
+      'The ONLY way to reference a Sentry monitor (cron, uptime, or metric ' +
+      'detector). Use the detector ID exactly as the monitors API returns it. ' +
+      'Include the API-provided name when available. ' +
+      'Never use a markdown link for monitor references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      id: z.string().min(1),
+      name: z.string().min(1).optional(),
+    }),
+    examples: [{label: 'Monitor', data: {id: '9931', name: 'nightly-billing-sync'}}],
+  },
+  savedIssueView: {
+    description:
+      'The ONLY way to reference a saved Sentry issue view. ' +
+      'Use the view ID exactly as the issue-views API returns it. ' +
+      'Include the API-provided name when available. ' +
+      'Never use a markdown link for issue view references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      id: z.string().min(1),
+      name: z.string().min(1).optional(),
+    }),
+    examples: [
+      {label: 'Saved issue view', data: {id: '77', name: 'Unresolved in checkout'}},
+    ],
+  },
+  savedQuery: {
+    description:
+      'The ONLY way to reference a saved Explore query. ' +
+      'Use the saved query ID exactly as the API returns it and set `dataset` ' +
+      'to the dataset it was saved against. ' +
+      'Include the API-provided name when available. ' +
+      'Never use a markdown link for saved query references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      id: z.string().min(1),
+      dataset: z.enum(['spans', 'logs', 'metrics', 'replays']),
+      name: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Saved query',
+        data: {id: '312', dataset: 'spans', name: 'Slow checkout spans'},
+      },
+    ],
+  },
+  trace: {
+    description:
+      'The ONLY way to reference a Sentry trace (the trace waterfall view). ' +
+      'Use the 32-character trace ID. Provide `timestamp` when known so the ' +
+      'waterfall opens on the right time range, and `spanId` to focus a span. ' +
+      'Never use a markdown link for trace references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      traceId: z.string().min(1),
+      timestamp: isoTimestampSchema.optional(),
+      spanId: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Trace',
+        data: {
+          traceId: 'a1b2c3d4e5f678901234567890abcdef',
+          timestamp: '2026-08-25T16:37:12Z',
+        },
+      },
+    ],
+  },
+  profile: {
+    description:
+      'The ONLY way to reference a Sentry profile (the flamegraph view). ' +
+      'Requires both the profile ID and the slug of the project it belongs to. ' +
+      'Never use a markdown link for profile references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      projectSlug: z.string().min(1),
+      profileId: z.string().min(1),
+    }),
+    examples: [
+      {
+        label: 'Profile',
+        data: {projectSlug: 'javascript', profileId: '7f3c2b1a9d8e4f60'},
+      },
+    ],
+  },
+  issuesQuery: {
+    description:
+      'Link to the issue stream filtered by a search query. ' +
+      'Use this when pointing the user at a SET of issues defined by a search ' +
+      'rather than specific known issues — if you already have the short IDs, ' +
+      'use the `issue` or `issues` embed instead. ' +
+      '`query` uses issue search syntax, e.g. "is:unresolved level:error".',
+    level: ['inline', 'block'],
+    schema: z.object({
+      ...pageFilterFields,
+      query: z.string().default(''),
+      sort: z.string().optional(),
+      title: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Unresolved errors',
+        data: {
+          query: 'is:unresolved level:error',
+          statsPeriod: '7d',
+          title: 'Unresolved errors',
+        },
+      },
+    ],
+  },
+  errorsQuery: {
+    description:
+      'Link to an errors (Discover) query results page. ' +
+      'Use this for tabular error exploration across events. ' +
+      '`query` uses event search syntax and `fields` are the table columns. ' +
+      'Provide `yAxes` to chart aggregates alongside the table.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      ...pageFilterFields,
+      query: z.string().default(''),
+      fields: z.array(z.string()).optional(),
+      yAxes: z.array(z.string()).optional(),
+      sort: z.string().optional(),
+      title: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Errors by URL',
+        data: {
+          query: 'event.type:error',
+          fields: ['title', 'count()', 'url'],
+          statsPeriod: '24h',
+          title: 'Checkout errors',
+        },
+      },
+    ],
+  },
+  spansQuery: {
+    description:
+      'Link to an Explore > Traces (spans) query. ' +
+      'Use mode "samples" to show individual spans and "aggregate" to group and ' +
+      'chart them. In aggregate mode supply `groupBy` and `yAxes`. ' +
+      '`query` uses span search syntax, e.g. "span.op:http.client".',
+    level: ['inline', 'block'],
+    schema: z.object(exploreQueryFields),
+    examples: [
+      {
+        label: 'Slow HTTP spans',
+        data: {
+          query: 'span.op:http.client',
+          mode: 'samples',
+          sort: '-span.duration',
+          statsPeriod: '24h',
+        },
+      },
+      {
+        label: 'p95 by span op',
+        data: {
+          query: '',
+          mode: 'aggregate',
+          groupBy: ['span.op'],
+          yAxes: ['p95(span.duration)'],
+          statsPeriod: '7d',
+        },
+      },
+    ],
+  },
+  logsQuery: {
+    description:
+      'Link to an Explore > Logs query. ' +
+      'Use mode "samples" to show individual log rows and "aggregate" to group ' +
+      'and chart them. In aggregate mode supply `groupBy` and `yAxes`. ' +
+      '`query` uses log search syntax, e.g. "severity:error".',
+    level: ['inline', 'block'],
+    schema: z.object(exploreQueryFields),
+    examples: [
+      {
+        label: 'Error logs',
+        data: {query: 'severity:error', mode: 'samples', statsPeriod: '24h'},
+      },
+      {
+        label: 'Log volume by severity',
+        data: {
+          query: '',
+          mode: 'aggregate',
+          groupBy: ['severity'],
+          yAxes: ['count(message)'],
+          statsPeriod: '7d',
+        },
+      },
+    ],
+  },
+  replaysQuery: {
+    description:
+      'Link to the Session Replay list filtered by a search query. ' +
+      'Use this when pointing the user at a SET of replays — if you have a ' +
+      'specific replay ID, use the `replay` embed instead. ' +
+      '`query` uses replay search syntax, e.g. "user.email:user@example.com".',
+    level: ['inline', 'block'],
+    schema: z.object({
+      ...pageFilterFields,
+      query: z.string().default(''),
+      sort: z.string().optional(),
+      title: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Replays with rage clicks',
+        data: {query: 'count_rage_clicks:>0', statsPeriod: '7d'},
+      },
+    ],
+  },
+  metricsQuery: {
+    description:
+      'Link to an Explore > Metrics query for a single trace metric. ' +
+      'Requires the metric `name` and `type` exactly as the metrics API returns ' +
+      'them. Use mode "aggregate" with `groupBy`/`yAxes` to chart the metric, or ' +
+      '"samples" to list raw points.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      ...exploreQueryFields,
+      name: z.string().min(1),
+      type: z.string().min(1),
+      unit: z.string().min(1).nullish(),
+    }),
+    examples: [
+      {
+        label: 'Checkout latency metric',
+        data: {
+          name: 'checkout.latency',
+          type: 'distribution',
+          unit: 'millisecond',
+          mode: 'aggregate',
+          yAxes: ['p95(value)'],
+          statsPeriod: '24h',
         },
       },
     ],


### PR DESCRIPTION
Seer could only reference issues, docs and DSNs with purpose-built embeds; every other Sentry resource fell back to a plain markdown link. This adds twelve typed embeds covering the rest of the entity, telemetry and search-query surfaces.

Each embed takes typed params rather than a pre-built URL and constructs the destination from the canonical pathname helpers, so links stay correct on customer domains and cannot drift from route changes.

The three aggregate query variants are folded into their base embeds via the samples/aggregate mode that Explore already uses in the URL. Alerts take a kind discriminator because the workflow engine routes issue alerts to automations and everything else to detectors.

<!-- Describe your PR here. -->