### PR TITLE
fix(autofix): Autoscroll the Seer Autofix drawer to the bottom on open

### DIFF
--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -18,10 +18,7 @@ export function ArtifactLoadingDetails({
   loadingMessage,
   blocks,
 }: ArtifactLoadingDetailsProps) {
-  const {containerRef, onScrollHandler} = useAutoScroll({
-    enabled: true,
-    key: blocks,
-  });
+  const {containerRef, onScrollHandler} = useAutoScroll({key: blocks});
 
   return (
     <ArtifactDetails>

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -55,18 +55,7 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
     [aiAutofix.runState?.blocks]
   );
 
-  // For autoscroll, we only want to turn it on if we ever encounter a processing state.
-  // If not, it indicates the users is viewing an already completed autofix, so we do
-  // not want to enable autoscroll.
-  const enableAutoScroll = useRef(false);
-  if (aiAutofix.runState?.status === 'processing') {
-    enableAutoScroll.current = true;
-  }
-
-  const {containerRef, onScrollHandler} = useAutoScroll({
-    enabled: enableAutoScroll.current,
-    key: aiAutofix.runState,
-  });
+  const {containerRef, onScrollHandler} = useAutoScroll({key: aiAutofix.runState});
 
   return (
     <Stack

--- a/static/app/utils/useAutoScroll.spec.tsx
+++ b/static/app/utils/useAutoScroll.spec.tsx
@@ -1,0 +1,114 @@
+import type {ReactNode} from 'react';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useAutoScroll} from 'sentry/utils/useAutoScroll';
+
+function ScrollContainer({
+  children,
+  contentKey,
+}: {
+  children: ReactNode;
+  contentKey: unknown;
+}) {
+  const {containerRef, onScrollHandler} = useAutoScroll({key: contentKey});
+
+  return (
+    <div data-test-id="container" ref={containerRef} onScroll={onScrollHandler}>
+      {children}
+    </div>
+  );
+}
+
+describe('useAutoScroll', () => {
+  let scrollToSpy!: jest.Mock;
+
+  beforeEach(() => {
+    scrollToSpy = jest.fn();
+    // jsdom does not implement Element.prototype.scrollTo
+    Object.defineProperty(Element.prototype, 'scrollTo', {
+      value: scrollToSpy,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error removing the jsdom stub added above
+    delete Element.prototype.scrollTo;
+  });
+
+  it('scrolls to the bottom when the key changes', async () => {
+    const {rerender} = render(<ScrollContainer contentKey="a">short</ScrollContainer>);
+
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+    scrollToSpy.mockClear();
+
+    rerender(<ScrollContainer contentKey="b">short</ScrollContainer>);
+
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+  });
+
+  it('re-scrolls when content grows after the key last changed', async () => {
+    const {rerender} = render(
+      <ScrollContainer contentKey="stable">
+        <p>placeholder</p>
+      </ScrollContainer>
+    );
+
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+    scrollToSpy.mockClear();
+
+    // The autofix drawer swaps placeholders for real content once a *separate*
+    // query resolves, so the content grows without `key` ever changing again.
+    rerender(
+      <ScrollContainer contentKey="stable">
+        <p>real content</p>
+        <p>more real content</p>
+      </ScrollContainer>
+    );
+
+    await screen.findByText('more real content');
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+  });
+
+  it('does not disarm when a smooth scroll emits intermediate events', async () => {
+    const {rerender} = render(<ScrollContainer contentKey="a">content</ScrollContainer>);
+
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+
+    const container = screen.getByTestId('container');
+    Object.defineProperty(container, 'scrollHeight', {value: 1000, configurable: true});
+    Object.defineProperty(container, 'clientHeight', {value: 100, configurable: true});
+
+    // Mid-animation position: moving down, but not at the bottom yet.
+    Object.defineProperty(container, 'scrollTop', {value: 400, configurable: true});
+    container.dispatchEvent(new Event('scroll', {bubbles: true}));
+
+    scrollToSpy.mockClear();
+    rerender(<ScrollContainer contentKey="b">content</ScrollContainer>);
+
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+  });
+
+  it('stops auto-scrolling once the user scrolls up', async () => {
+    const {rerender} = render(<ScrollContainer contentKey="a">content</ScrollContainer>);
+
+    await waitFor(() => expect(scrollToSpy).toHaveBeenCalled());
+
+    const container = screen.getByTestId('container');
+    Object.defineProperty(container, 'scrollHeight', {value: 1000, configurable: true});
+    Object.defineProperty(container, 'clientHeight', {value: 100, configurable: true});
+
+    // Settle at the bottom, then scroll back up.
+    Object.defineProperty(container, 'scrollTop', {value: 900, configurable: true});
+    container.dispatchEvent(new Event('scroll', {bubbles: true}));
+    Object.defineProperty(container, 'scrollTop', {value: 200, configurable: true});
+    container.dispatchEvent(new Event('scroll', {bubbles: true}));
+
+    scrollToSpy.mockClear();
+    rerender(<ScrollContainer contentKey="b">content</ScrollContainer>);
+
+    await waitFor(() => expect(scrollToSpy).not.toHaveBeenCalled());
+  });
+});

--- a/static/app/utils/useAutoScroll.tsx
+++ b/static/app/utils/useAutoScroll.tsx
@@ -2,20 +2,23 @@ import {useCallback, useEffect, useRef, type UIEventHandler} from 'react';
 
 import {defined} from 'sentry/utils/defined';
 
+// Tolerance for sub-pixel rounding when deciding whether we sit at the bottom.
+const BOTTOM_THRESHOLD_PX = 4;
+
 interface UseAutoScrollOptions {
-  enabled: boolean;
   key: unknown;
 }
 
-export function useAutoScroll({enabled, key}: UseAutoScrollOptions) {
+export function useAutoScroll({key}: UseAutoScrollOptions) {
   const canAutoScroll = useRef(true);
+  const lastScrollTop = useRef(0);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  const scrollToBottom = useCallback(() => {
     const container = containerRef.current;
 
-    if (!enabled || !canAutoScroll.current || !defined(container)) {
+    if (!canAutoScroll.current || !defined(container)) {
       return;
     }
 
@@ -23,12 +26,48 @@ export function useAutoScroll({enabled, key}: UseAutoScrollOptions) {
       top: container.scrollHeight,
       behavior: 'smooth',
     });
-  }, [enabled, key]);
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [scrollToBottom, key]);
+
+  // Content keeps growing after `key` has settled: markdown renders, cards swap
+  // in once their own requests resolve, and placeholders give way to real
+  // content. Without this we scroll to whatever height the container happened
+  // to have when `key` last changed, and then stop.
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!defined(container)) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => scrollToBottom());
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    return () => observer.disconnect();
+  }, [scrollToBottom]);
 
   const onScrollHandler: UIEventHandler = useCallback(event => {
     const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
-    const atBottom = scrollHeight - scrollTop - clientHeight < 1;
-    canAutoScroll.current = atBottom;
+    const atBottom = scrollHeight - scrollTop - clientHeight < BOTTOM_THRESHOLD_PX;
+    const scrolledUp = scrollTop < lastScrollTop.current;
+
+    lastScrollTop.current = scrollTop;
+
+    // Only the user scrolling away from the bottom should stop auto-scrolling.
+    // A smooth scroll emits intermediate events that are not yet at the bottom,
+    // so treating every one of those as intent would cancel our own animation.
+    if (atBottom) {
+      canAutoScroll.current = true;
+    } else if (scrolledUp) {
+      canAutoScroll.current = false;
+    }
   }, []);
 
   return {

--- a/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.spec.tsx
@@ -321,6 +321,48 @@ describe('SeerDrawer', () => {
     ).toBeInTheDocument();
   });
 
