### PR TITLE
ref(debug-files): Shard the artifact bundle in-use set by day

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -46,8 +46,36 @@ def get_redis_cluster_for_artifact_bundles() -> RedisCluster:
     return redis.redis_clusters.get(cluster_key)
 
 
-def get_refresh_key() -> str:
-    return "artifact_bundles_in_use"
+# The bundle ids reported as in use are collected in one Redis set per day, so that a
+# set can never keep growing across days. Each set also gets a TTL, so a shard that the
+# consumer never reaches still goes away by itself.
+REFRESH_KEY_PREFIX = "artifact_bundles_in_use"
+REFRESH_KEY_TTL = int(timedelta(days=1).total_seconds())
+
+# The unsharded key that was used before the daily shards. The consumer still drains it
+# so that the ids written by the previous release are not lost.
+# TODO(INFRENG-460): delete this constant, the drain of it and the key itself one
+# release after the daily shards ship.
+LEGACY_REFRESH_KEY = "artifact_bundles_in_use"
+
+
+def get_refresh_key(date: datetime | None = None) -> str:
+    date = date or timezone.now()
+    return f"{REFRESH_KEY_PREFIX}:{date.strftime('%Y%m%d')}"
+
+
+# How many ids the consumer pops in one Redis round trip.
+IDS_PER_LOOP = 50
+
+# The most ids that one consumer run pops, across all the keys it reads. This is the
+# same ceiling the consumer had before the keys were sharded.
+TOTAL_DRAIN_BUDGET = 5000
+
+# The share of the total budget that one run can spend on the previous day shard, and
+# on the old unsharded key. What is left over goes to the current day, so the current
+# day always keeps at least the difference.
+PREVIOUS_DAY_DRAIN_BUDGET = 1500
+LEGACY_DRAIN_BUDGET = 1000
 
 
 def _generate_artifact_bundle_indexing_state_cache_key(
@@ -201,25 +229,38 @@ def maybe_renew_artifact_bundles_from_processing(project_id: int, used_download_
             continue
         artifact_bundle_ids.append(ty_id)
 
-    redis_client = get_redis_cluster_for_artifact_bundles()
-
-    redis_client.sadd(get_refresh_key(), *artifact_bundle_ids)
-
-
-@trace
-def refresh_artifact_bundles_in_use():
-    LOOP_TIMES = 100
-    IDS_PER_LOOP = 50
+    if not artifact_bundle_ids:
+        return
 
     redis_client = get_redis_cluster_for_artifact_bundles()
 
-    now = timezone.now()
-    threshold_date = now - timedelta(
-        days=options.get("system.debug-files-renewal-age-threshold-days")
-    )
+    key = get_refresh_key()
+    redis_client.sadd(key, *artifact_bundle_ids)
+    # `sadd` does not refresh an existing TTL, so the TTL is set again on every write.
+    # That keeps the shard alive for the whole of the next day, while the consumer
+    # drains it. The key is per day, so it stops getting writes when the day ends. The
+    # TTL is therefore a real bound: the shard goes away at the latest one day after
+    # the last write to it, even if the consumer never drains it.
+    redis_client.expire(key, REFRESH_KEY_TTL)
 
-    for _ in range(LOOP_TIMES):
-        artifact_bundle_ids = redis_client.spop(get_refresh_key(), IDS_PER_LOOP)
+
+def _drain_refresh_key(
+    redis_client: RedisCluster, key: str, budget: int, threshold_date: datetime
+) -> int:
+    """
+    Pops at most `budget` bundle ids from `key` and renews the bundles that need it.
+
+    Returns the number of ids that were popped.
+    """
+    popped = 0
+
+    while popped < budget:
+        wanted = min(IDS_PER_LOOP, budget - popped)
+        artifact_bundle_ids = redis_client.spop(key, wanted)
+        if not artifact_bundle_ids:
+            break
+        popped += len(artifact_bundle_ids)
+
         used_artifact_bundles = {
             id: date_added
             for id, date_added in ArtifactBundle.objects.filter(
@@ -229,8 +270,51 @@ def refresh_artifact_bundles_in_use():
 
         maybe_renew_artifact_bundles(used_artifact_bundles)
 
-        if len(artifact_bundle_ids) < IDS_PER_LOOP:
+        if len(artifact_bundle_ids) < wanted:
             break
+
+    return popped
+
+
+@trace
+def refresh_artifact_bundles_in_use():
+    redis_client = get_redis_cluster_for_artifact_bundles()
+
+    now = timezone.now()
+    threshold_date = now - timedelta(
+        days=options.get("system.debug-files-renewal-age-threshold-days")
+    )
+
+    keys = {
+        "previous_day": get_refresh_key(now - timedelta(days=1)),
+        "current_day": get_refresh_key(now),
+        # TODO(INFRENG-460): drop this entry one release after the daily shards ship.
+        "legacy": LEGACY_REFRESH_KEY,
+    }
+
+    # The shards are only bounded across days, not inside one day. Report their size so
+    # that a consumer which falls behind is visible before the shard gets very large.
+    for shard, key in keys.items():
+        metrics.gauge(
+            "artifact_bundle_renewal.in_use_set_size",
+            redis_client.scard(key),
+            tags={"shard": shard},
+        )
+
+    # The previous day shard is drained first, because it is the only key whose TTL is
+    # running out. Each of the older keys has its own share of the budget, so that one
+    # shard which is too large to drain cannot starve the current day.
+    remaining = TOTAL_DRAIN_BUDGET
+    remaining -= _drain_refresh_key(
+        redis_client,
+        keys["previous_day"],
+        min(PREVIOUS_DAY_DRAIN_BUDGET, remaining),
+        threshold_date,
+    )
+    remaining -= _drain_refresh_key(
+        redis_client, keys["legacy"], min(LEGACY_DRAIN_BUDGET, remaining), threshold_date
+    )
+    _drain_refresh_key(redis_client, keys["current_day"], remaining, threshold_date)
 
 
 def maybe_renew_artifact_bundles(used_artifact_bundles: dict[int, datetime]):

--- a/tests/sentry/debug_files/test_artifact_bundles.py
+++ b/tests/sentry/debug_files/test_artifact_bundles.py
@@ -1,15 +1,20 @@
 import uuid
 import zipfile
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from hashlib import sha1
 from io import BytesIO
+from unittest import mock
 
 from django.core.files.base import ContentFile
 from django.utils import timezone
 
+from sentry.debug_files import artifact_bundles
 from sentry.debug_files.artifact_bundles import (
     get_artifact_bundles_containing_url,
     get_redis_cluster_for_artifact_bundles,
+    get_refresh_key,
+    maybe_renew_artifact_bundles_from_processing,
+    refresh_artifact_bundles_in_use,
 )
 from sentry.models.artifactbundle import (
     ArtifactBundle,
@@ -20,6 +25,8 @@ from sentry.models.artifactbundle import (
 from sentry.models.files.fileblob import FileBlob
 from sentry.tasks.assemble import assemble_artifacts
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 
@@ -455,3 +462,122 @@ class GetArtifactBundlesContainingUrlTest(TestCase):
             ),
             {bundle3.id},
         )
+
+
+class RefreshArtifactBundlesInUseTest(TestCase):
+    """
+    The bundle ids reported as in use are collected in one Redis set per day.
+    These tests cover the day boundary, the split of the drain budget, and the
+    transitional drain of the old unsharded key.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.redis_client = get_redis_cluster_for_artifact_bundles()
+        self.redis_client.flushall()
+
+    def _make_bundle(self, date_added: datetime) -> ArtifactBundle:
+        bundle = self.create_artifact_bundle(org=self.organization)
+        ArtifactBundle.objects.filter(id=bundle.id).update(date_added=date_added)
+        bundle.refresh_from_db()
+        return bundle
+
+    def test_producer_writes_to_the_shard_of_the_day(self) -> None:
+        with freeze_time(datetime(2023, 8, 25, 12, 0, tzinfo=UTC)):
+            assert get_refresh_key() == "artifact_bundles_in_use:20230825"
+
+            with override_options(
+                {"symbolicator.sourcemaps-bundle-index-refresh-sample-rate": 1.0}
+            ):
+                maybe_renew_artifact_bundles_from_processing(
+                    self.project.id, ["artifact_bundle/1234"]
+                )
+
+        assert self.redis_client.smembers("artifact_bundles_in_use:20230825") == {"1234"}
+        # the shard goes away by itself, even if the consumer never reaches it
+        assert 0 < self.redis_client.ttl("artifact_bundles_in_use:20230825") <= 86400
+
+    def test_drain_across_the_day_boundary(self) -> None:
+        before_midnight = datetime(2023, 8, 25, 23, 59, tzinfo=UTC)
+        after_midnight = datetime(2023, 8, 26, 0, 1, tzinfo=UTC)
+
+        bundle = self._make_bundle(before_midnight - timedelta(days=60))
+
+        with freeze_time(before_midnight):
+            with override_options(
+                {"symbolicator.sourcemaps-bundle-index-refresh-sample-rate": 1.0}
+            ):
+                maybe_renew_artifact_bundles_from_processing(
+                    self.project.id, [f"artifact_bundle/{bundle.id}"]
+                )
+
+        assert self.redis_client.smembers("artifact_bundles_in_use:20230825") == {str(bundle.id)}
+
+        with freeze_time(after_midnight):
+            refresh_artifact_bundles_in_use()
+
+        # the id written just before midnight is drained on the next day, from the
+        # shard of the previous day
+        bundle.refresh_from_db()
+        assert bundle.date_added == after_midnight
+        assert self.redis_client.scard("artifact_bundles_in_use:20230825") == 0
+        assert self.redis_client.scard("artifact_bundles_in_use:20230826") == 0
+
+    def test_large_previous_day_shard_does_not_starve_the_current_day(self) -> None:
+        now = datetime(2023, 8, 26, 12, 0, tzinfo=UTC)
+        previous_key = "artifact_bundles_in_use:20230825"
+        current_key = "artifact_bundles_in_use:20230826"
+
+        current_bundle = self._make_bundle(now - timedelta(days=60))
+
+        # a previous day shard which is bigger than the whole drain budget
+        filler = [str(current_bundle.id + 100 + i) for i in range(20)]
+        self.redis_client.sadd(previous_key, *filler)
+        self.redis_client.sadd(current_key, str(current_bundle.id))
+
+        with freeze_time(now):
+            with mock.patch.multiple(
+                artifact_bundles,
+                IDS_PER_LOOP=2,
+                TOTAL_DRAIN_BUDGET=6,
+                PREVIOUS_DAY_DRAIN_BUDGET=4,
+                LEGACY_DRAIN_BUDGET=1,
+            ):
+                refresh_artifact_bundles_in_use()
+
+        # the previous day only got its share of the budget, so it is still not empty
+        assert self.redis_client.scard(previous_key) == len(filler) - 4
+        # ... and the current day was drained all the same
+        assert self.redis_client.scard(current_key) == 0
+        current_bundle.refresh_from_db()
+        assert current_bundle.date_added == now
+
+    def test_drains_the_old_unsharded_key(self) -> None:
+        now = datetime(2023, 8, 26, 12, 0, tzinfo=UTC)
+        bundle = self._make_bundle(now - timedelta(days=60))
+
+        self.redis_client.sadd("artifact_bundles_in_use", str(bundle.id))
+
+        with freeze_time(now):
+            refresh_artifact_bundles_in_use()
+
+        bundle.refresh_from_db()
+        assert bundle.date_added == now
+        assert self.redis_client.scard("artifact_bundles_in_use") == 0
+
+    def test_emits_the_size_of_every_shard_as_a_gauge(self) -> None:
+        now = datetime(2023, 8, 26, 12, 0, tzinfo=UTC)
+
+        self.redis_client.sadd("artifact_bundles_in_use:20230825", "1", "2", "3")
+        self.redis_client.sadd("artifact_bundles_in_use:20230826", "4")
+
+        with freeze_time(now):
+            with mock.patch("sentry.debug_files.artifact_bundles.metrics.gauge") as gauge:
+                refresh_artifact_bundles_in_use()
+
+        sizes = {
+            call.kwargs["tags"]["shard"]: call.args[1]
+            for call in gauge.call_args_list
+            if call.args[0] == "artifact_bundle_renewal.in_use_set_size"
+        }
+        assert sizes == {"previous_day": 3, "current_day": 1, "legacy": 0}


### PR DESCRIPTION
Symbolication reports every artifact bundle it uses into one Redis set, and a task
that runs every minute drains that set and pushes each bundle's `date_added`
forward so the cleanup job does not delete a bundle a customer still needs.

The set is one global key with no expiry. The task drains at most 5000 ids a run,
about 300k an hour. Above that rate the key grows and never stops growing, and
every id that is never drained is a renewal that never happens.

This change makes the key one set per day, `artifact_bundles_in_use:{YYYYMMDD}`,
with a one day TTL. A shard stops taking writes when its day ends, so its TTL is a
real bound: it goes away at the latest one day after its last write, whether or not
the consumer ever reached it.

A plain `expire` on the single key does not work, which is why the key is sharded
instead. Every `sadd` would push the expiry out, so on a busy region the key would
never expire and the growth would still be unbounded.

## The drain

The consumer now reads three keys, and the total budget stays at 5000 ids a run.

- The previous day shard first, at most 1500. It is drained first because it is the
  only key whose TTL is running out.
- The old unsharded key, at most 1000. This is the transition, see below.
- The current day gets what is left, so at least 2500.

The split matters. If the consumer simply ran the old loop once per key, one large
previous day shard would block today's renewals for as long as it took to drain.

## The size signal

Sharding by day bounds growth across days. It does not bound growth inside one day,
so a consumer stalled for six hours still builds one large set. The consumer now
emits `scard` of each key as the `artifact_bundle_renewal.in_use_set_size` gauge,
tagged by shard, so that case is visible before the shard gets very large.

The alert threshold on that gauge still needs to be agreed with @getsentry/ingest.

## Rollout

For one release the consumer also drains the old unsharded key
`artifact_bundles_in_use`, so the ids written by the previous release are not lost.
A follow-up pull request deletes that drain, the constant and the key. Both places
carry a `TODO(INFRENG-460)`.

During the transition the current day ceiling drops from 5000 to 4000 ids a run,
about 240k an hour. That is below the growth rate the ticket names, so the
transition should not stay in place longer than the one release it needs.

## Tests

`tests/sentry/debug_files/test_artifact_bundles.py`, 23 passed. Five tests are new,
including the two the ticket asks for by name: a drain across the day boundary on a
frozen clock, with a bundle added just before midnight and drained after, and a
previous day shard larger than the whole budget that still leaves the current day
drained. Both were confirmed to fail against the unchanged code, so they exercise
the change rather than passing regardless.

Refs INFRENG-460
