### PR TITLE
fix(seer): Clarify Night Shift run errors

### DIFF
--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -58,7 +58,7 @@ describe('SeerWorkflows', () => {
           id: '1',
           dateAdded: '2026-04-20T00:00:00Z',
           triageStrategy: 'agentic',
-          errorMessage: 'No Seer quota available',
+          errorMessage: 'Unexpected Seer error',
           extras: {},
           issues: [],
         },
@@ -69,13 +69,44 @@ describe('SeerWorkflows', () => {
 
     expect(await screen.findByText('Run failed')).toBeInTheDocument();
     expect(screen.getByLabelText('Failed')).toBeInTheDocument();
-    expect(screen.queryByText('No Seer quota available')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unexpected Seer error')).not.toBeInTheDocument();
 
     // The raw error string is now debug-only (employees see it inside the
     // Debug disclosure). For a non-employee user, expanding the row should NOT
-    // surface the raw "No Seer quota available" string.
+    // surface the raw error string.
     await userEvent.click(screen.getByRole('button', {name: 'Expand run'}));
-    expect(screen.queryByText(/No Seer quota available/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unexpected Seer error/)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['No Seer quota available', 'No Seer quota available', 'Skipped'],
+    ['Organization does not have Seer access', 'Seer is not enabled', 'Skipped'],
+    ['Failed to get eligible projects', 'Could not check eligible projects', 'Failed'],
+    ['Invalid Night Shift shard plan', 'Could not prepare triage', 'Failed'],
+    [
+      'Failed to dispatch 1 of 3 triage shards',
+      'Could not start all triage batches',
+      'Failed',
+    ],
+  ])('shows friendly messaging for %s', async (errorMessage, resultText, status) => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage,
+          extras: {},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText(resultText)).toBeInTheDocument();
+    expect(screen.getByLabelText(status)).toBeInTheDocument();
   });
 
   it('renders zero-issue triage runs as muted "No issues processed"', async () => {
@@ -746,7 +777,7 @@ describe('SeerWorkflows', () => {
           id: '2',
           dateAdded: '2026-04-21T00:00:00Z',
           triageStrategy: 'agentic',
-          errorMessage: 'No Seer quota available',
+          errorMessage: 'Unexpected Seer error',
           extras: {options: {source: 'cron'}},
           issues: [],
         },
@@ -894,7 +925,7 @@ describe('SeerWorkflows', () => {
           id: '1',
           dateAdded: '2026-04-20T00:00:00Z',
           triageStrategy: 'agentic',
-          errorMessage: 'No Seer quota available',
+          errorMessage: 'Unexpected Seer error',
           extras: {agent_run_id: 42},
           issues: [],
         },
@@ -908,7 +939,7 @@ describe('SeerWorkflows', () => {
     expect(screen.queryByRole('link', {name: /Run failed/})).not.toBeInTheDocument();
   });
 
-  it('Status filter offers only Succeeded and Failed', async () => {
+  it('Status filter offers every status produced by workflow rows', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -929,8 +960,8 @@ describe('SeerWorkflows', () => {
 
     expect(screen.getByRole('option', {name: 'Succeeded'})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: 'Failed'})).toBeInTheDocument();
-    // toWorkflowRow never produces these statuses, so they aren't offered.
-    expect(screen.queryByRole('option', {name: 'Skipped'})).not.toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Skipped'})).toBeInTheDocument();
+    // Running is not derivable from the current API response.
     expect(screen.queryByRole('option', {name: 'Running'})).not.toBeInTheDocument();
   });
 
@@ -943,7 +974,7 @@ describe('SeerWorkflows', () => {
           id: 'newer-failed',
           dateAdded: '2026-04-21T00:00:00Z',
           triageStrategy: 'agentic',
-          errorMessage: 'No Seer quota available',
+          errorMessage: 'Unexpected Seer error',
           extras: {},
           issues: [],
         },

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -59,6 +59,7 @@ describe('SeerWorkflows', () => {
           dateAdded: '2026-04-20T00:00:00Z',
           triageStrategy: 'agentic',
           errorMessage: 'Unexpected Seer error',
+          errorType: 'unknown',
           extras: {},
           issues: [],
         },
@@ -79,16 +80,12 @@ describe('SeerWorkflows', () => {
   });
 
   it.each([
-    ['No Seer quota available', 'No Seer quota available', 'Skipped'],
-    ['Organization does not have Seer access', 'Seer is not enabled', 'Skipped'],
-    ['Failed to get eligible projects', 'Could not check eligible projects', 'Failed'],
-    ['Invalid Night Shift shard plan', 'Could not prepare triage', 'Failed'],
-    [
-      'Failed to dispatch 1 of 3 triage shards',
-      'Could not start all triage batches',
-      'Failed',
-    ],
-  ])('shows friendly messaging for %s', async (errorMessage, resultText, status) => {
+    ['no_quota', 'No Seer quota available', 'Skipped'],
+    ['no_seer_access', 'Seer is not enabled', 'Skipped'],
+    ['eligible_projects_failed', 'Could not check eligible projects', 'Failed'],
+    ['invalid_shard_plan', 'Could not prepare triage', 'Failed'],
+    ['shard_dispatch_failed', 'Could not start all triage batches', 'Failed'],
+  ])('shows friendly messaging for %s', async (errorType, resultText, status) => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -96,7 +93,8 @@ describe('SeerWorkflows', () => {
           id: '1',
           dateAdded: '2026-04-20T00:00:00Z',
           triageStrategy: 'agentic',
-          errorMessage,
+          errorMessage: 'Backend diagnostic details',
+          errorType,
           extras: {},
           issues: [],
         },
@@ -778,6 +776,7 @@ describe('SeerWorkflows', () => {
           dateAdded: '2026-04-21T00:00:00Z',
           triageStrategy: 'agentic',
           errorMessage: 'Unexpected Seer error',
+          errorType: 'unknown',
           extras: {options: {source: 'cron'}},
           issues: [],
         },
@@ -926,6 +925,7 @@ describe('SeerWorkflows', () => {
           dateAdded: '2026-04-20T00:00:00Z',
           triageStrategy: 'agentic',
           errorMessage: 'Unexpected Seer error',
+          errorType: 'unknown',
           extras: {agent_run_id: 42},
           issues: [],
         },
@@ -975,6 +975,7 @@ describe('SeerWorkflows', () => {
           dateAdded: '2026-04-21T00:00:00Z',
           triageStrategy: 'agentic',
           errorMessage: 'Unexpected Seer error',
+          errorType: 'unknown',
           extras: {},
           issues: [],
         },

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -54,6 +54,7 @@ import {
 import type {
   RunStatus,
   SeerNightShiftRun,
+  SeerNightShiftRunErrorType,
   SeerNightShiftRunIssue,
   SeerNightShiftRunPullRequest,
   WorkflowKind,
@@ -917,7 +918,7 @@ function TriageIssuesDebugAddendum({row}: {row: WorkflowRow}) {
 }
 
 function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
-  const errorPresentation = getErrorPresentation(run.errorMessage);
+  const errorPresentation = getErrorPresentation(run.errorType ?? null);
   const agentRunId = run.extras.agent_run_id;
   return {
     id: `${run.id}:agentic_triage`,
@@ -943,23 +944,22 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
 }
 
 function getErrorPresentation(
-  errorMessage: string | null
+  errorType: SeerNightShiftRunErrorType | null
 ): {resultText: string; status: RunStatus} | null {
-  switch (errorMessage) {
+  switch (errorType) {
     case null:
       return null;
-    case 'No Seer quota available':
+    case 'no_quota':
       return {status: 'skipped', resultText: t('No Seer quota available')};
-    case 'Organization does not have Seer access':
+    case 'no_seer_access':
       return {status: 'skipped', resultText: t('Seer is not enabled')};
-    case 'Failed to get eligible projects':
+    case 'eligible_projects_failed':
       return {status: 'failed', resultText: t('Could not check eligible projects')};
-    case 'Invalid Night Shift shard plan':
+    case 'invalid_shard_plan':
       return {status: 'failed', resultText: t('Could not prepare triage')};
+    case 'shard_dispatch_failed':
+      return {status: 'failed', resultText: t('Could not start all triage batches')};
     default:
-      if (/^Failed to dispatch \d+ of \d+ triage shards$/.test(errorMessage)) {
-        return {status: 'failed', resultText: t('Could not start all triage batches')};
-      }
       return {status: 'failed', resultText: t('Run failed')};
   }
 }

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -483,11 +483,10 @@ function SourceIcon({source}: {source: string | undefined}) {
   );
 }
 
-// toWorkflowRow only ever derives 'succeeded' or 'failed' from a run, so only
-// offer those as filter choices — 'skipped'/'running' would never match.
 const STATUS_FILTER_OPTIONS: Array<{label: string; value: RunStatus}> = [
   {value: 'succeeded', label: 'Succeeded'},
   {value: 'failed', label: 'Failed'},
+  {value: 'skipped', label: 'Skipped'},
 ];
 
 const PERIOD_FILTER_OPTIONS: Array<{label: string; value: string}> = [
@@ -532,7 +531,7 @@ function getResultContent(row: WorkflowRow) {
   if (row.status === 'failed') {
     return (
       <Text variant="danger" size="sm">
-        {t('Run failed')}
+        {row.resultText ?? t('Run failed')}
       </Text>
     );
   }
@@ -918,17 +917,18 @@ function TriageIssuesDebugAddendum({row}: {row: WorkflowRow}) {
 }
 
 function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
-  const status: RunStatus = run.errorMessage ? 'failed' : 'succeeded';
+  const errorPresentation = getErrorPresentation(run.errorMessage);
   const agentRunId = run.extras.agent_run_id;
   return {
     id: `${run.id}:agentic_triage`,
     runId: run.id,
     dateAdded: run.dateAdded,
     kind: 'agentic_triage',
-    status,
+    status: errorPresentation?.status ?? 'succeeded',
     source: run.extras.options?.source,
     errorMessage: run.errorMessage,
     options: run.extras.options,
+    resultText: errorPresentation?.resultText,
     triage: {
       maxCandidates: run.extras.options?.max_candidates,
       dryRun: run.extras.options?.dry_run,
@@ -940,6 +940,28 @@ function toWorkflowRow(run: SeerNightShiftRun): WorkflowRow {
           : undefined,
     },
   };
+}
+
+function getErrorPresentation(
+  errorMessage: string | null
+): {resultText: string; status: RunStatus} | null {
+  switch (errorMessage) {
+    case null:
+      return null;
+    case 'No Seer quota available':
+      return {status: 'skipped', resultText: t('No Seer quota available')};
+    case 'Organization does not have Seer access':
+      return {status: 'skipped', resultText: t('Seer is not enabled')};
+    case 'Failed to get eligible projects':
+      return {status: 'failed', resultText: t('Could not check eligible projects')};
+    case 'Invalid Night Shift shard plan':
+      return {status: 'failed', resultText: t('Could not prepare triage')};
+    default:
+      if (/^Failed to dispatch \d+ of \d+ triage shards$/.test(errorMessage)) {
+        return {status: 'failed', resultText: t('Could not start all triage batches')};
+      }
+      return {status: 'failed', resultText: t('Run failed')};
+  }
 }
 
 function getExplorerRunIds(row: WorkflowRow): Array<number | string> {

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -38,9 +38,19 @@ type SeerNightShiftRunExtras = {
   triggering_user_id?: number;
 };
 
+export type SeerNightShiftRunErrorType =
+  | 'no_quota'
+  | 'eligible_projects_failed'
+  | 'no_seer_access'
+  | 'invalid_shard_plan'
+  | 'shard_dispatch_failed'
+  | 'shard_delivery_failed'
+  | 'unknown';
+
 export type SeerNightShiftRun = {
   dateAdded: string;
   errorMessage: string | null;
+  errorType: SeerNightShiftRunErrorType | null;
   extras: SeerNightShiftRunExtras;
   id: string;
   issues: SeerNightShiftRunIssue[];


### PR DESCRIPTION
Night Shift history now presents quota and access preflight outcomes as skipped runs instead of alarming failures. Historical no-quota rows show “No Seer quota available,” organizations without access show “Seer is not enabled,” and the status filter includes skipped runs.

Known operational failures also receive concise user-facing messages while unexpected Seer errors retain the generic “Run failed” fallback. Presentation is keyed by the workflows API's structured `errorType`; raw backend errors remain available only in the employee debug view.
