### PR TITLE
fix(issues): Cap page size when listing issue events with full=true

### DIFF
--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -58,6 +58,9 @@ class GroupEventsError(Exception):
     pass
 
 
+FULL_PAYLOAD_MAX_PER_PAGE = 10
+
+
 @extend_schema(tags=["Events"])
 @cell_silo_endpoint
 class GroupEventsEndpoint(GroupEndpoint):
@@ -65,6 +68,14 @@ class GroupEventsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
+
+    def get_per_page(
+        self, request: Request, default_per_page: int | None = None, max_per_page: int | None = None
+    ) -> int:
+        per_page = super().get_per_page(request, default_per_page, max_per_page)
+        if request.GET.get("full") in ("1", "true"):
+            return min(per_page, FULL_PAYLOAD_MAX_PER_PAGE)
+        return per_page
 
     @extend_schema(
         operation_id="listOrganizationIssueEvents",

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 
+from sentry.issues.endpoints.group_events import FULL_PAYLOAD_MAX_PER_PAGE
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.group import Group
 from sentry.search.eap.occurrences.rollout_utils import EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION
@@ -470,6 +471,56 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         assert links["previous"]["results"] == "false"
         assert links["next"]["results"] == "true"
         assert len(response.data) == 1
+
+    def _store_events(self, count: int) -> Group:
+        event = None
+        for i in range(count):
+            event = self.store_event(
+                data={
+                    "fingerprint": ["group_1"],
+                    "event_id": f"{i:032x}",
+                    "message": "foo",
+                    "timestamp": self.min_ago.isoformat(),
+                },
+                project_id=self.project.id,
+            )
+        assert event is not None
+        return event.group
+
+    def test_full_clamps_per_page_and_pages_with_cursor(self) -> None:
+        self.login_as(user=self.user)
+        total = FULL_PAYLOAD_MAX_PER_PAGE + 5
+        group = self._store_events(total)
+
+        url: str | None = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/"
+            f"?full=true&per_page=100"
+        )
+        seen: list[str] = []
+        pages = 0
+        while url and pages < 4:
+            response = self.do_request(url)
+            assert response.status_code == 200, response.content
+            assert len(response.data) <= FULL_PAYLOAD_MAX_PER_PAGE
+            seen.extend(row["eventID"] for row in response.data)
+            links = self._parse_links(response["Link"])
+            url = links["next"]["href"] if links["next"]["results"] == "true" else None
+            pages += 1
+
+        assert pages == 2
+        assert len(set(seen)) == total
+
+    def test_per_page_not_clamped_without_full(self) -> None:
+        self.login_as(user=self.user)
+        total = FULL_PAYLOAD_MAX_PER_PAGE + 5
+        group = self._store_events(total)
+
+        url = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{group.id}/events/?per_page=100"
+        )
+        response = self.do_request(url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == total
 
     def test_orderby(self) -> None:
         self.login_as(user=self.user)


### PR DESCRIPTION
`full=true` binds every event's full nodestore body and serializes it with `EventSerializer`, so a page costs by the frames inside it, not by the event count. `per_page` counts events and defaults to 100.

That is a poor fit for native events, where each one can carry a large number of threads and frames. A single page can reach hundreds of megabytes of JSON, take several times that in memory while it is parsed, serialized and encoded, and spend a long time doing it.

Clamp `per_page` to 10 when `full` is set. `full` keeps working and cursors still page through the whole set, so the only visible change is a smaller page.

Note this is the default path, not something a caller has to opt into: `get_per_page` reads `per_page`, and `PAGINATION_DEFAULT_PER_PAGE` is already 100.

Clamping is preferable to lowering `max_per_page`, which would 400 existing `per_page=100&full=1` callers, and would be a no-op anyway since `clamp_pagination_per_page()` floors the maximum at `default_per_page`. Cursors are unaffected — `GenericOffsetPaginator` encodes only the offset.