### PR TITLE
feat(explore): Add expandable span sample details

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -208,6 +208,9 @@ export type TracingEventParameters = {
     save_type: 'star_query' | 'unstar_query';
     ui_source: 'table' | 'explorer';
   };
+  'trace_explorer.toggle_span_details': {
+    expanded: boolean;
+  };
   'trace_explorer.toggle_trace_details': {
     expanded: boolean;
     source: 'trace explorer' | 'new explore';
@@ -275,6 +278,7 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace_explorer.open_trace_span': 'Trace Explorer: Open Trace Span in Trace Viewer',
   'trace_explorer.remove_span_condition': 'Trace Explorer: Remove Span',
   'trace_explorer.toggle_trace_details': 'Trace Explorer: Toggle Trace Details in Table',
+  'trace_explorer.toggle_span_details': 'Trace Explorer: Toggle Span Details in Table',
   'trace_explorer.search_failure': 'Trace Explorer: Search Failure',
   'trace_explorer.search_request': 'Trace Explorer: Search Request',
   'trace_explorer.search_success': 'Trace Explorer: Search Success',

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -97,38 +97,62 @@ export function SpanItemDetails({dataRow}: {dataRow: EventData}) {
     [data?.attributes]
   );
 
-  return (
-    <Container background="primary" border="primary" radius="md" padding="md">
-      {isFetching ? (
+  if (isFetching) {
+    return (
+      <SpanItemDetailsContainer>
         <Flex align="center" justify="center" minHeight="100px">
           <LoadingIndicator />
         </Flex>
-      ) : isError || !canLoadDetails ? (
+      </SpanItemDetailsContainer>
+    );
+  }
+
+  if (isError || !canLoadDetails) {
+    return (
+      <SpanItemDetailsContainer>
         <LoadingError
           message={t('Failed to load span details')}
           onRetry={canLoadDetails ? () => void refetch() : undefined}
         />
-      ) : visibleAttributes.length > 0 ? (
-        <AttributesTree<SpanAttributesRendererExtra>
-          attributes={visibleAttributes}
-          getCustomActions={getActions}
-          renderers={renderers}
-          rendererExtra={{
-            location,
-            navigate,
-            organization,
-            projectSlug,
-            spanId,
-            theme,
-            timestamp,
-            traceItemMeta: data?.meta,
-          }}
-        />
-      ) : (
+      </SpanItemDetailsContainer>
+    );
+  }
+
+  if (visibleAttributes.length === 0) {
+    return (
+      <SpanItemDetailsContainer>
         <Flex align="center" justify="center" padding="xl">
           <Text variant="muted">{t('No attributes found for this span')}</Text>
         </Flex>
-      )}
+      </SpanItemDetailsContainer>
+    );
+  }
+
+  return (
+    <SpanItemDetailsContainer>
+      <AttributesTree<SpanAttributesRendererExtra>
+        attributes={visibleAttributes}
+        getCustomActions={getActions}
+        renderers={renderers}
+        rendererExtra={{
+          location,
+          navigate,
+          organization,
+          projectSlug,
+          spanId,
+          theme,
+          timestamp,
+          traceItemMeta: data?.meta,
+        }}
+      />
+    </SpanItemDetailsContainer>
+  );
+}
+
+function SpanItemDetailsContainer({children}: {children: React.ReactNode}) {
+  return (
+    <Container background="primary" border="primary" radius="md" padding="md">
+      {children}
     </Container>
   );
 }

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -1,0 +1,265 @@
+import {useCallback, useMemo} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t} from 'sentry/locale';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
+import type {EventData} from 'sentry/utils/discover/eventView';
+import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import {FieldKey} from 'sentry/utils/fields';
+import {formatDollars} from 'sentry/utils/formatters';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import type {
+  AttributesFieldRendererProps,
+  AttributesTreeContent,
+} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {useAttributeTreeSearchActions} from 'sentry/views/explore/components/traceItemAttributes/useAttributeTreeSearchActions';
+import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {
+  useQueryParamsFields,
+  useQueryParamsGroupBys,
+  useSetQueryParamsFields,
+  useSetQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {SpanFields} from 'sentry/views/insights/types';
+import {sortAttributes} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
+
+const HIDDEN_SPAN_DETAIL_ATTRIBUTES = new Set(['is_segment', 'project_id', 'received']);
+
+type SpanAttributesRendererExtra = RenderFunctionBaggage & {
+  spanId: string;
+  timestamp?: number;
+};
+
+type SpanAttributeRenderer = (
+  props: AttributesFieldRendererProps<SpanAttributesRendererExtra>
+) => React.ReactNode;
+
+export function SpanItemDetails({dataRow}: {dataRow: EventData}) {
+  const theme = useTheme();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {projects} = useProjects();
+  const getActions = useSpanAttributesTreeActions();
+
+  const spanId = String(dataRow.id ?? '');
+  const traceId = String(dataRow.trace ?? '');
+  const projectSlug = String(dataRow.project ?? '');
+  const project = projects.find(candidate => candidate.slug === projectSlug);
+  const timestamp = getTimeStampFromTableDateField(dataRow.timestamp);
+  const canLoadDetails = Boolean(spanId && traceId && project);
+
+  const {data, isError, isFetching, refetch} = useTraceItemDetails({
+    traceItemId: spanId,
+    projectId: project?.id ?? '',
+    traceId,
+    timestamp,
+    traceItemType: TraceItemDataset.SPANS,
+    referrer: 'api.explore.span-item-details',
+    enabled: canLoadDetails,
+  });
+
+  const renderers = useSpanAttributeRenderers({
+    location,
+    organization,
+    projectSlug,
+    spanId,
+    timestamp,
+    dateSelection: normalizeDateTimeParams(selection.datetime),
+  });
+
+  const visibleAttributes = useMemo(
+    () =>
+      sortAttributes(
+        (data?.attributes ?? []).filter(
+          attribute => !HIDDEN_SPAN_DETAIL_ATTRIBUTES.has(attribute.name)
+        )
+      ),
+    [data?.attributes]
+  );
+
+  return (
+    <Container background="primary" border="primary" radius="md" padding="md">
+      {isFetching ? (
+        <Flex align="center" justify="center" minHeight="100px">
+          <LoadingIndicator />
+        </Flex>
+      ) : isError || !canLoadDetails ? (
+        <LoadingError
+          message={t('Failed to load span details')}
+          onRetry={canLoadDetails ? () => void refetch() : undefined}
+        />
+      ) : visibleAttributes.length > 0 ? (
+        <AttributesTree<SpanAttributesRendererExtra>
+          attributes={visibleAttributes}
+          getCustomActions={getActions}
+          renderers={renderers}
+          rendererExtra={{
+            location,
+            navigate,
+            organization,
+            projectSlug,
+            spanId,
+            theme,
+            timestamp,
+            traceItemMeta: data?.meta,
+          }}
+        />
+      ) : (
+        <Flex align="center" justify="center" padding="xl">
+          <Text variant="muted">{t('No attributes found for this span')}</Text>
+        </Flex>
+      )}
+    </Container>
+  );
+}
+
+function useSpanAttributesTreeActions() {
+  const getSearchActions = useAttributeTreeSearchActions();
+  const fields = useQueryParamsFields();
+  const setFields = useSetQueryParamsFields();
+  const groupBys = useQueryParamsGroupBys();
+  const setGroupBys = useSetQueryParamsGroupBys();
+
+  return useCallback(
+    (content: AttributesTreeContent) => {
+      const attribute = content.originalAttribute;
+      if (!attribute) {
+        return [];
+      }
+
+      const key = attribute.original_attribute_key;
+      const actions = getSearchActions(content);
+
+      actions.push(
+        {
+          key: 'add-column',
+          label: t('Add this as table column'),
+          disabled: fields.includes(key),
+          onAction: () => setFields([...fields, key]),
+        },
+        {
+          key: 'add-group-by',
+          label: t('Group by attribute'),
+          disabled: groupBys.includes(key),
+          onAction: () => setGroupBys([...groupBys.filter(Boolean), key], Mode.AGGREGATE),
+        }
+      );
+
+      return actions;
+    },
+    [fields, getSearchActions, groupBys, setFields, setGroupBys]
+  );
+}
+
+function useSpanAttributeRenderers({
+  dateSelection,
+  location,
+  organization,
+  projectSlug,
+  spanId,
+  timestamp,
+}: {
+  dateSelection: ReturnType<typeof normalizeDateTimeParams>;
+  location: ReturnType<typeof useLocation>;
+  organization: ReturnType<typeof useOrganization>;
+  projectSlug: string;
+  spanId: string;
+  timestamp?: number;
+}): Record<string, SpanAttributeRenderer> {
+  return useMemo(() => {
+    const profileRenderer: SpanAttributeRenderer = ({item, basicRendered}) => {
+      if (!organization || !projectSlug || typeof item.value !== 'string') {
+        return basicRendered;
+      }
+
+      return (
+        <Link
+          to={{
+            pathname: generateProfileFlamechartRoute({
+              organization,
+              projectSlug,
+              profileId: item.value,
+            }),
+            query: {spanId},
+          }}
+        >
+          {basicRendered}
+        </Link>
+      );
+    };
+
+    const replayRenderer: SpanAttributeRenderer = ({item, basicRendered}) => {
+      if (!organization || typeof item.value !== 'string') {
+        return basicRendered;
+      }
+
+      return (
+        <Link
+          to={{
+            pathname: makeReplaysPathname({
+              path: `/${item.value}/`,
+              organization,
+            }),
+            query: {
+              event_t: timestamp,
+              referrer: 'trace_explorer.span_samples',
+            },
+          }}
+        >
+          {basicRendered}
+        </Link>
+      );
+    };
+
+    const costRenderer: SpanAttributeRenderer = ({item, basicRendered}) => {
+      const value = Number(item.value);
+      return Number.isFinite(value) ? formatDollars(+value.toFixed(10)) : basicRendered;
+    };
+
+    return {
+      [FieldKey.PROFILE_ID]: profileRenderer,
+      [SpanFields.PROFILE_ID]: profileRenderer,
+      [FieldKey.TRACE]: ({item, basicRendered}) => {
+        if (!organization || typeof item.value !== 'string') {
+          return basicRendered;
+        }
+
+        const target = getTraceDetailsUrl({
+          organization,
+          traceSlug: item.value,
+          spanId,
+          timestamp,
+          dateSelection,
+          location,
+          source: TraceViewSources.TRACES,
+        });
+        return <Link to={target}>{basicRendered}</Link>;
+      },
+      [FieldKey.REPLAY_ID]: replayRenderer,
+      [SpanFields.REPLAY_ID]: replayRenderer,
+      [SpanFields.GEN_AI_COST_INPUT_TOKENS]: costRenderer,
+      [SpanFields.GEN_AI_COST_OUTPUT_TOKENS]: costRenderer,
+      [SpanFields.GEN_AI_COST_TOTAL_TOKENS]: costRenderer,
+    };
+  }, [dateSelection, location, organization, projectSlug, spanId, timestamp]);
+}

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -188,7 +188,12 @@ function useSpanAttributeRenderers({
 }): Record<string, SpanAttributeRenderer> {
   return useMemo(() => {
     const profileRenderer: SpanAttributeRenderer = ({item, basicRendered}) => {
-      if (!organization || !projectSlug || typeof item.value !== 'string') {
+      if (
+        !organization ||
+        !projectSlug ||
+        typeof item.value !== 'string' ||
+        !item.value
+      ) {
         return basicRendered;
       }
 
@@ -209,7 +214,7 @@ function useSpanAttributeRenderers({
     };
 
     const replayRenderer: SpanAttributeRenderer = ({item, basicRendered}) => {
-      if (!organization || typeof item.value !== 'string') {
+      if (!organization || typeof item.value !== 'string' || !item.value) {
         return basicRendered;
       }
 
@@ -240,7 +245,7 @@ function useSpanAttributeRenderers({
       [FieldKey.PROFILE_ID]: profileRenderer,
       [SpanFields.PROFILE_ID]: profileRenderer,
       [FieldKey.TRACE]: ({item, basicRendered}) => {
-        if (!organization || typeof item.value !== 'string') {
+        if (!organization || typeof item.value !== 'string' || !item.value) {
           return basicRendered;
         }
 

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -67,6 +67,10 @@ export function SpanItemDetails({dataRow}: {dataRow: EventData}) {
   const project = projects.find(candidate => candidate.slug === projectSlug);
   const timestamp = getTimeStampFromTableDateField(dataRow.timestamp);
   const canLoadDetails = Boolean(spanId && traceId && project);
+  const dateSelection = useMemo(
+    () => normalizeDateTimeParams(selection.datetime),
+    [selection.datetime]
+  );
 
   const {data, isError, isFetching, refetch} = useTraceItemDetails({
     traceItemId: spanId,
@@ -84,7 +88,7 @@ export function SpanItemDetails({dataRow}: {dataRow: EventData}) {
     projectSlug,
     spanId,
     timestamp,
-    dateSelection: normalizeDateTimeParams(selection.datetime),
+    dateSelection,
   });
 
   const visibleAttributes = useMemo(

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -72,7 +72,7 @@ export function SpanItemDetails({dataRow}: {dataRow: EventData}) {
     [selection.datetime]
   );
 
-  const {data, isError, isFetching, refetch} = useTraceItemDetails({
+  const {data, isError, isLoading, refetch} = useTraceItemDetails({
     traceItemId: spanId,
     projectId: project?.id ?? '',
     traceId,
@@ -101,7 +101,7 @@ export function SpanItemDetails({dataRow}: {dataRow: EventData}) {
     [data?.attributes]
   );
 
-  if (isFetching) {
+  if (isLoading) {
     return (
       <SpanItemDetailsContainer>
         <Flex align="center" justify="center" minHeight="100px">

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -321,6 +321,20 @@ describe('SpansTable', () => {
       await screen.findByText('No attributes found for this span')
     ).toBeInTheDocument();
   });
+
+  it('does not link empty span detail identifiers', async () => {
+    mockSpanDetails(firstRow, [
+      {name: 'profile.id', type: 'str', value: ''},
+      {name: 'replayId', type: 'str', value: ''},
+      {name: 'trace', type: 'str', value: ''},
+    ]);
+
+    renderTable({tableRows: [firstRow]});
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+
+    const attributesTree = await screen.findByTestId('fields-tree');
+    expect(within(attributesTree).queryByRole('link')).not.toBeInTheDocument();
+  });
 });
 
 function makeQueryResult(

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -1,8 +1,39 @@
+import type {ReactNode} from 'react';
+import {QueryObserver} from '@tanstack/react-query';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {ProjectFixture} from 'sentry-fixture/project';
 
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {ResponseMeta} from 'sentry/types/api';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {FieldValueType} from 'sentry/utils/fields';
-import {addValidatedFieldTypesToMeta} from 'sentry/views/explore/tables/spansTable';
+import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
+import {
+  addValidatedFieldTypesToMeta,
+  SpansTable,
+} from 'sentry/views/explore/tables/spansTable';
+
+jest.mock('sentry/utils/analytics');
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
+}
 
 describe('addValidatedFieldTypesToMeta', () => {
   it('preserves table meta field types over validated field types', () => {
@@ -56,3 +87,272 @@ describe('addValidatedFieldTypesToMeta', () => {
     expect(eventView.getColumns(meta)[0]?.type).toBe(FieldValueType.NUMBER);
   });
 });
+
+describe('SpansTable', () => {
+  const {organization, project} = initializeOrg({
+    organization: {features: ['explore-span-item-details']},
+  });
+
+  const eventView = EventView.fromNewQueryWithLocation(
+    {
+      name: 'Span Samples',
+      fields: [
+        'id',
+        'span.name',
+        'span.description',
+        'span.duration',
+        'transaction',
+        'timestamp',
+        'project',
+        'trace',
+        'transaction.span_id',
+      ],
+      version: 2,
+      query: '',
+    },
+    LocationFixture()
+  );
+
+  const firstRow = {
+    id: 'aaaaaaaaaaaaaaaa',
+    project: project.slug,
+    trace: '11111111111111111111111111111111',
+    timestamp: '2026-08-26T12:00:00Z',
+    'span.name': 'span one',
+    'span.description': 'GET /one',
+    'span.duration': 100,
+    transaction: 'transaction one',
+  };
+  const secondRow = {
+    id: 'bbbbbbbbbbbbbbbb',
+    project: project.slug,
+    trace: '22222222222222222222222222222222',
+    timestamp: '2026-08-26T12:01:00Z',
+    'span.name': 'span two',
+    'span.description': 'GET /two',
+    'span.duration': 200,
+    transaction: 'transaction two',
+  };
+  const rows = [firstRow, secondRow];
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.mocked(trackAnalytics).mockClear();
+    ProjectsStore.loadInitialData([
+      ProjectFixture({
+        ...project,
+        organization: {id: organization.id, slug: organization.slug},
+      }),
+    ]);
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [Number(project.id)],
+      environments: [],
+      datetime: {period: '7d', start: null, end: null, utc: null},
+    });
+  });
+
+  function renderTable({
+    features = ['explore-span-item-details'],
+    tableRows = rows,
+  }: {features?: string[]; tableRows?: Array<Record<string, unknown>>} = {}) {
+    return render(
+      <SpansTable
+        booleanTags={{}}
+        numberTags={{}}
+        spansTableResult={{eventView, result: makeQueryResult(tableRows)}}
+        stringTags={{}}
+        validatedFieldTypes={{}}
+      />,
+      {
+        organization: {...organization, features},
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/traces/`,
+          },
+        },
+      }
+    );
+  }
+
+  function mockSpanDetails(
+    row: (typeof rows)[number],
+    attributes: TraceItemResponseAttribute[]
+  ) {
+    return MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${row.id}/`,
+      match: [
+        MockApiClient.matchQuery({
+          item_type: 'spans',
+          trace_id: row.trace,
+          timestamp: new Date(row.timestamp).getTime() / 1000,
+        }),
+      ],
+      body: {
+        attributes,
+        itemId: row.id,
+        links: null,
+        meta: {},
+        timestamp: row.timestamp,
+      },
+    });
+  }
+
+  it('does not render or fetch span details when the feature is disabled', () => {
+    const detailsMock = mockSpanDetails(firstRow, []);
+
+    renderTable({features: []});
+
+    expect(
+      screen.queryByRole('button', {name: 'Show span details'})
+    ).not.toBeInTheDocument();
+    expect(detailsMock).not.toHaveBeenCalled();
+  });
+
+  it('independently expands span details only after clicking the chevrons', async () => {
+    const firstDetailsMock = mockSpanDetails(firstRow, [
+      {name: 'project_id', type: 'int', value: Number(project.id)},
+      {name: 'received', type: 'float', value: 123},
+      {name: 'is_segment', type: 'bool', value: false},
+      {name: 'span.custom_one', type: 'str', value: 'first detail'},
+    ]);
+    const secondDetailsMock = mockSpanDetails(secondRow, [
+      {name: 'span.custom_two', type: 'str', value: 'second detail'},
+    ]);
+
+    renderTable();
+
+    const showButtons = screen.getAllByRole('button', {
+      name: 'Show span details',
+    });
+    expect(firstDetailsMock).not.toHaveBeenCalled();
+    expect(secondDetailsMock).not.toHaveBeenCalled();
+
+    await userEvent.click(showButtons[0]!);
+    expect(await screen.findByText('first detail')).toBeInTheDocument();
+    expect(firstDetailsMock).toHaveBeenCalledTimes(1);
+    expect(secondDetailsMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('tree-key-project_id')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tree-key-received')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tree-key-is_segment')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByRole('button', {name: 'Show span details'})[0]!);
+    expect(await screen.findByText('second detail')).toBeInTheDocument();
+    expect(screen.getByText('first detail')).toBeInTheDocument();
+
+    await userEvent.click(screen.getAllByRole('button', {name: 'Hide span details'})[0]!);
+    expect(screen.queryByText('first detail')).not.toBeInTheDocument();
+    expect(screen.getByText('second detail')).toBeInTheDocument();
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'trace_explorer.toggle_span_details',
+      expect.objectContaining({expanded: false})
+    );
+  });
+
+  it('offers filtering, column, and group-by actions for attributes', async () => {
+    mockSpanDetails(firstRow, [
+      {name: 'span.custom', type: 'str', value: 'custom value'},
+    ]);
+
+    const {router} = renderTable({tableRows: [firstRow]});
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+
+    const attributeKey = await screen.findByTestId('tree-key-span.custom');
+    const attributeRow = attributeKey.closest<HTMLElement>(
+      '[data-test-id="attribute-tree-row"]'
+    );
+    expect(attributeRow).not.toBeNull();
+    await userEvent.hover(attributeRow!);
+    await userEvent.click(
+      within(attributeRow!).getByRole('button', {
+        name: 'Attribute Actions Menu',
+      }),
+      {pointerEventsCheck: 0}
+    );
+
+    expect(await screen.findByText('Add to filter')).toBeInTheDocument();
+    expect(screen.getByText('Exclude this value')).toBeInTheDocument();
+    expect(screen.getByText('Add this as table column')).toBeInTheDocument();
+    expect(screen.getByText('Group by attribute')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Add this as table column'));
+    await waitFor(() => {
+      expect(router.location.query.field).toEqual(
+        expect.arrayContaining(['span.custom'])
+      );
+    });
+    expect(screen.getByRole('button', {name: 'Show span details'})).toBeInTheDocument();
+  });
+
+  it('retries a failed span details request without collapsing the row', async () => {
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${firstRow.id}/`,
+      statusCode: 500,
+      body: {detail: 'Internal error'},
+    });
+
+    renderTable({tableRows: [firstRow]});
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+    expect(await screen.findByText('Failed to load span details')).toBeInTheDocument();
+
+    mockSpanDetails(firstRow, [
+      {name: 'span.recovered', type: 'str', value: 'recovered detail'},
+    ]);
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    expect(await screen.findByText('recovered detail')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no visible attributes are returned', async () => {
+    mockSpanDetails(firstRow, [
+      {name: 'project_id', type: 'int', value: Number(project.id)},
+      {name: 'received', type: 'float', value: 123},
+      {name: 'is_segment', type: 'bool', value: false},
+    ]);
+
+    renderTable({tableRows: [firstRow]});
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+
+    expect(
+      await screen.findByText('No attributes found for this span')
+    ).toBeInTheDocument();
+  });
+});
+
+function makeQueryResult(
+  data: Array<Record<string, unknown>>
+): SpansTableResult['result'] {
+  const queryClient = makeTestQueryClient();
+  const queryKey = ['spans-table-test'];
+  queryClient.setQueryData(queryKey, [{data: []}, undefined, undefined]);
+
+  const base = new QueryObserver<
+    [TableData, string | undefined, ResponseMeta<TableData> | undefined],
+    QueryError
+  >(queryClient, {queryKey, enabled: false}).getCurrentResult();
+
+  return {
+    // eslint-disable-next-line @tanstack/query/no-rest-destructuring
+    ...base,
+    data,
+    error: null,
+    statusCode: undefined,
+    response: undefined,
+    meta: {
+      fields: {
+        id: FieldValueType.STRING,
+        'span.name': FieldValueType.STRING,
+        'span.description': FieldValueType.STRING,
+        'span.duration': FieldValueType.DURATION,
+        transaction: FieldValueType.STRING,
+        timestamp: FieldValueType.DATE,
+      },
+      units: {},
+    },
+    pageLinks: undefined,
+  };
+}

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -149,19 +149,16 @@ export function SpansTable({
               <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
             </DataTable.Status>
           ) : result.isFetched && result.data?.length ? (
-            result.data?.map((row, i) => {
-              const spanKey = getSpanKey(row, i);
-              return (
-                <SpanSampleRow
-                  key={`${expansionResetKey}:${spanKey}`}
-                  canExpandSpanDetails={canExpandSpanDetails}
-                  columns={columnsFromEventView}
-                  data={row}
-                  fields={visibleFields}
-                  meta={meta}
-                />
-              );
-            })
+            result.data?.map((row, i) => (
+              <SpanSampleRow
+                key={`${expansionResetKey}:${getSpanKey(row, i)}`}
+                canExpandSpanDetails={canExpandSpanDetails}
+                columns={columnsFromEventView}
+                data={row}
+                fields={visibleFields}
+                meta={meta}
+              />
+            ))
           ) : (
             <DataTable.Status>
               <EmptyStateWarning>
@@ -195,19 +192,10 @@ function SpanSampleRow({
   const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  function toggleExpanded() {
-    const expanded = !isExpanded;
-    setIsExpanded(expanded);
-    trackAnalytics('trace_explorer.toggle_span_details', {
-      organization,
-      expanded,
-    });
-  }
-
   return (
     <Fragment>
       <DataTable.Row>
-        {canExpandSpanDetails && (
+        {canExpandSpanDetails ? (
           <SpanDetailsToggleCell>
             <Button
               aria-expanded={isExpanded}
@@ -215,10 +203,16 @@ function SpanSampleRow({
               icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
               size="zero"
               variant="transparent"
-              onClick={toggleExpanded}
+              onClick={() => {
+                setIsExpanded(e => !e);
+                trackAnalytics('trace_explorer.toggle_span_details', {
+                  organization,
+                  expanded: !isExpanded,
+                });
+              }}
             />
           </SpanDetailsToggleCell>
-        )}
+        ) : null}
         {fields.map((field, index) => (
           <DataTable.Cell key={field}>
             <FieldRenderer
@@ -230,13 +224,13 @@ function SpanSampleRow({
           </DataTable.Cell>
         ))}
       </DataTable.Row>
-      {canExpandSpanDetails && isExpanded && (
+      {canExpandSpanDetails && isExpanded ? (
         <DataTable.Row>
           <SpanDetailsCell>
             <SpanItemDetails dataRow={data} />
           </SpanDetailsCell>
         </DataTable.Row>
-      )}
+      ) : null}
     </Fragment>
   );
 }

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -1,25 +1,36 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Pagination} from '@sentry/scraps/pagination';
 
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {DataTable} from 'sentry/components/tables/dataTable';
+import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import type {MetaType} from 'sentry/utils/discover/eventView';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
 import {FieldValueType, getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {TableColumn} from 'sentry/views/discover/table/types';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 import {
+  useQueryParamsCursor,
   useQueryParamsFields,
+  useQueryParamsQuery,
   useQueryParamsSortBys,
   useSetQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
 
 import {FieldRenderer} from './fieldRenderer';
+import {SpanItemDetails} from './spanItemDetails';
+
+const SPAN_DETAILS_COLUMN_WIDTH = 40;
 
 interface SpansTableProps {
   booleanTags: TagCollection;
@@ -37,8 +48,14 @@ export function SpansTable({
   validatedFieldTypes,
 }: SpansTableProps) {
   const fields = useQueryParamsFields();
+  const query = useQueryParamsQuery();
+  const cursor = useQueryParamsCursor();
   const sortBys = useQueryParamsSortBys();
   const setSortBys = useSetQueryParamsSortBys();
+  const organization = useOrganization();
+  const canExpandSpanDetails = organization.features.includes(
+    'explore-span-item-details'
+  );
 
   const visibleFields = useMemo(
     () => (fields.includes('id') ? [...fields] : ['id', ...fields]),
@@ -59,6 +76,10 @@ export function SpansTable({
     () => eventView.getColumns(meta),
     [eventView, meta]
   );
+  const expansionResetKey = useMemo(
+    () => JSON.stringify([query, cursor, fields, sortBys]),
+    [cursor, fields, query, sortBys]
+  );
 
   const paginationAnalyticsEvent = usePaginationAnalytics(
     'samples',
@@ -71,13 +92,22 @@ export function SpansTable({
         data-test-id="spans-table"
         fields={visibleFields}
         minimumColumnWidth={50}
+        prefixColumnWidth={canExpandSpanDetails ? SPAN_DETAILS_COLUMN_WIDTH : undefined}
       >
         <DataTable.Head>
           <DataTable.Row>
+            {canExpandSpanDetails && (
+              <SpanDetailsToggleHeadCell aria-label={t('Span details')} isFirst />
+            )}
             {visibleFields.map((field, i) => {
               // Hide column names before alignment is determined
               if (result.isPending) {
-                return <DataTable.HeadCell key={i} isFirst={i === 0} />;
+                return (
+                  <DataTable.HeadCell
+                    key={i}
+                    isFirst={!canExpandSpanDetails && i === 0}
+                  />
+                );
               }
 
               const fieldType = meta.fields?.[field];
@@ -99,7 +129,7 @@ export function SpansTable({
                   align={align}
                   columnIndex={i}
                   key={i}
-                  isFirst={i === 0}
+                  isFirst={!canExpandSpanDetails && i === 0}
                   onSort={updateSort}
                   sort={direction}
                 >
@@ -119,22 +149,19 @@ export function SpansTable({
               <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
             </DataTable.Status>
           ) : result.isFetched && result.data?.length ? (
-            result.data?.map((row, i) => (
-              <DataTable.Row key={i}>
-                {visibleFields.map((field, j) => {
-                  return (
-                    <DataTable.Cell key={j}>
-                      <FieldRenderer
-                        column={columnsFromEventView[j]}
-                        data={row}
-                        unit={meta?.units?.[field]}
-                        meta={meta}
-                      />
-                    </DataTable.Cell>
-                  );
-                })}
-              </DataTable.Row>
-            ))
+            result.data?.map((row, i) => {
+              const spanKey = getSpanKey(row, i);
+              return (
+                <SpanSampleRow
+                  key={`${expansionResetKey}:${spanKey}`}
+                  canExpandSpanDetails={canExpandSpanDetails}
+                  columns={columnsFromEventView}
+                  data={row}
+                  fields={visibleFields}
+                  meta={meta}
+                />
+              );
+            })
           ) : (
             <DataTable.Status>
               <EmptyStateWarning>
@@ -151,6 +178,90 @@ export function SpansTable({
     </Fragment>
   );
 }
+
+function SpanSampleRow({
+  canExpandSpanDetails,
+  columns,
+  data,
+  fields,
+  meta,
+}: {
+  canExpandSpanDetails: boolean;
+  columns: Array<TableColumn<string>>;
+  data: EventData;
+  fields: readonly string[];
+  meta: MetaType;
+}) {
+  const organization = useOrganization();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  function toggleExpanded() {
+    const expanded = !isExpanded;
+    setIsExpanded(expanded);
+    trackAnalytics('trace_explorer.toggle_span_details', {
+      organization,
+      expanded,
+    });
+  }
+
+  return (
+    <Fragment>
+      <DataTable.Row>
+        {canExpandSpanDetails && (
+          <SpanDetailsToggleCell>
+            <Button
+              aria-expanded={isExpanded}
+              aria-label={isExpanded ? t('Hide span details') : t('Show span details')}
+              icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
+              size="zero"
+              variant="transparent"
+              onClick={toggleExpanded}
+            />
+          </SpanDetailsToggleCell>
+        )}
+        {fields.map((field, index) => (
+          <DataTable.Cell key={field}>
+            <FieldRenderer
+              column={columns[index]}
+              data={data}
+              unit={meta.units?.[field]}
+              meta={meta}
+            />
+          </DataTable.Cell>
+        ))}
+      </DataTable.Row>
+      {canExpandSpanDetails && isExpanded && (
+        <DataTable.Row>
+          <SpanDetailsCell>
+            <SpanItemDetails dataRow={data} />
+          </SpanDetailsCell>
+        </DataTable.Row>
+      )}
+    </Fragment>
+  );
+}
+
+function getSpanKey(row: EventData, index: number) {
+  return (
+    [row.project, row.trace, row.id, row.timestamp].filter(Boolean).join(':') || index
+  );
+}
+
+const SpanDetailsToggleHeadCell = styled(DataTable.HeadCell)`
+  align-items: center;
+  padding: 0;
+`;
+
+const SpanDetailsToggleCell = styled(DataTable.Cell)`
+  align-items: center;
+  padding: 0;
+`;
+
+const SpanDetailsCell = styled(DataTable.Cell)`
+  background-color: ${p => p.theme.colors.gray100};
+  grid-column: 1 / -1;
+  padding-block: ${p => p.theme.space.lg};
+`;
 
 export function addValidatedFieldTypesToMeta({
   meta,

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -260,7 +260,7 @@ const SpanDetailsToggleCell = styled(DataTable.Cell)`
 const SpanDetailsCell = styled(DataTable.Cell)`
   background-color: ${p => p.theme.colors.gray100};
   grid-column: 1 / -1;
-  padding-block: ${p => p.theme.space.lg};
+  padding: ${p => p.theme.space.md};
 `;
 
 export function addValidatedFieldTypesToMeta({


### PR DESCRIPTION
## Summary

- add a non-removable expansion control to Span Samples behind the explore-span-item-details feature flag
- lazily load span trace-item attributes and render them with the shared attribute tree, including filter, column, and group-by actions
- support independent row expansion, loading/error/empty states, span-specific rich renderers, and toggle analytics

Closes EXP-1155

**Example:**
<img width="1292" height="812" alt="Screenshot 2026-08-26 at 14 13 50" src="https://github.com/user-attachments/assets/c2c3e7fd-36eb-4ed8-98e0-20b2a81c5a99" />