### PR TITLE
feat(seer): Add org-scoped batch autofix repos endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -574,6 +574,9 @@ from sentry.seer.endpoints.organization_seer_agent_update import (
 from sentry.seer.endpoints.organization_seer_autofix_overview import (
     OrganizationSeerAutofixOverviewEndpoint,
 )
+from sentry.seer.endpoints.organization_seer_autofix_repos import (
+    OrganizationSeerAutofixReposEndpoint,
+)
 from sentry.seer.endpoints.organization_seer_onboarding_check import OrganizationSeerOnboardingCheck
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
 from sentry.seer.endpoints.organization_seer_runs import OrganizationSeerRunsEndpoint
@@ -2535,6 +2538,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/seer/autofix-overview/$",
         OrganizationSeerAutofixOverviewEndpoint.as_view(),
         name="sentry-api-0-organization-seer-autofix-overview",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/autofix-repos/$",
+        OrganizationSeerAutofixReposEndpoint.as_view(),
+        name="sentry-api-0-organization-seer-autofix-repos",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/runs/$",

--- a/src/sentry/seer/endpoints/organization_seer_autofix_repos.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_repos.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.models import SeerPermissionError
+from sentry.seer.models.run import SeerAgentRun
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+
+_MAX_WORKERS = 10
+
+
+class OrganizationSeerAutofixReposPermission(OrganizationPermission):
+    scope_map = {"GET": ["org:read"]}
+
+
+@cell_silo_endpoint
+class OrganizationSeerAutofixReposEndpoint(OrganizationEndpoint):
+    """Batch sibling of the per-group ``autofix/repos/`` endpoint.
+
+    Returns ``{group_id: {repos: [...]}}`` for many groups in one request so the
+    overview page fetches repos once instead of once per card. Access flags are
+    per-(org, repo), so batching lets Seer's work be shared across cards.
+    """
+
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.ML_AI
+    permission_classes = (OrganizationSeerAutofixReposPermission,)
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.IP: RateLimit(limit=500, window=60, concurrent_limit=100),
+                RateLimitCategory.USER: RateLimit(limit=500, window=60, concurrent_limit=100),
+                RateLimitCategory.ORGANIZATION: RateLimit(
+                    limit=1000, window=60, concurrent_limit=100
+                ),
+            }
+        }
+    )
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        group_ids = _parse_group_ids(request)
+        if not group_ids:
+            return Response({}, status=status.HTTP_200_OK)
+
+        try:
+            client = SeerAgentClient(organization=organization, user=None)
+        except SeerPermissionError:
+            return Response(
+                {"detail": "Seer access is not enabled for this organization"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        accessible_group_ids = _accessible_group_ids(request, organization, group_ids)
+        if not accessible_group_ids:
+            return Response({}, status=status.HTTP_200_OK)
+
+        state_id_by_group = _latest_state_id_per_group(organization, accessible_group_ids)
+
+        result: dict[str, dict[str, list]] = {}
+        # A group with no run has no repos to report; the per-group endpoint
+        # returns the same legitimate empty for this case.
+        for group_id in accessible_group_ids:
+            if group_id not in state_id_by_group:
+                result[str(group_id)] = {"repos": []}
+
+        def fetch(item: tuple[int, int]) -> tuple[int, dict[str, list] | None]:
+            group_id, state_id = item
+            try:
+                response = client.get_repos(state_id)
+            except Exception:
+                return group_id, None
+            if response.status == 404:
+                return group_id, {"repos": []}
+            if response.status >= 400:
+                return group_id, None
+            return group_id, response.json()
+
+        if state_id_by_group:
+            with ContextPropagatingThreadPoolExecutor(max_workers=_MAX_WORKERS) as executor:
+                for group_id, repos in executor.map(fetch, state_id_by_group.items()):
+                    # Omit (rather than fabricate empty) when Seer fails, so the
+                    # client can fall back instead of trusting a false "no repos".
+                    if repos is not None:
+                        result[str(group_id)] = repos
+
+        return Response(result, status=status.HTTP_200_OK)
+
+
+def _parse_group_ids(request: Request) -> set[int]:
+    group_ids: set[int] = set()
+    for raw in request.GET.getlist("group"):
+        try:
+            group_ids.add(int(raw))
+        except (TypeError, ValueError):
+            continue
+    return group_ids
+
+
+def _accessible_group_ids(
+    request: Request, organization: Organization, group_ids: set[int]
+) -> list[int]:
+    groups = Group.objects.filter(
+        id__in=group_ids, project__organization_id=organization.id
+    ).select_related("project")
+    return [group.id for group in groups if request.access.has_project_access(group.project)]
+
+
+def _latest_state_id_per_group(organization: Organization, group_ids: list[int]) -> dict[int, int]:
+    rows = (
+        SeerAgentRun.objects.filter(
+            run__organization_id=organization.id,
+            source="autofix",
+            group_id__in=group_ids,
+            run__seer_run_state_id__isnull=False,
+        )
+        .select_related("run")
+        .order_by("-run__last_triggered_at")
+    )
+    # Rows are newest-first, so the first run seen for a group is its latest.
+    latest: dict[int, int] = {}
+    for row in rows:
+        if row.group_id not in latest:
+            latest[row.group_id] = row.run.seer_run_state_id
+    return latest

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -367,6 +367,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/search-agent/translate/'
   | '/organizations/$organizationIdOrSlug/seer-rpc/$methodName/'
   | '/organizations/$organizationIdOrSlug/seer/autofix-overview/'
+  | '/organizations/$organizationIdOrSlug/seer/autofix-repos/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-chat/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-chat/$runId/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-update/$runId/'

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_repos.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_repos.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+@with_feature("organizations:gen-ai-features")
+class OrganizationSeerAutofixReposEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.url = f"/api/0/organizations/{self.organization.slug}/seer/autofix-repos/"
+
+    def _create_run_mirror(self, group, seer_run_state_id: int) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=seer_run_state_id
+        )
+        self.create_seer_agent_run(run, source="autofix", group=group)
+
+    def _repos_response(self, repo_name: str) -> MagicMock:
+        response = MagicMock()
+        response.status = 200
+        response.json.return_value = {
+            "repos": [
+                {
+                    "repo_name": repo_name,
+                    "provider": "github",
+                    "owner": "owner",
+                    "name": repo_name.split("/")[-1],
+                    "external_id": "123",
+                    "default_branch": "main",
+                    "has_write_access": True,
+                    "has_read_access": True,
+                }
+            ]
+        }
+        return response
+
+    @patch("sentry.seer.agent.client.SeerAgentClient.get_repos")
+    def test_batches_repos_for_multiple_groups(self, mock_get_repos: MagicMock) -> None:
+        group_one = self.create_group()
+        group_two = self.create_group()
+        self._create_run_mirror(group_one, 42)
+        self._create_run_mirror(group_two, 43)
+
+        def fake_get_repos(run_id: int) -> MagicMock:
+            return self._repos_response(f"owner/repo-{run_id}")
+
+        mock_get_repos.side_effect = fake_get_repos
+
+        response = self.client.get(self.url, {"group": [group_one.id, group_two.id]})
+
+        assert response.status_code == 200
+        assert response.data[str(group_one.id)]["repos"][0]["repo_name"] == "owner/repo-42"
+        assert response.data[str(group_two.id)]["repos"][0]["repo_name"] == "owner/repo-43"
+        # One Seer call per group, not one per card render.
+        assert mock_get_repos.call_count == 2
+
+    @patch("sentry.seer.agent.client.SeerAgentClient.get_repos")
+    def test_group_without_run_returns_empty(self, mock_get_repos: MagicMock) -> None:
+        group = self.create_group()
+
+        response = self.client.get(self.url, {"group": [group.id]})
+
+        assert response.status_code == 200
+        assert response.data[str(group.id)] == {"repos": []}
+        mock_get_repos.assert_not_called()
+
+    @patch("sentry.seer.agent.client.SeerAgentClient.get_repos")
+    def test_seer_404_returns_empty(self, mock_get_repos: MagicMock) -> None:
+        group = self.create_group()
+        self._create_run_mirror(group, 42)
+        not_found = MagicMock()
+        not_found.status = 404
+        mock_get_repos.return_value = not_found
+
+        response = self.client.get(self.url, {"group": [group.id]})
+
+        assert response.status_code == 200
+        assert response.data[str(group.id)] == {"repos": []}
+
+    @patch("sentry.seer.agent.client.SeerAgentClient.get_repos")
+    def test_omits_group_when_seer_fails(self, mock_get_repos: MagicMock) -> None:
+        good = self.create_group()
+        bad = self.create_group()
+        self._create_run_mirror(good, 42)
+        self._create_run_mirror(bad, 43)
+
+        def fake_get_repos(run_id: int) -> MagicMock:
+            if run_id == 43:
+                raise Exception("Connection refused")
+            return self._repos_response("owner/good")
+
+        mock_get_repos.side_effect = fake_get_repos
+
+        response = self.client.get(self.url, {"group": [good.id, bad.id]})
+
+        assert response.status_code == 200
+        # A single group's Seer failure must not fabricate empty repos or fail the batch.
+        assert response.data[str(good.id)]["repos"][0]["repo_name"] == "owner/good"
+        assert str(bad.id) not in response.data
+
+    @patch("sentry.seer.agent.client.SeerAgentClient.get_repos")
+    def test_excludes_groups_outside_org(self, mock_get_repos: MagicMock) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_group = self.create_group(project=other_project)
+
+        response = self.client.get(self.url, {"group": [other_group.id]})
+
+        assert response.status_code == 200
+        assert response.data == {}
+        mock_get_repos.assert_not_called()
+
+    @patch("sentry.seer.agent.client.SeerAgentClient.get_repos")
+    def test_no_groups_returns_empty(self, mock_get_repos: MagicMock) -> None:
+        response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data == {}
+        mock_get_repos.assert_not_called()


### PR DESCRIPTION
## Summary

The Seer Autofix Overview gates each issue card's "Draft PR" affordance on repo write-access, fetched from the per-group `GET .../issues/{group}/autofix/repos/` endpoint. That's fired **once per card** (for cards at the `code_changes_ready` milestone), an N+1 that pressures the endpoint's concurrency limit and produces 429s.

This adds an **org-scoped batch sibling** so the frontend can fetch repos for every visible card in **one request**:

`GET /organizations/{org}/seer/autofix-repos/?group=123&group=456` → `{ "123": {repos: [...]}, "456": {repos: [...]} }`

Frontend wiring lands in a **separate PR** (frontend/backend aren't atomically deployed; backend first).

## Why batching helps beyond fewer HTTP calls

Repo access flags (`has_write_access`) are computed Seer-side and are keyed by **(org, repo)** — the `run_id` never reaches the access check. So today, cards sharing a project make Seer re-run the same uncached GitHub permission checks over and over. Collapsing to one call lets that work be shared/deduped server-side.

## How it works

- Scopes requested group ids to the org **and** the requester's project access (`request.access.has_project_access`) — untrusted ids can't reach another org's data.
- Resolves each group's latest autofix run's `seer_run_state_id` in **one query** (`SeerAgentRun … group_id__in …`, newest-first, first-seen-per-group).
- Fans out the per-run Seer `get_repos` calls **concurrently** (`ContextPropagatingThreadPoolExecutor`), since there's no batch repos RPC on the Seer side yet. Wall-time ≈ one Seer call, not N.
- A group with **no run** → `{repos: []}` (same legitimate empty the per-group endpoint returns). A group whose Seer call **fails** (exception or ≥400) is **omitted** rather than reported as empty, so the client can fall back instead of trusting a false "no repos".
- Mirrors `OrganizationSeerAutofixOverviewEndpoint`'s auth/silo (`OrganizationEndpoint`, `@cell_silo_endpoint`, `org:read`, PRIVATE, ML_AI) and reuses the same rate-limit override as the per-group endpoint.

The existing per-group `autofix/repos/` endpoint is left in place (still used elsewhere).

## Test Plan

New `test_organization_seer_autofix_repos.py` (6 tests, all passing):
- batches repos for multiple groups → one Seer call per group, correct per-group payload
- group without a run → `{repos: []}`
- Seer 404 → `{repos: []}`
- one group's Seer failure → that group omitted, others still returned (no fabricated empty, batch not failed)
- group outside the org → excluded, no Seer call (IDOR guard)
- no `group` params → `{}`

`ruff` and `mypy` clean.

## Follow-ups (tracked)

- **Frontend PR:** overview fetches once, indexes by group, feeds each card (with the per-card fetch kept as a fallback for groups the batch omits).
- **Seer-side `repos/by-ids`:** a true batch RPC (mirroring `runs/by-ids`) with repo-dedup + an access-result cache would let Seer answer in one round-trip and do `O(unique repos)` GitHub checks instead of `O(runs × repos)`. Cross-team; not required to remove the browser 429s.
