### PR TITLE
fix(ci): use exact PR file lists for change detection

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+      pull-requests: read
     # Map a step output to a job output
     outputs:
       acceptance: ${{ steps.changes.outputs.acceptance }}
@@ -41,7 +42,7 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
-          token: ''
+          token: ${{ github.token }}
           filters: .github/file-filters.yml
 
   acceptance:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -27,6 +27,7 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+      pull-requests: read
     # Map a step output to a job output
     outputs:
       api_docs: ${{ steps.changes.outputs.api_docs }}
@@ -44,7 +45,7 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
-          token: ''
+          token: ${{ github.token }}
           filters: .github/file-filters.yml
 
   api-docs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+      pull-requests: read
     # Map a step output to a job output
     outputs:
       testable_modified: ${{ steps.changes.outputs.testable_modified }}
@@ -40,7 +41,7 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
-          token: ''
+          token: ${{ github.token }}
           filters: .github/file-filters.yml
           list-files: shell
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+      pull-requests: read
     # Map a step output to a job output
     outputs:
       added: ${{ steps.changes.outputs.migrations_added }}
@@ -32,7 +33,7 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
-          token: ''
+          token: ${{ github.token }}
           filters: .github/file-filters.yml
 
   sql:

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -26,7 +27,7 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
-          token: ''
+          token: ${{ github.token }}
           filters: .github/file-filters.yml
 
       - name: Setup sentry env

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,6 +32,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - # get a non-default github token so that any changes are verified by CI
         if: env.SECRET_ACCESS == 'true'
@@ -45,7 +46,7 @@ jobs:
         id: changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
-          token: ''
+          token: ${{ github.token }}
           # Enable listing of files matching each filter.
           # Paths to files will be available in `${FILTER_NAME}_files` output variable.
           list-files: json

--- a/.github/workflows/type-coverage-diff.yml
+++ b/.github/workflows/type-coverage-diff.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
     steps:
@@ -32,7 +33,7 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
-          token: ''
+          token: ${{ github.token }}
           filters: .github/file-filters.yml
 
   type-coverage-diff:


### PR DESCRIPTION
Looks like #120989 removed the Github token for PR workflows which makes paths-filter fall back to a local git diff instead of referencing Github API. 

paths-filter does not diff the merge commit against its own first parent (as this is not always available in general cases), but rather master from when you last pushed (the master snapshot recorded in the PR event); i.e. the diff compares the PR merged with current master against a stale snapshot, attributing any commits merged in between to the PR.

E.g. https://github.com/getsentry/sentry/pull/122604 as an example case.

Let's restore the token so we can retrieve the exact per-PR file list via API, and maintain least access by just adding the read-only permission which is also required. Workflows that only run on push to master keep the tokenless diff, which is exact there (push events carry the exact before/after of the push, so the diff there is always correct).