### PR TITLE
ref(autofix): Relax rate limit on group autofix repos endpoint

### DIFF
--- a/src/sentry/seer/endpoints/group_autofix_repos.py
+++ b/src/sentry/seer/endpoints/group_autofix_repos.py
@@ -9,8 +9,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
+from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.models import SeerApiError, SeerPermissionError
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 @cell_silo_endpoint
@@ -19,6 +21,18 @@ class GroupAutofixReposEndpoint(GroupAiEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=500, window=60, concurrent_limit=100),
+                RateLimitCategory.USER: RateLimit(limit=500, window=60, concurrent_limit=100),
+                RateLimitCategory.ORGANIZATION: RateLimit(
+                    limit=1000, window=60, concurrent_limit=100
+                ),
+            }
+        }
+    )
 
     def get(self, request: Request, group: Group) -> Response:
         try:


### PR DESCRIPTION
## Summary

`GroupAutofixReposEndpoint` (`GET /issues/{id}/autofix/repos/`) never declared its own `rate_limits`, so it inherited the global production default of **40/min, 25 concurrent** per IP/user/org — an aggressively low ceiling.

This adds an explicit `rate_limits` override for `GET`, matching the pattern of the sibling `group_autofix_setup_check` endpoint:

| Category | Before (inherited default) | After |
|---|---|---|
| IP | 40/min · 25 concurrent | 500/min · 100 concurrent |
| User | 40/min · 25 concurrent | 500/min · 100 concurrent |
| Org | 40/min · 25 concurrent | 1000/min · 100 concurrent |

## What this endpoint does

The frontend fetches it once on load (not polled), only when an autofix run has reached the **code-changes** stage (`code_changes_ready`), to check whether Seer has **write access** to the connected repo(s). That result gates the main "Draft PR" action button — showing "Draft PR" when write access exists, or an "Update permissions" link when it's missing. Since it's gated behind `code_changes_ready`, it fires for a subset of issues, not on every load.

## Why these numbers

- **Per-minute (500/1000)** is safe to relax generously: `get_runs` on the Seer side is a single indexed, read-only SQL query with no external fan-out.
- **Concurrency raised to 100**: this is a one-time-per-load fetch resolving the repo write-access check that gates the PR button. Setting the concurrent ceiling to 100 comfortably covers many issues resolving that check at once, up to the realistic worst case, without the default's tight squeeze. The heavier `get_repos` path (uncached SCM/GitHub App checks, only for runs that generated patches) is still bounded per-request and isn't polled.

Only affects production (getsentry), where `SENTRY_RATELIMITER_ENABLED = True`; the OSS default leaves the limiter off.

## Test Plan

- No behavior change to request handling; only the declarative rate-limit config changed. Consistent with the sibling Seer endpoints, which carry rate-limit overrides without dedicated tests.
- `prek run` (ruff/flake8/mypy) passes.
