### PR TITLE
fix(breadcrumbs): Avoid expanding the top bar

### DIFF
--- a/static/app/components/core/breadcrumbList/breadcrumbList.tsx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.tsx
@@ -123,7 +123,7 @@ export function BreadcrumbList({items}: BreadcrumbListProps) {
         containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}
         width="100%"
       >
-        <Flex as="ol" align="center" gap="xs" margin="0" wrap="nowrap">
+        <Flex as="ol" align="center" gap="xs" margin="0" padding="0" wrap="nowrap">
           {items.map((item, index) => (
             // Wide: show every item. Narrow: hide them all — 'link' parents
             // reappear in the overflow menu below; other types (e.g. 'select-projects')

--- a/static/app/components/core/breadcrumbList/breadcrumbList.tsx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.tsx
@@ -123,7 +123,7 @@ export function BreadcrumbList({items}: BreadcrumbListProps) {
         containerType={hasParentQueryContainer ? 'normal' : 'inline-size'}
         width="100%"
       >
-        <Flex as="ol" align="center" gap="xs" padding="md 0" margin="0" wrap="nowrap">
+        <Flex as="ol" align="center" gap="xs" margin="0" wrap="nowrap">
           {items.map((item, index) => (
             // Wide: show every item. Narrow: hide them all — 'link' parents
             // reappear in the overflow menu below; other types (e.g. 'select-projects')


### PR DESCRIPTION
Keeps top bars containing the new `BreadcrumbList` aligned with the fixed-height
secondary navigation header by removing redundant vertical padding from the
breadcrumb list. The top bar remains responsible for its own spacing, while
breadcrumb labels, actions, and container-query collapsing are unchanged.

The regression became visible when the fixed top-bar height became a minimum
height in #121883: `BreadcrumbList` and `TopBar` both supplied vertical padding,
expanding a single-row header to 65px. This leaves #121883's flexible height and
wrapping behavior intact for narrow dashboard layouts.


**Before**

<img width="1352" height="103" alt="image" src="https://github.com/user-attachments/assets/1e7ab6e9-ca61-49e8-8f4e-ed25e85ba8af" />


**After**

<img width="823" height="120" alt="image" src="https://github.com/user-attachments/assets/f5a6e14c-27c1-4d89-8f8f-dab493675027" />

contributes to DE-1540
