### PR TITLE
fix(ai-monitoring): Refresh active conversation metadata

### DIFF
--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -77,6 +77,8 @@ def generate_ai_conversation_title(
 
     # Skip Seer if we already have a title from an earlier-or-equal span.
     existing = qs.first()
+    if existing is not None:
+        existing.save(update_fields=["date_updated"])
     if (
         existing is not None
         and existing.title_source_timestamp is not None

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -300,13 +300,18 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Later Title")
     def test_skips_when_existing_title_is_earlier(self, mock_generate: MagicMock) -> None:
         earlier = _ts()
-        self._create_metadata(title="Earlier Title", source_timestamp=earlier)
+        metadata = self._create_metadata(title="Earlier Title", source_timestamp=earlier)
+        stale_date_updated = datetime.now(UTC) - timedelta(days=1)
+        AIConversationMetadata.objects.filter(id=metadata.id).update(
+            date_updated=stale_date_updated
+        )
 
         generate_ai_conversation_title(**self._task_kwargs(source_timestamp=TS + 60))
 
         row = self._row()
         assert row.title == "Earlier Title"
         assert row.title_source_timestamp == earlier
+        assert row.date_updated > stale_date_updated
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Same Ts Title")


### PR DESCRIPTION
Existing conversation metadata now refreshes its update timestamp when title generation sees the conversation again, including when an earlier title means no new Seer request is needed.

This lets future retention cleanup distinguish active conversations from metadata that is no longer queryable.

Refs TET-2722