+  describe('autoscroll', () => {
+    let scrollToSpy!: jest.Mock;
+
+    beforeEach(() => {
+      scrollToSpy = jest.fn();
+      // jsdom does not implement Element.prototype.scrollTo
+      Object.defineProperty(Element.prototype, 'scrollTo', {
+        value: scrollToSpy,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      // @ts-expect-error removing the jsdom stub added above
+      delete Element.prototype.scrollTo;
+    });
+
+    it('scrolls the drawer body to the bottom on open for a completed run', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
+        body: {
+          autofix: makeExplorerAutofixData({status: 'completed'}),
+        },
+      });
+
+      render(<SeerDrawer group={mockGroup} project={mockProject} />, {
+        organization,
+      });
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId('ai-setup-loading-indicator')
+      );
+
+      // Guards the wiring between the drawer body and useAutoScroll: the body
+      // is the scroll container, so it must receive the hook's ref.
+      await waitFor(() => {
+        expect(scrollToSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('PR polling', () => {
     const autofixUrl = `/organizations/${DetailedProjectFixture().organization.slug}/issues/${GroupFixture().id}/autofix/`;
 


### PR DESCRIPTION
Opening the Seer Autofix drawer on a finished run left it pinned to the top, so you had to scroll past Root Cause and Plan to reach the newest content and the next-step CTA. The drawer now scrolls to the bottom whenever its content overflows, on open and while a run streams.

**The gate was only half the problem**

Autoscroll was deliberately restricted to runs observed in a `processing` state, so a completed run never scrolled. Removing that gate alone did not fix it — the scroll still did not reach the bottom, because of two defects in `useAutoScroll`:

- The effect only re-ran when `key` changed. A completed run resolves its query once, so there was exactly one scroll attempt, and at that moment the body can still be rendering `Placeholder`s — content is gated on `aiConfig.isAutofixSetupLoading`, a separate query that is not in the effect's deps. It scrolled to the placeholder height and stopped. A `MutationObserver` on the container now re-pins to the bottom when content lands late.
- `behavior: 'smooth'` emits intermediate scroll events, and `onScrollHandler` read every one of them as "not at the bottom", disarming autoscroll mid-animation. It now only disarms when the user scrolls *up*, so a programmatic scroll cannot cancel itself.

Both defects are covered by tests in the new `useAutoScroll.spec.tsx` that fail against the previous implementation.

**Threshold widened to 4px**

At-bottom detection used `< 1`, which sub-pixel and zoom rounding could leave permanently false, making autoscroll disarm itself for good. It is now `< 4`.

**`enabled` removed**

Both call sites passed `true` once the gate was gone, so the option is deleted rather than left as a no-op flag. This also drops a ref write during render in `drawer.tsx`, which `static/AGENTS.md` explicitly forbids.

Manually verified against production data via `pnpm run dev-ui`: a long completed run now opens at the bottom, and scrolling up still stops it from pulling you back down.