### PR TITLE
fix(github): Chunk pull request status GraphQL queries

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -1265,6 +1265,14 @@ class GitHubBaseClient(
 
         # GitHub terminates a GraphQL query it can't process in ~10s, so fetch in
         # bounded chunks (one query each) rather than a single oversized query.
+        #
+        # Chunks run sequentially, not in parallel. Chunk *size* alone keeps each
+        # query under the 10s timeout, so parallel would clear that too -- but the
+        # `files` block makes each query CPU-heavy for GitHub, and running them
+        # concurrently concentrates that CPU into a short real-time window. That
+        # trips GitHub's secondary rate limit (~90s of CPU per 60s of real time),
+        # which 403s the whole installation token -- shared with every other org
+        # using it -- and is worse than a slightly slower serial fetch.
         chunk_size = max(options.get("github-app.pull-request-status.chunk-size"), 1)
         for chunk in chunked(uncached_pull_requests, chunk_size):
             fetched_results = self._fetch_pull_request_status_batch(chunk)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -14,6 +14,7 @@ import sentry_sdk
 from django.core.cache import cache
 from requests import PreparedRequest, Response
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
     create_blame_query,
@@ -66,6 +67,7 @@ from sentry.silo.util import PROXY_PATH, trim_leading_slashes
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.dates import deprecated_utcnow
+from sentry.utils.iterators import chunked
 from sentry.utils.tracing import start_span
 
 logger = logging.getLogger("sentry.integrations.github")
@@ -1244,7 +1246,7 @@ class GitHubBaseClient(
     def get_pull_request_statuses(
         self, pull_requests: Sequence[PullRequestStatusRequest]
     ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
-        """Return checks and review state, fetching all cache misses in one query."""
+        """Return checks and review state, fetching cache misses in sequential chunks."""
         results: dict[PullRequestStatusRequest, PullRequestStatusResult] = {}
         cache_keys: dict[PullRequestStatusRequest, str] = {}
         uncached_pull_requests: list[PullRequestStatusRequest] = []
@@ -1261,7 +1263,21 @@ class GitHubBaseClient(
         if not uncached_pull_requests:
             return results
 
-        data = create_pull_request_status_query(uncached_pull_requests)
+        # GitHub terminates a GraphQL query it can't process in ~10s, so fetch in
+        # bounded chunks (one query each) rather than a single oversized query.
+        chunk_size = max(options.get("github-app.pull-request-status.chunk-size"), 1)
+        for chunk in chunked(uncached_pull_requests, chunk_size):
+            fetched_results = self._fetch_pull_request_status_batch(chunk)
+            for pull_request, result in fetched_results.items():
+                # Short enough that checks still appear to advance while CI runs.
+                self.set_cache(cache_keys[pull_request], result, 60)
+            results.update(fetched_results)
+        return results
+
+    def _fetch_pull_request_status_batch(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        data = create_pull_request_status_query(pull_requests)
         response = self.post(
             path="/graphql",
             data=data,
@@ -1283,14 +1299,7 @@ class GitHubBaseClient(
                 extra={"error_count": len(errors)},
             )
 
-        fetched_results = extract_pull_request_statuses_from_response(
-            response, uncached_pull_requests
-        )
-        for pull_request, result in fetched_results.items():
-            # Short enough that checks still appear to advance while CI runs.
-            self.set_cache(cache_keys[pull_request], result, 60)
-        results.update(fetched_results)
-        return results
+        return extract_pull_request_statuses_from_response(response, pull_requests)
 
     def create_check_run(self, repo: str, data: dict[str, Any]) -> Any:
         """

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -690,6 +690,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "github-app.pull-request-status.chunk-size",
+    type=Int,
+    default=25,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "integrations.backfill_github_external_actor.gh_api_fetch_interval_s",
     type=Float,
     default=0.1,

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -53,6 +53,7 @@ from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_PATH, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.integrations import get_installation_of_type
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.cache import cache
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
@@ -1215,6 +1216,68 @@ class GitHubApiClientTest(TestCase):
             "owner1": "Test-Organization",
             "name1": "foo",
             "number1": 42,
+        }
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_pull_request_statuses_chunks_cache_misses(self, get_jwt) -> None:
+        # A batch larger than the chunk size is fetched over several sequential
+        # queries so no single query exceeds GitHub's ~10s server-side timeout.
+        self.add_graphql_response(
+            {
+                "data": {
+                    "repository0": {
+                        "pullRequest": {
+                            "reviewDecision": "APPROVED",
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": "SUCCESS"}}}]
+                            },
+                        }
+                    }
+                }
+            }
+        )
+        self.add_graphql_response(
+            {
+                "data": {
+                    "repository0": {
+                        "pullRequest": {
+                            "reviewDecision": "CHANGES_REQUESTED",
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": "FAILURE"}}}]
+                            },
+                        }
+                    }
+                }
+            }
+        )
+        first = PullRequestStatusRequest(repo=self.repo.name, pull_number="41")
+        second = PullRequestStatusRequest(repo=self.repo.name, pull_number="42")
+
+        with override_options({"github-app.pull-request-status.chunk-size": 1}):
+            results = self.github_client.get_pull_request_statuses([first, second])
+
+        assert results == {
+            first: PullRequestStatusResult(
+                checks=AggregateChecksStatus.SUCCESS,
+                review=AggregateReviewStatus.APPROVED,
+            ),
+            second: PullRequestStatusResult(
+                checks=AggregateChecksStatus.FAILURE,
+                review=AggregateReviewStatus.CHANGES_REQUESTED,
+            ),
+        }
+        # One GraphQL POST per chunk, each carrying only its own PR's variables.
+        assert len(responses.calls) == 2
+        assert orjson.loads(responses.calls[0].request.body)["variables"] == {
+            "owner0": "Test-Organization",
+            "name0": "foo",
+            "number0": 41,
+        }
+        assert orjson.loads(responses.calls[1].request.body)["variables"] == {
+            "owner0": "Test-Organization",
+            "name0": "foo",
+            "number0": 42,
         }
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")


### PR DESCRIPTION
## Summary

The Autofix Overview `scmInfo` enrichment fetches PR checks/review/changed-files from GitHub in a **single** GraphQL query that batches every open/draft PR on the page. The `files` block forces GitHub to compute each PR's diff, so a page with many open PRs (~50+) produces one query GitHub can't finish within its ~10s server-side timeout. GitHub terminates it (502/504) — our client also read-times-out at 10s — the enrichment fails, and the review-PR cards shimmer indefinitely.

## What changed

- **Chunk the GraphQL fetch.** Cache-misses are now fetched in bounded, **sequential** chunks (one query per chunk) instead of a single oversized query, so each query stays under GitHub's ~10s limit. GitHub's own guidance for oversized queries is to split them; sequential (not concurrent) avoids the secondary rate limits that bursts of parallel requests trigger.
- **Runtime-tunable chunk size.** New option `github-app.pull-request-status.chunk-size` (`Int`, default `25`, `FLAG_AUTOMATOR_MODIFIABLE`) — adjustable without a redeploy.
- Extracted the fetch+parse into `_fetch_pull_request_status_batch`; per-chunk caching, dedup, and error handling are unchanged.

The change lives in the shared GitHub client, so `group_pull_requests` benefits from the same bounding.
