### PR TITLE
perf(seer): Batch overview assignee team avatars into one request

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -3,6 +3,7 @@ import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
@@ -21,6 +22,7 @@ import {setPageFiltersStorage} from 'sentry/components/pageFilters/persistence';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
 import type {Actor} from 'sentry/types/core';
 import type {PullRequestStatus} from 'sentry/types/integrations';
 import AutofixOverview from 'sentry/views/seerWorkflows/overview';
@@ -1824,6 +1826,91 @@ describe('AutofixOverview', () => {
       await userEvent.click(screen.getByRole('button', {name: /Assignee/}));
 
       expect(await screen.findByRole('option', {name: /#squad/})).toBeInTheDocument();
+    });
+
+    it('batches team avatar fetches into a single request across cards', async () => {
+      act(() => {
+        TeamStore.loadInitialData([]);
+      });
+      const teamOne: Actor = {type: 'team', id: '8', name: 'team-eight'};
+      const teamTwo: Actor = {type: 'team', id: '9', name: 'team-nine'};
+      mockOverview({
+        base: {
+          autofix_root_cause: [
+            {
+              ...rootCauseRun,
+              groupId: '2',
+              seerRunId: 'run-1',
+              title: 'First team issue',
+              issue: issueFixture({assignedTo: teamOne}),
+            },
+            {
+              ...rootCauseRun,
+              groupId: '3',
+              seerRunId: 'run-2',
+              title: 'Second team issue',
+              issue: issueFixture({assignedTo: teamTwo}),
+            },
+          ],
+        },
+      });
+      const teamsMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/teams/`,
+        body: [
+          TeamFixture({id: '8', slug: 'team-eight'}),
+          TeamFixture({id: '9', slug: 'team-nine'}),
+        ],
+      });
+
+      renderPage();
+
+      expect(await screen.findByText('First team issue')).toBeInTheDocument();
+      expect(await screen.findByText('Second team issue')).toBeInTheDocument();
+
+      // Both assignee teams should resolve via one batched request, not one per team.
+      await waitFor(() => {
+        const batched = teamsMock.mock.calls.find(([, options]: any) => {
+          const query = options?.query?.query ?? '';
+          return query.includes('id:8') && query.includes('id:9');
+        });
+        expect(batched).toBeDefined();
+      });
+      expect(teamsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores a usable assignee control when an assigned team never resolves', async () => {
+      act(() => {
+        TeamStore.loadInitialData([]);
+      });
+      const deletedTeam: Actor = {type: 'team', id: '404', name: 'gone'};
+      mockOverview({
+        base: {
+          autofix_root_cause: [
+            {
+              ...rootCauseRun,
+              groupId: '2',
+              seerRunId: 'run-1',
+              title: 'Orphaned issue',
+              issue: issueFixture({assignedTo: deletedTeam}),
+            },
+          ],
+        },
+      });
+      // The batched request omits the assigned team (deleted / inaccessible),
+      // so it never enters the resolved set.
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/teams/`,
+        body: [],
+      });
+
+      renderPage();
+
+      expect(await screen.findByText('Orphaned issue')).toBeInTheDocument();
+      // Once the batch settles, the card must fall back to the interactive
+      // assignee control rather than hang on a placeholder.
+      expect(
+        await screen.findByRole('button', {name: 'Modify issue assignee'})
+      ).toBeInTheDocument();
     });
 
     it('clears the filter and restores all sections', async () => {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -1,4 +1,11 @@
-import {type ComponentProps, Fragment, type ReactNode, useMemo} from 'react';
+import {
+  type ComponentProps,
+  Fragment,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -25,6 +32,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
+import type {Actor} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
@@ -39,6 +47,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {useUser} from 'sentry/utils/useUser';
 
 import {AssigneeFilter, matchesAssignee} from './assigneeFilter';
@@ -205,6 +214,37 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     enabled: memberProjectIds.length > 0,
   });
   const membersByProject = useMemo(() => indexMembersByProject(members), [members]);
+  // Sorted so a given id set yields a stable key regardless of run ordering.
+  const assigneeTeamIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          allRuns
+            .map(run => run.issue.assignedTo)
+            .filter((actor): actor is Actor => actor?.type === 'team')
+            .map(actor => actor.id)
+        )
+      ).sort(),
+    [allRuns]
+  );
+  const {teams: prefetchedTeams, isLoading: teamsLoading} = useTeamsById({
+    ids: assigneeTeamIds,
+  });
+  const resolvedTeamIds = useMemo(
+    () => new Set(prefetchedTeams.map(team => team.id)),
+    [prefetchedTeams]
+  );
+  // Effect-deferred so it lands no earlier than the team-store prime: releasing
+  // this gate during render would beat the prime by a frame and refire the N+1.
+  const teamIdsKey = assigneeTeamIds.join(',');
+  const [settledTeamIdsKey, setSettledTeamIdsKey] = useState<string | null>(null);
+  useEffect(() => {
+    if (!teamsLoading) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
+      setSettledTeamIdsKey(teamIdsKey);
+    }
+  }, [teamsLoading, teamIdsKey]);
+  const teamsSettled = teamIdsKey !== '' && settledTeamIdsKey === teamIdsKey;
   const passesAssignee = (run: OverviewRun) =>
     assignee === null || matchesAssignee(run, assignee);
   const assigneeRuns = allRuns.filter(passesAssignee);
