### PR TITLE
ref(dynamic-sampling): add a TTL to the latest release date key

### DIFF
--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -284,6 +284,14 @@ class LatestReleaseBias:
 
     OBSERVED_VALUE = "1"
     ONE_DAY_TIMEOUT_MS = 60 * 60 * 24 * 1000
+    # This key holds the date of the newest release seen for the project, and it is the only thing
+    # that stops an older release from being boosted. The expiry is here to drop the projects that
+    # stopped shipping releases, so it must be much longer than the gap between two releases of a
+    # live project. If it fires between two releases, the next event of an older release counts as
+    # a new latest release and gets one boost it should not get. 90 days gives that margin, and it
+    # is the same bound the transaction clusterer uses for its per-project hash. Each new latest
+    # release rewrites the key with a full 90 days, so an active project always keeps its date.
+    LATEST_RELEASE_TIMEOUT_MS = 60 * 60 * 24 * 90 * 1000
 
     def __init__(self, latest_release_params: LatestReleaseParams):
         self.redis_client = get_redis_client_for_ds()
@@ -334,7 +342,9 @@ class LatestReleaseBias:
 
     def _update_latest_release_date(self, timestamp: float) -> None:
         cache_key = self._generate_cache_key_for_project_latest_release()
-        self.redis_client.set(cache_key, timestamp)
+        # The expiry goes in the same command as the value, so the key can never be left without
+        # one.
+        self.redis_client.set(cache_key, timestamp, px=self.LATEST_RELEASE_TIMEOUT_MS)
 
     def _get_release_date_from_incoming_release(self) -> float | None:
         release = self.latest_release_params.release

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -284,14 +284,7 @@ class LatestReleaseBias:
 
     OBSERVED_VALUE = "1"
     ONE_DAY_TIMEOUT_MS = 60 * 60 * 24 * 1000
-    # This key holds the date of the newest release seen for the project, and it is the only thing
-    # that stops an older release from being boosted. The expiry is here to drop the projects that
-    # stopped shipping releases, so it must be much longer than the gap between two releases of a
-    # live project. If it fires between two releases, the next event of an older release counts as
-    # a new latest release and gets one boost it should not get. 90 days gives that margin, and it
-    # is the same bound the transaction clusterer uses for its per-project hash. Each new latest
-    # release rewrites the key with a full 90 days, so an active project always keeps its date.
-    LATEST_RELEASE_TIMEOUT_MS = 60 * 60 * 24 * 90 * 1000
+    LATEST_RELEASE_TIMEOUT_SECS = 60 * 60 * 24 * 90
 
     def __init__(self, latest_release_params: LatestReleaseParams):
         self.redis_client = get_redis_client_for_ds()
@@ -327,7 +320,7 @@ class LatestReleaseBias:
         incoming_release_date = self._get_release_date_from_incoming_release()
         latest_release_date = self._get_release_date_from_latest_release()
 
-        if incoming_release_date is not None:
+        if incoming_release_date is not None and self._is_recent_release(incoming_release_date):
             # We also accept release with the same timestamp because that covers the case in which we have the same
             # release with a different environment.
             #
@@ -340,11 +333,18 @@ class LatestReleaseBias:
 
         return False
 
+    def _is_recent_release(self, release_date: float) -> bool:
+        """
+        Tells whether a release is new enough to be worth boosting.
+        """
+        age = datetime.now(timezone.utc).timestamp() - release_date
+        return age <= self.LATEST_RELEASE_TIMEOUT_SECS
+
     def _update_latest_release_date(self, timestamp: float) -> None:
         cache_key = self._generate_cache_key_for_project_latest_release()
         # The expiry goes in the same command as the value, so the key can never be left without
         # one.
-        self.redis_client.set(cache_key, timestamp, px=self.LATEST_RELEASE_TIMEOUT_MS)
+        self.redis_client.set(cache_key, timestamp, ex=self.LATEST_RELEASE_TIMEOUT_SECS)
 
     def _get_release_date_from_incoming_release(self) -> float | None:
         release = self.latest_release_params.release

