### PR TITLE
ref(digests): Expire the two scheduler zsets when a namespace goes quiet

### DIFF
--- a/src/sentry/scripts/digests/digests.lua
+++ b/src/sentry/scripts/digests/digests.lua
@@ -164,19 +164,8 @@ end
 
 -- Timeline and Schedule Operations
 
--- The two schedule sets ("{namespace}:s:w" and "{namespace}:s:r") are the only
--- keys in this file that are not covered by the record TTL. They hold the
--- pending state of the digest scheduler, so an expiry that can fire while a
--- digest is still scheduled would drop that digest.
---
--- The expiry below is refreshed on every write to a timeline and on every
--- scheduler pass, so it slides forward and can only fire after a namespace has
--- been quiet for the whole window. The window is never shorter than the record
--- TTL, so the schedule always outlives every record it points to. The floor of
--- 7 days is many orders of magnitude longer than the scheduler interval (the
--- "schedule-digests" beat entry runs every 30 seconds), so an expired schedule
--- means the scheduler has been stopped for a week, by which point the records
--- themselves are long gone.
+-- Expiry prevents leakage for the case when scheduler sets have residual members but no activity
+-- 7 days is substantial headroom over both the scheduling cadence and maximum digest waiting period
 local SCHEDULE_EXPIRY_MINIMUM = 60 * 60 * 24 * 7
 
 local function schedule(configuration, deadline)
@@ -191,10 +180,6 @@ local function schedule(configuration, deadline)
             response[i] = {timeline_id, timestamp}
         end
     )
-    -- Keep the refresh after the move, so that it applies to a destination key
-    -- that exists. The move can create the destination set, and EXPIRE is a
-    -- noop on a key that is not there yet. Nothing here returns early, so this
-    -- still runs on every pass, including a pass with nothing to move.
     configuration:refresh_schedule_expiry()
     return response
 end
@@ -205,7 +190,6 @@ local function maintenance(configuration, deadline)
         configuration:get_schedule_waiting_key(),
         deadline
     )
-    -- After the move, for the same reason as in schedule().
     configuration:refresh_schedule_expiry()
 end
 
