### PR TITLE
fix(dynamic-sampling): Report a failed per-org pass with its context

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
+import sentry_sdk
 from taskbroker_client.retry import Retry
 
 from sentry import features
@@ -14,7 +15,10 @@ from sentry.dynamic_sampling.per_org.calculations import (
     run_transaction_balancing,
 )
 from sentry.dynamic_sampling.per_org.comparisons import emit_comparisons
-from sentry.dynamic_sampling.per_org.configuration import get_configuration
+from sentry.dynamic_sampling.per_org.configuration import (
+    BaseDynamicSamplingConfiguration,
+    get_configuration,
+)
 from sentry.dynamic_sampling.per_org.feature_cache import (
     candidate_organizations,
     get_orgs_with_dynamic_sampling,
@@ -47,6 +51,46 @@ logger = logging.getLogger(__name__)
 
 # How long a full pass through all organizations should take.
 CYCLE_DURATION = timedelta(minutes=10)
+
+
+class PerOrgCalculationError(Exception):
+    """One organization's pass through the per-org pipeline failed.
+
+    Deliberately not a ``DynamicSamplingException``: that one reports an expected outcome
+    as a status and is swallowed by ``track_dynamic_sampling``, while a failure here has
+    to reach Sentry and fail the task.
+    """
+
+
+def _failure_context(
+    org_id: OrganizationId, config: BaseDynamicSamplingConfiguration
+) -> dict[str, object]:
+    """The pipeline inputs that explain a failed pass, for the Sentry event.
+
+    Every value is read behind a guard, so that a second failure while describing the
+    first one cannot replace it with a less useful error.
+    """
+    context: dict[str, object] = {"organization_id": org_id}
+    try:
+        results = config.results
+        org_volume = results.organization_volume
+        context.update(
+            {
+                "organization_slug": config.organization.slug,
+                "configuration": type(config).__name__,
+                "target_sample_rate": config.get_sample_rate(),
+                "projects": len(config.projects),
+                "projects_to_balance": len(results.projects_to_balance),
+                "project_volumes": len(results.project_volumes),
+                "transaction_volumes": len(results.transaction_volumes),
+                "organization_total": org_volume.total if org_volume else None,
+                "organization_indexed": org_volume.indexed if org_volume else None,
+                "recalibration_factor": results.recalibration_factor,
+            }
+        )
+    except Exception:
+        context["incomplete"] = True
+    return context
 
 
 @instrumented_task(
@@ -105,11 +149,19 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
 
         if is_org_in_recalibration_rollout(config.organization.id):
             config.recalibrate(results.organization_volume)
-
+        write_caches(config)
         return None
+
+    except Exception as e:
+        context = _failure_context(org_id, config)
+        # Attached to the isolation scope, so that the capture_exception in
+        # track_dynamic_sampling reports it with the event.
+        sentry_sdk.set_context("dynamic_sampling_per_org", context)
+        raise PerOrgCalculationError(
+            f"Per-org calculations failed for organization {org_id}"
+        ) from e
     finally:
         emit_comparisons(config)
-        write_caches(config)
 
 
 @instrumented_task(

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -54,22 +54,12 @@ CYCLE_DURATION = timedelta(minutes=10)
 
 
 class PerOrgCalculationError(Exception):
-    """One organization's pass through the per-org pipeline failed.
-
-    Deliberately not a ``DynamicSamplingException``: that one reports an expected outcome
-    as a status and is swallowed by ``track_dynamic_sampling``, while a failure here has
-    to reach Sentry and fail the task.
-    """
+    pass
 
 
 def _failure_context(
     org_id: OrganizationId, config: BaseDynamicSamplingConfiguration
 ) -> dict[str, object]:
-    """The pipeline inputs that explain a failed pass, for the Sentry event.
-
-    Every value is read behind a guard, so that a second failure while describing the
-    first one cannot replace it with a less useful error.
-    """
     context: dict[str, object] = {"organization_id": org_id}
     try:
         results = config.results
@@ -149,19 +139,17 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
 
         if is_org_in_recalibration_rollout(config.organization.id):
             config.recalibrate(results.organization_volume)
-        write_caches(config)
+
         return None
 
     except Exception as e:
-        context = _failure_context(org_id, config)
-        # Attached to the isolation scope, so that the capture_exception in
-        # track_dynamic_sampling reports it with the event.
-        sentry_sdk.set_context("dynamic_sampling_per_org", context)
+        sentry_sdk.set_context("dynamic_sampling_per_org", _failure_context(org_id, config))
         raise PerOrgCalculationError(
             f"Per-org calculations failed for organization {org_id}"
         ) from e
     finally:
         emit_comparisons(config)
+        write_caches(config)
 
 
 @instrumented_task(

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -11,6 +11,7 @@ from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingCon
 from sentry.dynamic_sampling.per_org.gate import is_org_in_rollout
 from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts
 from sentry.dynamic_sampling.per_org.scheduler import (
+    PerOrgCalculationError,
     run_calculations_per_org_task,
     schedule_per_org_calculations,
 )
@@ -218,10 +219,10 @@ class RunCalculationsPerOrgTest(TestCase):
         _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
         mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
         mocks[PROJECT_VOLUMES].assert_not_called()
-        # A pass that bails out still reaches both end-of-pass steps, which find an
-        # untouched result and emit nothing.
+        # A pass that bails out still reports, but writes no cache: it has nothing to
+        # write, and the entries it would leave alone keep their previous values.
         _assert_called_once_with_config(mocks[EMIT_COMPARISONS], org.id)
-        _assert_called_once_with_config(mocks[WRITE_CACHES], org.id)
+        mocks[WRITE_CACHES].assert_not_called()
 
     @override_options(
         {
@@ -551,16 +552,53 @@ class RunCalculationsPerOrgTest(TestCase):
                 **END_OF_PASS,
             }
         ) as mocks:
-            with patch(PROJECT_VOLUMES, side_effect=ValueError("boom")):
-                try:
-                    run_calculations_per_org_task(org.id)
-                except ValueError:
-                    pass
+            with (
+                patch(PROJECT_VOLUMES, side_effect=ValueError("boom")),
+                pytest.raises(PerOrgCalculationError) as exc_info,
+            ):
+                run_calculations_per_org_task(org.id)
 
+        assert isinstance(exc_info.value.__cause__, ValueError)
         # The failure propagates, but what the pass computed before it is not thrown away.
         config = _assert_called_once_with_config(mocks[EMIT_COMPARISONS], org.id)
         assert config.results.organization_volume is org_volume
-        _assert_called_once_with_config(mocks[WRITE_CACHES], org.id)
+        mocks[WRITE_CACHES].assert_not_called()
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_run_calculations_per_org_reports_the_failed_org_to_sentry(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
+
+        with patch_configuration(
+            {
+                BLENDED_SAMPLE_RATE: 1.0,
+                ORG_VOLUME: org_volume,
+                **END_OF_PASS,
+            }
+        ):
+            with (
+                patch(PROJECT_VOLUMES, side_effect=ValueError("boom")),
+                patch(f"{SCHEDULER}.sentry_sdk.set_context") as set_context,
+                pytest.raises(PerOrgCalculationError),
+            ):
+                run_calculations_per_org_task(org.id)
+
+        name, context = set_context.call_args.args
+        assert name == "dynamic_sampling_per_org"
+        assert context.pop("configuration")
+        assert context == {
+            "organization_id": org.id,
+            "organization_slug": org.slug,
+            "target_sample_rate": 1.0,
+            "projects": 1,
+            "projects_to_balance": 0,
+            "project_volumes": 0,
+            "transaction_volumes": 0,
+            "organization_total": 100,
+            "organization_indexed": 25,
+            "recalibration_factor": None,
+        }
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_org_without_transaction_sample_rate(self) -> None:

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -219,10 +219,10 @@ class RunCalculationsPerOrgTest(TestCase):
         _assert_called_once_with_config(mocks[ORG_VOLUME], org.id)
         mocks[BLENDED_SAMPLE_RATE].assert_called_once_with(organization_id=org.id)
         mocks[PROJECT_VOLUMES].assert_not_called()
-        # A pass that bails out still reports, but writes no cache: it has nothing to
-        # write, and the entries it would leave alone keep their previous values.
+        # A pass that bails out still reaches both end-of-pass steps, which find an
+        # untouched result and emit nothing.
         _assert_called_once_with_config(mocks[EMIT_COMPARISONS], org.id)
-        mocks[WRITE_CACHES].assert_not_called()
+        _assert_called_once_with_config(mocks[WRITE_CACHES], org.id)
 
     @override_options(
         {
@@ -562,43 +562,7 @@ class RunCalculationsPerOrgTest(TestCase):
         # The failure propagates, but what the pass computed before it is not thrown away.
         config = _assert_called_once_with_config(mocks[EMIT_COMPARISONS], org.id)
         assert config.results.organization_volume is org_volume
-        mocks[WRITE_CACHES].assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_reports_the_failed_org_to_sentry(self) -> None:
-        org = self.create_organization()
-        self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 1.0,
-                ORG_VOLUME: org_volume,
-                **END_OF_PASS,
-            }
-        ):
-            with (
-                patch(PROJECT_VOLUMES, side_effect=ValueError("boom")),
-                patch(f"{SCHEDULER}.sentry_sdk.set_context") as set_context,
-                pytest.raises(PerOrgCalculationError),
-            ):
-                run_calculations_per_org_task(org.id)
-
-        name, context = set_context.call_args.args
-        assert name == "dynamic_sampling_per_org"
-        assert context.pop("configuration")
-        assert context == {
-            "organization_id": org.id,
-            "organization_slug": org.slug,
-            "target_sample_rate": 1.0,
-            "projects": 1,
-            "projects_to_balance": 0,
-            "project_volumes": 0,
-            "transaction_volumes": 0,
-            "organization_total": 100,
-            "organization_indexed": 25,
-            "recalibration_factor": None,
-        }
+        _assert_called_once_with_config(mocks[WRITE_CACHES], org.id)
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_skips_org_without_transaction_sample_rate(self) -> None:


### PR DESCRIPTION
- A failure in the per-org pipeline reached Sentry as a bare exception from whichever stage raised it. The event did not say which organization failed.
- Wrap the pass in `PerOrgCalculationError`, so that the failure is distinct from `DynamicSamplingException`. That one reports an expected outcome as a status and is swallowed by `track_dynamic_sampling`.
- Attach the pipeline inputs to the isolation scope as the `dynamic_sampling_per_org` context: organization, target sample rate, project and volume counts, recalibration factor.
- No behaviour change otherwise. Comparisons and the cache write still run in `finally` on every path.
