### PR TITLE
fix(trace-meta): Exclude span-sourced metrics from count

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_meta.py
+++ b/src/sentry/api/endpoints/organization_trace_meta.py
@@ -205,7 +205,12 @@ class OrganizationTraceMetaEndpoint(OrganizationEventsEndpointBase):
                     name="logs_meta",
                 ),
                 TableQuery(
-                    query_string=f"trace:{trace_id}",
+                    # Metrics tagged with `sentry.metric.source=span` are derived from spans
+                    # and are intentionally excluded from `metricsCount`.
+                    query_string=(
+                        f"trace:{trace_id} "
+                        "(!has:sentry.metric.source OR !sentry.metric.source:span)"
+                    ),
                     selected_columns=[
                         "count(value)",
                     ],

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -218,7 +218,7 @@ class OrganizationEventsTraceMetaEndpointTest(
                 )
         assert response.status_code == 400, response.content
 
-    def test_trace_metrics(self) -> None:
+    def test_trace_metrics_excludes_span_metrics(self) -> None:
         self.load_trace()
         self.load_errors(self.gen1_project, self.gen1_span_ids[0])
         self.store_eap_items(
@@ -230,16 +230,18 @@ class OrganizationEventsTraceMetaEndpointTest(
                     trace_id=self.trace_id,
                 ),
                 self.create_trace_metric(
-                    metric_name="foo",
+                    metric_name="other_source",
                     metric_value=1,
                     metric_type="counter",
                     trace_id=self.trace_id,
+                    attributes={"sentry.metric.source": "other"},
                 ),
                 self.create_trace_metric(
-                    metric_name="foo",
+                    metric_name="span_source",
                     metric_value=1000,
                     metric_type="counter",
                     trace_id=self.trace_id,
+                    attributes={"sentry.metric.source": "span"},
                 ),
             ]
         )
@@ -247,7 +249,27 @@ class OrganizationEventsTraceMetaEndpointTest(
             response = self.client_get(data={"project": -1}, url=self.url)
         assert response.status_code == 200, response.content
         data = response.data
-        assert data["metricsCount"] == 3
+        assert data["metricsCount"] == 2
+
+    def test_trace_metrics_excludes_span_only_metrics(self) -> None:
+        self.load_trace()
+        self.load_errors(self.gen1_project, self.gen1_span_ids[0])
+        self.store_eap_items(
+            [
+                self.create_trace_metric(
+                    metric_name="span_source",
+                    metric_value=1,
+                    metric_type="counter",
+                    trace_id=self.trace_id,
+                    attributes={"sentry.metric.source": "span"},
+                ),
+            ]
+        )
+        with self.feature(self.FEATURES):
+            response = self.client_get(data={"project": -1}, url=self.url)
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert data["metricsCount"] == 0
 
 
 class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, UptimeResultEAPTestCase):


### PR DESCRIPTION
## Summary

- exclude trace metrics tagged `sentry.metric.source=span` from trace meta `metricsCount`
- preserve metrics with a missing source or any non-span source
- document the behavior at the query and cover mixed-source and span-only traces

Related: #122474