### PR TITLE
perf(seer): Batch overview assignee member fetches into one request

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -256,6 +256,51 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText('No issues')).not.toBeInTheDocument();
   });
 
+  it('batches project member fetches into a single request across projects', async () => {
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: '2', slug: 'project-slug'}),
+      ProjectFixture({id: '3', slug: 'other-project'}),
+    ]);
+    const runOne = {
+      ...rootCauseRun,
+      groupId: '2',
+      seerRunId: 'run-1',
+      title: 'First project issue',
+      issue: issueFixture({project: {id: '2', slug: 'project-slug', platform: 'python'}}),
+    };
+    const runTwo = {
+      ...rootCauseRun,
+      groupId: '3',
+      seerRunId: 'run-2',
+      title: 'Second project issue',
+      issue: issueFixture({
+        project: {id: '3', slug: 'other-project', platform: 'python'},
+      }),
+    };
+    mockOverview({base: {autofix_root_cause: [runOne, runTwo]}});
+    const usersMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('First project issue')).toBeInTheDocument();
+    expect(await screen.findByText('Second project issue')).toBeInTheDocument();
+
+    // Both visible projects should be fetched in one batched request, not one
+    // request per project.
+    await waitFor(() =>
+      expect(usersMock).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/users/`,
+        expect.objectContaining({
+          query: expect.objectContaining({project: expect.arrayContaining(['2', '3'])}),
+        })
+      )
+    );
+    expect(usersMock).toHaveBeenCalledTimes(1);
+  });
+
   it('refetches the overview after a card action is dispatched', async () => {
     const {enrichedRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
@@ -1775,7 +1820,7 @@ describe('AutofixOverview', () => {
       const nextAssignee = UserFixture({id: '42', name: 'Next Assignee'});
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/users/`,
-        body: [MemberFixture({user: nextAssignee})],
+        body: [MemberFixture({user: nextAssignee, projects: ['project-slug']})],
       });
       mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
       const assignRequest = MockApiClient.addMockResponse({

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -1,4 +1,5 @@
 import {type ComponentProps, Fragment, type ReactNode, useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge} from '@sentry/scraps/badge';
@@ -26,6 +27,11 @@ import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
+import {
+  indexMembersByProject,
+  type IndexedMembersByProject,
+} from 'sentry/utils/members/shared';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -190,6 +196,15 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     () => Object.values(data?.runsByMilestone ?? {}).flat(),
     [data]
   );
+  const memberProjectIds = useMemo(
+    () => Array.from(new Set(allRuns.map(run => run.issue.project.id))),
+    [allRuns]
+  );
+  const {data: members = []} = useQuery({
+    ...useProjectMembersQueryOptions(memberProjectIds),
+    enabled: memberProjectIds.length > 0,
+  });
+  const membersByProject = useMemo(() => indexMembersByProject(members), [members]);
   const passesAssignee = (run: OverviewRun) =>
     assignee === null || matchesAssignee(run, assignee);
   const assigneeRuns = allRuns.filter(passesAssignee);
@@ -343,6 +358,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
                   orgSlug={organization.slug}
                   statsPeriod={selection.datetime.period}
                   enrichmentPending={enrichmentPending}
+                  membersByProject={membersByProject}
                 />
               )}
             </Fragment>