--- a/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
@@ -55,7 +55,7 @@ LATEST_RELEASE_TTAS = {
     "java-android": 608689,
     "java-log4j2": 4733,
     "java-logback": 51312,
-    "java-logging": 11843950,
+    "java-logging": 7776000,
     "javascript": 11035,
     "javascript-angular": 5156,
     "javascript-angularjs": 11592,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -4298,12 +4298,64 @@ class DSLatestReleaseBoostTest(TestCase):
         cache_key = f"ds::p:{project.id}:latest_release"
         assert self.redis_client.get(cache_key) is not None
 
-        lifetime_secs = LatestReleaseBias.LATEST_RELEASE_TIMEOUT_MS // 1000
+        lifetime_secs = LatestReleaseBias.LATEST_RELEASE_TIMEOUT_SECS
         ttl = self.redis_client.ttl(cache_key)
         assert ttl > 0
         assert ttl <= lifetime_secs
         # A fresh write gets the full lifetime, so the key must not be near the end of it.
         assert ttl > lifetime_secs - 60
+
+    @freeze_time("2022-11-03 10:00:00")
+    def test_boost_release_skips_release_older_than_the_key_lifetime(self) -> None:
+        """A release too old to be an adoption is not boosted, even with no date key present."""
+        project = self.create_project(platform="python")
+        stale_date = timezone.now() - timedelta(
+            seconds=LatestReleaseBias.LATEST_RELEASE_TIMEOUT_SECS + 1
+        )
+        stale_release = Release.get_or_create(project=project, version="1.0", date_added=stale_date)
+
+        self.make_release_transaction(
+            release_version=stale_release.version,
+            environment_name=self.environment1.name,
+            project_id=project.id,
+            checksum="a" * 32,
+            timestamp=self.timestamp,
+        )
+
+        assert self.redis_client.get(f"ds::p:{project.id}:latest_release") is None
+        assert self.redis_client.hgetall(f"ds::p:{project.id}:boosted_releases") == {}
+
+    @freeze_time("2022-11-03 10:00:00")
+    def test_boost_release_skips_stale_releases_after_the_key_expires(self) -> None:
+        """Losing the date key must not let a run of old releases each take a boost."""
+        ts = timezone.now().timestamp()
+
+        project = self.create_project(platform="python")
+        stale_1 = Release.get_or_create(
+            project=project, version="1.0", date_added=timezone.now() - timedelta(days=200)
+        )
+        stale_2 = Release.get_or_create(
+            project=project, version="2.0", date_added=timezone.now() - timedelta(days=100)
+        )
+        current = Release.get_or_create(project=project, version="3.0", date_added=timezone.now())
+
+        # The date key is absent, as it would be after the expiry fired on a project that stopped
+        # shipping. The two old releases must not be read as a new latest release.
+        for release in (stale_1, stale_2, current):
+            self.make_release_transaction(
+                release_version=release.version,
+                environment_name=self.environment1.name,
+                project_id=project.id,
+                checksum="a" * 32,
+                timestamp=self.timestamp,
+            )
+
+        assert self.redis_client.hgetall(f"ds::p:{project.id}:boosted_releases") == {
+            f"ds::r:{current.id}:e:{self.environment1.name}": str(ts),
+        }
+        assert self.redis_client.get(f"ds::p:{project.id}:latest_release") == str(
+            float(current.date_added.timestamp())
+        )
 
 
 class TestSaveGroupHashAndGroup(TestCase):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -30,6 +30,7 @@ from sentry.dynamic_sampling import (
     ProjectBoostedReleases,
     get_redis_client_for_ds,
 )
+from sentry.dynamic_sampling.rules.helpers.latest_releases import LatestReleaseBias
 from sentry.event_manager import (
     EventManager,
     _get_event_instance,
@@ -4279,6 +4280,30 @@ class DSLatestReleaseBoostTest(TestCase):
                 platform=Platform(project.platform),
             ),
         ]
+
+    @freeze_time("2022-11-03 10:00:00")
+    def test_boost_release_sets_expiry_on_latest_release_date(self) -> None:
+        """The project latest release date expires, so a dead project does not keep a key forever."""
+        project = self.create_project(platform="python")
+        release = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
+
+        self.make_release_transaction(
+            release_version=release.version,
+            environment_name=self.environment1.name,
+            project_id=project.id,
+            checksum="a" * 32,
+            timestamp=self.timestamp,
+        )
+
+        cache_key = f"ds::p:{project.id}:latest_release"
+        assert self.redis_client.get(cache_key) is not None
+
+        lifetime_secs = LatestReleaseBias.LATEST_RELEASE_TIMEOUT_MS // 1000
+        ttl = self.redis_client.ttl(cache_key)
+        assert ttl > 0
+        assert ttl <= lifetime_secs
+        # A fresh write gets the full lifetime, so the key must not be near the end of it.
+        assert ttl > lifetime_secs - 60
 
 
 class TestSaveGroupHashAndGroup(TestCase):


### PR DESCRIPTION
Problem: `LatestReleaseBias` keeps one Redis key per project which holds the date of the newest release seen for that project. That key is written without expiry and nothing deleted it, so every project that has ever had a release observed keeps a key forever.

Fix: write the value and the expiry in the same command. A project that keeps shipping releases rewrites the key and gets a full lifetime each time, so nothing changes for a live project.

Notes:
- Context: a "boost" means we keep a larger share of events for that release instead of letting normal sampling throw them away. We boost new releases while the adoption curve settles down.
- 90 days because we want the expiry to be longer than a normal gap between two releases. Otherwise - if a key expires between two releases, the next event on the older release will appear like a new latest release.
- There was a problem with naively adding a TTL here: old releases could have their keys dropped due to an expiry, resulting in that old release to get boosted. Added a check that determines if a release is _actually_ new enough to warrant a boost.
- This ^ does come with some small behavioral changes: e.g. dormant projects with really old stored release dates will no longer get boosted when an event comes through

Refs INFRENG-474
