### PR TITLE
chore(sentry apps): Loosen request log permisisons for internal apps

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
@@ -125,7 +125,12 @@ describe('Sentry Application Dashboard', () => {
       await waitFor(() => expect(screen.getAllByTestId('chart')).toHaveLength(3));
       expect(statsMock).toHaveBeenCalledTimes(1);
       expect(interactionMock).toHaveBeenCalledTimes(1);
-      expect(screen.queryByText('Request Log')).not.toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Request Log'})).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Only organization admins and members with integration management access can view the request log.'
+        )
+      ).toBeInTheDocument();
       expect(screen.queryByTestId('request-item')).not.toBeInTheDocument();
       expect(webhookRequestMock).not.toHaveBeenCalled();
     });
@@ -194,7 +199,7 @@ describe('Sentry Application Dashboard', () => {
         },
       });
 
-      MockApiClient.addMockResponse({
+      webhookRequestMock = MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/webhook-requests/`,
         body: [webhookRequest],
       });
@@ -215,8 +220,8 @@ describe('Sentry Application Dashboard', () => {
       });
     });
 
-    it('shows the request log', async () => {
-      renderDashboard();
+    it('shows the request log for users with only org read access', async () => {
+      renderDashboard(OrganizationFixture({access: ['org:read']}));
       // The mock response has 1 request
       expect(await screen.findByTestId('request-item')).toBeInTheDocument();
       const requestLog = within(screen.getByTestId('request-item'));
@@ -224,6 +229,8 @@ describe('Sentry Application Dashboard', () => {
       expect(requestLog.getByText('https://example.com/webhook')).toBeInTheDocument();
       expect(requestLog.getByText('400')).toBeInTheDocument();
       expect(requestLog.getByText('issue.assigned')).toBeInTheDocument();
+      expect(webhookRequestMock).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('org-permission-alert')).not.toBeInTheDocument();
 
       // Does not show the integration views
       expect(screen.queryByText('Integration Views')).not.toBeInTheDocument();

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
@@ -2,9 +2,9 @@ import {Fragment, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import {useQuery} from '@tanstack/react-query';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {sentryAppApiOptions} from 'sentry/actionCreators/sentryApps';
 import {BarChart} from 'sentry/components/charts/barChart';
@@ -25,6 +25,7 @@ import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 import {RequestLog} from './requestLog';
 
@@ -99,6 +100,7 @@ function SentryApplicationDashboard() {
   const showInstallData = app.status === 'published';
   const showComponentInteractions = Boolean(app.schema?.elements);
   const canViewRequestLogs =
+    app.status === 'internal' ||
     organization.access.includes('org:admin') ||
     organization.access.includes('org:integrations') ||
     isActiveSuperuser();
@@ -120,7 +122,19 @@ function SentryApplicationDashboard() {
       {showComponentInteractions ? (
         <ComponentInteractionsSection appSlug={appSlug} timeRange={timeRange} />
       ) : null}
-      {canViewRequestLogs && <RequestLog app={app} />}
+      {canViewRequestLogs ? (
+        <RequestLog app={app} />
+      ) : (
+        <Stack gap="md">
+          <Heading as="h5">{t('Request Log')}</Heading>
+          <OrganizationPermissionAlert
+            access={['org:integrations']}
+            message={t(
+              'Only organization admins and members with integration management access can view the request log.'
+            )}
+          />
+        </Stack>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Internal apps are just sending info from that org so I think showing the request log for them is fine for org members

Also display a message for public apps
<img width="995" height="115" alt="image" src="https://github.com/user-attachments/assets/6a4880ce-6559-4e1e-82f6-f7b63b1d3be0" />
