### PR TITLE
perf(issues): Extend repository list cap to link issue config modal

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -269,7 +269,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
     def get_link_issue_config(self, group: Group, **kwargs: Any) -> list[dict[str, Any]]:
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params)
+        default_repo, repo_choices = self.get_repository_choices(group, params, PAGE_NUMBER_LIMIT)
 
         org = group.organization
         autocomplete_url = reverse(


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/100064. We're extending it to another modal. We'll pre-populate the dropdown with the first page results. Typing in the input box initiates a search request and will fill in the rest.