@@ -359,6 +399,8 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
                   statsPeriod={selection.datetime.period}
                   enrichmentPending={enrichmentPending}
                   membersByProject={membersByProject}
+                  resolvedTeamIds={resolvedTeamIds}
+                  teamsSettled={teamsSettled}
                 />
               )}
             </Fragment>
@@ -377,14 +419,18 @@ function OverviewSectionList({
   statsPeriod,
   enrichmentPending,
   membersByProject,
+  resolvedTeamIds,
+  teamsSettled,
 }: {
   collapsedGroups: StatusGroupKey[];
   enrichmentPending: boolean;
   membersByProject: IndexedMembersByProject;
   onToggle: (groupKey: StatusGroupKey, expanded: boolean) => void;
   orgSlug: string;
+  resolvedTeamIds: Set<string>;
   sections: Array<(typeof OVERVIEW_SECTIONS)[number] & {runs: OverviewRun[]}>;
   statsPeriod: ComponentProps<typeof OverviewCard>['statsPeriod'];
+  teamsSettled: boolean;
 }) {
   return (
     <Stack gap="lg">
@@ -412,17 +458,25 @@ function OverviewSectionList({
             </GroupHeader>
             <Disclosure.Content>
               <Stack gap="md" paddingTop="sm">
-                {runs.map(run => (
-                  <OverviewCard
-                    key={run.seerRunId}
-                    run={run}
-                    orgSlug={orgSlug}
-                    sectionKey={key}
-                    statsPeriod={statsPeriod}
-                    enrichmentPending={enrichmentPending}
-                    memberList={membersByProject.get(run.issue.project.slug) ?? []}
-                  />
-                ))}
+                {runs.map(run => {
+                  const assignee = run.issue.assignedTo;
+                  const assigneeReady =
+                    assignee?.type !== 'team' ||
+                    resolvedTeamIds.has(assignee.id) ||
+                    teamsSettled;
+                  return (
+                    <OverviewCard
+                      key={run.seerRunId}
+                      run={run}
+                      orgSlug={orgSlug}
+                      sectionKey={key}
+                      statsPeriod={statsPeriod}
+                      enrichmentPending={enrichmentPending}
+                      memberList={membersByProject.get(run.issue.project.slug) ?? []}
+                      assigneeReady={assigneeReady}
+                    />
+                  );
+                })}
               </Stack>
             </Disclosure.Content>
           </StatusGroup>

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -469,7 +469,15 @@ function IssueVitals({
   );
 }
 
-function PriorityAndAssignee({run, memberList}: {run: OverviewRun; memberList?: User[]}) {
+function PriorityAndAssignee({
+  run,
+  memberList,
+  assigneeReady,
+}: {
+  assigneeReady: boolean;
+  run: OverviewRun;
+  memberList?: User[];
+}) {
   const {issue} = run;
   const priorityGroup: OverviewIssuePriorityGroup = {
     id: run.groupId,
@@ -488,14 +496,18 @@ function PriorityAndAssignee({run, memberList}: {run: OverviewRun; memberList?: 
   return (
     <Flex gap="xs" align="center">
       <OverviewIssuePriority group={priorityGroup} />
-      <OverviewIssueAssignee
-        groupId={run.groupId}
-        projectId={issue.project.id}
-        projectSlug={issue.project.slug}
-        assignedTo={issue.assignedTo ?? undefined}
-        owners={issue.owners}
-        memberList={memberList}
-      />
+      {assigneeReady ? (
+        <OverviewIssueAssignee
+          groupId={run.groupId}
+          projectId={issue.project.id}
+          projectSlug={issue.project.slug}
+          assignedTo={issue.assignedTo ?? undefined}
+          owners={issue.owners}
+          memberList={memberList}
+        />
+      ) : (
+        <Placeholder shape="circle" width="24px" height="24px" />
+      )}
     </Flex>
   );
 }
@@ -507,7 +519,9 @@ export function OverviewCard({
   statsPeriod,
   enrichmentPending,
   memberList,
+  assigneeReady,
 }: {
+  assigneeReady: boolean;
   enrichmentPending: boolean;
   orgSlug: string;
   run: OverviewRun;
@@ -541,7 +555,11 @@ export function OverviewCard({
             issueUrl={issueUrl}
             enrichmentPending={enrichmentPending}
           />
-          <PriorityAndAssignee run={run} memberList={memberList} />
+          <PriorityAndAssignee
+            run={run}
+            memberList={memberList}
+            assigneeReady={assigneeReady}
+          />
         </Fragment>
       }
     >


### PR DESCRIPTION
## Summary

The Seer Autofix overview renders one assignee avatar per issue card. For team-assigned issues, each card's avatar bottoms out at `AsyncTeamAvatar` → `useTeamsById({ids: [teamId]})`, and each single-id lookup produces a **distinct** query key (`query=id:8` vs `query=id:9`), so React Query can't dedupe them. The result is **one `GET /teams/` request per team-assigned card**, which exhausts the endpoint's concurrency limit and produces 429s when many issues are assigned to teams.

This batches all of it into a single request: the overview collects the distinct assignee team ids across every visible run and prefetches them once via `useTeamsById({ids})`, which populates `TeamStore`. Each card's own `AsyncTeamAvatar` then finds its team already in-store and skips its request.

**N per-team requests → 1 batched request. Frontend-only.**

## How it works

- `index.tsx` derives `assigneeTeamIds` from the (unfiltered) runs, so toggling the assignee filter never re-triggers the batch.
- The single `useTeamsById({ids: assigneeTeamIds})` call primes the store.
- Each card is gated on `resolvedTeamIds.has(id)` — the gate keeps the child `AsyncTeamAvatar` unmounted until the store is primed, which is what actually kills the N+1 (an ungated child fires its own request on a cold load before the batch lands).

## Deleted / unresolvable teams

A team assigned to an issue but no longer returned by `/teams/` (deleted, deactivated, or a failed batch request) never enters `resolvedTeamIds`. Gating on membership alone would leave that card on a **permanent placeholder** — worse than today, since the placeholder also swallows the assignee dropdown, blocking reassignment of exactly the issue you'd most want to reassign.

To preserve today's graceful behavior, a `teamsSettled` flag (set from an effect, keyed to the id set) releases the gate once the batch settles. Resolved teams still render straight from the primed store (no fetch); an unresolvable team falls through to `AsyncTeamAvatar`'s existing letter-avatar fallback inside the still-clickable selector — one bounded request for the rare stale id, not the N+1 this PR targets.

The flag is deliberately effect-deferred rather than computed from `isLoading` during render: `isLoading` flips false one frame before the store-prime effect runs, so releasing the gate during render would refire the exact per-card N+1 on every cold load.

## Test Plan

- New test asserts a single batched `/teams/` request carrying both `id:8` and `id:9` (`toHaveBeenCalledTimes(1)`) — fails on un-batched code.
- New test asserts a card assigned to a team absent from the `/teams/` response still renders the interactive "Modify issue assignee" control instead of hanging on a placeholder.
- Full overview suite (69 tests), `lint:js`, and `typecheck` pass.

## Follow-ups (tracked separately)

- **Shared-layer fix:** the N+1 root cause lives in `useTeamsById` / `AsyncTeamAvatar` — coalescing concurrent single-id team lookups into one request there would fix every `ActorAvatar` list app-wide and let this view drop its prime + gate apparatus. Larger, separate change.
- Bumping the shared `users/` + `teams/` endpoint concurrency limits, since they're hit from many other places app-wide.
