### PR TITLE
feat(billing): show billing-platform migration banner on subscription overview

### DIFF
--- a/static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.spec.tsx
@@ -1,0 +1,102 @@
+import {ConfigFixture} from 'sentry-fixture/config';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ConfigStore} from 'sentry/stores/configStore';
+
+import {BillingPlatformMigrationAlert} from './billingPlatformMigrationAlert';
+
+function setEmployeeUser(isEmployee: boolean) {
+  ConfigStore.loadInitialData(
+    ConfigFixture({
+      user: UserFixture({
+        emails: [
+          {
+            email: isEmployee ? 'dev@sentry.io' : 'dev@example.com',
+            is_verified: true,
+            id: '1',
+          },
+        ],
+      }),
+    })
+  );
+}
+
+describe('BillingPlatformMigrationAlert', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    localStorage.clear();
+    setEmployeeUser(true);
+  });
+
+  it('renders for employees when the org is migrated', () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      hasMigratedToBillingPlatform: true,
+    });
+
+    render(<BillingPlatformMigrationAlert subscription={subscription} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('This organization is migrated to the billing platform.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when the org is not migrated', () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      hasMigratedToBillingPlatform: false,
+    });
+
+    render(<BillingPlatformMigrationAlert subscription={subscription} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByText('This organization is migrated to the billing platform.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render for non-employees', () => {
+    setEmployeeUser(false);
+    const subscription = SubscriptionFixture({
+      organization,
+      hasMigratedToBillingPlatform: true,
+    });
+
+    render(<BillingPlatformMigrationAlert subscription={subscription} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByText('This organization is migrated to the billing platform.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides after the banner is dismissed', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      hasMigratedToBillingPlatform: true,
+    });
+
+    render(<BillingPlatformMigrationAlert subscription={subscription} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('This organization is migrated to the billing platform.')
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Dismiss banner'}));
+
+    expect(
+      screen.queryByText('This organization is migrated to the billing platform.')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.tsx
@@ -1,9 +1,9 @@
 import {Alert} from '@sentry/scraps/alert';
+import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';

--- a/static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.tsx
@@ -1,0 +1,51 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useDismissAlert} from 'sentry/utils/useDismissAlert';
+import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {Subscription} from 'getsentry/types';
+
+interface Props {
+  subscription: Subscription;
+}
+
+export function BillingPlatformMigrationAlert({subscription}: Props) {
+  const organization = useOrganization();
+  const isSentryEmployee = useIsSentryEmployee();
+  const {dismiss, isDismissed} = useDismissAlert({
+    key: `${organization.id}:billing-platform-migrated-alert`,
+  });
+
+  if (!subscription.hasMigratedToBillingPlatform || !isSentryEmployee || isDismissed) {
+    return null;
+  }
+
+  return (
+    <Alert.Container>
+      <Alert
+        variant="info"
+        trailingItems={
+          <Button
+            icon={<IconClose />}
+            onClick={dismiss}
+            size="zero"
+            variant="transparent"
+            aria-label={t('Dismiss banner')}
+          />
+        }
+      >
+        <Flex align="center" gap="sm">
+          <FeatureBadge type="experimental" />
+          <Text>{t('This organization is migrated to the billing platform.')}</Text>
+        </Flex>
+      </Alert>
+    </Alert.Container>
+  );
+}

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -18,10 +18,11 @@ import {ContactBillingMembers} from 'getsentry/views/contactBillingMembers';
 import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 import {UsageOverview} from 'getsentry/views/subscriptionPage/usageOverview';
 
-import {TrialEnded} from './trial/trialEnded';
+import {BillingPlatformMigrationAlert} from './billingPlatformMigrationAlert';
 import {OnDemandDisabled} from './ondemandDisabled';
 import {RecurringCredits} from './recurringCredits';
 import {SubscriptionHeader} from './subscriptionHeader';
+import {TrialEnded} from './trial/trialEnded';
 import {UsageAlert} from './usageAlert';
 
 type Props = {
@@ -118,6 +119,7 @@ function Overview({subscription}: Props) {
               </Fragment>
             ) : null}
             <OnDemandDisabled organization={organization} subscription={subscription} />
+            <BillingPlatformMigrationAlert subscription={subscription} />
             <UsageAlert subscription={subscription} usage={usage} />
             <UsageOverview
               subscription={subscription}

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -18,11 +18,11 @@ import {ContactBillingMembers} from 'getsentry/views/contactBillingMembers';
 import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 import {UsageOverview} from 'getsentry/views/subscriptionPage/usageOverview';
 
+import {TrialEnded} from './trial/trialEnded';
 import {BillingPlatformMigrationAlert} from './billingPlatformMigrationAlert';
 import {OnDemandDisabled} from './ondemandDisabled';
 import {RecurringCredits} from './recurringCredits';
 import {SubscriptionHeader} from './subscriptionHeader';
-import {TrialEnded} from './trial/trialEnded';
 import {UsageAlert} from './usageAlert';
 
 type Props = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small, dismissable info banner on the Subscription Overview page when an organization is migrated to the billing platform.

This is for Sentry employees checking customer orgs during the billing-platform rollout. Customers do not see it.

<img width="1520" height="188" alt="image" src="https://github.com/user-attachments/assets/e081fcee-da2d-4f57-a389-0d04be8dc7da" />


## Existing pattern

The subscription page already uses this shape in `SeerAutomationAlert`: `Alert` + close button + `useDismissAlert` (localStorage). Employee-only banners elsewhere (for example the AI Agents dashboard) combine that with `useIsSentryEmployee`.

## Behavior

- Shows only when `subscription.hasMigratedToBillingPlatform` is true
- Shows only for verified `@sentry.io` users
- Can be dismissed per organization (persisted in localStorage)
- Uses the experimental feature badge so it reads as internal/temporary

## Test plan

- [x] Unit tests for migrated / not migrated / non-employee / dismiss
- [x] `pnpm test-ci static/gsApp/views/subscriptionPage/billingPlatformMigrationAlert.spec.tsx`
- [x] ESLint on the changed files


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eacf74b3-a3e3-4855-b27c-180e4e1d6404?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eacf74b3-a3e3-4855-b27c-180e4e1d6404&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