@@ -280,9 +264,6 @@ local function add_record_to_timeline(configuration, timeline_id, record_id, val
     redis.call('EXPIRE', configuration:get_timeline_key(timeline_id), configuration.ttl)
 
     local ready = add_timeline_to_schedule(configuration, timeline_id, timestamp, delay_increment, delay_maximum)
-    -- This has to stay on the write path. It is what makes the schedule outlive
-    -- the record that was just written, whether or not the timeline was already
-    -- scheduled.
     configuration:refresh_schedule_expiry()
 
     if timeline_capacity > 0 and math.random() < truncation_chance then
@@ -393,8 +374,6 @@ local configuration_argument_parser = object_argument_parser({
 
     function configuration:refresh_schedule_expiry()
         local expiry = math.max(self.ttl, SCHEDULE_EXPIRY_MINIMUM)
-        -- EXPIRE is a noop on a key that does not exist, so this never revives
-        -- a schedule set that Redis already dropped.
         redis.call('EXPIRE', self:get_schedule_waiting_key(), expiry)
         redis.call('EXPIRE', self:get_schedule_ready_key(), expiry)
     end

--- a/src/sentry/scripts/digests/digests.lua
+++ b/src/sentry/scripts/digests/digests.lua
@@ -164,6 +164,21 @@ end
 
 -- Timeline and Schedule Operations
 
+-- The two schedule sets ("{namespace}:s:w" and "{namespace}:s:r") are the only
+-- keys in this file that are not covered by the record TTL. They hold the
+-- pending state of the digest scheduler, so an expiry that can fire while a
+-- digest is still scheduled would drop that digest.
+--
+-- The expiry below is refreshed on every write to a timeline and on every
+-- scheduler pass, so it slides forward and can only fire after a namespace has
+-- been quiet for the whole window. The window is never shorter than the record
+-- TTL, so the schedule always outlives every record it points to. The floor of
+-- 7 days is many orders of magnitude longer than the scheduler interval (the
+-- "schedule-digests" beat entry runs every 30 seconds), so an expired schedule
+-- means the scheduler has been stopped for a week, by which point the records
+-- themselves are long gone.
+local SCHEDULE_EXPIRY_MINIMUM = 60 * 60 * 24 * 7
+
 local function schedule(configuration, deadline)
     local response = {}
     local i = 0
@@ -176,6 +191,11 @@ local function schedule(configuration, deadline)
             response[i] = {timeline_id, timestamp}
         end
     )
+    -- Keep the refresh after the move, so that it applies to a destination key
+    -- that exists. The move can create the destination set, and EXPIRE is a
+    -- noop on a key that is not there yet. Nothing here returns early, so this
+    -- still runs on every pass, including a pass with nothing to move.
+    configuration:refresh_schedule_expiry()
     return response
 end
 
@@ -185,6 +205,8 @@ local function maintenance(configuration, deadline)
         configuration:get_schedule_waiting_key(),
         deadline
     )
+    -- After the move, for the same reason as in schedule().
+    configuration:refresh_schedule_expiry()
 end
 
 local function add_timeline_to_schedule(configuration, timeline_id, timestamp, increment, maximum)
@@ -258,6 +280,10 @@ local function add_record_to_timeline(configuration, timeline_id, record_id, val
     redis.call('EXPIRE', configuration:get_timeline_key(timeline_id), configuration.ttl)
 
     local ready = add_timeline_to_schedule(configuration, timeline_id, timestamp, delay_increment, delay_maximum)
+    -- This has to stay on the write path. It is what makes the schedule outlive
+    -- the record that was just written, whether or not the timeline was already
+    -- scheduled.
+    configuration:refresh_schedule_expiry()
 
     if timeline_capacity > 0 and math.random() < truncation_chance then
         truncate_timeline(configuration, timeline_id, timeline_capacity)
@@ -331,6 +357,7 @@ local function close_digest(configuration, timeline_id, delay_minimum, record_id
         redis.call('SETEX', configuration:get_timeline_last_processed_timestamp_key(timeline_id), configuration.ttl, configuration.timestamp)
         redis.call('ZREM', configuration:get_schedule_ready_key(), timeline_id)
         redis.call('ZADD', configuration:get_schedule_waiting_key(), configuration.timestamp + delay_minimum, timeline_id)
+        configuration:refresh_schedule_expiry()
     else
         redis.call('DEL', configuration:get_timeline_last_processed_timestamp_key(timeline_id))
         redis.call('ZREM', configuration:get_schedule_ready_key(), timeline_id)
@@ -362,6 +389,14 @@ local configuration_argument_parser = object_argument_parser({
 
     function configuration:get_schedule_ready_key()
         return string.format('%s:s:r', self.namespace)
+    end
+
+    function configuration:refresh_schedule_expiry()
+        local expiry = math.max(self.ttl, SCHEDULE_EXPIRY_MINIMUM)
+        -- EXPIRE is a noop on a key that does not exist, so this never revives
+        -- a schedule set that Redis already dropped.
+        redis.call('EXPIRE', self:get_schedule_waiting_key(), expiry)
+        redis.call('EXPIRE', self:get_schedule_ready_key(), expiry)
     end
 
     function configuration:get_timeline_key(timeline_id)

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -163,3 +163,68 @@ class RedisBackendTestCase(TestCase):
 
         with backend.digest("timeline", 0) as records:
             assert len(records) == n
+
+    def test_schedule_sets_have_an_expiry(self) -> None:
+        backend = RedisBackend()
+        connection = backend._get_connection("timeline")
+
+        # The first record puts the timeline in the "ready" set.
+        backend.add("timeline", Record("record:1", self.notification, time.time()))
+
+        ready_ttl = connection.ttl("d:s:r")
+        assert ready_ttl > 0
+        assert ready_ttl >= backend.ttl
+
+        # A scheduler pass refreshes the expiry even when it has nothing to
+        # move, so a namespace that keeps members but goes quiet cannot expire
+        # while the scheduler still runs.
+        connection.expire("d:s:r", 60)
+        assert set(backend.schedule(time.time() - 3600)) == set()
+        assert connection.ttl("d:s:r") > 60
+
+        # The maintenance pass does the same.
+        connection.expire("d:s:r", 60)
+        backend.maintenance(time.time() - 3600)
+        assert connection.ttl("d:s:r") > 60
+
+        # Closing a digest puts the timeline back in the "waiting" set, which
+        # also has to carry an expiry.
+        with backend.digest("timeline", 0):
+            pass
+
+        waiting_ttl = connection.ttl("d:s:w")
+        assert waiting_ttl > 0
+        assert waiting_ttl >= backend.ttl
+
+        # The ready set is gone now that the timeline went back to the waiting
+        # set. A scheduler pass creates it again, so the expiry has to be set
+        # after the move. A TTL of -2 means the key is not there.
+        assert connection.ttl("d:s:r") == -2
+        assert {entry.key for entry in backend.schedule(time.time() + 3600)} == {"timeline"}
+        assert connection.ttl("d:s:r") >= backend.ttl
+
+    def test_pending_digest_is_not_dropped_by_the_schedule_expiry(self) -> None:
+        """
+        The schedule expiry slides forward on every write to a timeline, so it
+        is never shorter than the expiry of the keys the schedule points to.
+
+        This asserts that ordering rather than waiting out a wall clock,
+        because Redis counts time to live on the server.
+        """
+        backend = RedisBackend()
+        connection = backend._get_connection("timeline")
+
+        records = [Record(f"record:{i}", self.notification, time.time()) for i in range(5)]
+        for record in records:
+            backend.add("timeline", record)
+
+        # The schedule outlives the timeline and every record in it, so it
+        # cannot expire while those records are still deliverable.
+        schedule_ttl = connection.ttl("d:s:r")
+        assert schedule_ttl >= connection.ttl("d:t:timeline")
+        for record in records:
+            assert schedule_ttl >= connection.ttl(f"d:t:timeline:r:{record.key}")
+
+        # Nothing pending was dropped.
+        with backend.digest("timeline", 0) as digested:
+            assert {record.key for record in digested} == {record.key for record in records}

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -175,14 +175,10 @@ class RedisBackendTestCase(TestCase):
         assert ready_ttl > 0
         assert ready_ttl >= backend.ttl
 
-        # A scheduler pass refreshes the expiry even when it has nothing to
-        # move, so a namespace that keeps members but goes quiet cannot expire
-        # while the scheduler still runs.
         connection.expire("d:s:r", 60)
         assert set(backend.schedule(time.time() - 3600)) == set()
         assert connection.ttl("d:s:r") > 60
 
-        # The maintenance pass does the same.
         connection.expire("d:s:r", 60)
         backend.maintenance(time.time() - 3600)
         assert connection.ttl("d:s:r") > 60
@@ -218,8 +214,6 @@ class RedisBackendTestCase(TestCase):
         for record in records:
             backend.add("timeline", record)
 
-        # The schedule outlives the timeline and every record in it, so it
-        # cannot expire while those records are still deliverable.
         schedule_ttl = connection.ttl("d:s:r")
         assert schedule_ttl >= connection.ttl("d:t:timeline")
         for record in records:


### PR DESCRIPTION
We keep two sorted sets per digest namespace (namespace -> "the key prefix which allows us to have two digest backends on a single Redis"): 
- "waiting" -> timelines that must wait before the next digest goes out (score is when the timeline is due)
- "ready" -> timelines that are due now

Redis drops sorted sets when the last member is removed, so namespaces where all the digests are delivered gets auto-cleaned. The problem is when we have a namespace which keeps members and then stops being written to - these keys have no expiry and will sit there forever in that case. This isn't a common path (only happens if we were to move the backend off of Redis, for example), so this is a hygiene change more than anything.

Notes
- Adding a TTL seems like it could add a risk of dropping a pending digest (where the key is dropped before the digest is scheduled). But that is not a problem because the records themselves have a TTL and we're setting the waiting/ready TTLs to be higher than that.
- To be specific; the scheduler hits every 30s, and the maximum delay cap is 3600s. We're setting this to 7 days which is plenty of headroom

Refs INFRENG-481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
