### PR TITLE
fix(options): honor config.yml for delayed_workflow.rollout

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3472,7 +3472,7 @@ register(
     "delayed_workflow.rollout",
     type=Bool,
     default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "workflow_engine.associate_error_detectors",


### PR DESCRIPTION
## Context

- On self-hosted, `delayed_workflow.rollout` is registered without `FLAG_PRIORITIZE_DISK`, so `OptionsManager.get()` returns the cached default (`False`) before consulting `settings.SENTRY_OPTIONS` / `config.yml`.
- The cache check is `value is not None`, and `False is not None`, so the disk value never wins.
- Result: operators who set `delayed_workflow.rollout: true` in `config.yml` see the option effectively stuck at `False`, and workflow frequency-alert buffers never drain via the delayed path.

## Changes

- Add `FLAG_PRIORITIZE_DISK` to the `delayed_workflow.rollout` registration in `src/sentry/options/defaults.py`, alongside the existing `FLAG_AUTOMATOR_MODIFIABLE`.
- This mirrors the pattern already used by other operator-tunable options such as `system.url-prefix` and `system.event-retention-days`. The combination is explicitly allowed by `INVALID_COMBINATIONS`.

## Testing

- Existing behavior around `FLAG_PRIORITIZE_DISK` is covered by `tests/sentry/options/test_manager.py`; this change is a one-flag addition on a single option and does not alter the manager's semantics.
- Verified on a self-hosted deployment: with `config.yml` setting `delayed_workflow.rollout: true`, `sentry configoptions list` now reports the disk value as effective, and the delayed-workflow scheduler picks up filters as expected.