### PR TITLE
feat(investigations): Add lifecycle telemetry

### DIFF
--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -32,6 +32,14 @@ from sentry.investigations.services.investigations import (
     investigation_source,
     mark_downstream_blocks_stale,
 )
+from sentry.investigations.telemetry import (
+    record_execution_completed,
+    record_execution_failed,
+    record_execution_started,
+    record_investigation_completed,
+    record_title_generation_completed,
+    record_title_generation_failed,
+)
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.agent.client import SeerAgentClient
@@ -86,6 +94,7 @@ ACTIVE_BLOCK_EXECUTION_STATUSES = (
     InvestigationBlockExecutionStatus.AWAITING_INPUT,
     InvestigationBlockExecutionStatus.STOPPING,
 )
+
 
 QUERY_INSTRUCTIONS = """You are answering a query block inside a Sentry investigation.
 Use Code Mode only for telemetry analysis. You may call sentry.telemetry_live_search and
@@ -191,6 +200,8 @@ def start_execution_run(
         record_in_history=False,
         on_run_created=mark_dispatched,
     )
+    if dispatch_won is True:
+        record_execution_started(execution)
     if dispatch_won is False and run.seer_run_state_id is not None:
         _interrupt_execution_best_effort(organization, run.seer_run_state_id)
 
@@ -717,6 +728,7 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
         )
         database = router.db_for_write(InvestigationBlockExecution)
         with transaction.atomic(using=database):
+            completed_at = timezone.now()
             updated = (
                 InvestigationBlockExecution.objects.filter(id=execution.id)
                 .exclude(status__in=TERMINAL_BLOCK_EXECUTION_STATUSES)
@@ -728,11 +740,21 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
                         "code": "unsupported_tool_use",
                         "message": policy_error,
                     },
-                    completed_at=timezone.now(),
+                    completed_at=completed_at,
                 )
             )
             if not updated:
                 return
+            execution.completed_at = completed_at
+            transaction.on_commit(
+                partial(
+                    record_execution_failed,
+                    execution,
+                    reason="unsupported_tool_use",
+                    seer_run_id=state.run_id,
+                ),
+                using=database,
+            )
             _cancel_investigation_executions_after_commit(execution)
             if execution.seer_run and execution.seer_run.seer_run_state_id:
                 transaction.on_commit(
@@ -783,6 +805,15 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
                 "message": policy_error if off_policy else "The agent run failed.",
             }
             execution.save()
+            transaction.on_commit(
+                partial(
+                    record_execution_failed,
+                    execution,
+                    reason=execution.error["code"],
+                    seer_run_id=state.run_id,
+                ),
+                using=database,
+            )
             _cancel_investigation_executions_after_commit(execution)
             return
 
@@ -808,6 +839,15 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
                     "message": "The agent returned malformed or unsupported result JSON.",
                 }
             execution.save()
+            transaction.on_commit(
+                partial(
+                    record_execution_failed,
+                    execution,
+                    reason=execution.error["code"],
+                    seer_run_id=state.run_id,
+                ),
+                using=database,
+            )
             _cancel_investigation_executions_after_commit(execution)
             return
         try:
@@ -845,6 +885,15 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
             execution.status = InvestigationBlockExecutionStatus.FAILED
             execution.error = {"code": "invalid_result", "message": str(error)[:1000]}
             execution.save()
+            transaction.on_commit(
+                partial(
+                    record_execution_failed,
+                    execution,
+                    reason="invalid_result",
+                    seer_run_id=state.run_id,
+                ),
+                using=database,
+            )
             _cancel_investigation_executions_after_commit(execution)
             return
 
@@ -852,6 +901,7 @@ def synchronize_execution(execution: InvestigationBlockExecution, state: SeerRun
         execution.status = InvestigationBlockExecutionStatus.COMPLETED
         execution.error = None
         execution.save()
+        transaction.on_commit(partial(record_execution_completed, execution), using=database)
         InvestigationBlockExecutionProject.objects.bulk_create(
             [InvestigationBlockExecutionProject(execution=execution, project=p) for p in projects],
             ignore_conflicts=True,
@@ -944,8 +994,13 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
         ):
             return
         locked.update(title_generation_status=TitleGenerationStatus.PENDING)
+    record_investigation_completed(locked)
+
+    title_seer_run_state_id: int | None = None
 
     def link_title_run(run: Any) -> None:
+        nonlocal title_seer_run_state_id
+        title_seer_run_state_id = run.seer_run_state_id
         Investigation.objects.filter(id=investigation.id).update(
             title_seer_run_id=run.id, title_generation_status=TitleGenerationStatus.RUNNING
         )
@@ -964,16 +1019,26 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
         Investigation.objects.filter(
             id=investigation.id, title_generation_status__in=IN_FLIGHT_TITLE_STATUSES
         ).update(title_generation_status=TitleGenerationStatus.FAILED)
+        record_title_generation_failed(
+            investigation,
+            reason="dispatch_failed",
+            seer_run_id=title_seer_run_state_id,
+        )
         raise
 
 
 def synchronize_title(investigation: Investigation, state: SeerRunState) -> None:
+    if investigation.title_generation_status not in IN_FLIGHT_TITLE_STATUSES:
+        return
     if any(
         _block_policy_error(block, allow_query_tools=False) is not None for block in state.blocks
     ):
         if state.status in {"processing", "awaiting_user_input"}:
             interrupt_run(investigation.organization, state.run_id)
         investigation.update(title_generation_status=TitleGenerationStatus.FAILED)
+        record_title_generation_failed(
+            investigation, reason="unsupported_tool_use", seer_run_id=state.run_id
+        )
         return
     if state.status in {"processing", "awaiting_user_input"}:
         return
@@ -998,6 +1063,16 @@ def synchronize_title(investigation: Investigation, state: SeerRunState) -> None
         updates["summary_description"] = metadata["summary_description"]
         updates["version"] = F("version") + 1
     investigation.update(**updates)
+    if metadata is not None:
+        record_title_generation_completed(investigation)
+    else:
+        record_title_generation_failed(
+            investigation,
+            reason="seer_execution_failed"
+            if state.status == "error"
+            else ("missing_result" if not content else "invalid_result"),
+            seer_run_id=state.run_id,
+        )
 
 
 def _block_has_current_result(block: InvestigationBlock) -> bool:

--- a/src/sentry/investigations/endpoints/organization_investigation_index.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_index.py
@@ -33,6 +33,7 @@ from sentry.investigations.services import (
     create_template_investigation,
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
+from sentry.investigations.telemetry import record_investigation_started
 from sentry.models.organization import Organization
 
 
@@ -125,6 +126,8 @@ class OrganizationInvestigationsIndexEndpoint(OrganizationInvestigationsBaseEndp
             if response is not None:
                 return response
             raise
+        if created:
+            record_investigation_started(investigation)
         return Response(
             serialize(
                 investigation,

--- a/src/sentry/investigations/telemetry.py
+++ b/src/sentry/investigations/telemetry.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+from django.utils import timezone
+
+from sentry.investigations.models import Investigation, InvestigationBlockExecution
+
+logger = logging.getLogger(__name__)
+
+
+def _investigation_attributes(investigation: Investigation) -> dict[str, str]:
+    return {
+        "source_type": str(investigation.source.get("type") or investigation.source_type),
+        "template": investigation.template_key or "manual",
+    }
+
+
+def _execution_attributes(execution: InvestigationBlockExecution) -> dict[str, str]:
+    return {
+        **_investigation_attributes(execution.block.investigation),
+        "block_kind": execution.block.kind,
+        "executor": execution.executor,
+    }
+
+
+def record_investigation_started(investigation: Investigation) -> None:
+    sentry_sdk.metrics.count(
+        "investigations.started",
+        1,
+        attributes=_investigation_attributes(investigation),
+    )
+
+
+def record_investigation_completed(investigation: Investigation) -> None:
+    attributes = _investigation_attributes(investigation)
+    sentry_sdk.metrics.count("investigations.completed", 1, attributes=attributes)
+    sentry_sdk.metrics.distribution(
+        "investigations.duration",
+        (timezone.now() - investigation.date_added).total_seconds(),
+        unit="second",
+        attributes=attributes,
+    )
+
+
+def record_execution_started(execution: InvestigationBlockExecution) -> None:
+    sentry_sdk.metrics.count(
+        "investigations.execution.started",
+        1,
+        attributes=_execution_attributes(execution),
+    )
+
+
+def record_execution_completed(execution: InvestigationBlockExecution) -> None:
+    attributes = _execution_attributes(execution)
+    sentry_sdk.metrics.count("investigations.execution.completed", 1, attributes=attributes)
+    if execution.completed_at is not None:
+        sentry_sdk.metrics.distribution(
+            "investigations.execution.duration",
+            (execution.completed_at - execution.date_added).total_seconds(),
+            unit="second",
+            attributes={**attributes, "outcome": "completed"},
+        )
+
+
+def record_execution_failed(
+    execution: InvestigationBlockExecution, *, reason: str, seer_run_id: int
+) -> None:
+    attributes = _execution_attributes(execution)
+    sentry_sdk.metrics.count(
+        "investigations.execution.failed",
+        1,
+        attributes={**attributes, "reason": reason},
+    )
+    if execution.completed_at is not None:
+        sentry_sdk.metrics.distribution(
+            "investigations.execution.duration",
+            (execution.completed_at - execution.date_added).total_seconds(),
+            unit="second",
+            attributes={**attributes, "outcome": "failed"},
+        )
+    logger.warning(
+        "investigations.execution.failed",
+        extra={
+            "organization_id": execution.block.investigation.organization_id,
+            "investigation_id": execution.block.investigation_id,
+            "block_id": execution.block_id,
+            "execution_id": execution.id,
+            "seer_run_id": seer_run_id,
+            "reason": reason,
+        },
+    )
+
+
+def record_title_generation_completed(investigation: Investigation) -> None:
+    sentry_sdk.metrics.count(
+        "investigations.title_generation.completed",
+        1,
+        attributes=_investigation_attributes(investigation),
+    )
+
+
+def record_title_generation_failed(
+    investigation: Investigation, *, reason: str, seer_run_id: int | None
+) -> None:
+    sentry_sdk.metrics.count(
+        "investigations.title_generation.failed",
+        1,
+        attributes={**_investigation_attributes(investigation), "reason": reason},
+    )
+    logger.warning(
+        "investigations.title_generation.failed",
+        extra={
+            "organization_id": investigation.organization_id,
+            "investigation_id": investigation.id,
+            "seer_run_id": seer_run_id,
+            "reason": reason,
+        },
+    )

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
@@ -33,7 +33,8 @@ class OrganizationInvestigationIndexTest(APITestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    def test_create_manual_and_list(self) -> None:
+    @mock.patch("sentry.investigations.telemetry.sentry_sdk.metrics.count")
+    def test_create_manual_and_list(self, metrics_count: mock.MagicMock) -> None:
         response = self.client.post(
             self.collection_url,
             data={
@@ -47,6 +48,11 @@ class OrganizationInvestigationIndexTest(APITestCase):
         assert response.data["title"] == "Checkout follow-up"
         assert response.data["projectIds"] == [self.project.id]
         assert response.data["blocks"] == []
+        metrics_count.assert_any_call(
+            "investigations.started",
+            1,
+            attributes={"source_type": "manual", "template": "manual"},
+        )
 
         response = self.client.get(self.collection_url)
         assert response.status_code == 200

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -296,6 +296,27 @@ class InvestigationAgentTest(TestCase):
             "2026-08-14T23:56:02+00:00"
         )
 
+    @patch("sentry.investigations.agent.record_execution_started")
+    def test_start_run_records_execution_started(self, record_started: MagicMock) -> None:
+        pending_execution = self.create_investigation_block_execution(
+            block=self.block,
+            executor="code_mode",
+            status=InvestigationBlockExecutionStatus.PENDING,
+            block_version=self.block.version,
+        )
+        self.block.update(current_execution=pending_execution)
+        client = MagicMock()
+
+        def start_run(*args: Any, **kwargs: Any) -> Any:
+            kwargs["on_run_created"](self.seer_run)
+            return self.seer_run
+
+        client.start_run.side_effect = start_run
+
+        start_execution_run(pending_execution, self.organization, self.user, client)
+
+        record_started.assert_called_once_with(pending_execution)
+
     @patch("sentry.investigations.agent.interrupt_run")
     def test_start_run_interrupts_seer_when_cancellation_wins_dispatch_race(
         self, interrupt_run: MagicMock
@@ -357,6 +378,31 @@ class InvestigationAgentTest(TestCase):
         self.execution.refresh_from_db()
         assert self.execution.status == InvestigationBlockExecutionStatus.COMPLETED
         assert self.execution.result["tableMarkdown"].startswith("| Errors |")
+
+    @patch("sentry.investigations.agent.record_execution_completed")
+    def test_completed_execution_records_success(self, record_completed: MagicMock) -> None:
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="result",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(
+                        role="assistant",
+                        content=(
+                            '{"tableMarkdown":"| Errors |\\n| ---: |\\n| 12 |",'
+                            '"chart":null,"preferredView":"table","isEmpty":false,'
+                            '"chartUnavailableReason":"A chart was not requested."}'
+                        ),
+                    ),
+                )
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            synchronize_execution(self.execution, run_state)
+
+        record_completed.assert_called_once()
+        assert record_completed.call_args.args[0].id == self.execution.id
 
     def test_completed_query_rejects_prose_wrapped_json(self) -> None:
         run_state = state(
@@ -422,6 +468,23 @@ class InvestigationAgentTest(TestCase):
         }
         assert sibling_execution.completed_at is not None
         interrupt_run.assert_called_once_with(self.organization, 43)
+
+    @patch("sentry.investigations.telemetry.sentry_sdk.metrics.count")
+    def test_failed_execution_records_sentry_metric(self, metrics_count: MagicMock) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            synchronize_execution(self.execution, state(status="error", blocks=[]))
+
+        metrics_count.assert_called_once_with(
+            "investigations.execution.failed",
+            1,
+            attributes={
+                "reason": "seer_execution_failed",
+                "source_type": "manual",
+                "template": "manual",
+                "block_kind": "query",
+                "executor": "code_mode",
+            },
+        )
 
     @patch("sentry.investigations.agent.interrupt_run")
     def test_superseded_execution_failure_does_not_cancel_current_run(
@@ -954,7 +1017,8 @@ class InvestigationAgentTest(TestCase):
         assert set(link["params"]) == {"dataset", "query", "project_slugs"}
         assert len(link["params"]["query"]) == 2000
 
-    def test_title_uses_the_final_assistant_message(self) -> None:
+    @patch("sentry.investigations.agent.record_title_generation_completed")
+    def test_title_uses_the_final_assistant_message(self, record_completed: MagicMock) -> None:
         self.investigation.title = "Untitled investigation"
         self.investigation.title_generation_status = "running"
         self.investigation.save(update_fields=["title", "title_generation_status"])
@@ -977,6 +1041,7 @@ class InvestigationAgentTest(TestCase):
             "One endpoint drove most errors.\nRoll back the latest endpoint change."
         )
         assert self.investigation.title_generation_status == "completed"
+        record_completed.assert_called_once_with(self.investigation)
 
     def test_title_accepts_metadata_in_a_json_code_fence(self) -> None:
         self.investigation.update(
@@ -1002,6 +1067,33 @@ class InvestigationAgentTest(TestCase):
         assert self.investigation.summary == "Error volume crossed threshold"
         assert self.investigation.title_generation_status == "completed"
 
+    @patch("sentry.investigations.telemetry.sentry_sdk.metrics.count")
+    def test_invalid_title_records_sentry_metric(self, metrics_count: MagicMock) -> None:
+        self.investigation.update(
+            title=DEFAULT_INVESTIGATION_TITLE, title_generation_status="running"
+        )
+        run_state = state(
+            blocks=[
+                MemoryBlock(
+                    id="title",
+                    timestamp="2026-08-03T00:00:00Z",
+                    message=Message(role="assistant", content="not json"),
+                )
+            ]
+        )
+
+        synchronize_title(self.investigation, run_state)
+
+        metrics_count.assert_called_once_with(
+            "investigations.title_generation.failed",
+            1,
+            attributes={
+                "source_type": "manual",
+                "template": "manual",
+                "reason": "invalid_result",
+            },
+        )
+
     @patch("sentry.investigations.agent.SeerAgentClient")
     def test_title_prompt_uses_specific_incident_source_context(
         self, mock_client: MagicMock
@@ -1026,8 +1118,11 @@ class InvestigationAgentTest(TestCase):
         assert "at most 5 words" in prompt
         assert "summary_description" in prompt
 
+    @patch("sentry.investigations.agent.record_investigation_completed")
     @patch("sentry.investigations.agent.SeerAgentClient")
-    def test_title_generation_waits_for_every_auto_run_block(self, mock_client: MagicMock) -> None:
+    def test_title_generation_waits_for_every_auto_run_block(
+        self, mock_client: MagicMock, record_completed: MagicMock
+    ) -> None:
         self.investigation.update(title=DEFAULT_INVESTIGATION_TITLE)
         self.block.update(config={"autoRun": True})
 
@@ -1044,6 +1139,7 @@ class InvestigationAgentTest(TestCase):
         _maybe_start_title_generation(self.investigation, None)
 
         mock_client.return_value.start_run.assert_called_once()
+        record_completed.assert_called_once()
 
     @patch("sentry.investigations.agent.SeerAgentClient")
     def test_title_generation_skips_an_in_flight_run(self, mock_client: MagicMock) -> None:


### PR DESCRIPTION
Investigations now emit Sentry SDK metrics for investigations started and completed, cell executions started, completed, and failed, and title generation completed or failed. Duration distributions measure end-to-end investigation and per-cell latency, while bounded source, template, block, executor, outcome, and failure-reason attributes support funnel and error-rate breakdowns.

Lifecycle signals are emitted only after the corresponding state transition succeeds, and duplicate terminal title callbacks are ignored. Expected agent failures remain metrics plus structured warnings with investigation, execution, and Seer run identifiers; unexpected dispatch exceptions continue to surface as error events.
