### PR TITLE
fix(seer): Use absolute redirect target for autofix overview

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2553,7 +2553,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'autofix/overview/',
-      redirectTo: 'autofix/',
+      redirectTo: '../autofix/',
     },
     {
       path: 'views/:viewId/',


### PR DESCRIPTION
## Summary

Follow-up to #122664, which promoted the Autofix Overview to `/issues/autofix/` and added a redirect from the old `/issues/autofix/overview/` path so existing links keep working.

That redirect used a **relative** target:

```tsx
{path: 'autofix/overview/', redirectTo: 'autofix/'}
```

`redirectTo` renders `<Navigate to="autofix/" replace />`, and React Router v6 resolves a relative `to` against the **matched route's pathname**, not its parent. So from `/issues/autofix/overview/` it appends rather than replaces, landing on `/issues/autofix/overview/autofix/` — the not-found catch-all — instead of the promoted Overview. The redirect's whole purpose (keeping old links alive) was defeated.

Verified with a `createMemoryRouter` repro matching this route shape:
- `to="autofix/"` → `/issues/autofix/overview/autofix/` (broken)
- `to="/issues/autofix/"` → `/issues/autofix/` (correct)

## Fix

Use the absolute `/issues/autofix/` target, matching every other redirect in the issues route block (the legacy tags and insights redirects all use absolute `/issues/...` paths for exactly this reason). Relative `redirectTo` only resolves correctly on `index: true` routes, which contribute no path segment.

Caught by Cursor Bugbot on #122664.