### PR TITLE
feat(auth): add signup_method to signup verification analytics, add logs, metrics, analytics to sso email verification required feature

### DIFF
--- a/src/sentry/analytics/events/signup_email_verification.py
+++ b/src/sentry/analytics/events/signup_email_verification.py
@@ -1,10 +1,18 @@
 from sentry import analytics
 
 
+@analytics.eventclass("signup_email_verification.sent")
+class SignupEmailVerificationSentEvent(analytics.Event):
+    email_hash: str
+    signup_method: str
+
+
 @analytics.eventclass("signup_email_verification.clicked")
 class SignupEmailVerificationClickedEvent(analytics.Event):
     email_hash: str
     outcome: str  # "success", "expired", "tampered", "session_mismatch"
+    signup_method: str
 
 
+analytics.register(SignupEmailVerificationSentEvent)
 analytics.register(SignupEmailVerificationClickedEvent)

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -10,7 +10,9 @@ from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired
 from django.urls import reverse
 
-from sentry import options
+from sentry import analytics, options
+from sentry import ratelimits as ratelimiter
+from sentry.analytics.events.signup_email_verification import SignupEmailVerificationSentEvent
 from sentry.utils.dates import format_duration
 from sentry.utils.email import MessageBuilder
 from sentry.utils.hashlib import sha256_text
