### PR TITLE
fix(onboarding): Hide SCM install UI from members without access

### DIFF
--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -292,6 +292,10 @@ describe('ScmCreateProject', () => {
   });
 
   it('hides the repository section for members without a connected integration', async () => {
+    const integrationsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [],
+    });
     const memberOrganization = OrganizationFixture({
       features: ['performance-view'],
       access: ['org:read', 'project:read', 'team:read'],
@@ -300,6 +304,9 @@ describe('ScmCreateProject', () => {
     render(<ScmCreateProject />, {organization: memberOrganization});
 
     expect(await screen.findByRole('heading', {name: 'Platform'})).toBeInTheDocument();
+    // Wait for the integrations fetch so the section's absence reflects the
+    // settled empty result, not the pending state.
+    await waitFor(() => expect(integrationsRequest).toHaveBeenCalled());
     expect(screen.queryByRole('heading', {name: 'Repository'})).not.toBeInTheDocument();
   });
 

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -291,6 +291,31 @@ describe('ScmCreateProject', () => {
     expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();
   });
 
+  it('hides the repository section for members without a connected integration', async () => {
+    const memberOrganization = OrganizationFixture({
+      features: ['performance-view'],
+      access: ['org:read', 'project:read', 'team:read'],
+      allowMemberProjectCreation: true,
+    });
+    render(<ScmCreateProject />, {organization: memberOrganization});
+
+    expect(await screen.findByRole('heading', {name: 'Platform'})).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Repository'})).not.toBeInTheDocument();
+  });
+
+  it('keeps the repository section for members when an integration is connected', async () => {
+    mockExistingGithubRepository();
+    const memberOrganization = OrganizationFixture({
+      features: ['performance-view'],
+      access: ['org:read', 'project:read', 'team:read'],
+      allowMemberProjectCreation: true,
+    });
+    render(<ScmCreateProject />, {organization: memberOrganization});
+
+    expect(await screen.findByRole('heading', {name: 'Repository'})).toBeInTheDocument();
+    expect(await screen.findByText('Search repositories')).toBeInTheDocument();
+  });
+
   it('shows a tooltip on the disabled Create CTA explaining what is missing', async () => {
     render(<ScmCreateProject />, {organization});
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -129,11 +129,20 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
   } = wizardState;
 
   const canUserCreateProject = useCanCreateProject();
-  // Subscribe so the parent re-renders when integration state changes inside
+  // Also subscribes the parent to integration state changes inside
   // ScmIntegrationConnect, letting framer-motion's layout="position" siblings
   // below re-measure and animate position shifts. React Query dedupes with
   // the child's call.
-  useScmProviders();
+  const {activeIntegrations} = useScmProviders();
+
+  // Members lack org:integrations, so the install pipeline rejects them with a
+  // 403 — but an already-connected integration is fully usable with member
+  // scopes (listing, repo search, and the post-create repo link). Hide the
+  // section only when it could offer nothing but install buttons that would
+  // fail. While integrations load, members see the section only once an
+  // active integration is confirmed.
+  const showRepositorySection =
+    organization.access.includes('org:integrations') || activeIntegrations.length > 0;
 
   useScmPlatformDetection(selectedRepository);
 
@@ -276,30 +285,32 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
                 </Text>
               </MotionStack>
 
-              <MotionStack gap="md" paddingBottom="2xl" layout="position">
-                <Flex justify="between" align="center">
-                  <Stack gap="sm">
-                    <Heading as="h4">{t('Repository')}</Heading>
-                    <Text variant="secondary" density="comfortable" size="sm">
-                      {t(
-                        'Source context in stack traces, suspect commits, and deploy tracking'
-                      )}
-                    </Text>
-                  </Stack>
-                  <Tag variant="muted">{t('Optional')}</Tag>
-                </Flex>
+              {showRepositorySection && (
+                <MotionStack gap="md" paddingBottom="2xl" layout="position">
+                  <Flex justify="between" align="center">
+                    <Stack gap="sm">
+                      <Heading as="h4">{t('Repository')}</Heading>
+                      <Text variant="secondary" density="comfortable" size="sm">
+                        {t(
+                          'Source context in stack traces, suspect commits, and deploy tracking'
+                        )}
+                      </Text>
+                    </Stack>
+                    <Tag variant="muted">{t('Optional')}</Tag>
+                  </Flex>
 
-                <ScmIntegrationConnect
-                  analyticsFlow="project-creation"
-                  allowIntegrationSwitching
-                  selectedIntegration={selectedIntegration}
-                  selectedRepository={selectedRepository}
-                  onIntegrationChange={handleIntegrationChange}
-                  onRepositoryChange={handleRepositoryChange}
-                  onClearDerivedState={handleClearDerivedState}
-                  maxWidth={CREATE_PROJECT_MAX_WIDTH}
-                />
-              </MotionStack>
+                  <ScmIntegrationConnect
+                    analyticsFlow="project-creation"
+                    allowIntegrationSwitching
+                    selectedIntegration={selectedIntegration}
+                    selectedRepository={selectedRepository}
+                    onIntegrationChange={handleIntegrationChange}
+                    onRepositoryChange={handleRepositoryChange}
+                    onClearDerivedState={handleClearDerivedState}
+                    maxWidth={CREATE_PROJECT_MAX_WIDTH}
+                  />
+                </MotionStack>
+              )}
 
               <MotionContainer layout="position" paddingBottom="2xl">
                 <ScmPlatformFeaturesCore

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -137,10 +137,9 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
 
   // Members lack org:integrations, so the install pipeline rejects them with a
   // 403 — but an already-connected integration is fully usable with member
-  // scopes (listing, repo search, and the post-create repo link). Hide the
-  // section only when it could offer nothing but install buttons that would
-  // fail. While integrations load, members see the section only once an
-  // active integration is confirmed.
+  // scopes (listing, repo search, and the post-create repo link). While
+  // integrations load, members see the section only once an active
+  // integration is confirmed.
   const showRepositorySection =
     organization.access.includes('org:integrations') || activeIntegrations.length > 0;
 


### PR DESCRIPTION
Members without the `org:integrations` scope no longer see the SCM provider install buttons in the project-creation flow. The install pipeline endpoint requires `org:write`, `org:admin`, or `org:integrations` for POST, so a member who clicked a provider pill always got a permission error inside the install modal.

`ScmCreateProjectWizard` now computes `showRepositorySection` from `organization.access.includes('org:integrations')`, the same check the settings integrations page uses, or the presence of an active integration, so the section is withheld only in the one state where it could offer nothing but install buttons. The Repository section still renders for members whenever the org already has an active SCM integration, and the rest of the section works with member scopes: integration listing and repo search accept `org:read`, and the post-create repo link needs `project:write`, which the creating member holds as Team Admin of the auto-created personal team.
