### PR TITLE
 fix(control) Add using_replica to high volume integration_service methods

### DIFF
--- a/src/sentry/integrations/jira/actions/form.py
+++ b/src/sentry/integrations/jira/actions/form.py
@@ -19,6 +19,7 @@ class JiraNotifyServiceForm(IntegrationNotifyServiceForm):
             return None
 
         integration_id = cleaned_data.get("integration")
+        # TODO(mark) Add using_replica here
         integration = integration_service.get_integration(
             integration_id=integration_id, provider=self.provider
         )

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -593,6 +593,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         from sentry.identity.services.identity.service import identity_service
         from sentry.users.services.user.service import user_service
 
+        # TODO(mark) Add using_replica here
         integration = self.get_integration(
             provider=integration_provider,
             external_id=integration_external_id,

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -146,6 +146,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         organization_id: int | None = None,
         organization_integration_id: int | None = None,
         status: int | None = None,
+        using_replica: bool = False,
     ) -> RpcIntegration | None:
         integration_kwargs: dict[str, Any] = {}
         if integration_id is not None:
@@ -163,8 +164,12 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if not integration_kwargs:
             return None
 
+        queryset = Integration.objects
+        if using_replica:
+            queryset = Integration.objects.using_replica()
+
         try:
-            integration = Integration.objects.get(**integration_kwargs)
+            integration = queryset.get(**integration_kwargs)
         except Integration.DoesNotExist:
             return None
         except Integration.MultipleObjectsReturned:
@@ -184,6 +189,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         grace_period_expired: bool | None = None,
         limit: int | None = None,
         name: str | None = None,
+        using_replica: bool = False,
     ) -> list[RpcOrganizationIntegration]:
         oi_kwargs: dict[str, Any] = {}
         if org_integration_ids is not None:
@@ -209,8 +215,11 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if not oi_kwargs:
             return []
 
-        ois = OrganizationIntegration.objects.filter(**oi_kwargs).select_related("integration")
+        queryset = OrganizationIntegration.objects
+        if using_replica:
+            queryset = OrganizationIntegration.objects.using_replica()
 
+        ois = queryset.filter(**oi_kwargs).select_related("integration")
         if limit is not None:
             ois = ois[:limit]
 

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -164,7 +164,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if not integration_kwargs:
             return None
 
-        queryset = Integration.objects
+        queryset = Integration.objects.all()
         if using_replica:
             queryset = Integration.objects.using_replica()
 
@@ -215,7 +215,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if not oi_kwargs:
             return []
 
-        queryset = OrganizationIntegration.objects
+        queryset = OrganizationIntegration.objects.all()
         if using_replica:
             queryset = OrganizationIntegration.objects.using_replica()
 

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -81,6 +81,7 @@ class IntegrationService(RpcService):
         organization_id: int | None = None,
         organization_integration_id: int | None = None,
         status: int | None = None,
+        using_replica: bool = False,
     ) -> RpcIntegration | None:
         """
         Returns an RpcIntegration using either the id or a combination of the provider and external_id
@@ -101,6 +102,7 @@ class IntegrationService(RpcService):
         grace_period_expired: bool | None = None,
         limit: int | None = None,
         name: str | None = None,
+        using_replica: bool = False,
     ) -> list[RpcOrganizationIntegration]:
         """
         Returns all RpcOrganizationIntegrations from the matching kwargs.

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -118,6 +118,7 @@ def _unfurl_dashboards(
     links: list[UnfurlableUrl],
     user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
+    # TODO(mark) Add using_replica here
     org_integrations = integration_service.get_organization_integrations(
         integration_id=integration.id
     )

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -134,6 +134,7 @@ def _unfurl_discover(
     links: list[UnfurlableUrl],
     user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
+    # TODO(mark) Add using_replica here
     org_integrations = integration_service.get_organization_integrations(
         integration_id=integration.id
     )

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -541,6 +541,7 @@ def _unfurl_explore(
     links: list[UnfurlableUrl],
     user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
+    # TODO(mark) Add using_replica here
     org_integrations = integration_service.get_organization_integrations(
         integration_id=integration.id
     )

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -554,6 +554,7 @@ class SlackActionEndpoint(Endpoint):
         return self.respond(response)
 
     def handle_unfurl(self, slack_request: SlackActionRequest, action: str) -> Response:
+        # TODO(mark) Add using_replica here
         organization_integrations = integration_service.get_organization_integrations(
             integration_id=slack_request.integration.id, limit=1
         )

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -303,6 +303,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
         data = slack_request.data.get("event", {})
 
+        # TODO(mark) Add using_replica here
         ois = integration_service.get_organization_integrations(
             integration_id=slack_request.integration.id, limit=1
         )

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -78,6 +78,7 @@ def get_integration_from_jwt(
     issuer = claims.get("iss")
     # Look up the sharedSecret for the clientKey, as stored
     # by the add-on during the installation handshake
+    # TODO(mark) Add using_replica here
     integration = integration_service.get_integration(provider=provider, external_id=issuer)
     if not integration:
         raise AtlassianConnectValidationError("No integration found")

--- a/tests/sentry/integrations/services/test_integration.py
+++ b/tests/sentry/integrations/services/test_integration.py
@@ -156,6 +156,12 @@ class IntegrationServiceTest(BaseIntegrationServiceTest):
         result = integration_service.get_integration(provider="example", external_id="example:1")
         self.verify_integration_result(result=result, expected=self.integration1)
 
+        # With replica usage
+        result = integration_service.get_integration(
+            provider="example", external_id="example:1", using_replica=True
+        )
+        self.verify_integration_result(result=result, expected=self.integration1)
+
         # no results
         result = integration_service.get_integration(provider="🚀")
         assert result is None
@@ -225,6 +231,13 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
         # by integration_id
         result = integration_service.get_organization_integrations(
             org_integration_ids=[self.org_integration1.id]
+        )
+        self.verify_result(result=result, expected=[self.org_integration1])
+
+        # by integration_id with replica
+        result = integration_service.get_organization_integrations(
+            integration_id=self.org_integration1.integration_id,
+            using_replica=True,
         )
         self.verify_result(result=result, expected=[self.org_integration1])
 


### PR DESCRIPTION
Expand the RPC call signatures of a couple high-volume RPC methods to allow callers to indicate that their request is safe to run on a replica. Not all calls to `get_integration()` or `organziation_contexts()` are replica lag safe.

My plan is to incrementally apply this parameter where it is safe to reduce load on the primary. I've added a few `TODO` comments on the calls that match the query profile we would like to move and also seem tolerant of replica lag. My plan is to follow this up with a change that uses an option to enable replica reads.