### PR TITLE
feat(dynamic-sampling): Seed per-org recalibration from the served factor

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 import orjson
 import sentry_sdk
 
+from sentry.dynamic_sampling.per_org.gate import is_recalibration_served_by_per_org
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import sample_rate_to_float
 from sentry.dynamic_sampling.tasks.constants import (
@@ -31,6 +33,13 @@ if TYPE_CHECKING:
 PER_ORG_RECALIBRATION_FACTOR_CACHE_KEY = "ds::per_org:o:{org_id}:recalibration_factor"
 
 CachedTransactionSampleRates = dict[int, tuple[dict[str, float], float] | None]
+
+
+class RecalibrationSeed(StrEnum):
+    """Which pipeline's factor a recalibration step started from."""
+
+    LEGACY = "legacy"
+    PER_ORG = "per_org"
 
 
 def write_caches(config: BaseDynamicSamplingConfiguration) -> None:
@@ -144,3 +153,26 @@ def get_cached_rebalanced_transaction_sample_rates(
 
 def get_cached_recalibration_factor(org_id: int) -> float:
     return legacy_recalibration_cache.get_adjusted_factor(org_id, source="per_org_comparison")
+
+
+def get_previous_recalibration_factor(org_id: int) -> tuple[float, RecalibrationSeed]:
+    """The factor the org's next recalibration step continues from.
+
+    The step multiplies the previous factor by how far the measured rate missed the
+    target, which only converges when the previous factor is the one that produced the
+    measurement. While the per-org pipeline shadows the legacy one, its own stored factor
+    is applied by nothing, so stepping from it would compound every earlier cycle's
+    measurement difference into a value that never corrects itself. Stepping from the
+    legacy factor instead makes each shadow pass one step from the applied state, which
+    is also what the comparison log's same-seed fields measure.
+
+    Once serving applies the per-org factor, that is the applied state and the legacy
+    one stops mattering, so the step continues from the per-org cache. The shadow passes
+    have kept that cache warm, so the switch does not restart the factor at 1.0.
+    """
+    if is_recalibration_served_by_per_org(org_id):
+        return get_adjusted_factor(org_id, source="task"), RecalibrationSeed.PER_ORG
+    return (
+        legacy_recalibration_cache.get_adjusted_factor(org_id, source="per_org_seed"),
+        RecalibrationSeed.LEGACY,
+    )

--- a/src/sentry/dynamic_sampling/per_org/comparisons.py
+++ b/src/sentry/dynamic_sampling/per_org/comparisons.py
@@ -289,6 +289,7 @@ def compare_recalibration_factor_with_cache(config: BaseDynamicSamplingConfigura
             "generic_metrics_factor": cached_factor,
             "eap_factor": calculated_factor,
             "previous_eap_factor": results.previous_recalibration_factor,
+            "recalibration_seed": results.recalibration_seed,
             "total_transactions": None if org_volume is None else org_volume.total,
             "stored_segments": None if org_volume is None else org_volume.indexed,
             "eap_effective_sample_rate": get_effective_sample_rate(org_volume),

--- a/src/sentry/dynamic_sampling/per_org/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/configuration.py
@@ -117,8 +117,8 @@ class BaseDynamicSamplingConfiguration(ABC):
         if not self.projects or self.get_sample_rate() is None:
             return
 
-        results.previous_recalibration_factor = per_org_recalibration_cache.get_adjusted_factor(
-            self.organization.id, source="task"
+        results.previous_recalibration_factor, results.recalibration_seed = (
+            per_org_recalibration_cache.get_previous_recalibration_factor(self.organization.id)
         )
         results.recalibration_factor = calculate_recalibration_factor(
             org_volume,

--- a/src/sentry/dynamic_sampling/per_org/gate.py
+++ b/src/sentry/dynamic_sampling/per_org/gate.py
@@ -21,6 +21,10 @@ SLIDING_WINDOW_COMPARISON_ORG_IDS_OPTION = (
 SAMPLE_RATES_SUMMARY_LOG_ROLLOUT_RATE_OPTION = (
     "dynamic-sampling.per_org.sample-rates-summary-log-rollout-rate"
 )
+RECALIBRATION_SERVING_ORG_IDS_OPTION = "dynamic-sampling.per_org.recalibration-serving-org-ids"
+RECALIBRATION_SERVING_ROLLOUT_RATE_OPTION = (
+    "dynamic-sampling.per_org.recalibration-serving-rollout-rate"
+)
 
 
 def is_killswitch_engaged() -> bool:
@@ -45,6 +49,21 @@ def is_org_in_recalibration_rollout(org_id: int) -> bool:
 
 def is_org_in_sample_rates_summary_log_rollout(org_id: int) -> bool:
     return in_rollout_group(SAMPLE_RATES_SUMMARY_LOG_ROLLOUT_RATE_OPTION, org_id)
+
+
+def is_recalibration_served_by_per_org(org_id: int) -> bool:
+    """Whether serving applies the recalibration factor the per-org pipeline computes.
+
+    Off, serving applies the legacy factor and the per-org pipeline only shadows it. On,
+    the per-org factor drives sampling and the pipeline steps from its own factor. The
+    killswitch stops the pipeline, so it also hands the org back to the legacy factor
+    rather than leaving it on one that is no longer updated.
+    """
+    if is_killswitch_engaged():
+        return False
+    return org_id in _org_ids(RECALIBRATION_SERVING_ORG_IDS_OPTION) or in_rollout_group(
+        RECALIBRATION_SERVING_ROLLOUT_RATE_OPTION, org_id
+    )
 
 
 def metrics_sample_rate() -> float:
@@ -76,8 +95,12 @@ def transaction_volume_debug_project_ids() -> set[int]:
 
 
 def sliding_window_comparison_org_ids() -> set[int]:
+    return _org_ids(SLIDING_WINDOW_COMPARISON_ORG_IDS_OPTION)
+
+
+def _org_ids(option: str) -> set[int]:
     return {
         int(org_id)
-        for org_id in options.get(SLIDING_WINDOW_COMPARISON_ORG_IDS_OPTION)
+        for org_id in options.get(option)
         if isinstance(org_id, int) or (isinstance(org_id, str) and org_id.isdigit())
     }

--- a/src/sentry/dynamic_sampling/per_org/results.py
+++ b/src/sentry/dynamic_sampling/per_org/results.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
+from sentry.dynamic_sampling.per_org.cache import RecalibrationSeed
 from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.models.project import Project
@@ -27,4 +28,5 @@ class DynamicSamplingResults:
     projects_to_balance: list[Project] = field(default_factory=list)
     rebalanced_transactions: TransactionSampleRates = field(default_factory=dict)
     previous_recalibration_factor: float = 1.0
+    recalibration_seed: RecalibrationSeed | None = None
     recalibration_factor: float | None = None

--- a/src/sentry/dynamic_sampling/rules/biases/recalibration_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/recalibration_bias.py
@@ -1,3 +1,5 @@
+from sentry.dynamic_sampling.per_org import cache as per_org_recalibration_cache
+from sentry.dynamic_sampling.per_org.gate import is_recalibration_served_by_per_org
 from sentry.dynamic_sampling.rules.biases.base import Bias
 from sentry.dynamic_sampling.rules.utils import RESERVED_IDS, PolymorphicRule, RuleType
 from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
@@ -23,6 +25,10 @@ class RecalibrationBias(Bias):
     def generate_rules(self, project: Project, base_sample_rate: float) -> list[PolymorphicRule]:
         if is_project_mode_sampling(project.organization):
             adjusted_factor = get_adjusted_project_factor(project.id, source="serving")
+        elif is_recalibration_served_by_per_org(project.organization.id):
+            adjusted_factor = per_org_recalibration_cache.get_adjusted_factor(
+                project.organization.id, source="serving"
+            )
         else:
             adjusted_factor = get_adjusted_factor(project.organization.id, source="serving")
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2417,6 +2417,24 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Organizations whose recalibration factor serving takes from the per-org pipeline
+# instead of the legacy one. For those orgs the per-org pipeline also steps from its own
+# factor rather than the legacy one, which closes its feedback loop. Use the id list for
+# a handful of canary orgs and the rate for the wider rollout; an org is switched over
+# when either includes it. The per-org killswitch overrides both.
+register(
+    "dynamic-sampling.per_org.recalibration-serving-org-ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "dynamic-sampling.per_org.recalibration-serving-rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Organizations for which the per-org pipeline logs the EAP-vs-outcomes sliding-window
 # sample rate comparison. Empty disables the comparison entirely.
 register(

--- a/tests/sentry/dynamic_sampling/per_org/test_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_cache.py
@@ -6,9 +6,12 @@ import orjson
 
 from sentry.dynamic_sampling.per_org import cache as per_org_recalibration_cache
 from sentry.dynamic_sampling.per_org.cache import (
+    RecalibrationSeed,
+    generate_recalibrate_orgs_cache_key,
     get_cached_rebalanced_project_sample_rates,
     get_cached_rebalanced_transaction_sample_rates,
     get_cached_recalibration_factor,
+    get_previous_recalibration_factor,
     write_caches,
 )
 from sentry.dynamic_sampling.per_org.results import DynamicSamplingResults
@@ -24,6 +27,7 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
     generate_boost_low_volume_transactions_cache_key,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     DELETE_FACTOR,
     SET_FACTOR,
@@ -114,6 +118,44 @@ class LegacyCacheReadersTest(TestCase):
         self.redis.set(cache_key, 2.5)
 
         assert get_cached_recalibration_factor(org.id) == 2.5
+
+    def test_get_previous_recalibration_factor_steps_from_the_legacy_factor(self) -> None:
+        org = self.create_organization()
+        legacy_key = legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(org.id)
+        per_org_key = generate_recalibrate_orgs_cache_key(org.id)
+        self.addCleanup(self.redis.delete, legacy_key, per_org_key)
+        self.redis.set(legacy_key, 2.5)
+        self.redis.set(per_org_key, 7.0)
+
+        # While serving applies the legacy factor, the per-org one is applied by nothing, so
+        # the step starts from the legacy factor no matter what the per-org cache holds.
+        assert get_previous_recalibration_factor(org.id) == (2.5, RecalibrationSeed.LEGACY)
+
+    def test_get_previous_recalibration_factor_steps_from_its_own_factor_once_served(
+        self,
+    ) -> None:
+        org = self.create_organization()
+        legacy_key = legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(org.id)
+        per_org_key = generate_recalibrate_orgs_cache_key(org.id)
+        self.addCleanup(self.redis.delete, legacy_key, per_org_key)
+        self.redis.set(legacy_key, 2.5)
+        self.redis.set(per_org_key, 7.0)
+
+        with override_options({"dynamic-sampling.per_org.recalibration-serving-org-ids": [org.id]}):
+            assert get_previous_recalibration_factor(org.id) == (7.0, RecalibrationSeed.PER_ORG)
+
+    def test_get_previous_recalibration_factor_starts_served_orgs_at_the_identity(self) -> None:
+        org = self.create_organization()
+        legacy_key = legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(org.id)
+        per_org_key = generate_recalibrate_orgs_cache_key(org.id)
+        self.addCleanup(self.redis.delete, legacy_key, per_org_key)
+        self.redis.set(legacy_key, 2.5)
+        self.redis.delete(per_org_key)
+
+        # A served org whose own cache is empty starts at 1.0, like the legacy pipeline
+        # does, rather than falling back to a legacy factor serving no longer applies.
+        with override_options({"dynamic-sampling.per_org.recalibration-serving-org-ids": [org.id]}):
+            assert get_previous_recalibration_factor(org.id) == (1.0, RecalibrationSeed.PER_ORG)
 
     def test_get_cached_recalibration_factor_reports_a_cache_miss_as_the_identity(self) -> None:
         org = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -9,6 +9,7 @@ import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
+from sentry.dynamic_sampling.per_org.cache import RecalibrationSeed
 from sentry.dynamic_sampling.per_org.configuration import (
     AutomaticDynamicSamplingConfiguration,
     BaseDynamicSamplingConfiguration,
@@ -170,7 +171,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: None,
-                GET_FACTOR: 1.4,
+                GET_FACTOR: (1.4, RecalibrationSeed.LEGACY),
                 SET_FACTOR: DEFAULT,
                 CALCULATE_FACTOR: 0.7,
             }
@@ -182,7 +183,8 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.results.recalibration_factor == 0.7
         assert configuration.results.previous_recalibration_factor == 1.4
-        mocks[GET_FACTOR].assert_called_once_with(org.id, source="task")
+        assert configuration.results.recalibration_seed == RecalibrationSeed.LEGACY
+        mocks[GET_FACTOR].assert_called_once_with(org.id)
         mocks[CALCULATE_FACTOR].assert_called_once_with(org_volume, 1.4, 0.5)
         mocks[SET_FACTOR].assert_not_called()
 
@@ -194,7 +196,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: None,
-                GET_FACTOR: 1.0,
+                GET_FACTOR: (1.0, RecalibrationSeed.LEGACY),
             }
         ):
             configuration = get_configuration(org.id)
@@ -214,7 +216,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: None,
-                GET_FACTOR: 1.0,
+                GET_FACTOR: (1.0, RecalibrationSeed.LEGACY),
             }
         ):
             configuration = get_configuration(org.id)
@@ -237,7 +239,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             {
                 BLENDED_SAMPLE_RATE: 0.5,
                 OUTCOMES_VOLUME: None,
-                GET_FACTOR: 1.0,
+                GET_FACTOR: (1.0, RecalibrationSeed.LEGACY),
                 CALCULATE_FACTOR: None,
             }
         ):
@@ -275,7 +277,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
             self.feature("organizations:dynamic-sampling-custom"),
             patch_configuration(
                 {
-                    GET_FACTOR: 1.2,
+                    GET_FACTOR: (1.2, RecalibrationSeed.LEGACY),
                     CALCULATE_FACTOR: 0.9,
                 }
             ) as mocks,

--- a/tests/sentry/dynamic_sampling/per_org/test_gate.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_gate.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from sentry.dynamic_sampling.per_org.gate import is_recalibration_served_by_per_org
+from sentry.testutils.helpers.options import override_options
+
+ORG_ID = 1234
+_OPTIONS = {
+    "dynamic-sampling.per_org.killswitch": False,
+    "dynamic-sampling.per_org.recalibration-serving-org-ids": [],
+    "dynamic-sampling.per_org.recalibration-serving-rollout-rate": 0.0,
+}
+
+
+@override_options(_OPTIONS)
+def test_recalibration_is_served_by_legacy_by_default() -> None:
+    assert is_recalibration_served_by_per_org(ORG_ID) is False
+
+
+@override_options(
+    {**_OPTIONS, "dynamic-sampling.per_org.recalibration-serving-org-ids": [ORG_ID, "99"]}
+)
+def test_recalibration_is_served_by_per_org_for_listed_orgs() -> None:
+    assert is_recalibration_served_by_per_org(ORG_ID) is True
+    assert is_recalibration_served_by_per_org(99) is True
+    assert is_recalibration_served_by_per_org(5678) is False
+
+
+@override_options({**_OPTIONS, "dynamic-sampling.per_org.recalibration-serving-rollout-rate": 1.0})
+def test_recalibration_is_served_by_per_org_inside_the_rollout() -> None:
+    assert is_recalibration_served_by_per_org(ORG_ID) is True
+
+
+@override_options(
+    {
+        **_OPTIONS,
+        "dynamic-sampling.per_org.recalibration-serving-org-ids": [ORG_ID],
+        "dynamic-sampling.per_org.recalibration-serving-rollout-rate": 1.0,
+        "dynamic-sampling.per_org.killswitch": True,
+    }
+)
+def test_killswitch_hands_every_org_back_to_legacy() -> None:
+    # The killswitch stops the per-org pipeline, so its factor stops being updated and
+    # serving must not keep applying it.
+    assert is_recalibration_served_by_per_org(ORG_ID) is False

--- a/tests/sentry/dynamic_sampling/per_org/test_helpers.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_helpers.py
@@ -17,7 +17,7 @@ BLENDED_SAMPLE_RATE = f"{CONFIGURATION}.quotas.backend.get_blended_sample_rate"
 OUTCOMES_VOLUME = f"{CONFIGURATION}.get_outcomes_organization_volume"
 SLIDING_WINDOW_RATE = f"{CONFIGURATION}.compute_sliding_window_sample_rate"
 CALCULATE_FACTOR = f"{CONFIGURATION}.calculate_recalibration_factor"
-GET_FACTOR = f"{CONFIGURATION}.per_org_recalibration_cache.get_adjusted_factor"
+GET_FACTOR = f"{CONFIGURATION}.per_org_recalibration_cache.get_previous_recalibration_factor"
 # The factor is written by write_caches at the end of the pass, not by the configuration.
 SET_FACTOR = f"{CACHE}.set_guarded_adjusted_factor"
 DELETE_FACTOR = f"{CACHE}.delete_adjusted_factor"

--- a/tests/sentry/dynamic_sampling/rules/biases/test_recalibration_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_recalibration_bias.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from sentry.dynamic_sampling.per_org import cache as per_org_recalibration_cache
+from sentry.dynamic_sampling.rules.biases.recalibration_bias import RecalibrationBias
+from sentry.dynamic_sampling.rules.utils import RESERVED_IDS, RuleType, get_redis_client_for_ds
+from sentry.dynamic_sampling.tasks.helpers import recalibrate_orgs as legacy_recalibration_cache
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+
+
+def _factor_rule(factor: float) -> dict:
+    return {
+        "samplingValue": {"type": "factor", "value": factor},
+        "type": "trace",
+        "condition": {"op": "and", "inner": []},
+        "id": RESERVED_IDS[RuleType.RECALIBRATION_RULE],
+    }
+
+
+class RecalibrationBiasTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        redis = get_redis_client_for_ds()
+        self.legacy_key = legacy_recalibration_cache.generate_recalibrate_orgs_cache_key(
+            self.organization.id
+        )
+        self.per_org_key = per_org_recalibration_cache.generate_recalibrate_orgs_cache_key(
+            self.organization.id
+        )
+        self.addCleanup(redis.delete, self.legacy_key, self.per_org_key)
+        redis.set(self.legacy_key, 2.0)
+        redis.set(self.per_org_key, 0.5)
+
+    def test_serves_the_legacy_factor_by_default(self) -> None:
+        rules = RecalibrationBias().generate_rules(self.project, base_sample_rate=1.0)
+
+        assert rules == [_factor_rule(2.0)]
+
+    @override_options({"dynamic-sampling.per_org.recalibration-serving-rollout-rate": 1.0})
+    def test_serves_the_per_org_factor_once_switched_over(self) -> None:
+        rules = RecalibrationBias().generate_rules(self.project, base_sample_rate=1.0)
+
+        assert rules == [_factor_rule(0.5)]
+
+    @override_options({"dynamic-sampling.per_org.recalibration-serving-rollout-rate": 1.0})
+    def test_serves_no_rule_when_the_per_org_factor_is_the_identity(self) -> None:
+        get_redis_client_for_ds().delete(self.per_org_key)
+
+        rules = RecalibrationBias().generate_rules(self.project, base_sample_rate=1.0)
+
+        # A missing per-org factor is the identity, and the legacy factor is not a
+        # fallback for a switched-over org.
+        assert rules == []


### PR DESCRIPTION
- The per-org pipeline computed its recalibration factor from its own previous factor. But serving still applies the legacy factor, so the per-org one never affected the sample rate. Without that feedback the factor kept drifting, hit a rebalance bound every 5-10 cycles, and reset to 1.0.
- While the per-org pipeline runs in shadow, start each step from the legacy factor instead. Every cycle is then one step from the factor that is actually applied, and the logged factor stops drifting.
- Add a switch to move an org over: `dynamic-sampling.per_org.recalibration-serving-org-ids` for canary orgs, `dynamic-sampling.per_org.recalibration-serving-rollout-rate` for the wider rollout. For a switched-over org, serving reads the per-org factor and the pipeline steps from its own cache. The shadow runs keep that cache warm, so the switch continues from the current factor rather than restarting at 1.0.
- The per-org killswitch sends every org back to the legacy factor.
- The comparison log gains `recalibration_seed` (`legacy` / `per_org`).
- Not included: a per-step clamp on the factor change. Worth adding before the wide rollout.

Contributes to TET-2834