### PR TITLE
chore(dynamic-sampling): remove rollout flag for recalibration

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/comparisons.py
+++ b/src/sentry/dynamic_sampling/per_org/comparisons.py
@@ -19,7 +19,6 @@ from sentry.dynamic_sampling.per_org.configuration import (
     BaseDynamicSamplingConfiguration,
 )
 from sentry.dynamic_sampling.per_org.gate import (
-    is_org_in_recalibration_rollout,
     is_org_in_sample_rates_summary_log_rollout,
     project_balancing_debug_project_ids,
     sliding_window_comparison_org_ids,
@@ -67,10 +66,7 @@ def emit_comparisons(config: BaseDynamicSamplingConfiguration) -> None:
         config.organization.id
     ):
         comparisons.append(lambda: log_sample_rates_summary(config))
-    if (
-        is_org_in_recalibration_rollout(config.organization.id)
-        and config.get_sample_rate() is not None
-    ):
+    if config.get_sample_rate() is not None:
         comparisons.append(lambda: compare_recalibration_factor_with_cache(config))
 
     for comparison in comparisons:

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -20,7 +20,6 @@ from sentry.dynamic_sampling.per_org.feature_cache import (
     get_orgs_with_dynamic_sampling,
 )
 from sentry.dynamic_sampling.per_org.gate import (
-    is_org_in_recalibration_rollout,
     is_org_in_rollout,
 )
 from sentry.dynamic_sampling.per_org.queries import (
@@ -103,8 +102,7 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
             config, results.project_volumes, results.transaction_volumes
         )
 
-        if is_org_in_recalibration_rollout(config.organization.id):
-            config.recalibrate(results.organization_volume)
+        config.recalibrate(results.organization_volume)
 
         return None
     finally:

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -197,7 +197,6 @@ class RunCalculationsPerOrgTest(TestCase):
     @override_options(
         {
             "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
         }
     )
     def test_run_calculations_per_org_returns_no_volume_without_traffic(self) -> None:
@@ -226,7 +225,6 @@ class RunCalculationsPerOrgTest(TestCase):
     @override_options(
         {
             "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
         }
     )
     def test_run_calculations_per_org_skips_transaction_volumes_at_full_sample_rate(self) -> None:
@@ -358,7 +356,6 @@ class RunCalculationsPerOrgTest(TestCase):
     @override_options(
         {
             "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
         }
     )
     def test_run_calculations_per_org_queries_projects_for_am3_org_mode(self) -> None:
@@ -428,7 +425,6 @@ class RunCalculationsPerOrgTest(TestCase):
     @override_options(
         {
             "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
         }
     )
     def test_run_calculations_per_org_queries_projects_for_am2(self) -> None:
@@ -476,7 +472,6 @@ class RunCalculationsPerOrgTest(TestCase):
     @override_options(
         {
             "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 1.0,
         }
     )
     def test_run_calculations_per_org_skips_the_factor_without_stored_segments(
@@ -512,7 +507,6 @@ class RunCalculationsPerOrgTest(TestCase):
     @override_options(
         {
             "dynamic-sampling.per_org.rollout-rate": 1.0,
-            "dynamic-sampling.per_org.recalibration-rollout-rate": 0.0,
         }
     )
     def test_run_calculations_per_org_skips_recalibration_outside_its_rollout(self) -> None:

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -504,34 +504,6 @@ class RunCalculationsPerOrgTest(TestCase):
         # The comparison still runs, so the legacy factor is reported next to no EAP factor.
         _assert_called_once_with_config(mocks[EMIT_COMPARISONS], org.id)
 
-    @override_options(
-        {
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-        }
-    )
-    def test_run_calculations_per_org_skips_recalibration_outside_its_rollout(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [make_project_volume(project.id)]
-
-        with patch_configuration(
-            {
-                BLENDED_SAMPLE_RATE: 0.5,
-                ORG_VOLUME: org_volume,
-                PROJECT_VOLUMES: project_volumes,
-                PROJECT_BALANCING: [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)],
-                TRANSACTION_VOLUMES: _transaction_volumes(org, project.id),
-                TRANSACTION_BALANCING: {},
-                **END_OF_PASS,
-            }
-        ) as mocks:
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        config = _assert_called_once_with_config(mocks[PROJECT_VOLUMES], org.id)
-        assert config.results.recalibration_factor is None
-
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_still_reports_when_a_stage_raises(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
- Remove the recalibration rollout option, we run it for all orgs now