### PR TITLE
feat(seer): Default the Seer Autofix drawer to 80% width

### DIFF
--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -40,7 +40,7 @@ export function useDrawerContentContext() {
  */
 interface DrawerPanelProps extends Pick<
   DrawerOptions,
-  'ariaLabel' | 'drawerKey' | 'drawerWidth' | 'resizable' | 'onClose'
+  'ariaLabel' | 'drawerKey' | 'drawerWidth' | 'drawerMaxWidth' | 'resizable' | 'onClose'
 > {
   children: React.ReactNode;
   /** Required — GlobalDrawer applies the default before passing it down. */
@@ -55,6 +55,7 @@ function DrawerPanel({
   children,
   onClose,
   drawerWidth,
+  drawerMaxWidth,
   drawerKey,
   resizable = true,
 }: DrawerPanelProps) {
@@ -62,6 +63,7 @@ function DrawerPanel({
     useDrawerResizing({
       drawerKey,
       drawerWidth,
+      drawerMaxWidth,
       enabled: resizable,
     });
   const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);

--- a/static/app/components/core/drawer/index.spec.tsx
+++ b/static/app/components/core/drawer/index.spec.tsx
@@ -341,4 +341,51 @@ describe('GlobalDrawer', () => {
     expect(closeSpy).toHaveBeenCalled();
     expect(drawer).not.toBeInTheDocument();
   });
+
+  it('applies drawerWidth and drawerMaxWidth as CSS custom properties', async () => {
+    render(
+      <GlobalDrawerTestComponent
+        config={{
+          renderer: () => (
+            <DrawerBody data-test-id="drawer-test-content">width</DrawerBody>
+          ),
+          options: {
+            ariaLabel,
+            drawerKey: 'drawer-test-width',
+            drawerWidth: '80%',
+            drawerMaxWidth: '1600px',
+          },
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByTestId('drawer-test-open'));
+    expect(await screen.findByTestId('drawer-test-content')).toBeInTheDocument();
+
+    const drawer = screen.getByRole('complementary', {name: ariaLabel});
+
+    expect(drawer.style.getPropertyValue('--drawer-width')).toBe('80%');
+    expect(drawer.style.getPropertyValue('--drawer-max-width')).toBe('1600px');
+  });
+
+  it('falls back to the default max width when drawerMaxWidth is omitted', async () => {
+    render(
+      <GlobalDrawerTestComponent
+        config={{
+          renderer: () => (
+            <DrawerBody data-test-id="drawer-test-content">width</DrawerBody>
+          ),
+          options: {ariaLabel, drawerKey: 'drawer-test-default-width'},
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByTestId('drawer-test-open'));
+    expect(await screen.findByTestId('drawer-test-content')).toBeInTheDocument();
+
+    const drawer = screen.getByRole('complementary', {name: ariaLabel});
+
+    expect(drawer.style.getPropertyValue('--drawer-width')).toBe('50%');
+    expect(drawer.style.getPropertyValue('--drawer-max-width')).toBe('85%');
+  });
 });

--- a/static/app/components/core/drawer/index.spec.tsx
+++ b/static/app/components/core/drawer/index.spec.tsx
@@ -365,7 +365,7 @@ describe('GlobalDrawer', () => {
     const drawer = screen.getByRole('complementary', {name: ariaLabel});
 
     expect(drawer.style.getPropertyValue('--drawer-width')).toBe('80%');
-    expect(drawer.style.getPropertyValue('--drawer-max-width')).toBe('1600px');
+    expect(drawer.style.getPropertyValue('--drawer-max-width')).toBe('min(85%, 1600px)');
   });
 
   it('falls back to the default max width when drawerMaxWidth is omitted', async () => {

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -33,6 +33,10 @@ export interface DrawerOptions {
    */
   drawerKey?: string;
   /**
+   * Custom max width for the drawer, as any CSS length
+   */
+  drawerMaxWidth?: string;
+  /**
    * Custom width for the drawer
    */
   drawerWidth?: string;
@@ -231,6 +235,7 @@ export function GlobalDrawer({children}: any) {
               ref={panelRef}
               mode={currentDrawerConfig.options.mode ?? 'blocking'}
               drawerWidth={currentDrawerConfig?.options?.drawerWidth}
+              drawerMaxWidth={currentDrawerConfig?.options?.drawerMaxWidth}
               drawerKey={currentDrawerConfig?.options?.drawerKey}
               resizable={currentDrawerConfig?.options?.resizable}
             >

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -33,7 +33,8 @@ export interface DrawerOptions {
    */
   drawerKey?: string;
   /**
-   * Custom max width for the drawer, as any CSS length
+   * Custom max width for the drawer, as any CSS length. Applies on top of the
+   * default percentage ceiling rather than replacing it.
    */
   drawerMaxWidth?: string;
   /**

--- a/static/app/components/core/drawer/useDrawerResizing.tsx
+++ b/static/app/components/core/drawer/useDrawerResizing.tsx
@@ -87,7 +87,9 @@ export function useDrawerResizing({
       panelRef.current?.style.setProperty('--drawer-min-width', `${MIN_WIDTH_PERCENT}%`);
       panelRef.current?.style.setProperty(
         '--drawer-max-width',
-        drawerMaxWidth ?? `${MAX_WIDTH_PERCENT}%`
+        drawerMaxWidth
+          ? `min(${MAX_WIDTH_PERCENT}%, ${drawerMaxWidth})`
+          : `${MAX_WIDTH_PERCENT}%`
       );
     }
   }, [persistedWidthPercent, isSmallScreen, drawerWidth, drawerMaxWidth, enabled]);

--- a/static/app/components/core/drawer/useDrawerResizing.tsx
+++ b/static/app/components/core/drawer/useDrawerResizing.tsx
@@ -14,6 +14,7 @@ function getDrawerWidthKey(drawerKey: string) {
 
 interface UseDrawerResizingOptions {
   drawerKey?: string;
+  drawerMaxWidth?: string;
   drawerWidth?: string;
   enabled?: boolean;
 }
@@ -29,6 +30,7 @@ interface UseDrawerResizingResult {
 export function useDrawerResizing({
   drawerKey,
   drawerWidth,
+  drawerMaxWidth,
   enabled = true,
 }: UseDrawerResizingOptions): UseDrawerResizingResult {
   const theme = useTheme();
@@ -83,9 +85,12 @@ export function useDrawerResizing({
     } else {
       panelRef.current?.style.setProperty('--drawer-width', `${persistedWidthPercent}%`);
       panelRef.current?.style.setProperty('--drawer-min-width', `${MIN_WIDTH_PERCENT}%`);
-      panelRef.current?.style.setProperty('--drawer-max-width', `${MAX_WIDTH_PERCENT}%`);
+      panelRef.current?.style.setProperty(
+        '--drawer-max-width',
+        drawerMaxWidth ?? `${MAX_WIDTH_PERCENT}%`
+      );
     }
-  }, [persistedWidthPercent, isSmallScreen, drawerWidth, enabled]);
+  }, [persistedWidthPercent, isSmallScreen, drawerWidth, drawerMaxWidth, enabled]);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -18,10 +18,12 @@ const OPEN_STYLES = {
   left: {transform: 'translateX(0) translateY(0)', opacity: 1},
 };
 
+// Percentages resolve against the panel's own width, so it starts fully
+// off-screen whatever width it ends up at.
 const COLLAPSED_STYLES = {
   bottom: {transform: `translateX(0) translateY(${PANEL_HEIGHT})`, opacity: 0},
-  right: {transform: `translateX(${RIGHT_SIDE_PANEL_WIDTH}) translateY(0)`, opacity: 0},
-  left: {transform: `translateX(-${LEFT_SIDE_PANEL_WIDTH}) translateY(0)`, opacity: 0},
+  right: {transform: 'translateX(100%) translateY(0)', opacity: 0},
+  left: {transform: 'translateX(-100%) translateY(0)', opacity: 0},
 };
 
 interface ChildRenderProps {

--- a/static/app/views/issueDetails/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.tsx
@@ -40,6 +40,8 @@ export const useOpenSeerDrawer = ({
     openDrawer(() => <SeerDrawer group={group} project={project} />, {
       ariaLabel: t('Seer drawer'),
       drawerKey: 'seer-autofix-drawer',
+      drawerWidth: '80%',
+      drawerMaxWidth: '1600px',
       resizable: true,
       mode: 'passive',
       shouldCloseOnLocationChange: nextLocation => {

--- a/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/useOverviewSeerDrawer.tsx
@@ -61,6 +61,8 @@ export function useOverviewSeerDrawer() {
     openDrawer(() => <SeerDrawerLoader groupId={groupId} />, {
       ariaLabel: t('Seer drawer'),
       drawerKey: 'seer-autofix-drawer',
+      drawerWidth: '80%',
+      drawerMaxWidth: '1600px',
       resizable: true,
       mode: 'passive',
       shouldCloseOnLocationChange: nextLocation =>


### PR DESCRIPTION
The Seer Autofix drawer opened at 50% of the viewport, which is cramped for what it renders — root-cause prose, a plan, and side-by-side code diffs. It now defaults to 80%, capped at 1600px so it doesn't become a 2000px-wide column of prose on an ultra-wide display. At 1920px the cap doesn't bind, so you still get the full 80%.

**New `drawerMaxWidth` option**

The drawer's width had only a percentage ceiling (`MAX_WIDTH_PERCENT`), so there was no way to cap a percentage width in pixels. `drawerMaxWidth` threads one optional CSS length into the `--drawer-max-width` custom property that the panel's `clamp()` already consumes.

It **composes with** the percentage ceiling rather than replacing it, emitting `min(85%, 1600px)`. That matters below ~1882px, where the pixel cap is wider than 85% of the viewport and would otherwise leave the drawer with no effective ceiling — draggable to the full viewport width, pushing the resize handle off the edge. So 85% governs narrow viewports and 1600px governs wide ones:

| Viewport | Effective cap | Governed by |
|---|---|---|
| 1400px | 1190px | 85% |
| 1920px | 1600px | 1600px |
| 2560px | 1600px | 1600px |

Drawers that omit the option keep the existing 85% ceiling untouched; only the two Seer entry points pass it.

**Collapsed slide-in transform**

`COLLAPSED_STYLES` translated by the hardcoded side-panel width defaults. That matched a 50% drawer exactly but is wrong at any other width — the panel animates in from partway inside its final position rather than from the viewport edge.

```diff
-  right: {transform: `translateX(${RIGHT_SIDE_PANEL_WIDTH}) translateY(0)`, opacity: 0},
-  left: {transform: `translateX(-${LEFT_SIDE_PANEL_WIDTH}) translateY(0)`, opacity: 0},
+  right: {transform: 'translateX(100%) translateY(0)', opacity: 0},
+  left: {transform: 'translateX(-100%) translateY(0)', opacity: 0},
```

A percentage resolves against the element's own width, so it starts fully off-screen at any size. This also reaches the two non-drawer `SlideOverPanel` consumers, `appSizeInsightsSidebar` and `widgetBuilderSlideout`, both of which are mis-animating today for the same reason — so it corrects them rather than changing them. Their suites pass unchanged.

**Only affects users who never resized**

Width is persisted per `drawerKey`, and a stored value takes precedence over the default. `setItem` runs only from the resize `mouseup` handler — the initializer is never persisted — so users who have never dragged the handle pick up 80%, and anyone who deliberately resized keeps their width. No migration.

Both Seer entry points share the `seer-autofix-drawer` key, so both set the width; otherwise whichever opened last would win.

One known gap: the resize handle's `data-at-max-width` attribute compares against `MAX_WIDTH_PERCENT`, so on viewports wide enough for the pixel cap to bind the "at max width" cursor won't fire. Below ~1882px the percentage ceiling is what binds, so the cursor is correct there. Cosmetic, drag cursor only.