### PR TITLE
feat(admin): show billing platform status on customer page

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -44,6 +44,44 @@ describe('CustomerOverview', () => {
     expect(screen.getByText('Soft Cap By Category:')).toBeInTheDocument();
   });
 
+  it('renders Billing Platform as no for legacy subscriptions', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      hasMigratedToBillingPlatform: false,
+    });
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    expect(screen.getByText('Billing Platform:')).toBeInTheDocument();
+    const billingPlatformLabel = screen.getByText('Billing Platform:').closest('dt');
+    expect(billingPlatformLabel?.nextElementSibling).toHaveTextContent('no');
+  });
+
+  it('renders Billing Platform as yes for migrated subscriptions', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      hasMigratedToBillingPlatform: true,
+    });
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    expect(screen.getByText('Billing Platform:')).toBeInTheDocument();
+    const billingPlatformLabel = screen.getByText('Billing Platform:').closest('dt');
+    expect(billingPlatformLabel?.nextElementSibling).toHaveTextContent('yes');
+  });
+
   it('renders soft cap type details', () => {
     const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -833,6 +833,10 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
           </DetailLabel>
           <DetailLabel title="Type">{customer.type || 'n/a'}</DetailLabel>
           <DetailLabel title="Managed" yesNo={customer.isManaged} />
+          <DetailLabel
+            title="Billing Platform"
+            yesNo={customer.hasMigratedToBillingPlatform}
+          />
           <DetailLabel title="Channel">{customer.channel || 'n/a'}</DetailLabel>
           <DetailLabel title="Sponsored Type">
             {customer.sponsoredType || 'n/a'}

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1124,6 +1124,38 @@ describe('Customer Details', () => {
     await screen.findByRole('heading', {name: 'Customers'});
   });
 
+  it('renders Legacy Billing badge for default subscriptions', async () => {
+    setUpMocks(organization);
+
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
+
+    await screen.findByRole('heading', {name: 'Customers'});
+    expect(screen.getByText('Legacy Billing')).toBeInTheDocument();
+    expect(screen.queryByText('Billing Platform')).not.toBeInTheDocument();
+  });
+
+  it('renders Billing Platform badge for migrated subscriptions', async () => {
+    setUpMocks(organization, {hasMigratedToBillingPlatform: true});
+
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
+
+    await screen.findByRole('heading', {name: 'Customers'});
+    expect(screen.getByText('Billing Platform')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy Billing')).not.toBeInTheDocument();
+  });
+
   it('renders correct dropdown options', async () => {
     setUpMocks(organization);
 

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -336,6 +336,15 @@ export function CustomerDetails() {
       level: 'warning',
       visible: subscription.onDemandDisabled,
     },
+    {
+      name: subscription.hasMigratedToBillingPlatform
+        ? 'Billing Platform'
+        : 'Legacy Billing',
+      level: subscription.hasMigratedToBillingPlatform ? 'success' : 'muted',
+      help: subscription.hasMigratedToBillingPlatform
+        ? 'This org is served by the billing platform.'
+        : 'This org is still served by the legacy billing system.',
+    },
   ];
 
   const billingSections = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surfaces whether a customer org is on the billing platform on the `_admin` customer page.

- Always-visible title badge: **Billing Platform** (migrated) or **Legacy Billing** (not migrated)
- Overview detail row after Managed: yes/no for **Billing Platform**

Uses the existing `hasMigratedToBillingPlatform` field already returned by the customer API serializers. Frontend-only change.

## Screenshots

<img width="494" height="181" alt="image" src="https://github.com/user-attachments/assets/e8f064e0-323f-450a-a987-960f6d67ecaa" />

<img width="531" height="186" alt="image" src="https://github.com/user-attachments/assets/640ff2f8-55b6-405b-ae25-7001c5f3cacf" />

## Test plan

- [x] Unit tests for CustomerOverview yes/no row in both states
- [x] Unit tests for CustomerDetails badge text in both states
- [x] `pnpm test-ci` on both specs (97 tests), `lint:js`, and `typecheck` pass
- [x] Rendered the real page in both states and visually confirmed the badge and detail row (screenshots above)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81df10c6-e438-4d1b-abbe-09567fa03cd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81df10c6-e438-4d1b-abbe-09567fa03cd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

