### PR TITLE
fix(seer): Keep failing-checks tooltip open on the overview card

### DIFF
--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -38,6 +38,7 @@ import type {
 import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {CodeChanges} from './codeChanges';
@@ -236,20 +237,18 @@ function OverviewAction({
     return (
       <Stack align="end" gap="xs">
         <ButtonBar>
-          <Tooltip title={REVIEW_PR_META.description} skipWrapper>
-            <LinkButton
-              size="sm"
-              variant="primary"
-              href={reviewPullRequest.url}
-              external
-              onClick={() => trackPrClicked('review_pr', reviewPullRequest)}
-            >
-              <Flex as="span" gap="xs" align="center">
-                {t('Review PR #%s', reviewPullRequest.number)}
-                <IconOpen size="xs" />
-              </Flex>
-            </LinkButton>
-          </Tooltip>
+          <LinkButton
+            size="sm"
+            variant="primary"
+            href={reviewPullRequest.url}
+            external
+            onClick={() => trackPrClicked('review_pr', reviewPullRequest)}
+          >
+            <Flex as="span" gap="xs" align="center">
+              {t('Review PR #%s', reviewPullRequest.number)}
+              <IconOpen size="xs" />
+            </Flex>
+          </LinkButton>
           <OpenSeerButton run={run} section={sectionKey} size="sm" variant="primary" />
         </ButtonBar>
         {enrichmentPending ? (
@@ -267,38 +266,40 @@ function OverviewAction({
               </Tag>
             )}
             {checksStatusTag && (
-              <Tooltip
-                disabled={failedChecks.length === 0}
-                title={
-                  <Stack gap="xs" align="start">
-                    <Text size="sm" bold align="left">
-                      {t('Failing checks:')}
-                    </Text>
-                    <Stack gap="2xs" align="start">
-                      {failedChecks.map((check, index) => (
-                        <Flex key={`${check.name}-${index}`} gap="xs" align="start">
-                          <Text size="sm" variant="muted">
-                            •
-                          </Text>
-                          <Text size="sm" align="left">
-                            {check.url ? (
-                              <ExternalLink href={check.url}>{check.name}</ExternalLink>
-                            ) : (
-                              check.name
-                            )}
-                          </Text>
-                        </Flex>
-                      ))}
+              <HoverOverlayGroupProvider>
+                <Tooltip
+                  disabled={failedChecks.length === 0}
+                  title={
+                    <Stack gap="xs" align="start">
+                      <Text size="sm" bold align="left">
+                        {t('Failing checks:')}
+                      </Text>
+                      <Stack gap="2xs" align="start">
+                        {failedChecks.map((check, index) => (
+                          <Flex key={`${check.name}-${index}`} gap="xs" align="start">
+                            <Text size="sm" variant="muted">
+                              •
+                            </Text>
+                            <Text size="sm" align="left">
+                              {check.url ? (
+                                <ExternalLink href={check.url}>{check.name}</ExternalLink>
+                              ) : (
+                                check.name
+                              )}
+                            </Text>
+                          </Flex>
+                        ))}
+                      </Stack>
                     </Stack>
-                  </Stack>
-                }
-              >
-                <Tag variant={checksStatusTag.variant} icon={checksStatusTag.icon}>
-                  {failedChecks.length > 0
-                    ? tn('%s Check Failing', '%s Checks Failing', failedChecks.length)
-                    : checksStatusTag.label}
-                </Tag>
-              </Tooltip>
+                  }
+                >
+                  <Tag variant={checksStatusTag.variant} icon={checksStatusTag.icon}>
+                    {failedChecks.length > 0
+                      ? tn('%s Check Failing', '%s Checks Failing', failedChecks.length)
+                      : checksStatusTag.label}
+                  </Tag>
+                </Tooltip>
+              </HoverOverlayGroupProvider>
             )}
           </Fragment>
         )}


### PR DESCRIPTION
The failing-checks tooltip on the Seer workflows overview card was nearly impossible to hover into: moving the cursor from the "N Checks Failing" badge toward its content made the tooltip vanish unless you traveled straight up over the arrow.

The cause is the shared hover *delay group*. Every hover tooltip belongs to one, and the group snap-closes all other open tooltips the instant any tooltip in it opens (to avoid two fading trails side-by-side). The checks tooltip shared the default group with the adjacent Review PR and Open Seer button tooltips, so grazing one of those triggers on the way to the checks list warmed the group and instantly unmounted the checks tooltip — bypassing the close-delay entirely, before the cursor could reach its interactive check links.

Wrapping the checks tooltip in its own `HoverOverlayGroupProvider` isolates it so a sibling tooltip can no longer snap it closed. The provider renders no DOM (context only), so there is no layout impact, and no change to the core tooltip/`useHoverOverlay` code was needed.

Also drops the tooltip on the numbered "Review PR #N" button — the label already says what the button does. The Open Seer button keeps its tooltip, and `REVIEW_PR_META.description` is still used by the no-URL fallback button, so nothing became dead code.