### PR TITLE
fix(pr iter): show correct perms update URL in modal

### DIFF
--- a/static/app/components/events/autofix/autofixGithubAppPermissionsModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixGithubAppPermissionsModal.spec.tsx
@@ -15,6 +15,45 @@ describe('AutofixGithubAppPermissionsModal', () => {
     expect(screen.getByText(/does not have sufficient permissions/)).toBeInTheDocument();
   });
 
+  it('uses a custom first sentence and always links settings in the body', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(deps => (
+        <AutofixGithubAppPermissionsModal
+          {...deps}
+          description="Seer had trouble talking to GitHub while running Autofix."
+        />
+      ));
+    });
+
+    expect(
+      await screen.findByText(/Seer had trouble talking to GitHub while running Autofix/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'GitHub App installation settings'})
+    ).toHaveAttribute('href', 'https://github.com/settings/installations/');
+  });
+
+  it('uses a provided installation URL', async () => {
+    const installationUrl =
+      'https://github.com/organizations/example-org/settings/installations/654321/permissions/update';
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(deps => (
+        <AutofixGithubAppPermissionsModal {...deps} installationUrl={installationUrl} />
+      ));
+    });
+
+    const updateButton = await screen.findByRole('button', {name: 'Update Permissions'});
+    expect(updateButton).toHaveAttribute('href', installationUrl);
+    expect(
+      screen.getByRole('link', {name: 'GitHub App installation settings'})
+    ).toHaveAttribute('href', installationUrl);
+  });
+
   it('renders update permissions button linking to GitHub settings', async () => {
     renderGlobalModal();
 

--- a/static/app/components/events/autofix/autofixGithubAppPermissionsModal.tsx
+++ b/static/app/components/events/autofix/autofixGithubAppPermissionsModal.tsx
@@ -9,7 +9,9 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
 
 interface AutofixGithubAppPermissionsModalProps extends ModalRenderProps {
-  description?: React.ReactNode;
+  /** First sentence. The linked "update settings" sentence is always appended. */
+  description?: string;
+  /** GitHub permissions URL for the install. Falls back to GitHub's installations index. */
   installationUrl?: string;
 }
 
@@ -21,7 +23,9 @@ export function AutofixGithubAppPermissionsModal({
   Footer,
   closeModal,
   installationUrl,
-  description,
+  description = t(
+    'The Sentry GitHub App does not have sufficient permissions to launch a coding agent.'
+  ),
 }: AutofixGithubAppPermissionsModalProps) {
   const settingsUrl = installationUrl ?? DEFAULT_INSTALLATIONS_URL;
 
@@ -32,13 +36,11 @@ export function AutofixGithubAppPermissionsModal({
       </Header>
       <Body>
         <Text as="p">
-          {description ??
-            tct(
-              'The Sentry GitHub App does not have sufficient permissions to launch a coding agent. Please update your [link:GitHub App installation settings] to grant the required permissions.',
-              {
-                link: <ExternalLink href={settingsUrl} />,
-              }
-            )}
+          {description}{' '}
+          {tct(
+            'Please update your [link:GitHub App installation settings] to grant the required permissions.',
+            {link: <ExternalLink href={settingsUrl} />}
+          )}
         </Text>
       </Body>
       <Footer>

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -877,7 +877,6 @@ export function useExplorerAutofix(
             error_message: string;
             repo_name: string;
             failure_type?: string;
-            github_installation_id?: string;
             github_installation_url?: string;
           }>;
           successes: unknown[];

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -29,7 +29,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
-import {getGithubPermissionsUpdateUrl} from 'sentry/utils/integrationUtil';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -879,6 +878,7 @@ export function useExplorerAutofix(
             repo_name: string;
             failure_type?: string;
             github_installation_id?: string;
+            github_installation_url?: string;
           }>;
           successes: unknown[];
         } = await api.requestPromise(
@@ -911,10 +911,7 @@ export function useExplorerAutofix(
           );
 
           if (permissionFailures.length > 0) {
-            const installationId = permissionFailures[0]?.github_installation_id;
-            const installationUrl = installationId
-              ? getGithubPermissionsUpdateUrl(installationId)
-              : undefined;
+            const installationUrl = permissionFailures[0]?.github_installation_url;
             openModal(deps => (
               <AutofixGithubAppPermissionsModal
                 {...deps}

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -3,7 +3,6 @@ import {Fragment, useCallback, useMemo, useState} from 'react';
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
 
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
@@ -24,7 +23,6 @@ import {t, tct} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils/defined';
-import {getGithubPermissionsUpdateUrl} from 'sentry/utils/integrationUtil';
 import {useAutoScroll} from 'sentry/utils/useAutoScroll';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
@@ -157,13 +155,12 @@ function useHandleOpenSeerAgent({
 type AutofixWarning = {
   warning_type: string;
   installation_id?: string;
+  installation_url?: string;
   repo_name?: string;
 };
 
-function InstallationPermissionsButton({installationId}: {installationId: string}) {
+function InstallationPermissionsButton({installationUrl}: {installationUrl?: string}) {
   const {openModal} = useModal();
-  const installationUrl = getGithubPermissionsUpdateUrl(installationId);
-
   return (
     <Button
       variant="primary"
@@ -173,10 +170,7 @@ function InstallationPermissionsButton({installationId}: {installationId: string
           <AutofixGithubAppPermissionsModal
             {...deps}
             installationUrl={installationUrl}
-            description={tct(
-              'Seer had trouble talking to GitHub while running Autofix. Please update your [link:GitHub App installation settings] to grant the required permissions.',
-              {link: <ExternalLink href={installationUrl} />}
-            )}
+            description={t('Seer had trouble talking to GitHub while running Autofix.')}
           />
         ))
       }
@@ -229,7 +223,12 @@ export function AutofixWarnings({
 
   const comp =
     installationIds.length === 1 && defined(installationId) ? (
-      <InstallationPermissionsButton installationId={installationId} />
+      <InstallationPermissionsButton
+        installationUrl={
+          permissionWarnings.find(w => w.installation_id === installationId)
+            ?.installation_url
+        }
+      />
     ) : (
       <ConfigurationPermissionsButton />
     );

--- a/static/app/utils/integrationUtil.spec.tsx
+++ b/static/app/utils/integrationUtil.spec.tsx
@@ -2,6 +2,7 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 
 import {
   getAlertText,
+  getGithubPermissionsUpdateUrl,
   getIntegrationNoun,
   getIntegrationSourceUrl,
 } from 'sentry/utils/integrationUtil';
@@ -95,5 +96,49 @@ describe('getAlertText()', () => {
       },
     });
     expect(getAlertText([integration])).toBeUndefined();
+  });
+});
+
+describe('getGithubPermissionsUpdateUrl()', () => {
+  it('uses the personal namespace for a user-owned installation', () => {
+    expect(
+      getGithubPermissionsUpdateUrl({
+        externalId: '123456',
+        accountType: 'User',
+        name: 'example-user',
+      })
+    ).toBe('https://github.com/settings/installations/123456/permissions/update');
+  });
+
+  it('uses the organization namespace for an org-owned installation', () => {
+    expect(
+      getGithubPermissionsUpdateUrl({
+        externalId: '654321',
+        accountType: 'Organization',
+        name: 'example-org',
+      })
+    ).toBe(
+      'https://github.com/organizations/example-org/settings/installations/654321/permissions/update'
+    );
+  });
+
+  it('returns undefined without an installation id', () => {
+    expect(
+      getGithubPermissionsUpdateUrl({
+        externalId: undefined,
+        accountType: 'User',
+        name: 'example-user',
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an org install with no account name', () => {
+    expect(
+      getGithubPermissionsUpdateUrl({
+        externalId: '654321',
+        accountType: 'Organization',
+        name: '',
+      })
+    ).toBeUndefined();
   });
 });

--- a/static/app/utils/integrationUtil.spec.tsx
+++ b/static/app/utils/integrationUtil.spec.tsx
@@ -2,7 +2,6 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 
 import {
   getAlertText,
-  getGithubPermissionsUpdateUrl,
   getIntegrationNoun,
   getIntegrationSourceUrl,
 } from 'sentry/utils/integrationUtil';
@@ -96,49 +95,5 @@ describe('getAlertText()', () => {
       },
     });
     expect(getAlertText([integration])).toBeUndefined();
-  });
-});
-
-describe('getGithubPermissionsUpdateUrl()', () => {
-  it('uses the personal namespace for a user-owned installation', () => {
-    expect(
-      getGithubPermissionsUpdateUrl({
-        externalId: '123456',
-        accountType: 'User',
-        name: 'example-user',
-      })
-    ).toBe('https://github.com/settings/installations/123456/permissions/update');
-  });
-
-  it('uses the organization namespace for an org-owned installation', () => {
-    expect(
-      getGithubPermissionsUpdateUrl({
-        externalId: '654321',
-        accountType: 'Organization',
-        name: 'example-org',
-      })
-    ).toBe(
-      'https://github.com/organizations/example-org/settings/installations/654321/permissions/update'
-    );
-  });
-
-  it('returns undefined without an installation id', () => {
-    expect(
-      getGithubPermissionsUpdateUrl({
-        externalId: undefined,
-        accountType: 'User',
-        name: 'example-user',
-      })
-    ).toBeUndefined();
-  });
-
-  it('returns undefined for an org install with no account name', () => {
-    expect(
-      getGithubPermissionsUpdateUrl({
-        externalId: '654321',
-        accountType: 'Organization',
-        name: '',
-      })
-    ).toBeUndefined();
   });
 });

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -293,30 +293,6 @@ export function getCodeOwnerIcon(
 export const integrationRequiresUpgrade = (integration: Integration): boolean =>
   integration.outOfDate === true;
 
-/**
- * URL where a user can review and accept a GitHub App installation's updated
- * permissions. Mirrors `get_github_permissions_update_url` on the backend.
- *
- * Org-owned installations live under the organization's settings namespace, so
- * the personal-account path only applies when the install is user-owned or the
- * account is unknown.
- */
-export const getGithubPermissionsUpdateUrl = (
-  integration: Pick<Integration, 'externalId' | 'accountType' | 'name'>
-): string | undefined => {
-  const installationId = integration.externalId;
-  if (!installationId) {
-    return undefined;
-  }
-
-  if (integration.accountType === 'Organization') {
-    return integration.name
-      ? `https://github.com/organizations/${integration.name}/settings/installations/${installationId}/permissions/update`
-      : undefined;
-  }
-  return `https://github.com/settings/installations/${installationId}/permissions/update`;
-};
-
 export const canManageIntegrations = (organization: Organization): boolean =>
   isActiveSuperuser() || hasEveryAccess(['org:integrations'], {organization});
 

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -295,10 +295,27 @@ export const integrationRequiresUpgrade = (integration: Integration): boolean =>
 
 /**
  * URL where a user can review and accept a GitHub App installation's updated
- * permissions. Mirrors `_build_permissions_update_url` on the backend.
+ * permissions. Mirrors `get_github_permissions_update_url` on the backend.
+ *
+ * Org-owned installations live under the organization's settings namespace, so
+ * the personal-account path only applies when the install is user-owned or the
+ * account is unknown.
  */
-export const getGithubPermissionsUpdateUrl = (installationId: string): string =>
-  `https://github.com/settings/installations/${installationId}/permissions/update`;
+export const getGithubPermissionsUpdateUrl = (
+  integration: Pick<Integration, 'externalId' | 'accountType' | 'name'>
+): string | undefined => {
+  const installationId = integration.externalId;
+  if (!installationId) {
+    return undefined;
+  }
+
+  if (integration.accountType === 'Organization') {
+    return integration.name
+      ? `https://github.com/organizations/${integration.name}/settings/installations/${installationId}/permissions/update`
+      : undefined;
+  }
+  return `https://github.com/settings/installations/${installationId}/permissions/update`;
+};
 
 export const canManageIntegrations = (organization: Organization): boolean =>
   isActiveSuperuser() || hasEveryAccess(['org:integrations'], {organization});

--- a/static/app/utils/integrations/useAutoOpenPermissionsModal.spec.tsx
+++ b/static/app/utils/integrations/useAutoOpenPermissionsModal.spec.tsx
@@ -1,19 +1,22 @@
-import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
 
 import * as modalActions from 'sentry/actionCreators/modal';
-import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
+import type {
+  IntegrationProvider,
+  OrganizationIntegration,
+} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {useAutoOpenPermissionsModal} from 'sentry/utils/integrations/useAutoOpenPermissionsModal';
 
 interface Params {
   isConfigurationsLoading: boolean;
   organization: Organization;
-  outdatedConfigurations: Integration[];
+  outdatedConfigurations: OrganizationIntegration[];
   provider: IntegrationProvider | undefined;
 }
 
@@ -21,7 +24,7 @@ function makeProps(overrides: Partial<Params> = {}): Params {
   return {
     provider: GitHubIntegrationProviderFixture(),
     organization: OrganizationFixture(),
-    outdatedConfigurations: [GitHubIntegrationFixture()],
+    outdatedConfigurations: [OrganizationIntegrationsFixture()],
     isConfigurationsLoading: false,
     ...overrides,
   };
@@ -102,7 +105,9 @@ describe('useAutoOpenPermissionsModal', () => {
     expect(router.location.query.showPermsModal).toBe('1');
 
     rerender(
-      makeProps({outdatedConfigurations: [GitHubIntegrationFixture({id: 'fresh'})]})
+      makeProps({
+        outdatedConfigurations: [OrganizationIntegrationsFixture({id: 'fresh'})],
+      })
     );
 
     await waitFor(() => {
@@ -125,13 +130,13 @@ describe('useAutoOpenPermissionsModal', () => {
   });
 
   it.each([
-    ['zero', [] as Integration[]],
+    ['zero', [] as OrganizationIntegration[]],
     [
       'multiple',
       [
-        GitHubIntegrationFixture({id: '1'}),
-        GitHubIntegrationFixture({id: '2'}),
-      ] as Integration[],
+        OrganizationIntegrationsFixture({id: '1'}),
+        OrganizationIntegrationsFixture({id: '2'}),
+      ],
     ],
   ])(
     'does not open but still clears the param with %s outdated configs',

--- a/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
@@ -4,23 +4,24 @@ import {useQueryState} from 'nuqs';
 import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {t} from 'sentry/locale';
-import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
+import type {
+  IntegrationProvider,
+  OrganizationIntegration,
+} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
-import {
-  canManageIntegrations,
-  getGithubPermissionsUpdateUrl,
-} from 'sentry/utils/integrationUtil';
+import {canManageIntegrations} from 'sentry/utils/integrationUtil';
+import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepositories/getProviderConfigUrl';
 
 /**
  * Opens the GitHub App update-permissions modal for a single installation.
  * Used both by the auto-open flow below and the manual "Update now" button on
  * the integration detail page.
  */
-export function openGithubPermissionsUpdateModal(integration: Integration) {
+export function openGithubPermissionsUpdateModal(integration: OrganizationIntegration) {
   openModal(deps => (
     <AutofixGithubAppPermissionsModal
       {...deps}
-      installationUrl={getGithubPermissionsUpdateUrl(integration)}
+      installationUrl={getProviderPermissionsUrl(integration) ?? undefined}
       description={t(
         'This GitHub App installation is missing permissions required for the latest features.'
       )}
@@ -38,7 +39,7 @@ interface Props {
   isConfigurationsLoading: boolean;
   organization: Organization;
   /** Installations flagged as requiring a permissions upgrade. */
-  outdatedConfigurations: Integration[];
+  outdatedConfigurations: OrganizationIntegration[];
   provider: IntegrationProvider | undefined;
 }
 

--- a/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
@@ -17,16 +17,12 @@ import {
  * the integration detail page.
  */
 export function openGithubPermissionsUpdateModal(integration: Integration) {
-  const installationUrl = integration.externalId
-    ? getGithubPermissionsUpdateUrl(integration.externalId)
-    : undefined;
-
   openModal(deps => (
     <AutofixGithubAppPermissionsModal
       {...deps}
-      installationUrl={installationUrl}
+      installationUrl={getGithubPermissionsUpdateUrl(integration)}
       description={t(
-        'This GitHub App installation is missing permissions required for the latest features. Update the installation to grant the required permissions.'
+        'This GitHub App installation is missing permissions required for the latest features.'
       )}
     />
   ));

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
@@ -14,7 +14,7 @@ describe('InstalledIntegration', () => {
 
   const defaultProps = {
     organization,
-    integration: OrganizationIntegrationsFixture() as any,
+    integration: OrganizationIntegrationsFixture(),
     provider: GitHubIntegrationProviderFixture(),
     onRemove: jest.fn(),
     onDisable: jest.fn(),

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -12,7 +12,10 @@ import {Confirm} from 'sentry/components/confirm';
 import {IconDelete, IconSettings, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {ObjectStatus} from 'sentry/types/core';
-import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
+import type {
+  IntegrationProvider,
+  OrganizationIntegration,
+} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {openGithubPermissionsUpdateModal} from 'sentry/utils/integrations/useAutoOpenPermissionsModal';
 import {getIntegrationStatus} from 'sentry/utils/integrationUtil';
@@ -22,9 +25,9 @@ import {AddIntegrationButton} from './addIntegrationButton';
 import {IntegrationItem} from './integrationItem';
 
 type Props = {
-  integration: Integration;
-  onDisable: (integration: Integration) => void;
-  onRemove: (integration: Integration) => void;
+  integration: OrganizationIntegration;
+  onDisable: (integration: OrganizationIntegration) => void;
+  onRemove: (integration: OrganizationIntegration) => void;
   organization: Organization;
   provider: IntegrationProvider;
   trackIntegrationAnalytics: (
@@ -38,7 +41,7 @@ export class InstalledIntegration extends Component<Props> {
     this.props.trackIntegrationAnalytics('integrations.uninstall_clicked');
   };
 
-  getRemovalBodyAndText(aspects: Integration['provider']['aspects']) {
+  getRemovalBodyAndText(aspects: OrganizationIntegration['provider']['aspects']) {
     if (aspects?.removal_dialog) {
       return {
         body: aspects.removal_dialog.body,
@@ -53,7 +56,7 @@ export class InstalledIntegration extends Component<Props> {
     };
   }
 
-  handleRemove(integration: Integration) {
+  handleRemove(integration: OrganizationIntegration) {
     this.props.onRemove(integration);
     this.props.trackIntegrationAnalytics('integrations.uninstall_completed');
   }

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -7,19 +7,15 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {openModal} from 'sentry/actionCreators/modal';
 import {Access} from 'sentry/components/acl/access';
 import {Confirm} from 'sentry/components/confirm';
-import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {IconDelete, IconSettings, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {ObjectStatus} from 'sentry/types/core';
 import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
-import {
-  getGithubPermissionsUpdateUrl,
-  getIntegrationStatus,
-} from 'sentry/utils/integrationUtil';
+import {openGithubPermissionsUpdateModal} from 'sentry/utils/integrations/useAutoOpenPermissionsModal';
+import {getIntegrationStatus} from 'sentry/utils/integrationUtil';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 
 import {AddIntegrationButton} from './addIntegrationButton';
@@ -63,20 +59,7 @@ export class InstalledIntegration extends Component<Props> {
   }
 
   handleUpdatePermissionsClick = () => {
-    const {integration} = this.props;
-    const installationId = integration.externalId;
-    const installationUrl = installationId
-      ? getGithubPermissionsUpdateUrl(installationId)
-      : undefined;
-    openModal(deps => (
-      <AutofixGithubAppPermissionsModal
-        {...deps}
-        installationUrl={installationUrl}
-        description={t(
-          'This GitHub App installation is missing permissions required for the latest features. Update the installation to grant the required permissions.'
-        )}
-      />
-    ));
+    openGithubPermissionsUpdateModal(this.props.integration);
   };
 
   get integrationStatus() {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -21,7 +21,11 @@ import {PanelItem} from 'sentry/components/panels/panelItem';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {PluginIcon} from 'sentry/icons/pluginIcon';
 import {t} from 'sentry/locale';
-import type {Integration, IntegrationProvider} from 'sentry/types/integrations';
+import type {
+  Integration,
+  IntegrationProvider,
+  OrganizationIntegration,
+} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -155,7 +159,7 @@ export default function IntegrationDetailedView() {
     isPending: isConfigurationsPending,
     isFetching: isConfigurationsFetching,
     isError: isConfigurationsError,
-  } = useApiQuery<Integration[]>(
+  } = useApiQuery<OrganizationIntegration[]>(
     makeIntegrationQueryKey({orgSlug: organization.slug, integrationSlug}),
     {
       staleTime: 0,
@@ -286,7 +290,7 @@ export default function IntegrationDetailedView() {
   );
 
   const {mutate: onRemove} = useMutation({
-    mutationFn: (integration: Integration) =>
+    mutationFn: (integration: OrganizationIntegration) =>
       fetchMutation({
         method: 'DELETE',
         url: getApiUrl(
@@ -302,12 +306,12 @@ export default function IntegrationDetailedView() {
       // Cancel in-flight refetches so they can't clobber the optimistic update.
       await queryClient.cancelQueries({queryKey});
 
-      const previousConfigurations = getApiQueryData<Integration[]>(
+      const previousConfigurations = getApiQueryData<OrganizationIntegration[]>(
         queryClient,
         queryKey
       );
 
-      setApiQueryData<Integration[]>(queryClient, queryKey, current =>
+      setApiQueryData<OrganizationIntegration[]>(queryClient, queryKey, current =>
         (current ?? []).map(config =>
           config.id === integration.id
             ? {
@@ -322,7 +326,7 @@ export default function IntegrationDetailedView() {
     },
     onError: (_error, _integration, context) => {
       if (context?.previousConfigurations) {
-        setApiQueryData<Integration[]>(
+        setApiQueryData<OrganizationIntegration[]>(
           queryClient,
           makeIntegrationQueryKey({orgSlug: organization.slug, integrationSlug}),
           context.previousConfigurations
@@ -338,7 +342,7 @@ export default function IntegrationDetailedView() {
     },
   });
 
-  const onDisable = useCallback((integration: Integration) => {
+  const onDisable = useCallback((integration: OrganizationIntegration) => {
     let url: string;
 
     if (!integration.domainName) {

--- a/static/app/views/settings/organizationRepositories/getProviderConfigUrl.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/getProviderConfigUrl.spec.tsx
@@ -1,0 +1,57 @@
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepositories/getProviderConfigUrl';
+
+const githubProvider: OrganizationIntegration['provider'] = {
+  key: 'github',
+  slug: 'github',
+  name: 'GitHub',
+  canAdd: true,
+  canDisable: true,
+  features: [],
+  aspects: {},
+};
+
+describe('getProviderPermissionsUrl()', () => {
+  it('uses the personal namespace for a user-owned GitHub installation', () => {
+    expect(
+      getProviderPermissionsUrl(
+        OrganizationIntegrationsFixture({
+          provider: githubProvider,
+          externalId: '123456',
+          accountType: 'User',
+          domainName: 'github.com/example-user',
+        })
+      )
+    ).toBe('https://github.com/settings/installations/123456/permissions/update');
+  });
+
+  it('uses the organization namespace for an org-owned GitHub installation', () => {
+    expect(
+      getProviderPermissionsUrl(
+        OrganizationIntegrationsFixture({
+          provider: githubProvider,
+          externalId: '654321',
+          accountType: 'Organization',
+          domainName: 'github.com/example-org',
+        })
+      )
+    ).toBe(
+      'https://github.com/organizations/example-org/settings/installations/654321/permissions/update'
+    );
+  });
+
+  it('returns null without an installation id', () => {
+    expect(
+      getProviderPermissionsUrl(
+        OrganizationIntegrationsFixture({
+          provider: githubProvider,
+          externalId: '',
+          accountType: 'User',
+          domainName: 'github.com/example-user',
+        })
+      )
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
we used to include the wrong github app permissions update URL in the
modal for the:
- autofix drawer banner
- coding agent handoff 403 banner
- integrations page banner

this is because the url for an org's installation is scoped to the org
and we weren't including the "/organizations/<org-name>" in the URL

we fix this by:
- updating the integration FE code that decides the URL
- updating the autofix drawer's banners to use the backend provided
  URL
  
 
<img width="1675" height="1085" alt="image" src="https://github.com/user-attachments/assets/15d8e512-7027-4409-bb97-9c20430862ca" />

notice the url at the bottom left of this image