### PR TITLE
test(detectors): Remove redundant automatic name test

### DIFF
--- a/static/app/views/detectors/detectorNewSettings.spec.tsx
+++ b/static/app/views/detectors/detectorNewSettings.spec.tsx
@@ -1075,50 +1075,6 @@ describe('DetectorEdit', () => {
         })
       );
     });
-
-    it('automatically sets monitor name from URL and stops after manual edit', async () => {
-      render(<DetectorNewSettings />, {
-        organization,
-        initialRouterConfig: uptimeRouterConfig,
-      });
-
-      const nameField = await screen.findByText('New Monitor');
-
-      // Type a simple hostname
-      await userEvent.type(
-        screen.getByRole('textbox', {name: 'URL'}),
-        'https://my-cool-site.com/'
-      );
-
-      await screen.findByText('Uptime check for my-cool-site.com');
-
-      // Clear and type a URL with a path - name should update
-      let urlInput = screen.getByRole('textbox', {name: 'URL'});
-      await userEvent.clear(urlInput);
-      await userEvent.type(urlInput, 'https://example.com/with-path');
-
-      // Name was updated with auto-generated name
-      expect(nameField).toHaveTextContent('Uptime check for example.com/with-path');
-
-      // Manually edit the name
-      await userEvent.click(nameField);
-      const nameInput = screen.getByRole('textbox', {name: 'Monitor Name'});
-      await userEvent.clear(nameInput);
-      await userEvent.type(nameInput, 'My Custom Name{Enter}');
-
-      await screen.findByText('My Custom Name');
-
-      // Change the URL - name should NOT update anymore
-      urlInput = screen.getByRole('textbox', {name: 'URL'});
-      await userEvent.clear(urlInput);
-      await userEvent.type(urlInput, 'https://different-site.com');
-
-      // Verify the name didn't change
-      expect(screen.getByText('My Custom Name')).toBeInTheDocument();
-      expect(
-        screen.queryByText('Uptime check for different-site.com')
-      ).not.toBeInTheDocument();
-    });
   });
 
   describe('Cron Detector', () => {


### PR DESCRIPTION
Removes the timeout-prone uptime automatic-name integration test from the new detector settings suite. The behavior remains covered by the detector submission assertion, the `useSetAutomaticName` unit tests, and the URL formatting unit tests, avoiding repeated character-by-character form interactions without reducing meaningful coverage.
