### PR TITLE
feat(subscriptions): Send the organization id for all subscriptions

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -277,8 +277,9 @@ def _create_snql_in_snuba(
     body = {
         "project_id": subscription.project_id,
         # Snuba attributes the resulting queries to this organization. Metrics entities
-        # also send it via get_entity_extra_params, which stays authoritative below.
-        "organization": subscription.project.organization_id,
+        # additionally send a legacy `organization` key via get_entity_extra_params,
+        # which their subscription processors are configured with.
+        "organization_id": subscription.project.organization_id,
         "query": str(snql_query.query),
         "time_window": snuba_query.time_window,
         "resolution": snuba_query.resolution,

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -276,6 +276,9 @@ def _create_snql_in_snuba(
 ) -> str:
     body = {
         "project_id": subscription.project_id,
+        # Snuba attributes the resulting queries to this organization. Metrics entities
+        # also send it via get_entity_extra_params, which stays authoritative below.
+        "organization": subscription.project.organization_id,
         "query": str(snql_query.query),
         "time_window": snuba_query.time_window,
         "resolution": snuba_query.resolution,

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -160,6 +160,13 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
         assert sub.status == QuerySubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
 
+    def test_organization_id(self) -> None:
+        sub = self.create_subscription(QuerySubscription.Status.CREATING)
+        with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
+            create_subscription_in_snuba(sub.id)
+            request_body = json.loads(urlopen.call_args[1]["body"])
+            assert request_body["organization"] == self.organization.id
+
     def test_group_id(self) -> None:
         group_id = 1234
         sub = self.create_subscription(

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -165,7 +165,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
         with patch.object(_snuba_pool, "urlopen", side_effect=_snuba_pool.urlopen) as urlopen:
             create_subscription_in_snuba(sub.id)
             request_body = json.loads(urlopen.call_args[1]["body"])
-            assert request_body["organization"] == self.organization.id
+            assert request_body["organization_id"] == self.organization.id
 
     def test_group_id(self) -> None:
         group_id = 1234


### PR DESCRIPTION
Snuba attributes subscription queries to an organization using a field in the subscription creation payload, but only the metrics entity subscriptions send one — `BaseMetricsEntitySubscription.get_entity_extra_params()` returns `organization`, while the events and transactions implementations return `{}`. Error and transaction subscriptions therefore reach Snuba with no organization at all, and their queries fall back to a placeholder. Those are also the subscriptions that hit Snuba's post-replacement consistency processor, where per-organization behavior is being introduced.

`_create_snql_in_snuba` already has the value on hand, so send `organization_id` for every SnQL subscription. Metrics entities keep sending their own `organization` via `get_entity_extra_params()`, which is spread later in the dict and stays authoritative.

Depends on getsentry/snuba#8400, which teaches Snuba to read the new key, persist it for entities that have no organization subscription processor, and accept either spelling in the metrics entities' `AddColumnCondition`. **That PR must be deployed first** — the metrics processors raise when their configured key is missing, so the fallback needs to be live before this ships.

Deploying this first is safe but useless rather than harmful: Snuba sweeps unrecognized payload keys into subscription metadata rather than rejecting them, and the `/subscriptions` endpoint does no schema validation of the body, so an older Snuba silently ignores the field. Verified against Snuba `master` — no 4xx, no `SnubaError`, no subscriptions stranded in `CREATING`.

Existing subscriptions keep their stored payloads until they are recreated, so attribution fills in over time rather than immediately.
