### PR TITLE
feat(onboarding): Persist agentic run initialization

### DIFF
--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -17,6 +17,8 @@ type OnboardingContextProps = {
   setAgentSetupProjectBaseline: (
     baseline?: OnboardingSessionState['agentSetupProjectBaseline']
   ) => void;
+  setAgenticProgressClientRunId: (clientRunId?: string) => void;
+  setAgenticProgressOnboardingCode: (onboardingCode?: string) => void;
   setCreatedProjectSlug: (slug?: string) => void;
   setMessagingSetup: (messagingSetup: ScmMessagingSetup) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
@@ -24,6 +26,8 @@ type OnboardingContextProps = {
   setSelectedPlatform: (selectedSDK?: OnboardingSelectedSDK) => void;
   setSelectedRepository: (repo?: Repository) => void;
   agentSetupProjectBaseline?: OnboardingSessionState['agentSetupProjectBaseline'];
+  agenticProgressClientRunId?: string;
+  agenticProgressOnboardingCode?: string;
   createdProjectSlug?: string;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
@@ -38,6 +42,8 @@ type OnboardingSessionState = {
     organizationId: string;
     projectIds: string[];
   };
+  agenticProgressClientRunId?: string;
+  agenticProgressOnboardingCode?: string;
   createdProjectSlug?: string;
   messagingSetup?: ScmMessagingSetup;
   selectedFeatures?: ProductSolution[];
@@ -64,6 +70,10 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setMessagingSetup: () => {},
   agentSetupProjectBaseline: undefined,
   setAgentSetupProjectBaseline: () => {},
+  agenticProgressClientRunId: undefined,
+  setAgenticProgressClientRunId: () => {},
+  agenticProgressOnboardingCode: undefined,
+  setAgenticProgressOnboardingCode: () => {},
   clearDerivedState: () => {},
   resetOnboarding: () => {},
   discardOnboardingSession: () => {},
@@ -137,6 +147,14 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
         agentSetupProjectBaseline?: OnboardingSessionState['agentSetupProjectBaseline']
       ) => {
         setOnboarding(prev => ({...prev, agentSetupProjectBaseline}));
+      },
+      agenticProgressClientRunId: onboarding?.agenticProgressClientRunId,
+      setAgenticProgressClientRunId: (agenticProgressClientRunId?: string) => {
+        setOnboarding(prev => ({...prev, agenticProgressClientRunId}));
+      },
+      agenticProgressOnboardingCode: onboarding?.agenticProgressOnboardingCode,
+      setAgenticProgressOnboardingCode: (agenticProgressOnboardingCode?: string) => {
+        setOnboarding(prev => ({...prev, agenticProgressOnboardingCode}));
       },
       // Clear state derived from the selected repository (platform, features,
       // created project) without wiping the entire session. Use this when the

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.spec.tsx
@@ -3,6 +3,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import type {RequestOptions} from 'sentry/api';
+import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
+
 import {useAgenticProgressInit} from './useAgenticProgressInit';
 
 describe('useAgenticProgressInit', () => {
@@ -47,5 +50,110 @@ describe('useAgenticProgressInit', () => {
 
     rerender();
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes with the client run ID and onboarding code stored in the session', async () => {
+    const run = AgenticProgressRunFixture();
+    const request = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      body: run,
+    });
+    const options = {
+      organization,
+      additionalWrapper: OnboardingContextProvider,
+    };
+
+    const firstRender = renderHookWithProviders(
+      () => useAgenticProgressInit({enabled: true}),
+      options
+    );
+
+    await waitFor(() => expect(firstRender.result.current.data).toEqual(run));
+    await waitFor(() =>
+      expect(
+        JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')
+          .agenticProgressClientRunId
+      ).toBeDefined()
+    );
+    const storedSession = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
+    const storedClientRunId = storedSession.agenticProgressClientRunId;
+    const storedOnboardingCode = storedSession.agenticProgressOnboardingCode;
+    expect(storedOnboardingCode).toMatch(/^[A-Za-z0-9]{10}$/);
+    firstRender.unmount();
+
+    const secondRender = renderHookWithProviders(
+      () => useAgenticProgressInit({enabled: true}),
+      options
+    );
+
+    await waitFor(() => expect(secondRender.result.current.data).toEqual(run));
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[1]?.[1]?.data).toEqual({
+      clientRunId: storedClientRunId,
+      onboardingCode: storedOnboardingCode,
+    });
+  });
+
+  it('generates a new onboarding code when it conflicts', async () => {
+    const staleClientRunId = 'stale-client-run-id';
+    const staleOnboardingCode = 'stale-code';
+    const replacementRequest = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      match: [(_url, options) => options.data.onboardingCode !== staleOnboardingCode],
+      body: (_url: string, options: RequestOptions) =>
+        AgenticProgressRunFixture({
+          clientRunId: options.data.clientRunId,
+          onboardingCode: options.data.onboardingCode,
+        }),
+    });
+    const conflictRequest = MockApiClient.addMockResponse({
+      url: endpoint,
+      method: 'POST',
+      statusCode: 409,
+      match: [
+        MockApiClient.matchData({
+          clientRunId: staleClientRunId,
+          onboardingCode: staleOnboardingCode,
+        }),
+      ],
+      body: {detail: 'Onboarding code is unavailable'},
+    });
+    window.sessionStorage.setItem(
+      'onboarding',
+      JSON.stringify({
+        agenticProgressClientRunId: staleClientRunId,
+        agenticProgressOnboardingCode: staleOnboardingCode,
+      })
+    );
+
+    const {result} = renderHookWithProviders(
+      () => useAgenticProgressInit({enabled: true}),
+      {organization, additionalWrapper: OnboardingContextProvider}
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(conflictRequest).toHaveBeenCalledWith(
+      endpoint,
+      expect.objectContaining({
+        data: {
+          clientRunId: staleClientRunId,
+          onboardingCode: staleOnboardingCode,
+        },
+      })
+    );
+    expect(replacementRequest).toHaveBeenCalledTimes(1);
+    const replacementData = replacementRequest.mock.calls[0]?.[1]?.data;
+    expect(replacementData.clientRunId).toBe(staleClientRunId);
+    expect(replacementData.onboardingCode).toMatch(/^[A-Za-z0-9]{10}$/);
+    await waitFor(() =>
+      expect(JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')).toEqual(
+        expect.objectContaining({
+          agenticProgressClientRunId: replacementData.clientRunId,
+          agenticProgressOnboardingCode: replacementData.onboardingCode,
+        })
+      )
+    );
   });
 });

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts
@@ -2,10 +2,11 @@ import {useEffect, useRef, useState} from 'react';
 import {uuid4} from '@sentry/core';
 import {useMutation} from '@tanstack/react-query';
 
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 import type {InitializedAgenticProgressRun} from './types';
 
