### PR TITLE
feat(seer): Add windowed autofix-overview SCM-info endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -575,6 +575,7 @@ from sentry.seer.endpoints.organization_seer_agent_update import (
 )
 from sentry.seer.endpoints.organization_seer_autofix_overview import (
     OrganizationSeerAutofixOverviewEndpoint,
+    OrganizationSeerAutofixScmInfoEndpoint,
 )
 from sentry.seer.endpoints.organization_seer_onboarding_check import OrganizationSeerOnboardingCheck
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
@@ -2537,6 +2538,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/seer/autofix-overview/$",
         OrganizationSeerAutofixOverviewEndpoint.as_view(),
         name="sentry-api-0-organization-seer-autofix-overview",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/autofix-scm-info/$",
+        OrganizationSeerAutofixScmInfoEndpoint.as_view(),
+        name="sentry-api-0-organization-seer-autofix-scm-info",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/runs/$",

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -6,6 +6,7 @@ from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import NamedTuple, cast
+from uuid import UUID
 
 from django.db.models import Exists, OuterRef, Q
 from pydantic import ValidationError
@@ -51,6 +52,8 @@ from sentry.seer.endpoints.organization_seer_autofix_overview_types import (
     PullRequestPayload,
     RootCausePayload,
     RunPayload,
+    ScmInfoResponse,
+    ScmInfoRunPayload,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.seer.models.run import (
@@ -85,6 +88,10 @@ _HIDDEN_PULL_REQUEST_STATES = (PullRequestLifecycleState.CLOSED,)
 _VISIBLE_PULL_REQUEST_FILTER = Q(pull_request__state__isnull=True) | ~Q(
     pull_request__state__in=_HIDDEN_PULL_REQUEST_STATES
 )
+
+# Agent sources that surface in the autofix overview. `autofix_rca` no longer gets new
+# writes; removable from these filters by 2026-11-11 (data retention).
+_AUTOFIX_AGENT_SOURCES = ("autofix", "autofix_rca")
 
 # The three issue-based sort params, mapped to their search-backend names.
 # Any other value (seer default, empty, unknown) keeps the default order.
@@ -354,6 +361,8 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
 
         start, end = get_date_range_from_stats_period(request.GET)
         expand = request.GET.getlist("expand")
+        # TODO: remove the scmInfo path once all clients fetch PR/SCM data from
+        # OrganizationSeerAutofixScmInfoEndpoint (frontend windowed rollout complete).
         include_scm_info = "scmInfo" in expand
         include_issue_stats = "issueStats" in expand
         include_status = "status" in expand
@@ -448,6 +457,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
                     "hasReposConnected": repo_eligibility_by_project[
                         project.id
                     ].has_repos_connected,
+                    "hasNonGithubRepo": repo_eligibility_by_project[project.id].has_non_github_repo,
                 }
                 for project in projects
             ]
