### PR TITLE
fix(hybridcloud): Scope webhook mailboxes to their destination cell

### DIFF
--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -113,13 +113,9 @@ class WebhookPayload(Model):
         integration_id: int | None = None,
     ) -> Self:
         metrics.incr("hybridcloud.deliver_webhooks.saved", tags={"provider": provider})
-        # The mailbox is scoped to its destination cell so an integration whose
-        # organizations span cells gets one mailbox per cell. The copies then
-        # drain independently instead of interleaving in one mailbox, where a
-        # single drain serializes deliveries to every cell and one cell's
-        # failure backoffs delay the others' copies. The cell rides in the
-        # middle so the first segment stays the provider and the last stays the
-        # event type for the providers that suffix one.
+        # One mailbox per destination cell, so each cell's copies drain
+        # independently. The cell rides in the middle: the first segment stays
+        # the provider, the last the event type for providers that suffix one.
         mailbox_name = f"{provider}:{cell}:{identifier}" if cell else f"{provider}:{identifier}"
         return cls.objects.create(
             mailbox_name=mailbox_name,

--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -8,6 +8,7 @@ from django.db.models import Q, TextChoices
 from django.http import HttpRequest
 from django.utils import timezone
 
+from sentry import options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, control_silo_model, sane_repr
 from sentry.utils import json, metrics
@@ -113,8 +114,19 @@ class WebhookPayload(Model):
         integration_id: int | None = None,
     ) -> Self:
         metrics.incr("hybridcloud.deliver_webhooks.saved", tags={"provider": provider})
+        if cell and options.get("hybridcloud.webhookpayload.cell_scoped_mailboxes"):
+            # Scope the mailbox to its destination cell so an integration whose
+            # organizations span cells gets one mailbox per cell. The copies then
+            # drain independently instead of interleaving in one mailbox, where a
+            # single drain serializes deliveries to every cell and one cell's
+            # failure backoffs delay the others' copies. The cell rides in the
+            # middle so the first segment stays the provider and the last stays
+            # the event type for the providers that suffix one.
+            mailbox_name = f"{provider}:{cell}:{identifier}"
+        else:
+            mailbox_name = f"{provider}:{identifier}"
         return cls.objects.create(
-            mailbox_name=f"{provider}:{identifier}",
+            mailbox_name=mailbox_name,
             provider=provider,
             destination_type=destination_type,
             cell_name=cell,

--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -8,7 +8,6 @@ from django.db.models import Q, TextChoices
 from django.http import HttpRequest
 from django.utils import timezone
 
-from sentry import options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, control_silo_model, sane_repr
 from sentry.utils import json, metrics
@@ -114,17 +113,14 @@ class WebhookPayload(Model):
         integration_id: int | None = None,
     ) -> Self:
         metrics.incr("hybridcloud.deliver_webhooks.saved", tags={"provider": provider})
