### PR TITLE
feat(flags): Create public identity fields getter

### DIFF
--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -64,6 +64,10 @@ class EvaluationContext:
         """
         return self.__id
 
+    @property
+    def identity_fields(self) -> frozenset[str]:
+        return frozenset(self.__identity_fields)
+
     def get(self, key: str) -> Any:
         return self.__data.get(key)
 

--- a/tests/flagpole/test_evaluation_context.py
+++ b/tests/flagpole/test_evaluation_context.py
@@ -37,6 +37,19 @@ class TestEvaluationContext:
         assert eval_context.id == expected_id
         assert eval_context.id % 100 == 1, "bucket should be correct"
 
+    def test_identity_fields_are_filtered_and_read_only(self) -> None:
+        eval_context = EvaluationContext(
+            {"foo": "bar", "baz": "barfoo"},
+            {"foo", "missing"},
+        )
+        assert eval_context.identity_fields == frozenset({"foo"})
+
+        fallback_context = EvaluationContext(
+            {"foo": "bar", "baz": "barfoo"},
+            {"missing"},
+        )
+        assert fallback_context.identity_fields == frozenset({"foo", "baz"})
+
     def test_no_identity_fields_included(self) -> None:
         eval_context = EvaluationContext({})
         assert eval_context.id == 1245845410931227995499360226027473197403882391305


### PR DESCRIPTION
We will be dual evaluating legacy and sentry-options feature flags. For this, we need to build the `EvaluationContext` twice, for each system. To reduce as much error as possible, this context should be the same for both systems.

Right now there is no way to get the private `__identity_fields` after it is set in the constructor, making it difficult to mirror the context object. This exposes it as `context.identity_fields`. 

This doesn't expose the actual values, just the set that was passed in (not that that would matter anyways, you can get the values via `context.to_dict()`, and these values are not sensitive). Related, the behaviour of `to_dict()` has not changed, it still doesn't return the identity fields set.