@@ -495,10 +505,9 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
     ) -> dict[int, _RunMilestones]:
         pr_links = SeerRunPullRequest.objects.filter(seer_run_id=OuterRef("seer_run_id"))
         milestone_rows = (
-            # writes for autofix_rca no longer happen, we should be able to remove this from the query by 11/11/2026 latest (data retention)
             SeerRunMilestone.objects.filter(
                 seer_run__organization=organization,
-                seer_run__agent__source__in=("autofix", "autofix_rca"),
+                seer_run__agent__source__in=_AUTOFIX_AGENT_SOURCES,
                 seer_run__agent__group_id__isnull=False,
                 seer_run__agent__project_id__in=project_ids,
                 seer_run__last_triggered_at__range=(start, end),
@@ -560,3 +569,42 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         # Candidates with no in-window events are absent from Snuba; keep them, sorted last.
         ordered_ids.extend(gid for gid in latest_run_per_group if gid not in seen)
         return {gid: latest_run_per_group[gid] for gid in ordered_ids}
+
+
+@cell_silo_endpoint
+class OrganizationSeerAutofixScmInfoEndpoint(OrganizationEndpoint):
+    # Split from the overview's `scmInfo` expand so the slow GitHub GraphQL work
+    # runs only for the window of runs a client is actually viewing. Keyed by seerRunId.
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.ML_AI
+    permission_classes = (OrganizationSeerAutofixOverviewPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        projects = self.get_projects(request, organization)
+        project_ids = [p.id for p in projects]
+
+        try:
+            run_uuids = [UUID(run_id) for run_id in request.GET.getlist("runIds")]
+        except ValueError:
+            return Response({"detail": "Invalid runIds."}, status=400)
+
+        # Scope to accessible projects (and autofix sources) so runIds can't reach PR
+        # data outside the caller's overview; runIds that don't resolve are omitted.
+        runs = SeerRun.objects.filter(
+            uuid__in=run_uuids,
+            organization=organization,
+            agent__project_id__in=project_ids,
+            agent__source__in=_AUTOFIX_AGENT_SOURCES,
+        )
+        uuid_by_run_id = {run.id: str(run.uuid) for run in runs}
+
+        pull_requests_by_seer_run_id = _pull_requests_by_seer_run_id(
+            list(uuid_by_run_id), include_scm_info=True
+        )
+
+        scm_info_by_run_id: dict[str, ScmInfoRunPayload] = {
+            run_uuid: {"pullRequests": pull_requests_by_seer_run_id.get(run_id, [])}
+            for run_id, run_uuid in uuid_by_run_id.items()
+        }
+        response: ScmInfoResponse = {"scmInfoByRunId": scm_info_by_run_id}
+        return Response(response)

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview_types.py
@@ -57,6 +57,7 @@ class ProjectConfigPayload(TypedDict):
     id: str
     slug: str
     hasReposConnected: bool
+    hasNonGithubRepo: bool
 
 
 class CodeChangeFilePayload(TypedDict):
@@ -90,3 +91,11 @@ class OverviewResponse(TypedDict):
     runsByMilestone: dict[str, list[RunPayload]]
     truncatedMilestones: list[str]
     projectConfig: NotRequired[list[ProjectConfigPayload]]
+
+
+class ScmInfoRunPayload(TypedDict):
+    pullRequests: list[PullRequestPayload]
+
+
+class ScmInfoResponse(TypedDict):
+    scmInfoByRunId: dict[str, ScmInfoRunPayload]

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -367,6 +367,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/search-agent/translate/'
   | '/organizations/$organizationIdOrSlug/seer-rpc/$methodName/'
   | '/organizations/$organizationIdOrSlug/seer/autofix-overview/'
+  | '/organizations/$organizationIdOrSlug/seer/autofix-scm-info/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-chat/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-chat/$runId/'
   | '/organizations/$organizationIdOrSlug/seer/explorer-update/$runId/'

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -629,6 +629,7 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
             "id": str(self.project.id),
             "slug": self.project.slug,
             "hasReposConnected": False,
+            "hasNonGithubRepo": False,
         }
 
     def test_project_config_includes_project_without_runs(self):

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_scm_info.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_scm_info.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from unittest import mock
+
+from sentry.integrations.source_code_management.status_check import (
+    AggregateChecksStatus,
+    AggregateReviewStatus,
+    PullRequestFileSummary,
+    PullRequestStatusClient,
+    PullRequestStatusRequest,
+    PullRequestStatusResult,
+)
+from sentry.models.pullrequest import PullRequestLifecycleState
+from sentry.testutils.cases import APITestCase
+
+_INTEGRATION_SERVICE = (
+    "sentry.integrations.source_code_management.pull_request_status_batch."
+    "integration_service.get_integration"
+)
+
+
+class PullRequestStatusClientFake(PullRequestStatusClient):
+    def __init__(self, status_by_key: dict[str, PullRequestStatusResult] | None = None) -> None:
+        self.status_by_key = status_by_key or {}
+        self.requested_keys: list[str] = []
+
+    def get_pull_request_statuses(
+        self, pull_requests: Sequence[PullRequestStatusRequest]
+    ) -> dict[PullRequestStatusRequest, PullRequestStatusResult]:
+        self.requested_keys.extend(pr.pull_number for pr in pull_requests)
+        return {
+            pr: self.status_by_key.get(pr.pull_number, PullRequestStatusResult())
+            for pr in pull_requests
+        }
+
+
+class OrganizationSeerAutofixScmInfoTest(APITestCase):
+    endpoint = "sentry-api-0-organization-seer-autofix-scm-info"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+    def _set_provider_client(self, mock_get_integration, client):
+        installation = mock.Mock()
+        installation.get_client.return_value = client
+        integration = mock.Mock()
+        integration.get_installation.return_value = installation
+        mock_get_integration.return_value = integration
+        return client
+
+    def _run(self, *, organization=None, project=None, source="autofix"):
+        organization = organization or self.organization
+        project = project or self.project
+        group = self.create_group(project=project)
+        run = self.create_seer_run(organization=organization)
+        self.create_seer_agent_run(run, source=source, group=group, project=project)
+        return run, group
+
+    def _add_pr(self, run, group, *, key="123", updates=None):
+        repo = self.create_repo(
+            project=group.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=123,
+            url="https://github.com/getsentry/sentry",
+        )
+        pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=group.project.organization_id, key=key
+        )
+        pr.update(**(updates or {"state": PullRequestLifecycleState.OPEN, "draft": False}))
+        self.create_seer_run_pull_request(run=run, pull_request=pr)
+        return pr
+
+    def _get(self, run_ids):
+        return self.get_success_response(self.organization.slug, qs_params={"runIds": run_ids})
+
+    @mock.patch(_INTEGRATION_SERVICE)
+    def test_returns_scm_info_for_run(self, mock_get_integration):
+        run, group = self._run()
+        pr = self._add_pr(run, group)
+        client = self._set_provider_client(
+            mock_get_integration,
+            PullRequestStatusClientFake(
+                {
+                    "123": PullRequestStatusResult(
+                        checks=AggregateChecksStatus.SUCCESS,
+                        review=AggregateReviewStatus.APPROVED,
+                        files=(
+                            PullRequestFileSummary(
+                                path="src/foo.py",
+                                additions=10,
+                                deletions=2,
+                                change_type="MODIFIED",
+                            ),
+                        ),
+                    )
+                }
+            ),
+        )
+
+        resp = self._get(str(run.uuid))
+
+        assert client.requested_keys == ["123"]
+        assert resp.data["scmInfoByRunId"] == {
+            str(run.uuid): {
+                "pullRequests": [
+                    {
+                        "id": str(pr.id),
+                        "number": 123,
+                        "url": "https://github.com/getsentry/sentry/pull/123",
+                        "status": "open",
+                        "checksStatus": "success",
+                        "reviewStatus": "approved",
+                        "repoName": "getsentry/sentry",
+                        "files": [
+                            {
+                                "path": "src/foo.py",
+                                "additions": 10,
+                                "deletions": 2,
+                                "changeType": "MODIFIED",
+                            }
+                        ],
+                        "failedCheckDetails": [],
+                    }
+                ]
+            }
+        }
+
+    def test_run_without_prs_returns_empty_list(self):
+        run, _ = self._run()
+        resp = self._get(str(run.uuid))
+        assert resp.data["scmInfoByRunId"] == {str(run.uuid): {"pullRequests": []}}
+
+    def test_no_run_ids_returns_empty(self):
+        resp = self._get([])
+        assert resp.data == {"scmInfoByRunId": {}}
+
+    def test_invalid_run_ids_returns_400(self):
+        self.get_error_response(
+            self.organization.slug, qs_params={"runIds": "not-a-uuid"}, status_code=400
+        )
+
+    def test_omits_runs_from_other_orgs(self):
+        other_org = self.create_organization(owner=self.create_user())
+        other_project = self.create_project(organization=other_org)
+        other_run, other_group = self._run(organization=other_org, project=other_project)
+        self._add_pr(other_run, other_group)
+        resp = self._get(str(other_run.uuid))
+        assert resp.data["scmInfoByRunId"] == {}
+
+    def test_omits_runs_from_inaccessible_same_org_projects(self):
+        org = self.create_organization(owner=self.create_user())
+        member = self.create_user()
+        my_team = self.create_team(organization=org)
+        self.create_member(user=member, organization=org, teams=[my_team])
+        self.create_project(organization=org, teams=[my_team])
+        other_team = self.create_team(organization=org)
+        inaccessible = self.create_project(organization=org, teams=[other_team])
+        run, group = self._run(organization=org, project=inaccessible)
+        self._add_pr(run, group)
+        self.login_as(member)
+
+        resp = self.get_success_response(org.slug, qs_params={"runIds": str(run.uuid)})
+        assert resp.data["scmInfoByRunId"] == {}
+
+    def test_omits_non_autofix_source_runs(self):
+        run, group = self._run(source="explorer")
+        self._add_pr(run, group)
+        resp = self._get(str(run.uuid))
+        assert resp.data["scmInfoByRunId"] == {}


### PR DESCRIPTION
## Summary

The Autofix Overview page enriches cards with GitHub PR checks/review/changed-files via the overview endpoint's `scmInfo` expand. That work runs `get_checks_and_review` against GitHub for **every open PR on the page** and is the page's dominant latency — even though cards render fully without it (title, status, milestone, priority, assignee, counts, PR links all come from non-`scmInfo` data).

This PR (backend, first of a series) adds a dedicated **`GET /organizations/{org}/seer/autofix-scm-info/`** endpoint that returns *only* the PR/SCM enrichment for an explicit set of run ids, so the frontend can fetch GitHub data in visibility-driven windows instead of up front for every card. No frontend changes here — the overview keeps serving `scmInfo` unchanged until the frontend switches over.

## What changed

- **New endpoint** `OrganizationSeerAutofixScmInfoEndpoint`: accepts `runIds` (SeerRun uuids), scopes them to the caller's org + accessible projects + autofix sources, and returns each run's PR `checksStatus`/`reviewStatus`/`files`/`failedCheckDetails` keyed by `seerRunId`. Reuses the existing `_pull_requests_by_seer_run_id(..., include_scm_info=True)` helper.
- **Overview addition**: `hasNonGithubRepo` on the projectConfig payload, so card repo-eligibility can be sourced there rather than from `scmInfo`.
- Lifted the `("autofix", "autofix_rca")` source filter to a shared `_AUTOFIX_AGENT_SOURCES` constant so the overview and scm-info queries can't drift.

## Ownership / rollout

The **frontend owns the window size** (how many runs it requests per scroll) and **gates rollout** — no feature flag or batch-size option on the backend. The endpoint just serves the requested `runIds`; if a client over-requests, it slows/times out the same way the underlying GitHub call would, so picking a sane batch size is the frontend's responsibility.

Backend-first: a follow-up frontend PR switches the overview to fetch SCM info from this endpoint (behind a frontend flag); once rolled out, a cleanup PR removes the now-dead `scmInfo` path from the overview (marked with a TODO).

## Test plan

- New `tests/sentry/seer/endpoints/test_organization_seer_autofix_scm_info.py`: serialization, invalid/empty `runIds`, and cross-org / same-org-inaccessible-project / non-autofix-source scoping (IDOR boundaries).
- Overview suite updated for the `hasNonGithubRepo` addition.
- `ruff`, `mypy`, `prek` clean.