-        if cell and options.get("hybridcloud.webhookpayload.cell_scoped_mailboxes"):
-            # Scope the mailbox to its destination cell so an integration whose
-            # organizations span cells gets one mailbox per cell. The copies then
-            # drain independently instead of interleaving in one mailbox, where a
-            # single drain serializes deliveries to every cell and one cell's
-            # failure backoffs delay the others' copies. The cell rides in the
-            # middle so the first segment stays the provider and the last stays
-            # the event type for the providers that suffix one.
-            mailbox_name = f"{provider}:{cell}:{identifier}"
-        else:
-            mailbox_name = f"{provider}:{identifier}"
+        # The mailbox is scoped to its destination cell so an integration whose
+        # organizations span cells gets one mailbox per cell. The copies then
+        # drain independently instead of interleaving in one mailbox, where a
+        # single drain serializes deliveries to every cell and one cell's
+        # failure backoffs delay the others' copies. The cell rides in the
+        # middle so the first segment stays the provider and the last stays the
+        # event type for the providers that suffix one.
+        mailbox_name = f"{provider}:{cell}:{identifier}" if cell else f"{provider}:{identifier}"
         return cls.objects.create(
             mailbox_name=mailbox_name,
             provider=provider,

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -174,9 +174,7 @@ class BaseRequestParser(ABC):
             return HttpResponse(status=status.HTTP_202_ACCEPTED)
 
         shard_identifier = identifier or self.webhook_identifier.value
-        # Create all payloads first, then trigger one drain per mailbox — each
-        # cell's copy queues under its own cell-scoped mailbox and drains
-        # independently.
+        # Create all payloads first, then trigger one drain per (cell-scoped) mailbox.
         payloads = [
             WebhookPayload.create_from_request(
                 destination_type=DestinationType.SENTRY_CELL,

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -174,8 +174,9 @@ class BaseRequestParser(ABC):
             return HttpResponse(status=status.HTTP_202_ACCEPTED)
 
         shard_identifier = identifier or self.webhook_identifier.value
-        # mailbox_name is provider:identifier, which is constant for all cells in
-        # this loop. Create all payloads first, then trigger a single drain.
+        # Create all payloads first, then trigger one drain per mailbox. With
+        # cell-scoped mailboxes each cell queues under its own name; otherwise
+        # every payload shares one name and the set keeps it to a single drain.
         payloads = [
             WebhookPayload.create_from_request(
                 destination_type=DestinationType.SENTRY_CELL,
@@ -187,8 +188,8 @@ class BaseRequestParser(ABC):
             )
             for cell in cells
         ]
-        if payloads:
-            maybe_trigger_drain(payloads[0].mailbox_name)
+        for mailbox_name in {payload.mailbox_name for payload in payloads}:
+            maybe_trigger_drain(mailbox_name)
 
         return HttpResponse(status=status.HTTP_202_ACCEPTED)
 

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -174,9 +174,9 @@ class BaseRequestParser(ABC):
             return HttpResponse(status=status.HTTP_202_ACCEPTED)
 
         shard_identifier = identifier or self.webhook_identifier.value
-        # Create all payloads first, then trigger one drain per mailbox. With
-        # cell-scoped mailboxes each cell queues under its own name; otherwise
-        # every payload shares one name and the set keeps it to a single drain.
+        # Create all payloads first, then trigger one drain per mailbox — each
+        # cell's copy queues under its own cell-scoped mailbox and drains
+        # independently.
         payloads = [
             WebhookPayload.create_from_request(
                 destination_type=DestinationType.SENTRY_CELL,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2550,6 +2550,17 @@ register(
     ],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Scope webhook mailboxes to their destination cell. An integration whose
+# organizations span cells stores one payload per cell; without the cell in the
+# mailbox name those copies interleave in one mailbox, so a single drain
+# serializes deliveries to every cell and one cell's failure backoffs delay the
+# others' copies. Flipping this only changes the names newly stored payloads
+# queue under — rows already stored keep draining from their old mailbox.
+register(
+    "hybridcloud.webhookpayload.cell_scoped_mailboxes",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Drops GitHub check webhooks that reference no pull request based in their own
 # repo (see ActionFilter.own_repo_pr_actions). The predicate reads payload shape
 # rather than a header, so it keeps a switch: setting this false stops the drop

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2550,17 +2550,6 @@ register(
     ],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Scope webhook mailboxes to their destination cell. An integration whose
-# organizations span cells stores one payload per cell; without the cell in the
-# mailbox name those copies interleave in one mailbox, so a single drain
-# serializes deliveries to every cell and one cell's failure backoffs delay the
-# others' copies. Flipping this only changes the names newly stored payloads
-# queue under — rows already stored keep draining from their old mailbox.
-register(
-    "hybridcloud.webhookpayload.cell_scoped_mailboxes",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Drops GitHub check webhooks that reference no pull request based in their own
 # repo (see ActionFilter.own_repo_pr_actions). The predicate reads payload shape
 # rather than a header, so it keeps a switch: setting this false stops the drop

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -78,13 +78,17 @@ def assert_webhook_payloads_for_mailbox(
      the given request
 
     :param request:
-    :param mailbox_name: The mailbox name that messages should be found in.
+    :param mailbox_name: The cell-less `<provider>:<identifier>` mailbox name.
+        Payloads queue under the cell-scoped `<provider>:<cell>:<identifier>`
+        variant, which this helper derives per cell.
     :param cell_names: List of cells each messages should be queued for
     :param destination_types: Optional Mapping of destination types to the number of messages that should be found for that destination type
     """
     expected_payload = WebhookPayload.get_attributes_from_request(request=request)
     cell_names_set = set(cell_names)
-    messages = WebhookPayload.objects.filter(mailbox_name=mailbox_name)
+    provider, _, identifier = mailbox_name.partition(":")
+    expected_mailboxes = {f"{provider}:{cell}:{identifier}" for cell in cell_names_set}
+    messages = WebhookPayload.objects.filter(mailbox_name__in=expected_mailboxes)
     messages_with_cell_count = messages.filter(cell_name__isnull=False).count()
     if messages_with_cell_count != len(cell_names_set):
         raise Exception(

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -78,9 +78,8 @@ def assert_webhook_payloads_for_mailbox(
      the given request
 
     :param request:
-    :param mailbox_name: The cell-less `<provider>:<identifier>` mailbox name.
-        Payloads queue under the cell-scoped `<provider>:<cell>:<identifier>`
-        variant, which this helper derives per cell.
+    :param mailbox_name: The cell-less `<provider>:<identifier>` name; the
+        cell-scoped variant is derived per cell.
     :param cell_names: List of cells each messages should be queued for
     :param destination_types: Optional Mapping of destination types to the number of messages that should be found for that destination type
     """

--- a/tests/sentry/hybridcloud/models/test_webhookpayload.py
+++ b/tests/sentry/hybridcloud/models/test_webhookpayload.py
@@ -10,7 +10,9 @@ from sentry.hybridcloud.models.webhookpayload import (
     MAX_ATTEMPTS,
     DestinationType,
 )
+from sentry.hybridcloud.webhook_event_types import event_type_from_mailbox
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -40,6 +42,28 @@ class WebhookPayloadTest(TestCase):
             == '{"Cookie":"","Content-Length":"36","Content-Type":"application/json"}'
         )
         assert hook.request_body == '{"installation": {"id": "github:1"}}'
+
+    @override_options({"hybridcloud.webhookpayload.cell_scoped_mailboxes": True})
+    def test_create_from_request_cell_scoped(self) -> None:
+        factory = RequestFactory()
+        request = factory.post(
+            "/extensions/github/webhook/",
+            data={"installation": {"id": "github:1"}},
+            content_type="application/json",
+        )
+        hook = WebhookPayload.create_from_request(
+            destination_type=DestinationType.SENTRY_CELL,
+            cell="us",
+            provider="github",
+            identifier="123:45:check_run",
+            request=request,
+            integration_id=123,
+        )
+        # The cell rides in the middle: the first segment stays the provider and
+        # the last stays the event type for providers that suffix one.
+        assert hook.mailbox_name == "github:us:123:45:check_run"
+        assert hook.cell_name == "us"
+        assert event_type_from_mailbox("github", hook.mailbox_name) == "check_run"
 
     def test_schedule_next_attempt_moves_forward(self) -> None:
         hook = self.create_webhook_payload("jira:123", "us")

--- a/tests/sentry/hybridcloud/models/test_webhookpayload.py
+++ b/tests/sentry/hybridcloud/models/test_webhookpayload.py
@@ -12,7 +12,6 @@ from sentry.hybridcloud.models.webhookpayload import (
 )
 from sentry.hybridcloud.webhook_event_types import event_type_from_mailbox
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -33,7 +32,7 @@ class WebhookPayloadTest(TestCase):
             request=request,
             integration_id=123,
         )
-        assert hook.mailbox_name == "github:123"
+        assert hook.mailbox_name == "github:us:123"
         assert hook.provider == "github"
         assert hook.request_method == request.method
         assert hook.request_path == request.get_full_path()
@@ -43,7 +42,6 @@ class WebhookPayloadTest(TestCase):
         )
         assert hook.request_body == '{"installation": {"id": "github:1"}}'
 
-    @override_options({"hybridcloud.webhookpayload.cell_scoped_mailboxes": True})
     def test_create_from_request_cell_scoped(self) -> None:
         factory = RequestFactory()
         request = factory.post(

--- a/tests/sentry/hybridcloud/models/test_webhookpayload.py
+++ b/tests/sentry/hybridcloud/models/test_webhookpayload.py
@@ -57,8 +57,6 @@ class WebhookPayloadTest(TestCase):
             request=request,
             integration_id=123,
         )
-        # The cell rides in the middle: the first segment stays the provider and
-        # the last stays the event type for providers that suffix one.
         assert hook.mailbox_name == "github:us:123:45:check_run"
         assert hook.cell_name == "us"
         assert event_type_from_mailbox("github", hook.mailbox_name) == "check_run"

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -17,6 +17,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.types.cell import Cell
 
 
@@ -128,6 +129,49 @@ class BaseRequestParserTest(TestCase):
             assert payload.request_path
             assert payload.request_method
             assert payload.destination_type == DestinationType.SENTRY_CELL
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_options({"hybridcloud.webhookpayload.cell_scoped_mailboxes": True})
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    def test_get_response_from_webhookpayload_cell_scoped_mailboxes(
+        self, mock_trigger: MagicMock
+    ) -> None:
+        class MockParser(BaseRequestParser):
+            webhook_identifier = WebhookProviderIdentifier.SLACK
+            provider = "slack"
+
+        parser = MockParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(cells=self.region_config)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        # Each cell's copy queues under its own mailbox and gets its own drain
+        # trigger, so the copies deliver independently.
+        payloads = WebhookPayload.objects.all()
+        assert {(payload.cell_name, payload.mailbox_name) for payload in payloads} == {
+            ("us", "slack:us:0"),
+            ("eu", "slack:eu:0"),
+        }
+        assert {call[0][0] for call in mock_trigger.call_args_list} == {
+            "slack:us:0",
+            "slack:eu:0",
+        }
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    def test_get_response_from_webhookpayload_shared_mailbox_single_trigger(
+        self, mock_trigger: MagicMock
+    ) -> None:
+        class MockParser(BaseRequestParser):
+            webhook_identifier = WebhookProviderIdentifier.SLACK
+            provider = "slack"
+
+        parser = MockParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(cells=self.region_config)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        # Without cell scoping every copy shares one mailbox, so only one drain
+        # is triggered for the batch.
+        mock_trigger.assert_called_once_with("slack:0")
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_get_organizations_from_integration_success(self) -> None:

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -17,7 +17,6 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.types.cell import Cell
 
 
@@ -125,15 +124,15 @@ class BaseRequestParserTest(TestCase):
         assert len(payloads) == 2
         for payload in payloads:
             assert payload.cell_name in ["us", "eu"]
-            assert payload.mailbox_name == "slack:0"
+            # Each cell's copy queues under its own cell-scoped mailbox.
+            assert payload.mailbox_name == f"slack:{payload.cell_name}:0"
             assert payload.request_path
             assert payload.request_method
             assert payload.destination_type == DestinationType.SENTRY_CELL
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"hybridcloud.webhookpayload.cell_scoped_mailboxes": True})
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    def test_get_response_from_webhookpayload_cell_scoped_mailboxes(
+    def test_get_response_from_webhookpayload_triggers_drain_per_mailbox(
         self, mock_trigger: MagicMock
     ) -> None:
         class MockParser(BaseRequestParser):
@@ -155,23 +154,6 @@ class BaseRequestParserTest(TestCase):
             "slack:us:0",
             "slack:eu:0",
         }
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    def test_get_response_from_webhookpayload_shared_mailbox_single_trigger(
-        self, mock_trigger: MagicMock
-    ) -> None:
-        class MockParser(BaseRequestParser):
-            webhook_identifier = WebhookProviderIdentifier.SLACK
-            provider = "slack"
-
-        parser = MockParser(self.request, self.response_handler)
-
-        response = parser.get_response_from_webhookpayload(cells=self.region_config)
-        assert response.status_code == status.HTTP_202_ACCEPTED
-        # Without cell scoping every copy shares one mailbox, so only one drain
-        # is triggered for the batch.
-        mock_trigger.assert_called_once_with("slack:0")
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_get_organizations_from_integration_success(self) -> None:

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -124,7 +124,6 @@ class BaseRequestParserTest(TestCase):
         assert len(payloads) == 2
         for payload in payloads:
             assert payload.cell_name in ["us", "eu"]
-            # Each cell's copy queues under its own cell-scoped mailbox.
             assert payload.mailbox_name == f"slack:{payload.cell_name}:0"
             assert payload.request_path
             assert payload.request_method
@@ -143,8 +142,7 @@ class BaseRequestParserTest(TestCase):
 
         response = parser.get_response_from_webhookpayload(cells=self.region_config)
         assert response.status_code == status.HTTP_202_ACCEPTED
-        # Each cell's copy queues under its own mailbox and gets its own drain
-        # trigger, so the copies deliver independently.
+        # One mailbox and one drain trigger per cell.
         payloads = WebhookPayload.objects.all()
         assert {(payload.cell_name, payload.mailbox_name) for payload in payloads} == {
             ("us", "slack:us:0"),


### PR DESCRIPTION
## Problem

An integration whose organizations span cells stores one payload copy per cell, but the mailbox name has no cell — all copies interleave in one mailbox. A single drain then serializes deliveries to every cell, and one cell's failure backoff delays the other cells' copies queued behind it. Observed in production as a deep mailbox that was two equal us/de halves of one stream.

## Change

Payloads with a destination cell queue under `<provider>:<cell>:<identifier>` — one independently draining mailbox per cell. The cell rides in the middle, so provider-first and event-type-last name parsing are unchanged. The receipt path triggers a drain per distinct mailbox. `assert_webhook_payloads_for_mailbox` derives the per-cell names from the cell-less name callers pass, keeping all 35 call sites unchanged.

## Deploy safety

Only newly stored payloads get the new names; existing rows drain from their old mailbox until it empties, and a revert is symmetric — hence no option. During the transition a stream briefly splits across old/new names, interleaving ordering once, within the weaker guarantee skip-on-failure providers already run with.

Related: #122686 — same investigation, independent change.