### PR TITLE
ref(explore): Stop gating the Metrics search bar on gen-ai-explore-metrics-search

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -82,9 +82,6 @@ export function Filter({
   const hasTranslateEndpoint = organization.features.includes(
     'gen-ai-search-agent-translate'
   );
-  const hasMetricsAISearch = organization.features.includes(
-    'gen-ai-explore-metrics-search'
-  );
   const supportsArrays = organization.features.includes('trace-item-array-query-support');
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
@@ -318,7 +315,7 @@ export function Filter({
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
       {...searchQueryBuilderProviderProps}
-      enableAISearch={hasTranslateEndpoint && hasMetricsAISearch}
+      enableAISearch={hasTranslateEndpoint}
     >
       <MetricsSearchBar
         tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -6,6 +6,7 @@ import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {ALL_DATE_TIME_QUERY_KEYS} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
+import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import type {
   AskSeerSearchQuery,
@@ -355,6 +356,10 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     ]
   );
 
+  const usePollingEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
       transformSeerResponse(
@@ -369,21 +374,31 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     return null;
   }
 
+  if (usePollingEndpoint) {
+    return (
+      <AskSeerPollingComboBox<AskSeerSearchQuery>
+        initialQuery={initialSeerQuery}
+        projectIds={selectedProjectIds}
+        strategy="Metrics"
+        options={{
+          metric_context: {
+            metric_name: traceMetric.name,
+            metric_type: traceMetric.type,
+            metric_unit: traceMetric.unit ?? NONE_UNIT,
+          },
+        }}
+        applySeerSearchQuery={applySeerSearchQuery}
+        transformResponse={transformResponse}
+        fallbackMutationOptions={metricsTabAskSeerMutationOptions}
+      />
+    );
+  }
+
   return (
-    <AskSeerPollingComboBox<AskSeerSearchQuery>
+    <AskSeerComboBox
       initialQuery={initialSeerQuery}
-      projectIds={selectedProjectIds}
-      strategy="Metrics"
-      options={{
-        metric_context: {
-          metric_name: traceMetric.name,
-          metric_type: traceMetric.type,
-          metric_unit: traceMetric.unit ?? NONE_UNIT,
-        },
-      }}
+      askSeerMutationOptions={metricsTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
-      transformResponse={transformResponse}
-      fallbackMutationOptions={metricsTabAskSeerMutationOptions}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -6,7 +6,6 @@ import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {ALL_DATE_TIME_QUERY_KEYS} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useAiQueryContext} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
-import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import type {
   AskSeerSearchQuery,
@@ -356,10 +355,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     ]
   );
 
-  const usePollingEndpoint =
-    organization.features.includes('gen-ai-search-agent-translate') &&
-    organization.features.includes('gen-ai-explore-metrics-search');
-
   const transformResponse = useCallback(
     (response: AskSeerSearchQuery): AskSeerSearchQuery[] =>
       transformSeerResponse(
@@ -374,31 +369,21 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     return null;
   }
 
-  if (usePollingEndpoint) {
-    return (
-      <AskSeerPollingComboBox<AskSeerSearchQuery>
-        initialQuery={initialSeerQuery}
-        projectIds={selectedProjectIds}
-        strategy="Metrics"
-        options={{
-          metric_context: {
-            metric_name: traceMetric.name,
-            metric_type: traceMetric.type,
-            metric_unit: traceMetric.unit ?? NONE_UNIT,
-          },
-        }}
-        applySeerSearchQuery={applySeerSearchQuery}
-        transformResponse={transformResponse}
-        fallbackMutationOptions={metricsTabAskSeerMutationOptions}
-      />
-    );
-  }
-
   return (
-    <AskSeerComboBox
+    <AskSeerPollingComboBox<AskSeerSearchQuery>
       initialQuery={initialSeerQuery}
-      askSeerMutationOptions={metricsTabAskSeerMutationOptions}
+      projectIds={selectedProjectIds}
+      strategy="Metrics"
+      options={{
+        metric_context: {
+          metric_name: traceMetric.name,
+          metric_type: traceMetric.type,
+          metric_unit: traceMetric.unit ?? NONE_UNIT,
+        },
+      }}
       applySeerSearchQuery={applySeerSearchQuery}
+      transformResponse={transformResponse}
+      fallbackMutationOptions={metricsTabAskSeerMutationOptions}
     />
   );
 }


### PR DESCRIPTION
Stops gating the Metrics search bar on `gen-ai-explore-metrics-search`. The flag went GA in getsentry/sentry-options-automator#9349 (empty-conditions segment, rollout 100), so the check on top of `gen-ai-search-agent-translate` no longer selects anyone. Metrics now matches Traces, Logs and Errors, which have never had a second flag.

Both call sites drop only the `gen-ai-explore-metrics-search` conjunct and keep `gen-ai-search-agent-translate`:

- `filter.tsx` — `enableAISearch` is now gated on the translate flag alone.
- `metricsTabSeerComboBox.tsx` — `usePollingEndpoint` is now gated on the translate flag alone, and the `AskSeerComboBox` fallback below it stays in place. Per review, the translate flag remains the global killswitch for the polling path.

**Safe to deploy independently of the backend.** The matching backend change is getsentry/sentry#122647, and neither half depends on the other — both remove a check that currently passes for every org, so either can ship first without a behavior change. Split into two PRs per the frontend/backend deploy policy rather than because of a dependency.
