### PR TITLE
feat(rollout): Add error metric to `SafeRolloutComparator`

### DIFF
--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 TData = TypeVar("TData")  # The type of data being compared
 
 SourceOfTruth = Literal["control", "experimental", "neither", "both"]
+RolloutBranch = Literal["control", "experimental"]
 
 
 class SafeRolloutComparator:
@@ -349,6 +350,26 @@ class SafeRolloutComparator:
             tags=tags,
         )
         return use_experimental_data
+
+    @classmethod
+    def record_error(
+        cls,
+        error: Exception,
+        callsite: str,
+        branch: RolloutBranch,
+        metric_sample_rate: float = 1.0,
+    ) -> None:
+        """Record an error from evaluating one rollout branch without changing control flow."""
+        metrics.incr(
+            "SafeRolloutComparator.error",
+            sample_rate=metric_sample_rate,
+            tags={
+                "rollout_name": cls.ROLLOUT_NAME,
+                "callsite": callsite,
+                "branch": branch,
+                "error_type": type(error).__name__,
+            },
+        )
 
     @classmethod
     def compare(

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -28,6 +28,27 @@ TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION = (
 )
 
 
+class SafeRolloutComparatorMetricsTestCase(TestCase):
+    @patch("sentry.utils.rollout.metrics.incr")
+    def test_record_error(self, mock_metrics_incr: MagicMock) -> None:
+        TestRolloutComparator.record_error(
+            error=ValueError("experimental failure"),
+            callsite="dogs_are_great",
+            branch="experimental",
+        )
+
+        mock_metrics_incr.assert_called_once_with(
+            "SafeRolloutComparator.error",
+            sample_rate=1.0,
+            tags={
+                "rollout_name": "test_rollout",
+                "callsite": "dogs_are_great",
+                "branch": "experimental",
+                "error_type": "ValueError",
+            },
+        )
+
+
 @django_db_all
 class SafeRolloutComparatorTestCase(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Sometimes a branch will error out before we get to complete the comparison, and it would be nice if this metric was built into the comparator rather than me having to add it myself after the fact.