### PR TITLE
fix(hybridcloud): Stop retrying read timeouts in the integration proxy

### DIFF
--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -160,8 +160,11 @@ class IntegrationProxyClient(ApiClient):
         if SiloMode.get_current_mode() == SiloMode.CELL:
             return build_session(
                 is_ipaddress_permitted=is_control_silo_ip_address,
+                # read=0: a read-timed-out request may have already run provider-side, so a
+                # retry risks a duplicate side effect and can blow the upstream 30s proxy budget.
                 max_retries=Retry(
                     total=options.get("hybridcloud.integrationproxy.retries"),
+                    read=0,
                     backoff_factor=0.1,
                     status_forcelist=[503],
                     allowed_methods=["PATCH", "HEAD", "PUT", "GET", "DELETE", "POST"],

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, patch
 from django.test import override_settings
 from pytest import raises
 from requests import Request
+from requests.adapters import HTTPAdapter
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.net.http import Session
 from sentry.shared_integrations.client.proxy import (
@@ -63,6 +65,16 @@ class IntegrationProxyClientTest(TestCase):
         second_inference = infer_org_integration(integration_id=integration.id)
         assert second_inference is not org_integration_invalid.id
         assert second_inference is None
+
+    @override_settings(SILO_MODE=SiloMode.CELL)
+    def test_build_session_does_not_retry_read_timeouts(self) -> None:
+        session = self.client_cls().build_session()
+        adapter = session.get_adapter(self.base_url)
+        assert isinstance(adapter, HTTPAdapter)
+        retry = adapter.max_retries
+        assert retry.read == 0
+        assert retry.status_forcelist == [503]
+        assert retry.total == options.get("hybridcloud.integrationproxy.retries")
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_authorize_request_noop(self) -> None:


### PR DESCRIPTION
## Summary

`IntegrationProxyClient` retries **read timeouts** (a request that reached the provider but got no response within the 10s timeout) up to `total` times (option `hybridcloud.integrationproxy.retries`, default 5). Retrying a read timeout re-issues the same request: it can't succeed if the provider is genuinely slow/overloaded, it wastes another full 10s per attempt (up to ~5×10s — enough to blow past the upstream `CellSiloClient`'s 30s budget and time the caller out), and GitHub deducts extra primary-rate-limit points for every timeout. This retry stacking is what sits behind the Autofix Overview `scmInfo` timeouts and the broader `ApiTimeoutError` volume (SENTRY-54B2).

## What changed

Add `read=0` to the urllib3 `Retry` mounted by `IntegrationProxyClient.build_session` (CELL/region silo). Read timeouts now **fail fast**; connection failures and `503`s are **still retried** (`total` and `status_forcelist=[503]` unchanged).

## Notes for reviewers

- **Platform-wide:** this affects *every* integration that proxies through the control silo, not just GitHub/Autofix. That's intended — retrying a read timeout multiplies latency and rate-limit cost for any provider, and a connect failure (which *is* still retried) is the case where the request never reached the provider.
- **Bonus safety:** `POST`/`PATCH`/`PUT` are in `allowed_methods`, so a retried read timeout could previously double-apply a side effect; `read=0` removes that duplicate-side-effect risk.
- **No kill switch:** read-retry suppression is hardcoded; only `total` stays option-gated. There is no runtime option to re-enable read retries.
- **Not a regression:** an exhausted read timeout already surfaced as `connection_error`/`ApiHostError` (not `ApiTimeoutError`); this only reduces the attempt count, so that metric tag absorbs read timeouts sooner.

Refs SENTRY-54B2
