### PR TITLE
feat(ai-monitoring): Register conversation metadata cleanup

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -792,6 +792,7 @@ def remove_cross_project_bulk_query_models(
 def generate_bulk_query_deletes() -> list[tuple[type[BaseModel], str, str | None]]:
     from django.apps import apps
 
+    from sentry.ai_monitoring.models import AIConversationMetadata
     from sentry.models.groupemailthread import GroupEmailThread
     from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
     from sentry.models.userreport import UserReport
@@ -806,6 +807,7 @@ def generate_bulk_query_deletes() -> list[tuple[type[BaseModel], str, str | None
         additional_bulk_query_deletes.append((model_tp, entry[1], entry[2]))
 
     BULK_QUERY_DELETES = [
+        (AIConversationMetadata, "date_updated", "date_updated"),
         (UserReport, "date_added", None),
         (GroupEmailThread, "date", None),
         (GroupOpenPeriodActivity, "date_added", None),

--- a/tests/sentry/runner/commands/test_cleanup.py
+++ b/tests/sentry/runner/commands/test_cleanup.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import click
 import pytest
 
+from sentry.ai_monitoring.models import AIConversationMetadata
 from sentry.constants import ObjectStatus
 from sentry.models.files.file import File
 from sentry.models.group import Group
@@ -24,6 +25,7 @@ from sentry.runner.commands.cleanup import (
     remove_old_notification_messages,
     run_bulk_deletes_by_project,
     run_bulk_deletes_in_deletes,
+    run_bulk_query_deletes,
     task_execution,
 )
 from sentry.seer.models.night_shift import (
@@ -271,6 +273,27 @@ class RemoveCrossProjectBulkQueryModelsTest(TestCase):
         models_after = {m for m, _, _ in bulk_query_deletes}
         assert GroupOpenPeriodActivity not in models_after
         assert WorkflowFireHistory not in models_after
+
+
+class AIConversationMetadataCleanupTest(TestCase):
+    @assume_test_silo_mode(SiloMode.CELL)
+    def test_deletes_metadata_older_than_retention(self) -> None:
+        old = self.create_ai_conversation_metadata(self.project, "old-conversation")
+        recent = self.create_ai_conversation_metadata(self.project, "recent-conversation")
+        AIConversationMetadata.objects.filter(id=old.id).update(date_updated=before_now(days=32))
+        AIConversationMetadata.objects.filter(id=recent.id).update(date_updated=before_now(days=30))
+
+        run_bulk_query_deletes(
+            generate_bulk_query_deletes(),
+            lambda model: model is not AIConversationMetadata,
+            31,
+            None,
+            None,
+            set(),
+        )
+
+        assert not AIConversationMetadata.objects.filter(id=old.id).exists()
+        assert AIConversationMetadata.objects.filter(id=recent.id).exists()
 
 
 class UptimeResponseCaptureCleanupTest(TestCase):


### PR DESCRIPTION
The cleanup command can now remove AI conversation metadata by its last update timestamp. This prepares inactive metadata for the planned 31-day retention policy without scheduling deletion yet.

Refs TET-2722