@@ -46,10 +48,23 @@ def is_email_verified_by_trusted_provider(provider_key: str, identity: Mapping[s
     )
 
 
+def is_verification_send_rate_limited(email: str, email_hash: str | None = None) -> bool:
+    """Throttle verification email sends per email address, across all signup methods.
+
+    Pass email_hash if the caller has already hashed the email, to avoid re-hashing it.
+    """
+    email_hash = email_hash or hash_email(email)
+    return ratelimiter.backend.is_limited(
+        f"signup-verify-send:email:{email_hash}", limit=5, window=300
+    )
+
+
 def send_signup_verification_email(
     email: str,
     url_name: str,
     max_age_minutes: int = DEFAULT_MAX_AGE_MINUTES,
+    record_analytics: bool = True,
+    email_hash: str | None = None,
 ) -> None:
     """
     Send a verification email for signup flows.
@@ -60,6 +75,10 @@ def send_signup_verification_email(
 
     url_name controls which verification endpoint the link points to,
     allowing different signup methods to have their own completion logic.
+
+    The record_analytics arg is temporary, only needed while we run the email+pword experiment.
+
+    Pass email_hash if the caller has already hashed the email, to avoid re-hashing it.
     """
     payload = {
         "email": email,
@@ -85,13 +104,18 @@ def send_signup_verification_email(
     )
     msg.send_async([email])
 
+    email_hash = email_hash or hash_email(email)
     logger.info(
         "signup_verification.sent",
         extra={
-            "email_hash": hash_email(email),
+            "email_hash": email_hash,
             "signup_method": url_name,
         },
     )
+    if record_analytics:
+        analytics.record(
+            SignupEmailVerificationSentEvent(email_hash=email_hash, signup_method=url_name)
+        )
 
 
 def verify_signup_link(signed_data: str) -> dict[str, Any]:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -23,13 +23,13 @@ from django.utils.translation import gettext_lazy as _
 
 from flagpole.conditions import glob_star_match
 from sentry import audit_log, features, options
-from sentry import ratelimits as ratelimiter
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.email_verification import (
     hash_email,
     is_email_verified_by_trusted_provider,
+    is_verification_send_rate_limited,
     send_signup_verification_email,
 )
 from sentry.auth.exceptions import (
@@ -127,13 +127,6 @@ def _sso_verification_required(email: str) -> bool:
     in_allowlist = any(glob_star_match(p, email) for p in force_emails)
 
     return features.has("auth:email-verification-at-sso-signup") or in_allowlist
-
-
-def _sso_verification_send_rate_limited(email: str) -> bool:
-    """Throttle verification email sends per email address"""
-    return ratelimiter.backend.is_limited(
-        f"signup-verify-send:email:{hash_email(email)}", limit=5, window=300
-    )
 
 
 @dataclass
@@ -581,9 +574,9 @@ class AuthIdentityHandler:
         If rate limited, match the rate limit response in BaseSignupVerificationView.
         """
         if not getattr(state, "verification_email_sent", False):
-            if _sso_verification_send_rate_limited(email):
+            if is_verification_send_rate_limited(email):
                 logger.warning(
-                    "sso_signup.verification_send_rate_limited",
+                    "sso_signup_verification.send_rate_limited",
                     extra={"email_hash": hash_email(email)},
                 )
                 return self._respond(

--- a/src/sentry/web/frontend/signup_email_verification.py
+++ b/src/sentry/web/frontend/signup_email_verification.py
@@ -15,6 +15,7 @@ from sentry.analytics.events.signup_email_verification import (
     SignupEmailVerificationClickedEvent,
 )
 from sentry.auth.email_verification import SignupLinkExpired, hash_email, verify_signup_link
+from sentry.utils import metrics
 from sentry.web.frontend.base import BaseView
 
 PENDING_VERIFICATION_SESSION_KEY = "pending_signup_verification_email"
@@ -37,18 +38,41 @@ class BaseSignupVerificationView(BaseView):
     method-specific completion logic.
     """
 
-    auth_required = False
+    auth_required: bool = False
+    record_analytics: bool = True
 
-    @staticmethod
-    def _record_clicked(request: HttpRequest, outcome: str, email: str | None = None) -> None:
+    @property
+    def signup_method(self) -> str:
+        resolver_match = self.request.resolver_match
+        assert resolver_match is not None and resolver_match.url_name is not None
+        return resolver_match.url_name
+
+    def _record_clicked(self, request: HttpRequest, outcome: str, email: str | None = None) -> None:
         if email is None:
             email = request.session.get(PENDING_VERIFICATION_SESSION_KEY, "")
         email_hash = hash_email(email) if email else ""
-        analytics.record(
-            SignupEmailVerificationClickedEvent(
-                email_hash=email_hash,
-                outcome=outcome,
+        logger.info(
+            "signup_verification.clicked",
+            extra={
+                "email_hash": email_hash,
+                "outcome": outcome,
+                "signup_method": self.signup_method,
+            },
+        )
+        if self.record_analytics:
+            analytics.record(
+                SignupEmailVerificationClickedEvent(
+                    email_hash=email_hash,
+                    outcome=outcome,
+                    signup_method=self.signup_method,
+                )
             )
+
+    def _record_failure_metric(self, reason: str) -> None:
+        metrics.incr(
+            "signup_verification.failure",
+            tags={"reason": reason, "signup_method": self.signup_method},
+            skip_internal=False,
         )
 
     def _render_error(self, title: str, message: str) -> HttpResponseBase:
@@ -103,7 +127,7 @@ class BaseSignupVerificationView(BaseView):
 
         logger.info(
             "signup_verification.verified",
-            extra={"email_hash": hash_email(email)},
+            extra={"email_hash": hash_email(email), "signup_method": self.signup_method},
         )
         self._record_clicked(request, "success", email=email)
 

--- a/src/sentry/web/frontend/sso_signup_verification.py
+++ b/src/sentry/web/frontend/sso_signup_verification.py
@@ -31,9 +31,16 @@ class SSOSignupVerificationView(BaseSignupVerificationView):
     and login via its normal code path.
     """
 
+    record_analytics = False
+
     def handle_verified_email(self, request: HttpRequest, verified_email: str) -> HttpResponseBase:
         helper = AuthHelper.get_for_request(request)
         if not helper:
+            logger.warning(
+                "sso_signup_verification.pipeline_not_found",
+                extra={"email_hash": hash_email(verified_email)},
+            )
+            self._record_failure_metric("pipeline_not_found")
             return self._render_error(
                 title="Signup error",
                 message="Could not find your signup data. It may have expired. Please restart the signup process.",
@@ -46,6 +53,7 @@ class SSOSignupVerificationView(BaseSignupVerificationView):
                 "sso_signup_verification.state_expired",
                 extra={"email_hash": hash_email(verified_email)},
             )
+            self._record_failure_metric("state_expired")
             return self._render_error(
                 title="Signup error",
                 message="Your session has expired. Please restart the signup process.",
@@ -60,6 +68,7 @@ class SSOSignupVerificationView(BaseSignupVerificationView):
                 "sso_signup_verification.identity_not_valid",
                 extra={"email_hash": hash_email(verified_email)},
             )
+            self._record_failure_metric("identity_not_valid")
             return self._render_error(
                 title="Signup error",
                 message="Something went wrong. Please restart the signup process.",
@@ -73,6 +82,7 @@ class SSOSignupVerificationView(BaseSignupVerificationView):
                     "identity_email_hash": hash_email(identity["email"]),
                 },
             )
+            self._record_failure_metric("email_mismatch")
             return self._render_error(
                 title="Verification error",
                 message="Email mismatch. Please restart the signup process.",
@@ -81,5 +91,11 @@ class SSOSignupVerificationView(BaseSignupVerificationView):
         helper.state.verified_email = verified_email
         request.session.pop(PENDING_VERIFICATION_SESSION_KEY, None)
         request.session.pop(PENDING_EXPIRY_TEXT_SESSION_KEY, None)
+
+        email_hash = hash_email(verified_email)
+        logger.info(
+            "sso_signup_verification.verification_complete",
+            extra={"email_hash": email_hash},
+        )
 
         return HttpResponseRedirect(reverse("sentry-auth-sso"))

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1597,7 +1597,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
 
         mock_send.assert_called_once()
 
-    @mock.patch("sentry.auth.helper.ratelimiter")
+    @mock.patch("sentry.auth.email_verification.ratelimiter")
     @mock.patch("sentry.auth.helper.send_signup_verification_email")
     def test_rate_limited_send_shows_error_instead_of_pending_page(
         self, mock_send: mock.MagicMock, mock_ratelimiter: mock.MagicMock

--- a/tests/sentry/web/frontend/test_signup_email_verification.py
+++ b/tests/sentry/web/frontend/test_signup_email_verification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from typing import Any
+from unittest import mock
 
 from django.conf import settings
 from django.http import HttpRequest
@@ -9,7 +10,10 @@ from django.http.response import HttpResponseBase
 from django.test import override_settings
 from django.urls import path, reverse
 
+from sentry.analytics.events.signup_email_verification import SignupEmailVerificationClickedEvent
+from sentry.auth.email_verification import hash_email
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.signing import sign
 from sentry.web.frontend.base import control_silo_view
@@ -24,12 +28,20 @@ class _TestVerificationView(BaseSignupVerificationView):
         return self.redirect(SIGNUP_URL)
 
 
-# Wire up a test URL so we can exercise the base class
+# Wire up two test URLs, under different names, both served by the same view class.
+# signup_method is derived from request.resolver_match.url_name, so hitting each one
+# should produce a different signup_method — that's what distinguishes it from a
+# hardcoded class attribute.
 urlpatterns = [
     path(
         "auth/signup/verify-email/test/<signed_data>/",
         _TestVerificationView.as_view(),
         name="test-signup-verify-email",
+    ),
+    path(
+        "auth/signup/verify-email/test-alt/<signed_data>/",
+        _TestVerificationView.as_view(),
+        name="test-signup-verify-email-alt",
     ),
 ]
 
@@ -46,10 +58,15 @@ def _make_signed_blob(email: str = "test@example.com", expires_at: float | None 
     ROOT_URLCONF="tests.sentry.web.frontend.test_signup_email_verification",
 )
 class BaseSignupVerificationViewTest(TestCase):
-    def _get_path(self, signed_data: str) -> str:
-        return reverse("test-signup-verify-email", args=[signed_data])
+    def _get_path(self, signed_data: str, url_name: str = "test-signup-verify-email") -> str:
+        return reverse(url_name, args=[signed_data])
 
-    def _get_with_session(self, email: str = "test@example.com", **blob_kwargs: Any) -> Any:
+    def _get_with_session(
+        self,
+        email: str = "test@example.com",
+        url_name: str = "test-signup-verify-email",
+        **blob_kwargs: Any,
+    ) -> Any:
         session = self.client.session
         session["pending_signup_verification_email"] = email
         session.save()
@@ -58,7 +75,7 @@ class BaseSignupVerificationViewTest(TestCase):
 
         signed = _make_signed_blob(email=email, **blob_kwargs)
 
-        return self.client.get(self._get_path(signed))
+        return self.client.get(self._get_path(signed, url_name=url_name))
 
     def test_expired_link_renders_error_page(self) -> None:
         resp = self._get_with_session(expires_at=time.time() - 1)
@@ -87,3 +104,29 @@ class BaseSignupVerificationViewTest(TestCase):
     def test_valid_link_redirects(self) -> None:
         resp = self._get_with_session(email="user@example.com")
         assert resp.status_code == 302
+
+    @mock.patch("sentry.analytics.record")
+    def test_signup_method_reflects_resolved_url_name(self, mock_record: mock.MagicMock) -> None:
+        resp = self._get_with_session(email="user@example.com", url_name="test-signup-verify-email")
+        assert resp.status_code == 302
+        assert_last_analytics_event(
+            mock_record,
+            SignupEmailVerificationClickedEvent(
+                email_hash=hash_email("user@example.com"),
+                outcome="success",
+                signup_method="test-signup-verify-email",
+            ),
+        )
+
+        resp = self._get_with_session(
+            email="other-user@example.com", url_name="test-signup-verify-email-alt"
+        )
+        assert resp.status_code == 302
+        assert_last_analytics_event(
+            mock_record,
+            SignupEmailVerificationClickedEvent(
+                email_hash=hash_email("other-user@example.com"),
+                outcome="success",
+                signup_method="test-signup-verify-email-alt",
+            ),
+        )


### PR DESCRIPTION
TLDR: adding metrics + logs for tracking email verification required feature for SSO signup. Email + pword uses `analytics` because we are running an experiment on that method - SSO does not need this and should not pollute the results.

Add a `signup_method` field to the signup verification failure metrics so SSO and password-based signups can be told apart in dashboards, instead of being lumped into one undifferentiated "signup_verification.failure" bucket. 

Adds a "sent" event alongside the existing "clicked" one, and a new completion event for the SSO flow.

Introduces a shared `_record_failure_metric helper` on `BaseSignupVerificationView` to replace the metrics.incr calls duplicated across the SSO and password views.

Also renames the SSO verification-email rate-limit warning log to match the rest of that flow's log keys, and generalizes the per-email send throttle into `email_verification.is_verification_send_rate_limited` so the getsentry password signup flow can share it.