### PR TITLE
chore(alerts): temporarily disable the deprecation brownout of the /rules/ post endpoint 

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -891,6 +891,12 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         examples=IssueAlertExamples.CREATE_ISSUE_ALERT_RULE,
     )
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-rules")
+    # Temporarily disabled until project issue creation uses the new workflow endpoints.
+    # @deprecated(
+    #     ALERTS_API_DEPRECATION_DATE,
+    #     suggested_api="sentry-api-0-organization-workflow-index",
+    #     key=ALERTS_API_DEPRECATION_KEY,
+    # )
     def post(self, request: Request, project) -> Response:
         """
         ## Deprecated

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -891,11 +891,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         examples=IssueAlertExamples.CREATE_ISSUE_ALERT_RULE,
     )
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-rules")
-    @deprecated(
-        ALERTS_API_DEPRECATION_DATE,
-        suggested_api="sentry-api-0-organization-workflow-index",
-        key=ALERTS_API_DEPRECATION_KEY,
-    )
     def post(self, request: Request, project) -> Response:
         """
         ## Deprecated


### PR DESCRIPTION
Turns out we are still using this in project creation, so this will keep that flow working until we can replace with the new APIs.