### PR TITLE
fix(seer): Show 0 affected users on Autofix overview cards

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -624,6 +624,36 @@ describe('AutofixOverview', () => {
     expect(screen.getAllByText('Plan')).toHaveLength(1);
   });
 
+  it('shows "0 users" for a card with events but zero affected users', async () => {
+    mockOverview({
+      base: {
+        autofix_root_cause: [
+          {...rootCauseRun, issue: issueFixture({count: '1200', userCount: 0})},
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('0 users')).toBeInTheDocument();
+    expect(screen.getByText('1.2K events')).toBeInTheDocument();
+  });
+
+  it('omits the users datapoint when the stat is unavailable', async () => {
+    mockOverview({
+      base: {
+        autofix_root_cause: [
+          {...rootCauseRun, issue: issueFixture({count: '1200', userCount: null})},
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('1.2K events')).toBeInTheDocument();
+    expect(screen.queryByText('0 users')).not.toBeInTheDocument();
+  });
+
   it('renders inline code in root cause and plan summaries', async () => {
     mockOverview({
       base: {

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -385,7 +385,7 @@ function IssueVitals({
   statsPeriod: string | null;
 }) {
   const eventCount = run.issue.count ? Number(run.issue.count) : null;
-  const userCount = run.issue.userCount ?? 0;
+  const userCount = run.issue.userCount ?? null;
   const windowLabel = periodWindowLabel(statsPeriod);
   return (
     <Fragment>
@@ -393,6 +393,10 @@ function IssueVitals({
         <Fragment>
           <Flex gap="xs" align="center">
             <IconGraph size="xs" variant="muted" aria-hidden />
+            <Placeholder height="1rem" width="4rem" />
+          </Flex>
+          <Flex gap="xs" align="center">
+            <IconUser size="xs" variant="muted" aria-hidden />
             <Placeholder height="1rem" width="4rem" />
           </Flex>
           <Flex gap="xs" align="center">
@@ -420,7 +424,7 @@ function IssueVitals({
               </InfoText>
             </Flex>
           )}
-          {userCount > 0 && (
+          {userCount !== null && (
             <Flex gap="xs" align="center">
               <IconUser size="xs" variant="muted" aria-hidden />
               <InfoText
@@ -676,7 +680,7 @@ export function OverviewCardSkeleton() {
         <Stack minWidth="0" gap="xs">
           <TextLineSkeleton size="lg" width="70%" />
           <Flex wrap="wrap" gap="md" align="center">
-            {['4.5rem', '4rem', '5rem', '5rem'].map((width, index) => (
+            {['4.5rem', '4rem', '4rem', '5rem', '5rem'].map((width, index) => (
               <TextLineSkeleton key={index} size="sm" width={width} />
             ))}
           </Flex>


### PR DESCRIPTION
Make the affected-users metric on Autofix overview cards use the same gating as events, so a card with events no longer silently drops the users datapoint.

On `/issues/autofix/overview`, users rendered only when `userCount > 0` and `null` was coerced to `0`, while events rendered whenever `count` was present. Because the endpoint serializes `count` and `userCount` together (both under the `issueStats` expand), a present events count means users is a real `0`, not missing data — commonly a backend/infra issue with no `sentry:user` attribution. `0 affected users` is a useful triage signal, so users now gates on presence (`userCount !== null`), keeping `null` (unavailable) distinct from a real `0`.

The two loading states also only rendered four meta slots (short id, events, issue time, autofix) and omitted users, so the users column popped in without a skeleton. Both `OverviewCardSkeleton` (initial load) and the `IssueVitals` enrichment placeholders now shimmer the users slot too, matching the five-column loaded row.

Frontend-only; `OverviewRunIssue.userCount` was already `number | null`.

Fixes AIML-3388