@@ -360,9 +376,11 @@ function OverviewSectionList({
   orgSlug,
   statsPeriod,
   enrichmentPending,
+  membersByProject,
 }: {
   collapsedGroups: StatusGroupKey[];
   enrichmentPending: boolean;
+  membersByProject: IndexedMembersByProject;
   onToggle: (groupKey: StatusGroupKey, expanded: boolean) => void;
   orgSlug: string;
   sections: Array<(typeof OVERVIEW_SECTIONS)[number] & {runs: OverviewRun[]}>;
@@ -402,6 +420,7 @@ function OverviewSectionList({
                     sectionKey={key}
                     statsPeriod={statsPeriod}
                     enrichmentPending={enrichmentPending}
+                    memberList={membersByProject.get(run.issue.project.slug) ?? []}
                   />
                 ))}
               </Stack>

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -35,6 +35,7 @@ import type {
   PullRequestChecksStatus,
   PullRequestReviewStatus,
 } from 'sentry/types/integrations';
+import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -464,7 +465,7 @@ function IssueVitals({
   );
 }
 
-function PriorityAndAssignee({run}: {run: OverviewRun}) {
+function PriorityAndAssignee({run, memberList}: {run: OverviewRun; memberList?: User[]}) {
   const {issue} = run;
   const priorityGroup: OverviewIssuePriorityGroup = {
     id: run.groupId,
@@ -489,6 +490,7 @@ function PriorityAndAssignee({run}: {run: OverviewRun}) {
         projectSlug={issue.project.slug}
         assignedTo={issue.assignedTo ?? undefined}
         owners={issue.owners}
+        memberList={memberList}
       />
     </Flex>
   );
@@ -500,12 +502,14 @@ export function OverviewCard({
   sectionKey,
   statsPeriod,
   enrichmentPending,
+  memberList,
 }: {
   enrichmentPending: boolean;
   orgSlug: string;
   run: OverviewRun;
   sectionKey: AutofixStateKey;
   statsPeriod: string | null;
+  memberList?: User[];
 }) {
   const organization = useOrganization();
   const rootCause = run.rootCause?.oneLineDescription;
@@ -533,7 +537,7 @@ export function OverviewCard({
             issueUrl={issueUrl}
             enrichmentPending={enrichmentPending}
           />
-          <PriorityAndAssignee run={run} />
+          <PriorityAndAssignee run={run} memberList={memberList} />
         </Fragment>
       }
     >


### PR DESCRIPTION
## Summary

The Seer Autofix overview renders one `AssigneeSelector` per issue card, and each card self-fetched its project's assignable members from `GET /organizations/{org}/users/?project=<id>`. When the visible issues span many projects, that fan-out issues **one request per distinct project** (React Query dedupes per project key), which can exhaust the endpoint's concurrency limit and produce 429s.

This batches all of it into a single request: the overview fetches members for **every visible project at once**, indexes the response by project, and threads each card its own project's slice down the existing `memberList` prop chain. `AssigneeSelector` already disables its own fetch when handed a `memberList` (`enabled: memberList === undefined`), so the per-card requests stop firing.

**N per-project requests → 1 batched request. Frontend-only. Zero behavior change** — each dropdown stays scoped to exactly its own project's members.

## How it works

- `index.tsx` collects the distinct project ids across all visible runs and fetches once via `useProjectMembersQueryOptions(projectIds)`.
- The response is indexed by project **slug** via `indexMembersByProject` (the `/users/` serializer scopes each member's `projects` to the requested/accessible projects, so no cross-project members leak).
- Each card receives `membersByProject.get(run.issue.project.slug) ?? []` through `OverviewCard → PriorityAndAssignee → OverviewIssueAssignee`.

## Scoping / security

Access enforcement is unchanged: the same `/users/` endpoint validates project access server-side via `get_projects`, and `OrganizationMemberWithProjectsSerializer` scopes `member.projects` to only the requested projects. Distributing the union response by slug reproduces exactly the same per-project member sets the per-card calls produced.

## Note

Because each card is always handed a defined array, its per-card fetch fallback is off, so if the single batched request fails, all cards render empty assignee dropdowns at once (mitigated by TanStack's default retries) rather than failing per-card. This is an intentional tradeoff for collapsing the fan-out.

## Test Plan

- New test in `index.spec.tsx` renders two runs across two distinct projects and asserts a single `/users/` request carrying both project ids (`toHaveBeenCalledTimes(1)`).
- Full overview suite (68 tests), sibling assignee spec, `lint:js`, and `typecheck` all pass.

## Follow-ups (tracked separately)

- Teams avatar N+1 on the same page (needs a shared-avatar refactor — not a contained overview change).
- Bumping the shared `users/` + `teams/` endpoint concurrency limits, since they're hit from many other places app-wide.
