### PR TITLE
ref(search): Drop the Metrics per-strategy check from the search agent endpoint

### DIFF
--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -149,12 +149,6 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         has_feature = features.has(
             "organizations:gen-ai-search-agent-translate", organization, actor=request.user
         )
-        if strategy == "Metrics":
-            has_feature = has_feature and features.has(
-                "organizations:gen-ai-explore-metrics-search",
-                organization,
-                actor=request.user,
-            )
         if strategy == "Issues":
             has_feature = has_feature and features.has(
                 "organizations:gen-ai-issues-search",

--- a/tests/sentry/seer/endpoints/test_search_agent_start.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_start.py
@@ -157,20 +157,10 @@ class SearchAgentStartEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
     @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
-    def test_metrics_strategy_needs_no_extra_flag(self, mock_send_request: MagicMock) -> None:
-        """Metrics is GA: the translate flag alone is enough, with no per-strategy gate."""
-        mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")
-
-        response = self._post(strategy="Metrics")
-
-        assert response.status_code == status.HTTP_200_OK
-        assert mock_send_request.call_args.kwargs["strategy"] == "Metrics"
-
-    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
-    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
     def test_issues_strategy_still_gated(self, mock_send_request: MagicMock) -> None:
         """Issues has not GA'd yet, so its per-strategy flag still gates the endpoint."""
-        response = self._post(strategy="Issues")
+        with self.feature({"organizations:gen-ai-issues-search": False}):
+            response = self._post(strategy="Issues")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         mock_send_request.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_search_agent_start.py
+++ b/tests/sentry/seer/endpoints/test_search_agent_start.py
@@ -157,6 +157,26 @@ class SearchAgentStartEndpointTest(APITestCase):
 
     @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
     @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    def test_metrics_strategy_needs_no_extra_flag(self, mock_send_request: MagicMock) -> None:
+        """Metrics is GA: the translate flag alone is enough, with no per-strategy gate."""
+        mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")
+
+        response = self._post(strategy="Metrics")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_send_request.call_args.kwargs["strategy"] == "Metrics"
+
+    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    def test_issues_strategy_still_gated(self, mock_send_request: MagicMock) -> None:
+        """Issues has not GA'd yet, so its per-strategy flag still gates the endpoint."""
+        response = self._post(strategy="Issues")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mock_send_request.assert_not_called()
+
+    @patch("sentry.seer.endpoints.search_agent_start.send_search_agent_start_request")
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
     def test_start_without_feature_flags(self, mock_send_request: MagicMock) -> None:
         """Options are False when the org has none of the flags."""
         mock_send_request.return_value = Mock(seer_run_state_id=42, uuid="run-uuid")


### PR DESCRIPTION
Drops the Metrics per-strategy feature check from the search agent start endpoint. `gen-ai-explore-metrics-search` went GA in getsentry/sentry-options-automator#9349 (empty-conditions segment, rollout 100), so the gate on top of `gen-ai-search-agent-translate` no longer selects anyone — Metrics now matches Traces, Logs and Errors, which have never had a second flag.

Issues keeps its check. `gen-ai-issues-search` has Internal and EA segments but no GA segment, so it is still early-adopter only.

Adds one test, `test_issues_strategy_still_gated`, which asserts Issues still 403s with its own flag explicitly off. The test class grants only `gen-ai-search-agent-translate` and `gen-ai-features`, so a plain GA org is what the rest of the suite already exercises.

**Safe to deploy independently of the frontend.** The matching frontend change is getsentry/sentry#122654, and neither half depends on the other — both remove a check that currently passes for every org, so either can ship first without a behavior change. Split into two PRs per the frontend/backend deploy policy rather than because of a dependency.

**The flag stays registered.** Per the options-automator README's "Deleting an Option" order, usage comes out first, then the Flagpole entry (getsentry/sentry-options-automator#9358), then the registration (getsentry/sentry#122648). Removing the registration ahead of the Flagpole entry trips the CI drift check.
