### PR TITLE
feat(investigations): Focus active investigation progress

### DIFF
--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -192,7 +192,7 @@ export function InvestigationCell({
   );
 
   const cellActions = (
-    <CellActions data-cell-actions flexShrink={0}>
+    <CellActions flexShrink={0}>
       <DropdownMenu
         position="bottom-end"
         usePortal
@@ -317,18 +317,21 @@ function QueryResult({
 
   return (
     <CellHoverSurface width="100%" gap="sm">
-      <QueryDisclosureButton
-        size="sm"
-        variant="transparent"
-        icon={<IconChevron direction={expanded ? 'down' : 'right'} size="xs" />}
-        aria-label={t('Toggle %s', title)}
-        aria-expanded={expanded}
-        onClick={() => setExpanded(value => !value)}
-      >
-        <Text data-test-id="query-cell-title" size="sm" tabular>
-          {title}
-        </Text>
-      </QueryDisclosureButton>
+      <Flex width="100%" align="center" gap="xs" data-test-id="query-cell-toolbar">
+        <QueryDisclosureButton
+          size="sm"
+          variant="transparent"
+          icon={<IconChevron direction={expanded ? 'down' : 'right'} size="xs" />}
+          aria-label={t('Toggle %s', title)}
+          aria-expanded={expanded}
+          onClick={() => setExpanded(value => !value)}
+        >
+          <Text data-test-id="query-cell-title" size="sm" tabular>
+            {title}
+          </Text>
+        </QueryDisclosureButton>
+        {actions}
+      </Flex>
       {expanded ? (
         <Stack
           width="100%"
@@ -360,7 +363,6 @@ function QueryResult({
                 </Text>
               ) : null}
             </Stack>
-            {actions}
           </Flex>
           <Container width="100%" overflow="hidden" padding={chart ? 'md lg' : '0'}>
             <CellExecutionAlert block={block} />
@@ -465,6 +467,8 @@ export function shouldDisplayInvestigationBlock(
   block: InvestigationBlock,
   blocks: InvestigationBlock[]
 ) {
+  // Waiting cells have no useful content yet. Dependency failures and cancellations
+  // remain visible so users can understand why downstream work stopped.
   return getCellProgressState(block, blocks) !== 'waiting';
 }
 
@@ -1121,7 +1125,7 @@ function getSeriesName(series: {label: string} | {name: string}) {
 }
 
 const QueryDisclosureButton = styled(Button)`
-  width: 100%;
+  flex: 1;
   justify-content: flex-start;
   padding-inline: ${p => p.theme.space.xs};
   text-align: left;
@@ -1129,17 +1133,20 @@ const QueryDisclosureButton = styled(Button)`
 
 const CellActions = styled(Flex)`
   opacity: 0;
+  pointer-events: none;
 `;
 
 const CellHoverSurface = styled(Stack)`
   &:hover ${CellActions},
   &:focus-within ${CellActions} {
     opacity: 1;
+    pointer-events: auto;
   }
 
   @media (hover: none) {
     ${CellActions} {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 `;
@@ -1170,7 +1177,6 @@ const AgentActivityTitle = styled(Text)`
   letter-spacing: 0;
   vertical-align: middle;
   font-variant-numeric: lining-nums tabular-nums;
-  text-box-trim: none;
 `;
 
 const RefinementPrompt = styled('div')`

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -708,7 +708,7 @@ function RefinementPanel({
 
   return (
     <RefinementDisclosure defaultExpanded size="sm">
-      <Disclosure.Title
+      <AgentActivityDisclosureTitle
         leadingItems={<IconSeer size="xs" animation={active ? 'waiting' : undefined} />}
         trailingItems={
           <Flex align="center" gap="sm">
@@ -723,8 +723,8 @@ function RefinementPanel({
           </Flex>
         }
       >
-        <Text monospace>{getExecutionTitle(status)}</Text>
-      </Disclosure.Title>
+        <AgentActivityTitle monospace>{getExecutionTitle(status)}</AgentActivityTitle>
+      </AgentActivityDisclosureTitle>
       <RefinementDisclosureContent>
         <Stack gap="md">
           <Transcript
@@ -1123,6 +1123,7 @@ function getSeriesName(series: {label: string} | {name: string}) {
 const QueryDisclosureButton = styled(Button)`
   width: 100%;
   justify-content: flex-start;
+  padding-inline: ${p => p.theme.space.xs};
   text-align: left;
 `;
 
@@ -1151,6 +1152,25 @@ const QueryTable = styled('table')`
 const RefinementDisclosure = styled(Disclosure)`
   width: 100%;
   margin-top: ${p => p.theme.space.lg};
+
+  & > div:first-child {
+    padding-inline: ${p => p.theme.space['2xs']};
+  }
+`;
+
+const AgentActivityDisclosureTitle = styled(Disclosure.Title)`
+  padding-inline: 0;
+`;
+
+const AgentActivityTitle = styled(Text)`
+  font-size: ${p => p.theme.font.size.sm};
+  font-style: normal;
+  font-weight: 700;
+  line-height: ${p => p.theme.font.lineHeight.fixed};
+  letter-spacing: 0;
+  vertical-align: middle;
+  font-variant-numeric: lining-nums tabular-nums;
+  text-box-trim: none;
 `;
 
 const RefinementPrompt = styled('div')`

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -62,9 +62,15 @@ export function InvestigationCell({
   investigation,
 }: InvestigationCellProps) {
   const organizationSlug = useOrganization().slug;
-  const [panelOpen, setPanelOpen] = useState(false);
-  const [traceExecutionId, setTraceExecutionId] = useState<string | null>(null);
-  const [showPrompt, setShowPrompt] = useState(true);
+  const activeExecutionId = isExecutionActive(block.currentExecution?.status)
+    ? (block.currentExecution?.id ?? null)
+    : null;
+  const autoOpenedExecutionId = useRef(activeExecutionId);
+  const [panelOpen, setPanelOpen] = useState(Boolean(activeExecutionId));
+  const [traceExecutionId, setTraceExecutionId] = useState<string | null>(
+    activeExecutionId
+  );
+  const [showPrompt, setShowPrompt] = useState(!activeExecutionId);
   const [prompt, setPrompt] = useState(() =>
     block.outputStatus === 'notRun' ? block.generationPrompt : ''
   );
@@ -108,6 +114,16 @@ export function InvestigationCell({
     {onError: () => addErrorMessage(t('Unable to delete this cell.'))}
   );
 
+  useEffect(() => {
+    if (!activeExecutionId || autoOpenedExecutionId.current === activeExecutionId) {
+      return;
+    }
+    autoOpenedExecutionId.current = activeExecutionId;
+    setPanelOpen(true);
+    setTraceExecutionId(activeExecutionId);
+    setShowPrompt(false);
+  }, [activeExecutionId]);
+
   function openPanel() {
     setPanelOpen(true);
     if (block.currentExecution && isExecutionActive(block.currentExecution.status)) {
@@ -128,6 +144,7 @@ export function InvestigationCell({
       setPanelOpen(true);
       setTraceExecutionId(execution.id);
       setShowPrompt(false);
+      autoOpenedExecutionId.current = execution.id;
     } catch {
       // The mutation owns user-facing error handling.
     }
@@ -292,7 +309,7 @@ function QueryResult({
   block: InvestigationBlock;
   progressState: CellProgressState;
 }) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(block.config.autoRun !== true);
   const output = getQueryOutput(block.output);
   const chart =
     output?.preferredView === 'chart' ? getRenderableChart(output.chart) : null;
@@ -447,6 +464,13 @@ function getCellProgressState(
     return 'blockedByCancellation';
   }
   return 'waiting';
+}
+
+export function shouldDisplayInvestigationBlock(
+  block: InvestigationBlock,
+  blocks: InvestigationBlock[]
+) {
+  return getCellProgressState(block, blocks) !== 'waiting';
 }
 
 export function shouldPollInvestigationBlocks(blocks: InvestigationBlock[]) {

--- a/static/app/views/investigations/detail/cell.tsx
+++ b/static/app/views/investigations/detail/cell.tsx
@@ -11,7 +11,7 @@ import {TextArea} from '@sentry/scraps/textarea';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {openConfirmModal} from 'sentry/components/confirm';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {Duration} from 'sentry/components/duration';
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
@@ -21,7 +21,6 @@ import {
   IconChevron,
   IconClose,
   IconEllipsis,
-  IconRefresh,
   IconReturn,
   IconSeer,
 } from 'sentry/icons';
@@ -150,33 +149,50 @@ export function InvestigationCell({
     }
   }
 
-  const refinementButton = (
-    <Button
-      size="xs"
-      variant="transparent"
-      icon={<IconSeer size="xs" />}
-      aria-label={t('Ask Seer about %s', displayTitle)}
-      disabled={waitingForDependencies}
-      onClick={panelOpen ? () => setPanelOpen(false) : openPanel}
-    />
+  const actionItems: MenuItemProps[] = [];
+  if (block.kind === 'query') {
+    actionItems.push({
+      key: 'rerun',
+      label: t('Rerun'),
+      disabled:
+        !canRun ||
+        rerunMutation.isPending ||
+        isExecutionActive(block.currentExecution?.status) ||
+        !(block.generationPrompt || block.content).trim(),
+      onAction: () => void rerun(),
+    });
+  }
+  actionItems.push(
+    {
+      key: 'refine',
+      label: t('Refine'),
+      disabled: waitingForDependencies,
+      onAction: openPanel,
+    },
+    {
+      key: 'delete',
+      label: t('Delete'),
+      priority: 'danger',
+      disabled:
+        !canRun ||
+        deleteMutation.isPending ||
+        isExecutionActive(block.currentExecution?.status),
+      onAction: () =>
+        openConfirmModal({
+          message: t('Are you sure you want to delete this cell?'),
+          priority: 'danger',
+          confirmText: t('Delete'),
+          onConfirm: () =>
+            deleteMutation.mutate({
+              block,
+              investigationVersion: investigation.version,
+            }),
+        }),
+    }
   );
 
-  const queryHeaderActions = (
-    <Flex align="center" gap="xs" flexShrink={0}>
-      {refinementButton}
-      <Button
-        size="xs"
-        variant="transparent"
-        icon={<IconRefresh size="xs" />}
-        aria-label={t('Rerun %s', displayTitle)}
-        busy={rerunMutation.isPending}
-        disabled={
-          !canRun ||
-          isExecutionActive(block.currentExecution?.status) ||
-          !(block.generationPrompt || block.content).trim()
-        }
-        onClick={() => void rerun()}
-      />
+  const cellActions = (
+    <CellActions data-cell-actions flexShrink={0}>
       <DropdownMenu
         position="bottom-end"
         usePortal
@@ -187,30 +203,9 @@ export function InvestigationCell({
           icon: <IconEllipsis size="xs" />,
           'aria-label': t('Cell actions for %s', displayTitle),
         }}
-        items={[
-          {
-            key: 'delete',
-            label: t('Delete'),
-            priority: 'danger',
-            disabled:
-              !canRun ||
-              deleteMutation.isPending ||
-              isExecutionActive(block.currentExecution?.status),
-            onAction: () =>
-              openConfirmModal({
-                message: t('Are you sure you want to delete this cell?'),
-                priority: 'danger',
-                confirmText: t('Delete'),
-                onConfirm: () =>
-                  deleteMutation.mutate({
-                    block,
-                    investigationVersion: investigation.version,
-                  }),
-              }),
-          },
-        ]}
+        items={actionItems}
       />
-    </Flex>
+    </CellActions>
   );
 
   const panel = panelOpen ? (
@@ -240,7 +235,7 @@ export function InvestigationCell({
       {block.kind === 'query' ? (
         <Fragment>
           <QueryResult
-            actions={queryHeaderActions}
+            actions={cellActions}
             block={block}
             progressState={progressState}
           />
@@ -250,8 +245,8 @@ export function InvestigationCell({
         <Fragment>
           <CellResult
             block={block}
+            actions={cellActions}
             progressState={progressState}
-            refinementButton={refinementButton}
             streamedMarkdown={
               isExecutionActive(block.currentExecution?.status)
                 ? streamedTextQuery.data?.partialMarkdown
@@ -266,20 +261,20 @@ export function InvestigationCell({
 }
 
 function CellResult({
+  actions,
   block,
   progressState,
-  refinementButton,
   streamedMarkdown,
 }: {
+  actions: React.ReactNode;
   block: InvestigationBlock;
   progressState: CellProgressState;
-  refinementButton: React.ReactNode;
   streamedMarkdown?: string | null;
 }) {
   const markdown =
     streamedMarkdown ?? getTextOutput(block.output) ?? (block.content.trim() || null);
   return (
-    <Stack
+    <CellHoverSurface
       position="relative"
       flex={1}
       minWidth={0}
@@ -288,7 +283,7 @@ function CellResult({
       data-cell-variant="unbordered"
     >
       <Container position="absolute" top={0} right={0}>
-        {refinementButton}
+        {actions}
       </Container>
       <CellExecutionAlert block={block} />
       {markdown ? (
@@ -296,7 +291,7 @@ function CellResult({
       ) : (
         <CellProgress state={progressState} />
       )}
-    </Stack>
+    </CellHoverSurface>
   );
 }
 
@@ -321,7 +316,7 @@ function QueryResult({
     getChartMetadata(chart);
 
   return (
-    <Stack width="100%" gap="sm">
+    <CellHoverSurface width="100%" gap="sm">
       <QueryDisclosureButton
         size="sm"
         variant="transparent"
@@ -381,7 +376,7 @@ function QueryResult({
           </Container>
         </Stack>
       ) : null}
-    </Stack>
+    </CellHoverSurface>
   );
 }
 
@@ -1129,6 +1124,23 @@ const QueryDisclosureButton = styled(Button)`
   width: 100%;
   justify-content: flex-start;
   text-align: left;
+`;
+
+const CellActions = styled(Flex)`
+  opacity: 0;
+`;
+
+const CellHoverSurface = styled(Stack)`
+  &:hover ${CellActions},
+  &:focus-within ${CellActions} {
+    opacity: 1;
+  }
+
+  @media (hover: none) {
+    ${CellActions} {
+      opacity: 1;
+    }
+  }
 `;
 
 const QueryTable = styled('table')`

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -190,6 +190,8 @@ describe('Investigation detail', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText('Investigate database latency')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Cell actions for Summary')).toBeInTheDocument();
     expect(screen.getByLabelText('Cell actions for Latency query')).toBeInTheDocument();
     expect(

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -163,6 +163,16 @@ function renderView(
   return {...result, queryClient};
 }
 
+async function chooseCellAction(
+  cellTitle: string,
+  action: 'Delete' | 'Refine' | 'Rerun'
+) {
+  await userEvent.click(
+    await screen.findByRole('button', {name: `Cell actions for ${cellTitle}`})
+  );
+  await userEvent.click(await screen.findByRole('menuitemradio', {name: action}));
+}
+
 describe('Investigation detail', () => {
   beforeEach(() => {
     jest.spyOn(indicators, 'addSuccessMessage').mockImplementation();
@@ -180,16 +190,27 @@ describe('Investigation detail', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText('Investigate database latency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cell actions for Summary')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cell actions for Latency query')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: 'Ask Seer about Summary'})
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Ask Seer about Latency query'})
-    ).toBeInTheDocument();
+      screen.queryByRole('button', {name: /Ask Seer about/})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Rerun/})).not.toBeInTheDocument();
     expect(screen.queryByText('Ask Seer')).not.toBeInTheDocument();
     expect(screen.queryByText(/"blocks":/)).not.toBeInTheDocument();
     expect(request).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('investigation-summary')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText('Cell actions for Summary'));
+    expect(screen.getByRole('menuitemradio', {name: 'Refine'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'Delete'})).toBeInTheDocument();
+    expect(screen.queryByRole('menuitemradio', {name: 'Rerun'})).not.toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+
+    await userEvent.click(screen.getByLabelText('Cell actions for Latency query'));
+    expect(screen.getByRole('menuitemradio', {name: 'Rerun'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'Refine'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'Delete'})).toBeInTheDocument();
   });
 
   it('opens feedback scoped to the investigation', async () => {
@@ -662,11 +683,7 @@ describe('Investigation detail', () => {
     });
 
     renderView();
-    await userEvent.click(
-      await screen.findByRole('button', {
-        name: 'Ask Seer about Latency query',
-      })
-    );
+    await chooseCellAction('Latency query', 'Refine');
 
     const prompt = screen.getByLabelText('Instructions for Seer');
     expect(screen.getByText('Ask Seer to refine')).toBeInTheDocument();
@@ -742,7 +759,7 @@ describe('Investigation detail', () => {
       'bordered'
     );
     expect(screen.getByTestId('query-cell-header')).toContainElement(
-      screen.getByRole('button', {name: 'Ask Seer about Database latency'})
+      screen.getByRole('button', {name: 'Cell actions for Database latency'})
     );
     expect(screen.getByTestId('investigation-cell-block-1')).toHaveAttribute(
       'data-has-divider',
@@ -944,12 +961,15 @@ describe('Investigation detail', () => {
     expect(
       within(chartHeader).getByText(/3:57pm–4:12pm PST\s+\|\s+363 Total Events/)
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Ask Seer about Latency query'})
-    ).toBeInTheDocument();
     expect(screen.getByLabelText('Cell actions for Latency query')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Ask Seer about Latency query'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Rerun Latency query'})
+    ).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Rerun Latency query'}));
+    await chooseCellAction('Latency query', 'Rerun');
     await waitFor(() =>
       expect(rerunRequest).toHaveBeenCalledWith(
         runUrl,
@@ -972,8 +992,7 @@ describe('Investigation detail', () => {
     });
 
     renderView(organization, queryClient);
-    await userEvent.click(await screen.findByLabelText('Cell actions for Latency query'));
-    await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Delete'}));
+    await chooseCellAction('Latency query', 'Delete');
     expect(deleteRequest).not.toHaveBeenCalled();
     renderGlobalModal();
     act(() => {
@@ -997,6 +1016,34 @@ describe('Investigation detail', () => {
       )
     );
     expect(screen.queryByDisplayValue('Latency query')).not.toBeInTheDocument();
+  });
+
+  it('deletes a text cell from its actions menu', async () => {
+    const investigation = InvestigationDetailFixture();
+    const block = investigation.blocks[0]!;
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+    const deleteRequest = MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/${block.id}/`,
+      method: 'DELETE',
+    });
+
+    renderView();
+    await chooseCellAction('Summary', 'Delete');
+    expect(deleteRequest).not.toHaveBeenCalled();
+    renderGlobalModal();
+    await userEvent.click(await screen.findByTestId('confirm-button'));
+
+    await waitFor(() =>
+      expect(deleteRequest).toHaveBeenCalledWith(
+        `${detailUrl}blocks/${block.id}/`,
+        expect.objectContaining({
+          data: {investigationVersion: 1, version: 1},
+        })
+      )
+    );
+    expect(
+      screen.queryByTestId(`investigation-cell-${block.id}`)
+    ).not.toBeInTheDocument();
   });
 
   it('adds text and query cells and starts a never-run cell from its stored prompt', async () => {
@@ -1047,7 +1094,7 @@ describe('Investigation detail', () => {
     );
     expect(
       await screen.findByRole('button', {
-        name: 'Ask Seer about Working theory',
+        name: 'Cell actions for Working theory',
       })
     ).toBeInTheDocument();
     expect(screen.queryByDisplayValue('Working theory')).not.toBeInTheDocument();
@@ -1114,9 +1161,7 @@ describe('Investigation detail', () => {
         error: null,
       },
     });
-    await userEvent.click(
-      screen.getByRole('button', {name: 'Ask Seer about Error volume'})
-    );
+    await chooseCellAction('Error volume', 'Refine');
     expect(screen.getByLabelText('Instructions for Seer')).toHaveValue(
       'Show errors over the last 24 hours'
     );
@@ -1264,7 +1309,7 @@ describe('Investigation detail', () => {
 
     renderView();
     expect(await screen.findByText('Previous successful result')).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', {name: 'Ask Seer about Summary'}));
+    await chooseCellAction('Summary', 'Refine');
     expect(screen.getByLabelText('Instructions for Seer')).toHaveValue('');
     const promptInput = screen.getByLabelText('Instructions for Seer');
     await userEvent.type(promptInput, 'Compare against deploys');
@@ -1342,9 +1387,7 @@ describe('Investigation detail', () => {
     });
 
     renderView();
-    await userEvent.click(
-      await screen.findByRole('button', {name: 'Ask Seer about Summary'})
-    );
+    await chooseCellAction('Summary', 'Refine');
     await userEvent.type(
       screen.getByLabelText('Instructions for Seer'),
       'Try another angle'

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -190,8 +190,8 @@ describe('Investigation detail', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(await screen.findByText('Investigate database latency')).toBeInTheDocument();
-    expect(screen.getByText('Completed')).toBeInTheDocument();
-    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Cell actions for Summary')).toBeInTheDocument();
     expect(screen.getByLabelText('Cell actions for Latency query')).toBeInTheDocument();
     expect(
@@ -760,7 +760,7 @@ describe('Investigation detail', () => {
       'data-cell-variant',
       'bordered'
     );
-    expect(screen.getByTestId('query-cell-header')).toContainElement(
+    expect(screen.getByTestId('query-cell-toolbar')).toContainElement(
       screen.getByRole('button', {name: 'Cell actions for Database latency'})
     );
     expect(screen.getByTestId('investigation-cell-block-1')).toHaveAttribute(
@@ -820,6 +820,9 @@ describe('Investigation detail', () => {
     const toggle = await screen.findByRole('button', {name: 'Toggle Latency query'});
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByText('820ms')).not.toBeInTheDocument();
+    expect(screen.getByTestId('query-cell-toolbar')).toContainElement(
+      screen.getByRole('button', {name: 'Cell actions for Latency query'})
+    );
 
     await userEvent.click(toggle);
 
@@ -1073,7 +1076,9 @@ describe('Investigation detail', () => {
     });
 
     renderView();
-    await userEvent.click(await screen.findByRole('button', {name: 'Text cell'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Add text cell (debug only)'})
+    );
     await userEvent.type(screen.getByLabelText('Cell title'), 'Working theory');
     await userEvent.type(
       screen.getByLabelText('Cell instructions'),
@@ -1112,7 +1117,9 @@ describe('Investigation detail', () => {
       method: 'POST',
       body: queryBlock,
     });
-    await userEvent.click(screen.getByRole('button', {name: 'Query cell'}));
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Add query cell (debug only)'})
+    );
     await userEvent.type(screen.getByLabelText('Cell title'), 'Error volume');
     await userEvent.type(
       screen.getByLabelText('Cell instructions'),

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -457,7 +457,7 @@ describe('Investigation detail', () => {
     );
   });
 
-  it('shows running and dependency-waiting states for auto-run cells', async () => {
+  it('shows active auto-run cells, hides waiting cells, and opens agent steps', async () => {
     const investigation = InvestigationDetailFixture({
       template: {key: 'breached_metric', version: 1},
     });
@@ -512,12 +512,32 @@ describe('Investigation detail', () => {
         error: null,
       },
     });
+    MockApiClient.addMockResponse({
+      url: `${detailUrl}blocks/block-2/executions/execution-2/`,
+      body: {
+        id: 'execution-2',
+        status: 'pending',
+        blocks: [],
+        transcriptTruncated: false,
+        pendingUserInput: null,
+        partialMarkdown: null,
+        error: null,
+      },
+    });
 
     renderView();
 
-    expect(await screen.findAllByText('Seer is working on this cell…')).toHaveLength(2);
-    expect(screen.getByText('Waiting for previous cells…')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Ask Seer about Synthesis'})).toBeDisabled();
+    expect(await screen.findAllByRole('button', {name: 'Close Seer panel'})).toHaveLength(
+      2
+    );
+    expect(screen.getByTestId('investigation-cell-block-1')).toBeInTheDocument();
+    expect(screen.getByTestId('investigation-cell-block-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('investigation-cell-block-3')).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for previous cells…')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Toggle Latency query'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
   });
 
   it('keeps polling while an auto-run cell is waiting to start', async () => {
@@ -546,7 +566,8 @@ describe('Investigation detail', () => {
 
     renderView();
 
-    expect(await screen.findByText('Waiting for previous cells…')).toBeInTheDocument();
+    await screen.findByText('Initial notes');
+    expect(screen.queryByTestId('investigation-cell-block-2')).not.toBeInTheDocument();
     await waitFor(() => expect(request).toHaveBeenCalledTimes(2), {timeout: 3000});
   });
 
@@ -622,10 +643,13 @@ describe('Investigation detail', () => {
 
     renderView();
 
-    expect(
-      await screen.findByText('Cancelled because a previous cell failed.')
-    ).toBeInTheDocument();
-    expect(screen.getByText('Waiting for previous cells…')).toBeInTheDocument();
+    expect(await screen.findByTestId('investigation-cell-block-2')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Toggle Latency query'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    expect(screen.queryByTestId('investigation-cell-block-4')).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for previous cells…')).not.toBeInTheDocument();
     expect(
       screen.queryByTestId('investigation-execution-failed')
     ).not.toBeInTheDocument();
@@ -742,6 +766,44 @@ describe('Investigation detail', () => {
     await userEvent.click(screen.getByTestId('query-cell-title'));
     expect(screen.queryByText('820ms')).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', {name: 'Toggle Database latency'}));
+    expect(screen.getByText('820ms')).toBeVisible();
+  });
+
+  it('starts generated query evidence collapsed', async () => {
+    const investigation = InvestigationDetailFixture();
+    investigation.blocks = [
+      {
+        ...investigation.blocks[1]!,
+        config: {autoRun: true},
+        outputStatus: 'completed',
+        output: {
+          schemaVersion: 1,
+          preferredView: 'table',
+          tableMarkdown: '| p95 |\n| --- |\n| 820ms |',
+          chart: null,
+          chartUnavailableReason: null,
+          isEmpty: false,
+          queryLinks: [],
+        },
+        currentExecution: {
+          id: 'execution-completed',
+          status: 'completed',
+          startedAt: '2026-08-17T10:00:00Z',
+          completedAt: '2026-08-17T10:00:10Z',
+          error: null,
+        },
+      },
+    ];
+    MockApiClient.addMockResponse({url: detailUrl, body: investigation});
+
+    renderView();
+
+    const toggle = await screen.findByRole('button', {name: 'Toggle Latency query'});
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('820ms')).not.toBeInTheDocument();
+
+    await userEvent.click(toggle);
+
     expect(screen.getByText('820ms')).toBeVisible();
   });
 
@@ -1343,9 +1405,6 @@ describe('Investigation detail', () => {
     });
 
     renderView();
-    await userEvent.click(
-      await screen.findByRole('button', {name: 'Ask Seer about Summary'})
-    );
     expect(
       await screen.findByText('Which environment should I inspect?')
     ).toBeInTheDocument();

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -574,7 +574,10 @@ const InvestigationCanvas = styled(Stack)`
 `;
 
 const NotebookSummaryCard = styled(InvestigationSummaryCard)`
+  width: calc(100% + ${p => p.theme.space['2xl']});
+  margin-inline: calc(-1 * ${p => p.theme.space.lg});
   margin-bottom: ${p => p.theme.space.xl};
+  padding-inline: ${p => p.theme.space.xl};
 `;
 
 const HeaderBreadcrumbs = styled(Flex)`

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -408,7 +408,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
                 summaryDescription={investigation.summaryDescription}
               />
 
-              <NotebookContent>
+              <Stack width="min(100%, 884px)" margin="0 auto">
                 {visibleSummaryBlock ? (
                   <InvestigationCell
                     block={visibleSummaryBlock}
@@ -433,7 +433,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
                     onAdd={handleAddBlock}
                   />
                 ) : null}
-              </NotebookContent>
+              </Stack>
             </InvestigationCanvas>
           </Layout.Main>
         </Layout.Body>
@@ -577,11 +577,6 @@ function getStatusVariant(status: string): 'success' | 'warning' | 'muted' {
 
 const InvestigationCanvas = styled(Stack)`
   width: min(100%, calc(884px + ${p => p.theme.space['2xl']}));
-  margin: 0 auto;
-`;
-
-const NotebookContent = styled(Stack)`
-  width: min(100%, 884px);
   margin: 0 auto;
 `;
 

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -41,6 +41,7 @@ import {
 } from 'sentry/views/investigations/api';
 import {
   InvestigationCell,
+  shouldDisplayInvestigationBlock,
   shouldPollInvestigationBlocks,
 } from 'sentry/views/investigations/detail/cell';
 import {updateInvestigationCache} from 'sentry/views/investigations/investigationCache';
@@ -263,6 +264,13 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
   const blocks = investigation.blocks ?? [];
   const summaryBlock = investigation.template ? blocks[0] : undefined;
   const notebookCells = summaryBlock ? blocks.slice(1) : blocks;
+  const visibleSummaryBlock =
+    summaryBlock && shouldDisplayInvestigationBlock(summaryBlock, blocks)
+      ? summaryBlock
+      : undefined;
+  const visibleNotebookCells = notebookCells.filter(block =>
+    shouldDisplayInvestigationBlock(block, blocks)
+  );
 
   async function handleAddBlock({
     kind,
@@ -400,16 +408,16 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
                 summaryDescription={investigation.summaryDescription}
               />
 
-              {summaryBlock ? (
+              {visibleSummaryBlock ? (
                 <InvestigationCell
-                  block={summaryBlock}
+                  block={visibleSummaryBlock}
                   canRun={investigation.status === 'active'}
                   investigation={investigation}
                 />
               ) : null}
 
               <Stack gap="xl">
-                {notebookCells.map(block => (
+                {visibleNotebookCells.map(block => (
                   <InvestigationCell
                     key={block.id}
                     block={block}

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -347,7 +347,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
             />
           </HeaderBreadcrumbs>
         </Layout.Title>
-        <Container as="header" width="100%" padding="xl" borderBottom="primary">
+        <InvestigationHeader as="header" width="100%" padding="xl">
           <Grid
             columns="minmax(0, 1fr) auto"
             align="start"
@@ -399,7 +399,7 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
               <IconSeer size="sm" />
             </Flex>
           </Grid>
-        </Container>
+        </InvestigationHeader>
         <Layout.Body>
           <Layout.Main width="full">
             <InvestigationCanvas>
@@ -551,6 +551,9 @@ function formatSourceType(sourceType: string) {
 }
 
 function formatStatus(status: string) {
+  if (status === 'active') {
+    return t('Completed');
+  }
   return status.replaceAll('_', ' ').replace(/^./, character => character.toUpperCase());
 }
 
@@ -571,6 +574,18 @@ function getStatusVariant(status: string): 'success' | 'warning' | 'muted' {
 const InvestigationCanvas = styled(Stack)`
   width: min(100%, 884px);
   margin: 0 auto;
+`;
+
+const InvestigationHeader = styled(Container)`
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: auto 0 0;
+    height: 1px;
+    background: ${p => p.theme.tokens.background.secondary};
+  }
 `;
 
 const NotebookSummaryCard = styled(InvestigationSummaryCard)`

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -408,30 +408,32 @@ function InvestigationPageContent({investigation}: {investigation: Investigation
                 summaryDescription={investigation.summaryDescription}
               />
 
-              {visibleSummaryBlock ? (
-                <InvestigationCell
-                  block={visibleSummaryBlock}
-                  canRun={investigation.status === 'active'}
-                  investigation={investigation}
-                />
-              ) : null}
-
-              <Stack gap="xl">
-                {visibleNotebookCells.map(block => (
+              <NotebookContent>
+                {visibleSummaryBlock ? (
                   <InvestigationCell
-                    key={block.id}
-                    block={block}
+                    block={visibleSummaryBlock}
                     canRun={investigation.status === 'active'}
                     investigation={investigation}
                   />
-                ))}
-              </Stack>
-              {investigation.status === 'active' ? (
-                <AddCellComposer
-                  isAdding={addBlockMutation.isPending}
-                  onAdd={handleAddBlock}
-                />
-              ) : null}
+                ) : null}
+
+                <Stack gap="xl">
+                  {visibleNotebookCells.map(block => (
+                    <InvestigationCell
+                      key={block.id}
+                      block={block}
+                      canRun={investigation.status === 'active'}
+                      investigation={investigation}
+                    />
+                  ))}
+                </Stack>
+                {investigation.status === 'active' ? (
+                  <AddCellComposer
+                    isAdding={addBlockMutation.isPending}
+                    onAdd={handleAddBlock}
+                  />
+                ) : null}
+              </NotebookContent>
             </InvestigationCanvas>
           </Layout.Main>
         </Layout.Body>
@@ -477,10 +479,10 @@ function AddCellComposer({
     return (
       <AddCellActions align="center" justify="center" gap="sm">
         <Button size="sm" icon={<IconAdd />} onClick={() => setKind('text')}>
-          {t('Text cell')}
+          {t('Add text cell (debug only)')}
         </Button>
         <Button size="sm" icon={<IconAdd />} onClick={() => setKind('query')}>
-          {t('Query cell')}
+          {t('Add query cell (debug only)')}
         </Button>
       </AddCellActions>
     );
@@ -490,7 +492,9 @@ function AddCellComposer({
     <CellComposer>
       <Stack gap="md">
         <Heading as="h2" size="md">
-          {kind === 'text' ? t('Add text cell') : t('Add query cell')}
+          {kind === 'text'
+            ? t('Add text cell (debug only)')
+            : t('Add query cell (debug only)')}
         </Heading>
         <Input
           aria-label={t('Cell title')}
@@ -552,7 +556,7 @@ function formatSourceType(sourceType: string) {
 
 function formatStatus(status: string) {
   if (status === 'active') {
-    return t('Completed');
+    return t('Active');
   }
   return status.replaceAll('_', ' ').replace(/^./, character => character.toUpperCase());
 }
@@ -572,6 +576,11 @@ function getStatusVariant(status: string): 'success' | 'warning' | 'muted' {
 }
 
 const InvestigationCanvas = styled(Stack)`
+  width: min(100%, calc(884px + ${p => p.theme.space['2xl']}));
+  margin: 0 auto;
+`;
+
+const NotebookContent = styled(Stack)`
   width: min(100%, 884px);
   margin: 0 auto;
 `;
@@ -580,6 +589,7 @@ const InvestigationHeader = styled(Container)`
   position: relative;
 
   &::after {
+    /* The specified divider is intentionally as subtle as the secondary surface. */
     content: '';
     position: absolute;
     inset: auto 0 0;
@@ -589,8 +599,7 @@ const InvestigationHeader = styled(Container)`
 `;
 
 const NotebookSummaryCard = styled(InvestigationSummaryCard)`
-  width: calc(100% + ${p => p.theme.space['2xl']});
-  margin-inline: calc(-1 * ${p => p.theme.space.lg});
+  width: 100%;
   margin-bottom: ${p => p.theme.space.xl};
   padding-inline: ${p => p.theme.space.xl};
 `;


### PR DESCRIPTION
Investigation notebooks now focus on work that has started: auto-run cells waiting on dependencies remain hidden and appear once their execution begins. Active cells automatically open their live Seer steps, while generated query evidence starts collapsed.

Manual query cells keep their existing expanded default, and closing an active trace remains respected until a new execution starts.
