### PR TITLE
fix(dashboards): Reject newly invalid widget heights on update

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -963,7 +963,8 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         return validate_project_ids(projects, {project.id for project in self.context["projects"]})
 
     def validate_widget_layout_updates(self, widgets: list[dict[str, Any]]) -> None:
-        if not isinstance(self.instance, Dashboard):
+        request = self.context.get("request")
+        if not isinstance(self.instance, Dashboard) or getattr(request, "method", None) != "PUT":
             return
 
         widget_ids = [widget["id"] for widget in widgets if "id" in widget]

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -228,7 +228,8 @@ def get_widget_layout_height_error(display_type: int, layout: dict[str, Any] | N
         return None
 
     min_height = get_min_widget_height(display_type)
-    if layout["h"] >= min_height:
+    height = layout.get("h")
+    if isinstance(height, int) and height >= min_height:
         return None
 
     display_type_name = DashboardWidgetDisplayTypes.get_type_name(display_type)

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -963,8 +963,9 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         return validate_project_ids(projects, {project.id for project in self.context["projects"]})
 
     def validate_widget_layout_updates(self, widgets: list[dict[str, Any]]) -> None:
-        request = self.context.get("request")
-        if not isinstance(self.instance, Dashboard) or getattr(request, "method", None) != "PUT":
+        if not isinstance(self.instance, Dashboard) or self.context.get(
+            "allow_legacy_widget_heights", False
+        ):
             return
 
         widget_ids = [widget["id"] for widget in widgets if "id" in widget]

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -223,6 +223,18 @@ class DashboardCreateWidgetLayoutSerializer(BaseWidgetLayoutSerializer):
     """
 
 
+def get_widget_layout_height_error(display_type: int, layout: dict[str, Any] | None) -> str | None:
+    if layout is None:
+        return None
+
+    min_height = get_min_widget_height(display_type)
+    if layout["h"] >= min_height:
+        return None
+
+    display_type_name = DashboardWidgetDisplayTypes.get_type_name(display_type)
+    return f"Height must be at least {min_height} for {display_type_name} widgets."
+
+
 class DashboardWidgetQueryOnDemandSerializer(CamelSnakeSerializer[Dashboard]):
     extraction_state = serializers.CharField(required=False)
     enabled = serializers.BooleanField(required=False)
@@ -950,6 +962,45 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
 
         return validate_project_ids(projects, {project.id for project in self.context["projects"]})
 
+    def validate_widget_layout_updates(self, widgets: list[dict[str, Any]]) -> None:
+        if not isinstance(self.instance, Dashboard):
+            return
+
+        widget_ids = [widget["id"] for widget in widgets if "id" in widget]
+        existing_widgets = DashboardWidget.objects.filter(
+            dashboard=self.instance, id__in=widget_ids
+        ).in_bulk()
+        widget_errors: list[dict[str, Any]] = [{} for _ in widgets]
+
+        for index, widget_data in enumerate(widgets):
+            widget_id = widget_data.get("id")
+            existing_widget = existing_widgets.get(widget_id) if widget_id is not None else None
+            if widget_id is not None and existing_widget is None:
+                continue
+
+            old_display_type = existing_widget.display_type if existing_widget else None
+            old_layout = (
+                existing_widget.detail.get("layout")
+                if existing_widget is not None and existing_widget.detail
+                else None
+            )
+            new_display_type = widget_data.get("display_type", old_display_type)
+            new_layout = widget_data.get("layout", old_layout)
+            if new_display_type is None:
+                continue
+
+            old_error = (
+                get_widget_layout_height_error(old_display_type, old_layout)
+                if old_display_type is not None
+                else None
+            )
+            new_error = get_widget_layout_height_error(new_display_type, new_layout)
+            if new_error is not None and (existing_widget is None or old_error is None):
+                widget_errors[index] = {"layout": {"h": new_error}}
+
+        if any(widget_errors):
+            raise serializers.ValidationError({"widgets": widget_errors})
+
     def validate(self, data):
         start = data.get("start")
         end = data.get("end")
@@ -961,6 +1012,8 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
             raise serializers.ValidationError(
                 f"Number of widgets must be less than {Dashboard.MAX_WIDGETS}"
             )
+
+        self.validate_widget_layout_updates(data.get("widgets", []))
 
         permissions = data.get("permissions")
         if permissions and self.instance:
@@ -1481,18 +1534,11 @@ class DashboardCreateWidgetSerializer(DashboardWidgetSerializer):
         if layout is None or display_type is None:
             return data
 
-        min_height = get_min_widget_height(display_type)
-        if layout["h"] < min_height:
-            display_type_name = DashboardWidgetDisplayTypes.get_type_name(display_type)
-            raise serializers.ValidationError(
-                {
-                    "layout": {
-                        "h": f"Height must be at least {min_height} for {display_type_name} widgets."
-                    }
-                }
-            )
+        height_error = get_widget_layout_height_error(display_type, layout)
+        if height_error is not None:
+            raise serializers.ValidationError({"layout": {"h": height_error}})
 
-        layout["minH"] = min_height
+        layout["minH"] = get_min_widget_height(display_type)
         return data
 
 

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
@@ -88,6 +88,7 @@ class OrganizationDashboardRevisionRestoreEndpoint(OrganizationDashboardBase):
                 "validation_projects": projects
                 or self.get_projects(request, organization, include_all_accessible=True),
                 "environment": self.request.GET.getlist("environment"),
+                "allow_legacy_widget_heights": True,
             },
         )
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -2280,6 +2280,82 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 200, response.data
         assert response.data["widgets"][0]["layout"] == layout
 
+    def test_update_widget_layout_rejects_new_invalid_height(self) -> None:
+        self.widget_1.detail = {"layout": {"x": 0, "y": 0, "w": 2, "h": 2, "minH": 2}}
+        self.widget_1.save()
+
+        response = self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={
+                "widgets": [
+                    {
+                        "id": self.widget_1.id,
+                        "layout": {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 2},
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert str(response.data["widgets"][0]["layout"]["h"]) == (
+            "Height must be at least 2 for line widgets."
+        )
+
+    def test_update_widget_display_type_rejects_new_invalid_height(self) -> None:
+        self.widget_1.display_type = DashboardWidgetDisplayTypes.BIG_NUMBER
+        self.widget_1.detail = {"layout": {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 1}}
+        self.widget_1.save()
+
+        response = self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={
+                "widgets": [
+                    {
+                        "id": self.widget_1.id,
+                        "displayType": "line",
+                        "layout": {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 1},
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert str(response.data["widgets"][0]["layout"]["h"]) == (
+            "Height must be at least 2 for line widgets."
+        )
+
+    def test_update_rejects_new_widget_with_invalid_height(self) -> None:
+        response = self.do_request(
+            "put",
+            self.url(self.dashboard.id),
+            data={
+                "widgets": [
+                    {
+                        "displayType": "line",
+                        "interval": "5m",
+                        "title": "Short line chart",
+                        "queries": [
+                            {
+                                "name": "Transactions",
+                                "fields": ["count()"],
+                                "columns": [],
+                                "aggregates": ["count()"],
+                                "conditions": "event.type:transaction",
+                            }
+                        ],
+                        "layout": {"x": 0, "y": 0, "w": 2, "h": 1, "minH": 2},
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert str(response.data["widgets"][0]["layout"]["h"]) == (
+            "Height must be at least 2 for line widgets."
+        )
+
     def test_update_layout_with_invalid_data_fails(self) -> None:
         response = self.do_request(
             "put",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revision_restore.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revision_restore.py
@@ -155,6 +155,38 @@ class PostOrganizationDashboardRevisionRestoreTest(OrganizationDashboardRevision
         assert "title" in response.data
         assert "widgets" in response.data
 
+    def test_restores_legacy_widget_height_below_minimum(self) -> None:
+        layout = {"x": 0, "y": 0, "w": 3, "h": 1, "minH": 2}
+        revision = self._create_revision(
+            snapshot={
+                "title": "Dashboard 1",
+                "widgets": [
+                    {
+                        "title": "Legacy widget",
+                        "displayType": "line",
+                        "interval": "5m",
+                        "queries": [
+                            {
+                                "name": "",
+                                "fields": ["count()"],
+                                "columns": [],
+                                "aggregates": ["count()"],
+                                "conditions": "",
+                                "orderby": "",
+                            }
+                        ],
+                        "widgetType": "error-events",
+                        "layout": layout,
+                    }
+                ],
+            }
+        )
+
+        response = self.client.post(self._url(revision.id))
+
+        assert response.status_code == 200, response.data
+        assert response.data["widgets"][0]["layout"] == layout
+
     def test_returns_400_for_unsupported_schema_version(self) -> None:
         revision = DashboardRevision.objects.create(
             dashboard=self.dashboard,


### PR DESCRIPTION
Dashboard PUT requests now compare each widget's effective persisted and submitted display type and layout. Existing invalid layouts can round-trip unchanged, while new widgets and updates that make a previously valid widget too short are rejected. Revision restore remains exempt so historical snapshots can be replayed unchanged.

The comparison bulk-loads existing widgets once and also catches display-type changes such as converting a one-row big number into a line chart. The frontend duplicate/import normalization and POST validation have already landed; this PR now contains only the PUT compatibility behavior on top of `master`.

Refs DAIN-1842
