### PR TITLE
ref(weekly report): Remove week-over-week change feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -425,8 +425,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:weekly-report-past-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Show top spans chart in weekly email reports
     manager.add("organizations:weekly-report-spans-chart", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable week-over-week percentage change metric in weekly email reports
-    manager.add("organizations:weekly-report-week-over-week-metric", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
     # Enable logging to debug workflow engine process workflows
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Disable issue stream detector notifications for metric issues

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -313,8 +313,7 @@ class OrganizationReportContextFactory:
             self._append_user_project_ownership(ctx)
             self._append_project_event_counts(ctx)
             self._append_organization_project_issue_summaries(ctx)
-            if features.has("organizations:weekly-report-week-over-week-metric", self.organization):
-                self._append_previous_week_counts(ctx)
+            self._append_previous_week_counts(ctx)
 
             # Enhanced privacy flag hides issue titles, transaction names, and source details
             if not self.organization.flags.enhanced_privacy:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -255,11 +255,7 @@ def prepare_organization_report(
 
         # Cache after delivery so a failed attempt doesn't poison the
         # previous-week lookup on retry.
-        if (
-            not dry_run
-            and not email_override
-            and features.has("organizations:weekly-report-week-over-week-metric", ctx.organization)
-        ):
+        if not dry_run and not email_override:
             try:
                 project_metrics: dict[int, dict[str, int]] = {}
                 for project_id, project_ctx in ctx.projects_context_map.items():
@@ -1021,9 +1017,6 @@ def render_template_context(
         "errors_discover_query": errors_discover_query,
         "view_all_issues_url": view_all_issues_url,
         "enhanced_privacy": ctx.organization.flags.enhanced_privacy,
-        "show_week_over_week_metric": features.has(
-            "organizations:weekly-report-week-over-week-metric", ctx.organization
-        ),
         "notification_settings_link": "/settings/account/notifications/reports/",
         **top_spans(),
     }

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -236,7 +236,7 @@
     <h4 class="total-count-title" style="font-weight: bold;">Total Issues</h4>
     <h1 style="margin: 0; font-weight: bold;" class="total-count">
       {{ trends.total_issue_count|small_count:1 }}
-      {% if show_week_over_week_metric and trends.issue_pct_change %}
+      {% if trends.issue_pct_change %}
       <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: {{ trends.issue_pct_change.bg_color }}; color: {{ trends.issue_pct_change.text_color }};">{{ trends.issue_pct_change.arrow }}&nbsp;{{ trends.issue_pct_change.pct }}</span>
       {% endif %}
     </h1>
@@ -278,7 +278,7 @@
     <h4 class="total-count-title" style="font-weight: bold;">Total Errors</h4>
     <h1 style="margin: 0; font-weight: bold;" class="total-count">
       {{ trends.total_error_count|small_count:1 }}
-      {% if show_week_over_week_metric and trends.error_pct_change %}
+      {% if trends.error_pct_change %}
       <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: {{ trends.error_pct_change.bg_color }}; color: {{ trends.error_pct_change.text_color }};">{{ trends.error_pct_change.arrow }}&nbsp;{{ trends.error_pct_change.pct }}</span>
       {% endif %}
     </h1>
@@ -484,7 +484,7 @@
     <h4 class="total-count-title" style="font-weight: bold; margin-top: 0; margin-bottom: 0;">Total Spans</h4>
     <h1 style="margin: 0; font-weight: bold;">
       {{ total_spans_count|small_count:1 }}
-      {% if show_week_over_week_metric and spans_pct_change %}
+      {% if spans_pct_change %}
       <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: {{ spans_pct_change.bg_color }}; color: {{ spans_pct_change.text_color }};">{{ spans_pct_change.arrow }}&nbsp;{{ spans_pct_change.pct }}</span>
       {% endif %}
     </h1>

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -261,9 +261,6 @@ class DebugWeeklyReportView(MailPreviewView):
         ctx.project_ownership[user_id] = {pid for pid in ctx.projects_context_map}
         context = render_template_context(ctx, user_id)
         if context is not None:
-            context["show_week_over_week_metric"] = (
-                request.GET.get("show_week_over_week_metric", "1") != "0"
-            )
             context["show_past_issues"] = True
             total_spans = sum(ctx.spans_count_by_project.values())
             prev_total_spans = sum(ctx.prev_week_spans_count_by_project.values())

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -885,7 +885,6 @@ class WeeklyReportsTest(
             )
             assert has_nonzero_issue_day
 
-    @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_issue_pct_change_with_previous_week(self, message_builder: mock.MagicMock) -> None:
         """Verify issue WoW percentage change uses non-zero values from both weeks."""
@@ -943,7 +942,6 @@ class WeeklyReportsTest(
                 "text_color": "#A45200",
             }
 
-    @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_pct_change_partial_cache_falls_back_per_key(
         self, message_builder: mock.MagicMock
@@ -1092,7 +1090,6 @@ class WeeklyReportsTest(
             )
             assert legend_substatus_total == 3
 
-    @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_issue_cache_round_trip(self, message_builder: mock.MagicMock) -> None:
         """Verify the 'i' key in cache is written and read correctly for WoW."""
@@ -1801,7 +1798,6 @@ class WeeklyReportsTest(
             assert "enhanced privacy" in html.lower()
             assert "Total Errors" in html
 
-    @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_pct_change_with_previous_week(self, message_builder: mock.MagicMock) -> None:
         user = self.create_user()
@@ -1826,9 +1822,7 @@ class WeeklyReportsTest(
                 "bg_color": "#F9F0D2",
                 "text_color": "#A45200",
             }
-            assert context["show_week_over_week_metric"] is True
 
-    @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_pct_change_no_previous_week(self, message_builder: mock.MagicMock) -> None:
         user = self.create_user()
@@ -1845,30 +1839,7 @@ class WeeklyReportsTest(
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
             assert context["trends"]["error_pct_change"] is None
-            assert context["show_week_over_week_metric"] is True
 
-    @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
-    def test_pct_change_hidden_without_feature_flag(self, message_builder: mock.MagicMock) -> None:
-        user = self.create_user()
-        self.create_member(teams=[self.team], user=user, organization=self.organization)
-
-        self.store_event_outcomes(
-            self.organization.id, self.project.id, self.three_days_ago, num_times=10
-        )
-
-        prev_week = self.three_days_ago - timedelta(days=7)
-        self.store_event_outcomes(self.organization.id, self.project.id, prev_week, num_times=5)
-
-        prepare_organization_report(
-            self.timestamp, ONE_DAY * 7, self.organization.id, self._dummy_batch_id
-        )
-
-        for call_args in message_builder.call_args_list:
-            context = call_args.kwargs["context"]
-            assert context["trends"]["error_pct_change"] is None
-            assert context["show_week_over_week_metric"] is False
-
-    @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_pct_change_from_cache(self, message_builder: mock.MagicMock) -> None:
         from sentry.tasks.summaries.weekly_report_cache import cache_project_metrics


### PR DESCRIPTION
https://linear.app/getsentry/issue/ID-1759/clean-up-week-over-week-feature-flag-now-at-100percent

Precursor to https://github.com/getsentry/sentry-options-automator/pull/9364

The `organizations:weekly-report-week-over-week-metric` feature flag has been at 100% GA since 07/28/2026 and has run successfully for several weekly cycles. This PR removes all flag checks and makes the week-over-week percentage change unconditional.