### PR TITLE
ref(seer): Promote Autofix Overview to /issues/autofix/

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2533,6 +2533,10 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'autofix/',
+      component: make(() => import('sentry/views/seerWorkflows/overview')),
+    },
+    {
+      path: 'autofix/workflows/',
       component: make(() => import('sentry/views/seerWorkflows')),
     },
     {
@@ -2549,7 +2553,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'autofix/overview/',
-      component: make(() => import('sentry/views/seerWorkflows/overview')),
+      redirectTo: 'autofix/',
     },
     {
       path: 'views/:viewId/',

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -96,7 +96,7 @@ describe('IssuesSecondaryNavigation', () => {
     const overviewLink = await screen.findByRole('link', {name: /Overview/});
     expect(overviewLink).toHaveAttribute(
       'href',
-      '/organizations/org-slug/issues/autofix/overview/'
+      '/organizations/org-slug/issues/autofix/'
     );
   });
 

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -96,7 +96,7 @@ export function IssuesSecondaryNavigation() {
                 {hasSeerNightShift && (
                   <SecondaryNavigation.ListItem>
                     <SecondaryNavigation.Link
-                      to={`${baseUrl}/autofix/overview/`}
+                      to={`${baseUrl}/autofix/`}
                       analyticsItemName="issues_autofix_overview"
                       end
                       trailingItems={<FeatureBadge type="new" />}

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -757,7 +757,7 @@ describe('SeerWorkflows', () => {
       organization,
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/issues/autofix/',
+          pathname: '/organizations/org-slug/issues/autofix/workflows/',
           query: {status: 'failed'},
         },
       },
@@ -796,7 +796,7 @@ describe('SeerWorkflows', () => {
       organization,
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/issues/autofix/',
+          pathname: '/organizations/org-slug/issues/autofix/workflows/',
           query: {status: 'failed'},
         },
       },
@@ -834,7 +834,7 @@ describe('SeerWorkflows', () => {
       organization,
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/issues/autofix/',
+          pathname: '/organizations/org-slug/issues/autofix/workflows/',
           query: {status: 'failed', strategy: 'agentic_triage', period: '7d'},
         },
       },
@@ -973,7 +973,7 @@ describe('SeerWorkflows', () => {
       organization,
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/issues/autofix/',
+          pathname: '/organizations/org-slug/issues/autofix/workflows/',
           query: {expandLatest: 'agentic_triage', status: 'succeeded'},
         },
       },

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -589,7 +589,7 @@ function RunDetail({
             </Flex>
           </Disclosure.Title>
           <Disclosure.Content>
-            <DebugSection row={row} organizationSlug={organizationSlug} />
+            <DebugSection row={row} />
           </Disclosure.Content>
         </Disclosure>
       ) : null}
@@ -646,13 +646,7 @@ function TriageDispatchesPanel({row}: {row: WorkflowRow}) {
   );
 }
 
-function DebugSection({
-  row,
-  organizationSlug,
-}: {
-  organizationSlug: string;
-  row: WorkflowRow;
-}) {
+function DebugSection({row}: {row: WorkflowRow}) {
   const {
     reasoning_effort,
     intelligence_level,
@@ -717,7 +711,7 @@ function DebugSection({
           {row.errorMessage}
         </Text>
       ) : null}
-      <TriageIssuesDebugAddendum row={row} organizationSlug={organizationSlug} />
+      <TriageIssuesDebugAddendum row={row} />
     </Stack>
   );
 }
@@ -864,13 +858,7 @@ function IssuePullRequestChip({
   );
 }
 
-function TriageIssuesDebugAddendum({
-  row,
-  organizationSlug,
-}: {
-  organizationSlug: string;
-  row: WorkflowRow;
-}) {
+function TriageIssuesDebugAddendum({row}: {row: WorkflowRow}) {
   const issues = row.triage?.issues ?? [];
   if (issues.length === 0) {
     return null;
@@ -918,10 +906,7 @@ function TriageIssuesDebugAddendum({
               key={`${issue.id}-explorer`}
               size="xs"
               icon={<IconOpen />}
-              to={{
-                pathname: `/organizations/${organizationSlug}/issues/autofix/`,
-                query: {explorerRunId: issue.seerRunId},
-              }}
+              to={getRelativeExplorerUrl(issue.seerRunId)}
             >
               {t('Explorer')}
             </LinkButton>

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -37,7 +37,7 @@ describe('AutofixOverview', () => {
   const organization = OrganizationFixture({
     features: ['seer-night-shift-ui', 'gen-ai-features'],
   });
-  const basePath = `/organizations/${organization.slug}/issues/autofix/overview/`;
+  const basePath = `/organizations/${organization.slug}/issues/autofix/`;
 
   const emptyMilestones = {
     autofix_root_cause: [],

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -189,7 +189,7 @@ describe('OverviewCardAction', () => {
       organization,
       initialRouterConfig: {
         location: {
-          pathname: '/organizations/org-slug/issues/autofix/overview/',
+          pathname: '/organizations/org-slug/issues/autofix/',
           query: {statsPeriod: '24h'},
         },
       },
@@ -199,7 +199,7 @@ describe('OverviewCardAction', () => {
 
     const openSeer = await screen.findByRole('menuitemradio', {name: 'Open Seer'});
     const href = openSeer.getAttribute('href') ?? '';
-    expect(href).toContain('/organizations/org-slug/issues/autofix/overview/');
+    expect(href).toContain('/organizations/org-slug/issues/autofix/');
     expect(href).toContain('seerDrawer=2');
     expect(href).toContain('statsPeriod=24h');
     expect(href).not.toContain('/issues/2/');


### PR DESCRIPTION
Make the user-facing Autofix Overview page own the canonical `/issues/autofix/` URL instead of living under `/issues/autofix/overview/`.

## What

- `/issues/autofix/` now renders the Autofix Overview (`seerWorkflows/overview`).
- The internal "Sentry Workflows" runs table that used to sit at `/issues/autofix/` moves to `/issues/autofix/workflows/`.
- `/issues/autofix/overview/` redirects to `/issues/autofix/` (via the route table's `redirectTo`) so existing links keep working.
- The issues secondary-nav "Overview" link is repointed to `/issues/autofix/`.

## Why

The Overview is the finished, user-facing Autofix page but was hidden one level down under `/overview/`, while the bare `/issues/autofix/` served an internal debug/history table (employee-gated strategy rows, an "Employee only" debug disclosure, and no navigation entry). Promoting the Overview gives it the canonical URL; the runs table keeps a home at `/autofix/workflows/`, which matches its component name (`seerWorkflows`) and page title ("Sentry Workflows").

The promoted page keeps its existing `seer-night-shift-ui` feature gate, so unentitled orgs see the same no-access state at the new URL.

## Note for reviewers

The runs table's employee-only "Explorer" debug link previously hardcoded the `/issues/autofix/` path plus an `explorerRunId` query param. It now uses `getRelativeExplorerUrl(...)`, which appends the param to the current URL so the Seer Explorer sidebar opens in place — consistent with the two other Explorer links in that same view. `explorerRunId` is consumed by the global Seer Explorer sidebar (mounted in `organizationLayout`), not by the autofix route, so this is unaffected by the URL move. This change made `organizationSlug` unused in the debug section, so the prop threading was removed.