### PR TITLE
fix(investigations): Make generated summaries friendlier

### DIFF
--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -977,9 +977,10 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
         "Describe a completed Sentry investigation. Do not use tools. Return exactly one raw JSON "
         "object with the keys title, summary, and summary_description and no other text. title "
         "must identify the incident in at most 5 words. summary must state what happened in at "
-        "most 10 words. summary_description must be 2 or 3 newline-separated, concise lines covering "
-        "the investigation's key evidence and the most useful next steps for a human fixing the "
-        "issue. Distinguish established facts from hypotheses and do not invent a cause. Put title "
+        "most 10 words. summary_description must use casual, plain language in 1 or 2 short "
+        "newline-separated sentences: lead with the strongest evidence and optionally add the most "
+        "useful next step. Avoid headings and jargon. Distinguish established facts from hypotheses "
+        "and do not invent a cause. Put title "
         "first in the JSON object. Do not call any function to write or save the result.\n"
         "<source_context>\n"
         f"{json.dumps(investigation_source(investigation))}\n</source_context>\n"
@@ -1121,7 +1122,7 @@ def _parse_completion_metadata(content: str) -> dict[str, str] | None:
     if not (
         1 <= len(title.split()) <= TITLE_WORD_LIMIT
         and SUMMARY_MIN_WORDS <= len(summary.split()) <= SUMMARY_WORD_LIMIT
-        and 2 <= len(description_lines) <= 3
+        and 1 <= len(description_lines) <= 3
     ):
         return None
     summary_description = "\n".join(description_lines)

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -58,6 +58,15 @@ def test_completion_metadata_accepts_concise_variable_summary_lengths() -> None:
     )
 
 
+def test_completion_metadata_accepts_single_line_description() -> None:
+    assert (
+        _parse_completion_metadata(
+            completion_metadata(description="Checkout errors came from one endpoint.")
+        )
+        is not None
+    )
+
+
 def test_completion_metadata_ignores_extra_keys() -> None:
     payload = json.loads(completion_metadata())
     payload["confidence"] = 0.9
@@ -1117,6 +1126,9 @@ class InvestigationAgentTest(TestCase):
         assert "checkout-api" in prompt
         assert "at most 5 words" in prompt
         assert "summary_description" in prompt
+        assert "casual, plain language" in prompt
+        assert "1 or 2 short" in prompt
+        assert "Avoid headings and jargon" in prompt
 
     @patch("sentry.investigations.agent.record_investigation_completed")
     @patch("sentry.investigations.agent.SeerAgentClient")


### PR DESCRIPTION
Completed investigations now use one or two short, plain-language sentences for the summary description, leading with the strongest evidence and optionally adding the most useful next step.

The parser continues to accept the previous three-line format so title-generation runs that started before deployment remain compatible during rollout.
