### PR TITLE
feat(notifications): Add referrer query param to activity notifications

### DIFF
--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -48,6 +48,7 @@ ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
     ActivityType.UNASSIGNED.value: NotificationSource.ACTIVITY_UNASSIGNED,
 }
 
+ACTIVITY_NOTIFICATION_REFERRER = "activity_notification"
 EXAMPLE_PROJECT_URL = "https://sentry.io/organizations/acme/issues/?project=123"
 EXAMPLE_ISSUE_URL = "https://sentry.io/organizations/acme/issues/1/"
 EXAMPLE_ALERT_URL = "https://sentry.io/organizations/acme/monitors/alerts/1/"
@@ -182,13 +183,21 @@ def build_activity_notification_data(
         except Workflow.DoesNotExist:
             raise ValueError(f"Workflow not found: {workflow_id}")
 
-    issue_url = group.get_absolute_url()
+    issue_url = group.get_absolute_url(params={"referrer": ACTIVITY_NOTIFICATION_REFERRER})
     if ActivityType(activity.type) in SEER_ACTIVITY_TYPES:
-        issue_url = group.get_absolute_url(params={"seerDrawer": "true"})
+        issue_url = group.get_absolute_url(
+            params={"seerDrawer": "true", "referrer": ACTIVITY_NOTIFICATION_REFERRER}
+        )
         if features.has("organizations:issue-inbox", organization):
             issue_url = organization.absolute_url(
                 f"organizations/{organization.slug}/issues/inbox/",
-                query=urlencode({"project": project.id, "preview": group.id}),
+                query=urlencode(
+                    {
+                        "project": project.id,
+                        "preview": group.id,
+                        "referrer": ACTIVITY_NOTIFICATION_REFERRER,
+                    }
+                ),
             )
 
     action_data = dict(
@@ -202,7 +211,7 @@ def build_activity_notification_data(
         project_slug=project.slug,
         project_url=organization.absolute_url(
             f"organizations/{organization.slug}/issues/",
-            query=urlencode({"project": project.id}),
+            query=urlencode({"project": project.id, "referrer": ACTIVITY_NOTIFICATION_REFERRER}),
         ),
         activity_data=activity.data,
         activity_user_name=None,
@@ -213,7 +222,8 @@ def build_activity_notification_data(
             {
                 "alert_name": workflow.name,
                 "alert_url": organization.absolute_url(
-                    f"organizations/{organization.slug}/monitors/alerts/{workflow_id}/"
+                    f"organizations/{organization.slug}/monitors/alerts/{workflow_id}/",
+                    query=urlencode({"referrer": ACTIVITY_NOTIFICATION_REFERRER}),
                 ),
             }
         )
@@ -228,7 +238,8 @@ def build_activity_notification_data(
         action_data.update(
             {
                 "user_settings_url": organization.absolute_url(
-                    f"settings/account/notifications/{notification_category}/"
+                    f"settings/account/notifications/{notification_category}/",
+                    query=urlencode({"referrer": ACTIVITY_NOTIFICATION_REFERRER}),
                 )
             }
         )
@@ -259,7 +270,9 @@ def build_activity_notification_data(
                 raw_version = activity.data["version"]
                 release_url = organization.absolute_url(
                     f"organizations/{organization.slug}/releases/{raw_version}/",
-                    query=urlencode({"project": project.id}),
+                    query=urlencode(
+                        {"project": project.id, "referrer": ACTIVITY_NOTIFICATION_REFERRER}
+                    ),
                 )
             return SetResolvedInReleaseNotificationData(**action_data, release_url=release_url)
 

--- a/tests/sentry/notifications/platform/templates/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/test_activity.py
@@ -2,12 +2,14 @@ from urllib.parse import urlencode
 
 from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.templates.activity.base import (
+    ACTIVITY_NOTIFICATION_REFERRER,
     ACTIVITY_TYPE_TO_SOURCE,
     EXAMPLE_ALERT_URL,
     EXAMPLE_ISSUE_URL,
     EXAMPLE_PROJECT_URL,
     EXAMPLE_USER_SETTINGS_URL,
     ActivityNotificationData,
+    SetResolvedInReleaseNotificationData,
     build_activity_notification_data,
     build_footer,
     build_issue_link,
@@ -129,9 +131,21 @@ class ActivityAlertBaseTest(TestCase):
         assert data.source == NotificationSource.ACTIVITY_SEER_RCA_STARTED
         assert data.activity_type == ActivityType.SEER_RCA_STARTED.value
         assert data.issue_short_id == self.group.qualified_short_id
-        assert absolute_uri(self.group.get_absolute_url()) in data.issue_url
+        expected_issue_url = self.group.get_absolute_url(
+            params={"seerDrawer": "true", "referrer": "activity_notification"}
+        )
+        assert absolute_uri(expected_issue_url) == data.issue_url
         assert data.issue_culprit == self.group.culprit
-        assert data.alert_url is not None
+        assert data.project_url == self.organization.absolute_url(
+            f"organizations/{self.organization.slug}/issues/",
+            query=urlencode(
+                {"project": self.project.id, "referrer": ACTIVITY_NOTIFICATION_REFERRER}
+            ),
+        )
+        assert data.alert_url == self.organization.absolute_url(
+            f"organizations/{self.organization.slug}/monitors/alerts/{workflow.id}/",
+            query=urlencode({"referrer": ACTIVITY_NOTIFICATION_REFERRER}),
+        )
         assert data.activity_data == activity.data
         assert data.user_settings_url is None
 
@@ -153,6 +167,7 @@ class ActivityAlertBaseTest(TestCase):
 
         assert data.user_settings_url is not None
         assert "notifications/alerts/" in data.user_settings_url
+        assert f"referrer={ACTIVITY_NOTIFICATION_REFERRER}" in data.user_settings_url
 
     def test_build_activity_notification_data_user_settings_url_email_without_workflow(
         self,
@@ -170,6 +185,7 @@ class ActivityAlertBaseTest(TestCase):
 
         assert data.user_settings_url is not None
         assert "notifications/workflow/" in data.user_settings_url
+        assert f"referrer={ACTIVITY_NOTIFICATION_REFERRER}" in data.user_settings_url
 
     def test_build_activity_notification_data_user_settings_url_dm(self) -> None:
         activity = self.create_group_activity(
@@ -185,6 +201,7 @@ class ActivityAlertBaseTest(TestCase):
 
         assert data.user_settings_url is not None
         assert "notifications/workflow/" in data.user_settings_url
+        assert f"referrer={ACTIVITY_NOTIFICATION_REFERRER}" in data.user_settings_url
 
     def test_build_activity_notification_data_user_settings_url_channel_excluded(self) -> None:
         activity = self.create_group_activity(
@@ -209,7 +226,13 @@ class ActivityAlertBaseTest(TestCase):
 
         expected_inbox_url = self.organization.absolute_url(
             f"organizations/{self.organization.slug}/issues/inbox/",
-            query=urlencode({"project": self.project.id, "preview": self.group.id}),
+            query=urlencode(
+                {
+                    "project": self.project.id,
+                    "preview": self.group.id,
+                    "referrer": "activity_notification",
+                }
+            ),
         )
         assert absolute_uri(expected_inbox_url) == data.issue_url
 
@@ -220,7 +243,26 @@ class ActivityAlertBaseTest(TestCase):
         )
         data = build_activity_notification_data(activity)
 
-        assert absolute_uri(self.group.get_absolute_url()) == data.issue_url
+        expected_issue_url = self.group.get_absolute_url(
+            params={"referrer": ACTIVITY_NOTIFICATION_REFERRER}
+        )
+        assert absolute_uri(expected_issue_url) == data.issue_url
+
+    def test_build_activity_notification_data_release_url_has_referrer(self) -> None:
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+            data={"version": "1.2.3"},
+        )
+        data = build_activity_notification_data(activity)
+
+        assert isinstance(data, SetResolvedInReleaseNotificationData)
+        assert data.release_url == self.organization.absolute_url(
+            f"organizations/{self.organization.slug}/releases/1.2.3/",
+            query=urlencode(
+                {"project": self.project.id, "referrer": ACTIVITY_NOTIFICATION_REFERRER}
+            ),
+        )
 
 
 class ActivitySeerAlertBaseTest(TestCase):


### PR DESCRIPTION
We want to track how many users are being driven to the inbox through Seer activity notifications, so this adds a `referrer` query param to all links generated by activity notifications. The frontend analytics hooks will automatically handle this when the referrer param is present.

I'm a bit surprised we weren't tracking this already!