### PR TITLE
feat(hybridcloud): Overselect scheduler heads to hit the dispatch target

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -68,7 +68,16 @@ but not at the timeout threshold
 """
 
 BATCH_SIZE = 1000
-"""The number of mailboxes that will have messages scheduled each cycle"""
+"""The number of mailboxes a scheduler cycle aims to dispatch drains for."""
+
+BATCH_SELECT_LIMIT = BATCH_SIZE * 2
+"""
+How many due mailbox heads a scheduler cycle selects to reach BATCH_SIZE
+dispatches. Push triggers and concurrent cycles claim heads out of the selected
+list before the loop reaches them, so selecting exactly BATCH_SIZE shrinks the
+cycle below its target by whatever the contention share is. Contention beyond
+the surplus leaves the remainder to the next cycle.
+"""
 
 
 MAX_DELIVERY_AGE = datetime.timedelta(days=3)
@@ -408,13 +417,13 @@ def schedule_webhook_delivery() -> None:
         .values("id", "mailbox_name")
     )
 
-    records = list(scheduled_mailboxes[:BATCH_SIZE])
-    # The dispatch batch already answers the metric for every normal cycle. Only
+    records = list(scheduled_mailboxes[:BATCH_SELECT_LIMIT])
+    # The selected batch already answers the metric for every normal cycle. Only
     # when it fills is the real number unknown, and only then is re-running the
     # head-of-line discovery worth it -- those wide cycles are the ones worth seeing.
     # `source` records which branch produced the value, so the share of cycles
     # still paying for the count query is visible rather than inferred.
-    batch_full = len(records) == BATCH_SIZE
+    batch_full = len(records) == BATCH_SELECT_LIMIT
     mailbox_count = scheduled_mailboxes.count() if batch_full else len(records)
     metrics.distribution(
         "hybridcloud.schedule_webhook_delivery.mailbox_count",
@@ -422,11 +431,20 @@ def schedule_webhook_delivery() -> None:
         tags={"source": "count_query" if batch_full else "batch"},
     )
 
+    dispatched = 0
     for record in records:
+        if dispatched >= BATCH_SIZE:
+            # Dispatch target reached; surplus heads stay due for the next cycle.
+            break
         mailbox_name = record["mailbox_name"]
+        skip_tags = {"provider": _provider_from_mailbox(mailbox_name)}
         try:
             if not cache.add(_drain_lock_key(mailbox_name), 1, timeout=DRAIN_LOCK_TTL):
                 # Another dispatcher is mid-claim for this mailbox; it will dispatch.
+                metrics.incr(
+                    "hybridcloud.deliver_webhooks.scheduler.skipped",
+                    tags={**skip_tags, "reason": "lock_held"},
+                )
                 continue
             lock_acquired = True
         except Exception:
@@ -434,10 +452,21 @@ def schedule_webhook_delivery() -> None:
             # proceed — just without serialization against push triggers.
             lock_acquired = False
         try:
-            _claim_and_dispatch(record["id"], mailbox_name, dispatcher=Dispatcher.SCHEDULER)
+            outcome = _claim_and_dispatch(
+                record["id"], mailbox_name, dispatcher=Dispatcher.SCHEDULER
+            )
         finally:
             if lock_acquired:
                 _release_drain_lock(mailbox_name)
+        if outcome is DispatchOutcome.NOT_DUE:
+            # Claimed out of the list between discovery and here, usually by a
+            # push trigger.
+            metrics.incr(
+                "hybridcloud.deliver_webhooks.scheduler.skipped",
+                tags={**skip_tags, "reason": "claim_lost"},
+            )
+        else:
+            dispatched += 1
 
 
 @instrumented_task(

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -367,6 +367,79 @@ class ScheduleWebhooksTest(TestCase):
         # Null provider (default priority) should be last
         assert call_args_list[1] == null_provider_webhook.id
 
+    def scheduler_skips(self, mock_metrics: MagicMock) -> list[dict[str, str]]:
+        return [
+            c[1]["tags"]
+            for c in mock_metrics.incr.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.scheduler.skipped"
+        ]
+
+    @patch.object(deliver_webhooks, "BATCH_SIZE", 2)
+    @patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 4)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_schedule_overselect_covers_mailboxes_lost_to_other_dispatchers(
+        self, mock_drain: MagicMock
+    ) -> None:
+        webhooks = [
+            self.create_webhook_payload(mailbox_name=f"github:{i}", cell_name="us")
+            for i in range(3)
+        ]
+        # A dispatcher is mid-claim on the first mailbox; the surplus select must
+        # let the cycle still reach its dispatch target.
+        cache.set(f"wh:drain_active:{webhooks[0].mailbox_name}", 1, timeout=DRAIN_LOCK_TTL)
+
+        schedule_webhook_delivery()
+
+        dispatched = [call[0][0] for call in mock_drain.delay.call_args_list]
+        assert dispatched == [webhooks[1].id, webhooks[2].id]
+
+    @patch.object(deliver_webhooks, "BATCH_SIZE", 2)
+    @patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 4)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_schedule_stops_at_dispatch_target(self, mock_drain: MagicMock) -> None:
+        webhooks = [
+            self.create_webhook_payload(mailbox_name=f"github:{i}", cell_name="us")
+            for i in range(3)
+        ]
+
+        schedule_webhook_delivery()
+
+        dispatched = [call[0][0] for call in mock_drain.delay.call_args_list]
+        assert dispatched == [webhooks[0].id, webhooks[1].id]
+        # The surplus head is untouched — still due for the next cycle.
+        webhooks[2].refresh_from_db()
+        assert webhooks[2].schedule_for <= timezone.now()
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_schedule_records_lock_skip(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        cache.set(f"wh:drain_active:{webhook.mailbox_name}", 1, timeout=DRAIN_LOCK_TTL)
+
+        schedule_webhook_delivery()
+
+        assert mock_drain.delay.call_count == 0
+        assert self.scheduler_skips(mock_metrics) == [{"provider": "github", "reason": "lock_held"}]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks._claim_mailbox_batch", return_value=0)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_schedule_records_claim_lost(
+        self, mock_drain: MagicMock, mock_claim: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # Another dispatcher claimed the head between this cycle's discovery and
+        # its own claim, so the claim finds nothing due.
+        self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        schedule_webhook_delivery()
+
+        assert mock_drain.delay.call_count == 0
+        assert self.scheduler_skips(mock_metrics) == [
+            {"provider": "github", "reason": "claim_lost"}
+        ]
+
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:
     # Keep path aligned with provider so responses mocks aren't misleading.


### PR DESCRIPTION
## Problem

Each webhook-scheduler cycle selects exactly `BATCH_SIZE` due mailbox heads, then walks them taking the drain lock and claiming. Any head another dispatcher (usually a push trigger) claims between the select and the loop reaching it is silently skipped — no drain, no metric. In production roughly **28% of the heads a cycle selects produce no drain** (push triggers out-dispatch the scheduler ~8:1, so the selected list goes stale while the loop runs), meaning cycles effectively run well below their intended batch size exactly when there is enough backlog to fill it.

## Approach

- Select `BATCH_SELECT_LIMIT` (2× `BATCH_SIZE`) due heads and stop once `BATCH_SIZE` drains have actually been enqueued. Heads lost to contention no longer shrink the cycle; surplus heads are left untouched and stay due for the next cycle.
- Record the previously invisible skips: `hybridcloud.deliver_webhooks.scheduler.skipped` tagged `reason:lock_held` (drain lock held by another dispatcher) or `reason:claim_lost` (head claimed between discovery and this cycle's claim), plus `provider`. Until now the loss was only inferable as the gap between `schedule_webhook_delivery.mailbox_count` and `dispatch{dispatcher:scheduler}`.

The `mailbox_count` metric semantics are unchanged; its `source:batch` values can now reach the select limit before falling back to the count query, so full-batch cycles get the exact count less often.