### PR TITLE
feat(seer): Render replay clip player in block-level replay embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -240,7 +240,14 @@
     },
     "examples": [
       {
-        "label": "Replay",
+        "label": "Inline",
+        "data": {
+          "id": "4c1f2e3d1234567890",
+          "eventTimestamp": "2026-08-25T16:37:12Z"
+        }
+      },
+      {
+        "label": "Block",
         "data": {
           "id": "4c1f2e3d1234567890",
           "eventTimestamp": "2026-08-25T16:37:12Z"

--- a/static/app/components/seer/markdown/__stories__/components.tsx
+++ b/static/app/components/seer/markdown/__stories__/components.tsx
@@ -144,7 +144,7 @@ function useReplayExamples(): SeerEmbedExample[] | undefined {
 
   const replayData = {
     id: replay.id,
-    eventTimestamp: replay.started_at.toISOString(),
+    eventTimestamp: String(replay.started_at),
   };
 
   return [

--- a/static/app/components/seer/markdown/__stories__/components.tsx
+++ b/static/app/components/seer/markdown/__stories__/components.tsx
@@ -179,7 +179,7 @@ function EmbedSection({
       </Text>
       {md && (
         <Stack gap="sm">
-          <Demo>
+          <Demo maxHeight={name === 'replay' ? '900px' : undefined}>
             <SeerMarkdown raw={md} />
           </Demo>
           <CodeBlock language="markdown" dark>

--- a/static/app/components/seer/markdown/__stories__/components.tsx
+++ b/static/app/components/seer/markdown/__stories__/components.tsx
@@ -55,7 +55,7 @@ const STREAMING_CHUNKS = [
   '    return token.expires_at > now\n```\n',
 ];
 
-export function StreamingEmbedDemo() {
+export function StreamingEmbedExamples() {
   const [text, setText] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const cancelRef = useRef(false);
@@ -157,7 +157,7 @@ function LevelDemo({
   );
 }
 
-export function EmbedDemo({name}: {name: string}) {
+export function EmbedExamples({name}: {name: string}) {
   const schema = SEER_EMBED_SCHEMAS[name as keyof typeof SEER_EMBED_SCHEMAS];
   const replayData = useReplayExampleData();
 

--- a/static/app/components/seer/markdown/__stories__/components.tsx
+++ b/static/app/components/seer/markdown/__stories__/components.tsx
@@ -1,4 +1,5 @@
 import {useRef, useState} from 'react';
+import {useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
@@ -11,6 +12,8 @@ import {
   type SeerEmbedExample,
 } from 'sentry/components/seer/markdown/embeds/schemas';
 import {Demo} from 'sentry/stories';
+import {replayListApiOptions} from 'sentry/utils/replays/replayListApiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 const BASIC_MD = `## Root Cause
 
@@ -124,38 +127,84 @@ function buildEmbedMarkdown(
     .join('\n');
 }
 
+function useReplayExamples(): SeerEmbedExample[] | undefined {
+  const organization = useOrganization();
+  const {data} = useQuery(
+    replayListApiOptions({
+      options: {query: {sort: '-started_at'}},
+      organization,
+      queryReferrer: 'replayList',
+    })
+  );
+
+  const replay = data?.data?.[0];
+  if (!replay?.started_at) {
+    return undefined;
+  }
+
+  const replayData = {
+    id: replay.id,
+    eventTimestamp: replay.started_at.toISOString(),
+  };
+
+  return [
+    {label: 'Inline', level: 'inline' as const, data: replayData},
+    {label: 'Block', level: 'block' as const, data: replayData},
+  ];
+}
+
+function EmbedSection({
+  name,
+  schema,
+  overrideExamples,
+}: {
+  name: string;
+  schema: (typeof SEER_EMBED_SCHEMAS)[keyof typeof SEER_EMBED_SCHEMAS];
+  overrideExamples?: SeerEmbedExample[];
+}) {
+  const examples = overrideExamples ?? schema.examples;
+  const md = examples ? buildEmbedMarkdown(name, schema.level, examples) : null;
+
+  return (
+    <Stack key={name} gap="md">
+      <Text bold size="md">
+        {name}
+      </Text>
+      <Text size="sm" variant="muted">
+        Level: {schema.level.join(', ')}
+        {'featureFlag' in schema ? ` · Flag: ${schema.featureFlag}` : null}
+      </Text>
+      <Text size="sm" variant="muted">
+        Prompt: {schema.description}
+      </Text>
+      {md && (
+        <Stack gap="sm">
+          <Demo>
+            <SeerMarkdown raw={md} />
+          </Demo>
+          <CodeBlock language="markdown" dark>
+            {md}
+          </CodeBlock>
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
 export function EmbedRegistry() {
   const entries = Object.entries(SEER_EMBED_SCHEMAS);
+  const replayExamples = useReplayExamples();
+
   return (
     <Stack gap="xl">
-      {entries.map(([name, schema]) => {
-        const examples = schema.examples;
-        const md = examples ? buildEmbedMarkdown(name, schema.level, examples) : null;
-        return (
-          <Stack key={name} gap="md">
-            <Text bold size="md">
-              {name}
-            </Text>
-            <Text size="sm" variant="muted">
-              Level: {schema.level.join(', ')}
-              {'featureFlag' in schema ? ` · Flag: ${schema.featureFlag}` : null}
-            </Text>
-            <Text size="sm" variant="muted">
-              Prompt: {schema.description}
-            </Text>
-            {md && (
-              <Stack gap="sm">
-                <Demo>
-                  <SeerMarkdown raw={md} />
-                </Demo>
-                <CodeBlock language="markdown" dark>
-                  {md}
-                </CodeBlock>
-              </Stack>
-            )}
-          </Stack>
-        );
-      })}
+      {entries.map(([name, schema]) => (
+        <EmbedSection
+          key={name}
+          name={name}
+          schema={schema}
+          overrideExamples={name === 'replay' ? replayExamples : undefined}
+        />
+      ))}
     </Stack>
   );
 }

--- a/static/app/components/seer/markdown/__stories__/components.tsx
+++ b/static/app/components/seer/markdown/__stories__/components.tsx
@@ -7,10 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
-import {
-  SEER_EMBED_SCHEMAS,
-  type SeerEmbedExample,
-} from 'sentry/components/seer/markdown/embeds/schemas';
+import {SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
 import {Demo} from 'sentry/stories';
 import {replayListApiOptions} from 'sentry/utils/replays/replayListApiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -110,24 +107,7 @@ function formatTag(name: string, data: unknown): string {
   return `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
 }
 
-function buildEmbedMarkdown(
-  name: string,
-  levels: readonly string[],
-  examples: SeerEmbedExample[]
-): string {
-  return examples
-    .map(example => {
-      const level = example.level ?? levels[0] ?? 'inline';
-      const tag = formatTag(name, example.data);
-      if (level === 'inline') {
-        return `${example.label}: Lorem ipsum ${tag} dolor sit amet.\n`;
-      }
-      return `${example.label}:\n\n${tag}\n`;
-    })
-    .join('\n');
-}
-
-function useReplayExamples(): SeerEmbedExample[] | undefined {
+function useReplayExampleData(): Record<string, unknown> | undefined {
   const organization = useOrganization();
   const {data} = useQuery(
     replayListApiOptions({
@@ -142,69 +122,74 @@ function useReplayExamples(): SeerEmbedExample[] | undefined {
     return undefined;
   }
 
-  const replayData = {
+  return {
     id: replay.id,
     eventTimestamp: String(replay.started_at),
   };
-
-  return [
-    {label: 'Inline', level: 'inline' as const, data: replayData},
-    {label: 'Block', level: 'block' as const, data: replayData},
-  ];
 }
 
-function EmbedSection({
+function LevelDemo({
   name,
-  schema,
-  overrideExamples,
+  level,
+  exampleData,
+  isLargeBlock,
 }: {
+  exampleData: Record<string, unknown>;
+  level: string;
   name: string;
-  schema: (typeof SEER_EMBED_SCHEMAS)[keyof typeof SEER_EMBED_SCHEMAS];
-  overrideExamples?: SeerEmbedExample[];
+  isLargeBlock?: boolean;
 }) {
-  const examples = overrideExamples ?? schema.examples;
-  const md = examples ? buildEmbedMarkdown(name, schema.level, examples) : null;
+  const tag = formatTag(name, exampleData);
+  const md = level === 'inline' ? `Lorem ipsum ${tag} dolor sit amet.` : tag;
 
   return (
-    <Stack key={name} gap="md">
-      <Text bold size="md">
-        {name}
+    <Stack gap="sm">
+      <Text size="sm" bold>
+        {level}
       </Text>
+      <Demo maxHeight={isLargeBlock ? '900px' : undefined}>
+        <SeerMarkdown raw={md} />
+      </Demo>
+      <CodeBlock language="markdown" dark>
+        {md}
+      </CodeBlock>
+    </Stack>
+  );
+}
+
+export function EmbedDemo({name}: {name: string}) {
+  const schema = SEER_EMBED_SCHEMAS[name as keyof typeof SEER_EMBED_SCHEMAS];
+  const replayData = useReplayExampleData();
+
+  if (!schema) {
+    return null;
+  }
+
+  const exampleData =
+    name === 'replay' && replayData ? replayData : (schema.examples?.[0]?.data ?? {});
+
+  const isLargeBlock = name === 'replay';
+
+  return (
+    <Stack gap="md">
       <Text size="sm" variant="muted">
         Level: {schema.level.join(', ')}
         {'featureFlag' in schema ? ` · Flag: ${schema.featureFlag}` : null}
       </Text>
       <Text size="sm" variant="muted">
-        Prompt: {schema.description}
+        {schema.description}
       </Text>
-      {md && (
-        <Stack gap="sm">
-          <Demo maxHeight={name === 'replay' ? '900px' : undefined}>
-            <SeerMarkdown raw={md} />
-          </Demo>
-          <CodeBlock language="markdown" dark>
-            {md}
-          </CodeBlock>
-        </Stack>
-      )}
-    </Stack>
-  );
-}
-
-export function EmbedRegistry() {
-  const entries = Object.entries(SEER_EMBED_SCHEMAS);
-  const replayExamples = useReplayExamples();
-
-  return (
-    <Stack gap="xl">
-      {entries.map(([name, schema]) => (
-        <EmbedSection
-          key={name}
-          name={name}
-          schema={schema}
-          overrideExamples={name === 'replay' ? replayExamples : undefined}
-        />
-      ))}
+      <Stack gap="lg">
+        {schema.level.map(level => (
+          <LevelDemo
+            key={level}
+            name={name}
+            level={level}
+            exampleData={exampleData}
+            isLargeBlock={isLargeBlock && level === 'block'}
+          />
+        ))}
+      </Stack>
     </Stack>
   );
 }

--- a/static/app/components/seer/markdown/embeds/components/replay.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replay.tsx
@@ -1,4 +1,5 @@
 import {lazy} from 'react';
+import styled from '@emotion/styled';
 import queryString from 'query-string';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
@@ -53,29 +54,39 @@ function ReplayBlockPreview({id, eventTimestamp}: EmbedOutput<'replay'>) {
 
   return (
     <ReplayAccess fallback={<ReplayLink id={id} eventTimestamp={eventTimestamp} />}>
-      <LazyLoad
-        analyticsContext="seer_embed"
-        replaySlug={id}
-        orgSlug={organization.slug}
-        eventTimestampMs={eventTimestampMs}
-        clipOffsets={CLIP_OFFSETS}
-        fullReplayButtonProps={{
-          analyticsEventKey: 'seer_embed.open_replay_details_clicked',
-          analyticsEventName: 'Seer Embed: Open Replay Details Clicked',
-        }}
-        loadingFallback={
-          <NegativeSpaceContainer
-            style={{height: REPLAY_LOADING_HEIGHT}}
-            data-test-id="replay-loading-placeholder"
-          >
-            <LoadingIndicator />
-          </NegativeSpaceContainer>
-        }
-        LazyComponent={ReplayClipPreview}
-      />
+      <ReplayBlockContainer>
+        <LazyLoad
+          analyticsContext="seer_embed"
+          replaySlug={id}
+          orgSlug={organization.slug}
+          eventTimestampMs={eventTimestampMs}
+          clipOffsets={CLIP_OFFSETS}
+          fullReplayButtonProps={{
+            analyticsEventKey: 'seer_embed.open_replay_details_clicked',
+            analyticsEventName: 'Seer Embed: Open Replay Details Clicked',
+          }}
+          loadingFallback={
+            <NegativeSpaceContainer
+              style={{height: REPLAY_LOADING_HEIGHT}}
+              data-test-id="replay-loading-placeholder"
+            >
+              <LoadingIndicator />
+            </NegativeSpaceContainer>
+          }
+          LazyComponent={ReplayClipPreview}
+        />
+      </ReplayBlockContainer>
     </ReplayAccess>
   );
 }
+
+const ReplayBlockContainer = styled('div')`
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: ${p => p.theme.tokens.background.secondary};
+  padding: ${p => p.theme.space.md};
+  overflow: hidden;
+`;
 
 export const Replay = defineSeerEmbed({
   name: 'replay',

--- a/static/app/components/seer/markdown/embeds/components/replay.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replay.tsx
@@ -1,5 +1,10 @@
+import {lazy} from 'react';
 import queryString from 'query-string';
 
+import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
+import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {
   defineSeerEmbed,
@@ -10,6 +15,15 @@ import {t} from 'sentry/locale';
 import {getShortEventId} from 'sentry/utils/events';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+
+const CLIP_OFFSETS = {
+  durationAfterMs: 5_000,
+  durationBeforeMs: 5_000,
+};
+
+const ReplayClipPreview = lazy(
+  () => import('sentry/components/events/eventReplay/replayClipPreview')
+);
 
 function ReplayLink({id, eventTimestamp}: EmbedOutput<'replay'>) {
   const organization = useOrganization();
@@ -27,9 +41,45 @@ function ReplayLink({id, eventTimestamp}: EmbedOutput<'replay'>) {
   );
 }
 
+function ReplayBlockPreview({id, eventTimestamp}: EmbedOutput<'replay'>) {
+  const organization = useOrganization();
+
+  if (!eventTimestamp) {
+    return <ReplayLink id={id} eventTimestamp={eventTimestamp} />;
+  }
+
+  const eventTimestampMs = Math.floor(new Date(eventTimestamp).getTime());
+
+  return (
+    <LazyLoad
+      analyticsContext="seer_embed"
+      replaySlug={id}
+      orgSlug={organization.slug}
+      eventTimestampMs={eventTimestampMs}
+      clipOffsets={CLIP_OFFSETS}
+      fullReplayButtonProps={{
+        analyticsEventKey: 'seer_embed.open_replay_details_clicked',
+        analyticsEventName: 'Seer Embed: Open Replay Details Clicked',
+      }}
+      loadingFallback={
+        <NegativeSpaceContainer
+          style={{height: REPLAY_LOADING_HEIGHT}}
+          data-test-id="replay-loading-placeholder"
+        >
+          <LoadingIndicator />
+        </NegativeSpaceContainer>
+      }
+      LazyComponent={ReplayClipPreview}
+    />
+  );
+}
+
 export const Replay = defineSeerEmbed({
   name: 'replay',
-  render(props) {
+  render(props, level) {
+    if (level === 'block') {
+      return <ReplayBlockPreview {...props} />;
+    }
     return <ReplayLink {...props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/replay.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replay.tsx
@@ -83,7 +83,7 @@ function ReplayBlockPreview({id, eventTimestamp}: EmbedOutput<'replay'>) {
 const ReplayBlockContainer = styled('div')`
   border: 1px solid ${p => p.theme.tokens.border.primary};
   border-radius: ${p => p.theme.radius.md};
-  background: ${p => p.theme.tokens.background.secondary};
+  background: ${p => p.theme.tokens.background.primary};
   padding: ${p => p.theme.space.md};
   overflow: hidden;
 `;

--- a/static/app/components/seer/markdown/embeds/components/replay.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replay.tsx
@@ -1,6 +1,7 @@
 import {lazy} from 'react';
-import styled from '@emotion/styled';
 import queryString from 'query-string';
+
+import {Container} from '@sentry/scraps/layout';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
@@ -54,7 +55,13 @@ function ReplayBlockPreview({id, eventTimestamp}: EmbedOutput<'replay'>) {
 
   return (
     <ReplayAccess fallback={<ReplayLink id={id} eventTimestamp={eventTimestamp} />}>
-      <ReplayBlockContainer>
+      <Container
+        background="primary"
+        border="primary"
+        radius="md"
+        padding="md"
+        overflow="hidden"
+      >
         <LazyLoad
           analyticsContext="seer_embed"
           replaySlug={id}
@@ -75,18 +82,10 @@ function ReplayBlockPreview({id, eventTimestamp}: EmbedOutput<'replay'>) {
           }
           LazyComponent={ReplayClipPreview}
         />
-      </ReplayBlockContainer>
+      </Container>
     </ReplayAccess>
   );
 }
-
-const ReplayBlockContainer = styled('div')`
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  background: ${p => p.theme.tokens.background.primary};
-  padding: ${p => p.theme.space.md};
-  overflow: hidden;
-`;
 
 export const Replay = defineSeerEmbed({
   name: 'replay',

--- a/static/app/components/seer/markdown/embeds/components/replay.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replay.tsx
@@ -5,6 +5,7 @@ import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceC
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
 import {LazyLoad} from 'sentry/components/lazyLoad';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ReplayAccess} from 'sentry/components/replays/replayAccess';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {
   defineSeerEmbed,
@@ -51,26 +52,28 @@ function ReplayBlockPreview({id, eventTimestamp}: EmbedOutput<'replay'>) {
   const eventTimestampMs = Math.floor(new Date(eventTimestamp).getTime());
 
   return (
-    <LazyLoad
-      analyticsContext="seer_embed"
-      replaySlug={id}
-      orgSlug={organization.slug}
-      eventTimestampMs={eventTimestampMs}
-      clipOffsets={CLIP_OFFSETS}
-      fullReplayButtonProps={{
-        analyticsEventKey: 'seer_embed.open_replay_details_clicked',
-        analyticsEventName: 'Seer Embed: Open Replay Details Clicked',
-      }}
-      loadingFallback={
-        <NegativeSpaceContainer
-          style={{height: REPLAY_LOADING_HEIGHT}}
-          data-test-id="replay-loading-placeholder"
-        >
-          <LoadingIndicator />
-        </NegativeSpaceContainer>
-      }
-      LazyComponent={ReplayClipPreview}
-    />
+    <ReplayAccess fallback={<ReplayLink id={id} eventTimestamp={eventTimestamp} />}>
+      <LazyLoad
+        analyticsContext="seer_embed"
+        replaySlug={id}
+        orgSlug={organization.slug}
+        eventTimestampMs={eventTimestampMs}
+        clipOffsets={CLIP_OFFSETS}
+        fullReplayButtonProps={{
+          analyticsEventKey: 'seer_embed.open_replay_details_clicked',
+          analyticsEventName: 'Seer Embed: Open Replay Details Clicked',
+        }}
+        loadingFallback={
+          <NegativeSpaceContainer
+            style={{height: REPLAY_LOADING_HEIGHT}}
+            data-test-id="replay-loading-placeholder"
+          >
+            <LoadingIndicator />
+          </NegativeSpaceContainer>
+        }
+        LazyComponent={ReplayClipPreview}
+      />
+    </ReplayAccess>
   );
 }
 

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -1,16 +1,21 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 
-function renderEmbed(name: string, data: Record<string, unknown>) {
-  const raw = `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
+function renderEmbed(
+  name: string,
+  data: Record<string, unknown>,
+  level: 'block' | 'inline' = 'block'
+) {
+  const tag = `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
+  const raw = level === 'inline' ? `text ${tag} text` : tag;
   return render(<SeerMarkdown raw={raw} />);
 }
 
 function hrefFor(name: string, label: string, data: Record<string, unknown>) {
-  renderEmbed(name, data);
+  renderEmbed(name, data, 'inline');
   return screen.getByRole('link', {name: label}).getAttribute('href') ?? '';
 }
 
@@ -51,11 +56,15 @@ describe('Seer resource embeds', () => {
     );
   });
 
-  it('links a replay to the relevant event timestamp', async () => {
-    const {router} = renderEmbed('replay', {
-      id: '4c1f2e3d1234567890',
-      eventTimestamp: '2026-08-25T16:37:12Z',
-    });
+  it('links a replay to the relevant event timestamp (inline)', async () => {
+    const {router} = renderEmbed(
+      'replay',
+      {
+        id: '4c1f2e3d1234567890',
+        eventTimestamp: '2026-08-25T16:37:12Z',
+      },
+      'inline'
+    );
 
     await userEvent.click(screen.getByRole('link', {name: 'Replay 4c1f2e3d'}));
 
@@ -65,8 +74,34 @@ describe('Seer resource embeds', () => {
     expect(router.location.query.event_t).toBe('2026-08-25T16:37:12Z');
   });
 
-  it('links a replay without a timestamp to the beginning', () => {
-    renderEmbed('replay', {id: 'abcdef1234567890'});
+  it('links a replay without a timestamp to the beginning (inline)', () => {
+    renderEmbed('replay', {id: 'abcdef1234567890'}, 'inline');
+
+    expect(screen.getByRole('link', {name: 'Replay abcdef12'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/replays/abcdef1234567890/'
+    );
+  });
+
+  it('renders a replay player preview at block level with a timestamp', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderEmbed(
+      'replay',
+      {
+        id: '4c1f2e3d1234567890',
+        eventTimestamp: '2026-08-25T16:37:12Z',
+      },
+      'block'
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('replay-loading-placeholder')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to a link at block level without a timestamp', () => {
+    renderEmbed('replay', {id: 'abcdef1234567890'}, 'block');
 
     expect(screen.getByRole('link', {name: 'Replay abcdef12'})).toHaveAttribute(
       'href',

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -212,7 +212,16 @@ export const SEER_EMBED_SCHEMAS = {
     }),
     examples: [
       {
-        label: 'Replay',
+        label: 'Inline',
+        level: 'inline',
+        data: {
+          id: '4c1f2e3d1234567890',
+          eventTimestamp: '2026-08-25T16:37:12Z',
+        },
+      },
+      {
+        label: 'Block',
+        level: 'block',
         data: {
           id: '4c1f2e3d1234567890',
           eventTimestamp: '2026-08-25T16:37:12Z',

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -10,7 +10,7 @@ import * as Storybook from 'sentry/stories';
 
 import {
   BasicDemo,
-  EmbedRegistry,
+  EmbedDemo,
   LinkifyDemo,
   StreamingEmbedDemo,
 } from './__stories__/components';
@@ -49,7 +49,93 @@ The JSON body between the opening and closing tags is the embed's data payload. 
 
 ### Registry
 
-<EmbedRegistry />
+#### timestamp
+
+<EmbedDemo name="timestamp" />
+
+#### docs
+
+<EmbedDemo name="docs" />
+
+#### dashboard
+
+<EmbedDemo name="dashboard" />
+
+#### dsn
+
+<EmbedDemo name="dsn" />
+
+#### user
+
+<EmbedDemo name="user" />
+
+#### issue
+
+<EmbedDemo name="issue" />
+
+#### issues
+
+<EmbedDemo name="issues" />
+
+#### replay
+
+<EmbedDemo name="replay" />
+
+#### chart
+
+<EmbedDemo name="chart" />
+
+#### autofix
+
+<EmbedDemo name="autofix" />
+
+#### alert
+
+<EmbedDemo name="alert" />
+
+#### monitor
+
+<EmbedDemo name="monitor" />
+
+#### savedIssueView
+
+<EmbedDemo name="savedIssueView" />
+
+#### savedQuery
+
+<EmbedDemo name="savedQuery" />
+
+#### trace
+
+<EmbedDemo name="trace" />
+
+#### profile
+
+<EmbedDemo name="profile" />
+
+#### issuesQuery
+
+<EmbedDemo name="issuesQuery" />
+
+#### errorsQuery
+
+<EmbedDemo name="errorsQuery" />
+
+#### spansQuery
+
+<EmbedDemo name="spansQuery" />
+
+#### logsQuery
+
+<EmbedDemo name="logsQuery" />
+
+#### replaysQuery
+
+<EmbedDemo name="replaysQuery" />
+
+#### metricsQuery
+
+<EmbedDemo name="metricsQuery" />
 
 ## Embed Architecture
 

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -10,9 +10,9 @@ import * as Storybook from 'sentry/stories';
 
 import {
   BasicDemo,
-  EmbedDemo,
+  EmbedExamples,
   LinkifyDemo,
-  StreamingEmbedDemo,
+  StreamingEmbedExamples,
 } from './__stories__/components';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
@@ -39,103 +39,95 @@ Renders standard markdown with Seer's component overrides and opinionated embeds
 
 Embeds are rich widgets rendered inline from [Markdoc-style tag syntax](https://markdoc.dev/). The Seer agent produces these tags; the frontend resolves them through a **registry + schema** system.
 
-### Syntax
+Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated against a Zod schema before rendering — invalid data renders nothing (with a dev-mode console warning).
 
-```
-{% timestamp %}{"value":"2025-07-15T14:30:00Z","format":"relative"}{% /timestamp %}
-```
+### timestamp
 
-The JSON body between the opening and closing tags is the embed's data payload. It is validated against a Zod schema before rendering — invalid data renders nothing (with a dev-mode console warning).
+<EmbedExamples name="timestamp" />
 
-### Registry
+### docs
 
-#### timestamp
+<EmbedExamples name="docs" />
 
-<EmbedDemo name="timestamp" />
+### dashboard
 
-#### docs
+<EmbedExamples name="dashboard" />
 
-<EmbedDemo name="docs" />
+### dsn
 
-#### dashboard
+<EmbedExamples name="dsn" />
 
-<EmbedDemo name="dashboard" />
+### user
 
-#### dsn
+<EmbedExamples name="user" />
 
-<EmbedDemo name="dsn" />
+### issue
 
-#### user
+<EmbedExamples name="issue" />
 
-<EmbedDemo name="user" />
+### issues
 
-#### issue
+<EmbedExamples name="issues" />
 
-<EmbedDemo name="issue" />
+### replay
 
-#### issues
+<EmbedExamples name="replay" />
 
-<EmbedDemo name="issues" />
+### chart
 
-#### replay
+<EmbedExamples name="chart" />
 
-<EmbedDemo name="replay" />
+### autofix
 
-#### chart
+<EmbedExamples name="autofix" />
 
-<EmbedDemo name="chart" />
+### alert
 
-#### autofix
+<EmbedExamples name="alert" />
 
-<EmbedDemo name="autofix" />
+### monitor
 
-#### alert
+<EmbedExamples name="monitor" />
 
-<EmbedDemo name="alert" />
+### savedIssueView
 
-#### monitor
+<EmbedExamples name="savedIssueView" />
 
-<EmbedDemo name="monitor" />
+### savedQuery
 
-#### savedIssueView
+<EmbedExamples name="savedQuery" />
 
-<EmbedDemo name="savedIssueView" />
+### trace
 
-#### savedQuery
+<EmbedExamples name="trace" />
 
-<EmbedDemo name="savedQuery" />
+### profile
 
-#### trace
+<EmbedExamples name="profile" />
 
-<EmbedDemo name="trace" />
+### issuesQuery
 
-#### profile
+<EmbedExamples name="issuesQuery" />
 
-<EmbedDemo name="profile" />
+### errorsQuery
 
-#### issuesQuery
+<EmbedExamples name="errorsQuery" />
 
-<EmbedDemo name="issuesQuery" />
+### spansQuery
 
-#### errorsQuery
+<EmbedExamples name="spansQuery" />
 
-<EmbedDemo name="errorsQuery" />
+### logsQuery
 
-#### spansQuery
+<EmbedExamples name="logsQuery" />
 
-<EmbedDemo name="spansQuery" />
+### replaysQuery
 
-#### logsQuery
+<EmbedExamples name="replaysQuery" />
 
-<EmbedDemo name="logsQuery" />
+### metricsQuery
 
-#### replaysQuery
-
-<EmbedDemo name="replaysQuery" />
-
-#### metricsQuery
-
-<EmbedDemo name="metricsQuery" />
+<EmbedExamples name="metricsQuery" />
 
 ## Embed Architecture
 


### PR DESCRIPTION
### Why?

The replay Seer embed currently renders as a plain link at every level. When Seer surfaces a replay in a block-level response, users should see the actual replay content rather than needing to click through.

### How?

At block level with an `eventTimestamp`, the replay embed lazy-loads the same `ReplayClipPreview` player used on issue details, showing a 10-second clip centered on the event. Without a timestamp, it falls back to the compact link since there is no meaningful moment to clip around. Inline embeds stay unchanged.

Follows up #122620.

<sub>Generated with Claude Code</sub>