### PR TITLE
fix(pr iter): link to org based github permissions url

### DIFF
--- a/src/sentry/integrations/utils/github_permissions.py
+++ b/src/sentry/integrations/utils/github_permissions.py
@@ -81,3 +81,18 @@ def get_missing_github_app_permissions(
             )
 
     return missing_permissions or None
+
+
+def get_github_permissions_update_url(
+    installation_id: str, account_type: str | None, account_login: str
+) -> str | None:
+    if not installation_id:
+        return None
+    if account_type == "Organization":
+        if not account_login:
+            return None
+        return (
+            f"https://github.com/organizations/{account_login}"
+            f"/settings/installations/{installation_id}/permissions/update"
+        )
+    return f"https://github.com/settings/installations/{installation_id}/permissions/update"

--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -20,6 +20,7 @@ from sentry.integrations.cursor.integration import CursorAgentIntegration
 from sentry.integrations.github_copilot.client import GithubCopilotAgentClient
 from sentry.integrations.services.github_copilot_identity import github_copilot_identity_service
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.github_permissions import get_github_permissions_update_url
 from sentry.models.organization import Organization
 from sentry.seer.autofix.coding_agent import (
     sanitize_branch_name,
@@ -145,6 +146,7 @@ def launch_coding_agents(
             failure_type = "generic"
             error_message = "Failed to launch coding agent"
             github_installation_id: str | None = None
+            github_installation_url: str | None = None
             if isinstance(e, HTTPError) and e.response is not None:
                 api_message = extract_api_error_message(e.response)
                 if api_message:
@@ -163,7 +165,13 @@ def launch_coding_agents(
                                 providers=["github"],
                             )
                             if github_integrations:
-                                github_installation_id = github_integrations[0].external_id
+                                github_integration = github_integrations[0]
+                                github_installation_id = github_integration.external_id
+                                github_installation_url = get_github_permissions_update_url(
+                                    str(github_integration.external_id),
+                                    github_integration.metadata.get("account_type"),
+                                    github_integration.name,
+                                )
                         except Exception:
                             sentry_sdk.capture_exception(level="warning")
                 elif (
@@ -182,6 +190,8 @@ def launch_coding_agents(
             }
             if github_installation_id:
                 failure["github_installation_id"] = github_installation_id
+            if github_installation_url:
+                failure["github_installation_url"] = github_installation_url
             failures.append(failure)
             continue
 

--- a/src/sentry/seer/autofix/github_perms.py
+++ b/src/sentry/seer/autofix/github_perms.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import RpcIntegration, integration_service
-from sentry.integrations.utils.github_permissions import get_missing_github_app_permissions
+from sentry.integrations.utils.github_permissions import (
+    get_github_permissions_update_url,
+    get_missing_github_app_permissions,
+)
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.seer.autofix.constants import SEER_GITHUB_PROVIDERS
@@ -22,16 +25,30 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class MissingGithubPermissions:
     integration: RpcIntegration
+    repo_id: int
     # Empty when the installation has every required permission.
     missing_scopes: list[str]
 
     @property
     def installation_id(self) -> str:
-        """GitHub App installation id (Integration.external_id)."""
         return str(self.integration.external_id)
 
+    @property
+    def installation_url(self) -> str | None:
+        """Page where the user reviews and accepts the installation's updated
+        permissions. Org-owned installs live under a different namespace than
+        user-owned ones, so this branches on the account type. None when the
+        install's account is unknown and the path can't be built."""
+        return get_github_permissions_update_url(
+            str(self.integration.external_id),
+            self.integration.metadata.get("account_type"),
+            self.integration.name,
+        )
 
-def get_github_missing_permissions(integration_id: int) -> MissingGithubPermissions | None:
+
+def get_github_missing_permissions(
+    integration_id: int, repo_id: int
+) -> MissingGithubPermissions | None:
     """Required GitHub App permissions the installation for `integration_id` is
     missing. Returns None if the integration no longer exists."""
     integration = integration_service.get_integration(integration_id=integration_id)
@@ -41,6 +58,7 @@ def get_github_missing_permissions(integration_id: int) -> MissingGithubPermissi
     missing = get_missing_github_app_permissions(integration.metadata)
     return MissingGithubPermissions(
         integration=integration,
+        repo_id=repo_id,
         missing_scopes=[permission["expected"]["scope"] for permission in (missing or [])],
     )
 
@@ -152,7 +170,7 @@ def get_out_of_date_github_permissions(
         # 2. Map those repo names to their GitHub integration (org-scoped, active).
         for (repo, integration_id) in Repository.filter(org, github, active, name in repos):
             # 3. Ask GitHub which required app permissions that install is missing.
-            perms = get_github_missing_permissions(integration_id)
+            perms = get_github_missing_permissions(integration_id, repo_id)
             if perms.missing_scopes:
                 result[repo] = perms
 
@@ -171,15 +189,15 @@ def get_out_of_date_github_permissions(
             status=ObjectStatus.ACTIVE,
         )
         .order_by("name", "integration_id")
-        .values_list("name", "integration_id")
+        .values_list("id", "name", "integration_id")
     )
 
     missing_by_repo: dict[str, MissingGithubPermissions] = {}
-    for repo_name, integration_id in repo_integration_ids:
+    for repo_id, repo_name, integration_id in repo_integration_ids:
         if not isinstance(integration_id, int):
             continue
 
-        perms = get_github_missing_permissions(integration_id)
+        perms = get_github_missing_permissions(integration_id, repo_id)
         if perms is not None and perms.missing_scopes:
             missing_by_repo[repo_name] = perms
 
@@ -202,7 +220,20 @@ def comment_on_out_of_date_github_permissions(
             continue
 
         integration = info.integration
-        url = f"https://github.com/settings/installations/{info.installation_id}/permissions/update"
+        url = info.installation_url
+        if url is None:
+            logger.error(
+                "autofix.permissions_comment.no_installation_url",
+                extra={
+                    "run_id": state.run_id,
+                    "organization_id": organization.id,
+                    "repo_id": info.repo_id,
+                    "integration_id": integration.id,
+                    "account_type": integration.metadata.get("account_type"),
+                },
+            )
+            continue
+
         body = (
             "⚠️ **Seer needs additional GitHub permissions**\n\n"
             "A Seer autofix tool failed because the Sentry GitHub App installation is "

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -14,6 +14,7 @@ class GithubAppPermissionsWarning(BaseModel):
     warning_type: Literal["github_app_permissions"] = "github_app_permissions"
     repo_name: str
     installation_id: str
+    installation_url: str | None = None
 
 
 # Discriminated on `warning_type`; add new warning models to this union.

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -572,6 +572,7 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
             GithubAppPermissionsWarning(
                 repo_name=repo_name,
                 installation_id=info.installation_id,
+                installation_url=info.installation_url,
             ).dict()
             for repo_name, info in missing_perms.items()
         ]

--- a/tests/sentry/integrations/utils/test_github_permissions.py
+++ b/tests/sentry/integrations/utils/test_github_permissions.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry.integrations.utils.github_permissions import (
     GITHUB_APP_REQUIRED_PERMISSIONS_OPTION,
+    get_github_permissions_update_url,
     get_missing_github_app_permissions,
 )
 from sentry.testutils.helpers.options import override_options
@@ -58,3 +59,37 @@ def test_get_missing_github_app_permissions(required_permissions, permissions, e
     )
     with override_options(options):
         assert get_missing_github_app_permissions({"permissions": permissions}) == expected
+
+
+@pytest.mark.parametrize(
+    ("installation_id", "account_type", "account_login", "expected"),
+    [
+        (
+            "123",
+            "User",
+            "example-user",
+            "https://github.com/settings/installations/123/permissions/update",
+        ),
+        (
+            "123",
+            "Organization",
+            "example-org",
+            "https://github.com/organizations/example-org"
+            "/settings/installations/123/permissions/update",
+        ),
+        (
+            "123",
+            None,
+            "example-user",
+            "https://github.com/settings/installations/123/permissions/update",
+        ),
+        ("123", "Organization", "", None),
+        ("", "User", "example-user", None),
+    ],
+)
+def test_get_github_permissions_update_url(
+    installation_id, account_type, account_login, expected
+) -> None:
+    assert (
+        get_github_permissions_update_url(installation_id, account_type, account_login) == expected
+    )

--- a/tests/sentry/seer/autofix/test_github_perms.py
+++ b/tests/sentry/seer/autofix/test_github_perms.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from unittest.mock import patch
 
+from sentry.integrations.services.integration import integration_service
 from sentry.seer.agent.client_models import (
     MemoryBlock,
     Message,
+    RepoPRState,
+    SeerRunState,
     ToolCall,
     ToolLink,
     ToolResult,
 )
 from sentry.seer.autofix.github_perms import (
+    MissingGithubPermissions,
     blocks_have_failed_tool_call,
+    comment_on_out_of_date_github_permissions,
     repos_with_failed_tool_calls,
 )
+from sentry.testutils.cases import TestCase
 from sentry.utils import json
 
 
@@ -81,3 +88,79 @@ def test_aggregates_across_blocks() -> None:
         _block(calls=[("t", "org/repo-b", True)]),
     ]
     assert repos_with_failed_tool_calls(blocks) == {"org/repo-a", "org/repo-b"}
+
+
+class CommentOnOutOfDateGithubPermissionsTest(TestCase):
+    def _missing_permissions(
+        self, account_type: str, account_login: str
+    ) -> MissingGithubPermissions:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="123456",
+            name=account_login,
+            metadata={"account_type": account_type},
+        )
+        rpc_integration = integration_service.get_integration(integration_id=integration.id)
+        assert rpc_integration is not None
+        return MissingGithubPermissions(
+            integration=rpc_integration, repo_id=1, missing_scopes=["workflows"]
+        )
+
+    def _run_state(self) -> SeerRunState:
+        return SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+            repo_pr_states={
+                "getsentry/sentry": RepoPRState(repo_name="getsentry/sentry", pr_number=92)
+            },
+        )
+
+    def _post_comment(self, account_type: str, account_login: str) -> str:
+        info = self._missing_permissions(account_type, account_login)
+        with patch(
+            "sentry.integrations.github.client.GitHubApiClient.create_comment"
+        ) as create_comment:
+            commented = comment_on_out_of_date_github_permissions(
+                self.organization, self._run_state(), {"getsentry/sentry": info}
+            )
+        assert commented == ["getsentry/sentry"]
+        return create_comment.call_args.args[2]["body"]
+
+    def test_user_installation_links_personal_namespace(self) -> None:
+        body = self._post_comment("User", "example-user")
+        assert "https://github.com/settings/installations/123456/permissions/update" in body
+
+    def test_org_installation_links_org_namespace(self) -> None:
+        body = self._post_comment("Organization", "getsentry")
+        assert (
+            "https://github.com/organizations/getsentry"
+            "/settings/installations/123456/permissions/update" in body
+        )
+
+    def test_org_installation_without_account_login_logs_and_skips(self) -> None:
+        info = self._missing_permissions("Organization", "")
+        with (
+            patch(
+                "sentry.integrations.github.client.GitHubApiClient.create_comment"
+            ) as create_comment,
+            patch("sentry.seer.autofix.github_perms.logger") as mock_logger,
+        ):
+            commented = comment_on_out_of_date_github_permissions(
+                self.organization, self._run_state(), {"getsentry/sentry": info}
+            )
+
+        assert commented == []
+        create_comment.assert_not_called()
+        assert (
+            mock_logger.error.call_args.args[0] == "autofix.permissions_comment.no_installation_url"
+        )
+        assert set(mock_logger.error.call_args.kwargs["extra"]) == {
+            "run_id",
+            "organization_id",
+            "repo_id",
+            "integration_id",
+            "account_type",
+        }

--- a/tests/sentry/seer/autofix/test_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_on_completion_hook.py
@@ -99,6 +99,7 @@ def _perms(integration_id: int) -> MissingGithubPermissions:
             metadata={},
             status=0,
         ),
+        repo_id=integration_id,
         missing_scopes=["contents"],
     )
 

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -226,6 +226,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     metadata={},
                     status=0,
                 ),
+                repo_id=1,
                 missing_scopes=["contents"],
             )
         }
@@ -239,6 +240,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                 "warning_type": "github_app_permissions",
                 "repo_name": "getsentry/sentry",
                 "installation_id": "9999",
+                "installation_url": "https://github.com/settings/installations/9999/permissions/update",
             }
         ]
 


### PR DESCRIPTION
previously we were always linking the user to the url for updating
permissions that wasn't org based even if the integration was for an
org

in testing i found that this URL is not valid

this was a bug in both the update permissions banner in the autofix
drawer, the modal in the integrations page and the modal opened
when coding agent handoff failed

so now we're linking to the correct page on github when the install
belongs to an org

there will be a follow-up change where i update the frontend to
use the right URL
