### PR TITLE
fix(explorer): Show progress while a Code Mode call is in flight

### DIFF
--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -1181,4 +1181,219 @@ describe('ToolUseBlock', () => {
       expect(screen.getAllByRole('link')).toHaveLength(1);
     });
   });
+
+  describe('in-flight Code Mode calls', () => {
+    // Code Mode's tool name is suppressed and its rows are built from work it has not done yet, so
+    // an in-flight call used to render nothing at all — the reader saw the answer stop mid-stream.
+    // `Loading` is the block placeholder; `Running...` is a call row's own status tick.
+    function runningBlock(overrides?: Partial<Block>): Block {
+      return createBlock({
+        loading: true,
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'sentry_api_search', args: '{}'}],
+        },
+        tool_results: [],
+        tool_links: [],
+        ...overrides,
+      });
+    }
+
+    function executeBlock(liveCalls: Block['live_calls']): Block {
+      return runningBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+        },
+        live_calls: liveCalls,
+      });
+    }
+
+    it('keeps the placeholder up while a search runs, which reports no calls', () => {
+      render(<BlockComponent block={runningBlock()} blockIndex={0} />);
+      expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+    });
+
+    it('renders the same placeholder a block with no tool calls yet would', () => {
+      // The transition the fix is about: the spinner must not vanish, move or change when the tool
+      // call attaches, so both states have to render the identical element.
+      const before = render(
+        <BlockComponent
+          block={createBlock({
+            loading: true,
+            message: {role: 'tool_use', content: null, tool_calls: null},
+          })}
+          blockIndex={0}
+        />
+      );
+      const placeholder = screen.getByRole('status', {name: 'Loading'}).outerHTML;
+      before.unmount();
+
+      render(<BlockComponent block={runningBlock()} blockIndex={0} />);
+      expect(screen.getByRole('status', {name: 'Loading'}).outerHTML).toBe(placeholder);
+    });
+
+    it('keeps the placeholder up alongside an in-flight call row', () => {
+      // The mirror publishes a record when a call starts, so this row is spinning too. Hiding the
+      // placeholder whenever a row spins would blink it out and back on every call the execute
+      // makes; the two say different things and are allowed to coexist.
+      const block = executeBlock([
+        {id: 1, kind: 'api', method: 'GET', path: '/issues/', title: 'Listing issues'},
+      ]);
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+
+      expect(screen.getByText('Listing issues')).toBeInTheDocument();
+      expect(screen.getByRole('status', {name: 'Running...'})).toBeInTheDocument();
+      expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+    });
+
+    it('keeps the placeholder up after the last call has returned', () => {
+      // The sandbox is still working after its final call came back, and no row says so: they have
+      // all settled to a checkmark.
+      const block = executeBlock([
+        {
+          id: 1,
+          kind: 'api',
+          method: 'GET',
+          path: '/issues/',
+          title: 'Listing issues',
+          status: 200,
+        },
+      ]);
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+
+      expect(screen.getByLabelText('All tool calls succeeded')).toBeInTheDocument();
+      expect(screen.queryByRole('status', {name: 'Running...'})).not.toBeInTheDocument();
+      expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+    });
+
+    it('does not spin for a call with no id, which can never be seen settling', () => {
+      // Results are matched to calls by id. Treating an id-less call as running would keep the
+      // placeholder up for as long as the block claims to be loading, with nothing able to clear
+      // it. Matches how `liveCallsForCallId` decides what is pending.
+      const block = runningBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: undefined, function: 'sentry_api_search', args: '{}'}],
+        },
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+      expect(screen.queryByRole('status', {name: 'Loading'})).not.toBeInTheDocument();
+    });
+
+    it('drops the placeholder once the call reports back', () => {
+      const block = runningBlock({
+        loading: false,
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'sentry_api_search',
+            content: 'ran',
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+      expect(screen.queryByRole('status', {name: 'Loading'})).not.toBeInTheDocument();
+    });
+
+    it('keeps it up while one of two calls is still in flight', () => {
+      // `loading` stays true until every call in the block responds, so it cannot be the signal on
+      // its own — the block would keep spinning after the last call settled.
+      const block = runningBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [
+            {id: 'call-1', function: 'sentry_api_search', args: '{}'},
+            {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+          ],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'call-1',
+            tool_call_function: 'sentry_api_search',
+            content: 'ran',
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+      expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    });
+
+    it('renders one placeholder for a block, not one per in-flight call', () => {
+      const block = runningBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [
+            {id: 'call-1', function: 'sentry_api_search', args: '{}'},
+            {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+          ],
+        },
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+      expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    });
+
+    it('puts the placeholder after every row, not beside the running call', () => {
+      // The running call is first, so a per-call placeholder would land between the two calls'
+      // rows and read as a stalled row rather than as the block still working.
+      const block = runningBlock({
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [
+            {id: 'call-1', function: 'sentry_api_execute', args: '{}'},
+            {id: 'call-2', function: 'sentry_api_execute', args: '{}'},
+          ],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'call-2',
+            tool_call_function: 'sentry_api_execute',
+            content: 'ran',
+            structuredContent: {
+              calls: [
+                {
+                  id: 1,
+                  kind: 'api',
+                  method: 'GET',
+                  path: '/issues/',
+                  title: 'Listing issues',
+                  status: 200,
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+
+      const spinner = screen.getByRole('status', {name: 'Loading'});
+      const row = screen.getByText('Listing issues');
+      expect(
+        row.compareDocumentPosition(spinner) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it('leaves a classic tool to its own label rather than adding a placeholder', () => {
+      const block = createBlock({loading: true, tool_results: [], tool_links: []});
+
+      render(<BlockComponent block={block} blockIndex={0} />);
+
+      expect(screen.getByText(/Querying spans/)).toBeInTheDocument();
+      expect(screen.getByRole('status', {name: 'Running...'})).toBeInTheDocument();
+      expect(screen.queryByRole('status', {name: 'Loading'})).not.toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -271,6 +271,29 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
   // on a Code Mode call that was suppressed.
   let rendered = 0;
 
+  // Whether any Code Mode call in this block is still running. Asked of the block rather than of
+  // each call: the placeholder says the block is working, so several in-flight calls warrant one
+  // spinner, not one each, and it belongs after every row rather than wherever the running call
+  // happens to sit in the list.
+  //
+  // Read off each call's own tool result rather than off `block.loading` alone, which stays true
+  // until every call responds. Loading is still required: a call that never reported at all (an
+  // interrupted run replayed from history) has no result either, and must not spin forever.
+  //
+  // An id is required to count as in flight, matching how `liveCallsForCallId` decides what is
+  // pending. Results are matched to calls by id, so a call without one can never be observed
+  // settling — treating it as running would spin for as long as the block claims to be loading.
+  // Seer synthesizes an id for every tool call, so this is a guard on the optional wire type
+  // rather than a case that is expected to arrive.
+  const isCodeModeRunning =
+    Boolean(block.loading) &&
+    (block.message.tool_calls ?? []).some(
+      toolCall =>
+        CODE_MODE_TOOLS.has(toolCall.function) &&
+        toolCall.id &&
+        !settledCallIds.has(toolCall.id)
+    );
+
   // `flatMap` into one row per call, each in its own MessageRow. How the run partitioned work into
   // blocks and tool calls is invisible to the reader, so it must not show up as spacing: one
   // execute that made three calls has to look exactly like three that made one each.
@@ -424,7 +447,9 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
         const toolString = isCodeMode ? '' : (toolsUsed[idx] ?? '');
 
         // Nothing to say: a Code Mode call whose label is suppressed and which reported no calls,
-        // todos, links or markdown would render an empty row with a lone status tick.
+        // todos, links or markdown would render an empty row with a lone status tick. A call that
+        // is still running contributes no row of its own either — the block's placeholder below
+        // covers it, wherever in the list the running call happens to be.
         // Use residual nav items, not the pre-pairing list: consumed destinations no longer render.
         const hasContent =
           Boolean(toolString) ||
@@ -506,6 +531,18 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
           </MessageRow>
         ));
       })}
+      {/*
+        The same placeholder the block renders before its tool calls attach, kept on screen for as
+        long as a Code Mode call is still running. Continuity is the point: the spinner does not
+        move, resize or change glyph at the moment a call attaches, so there is no frame where the
+        answer looks like it stopped. It brings its own MessageRow, so it sits beside the rows
+        rather than inside one.
+
+        It reads as the block still working, which is not what a call row's tick says — that is
+        per-row status, and it settles to a checkmark while the execute keeps going. Both can be on
+        screen at once for the same reason a spinning row can sit under an active heading.
+      */}
+      {isCodeModeRunning && <MessagePlaceholder />}
     </Fragment>
   );
 }


### PR DESCRIPTION
Code Mode's tool name is suppressed in the transcript and its rows are built from the calls it has made, so a `sentry_api_search` or `sentry_api_execute` that had not reported back yet rendered nothing at all — and the block's own placeholder is dropped the moment a tool call attaches, so the answer appeared to stop mid-stream. `search` reports no calls at any point, so it never rendered a row at all.

Keep that same `MessagePlaceholder` on screen while a Code Mode call is in flight. The spinner does not move, resize or change glyph as the call attaches — there is simply no frame where it disappears. It reads as the block still working, which is not what a call row's tick says: that is per-row status, and it settles to a checkmark while the execute keeps going.