@@ -13,26 +14,68 @@ type UseAgenticProgressInitOptions = {
   enabled: boolean;
 };
 
+const createOnboardingCode = () => uuid4().slice(0, 10);
+
 export function useAgenticProgressInit({enabled}: UseAgenticProgressInitOptions) {
   const organization = useOrganization();
+  const {
+    agenticProgressClientRunId,
+    agenticProgressOnboardingCode,
+    setAgenticProgressClientRunId,
+    setAgenticProgressOnboardingCode,
+  } = useOnboardingContext();
   const [initialClientRunId] = useState(uuid4);
-  const [clientRunId] = useSessionStorage(
-    `agentic-progress-client-run-id:${organization.id}`,
-    initialClientRunId
-  );
+  const [initialOnboardingCode] = useState(createOnboardingCode);
+  const clientRunId = agenticProgressClientRunId ?? initialClientRunId;
+  const onboardingCode = agenticProgressOnboardingCode ?? initialOnboardingCode;
   const startedForClientRunId = useRef<string | null>(null);
 
-  const mutation = useMutation({
-    mutationFn: () =>
-      fetchMutation<InitializedAgenticProgressRun>({
-        method: 'POST',
-        url: getApiUrl('/organizations/$organizationIdOrSlug/onboarding/agent/runs/', {
-          path: {organizationIdOrSlug: organization.slug},
-        }),
-        data: {clientRunId},
+  const initializeRun = (nextClientRunId: string, nextOnboardingCode: string) =>
+    fetchMutation<InitializedAgenticProgressRun>({
+      method: 'POST',
+      url: getApiUrl('/organizations/$organizationIdOrSlug/onboarding/agent/runs/', {
+        path: {organizationIdOrSlug: organization.slug},
       }),
+      data: {
+        clientRunId: nextClientRunId,
+        onboardingCode: nextOnboardingCode,
+      },
+    });
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      try {
+        return await initializeRun(clientRunId, onboardingCode);
+      } catch (error) {
+        if (!(error instanceof RequestError) || error.status !== 409) {
+          throw error;
+        }
+
+        const replacementOnboardingCode = createOnboardingCode();
+        setAgenticProgressOnboardingCode(replacementOnboardingCode);
+
+        return initializeRun(clientRunId, replacementOnboardingCode);
+      }
+    },
   });
   const {mutate} = mutation;
+
+  useEffect(() => {
+    if (!agenticProgressClientRunId) {
+      setAgenticProgressClientRunId(clientRunId);
+    }
+
+    if (!agenticProgressOnboardingCode) {
+      setAgenticProgressOnboardingCode(onboardingCode);
+    }
+  }, [
+    agenticProgressClientRunId,
+    agenticProgressOnboardingCode,
+    clientRunId,
+    onboardingCode,
+    setAgenticProgressClientRunId,
+    setAgenticProgressOnboardingCode,
+  ]);
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
Persists the agentic onboarding client run ID and onboarding code in the existing onboarding session so refreshing or revisiting the flow resumes the same run. Initialization now sends both required identifiers and, when a stale code collides with an existing run, regenerates only the code while retaining the client run ID.