### PR TITLE
feat(seer): Window autofix overview SCM enrichment by visibility

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -31,6 +31,7 @@ import type {
   OverviewPullRequest,
   OverviewRunIssue,
 } from 'sentry/views/seerWorkflows/overview/types';
+import {SCM_WINDOW_SIZE} from 'sentry/views/seerWorkflows/overview/types';
 import {useOverviewSeerDrawer} from 'sentry/views/seerWorkflows/overview/useOverviewSeerDrawer';
 
 describe('AutofixOverview', () => {
@@ -109,21 +110,21 @@ describe('AutofixOverview', () => {
 
   function mockOverview({
     base,
-    enriched,
-    enrichedAsyncDelay,
-    enrichedStatusCode,
     baseStatusCode,
     truncated,
     projectConfig,
     projectConfigAsyncDelay,
+    scmInfo,
+    scmInfoStatusCode,
+    scmInfoAsyncDelay,
   }: {
     base: Partial<AutofixOverviewResponse['runsByMilestone']>;
     baseStatusCode?: number;
-    enriched?: Partial<AutofixOverviewResponse['runsByMilestone']>;
-    enrichedAsyncDelay?: number | Promise<void>;
-    enrichedStatusCode?: number;
     projectConfig?: AutofixOverviewResponse['projectConfig'];
     projectConfigAsyncDelay?: number | Promise<void>;
+    scmInfo?: Record<string, {pullRequests: OverviewPullRequest[]}>;
+    scmInfoAsyncDelay?: number | Promise<void>;
+    scmInfoStatusCode?: number;
     truncated?: AutofixOverviewResponse['truncatedMilestones'];
   }) {
     const statusPollRequest = MockApiClient.addMockResponse({
@@ -131,16 +132,6 @@ describe('AutofixOverview', () => {
       statusCode: baseStatusCode,
       body: {
         runsByMilestone: {...emptyMilestones, ...base},
-        truncatedMilestones: truncated ?? [],
-      },
-    });
-    const enrichedRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
-      match: [MockApiClient.matchQuery({expand: ['scmInfo', 'issueStats', 'status']})],
-      asyncDelay: enrichedAsyncDelay,
-      statusCode: enrichedStatusCode,
-      body: {
-        runsByMilestone: {...emptyMilestones, ...(enriched ?? base)},
         truncatedMilestones: truncated ?? [],
       },
     });
@@ -154,23 +145,61 @@ describe('AutofixOverview', () => {
         ...(projectConfig ? {projectConfig} : {}),
       },
     });
-    return {statusPollRequest, enrichedRequest, projectConfigRequest};
+    const scmInfoRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-scm-info/`,
+      asyncDelay: scmInfoAsyncDelay,
+      statusCode: scmInfoStatusCode,
+      body: {scmInfoByRunId: scmInfo ?? {}},
+    });
+    return {statusPollRequest, projectConfigRequest, scmInfoRequest};
   }
 
-  // The un-expanded call cannot reach Snuba, so it nulls out the issue stats.
-  const unenrichedRootCauseRun = {
-    ...rootCauseRun,
-    issue: issueFixture({count: null, userCount: null, lastSeen: null}),
-  };
-
-  // Holds the enriched response open so the pending state can be asserted, with
-  // no reliance on real timers.
-  function deferEnriched() {
+  // Holds a mocked response open so a pending state can be asserted, with no
+  // reliance on real timers.
+  function deferredResponse() {
     let resolve!: () => void;
     const promise = new Promise<void>(r => {
       resolve = r;
     });
     return {promise, resolve};
+  }
+
+  // Cards enrich only once scrolled into view; this makes the IntersectionObserver
+  // report observed cards as visible. `onlyMatching` restricts visibility to the
+  // card whose element contains that text; `deferred` reports on a separate task
+  // like a real per-card observer.
+  const originalIntersectionObserver = window.IntersectionObserver;
+  function makeCardsVisible({
+    deferred = false,
+    onlyMatching,
+  }: {deferred?: boolean; onlyMatching?: string} = {}) {
+    class VisibleObserver {
+      root = null;
+      rootMargin = '';
+      thresholds = [];
+      constructor(private callback: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        const isIntersecting =
+          !onlyMatching || (target.textContent ?? '').includes(onlyMatching);
+        const fire = () =>
+          this.callback(
+            [{isIntersecting, target} as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver
+          );
+        if (deferred) {
+          setTimeout(fire, 0);
+        } else {
+          fire();
+        }
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
+    window.IntersectionObserver =
+      VisibleObserver as unknown as typeof IntersectionObserver;
   }
 
   beforeEach(() => {
@@ -203,6 +232,10 @@ describe('AutofixOverview', () => {
     });
   });
 
+  afterEach(() => {
+    window.IntersectionObserver = originalIntersectionObserver;
+  });
+
   function renderPage(query: Record<string, string> = {}) {
     return render(<AutofixOverview />, {
       organization,
@@ -217,7 +250,7 @@ describe('AutofixOverview', () => {
   }
 
   it('gates the page and issues no requests when the feature is disabled', async () => {
-    const {statusPollRequest, enrichedRequest} = mockOverview({
+    const {statusPollRequest, scmInfoRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
@@ -231,7 +264,7 @@ describe('AutofixOverview', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('Autofix Overview')).not.toBeInTheDocument();
     expect(statusPollRequest).not.toHaveBeenCalled();
-    expect(enrichedRequest).not.toHaveBeenCalled();
+    expect(scmInfoRequest).not.toHaveBeenCalled();
   });
 
   it('renders only populated sections with counts from the single endpoint', async () => {
@@ -304,7 +337,7 @@ describe('AutofixOverview', () => {
   });
 
   it('refetches the overview after a card action is dispatched', async () => {
-    const {enrichedRequest} = mockOverview({
+    const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
     MockApiClient.addMockResponse({
@@ -318,7 +351,7 @@ describe('AutofixOverview', () => {
     await userEvent.click(await screen.findByRole('button', {name: 'Create Plan'}));
 
     expect(await screen.findByRole('button', {name: /Creating Plan/})).toBeDisabled();
-    await waitFor(() => expect(enrichedRequest).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(statusPollRequest).toHaveBeenCalledTimes(2));
   });
 
   describe('Seer drawer', () => {
@@ -481,7 +514,7 @@ describe('AutofixOverview', () => {
   });
 
   it('filters to only in-progress runs when the In Progress tab is selected', async () => {
-    const {statusPollRequest, enrichedRequest} = mockOverview({
+    const {statusPollRequest} = mockOverview({
       base: {
         autofix_root_cause: [{...rootCauseRun, status: 'processing'}],
         autofix_solution: [solutionRun],
@@ -505,7 +538,6 @@ describe('AutofixOverview', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
     expect(statusPollRequest).toHaveBeenCalledTimes(1);
-    expect(enrichedRequest).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a pinned time window through param navigation instead of resetting it', async () => {
@@ -767,8 +799,8 @@ describe('AutofixOverview', () => {
     );
   });
 
-  it('issues a cheap request and an enriched expand request', async () => {
-    const {statusPollRequest, enrichedRequest} = mockOverview({
+  it('paints from the light status+snuba poll and never an scmInfo expand', async () => {
+    const {statusPollRequest, scmInfoRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
     // Overview reads everything from the overview endpoint; the legacy
@@ -794,7 +826,7 @@ describe('AutofixOverview', () => {
     expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
-        query: expect.objectContaining({expand: ['status']}),
+        query: expect.objectContaining({expand: ['status', 'issueStats']}),
       })
     );
     expect(statusPollRequest).toHaveBeenCalledWith(
@@ -803,14 +835,17 @@ describe('AutofixOverview', () => {
         query: expect.not.objectContaining({environment: expect.anything()}),
       })
     );
-    await waitFor(() =>
-      expect(enrichedRequest).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/seer/autofix-overview/`,
-        expect.objectContaining({
-          query: expect.objectContaining({expand: ['scmInfo', 'issueStats', 'status']}),
-        })
-      )
+    // The enriched scmInfo expand is gone; nothing ever requests it.
+    expect(statusPollRequest).not.toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          expand: expect.arrayContaining(['scmInfo']),
+        }),
+      })
     );
+    // A run with no PRs, and no card scrolled into view, never windows SCM info.
+    expect(scmInfoRequest).not.toHaveBeenCalled();
     expect(runsRequest).not.toHaveBeenCalled();
     expect(autofixRequest).not.toHaveBeenCalled();
     expect(issuesRequest).not.toHaveBeenCalled();
@@ -839,61 +874,244 @@ describe('AutofixOverview', () => {
     expect(await screen.findByText('Working…')).toBeInTheDocument();
   });
 
-  it('shimmers the enriched slots until the expand request resolves', async () => {
-    const enriched = deferEnriched();
-    mockOverview({
-      base: {autofix_root_cause: [unenrichedRootCauseRun]},
-      enriched: {autofix_root_cause: [rootCauseRun]},
-      enrichedAsyncDelay: enriched.promise,
+  it('windows scm-info for a visible PR card and shimmers until it resolves', async () => {
+    makeCardsVisible();
+    const scmInfo = deferredResponse();
+    const basePullRequest: OverviewPullRequest = {
+      id: '42',
+      number: 42,
+      url: 'https://github.com/getsentry/sentry/pull/42',
+      status: 'open',
+      checksStatus: null,
+      reviewStatus: null,
+      repoName: 'getsentry/sentry',
+      files: [],
+    };
+    const {scmInfoRequest} = mockOverview({
+      base: {has_pull_request: [{...rootCauseRun, pullRequests: [basePullRequest]}]},
+      scmInfoAsyncDelay: scmInfo.promise,
+      // The window fills in every SCM-sourced field: checks, review, and files.
+      scmInfo: {
+        'run-1': {
+          pullRequests: [
+            {
+              ...basePullRequest,
+              checksStatus: 'success',
+              reviewStatus: 'approved',
+              files: [
+                {
+                  path: 'src/sentry/foo.py',
+                  additions: 10,
+                  deletions: 2,
+                  changeType: 'MODIFIED',
+                },
+              ],
+            },
+          ],
+        },
+      },
     });
 
     renderPage();
 
+    // The base PR link paints immediately from the poll.
     expect(
-      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+      await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
     expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(scmInfoRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/seer/autofix-scm-info/`,
+        expect.objectContaining({query: expect.objectContaining({runIds: ['run-1']})})
+      )
+    );
 
-    enriched.resolve();
+    scmInfo.resolve();
 
-    expect(await screen.findByText('1.2K events')).toBeInTheDocument();
+    // The enriched checks/review tags and changed files land; the shimmer clears.
+    expect(await screen.findByText('Checks Passing')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('getsentry/sentry')).toBeInTheDocument();
+    expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
     expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
   });
 
-  it('stops shimmering when the enriched request fails', async () => {
-    mockOverview({
-      base: {autofix_root_cause: [unenrichedRootCauseRun]},
-      enrichedStatusCode: 500,
+  it('does not window scm-info for a card that never becomes visible', async () => {
+    const {scmInfoRequest} = mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [pullRequestFixture({number: 42, status: 'open'})],
+          },
+        ],
+      },
     });
 
     renderPage();
 
     expect(
-      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+      await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
+    // The default no-op observer never reports the card visible.
+    expect(scmInfoRequest).not.toHaveBeenCalled();
+  });
 
+  it('scopes the scm-info window request to the selected project', async () => {
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [2]}));
+    makeCardsVisible();
+    const {scmInfoRequest} = mockOverview({
+      base: {
+        has_pull_request: [
+          {
+            ...rootCauseRun,
+            pullRequests: [pullRequestFixture({number: 42, status: 'open'})],
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('button', {name: /Review PR #42/})
+    ).toBeInTheDocument();
+    // The window carries the same project scope as the poll so the endpoint
+    // resolves the same runs.
+    await waitFor(() =>
+      expect(scmInfoRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/seer/autofix-scm-info/`,
+        expect.objectContaining({
+          query: expect.objectContaining({project: [2], runIds: ['run-1']}),
+        })
+      )
+    );
+  });
+
+  const windowedRuns = (count: number) =>
+    Array.from({length: count}, (_, i) => ({
+      ...rootCauseRun,
+      groupId: String(100 + i),
+      seerRunId: `run-${i}`,
+      title: `Windowed run ${i}`,
+      pullRequests: [pullRequestFixture({number: 100 + i, status: 'open'})],
+    }));
+
+  it('prefetches the next window when only the first card is visible', async () => {
+    // Only the first card is in view. Its own window is fetched, and the next
+    // window is prefetched so it is enriched before the user reaches it.
+    makeCardsVisible({onlyMatching: 'Windowed run 0'});
+    // Two full windows worth of runs so both are exactly SCM_WINDOW_SIZE.
+    const runCount = SCM_WINDOW_SIZE * 2;
+    const {scmInfoRequest} = mockOverview({
+      base: {has_pull_request: windowedRuns(runCount)},
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Windowed run 0')).toBeInTheDocument();
+
+    // The visible window plus the prefetched next window, each fetched once.
+    await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(2));
+    const windows = scmInfoRequest.mock.calls.map(
+      ([, options]: [string, {query: {runIds: string[]}}]) => options.query.runIds
+    );
+    expect(windows.map(ids => ids.length)).toEqual([SCM_WINDOW_SIZE, SCM_WINDOW_SIZE]);
+    const requestedIds = windows.flat();
+    expect(new Set(requestedIds)).toEqual(
+      new Set(Array.from({length: runCount}, (_, i) => `run-${i}`))
+    );
+  });
+
+  it('partitions PR cards into disjoint windows of SCM_WINDOW_SIZE', async () => {
+    // Each card reports visible on its own task, like a real per-card observer.
+    makeCardsVisible({deferred: true});
+    // Two full windows plus a trailing partial one.
+    const runCount = SCM_WINDOW_SIZE * 2 + 1;
+    const {scmInfoRequest} = mockOverview({
+      base: {has_pull_request: windowedRuns(runCount)},
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Windowed run 0')).toBeInTheDocument();
+
+    // The runs form three disjoint windows, each fetched once, not one per card.
+    await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(3));
+    const windows = scmInfoRequest.mock.calls.map(
+      ([, options]: [string, {query: {runIds: string[]}}]) => options.query.runIds
+    );
+    expect(windows.map(ids => ids.length).sort((a, b) => b - a)).toEqual([
+      SCM_WINDOW_SIZE,
+      SCM_WINDOW_SIZE,
+      1,
+    ]);
+    // Every run enriched exactly once — no id dropped or requested twice.
+    const requestedIds = windows.flat();
+    expect(requestedIds).toHaveLength(runCount);
+    expect(new Set(requestedIds).size).toBe(runCount);
+  });
+
+  it('re-windows scm-info for cards reshown after a sort change', async () => {
+    makeCardsVisible();
+    const prRun = {
+      ...rootCauseRun,
+      pullRequests: [pullRequestFixture({number: 42, status: 'open'})],
+    };
+    const {scmInfoRequest} = mockOverview({base: {has_pull_request: [prRun]}});
+    // The re-sorted scope returns the same PR-bearing run.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({sort: 'events'})],
+      body: {
+        runsByMilestone: {...emptyMilestones, has_pull_request: [prRun]},
+        truncatedMilestones: [],
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('button', {name: /Review PR #42/})
+    ).toBeInTheDocument();
+    await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(screen.getByRole('button', {name: /Sort/}));
+    await userEvent.click(screen.getByRole('option', {name: 'Most events'}));
+
+    // The scope change clears the latch, so the reshown card re-windows
+    // instead of being deduped against the previous scope.
+    await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(2));
+  });
+
+  it('degrades a visible PR card gracefully when scm-info fails', async () => {
+    makeCardsVisible();
+    const basePullRequest: OverviewPullRequest = {
+      id: '42',
+      number: 42,
+      url: 'https://github.com/getsentry/sentry/pull/42',
+      status: 'open',
+      checksStatus: null,
+      reviewStatus: null,
+      files: [],
+    };
+    const {scmInfoRequest} = mockOverview({
+      base: {has_pull_request: [{...rootCauseRun, pullRequests: [basePullRequest]}]},
+      scmInfoStatusCode: 500,
+    });
+
+    renderPage();
+
+    // The base PR link still renders...
+    expect(
+      await screen.findByRole('button', {name: /Review PR #42/})
+    ).toBeInTheDocument();
+    await waitFor(() => expect(scmInfoRequest).toHaveBeenCalled());
+    // ...and the checks/review shimmer clears instead of hanging forever.
     await waitFor(() =>
       expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument()
     );
-    expect(screen.queryByText(/events/)).not.toBeInTheDocument();
-    expect(screen.getByText('PROJ-1')).toBeInTheDocument();
-  });
-
-  it('renders the enriched payload when the base request fails', async () => {
-    mockOverview({
-      base: {},
-      enriched: {autofix_root_cause: [rootCauseRun]},
-      baseStatusCode: 500,
-    });
-
-    renderPage();
-
-    expect(
-      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText('There was an error loading data.')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Checks Passing')).not.toBeInTheDocument();
   });
 
   it('shows the skeleton while a sort change reloads', async () => {
@@ -901,7 +1119,7 @@ describe('AutofixOverview', () => {
 
     // A sort change is a new scope, so previous data is dropped instead of held.
     // Hold the events-sorted response open to keep the skeleton on screen.
-    const events = deferEnriched();
+    const events = deferredResponse();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({sort: 'events'})],
@@ -937,7 +1155,7 @@ describe('AutofixOverview', () => {
 
   it('shows the skeleton again when the selected project changes', async () => {
     mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
-    const otherProject = deferEnriched();
+    const otherProject = deferredResponse();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({project: [3]})],
@@ -969,7 +1187,7 @@ describe('AutofixOverview', () => {
 
   it('shows the skeleton again when the time window changes', async () => {
     mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
-    const narrower = deferEnriched();
+    const narrower = deferredResponse();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({statsPeriod: '24h'})],
@@ -1015,67 +1233,6 @@ describe('AutofixOverview', () => {
     act(() => ProjectsStore.loadInitialData([ProjectFixture()]));
 
     expect(await screen.findByRole('button', {name: 'project-slug'})).toBeInTheDocument();
-  });
-
-  it('renders the changed files of an open pull request', async () => {
-    // Without `expand=scmInfo` the endpoint still returns the pull request, but
-    // its SCM-sourced fields come back empty.
-    const unenrichedPullRequest: OverviewPullRequest = {
-      id: '42',
-      number: 42,
-      url: 'https://github.com/getsentry/sentry/pull/42',
-      status: 'open',
-      checksStatus: null,
-      reviewStatus: null,
-      repoName: 'getsentry/sentry',
-      files: [],
-    };
-
-    const enriched = deferEnriched();
-    mockOverview({
-      enrichedAsyncDelay: enriched.promise,
-      base: {
-        has_pull_request: [{...rootCauseRun, pullRequests: [unenrichedPullRequest]}],
-      },
-      enriched: {
-        has_pull_request: [
-          {
-            ...rootCauseRun,
-            pullRequests: [
-              {
-                ...unenrichedPullRequest,
-                files: [
-                  {
-                    path: 'src/sentry/foo.py',
-                    additions: 10,
-                    deletions: 2,
-                    changeType: 'MODIFIED',
-                  },
-                  {
-                    path: 'src/sentry/bar.py',
-                    additions: 3,
-                    deletions: 0,
-                    changeType: 'ADDED',
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    });
-
-    renderPage();
-
-    expect(await screen.findByText('PROJ-1')).toBeInTheDocument();
-
-    enriched.resolve();
-
-    expect(await screen.findByText('getsentry/sentry')).toBeInTheDocument();
-    expect(screen.getByText('src/sentry/foo.py')).toBeInTheDocument();
-    expect(screen.getByText('src/sentry/bar.py')).toBeInTheDocument();
-    expect(screen.getByText('+10')).toBeInTheDocument();
-    expect(screen.getByText('-2')).toBeInTheDocument();
   });
 
   it('falls back to a file count when a pull request has no repo name', async () => {
@@ -1696,13 +1853,15 @@ describe('AutofixOverview', () => {
     );
   });
 
-  // A sort change refetches only the enriched request, not the base bootstrap.
+  // A sort change re-scopes the status poll, which carries the sort to the endpoint.
   it.each([
     {option: 'Most events', sort: 'events'},
     {option: 'Recent Issue Activity', sort: 'issue'},
     {option: 'Most users', sort: 'users'},
   ])('sends the $sort sort to the endpoint and URL', async ({option, sort}) => {
-    const {enrichedRequest} = mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
 
     const {router} = renderPage();
 
@@ -1714,7 +1873,7 @@ describe('AutofixOverview', () => {
     await userEvent.click(screen.getByRole('option', {name: option}));
 
     await waitFor(() =>
-      expect(enrichedRequest).toHaveBeenCalledWith(
+      expect(statusPollRequest).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/seer/autofix-overview/`,
         expect.objectContaining({
           query: expect.objectContaining({sort}),
@@ -1732,7 +1891,7 @@ describe('AutofixOverview', () => {
     };
 
     it('derives options with counts and filters sections via the URL', async () => {
-      const {enrichedRequest} = mockOverview({
+      const {statusPollRequest} = mockOverview({
         base: {autofix_root_cause: [assignedRun], autofix_solution: [solutionRun]},
       });
 
@@ -1755,7 +1914,7 @@ describe('AutofixOverview', () => {
         screen.queryByRole('button', {name: /Generate code changes/})
       ).not.toBeInTheDocument();
       expect(router.location.query.assignee).toBe('user:7');
-      expect(enrichedRequest).toHaveBeenCalledTimes(1);
+      expect(statusPollRequest).toHaveBeenCalledTimes(1);
     });
 
     it('shows a filtered empty state when no runs match the assignee', async () => {
@@ -1972,7 +2131,6 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    // Error waits for the enriched request (retry: 1) to also fail.
     expect(
       await screen.findByText('There was an error loading data.', undefined, {
         timeout: 5000,
@@ -1984,7 +2142,6 @@ describe('AutofixOverview', () => {
     const {projectConfigRequest} = mockOverview({
       base: {},
       baseStatusCode: 500,
-      enrichedStatusCode: 500,
       projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
     });
 
@@ -1999,7 +2156,7 @@ describe('AutofixOverview', () => {
   });
 
   it('replaces the overview content when the org is eligible for Seer but has not purchased it', () => {
-    const {statusPollRequest, enrichedRequest} = mockOverview({
+    const {statusPollRequest, scmInfoRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
@@ -2014,7 +2171,7 @@ describe('AutofixOverview', () => {
     expect(screen.queryByRole('button', {name: /Sort/})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: /Create Plan/})).not.toBeInTheDocument();
     expect(statusPollRequest).not.toHaveBeenCalled();
-    expect(enrichedRequest).not.toHaveBeenCalled();
+    expect(scmInfoRequest).not.toHaveBeenCalled();
   });
 
   it('renders the overview normally when the org has seat-based Seer', async () => {
@@ -2051,7 +2208,7 @@ describe('AutofixOverview', () => {
   });
 
   it('does not flash the generic empty state while project config is loading', async () => {
-    const deferred = deferEnriched();
+    const deferred = deferredResponse();
     mockOverview({
       base: {},
       projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
@@ -2079,7 +2236,7 @@ describe('AutofixOverview', () => {
       base: {},
       projectConfig: [{id: '2', slug: 'project-slug', hasReposConnected: false}],
     });
-    const configured = deferEnriched();
+    const configured = deferredResponse();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({project: [3]})],
@@ -2115,7 +2272,7 @@ describe('AutofixOverview', () => {
   });
 
   it('waits for project config before painting cards so the warning does not pop in', async () => {
-    const deferred = deferEnriched();
+    const deferred = deferredResponse();
     mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
       projectConfig: [

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -936,7 +936,7 @@ describe('AutofixOverview', () => {
     expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
   });
 
-  it('does not window scm-info for a card that never becomes visible', async () => {
+  it('shimmers an un-enriched PR card from first paint, before it is observed', async () => {
     const {scmInfoRequest} = mockOverview({
       base: {
         has_pull_request: [
@@ -953,7 +953,9 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
-    // The default no-op observer never reports the card visible.
+    // The shimmer is the default state, not toggled on after the window request:
+    // the no-op observer never reports the card visible, so nothing fetched.
+    expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
     expect(scmInfoRequest).not.toHaveBeenCalled();
   });
 

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -135,8 +135,6 @@ describe('AutofixOverview', () => {
       runsByMilestone: {...emptyMilestones, ...base},
       truncatedMilestones: truncated ?? [],
     };
-    // Three expands, three cadences: the fast status poll, the fetch-once Snuba
-    // vitals, and the one-shot project config.
     const statusPollRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({expand: ['status']})],
@@ -168,8 +166,6 @@ describe('AutofixOverview', () => {
     return {statusPollRequest, issueStatsRequest, projectConfigRequest, scmInfoRequest};
   }
 
-  // Holds a mocked response open so a pending state can be asserted, with no
-  // reliance on real timers.
   function deferredResponse() {
     let resolve!: () => void;
     const promise = new Promise<void>(r => {
@@ -178,10 +174,6 @@ describe('AutofixOverview', () => {
     return {promise, resolve};
   }
 
-  // Cards enrich only once scrolled into view; this makes the IntersectionObserver
-  // report observed cards as visible. `onlyMatching` restricts visibility to the
-  // card whose element contains that text; `deferred` reports on a separate task
-  // like a real per-card observer.
   const originalIntersectionObserver = window.IntersectionObserver;
   function makeCardsVisible({
     deferred = false,
@@ -756,14 +748,12 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    // The card paints from the status poll with the counts still behind a shimmer.
     expect(await screen.findByText('TypeError in checkout cart')).toBeInTheDocument();
     expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
     expect(screen.queryByText('1.2K events')).not.toBeInTheDocument();
 
     issueStats.resolve();
 
-    // Once vitals land, the counts replace the shimmer.
     expect(await screen.findByText('1.2K events')).toBeInTheDocument();
     expect(screen.getByText('5 users')).toBeInTheDocument();
   });
@@ -776,7 +766,6 @@ describe('AutofixOverview', () => {
     renderPage();
 
     expect(await screen.findByText('1.2K events')).toBeInTheDocument();
-    // No new run appears, so the Snuba fetch never re-triggers.
     expect(issueStatsRequest).toHaveBeenCalledTimes(1);
   });
 
@@ -870,7 +859,6 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    // The 10s poll carries only status; Snuba vitals ride a separate one-shot call.
     expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
@@ -889,7 +877,6 @@ describe('AutofixOverview', () => {
         query: expect.not.objectContaining({environment: expect.anything()}),
       })
     );
-    // A run with no PRs, and no card scrolled into view, never windows SCM info.
     expect(scmInfoRequest).not.toHaveBeenCalled();
     expect(runsRequest).not.toHaveBeenCalled();
     expect(autofixRequest).not.toHaveBeenCalled();
@@ -935,7 +922,6 @@ describe('AutofixOverview', () => {
     const {scmInfoRequest} = mockOverview({
       base: {has_pull_request: [{...rootCauseRun, pullRequests: [basePullRequest]}]},
       scmInfoAsyncDelay: scmInfo.promise,
-      // The window fills in every SCM-sourced field: checks, review, and files.
       scmInfo: {
         'run-1': {
           pullRequests: [
@@ -959,7 +945,6 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    // The base PR link paints immediately from the poll.
     expect(
       await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
@@ -973,7 +958,6 @@ describe('AutofixOverview', () => {
 
     scmInfo.resolve();
 
-    // The enriched checks/review tags and changed files land; the shimmer clears.
     expect(await screen.findByText('Checks Passing')).toBeInTheDocument();
     expect(screen.getByText('Approved')).toBeInTheDocument();
     expect(screen.getByText('getsentry/sentry')).toBeInTheDocument();
@@ -998,8 +982,6 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
-    // The shimmer is the default state, not toggled on after the window request:
-    // the no-op observer never reports the card visible, so nothing fetched.
     expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
     expect(scmInfoRequest).not.toHaveBeenCalled();
   });
@@ -1023,8 +1005,6 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
-    // The window carries the same project scope as the poll so the endpoint
-    // resolves the same runs.
     await waitFor(() =>
       expect(scmInfoRequest).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/seer/autofix-scm-info/`,
@@ -1045,10 +1025,7 @@ describe('AutofixOverview', () => {
     }));
 
   it('prefetches the next window when only the first card is visible', async () => {
-    // Only the first card is in view. Its own window is fetched, and the next
-    // window is prefetched so it is enriched before the user reaches it.
     makeCardsVisible({onlyMatching: 'Windowed run 0'});
-    // Two full windows worth of runs so both are exactly SCM_WINDOW_SIZE.
     const runCount = SCM_WINDOW_SIZE * 2;
     const {scmInfoRequest} = mockOverview({
       base: {has_pull_request: windowedRuns(runCount)},
@@ -1058,7 +1035,6 @@ describe('AutofixOverview', () => {
 
     expect(await screen.findByText('Windowed run 0')).toBeInTheDocument();
 
-    // The visible window plus the prefetched next window, each fetched once.
     await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(2));
     const windows = scmInfoRequest.mock.calls.map(
       ([, options]: [string, {query: {runIds: string[]}}]) => options.query.runIds
@@ -1071,9 +1047,7 @@ describe('AutofixOverview', () => {
   });
 
   it('partitions PR cards into disjoint windows of SCM_WINDOW_SIZE', async () => {
-    // Each card reports visible on its own task, like a real per-card observer.
     makeCardsVisible({deferred: true});
-    // Two full windows plus a trailing partial one.
     const runCount = SCM_WINDOW_SIZE * 2 + 1;
     const {scmInfoRequest} = mockOverview({
       base: {has_pull_request: windowedRuns(runCount)},
@@ -1083,7 +1057,6 @@ describe('AutofixOverview', () => {
 
     expect(await screen.findByText('Windowed run 0')).toBeInTheDocument();
 
-    // The runs form three disjoint windows, each fetched once, not one per card.
     await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(3));
     const windows = scmInfoRequest.mock.calls.map(
       ([, options]: [string, {query: {runIds: string[]}}]) => options.query.runIds
@@ -1093,7 +1066,6 @@ describe('AutofixOverview', () => {
       SCM_WINDOW_SIZE,
       1,
     ]);
-    // Every run enriched exactly once — no id dropped or requested twice.
     const requestedIds = windows.flat();
     expect(requestedIds).toHaveLength(runCount);
     expect(new Set(requestedIds).size).toBe(runCount);
@@ -1106,7 +1078,6 @@ describe('AutofixOverview', () => {
       pullRequests: [pullRequestFixture({number: 42, status: 'open'})],
     };
     const {scmInfoRequest} = mockOverview({base: {has_pull_request: [prRun]}});
-    // The re-sorted scope returns the same PR-bearing run.
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({sort: 'events'})],
@@ -1126,8 +1097,6 @@ describe('AutofixOverview', () => {
     await userEvent.click(screen.getByRole('button', {name: /Sort/}));
     await userEvent.click(screen.getByRole('option', {name: 'Most events'}));
 
-    // The scope change clears the latch, so the reshown card re-windows
-    // instead of being deduped against the previous scope.
     await waitFor(() => expect(scmInfoRequest).toHaveBeenCalledTimes(2));
   });
 
@@ -1149,12 +1118,10 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    // The base PR link still renders...
     expect(
       await screen.findByRole('button', {name: /Review PR #42/})
     ).toBeInTheDocument();
     await waitFor(() => expect(scmInfoRequest).toHaveBeenCalled());
-    // ...and the checks/review shimmer clears instead of hanging forever.
     await waitFor(() =>
       expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument()
     );
@@ -1900,7 +1867,6 @@ describe('AutofixOverview', () => {
     );
   });
 
-  // A sort change re-scopes the status poll, which carries the sort to the endpoint.
   it.each([
     {option: 'Most events', sort: 'events'},
     {option: 'Recent Issue Activity', sort: 'issue'},

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -114,12 +114,16 @@ describe('AutofixOverview', () => {
     truncated,
     projectConfig,
     projectConfigAsyncDelay,
+    issueStatsAsyncDelay,
+    issueStatsStatusCode,
     scmInfo,
     scmInfoStatusCode,
     scmInfoAsyncDelay,
   }: {
     base: Partial<AutofixOverviewResponse['runsByMilestone']>;
     baseStatusCode?: number;
+    issueStatsAsyncDelay?: number | Promise<void>;
+    issueStatsStatusCode?: number;
     projectConfig?: AutofixOverviewResponse['projectConfig'];
     projectConfigAsyncDelay?: number | Promise<void>;
     scmInfo?: Record<string, {pullRequests: OverviewPullRequest[]}>;
@@ -127,21 +131,31 @@ describe('AutofixOverview', () => {
     scmInfoStatusCode?: number;
     truncated?: AutofixOverviewResponse['truncatedMilestones'];
   }) {
+    const overviewBody = {
+      runsByMilestone: {...emptyMilestones, ...base},
+      truncatedMilestones: truncated ?? [],
+    };
+    // Three expands, three cadences: the fast status poll, the fetch-once Snuba
+    // vitals, and the one-shot project config.
     const statusPollRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({expand: ['status']})],
       statusCode: baseStatusCode,
-      body: {
-        runsByMilestone: {...emptyMilestones, ...base},
-        truncatedMilestones: truncated ?? [],
-      },
+      body: overviewBody,
+    });
+    const issueStatsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      match: [MockApiClient.matchQuery({expand: ['issueStats']})],
+      asyncDelay: issueStatsAsyncDelay,
+      statusCode: issueStatsStatusCode,
+      body: overviewBody,
     });
     const projectConfigRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/autofix-overview/`,
       match: [MockApiClient.matchQuery({expand: ['projectConfig']})],
       asyncDelay: projectConfigAsyncDelay,
       body: {
-        runsByMilestone: {...emptyMilestones, ...base},
-        truncatedMilestones: truncated ?? [],
+        ...overviewBody,
         ...(projectConfig ? {projectConfig} : {}),
       },
     });
@@ -151,7 +165,7 @@ describe('AutofixOverview', () => {
       statusCode: scmInfoStatusCode,
       body: {scmInfoByRunId: scmInfo ?? {}},
     });
-    return {statusPollRequest, projectConfigRequest, scmInfoRequest};
+    return {statusPollRequest, issueStatsRequest, projectConfigRequest, scmInfoRequest};
   }
 
   // Holds a mocked response open so a pending state can be asserted, with no
@@ -733,6 +747,39 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText('0 users')).not.toBeInTheDocument();
   });
 
+  it('shimmers the Snuba vitals until the issueStats call resolves', async () => {
+    const issueStats = deferredResponse();
+    mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+      issueStatsAsyncDelay: issueStats.promise,
+    });
+
+    renderPage();
+
+    // The card paints from the status poll with the counts still behind a shimmer.
+    expect(await screen.findByText('TypeError in checkout cart')).toBeInTheDocument();
+    expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
+    expect(screen.queryByText('1.2K events')).not.toBeInTheDocument();
+
+    issueStats.resolve();
+
+    // Once vitals land, the counts replace the shimmer.
+    expect(await screen.findByText('1.2K events')).toBeInTheDocument();
+    expect(screen.getByText('5 users')).toBeInTheDocument();
+  });
+
+  it('fetches the vitals once for a stable run set, without looping', async () => {
+    const {issueStatsRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('1.2K events')).toBeInTheDocument();
+    // No new run appears, so the Snuba fetch never re-triggers.
+    expect(issueStatsRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('renders inline code in root cause and plan summaries', async () => {
     mockOverview({
       base: {
@@ -799,8 +846,8 @@ describe('AutofixOverview', () => {
     );
   });
 
-  it('paints from the light status+snuba poll and never an scmInfo expand', async () => {
-    const {statusPollRequest, scmInfoRequest} = mockOverview({
+  it('polls status only and fetches Snuba vitals off the hot path', async () => {
+    const {statusPollRequest, issueStatsRequest, scmInfoRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
     // Overview reads everything from the overview endpoint; the legacy
@@ -823,25 +870,23 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
+    // The 10s poll carries only status; Snuba vitals ride a separate one-shot call.
     expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
-        query: expect.objectContaining({expand: ['status', 'issueStats']}),
+        query: expect.objectContaining({expand: ['status']}),
+      })
+    );
+    expect(issueStatsRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.objectContaining({expand: ['issueStats']}),
       })
     );
     expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
         query: expect.not.objectContaining({environment: expect.anything()}),
-      })
-    );
-    // The enriched scmInfo expand is gone; nothing ever requests it.
-    expect(statusPollRequest).not.toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/seer/autofix-overview/`,
-      expect.objectContaining({
-        query: expect.objectContaining({
-          expand: expect.arrayContaining(['scmInfo']),
-        }),
       })
     );
     // A run with no PRs, and no card scrolled into view, never windows SCM info.

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -270,10 +270,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     ),
   })).filter(section => section.runs.length > 0);
 
-  // Only the Review-PR section renders SCM detail (checks/review/files). Its runs
-  // in render order are partitioned into positional windows of SCM_WINDOW_SIZE. A
-  // card scrolling into view enriches its own window and prefetches the next one,
-  // so the following window is already loading before the user reaches it.
   const orderedPrRunIds = populatedSections
     .filter(section => section.key === 'review_pr')
     .flatMap(section => section.runs)

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -62,7 +62,13 @@ import {
   type StatusGroupKey,
   StatusGroupTooltip,
 } from './statusGroups';
-import {OVERVIEW_SECTIONS, type OverviewRun, type OverviewSort} from './types';
+import {
+  OVERVIEW_SECTIONS,
+  type OverviewRun,
+  type OverviewSort,
+  type ProjectConfig,
+  SCM_WINDOW_SIZE,
+} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
 import {useOverviewAnalytics} from './useOverviewAnalytics';
 import {useOverviewSeerDrawer} from './useOverviewSeerDrawer';
@@ -177,16 +183,21 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     projectConfigPending,
     isPending,
     isError,
-    enrichmentPending,
+    dataSettled,
+    requestScmWindow,
+    isScmPending,
     refetch,
-    enrichedSettled,
   } = useAutofixOverview({
     organization,
     selection,
     sort,
     enabled: pageFiltersReady,
   });
-  useMilestoneAdvanceToasts(data, enrichedSettled);
+  useMilestoneAdvanceToasts(data, dataSettled);
+  const projectConfigById = useMemo(
+    () => new Map((projectConfig ?? []).map(config => [config.id, config])),
+    [projectConfig]
+  );
   const unconfiguredProjects =
     projectConfig?.filter(project => !project.hasReposConnected) ?? [];
   useOverviewAnalytics({
@@ -257,6 +268,28 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       run => passesAssignee(run) && (view === 'all' || run.status === 'processing')
     ),
   })).filter(section => section.runs.length > 0);
+
+  // Only the Review-PR section renders SCM detail (checks/review/files). Its runs
+  // in render order are partitioned into positional windows of SCM_WINDOW_SIZE. A
+  // card scrolling into view enriches its own window and prefetches the next one,
+  // so the following window is already loading before the user reaches it.
+  const orderedPrRunIds = populatedSections
+    .filter(section => section.key === 'review_pr')
+    .flatMap(section => section.runs)
+    .filter(run => run.pullRequests.length > 0)
+    .map(run => run.seerRunId);
+  const scmWindows: string[][] = [];
+  for (let start = 0; start < orderedPrRunIds.length; start += SCM_WINDOW_SIZE) {
+    scmWindows.push(orderedPrRunIds.slice(start, start + SCM_WINDOW_SIZE));
+  }
+  const scmWindowsByRunId = new Map<string, string[][]>();
+  scmWindows.forEach((window, index) => {
+    const nextWindow = scmWindows[index + 1];
+    const toRequest = nextWindow ? [window, nextWindow] : [window];
+    for (const id of window) {
+      scmWindowsByRunId.set(id, toRequest);
+    }
+  });
 
   const toggleGroup = (groupKey: StatusGroupKey, expanded: boolean) => {
     setCollapsedGroups(previous =>
@@ -397,7 +430,10 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
                   onToggle={toggleGroup}
                   orgSlug={organization.slug}
                   statsPeriod={selection.datetime.period}
-                  enrichmentPending={enrichmentPending}
+                  requestScmWindow={requestScmWindow}
+                  scmWindowsByRunId={scmWindowsByRunId}
+                  isScmPending={isScmPending}
+                  projectConfigById={projectConfigById}
                   membersByProject={membersByProject}
                   resolvedTeamIds={resolvedTeamIds}
                   teamsSettled={teamsSettled}
@@ -417,17 +453,23 @@ function OverviewSectionList({
   onToggle,
   orgSlug,
   statsPeriod,
-  enrichmentPending,
+  requestScmWindow,
+  scmWindowsByRunId,
+  isScmPending,
+  projectConfigById,
   membersByProject,
   resolvedTeamIds,
   teamsSettled,
 }: {
   collapsedGroups: StatusGroupKey[];
-  enrichmentPending: boolean;
+  isScmPending: (seerRunId: string) => boolean;
   membersByProject: IndexedMembersByProject;
   onToggle: (groupKey: StatusGroupKey, expanded: boolean) => void;
   orgSlug: string;
+  projectConfigById: Map<string, ProjectConfig>;
+  requestScmWindow: (runIds: string[]) => void;
   resolvedTeamIds: Set<string>;
+  scmWindowsByRunId: Map<string, string[][]>;
   sections: Array<(typeof OVERVIEW_SECTIONS)[number] & {runs: OverviewRun[]}>;
   statsPeriod: ComponentProps<typeof OverviewCard>['statsPeriod'];
   teamsSettled: boolean;
@@ -471,7 +513,10 @@ function OverviewSectionList({
                       orgSlug={orgSlug}
                       sectionKey={key}
                       statsPeriod={statsPeriod}
-                      enrichmentPending={enrichmentPending}
+                      enrichmentPending={isScmPending(run.seerRunId)}
+                      requestScmWindow={requestScmWindow}
+                      scmWindows={scmWindowsByRunId.get(run.seerRunId)}
+                      projectConfig={projectConfigById.get(run.issue.project.id)}
                       memberList={membersByProject.get(run.issue.project.slug) ?? []}
                       assigneeReady={assigneeReady}
                     />

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -186,6 +186,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     dataSettled,
     requestScmWindow,
     isScmSettled,
+    isVitalsPending,
     refetch,
   } = useAutofixOverview({
     organization,
@@ -433,6 +434,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
                   requestScmWindow={requestScmWindow}
                   scmWindowsByRunId={scmWindowsByRunId}
                   isScmSettled={isScmSettled}
+                  isVitalsPending={isVitalsPending}
                   projectConfigById={projectConfigById}
                   membersByProject={membersByProject}
                   resolvedTeamIds={resolvedTeamIds}
@@ -456,6 +458,7 @@ function OverviewSectionList({
   requestScmWindow,
   scmWindowsByRunId,
   isScmSettled,
+  isVitalsPending,
   projectConfigById,
   membersByProject,
   resolvedTeamIds,
@@ -463,6 +466,7 @@ function OverviewSectionList({
 }: {
   collapsedGroups: StatusGroupKey[];
   isScmSettled: (seerRunId: string) => boolean;
+  isVitalsPending: (seerRunId: string) => boolean;
   membersByProject: IndexedMembersByProject;
   onToggle: (groupKey: StatusGroupKey, expanded: boolean) => void;
   orgSlug: string;
@@ -514,6 +518,7 @@ function OverviewSectionList({
                       sectionKey={key}
                       statsPeriod={statsPeriod}
                       scmSettled={isScmSettled(run.seerRunId)}
+                      vitalsPending={isVitalsPending(run.seerRunId)}
                       requestScmWindow={requestScmWindow}
                       scmWindows={scmWindowsByRunId.get(run.seerRunId)}
                       projectConfig={projectConfigById.get(run.issue.project.id)}

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -185,7 +185,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     isError,
     dataSettled,
     requestScmWindow,
-    isScmPending,
+    isScmSettled,
     refetch,
   } = useAutofixOverview({
     organization,
@@ -432,7 +432,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
                   statsPeriod={selection.datetime.period}
                   requestScmWindow={requestScmWindow}
                   scmWindowsByRunId={scmWindowsByRunId}
-                  isScmPending={isScmPending}
+                  isScmSettled={isScmSettled}
                   projectConfigById={projectConfigById}
                   membersByProject={membersByProject}
                   resolvedTeamIds={resolvedTeamIds}
@@ -455,14 +455,14 @@ function OverviewSectionList({
   statsPeriod,
   requestScmWindow,
   scmWindowsByRunId,
-  isScmPending,
+  isScmSettled,
   projectConfigById,
   membersByProject,
   resolvedTeamIds,
   teamsSettled,
 }: {
   collapsedGroups: StatusGroupKey[];
-  isScmPending: (seerRunId: string) => boolean;
+  isScmSettled: (seerRunId: string) => boolean;
   membersByProject: IndexedMembersByProject;
   onToggle: (groupKey: StatusGroupKey, expanded: boolean) => void;
   orgSlug: string;
@@ -513,7 +513,7 @@ function OverviewSectionList({
                       orgSlug={orgSlug}
                       sectionKey={key}
                       statsPeriod={statsPeriod}
-                      enrichmentPending={isScmPending(run.seerRunId)}
+                      scmSettled={isScmSettled(run.seerRunId)}
                       requestScmWindow={requestScmWindow}
                       scmWindows={scmWindowsByRunId.get(run.seerRunId)}
                       projectConfig={projectConfigById.get(run.issue.project.id)}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -500,7 +500,7 @@ export function OverviewCard({
   run,
   sectionKey,
   statsPeriod,
-  enrichmentPending,
+  scmSettled,
   requestScmWindow,
   scmWindows,
   projectConfig,
@@ -508,11 +508,11 @@ export function OverviewCard({
   assigneeReady,
 }: {
   assigneeReady: boolean;
-  enrichmentPending: boolean;
   orgSlug: string;
   projectConfig: ProjectConfig | undefined;
   requestScmWindow: (runIds: string[]) => void;
   run: OverviewRun;
+  scmSettled: boolean;
   scmWindows: string[][] | undefined;
   sectionKey: AutofixStateKey;
   statsPeriod: string | null;
@@ -536,6 +536,15 @@ export function OverviewCard({
   const reviewPullRequest =
     sectionKey === 'review_pr' ? selectReviewPullRequest(run.pullRequests) : undefined;
   const changedFiles = reviewPullRequest?.files ?? [];
+  // An actionable PR without SCM detail is still awaiting its window fetch, so
+  // shimmer from first paint (not once observed) until that window settles.
+  const hasEnrichment = Boolean(
+    reviewPullRequest?.checksStatus ||
+    reviewPullRequest?.reviewStatus ||
+    reviewPullRequest?.files?.length
+  );
+  const enrichmentPending =
+    Boolean(reviewPullRequest?.url) && !hasEnrichment && !scmSettled;
   const trackCodeChangesExpanded = () =>
     trackAnalytics('autofix.overview.code_changes_expanded', {
       organization,

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import {keyframes, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -51,7 +51,13 @@ import {
 } from './overviewIssuePriority';
 import {periodWindowLabel} from './periods';
 import {PullRequestFiles} from './pullRequestFiles';
-import type {AutofixStateKey, OverviewPullRequest, OverviewRun} from './types';
+import type {
+  AutofixStateKey,
+  OverviewPullRequest,
+  OverviewRun,
+  ProjectConfig,
+} from './types';
+import {useIsInView} from './useIsInView';
 
 // The endpoint orders links oldest-first and only enriches open/draft PRs, so
 // the newest actionable link is the one carrying badges and files.
@@ -135,9 +141,11 @@ function OverviewAction({
   reviewPullRequest,
   issueUrl,
   enrichmentPending,
+  projectConfig,
 }: {
   enrichmentPending: boolean;
   issueUrl: string;
+  projectConfig: ProjectConfig | undefined;
   reviewPullRequest: OverviewPullRequest | undefined;
   run: OverviewRun;
   sectionKey: AutofixStateKey;
@@ -321,7 +329,9 @@ function OverviewAction({
     );
   }
 
-  return <OverviewCardAction run={run} sectionKey={sectionKey} />;
+  return (
+    <OverviewCardAction run={run} sectionKey={sectionKey} projectConfig={projectConfig} />
+  );
 }
 
 const TitleLink = styled(Link)`
@@ -376,85 +386,58 @@ function NarrativeBlock({
   );
 }
 
-function IssueVitals({
-  run,
-  statsPeriod,
-  enrichmentPending,
-}: {
-  enrichmentPending: boolean;
-  run: OverviewRun;
-  statsPeriod: string | null;
-}) {
+function IssueVitals({run, statsPeriod}: {run: OverviewRun; statsPeriod: string | null}) {
   const eventCount = run.issue.count ? Number(run.issue.count) : null;
   const userCount = run.issue.userCount ?? null;
   const windowLabel = periodWindowLabel(statsPeriod);
   return (
     <Fragment>
-      {enrichmentPending ? (
-        <Fragment>
-          <Flex gap="xs" align="center">
-            <IconGraph size="xs" variant="muted" aria-hidden />
-            <Placeholder height="1rem" width="4rem" />
-          </Flex>
-          <Flex gap="xs" align="center">
-            <IconUser size="xs" variant="muted" aria-hidden />
-            <Placeholder height="1rem" width="4rem" />
-          </Flex>
-          <Flex gap="xs" align="center">
-            <IconClock size="xs" variant="muted" aria-hidden />
-            <Placeholder height="1rem" width="5rem" />
-          </Flex>
-        </Fragment>
-      ) : (
-        <Fragment>
-          {eventCount !== null && (
-            <Flex gap="xs" align="center">
-              <IconGraph size="xs" variant="muted" aria-hidden />
-              <InfoText
-                size="sm"
-                variant="muted"
-                title={
-                  windowLabel
-                    ? t('%s events %s', eventCount.toLocaleString(), windowLabel)
-                    : t('%s events', eventCount.toLocaleString())
-                }
-              >
-                {eventCount === 1
-                  ? t('1 event')
-                  : t('%s events', formatAbbreviatedNumber(eventCount))}
-              </InfoText>
-            </Flex>
-          )}
-          {userCount !== null && (
-            <Flex gap="xs" align="center">
-              <IconUser size="xs" variant="muted" aria-hidden />
-              <InfoText
-                size="sm"
-                variant="muted"
-                title={
-                  windowLabel
-                    ? t('%s affected users %s', userCount.toLocaleString(), windowLabel)
-                    : t('%s affected users', userCount.toLocaleString())
-                }
-              >
-                {userCount === 1
-                  ? t('1 user')
-                  : t('%s users', formatAbbreviatedNumber(userCount))}
-              </InfoText>
-            </Flex>
-          )}
-          {run.issue.lastSeen && (
-            <Flex gap="xs" align="center">
-              <IconClock size="xs" variant="muted" aria-hidden />
-              <Text size="sm" variant="muted">
-                <TimeSince
-                  date={run.issue.lastSeen}
-                  tooltipPrefix={t('The most recent event in this issue occurred')}
-                />
-              </Text>
-            </Flex>
-          )}
-        </Fragment>
+      {eventCount !== null && (
+        <Flex gap="xs" align="center">
+          <IconGraph size="xs" variant="muted" aria-hidden />
+          <InfoText
+            size="sm"
+            variant="muted"
+            title={
+              windowLabel
+                ? t('%s events %s', eventCount.toLocaleString(), windowLabel)
+                : t('%s events', eventCount.toLocaleString())
+            }
+          >
+            {eventCount === 1
+              ? t('1 event')
+              : t('%s events', formatAbbreviatedNumber(eventCount))}
+          </InfoText>
+        </Flex>
+      )}
+      {userCount !== null && (
+        <Flex gap="xs" align="center">
+          <IconUser size="xs" variant="muted" aria-hidden />
+          <InfoText
+            size="sm"
+            variant="muted"
+            title={
+              windowLabel
+                ? t('%s affected users %s', userCount.toLocaleString(), windowLabel)
+                : t('%s affected users', userCount.toLocaleString())
+            }
+          >
+            {userCount === 1
+              ? t('1 user')
+              : t('%s users', formatAbbreviatedNumber(userCount))}
+          </InfoText>
+        </Flex>
+      )}
+      {run.issue.lastSeen && (
+        <Flex gap="xs" align="center">
+          <IconClock size="xs" variant="muted" aria-hidden />
+          <Text size="sm" variant="muted">
+            <TimeSince
+              date={run.issue.lastSeen}
+              tooltipPrefix={t('The most recent event in this issue occurred')}
+            />
+          </Text>
+        </Flex>
       )}
       <Flex gap="xs" align="center">
         <IconSeer size="xs" variant="muted" aria-hidden />
@@ -518,18 +501,35 @@ export function OverviewCard({
   sectionKey,
   statsPeriod,
   enrichmentPending,
+  requestScmWindow,
+  scmWindows,
+  projectConfig,
   memberList,
   assigneeReady,
 }: {
   assigneeReady: boolean;
   enrichmentPending: boolean;
   orgSlug: string;
+  projectConfig: ProjectConfig | undefined;
+  requestScmWindow: (runIds: string[]) => void;
   run: OverviewRun;
+  scmWindows: string[][] | undefined;
   sectionKey: AutofixStateKey;
   statsPeriod: string | null;
   memberList?: User[];
 }) {
   const organization = useOrganization();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const inView = useIsInView(cardRef);
+  useEffect(() => {
+    // Scrolling a card into view enriches its own window and prefetches the next,
+    // so the following window is already loading before the user reaches it.
+    if (inView && scmWindows) {
+      for (const window of scmWindows) {
+        requestScmWindow(window);
+      }
+    }
+  }, [inView, scmWindows, requestScmWindow]);
   const rootCause = run.rootCause?.oneLineDescription;
   const proposedFix = run.proposedFix?.oneLineSummary;
   const issueUrl = `/organizations/${orgSlug}/issues/${run.groupId}/`;
@@ -546,6 +546,7 @@ export function OverviewCard({
 
   return (
     <CardFrame
+      containerRef={cardRef}
       aside={
         <Fragment>
           <OverviewAction
@@ -554,6 +555,7 @@ export function OverviewCard({
             reviewPullRequest={reviewPullRequest}
             issueUrl={issueUrl}
             enrichmentPending={enrichmentPending}
+            projectConfig={projectConfig}
           />
           <PriorityAndAssignee
             run={run}
@@ -595,11 +597,7 @@ export function OverviewCard({
                 {run.shortId}
               </Text>
             </Flex>
-            <IssueVitals
-              run={run}
-              statsPeriod={statsPeriod}
-              enrichmentPending={enrichmentPending}
-            />
+            <IssueVitals run={run} statsPeriod={statsPeriod} />
           </Flex>
         </Stack>
       </Grid>
@@ -641,12 +639,20 @@ export function OverviewCard({
 function CardFrame({
   aside,
   children,
+  containerRef,
 }: {
   aside: React.ReactNode;
   children: React.ReactNode;
+  containerRef?: React.Ref<HTMLDivElement>;
 }) {
   return (
-    <Container background="primary" border="primary" radius="md" padding="xl">
+    <Container
+      ref={containerRef}
+      background="primary"
+      border="primary"
+      radius="md"
+      padding="xl"
+    >
       <Stack gap="xl">
         <Flex
           gap={{xs: 'xl', sm: '3xl'}}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -564,8 +564,6 @@ export function OverviewCard({
   const cardRef = useRef<HTMLDivElement>(null);
   const inView = useIsInView(cardRef);
   useEffect(() => {
-    // Scrolling a card into view enriches its own window and prefetches the next,
-    // so the following window is already loading before the user reaches it.
     if (inView && scmWindows) {
       for (const window of scmWindows) {
         requestScmWindow(window);
@@ -578,8 +576,6 @@ export function OverviewCard({
   const reviewPullRequest =
     sectionKey === 'review_pr' ? selectReviewPullRequest(run.pullRequests) : undefined;
   const changedFiles = reviewPullRequest?.files ?? [];
-  // An actionable PR without SCM detail is still awaiting its window fetch, so
-  // shimmer from first paint (not once observed) until that window settles.
   const hasEnrichment = Boolean(
     reviewPullRequest?.checksStatus ||
     reviewPullRequest?.reviewStatus ||

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -386,10 +386,50 @@ function NarrativeBlock({
   );
 }
 
-function IssueVitals({run, statsPeriod}: {run: OverviewRun; statsPeriod: string | null}) {
+function IssueVitals({
+  run,
+  statsPeriod,
+  vitalsPending,
+}: {
+  run: OverviewRun;
+  statsPeriod: string | null;
+  vitalsPending: boolean;
+}) {
   const eventCount = run.issue.count ? Number(run.issue.count) : null;
   const userCount = run.issue.userCount ?? null;
   const windowLabel = periodWindowLabel(statsPeriod);
+  // lastTriggeredAt rides the status poll, so keep it visible even while the
+  // Snuba-sourced counts are still shimmering in.
+  const seerActivity = (
+    <Flex gap="xs" align="center">
+      <IconSeer size="xs" variant="muted" aria-hidden />
+      <Text size="sm" variant="muted">
+        <TimeSince
+          date={run.lastTriggeredAt}
+          tooltipPrefix={t('Last activity on this Seer run')}
+        />
+      </Text>
+    </Flex>
+  );
+  if (vitalsPending) {
+    return (
+      <Fragment>
+        <Flex gap="xs" align="center">
+          <IconGraph size="xs" variant="muted" aria-hidden />
+          <Placeholder height="1rem" width="4rem" />
+        </Flex>
+        <Flex gap="xs" align="center">
+          <IconUser size="xs" variant="muted" aria-hidden />
+          <Placeholder height="1rem" width="4rem" />
+        </Flex>
+        <Flex gap="xs" align="center">
+          <IconClock size="xs" variant="muted" aria-hidden />
+          <Placeholder height="1rem" width="5rem" />
+        </Flex>
+        {seerActivity}
+      </Fragment>
+    );
+  }
   return (
     <Fragment>
       {eventCount !== null && (
@@ -501,6 +541,7 @@ export function OverviewCard({
   sectionKey,
   statsPeriod,
   scmSettled,
+  vitalsPending,
   requestScmWindow,
   scmWindows,
   projectConfig,
@@ -516,6 +557,7 @@ export function OverviewCard({
   scmWindows: string[][] | undefined;
   sectionKey: AutofixStateKey;
   statsPeriod: string | null;
+  vitalsPending: boolean;
   memberList?: User[];
 }) {
   const organization = useOrganization();
@@ -606,7 +648,11 @@ export function OverviewCard({
                 {run.shortId}
               </Text>
             </Flex>
-            <IssueVitals run={run} statsPeriod={statsPeriod} />
+            <IssueVitals
+              run={run}
+              statsPeriod={statsPeriod}
+              vitalsPending={vitalsPending}
+            />
           </Flex>
         </Stack>
       </Grid>

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -9,6 +9,7 @@ import {OverviewCardAction} from 'sentry/views/seerWorkflows/overview/overviewCa
 import type {
   OverviewRun,
   OverviewRunIssue,
+  ProjectConfig,
 } from 'sentry/views/seerWorkflows/overview/types';
 
 jest.mock('sentry/utils/analytics');
@@ -291,19 +292,11 @@ describe('OverviewCardAction', () => {
     expect(agentItem).toHaveAttribute('aria-disabled', 'true');
   });
 
-  function runWithEligibility(hasReposConnected: boolean, hasNonGithubRepo: boolean) {
-    return runFixture({
-      issue: {
-        ...issueFixture(),
-        project: {
-          id: '2',
-          slug: 'project-slug',
-          platform: 'python',
-          hasReposConnected,
-          hasNonGithubRepo,
-        },
-      },
-    });
+  function projectConfigFixture(
+    hasReposConnected: boolean,
+    hasNonGithubRepo: boolean
+  ): ProjectConfig {
+    return {id: '2', slug: 'project-slug', hasReposConnected, hasNonGithubRepo};
   }
 
   it('uses precomputed repo eligibility and skips the repos fetch', async () => {
@@ -314,8 +307,9 @@ describe('OverviewCardAction', () => {
 
     render(
       <OverviewCardAction
-        run={runWithEligibility(true, false)}
+        run={runFixture()}
         sectionKey="needs_investigation"
+        projectConfig={projectConfigFixture(true, false)}
       />,
       {organization}
     );
@@ -337,8 +331,9 @@ describe('OverviewCardAction', () => {
 
     render(
       <OverviewCardAction
-        run={runWithEligibility(false, false)}
+        run={runFixture()}
         sectionKey="needs_investigation"
+        projectConfig={projectConfigFixture(false, false)}
       />,
       {organization}
     );
@@ -363,8 +358,9 @@ describe('OverviewCardAction', () => {
 
     render(
       <OverviewCardAction
-        run={runWithEligibility(true, false)}
+        run={runFixture()}
         sectionKey="needs_investigation"
+        projectConfig={projectConfigFixture(true, false)}
       />,
       {organization}
     );

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -37,8 +37,6 @@ export function OverviewCardAction({
   const {autofix, config, isDispatched, trigger} = useNextAction({run, sectionKey});
   const {to: openSeerTo, trackOpen} = useOpenSeerLink(run, sectionKey);
 
-  // DB-only eligibility from the separately-fetched projectConfig; lets the hook
-  // skip its own repo pagination without waiting on GitHub enrichment.
   const repoEligibility = projectConfig
     ? {
         hasReposConnected: projectConfig.hasReposConnected,

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -19,14 +19,16 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {useOpenSeerLink} from './openSeerButton';
 import {type ActionableSectionKey, useNextAction} from './overviewActions';
-import type {OverviewRun} from './types';
+import type {OverviewRun, ProjectConfig} from './types';
 
 export function OverviewCardAction({
   run,
   sectionKey,
+  projectConfig,
 }: {
   run: OverviewRun;
   sectionKey: ActionableSectionKey;
+  projectConfig?: ProjectConfig;
 }) {
   const organization = useOrganization();
   // Defer agent-option fetches until the dropdown opens to avoid per-card repo pagination.
@@ -35,11 +37,14 @@ export function OverviewCardAction({
   const {autofix, config, isDispatched, trigger} = useNextAction({run, sectionKey});
   const {to: openSeerTo, trackOpen} = useOpenSeerLink(run, sectionKey);
 
-  const {hasReposConnected, hasNonGithubRepo} = run.issue.project;
-  const repoEligibility =
-    hasReposConnected === undefined
-      ? undefined
-      : {hasReposConnected, hasNonGithubRepo: hasNonGithubRepo ?? false};
+  // DB-only eligibility from the separately-fetched projectConfig; lets the hook
+  // skip its own repo pagination without waiting on GitHub enrichment.
+  const repoEligibility = projectConfig
+    ? {
+        hasReposConnected: projectConfig.hasReposConnected,
+        hasNonGithubRepo: projectConfig.hasNonGithubRepo ?? false,
+      }
+    : undefined;
 
   const {
     codingAgentIntegrations,

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -192,8 +192,6 @@ export interface OverviewRunIssue {
   project: {
     id: string;
     slug: string;
-    hasNonGithubRepo?: boolean;
-    hasReposConnected?: boolean;
     platform?: PlatformKey;
   };
   substatus: string | null;
@@ -218,6 +216,7 @@ export interface ProjectConfig {
   hasReposConnected: boolean;
   id: string;
   slug: string;
+  hasNonGithubRepo?: boolean;
 }
 
 export interface AutofixOverviewResponse {
@@ -225,3 +224,14 @@ export interface AutofixOverviewResponse {
   projectConfig?: ProjectConfig[];
   truncatedMilestones?: MilestoneKey[];
 }
+
+// PR/SCM enrichment fetched per window of run ids from the autofix-scm-info
+// endpoint, keyed by seerRunId.
+export interface AutofixScmInfoResponse {
+  scmInfoByRunId: Record<string, {pullRequests: OverviewPullRequest[]}>;
+}
+
+// Positional window size: PR-bearing runs are partitioned by render order into
+// chunks of this many, and any card in a chunk scrolling into view fetches the
+// whole chunk. Owned here — the endpoint serves whatever it is given.
+export const SCM_WINDOW_SIZE = 5;

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -225,13 +225,10 @@ export interface AutofixOverviewResponse {
   truncatedMilestones?: MilestoneKey[];
 }
 
-// PR/SCM enrichment fetched per window of run ids from the autofix-scm-info
-// endpoint, keyed by seerRunId.
 export interface AutofixScmInfoResponse {
   scmInfoByRunId: Record<string, {pullRequests: OverviewPullRequest[]}>;
 }
 
-// Positional window size: PR-bearing runs are partitioned by render order into
-// chunks of this many, and any card in a chunk scrolling into view fetches the
-// whole chunk. Owned here — the endpoint serves whatever it is given.
+// PR-bearing runs are partitioned by render order into windows of this size; a
+// card scrolling into view fetches its whole window and prefetches the next.
 export const SCM_WINDOW_SIZE = 5;

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
@@ -1,11 +1,5 @@
 import type {AutofixOverviewResponse, OverviewRun, RunStatus} from './types';
-import {
-  detectMilestoneAdvances,
-  isSameScope,
-  overlayStatus,
-  sectionSignature,
-  shouldRefetchEnriched,
-} from './useAutofixOverview';
+import {detectMilestoneAdvances} from './useAutofixOverview';
 
 const emptyMilestones = {
   autofix_root_cause: [],
@@ -27,53 +21,6 @@ function response(
     truncatedMilestones: [],
   };
 }
-
-describe('sectionSignature', () => {
-  it('returns null when there is no data', () => {
-    expect(sectionSignature(undefined)).toBeNull();
-  });
-
-  it('changes when a run moves to a new section', () => {
-    const before = sectionSignature(response({autofix_root_cause: [run('r1')]}));
-    const after = sectionSignature(response({has_pull_request: [run('r1')]}));
-    expect(after).not.toEqual(before);
-  });
-
-  it('is stable when only a run status changes', () => {
-    const before = sectionSignature(response({autofix_root_cause: [run('r1', null)]}));
-    const after = sectionSignature(
-      response({autofix_root_cause: [run('r1', 'processing')]})
-    );
-    expect(after).toEqual(before);
-  });
-});
-
-describe('overlayStatus', () => {
-  it('applies the polled status onto the matching run', () => {
-    const base = response({autofix_root_cause: [run('r1', null)]});
-    const poll = response({autofix_root_cause: [run('r1', 'processing')]});
-    const merged = overlayStatus(base, poll);
-    expect(merged.runsByMilestone.autofix_root_cause[0]!.status).toBe('processing');
-  });
-
-  it('returns the base unchanged when the poll has no runs', () => {
-    const base = response({autofix_root_cause: [run('r1', 'completed')]});
-    expect(overlayStatus(base, undefined)).toBe(base);
-  });
-
-  it('keeps the existing status when the poll reports null', () => {
-    const base = response({autofix_root_cause: [run('r1', 'processing')]});
-    const poll = response({autofix_root_cause: [run('r1', null)]});
-    const merged = overlayStatus(base, poll);
-    expect(merged.runsByMilestone.autofix_root_cause[0]!.status).toBe('processing');
-  });
-
-  it('returns the base reference when no status changed', () => {
-    const base = response({autofix_root_cause: [run('r1', 'processing')]});
-    const poll = response({autofix_root_cause: [run('r1', 'processing')]});
-    expect(overlayStatus(base, poll)).toBe(base);
-  });
-});
 
 describe('detectMilestoneAdvances', () => {
   it('returns nothing when either poll is missing', () => {
@@ -132,74 +79,5 @@ describe('detectMilestoneAdvances', () => {
 
     expect(advanced).toEqual(expect.arrayContaining(['r1', 'r2']));
     expect(advanced).toHaveLength(2);
-  });
-});
-
-describe('shouldRefetchEnriched', () => {
-  it('is false when either side has no data', () => {
-    const data = response({autofix_root_cause: [run('r1')]});
-    expect(shouldRefetchEnriched(undefined, data)).toBe(false);
-    expect(shouldRefetchEnriched(data, undefined)).toBe(false);
-  });
-
-  it('is false when the sections match', () => {
-    const sections = {autofix_root_cause: [run('r1')]};
-    expect(shouldRefetchEnriched(response(sections), response(sections))).toBe(false);
-  });
-
-  it('is false when only a run status differs', () => {
-    expect(
-      shouldRefetchEnriched(
-        response({autofix_root_cause: [run('r1', 'processing')]}),
-        response({autofix_root_cause: [run('r1', 'completed')]})
-      )
-    ).toBe(false);
-  });
-
-  it('is true when the poll and enriched sections diverge', () => {
-    const poll = response({has_pull_request: [run('r1')]});
-    const enriched = response({autofix_root_cause: [run('r1')]});
-    expect(shouldRefetchEnriched(poll, enriched)).toBe(true);
-  });
-});
-
-describe('isSameScope', () => {
-  const scope = {project: [2], statsPeriod: '14d'};
-
-  it('is true across an expand change', () => {
-    expect(
-      isSameScope(
-        {...scope, expand: ['status']},
-        {...scope, expand: ['scmInfo', 'issueStats', 'status']}
-      )
-    ).toBe(true);
-  });
-
-  it('is false when the sort changes', () => {
-    expect(
-      isSameScope(
-        {...scope, expand: ['status']},
-        {...scope, sort: 'events', expand: ['status']}
-      )
-    ).toBe(false);
-  });
-
-  it('is false when the projects change', () => {
-    expect(isSameScope(scope, {...scope, project: [2, 3]})).toBe(false);
-  });
-
-  it('is false when the time window changes', () => {
-    expect(isSameScope(scope, {...scope, statsPeriod: '24h'})).toBe(false);
-    expect(
-      isSameScope(scope, {
-        project: [2],
-        start: '2026-07-01T00:00:00',
-        end: '2026-07-02T00:00:00',
-      })
-    ).toBe(false);
-  });
-
-  it('is false with no previous query', () => {
-    expect(isSameScope(undefined, scope)).toBe(false);
   });
 });

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.spec.tsx
@@ -1,5 +1,5 @@
 import type {AutofixOverviewResponse, OverviewRun, RunStatus} from './types';
-import {detectMilestoneAdvances} from './useAutofixOverview';
+import {detectMilestoneAdvances, runsMissingStats} from './useAutofixOverview';
 
 const emptyMilestones = {
   autofix_root_cause: [],
@@ -79,5 +79,35 @@ describe('detectMilestoneAdvances', () => {
 
     expect(advanced).toEqual(expect.arrayContaining(['r1', 'r2']));
     expect(advanced).toHaveLength(2);
+  });
+});
+
+describe('runsMissingStats', () => {
+  it('returns nothing when the poll is missing', () => {
+    expect(runsMissingStats(undefined, new Map())).toEqual([]);
+  });
+
+  it('returns nothing when every run already has stats', () => {
+    const poll = response({
+      autofix_root_cause: [run('r1')],
+      autofix_solution: [run('r2')],
+    });
+    expect(
+      runsMissingStats(
+        poll,
+        new Map([
+          ['r1', {}],
+          ['r2', {}],
+        ])
+      )
+    ).toEqual([]);
+  });
+
+  it('returns run ids the stats response does not cover', () => {
+    const poll = response({
+      autofix_root_cause: [run('r1'), run('r2')],
+      autofix_code_changes: [run('r3')],
+    });
+    expect(runsMissingStats(poll, new Map([['r1', {}]])).sort()).toEqual(['r2', 'r3']);
   });
 });

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -180,9 +180,9 @@ export function useAutofixOverview({
   );
 
   // Requested ids (dedup) live in a ref so a window request never re-reads state
-  // during render; the shimmer reads `pendingRunIds`.
+  // during render; the shimmer clears off `settledRunIds`.
   const requestedRunIdsRef = useRef<Set<string>>(new Set());
-  const [pendingRunIds, setPendingRunIds] = useState<Set<string>>(() => new Set());
+  const [settledRunIds, setSettledRunIds] = useState<Set<string>>(() => new Set());
   const [scmByRunId, setScmByRunId] = useState<Map<string, OverviewPullRequest[]>>(
     () => new Map()
   );
@@ -200,21 +200,15 @@ export function useAutofixOverview({
       for (const id of fresh) {
         requestedRunIdsRef.current.add(id);
       }
-      // Shimmer the whole window now, before the request resolves.
-      setPendingRunIds(prev => new Set([...prev, ...fresh]));
       // Snapshot the scope so a window landing after a scope change is dropped.
       const generation = scopeGenerationRef.current;
+      // Mark the window settled once its request finishes (success or failure);
+      // the shimmer is on by default for un-enriched cards until then.
       const settle = () => {
         if (scopeGenerationRef.current !== generation) {
           return;
         }
-        setPendingRunIds(prev => {
-          const next = new Set(prev);
-          for (const id of fresh) {
-            next.delete(id);
-          }
-          return next;
-        });
+        setSettledRunIds(prev => new Set([...prev, ...fresh]));
       };
 
       queryClient
@@ -250,12 +244,12 @@ export function useAutofixOverview({
     scopeGenerationRef.current += 1;
     requestedRunIdsRef.current.clear();
     setScmByRunId(new Map());
-    setPendingRunIds(new Set());
+    setSettledRunIds(new Set());
   }, [scopeKey]);
 
-  const isScmPending = useCallback(
-    (seerRunId: string) => pendingRunIds.has(seerRunId),
-    [pendingRunIds]
+  const isScmSettled = useCallback(
+    (seerRunId: string) => settledRunIds.has(seerRunId),
+    [settledRunIds]
   );
 
   const data = useMemo(
@@ -274,7 +268,7 @@ export function useAutofixOverview({
     // baseline off a real payload.
     dataSettled: !statusPollQuery.isPending && Boolean(statusPollQuery.data),
     requestScmWindow,
-    isScmPending,
+    isScmSettled,
     refetch: () => {
       statusPollQuery.refetch();
       projectConfigQuery.refetch();

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -67,8 +67,6 @@ export function detectMilestoneAdvances(
   return advances;
 }
 
-// Poll run ids the issueStats response doesn't cover yet; a non-empty result
-// means a new run appeared and its vitals still need fetching.
 export function runsMissingStats(
   poll: AutofixOverviewResponse | undefined,
   statsByRunId: ReadonlyMap<string, unknown>
@@ -87,8 +85,6 @@ export function runsMissingStats(
   return missing;
 }
 
-// Overlays the window's SCM fields (checks/review/files) onto the matching poll
-// PR by id, so the poll's live PR identity/status isn't clobbered by a snapshot.
 function overlayPullRequest(
   base: OverviewPullRequest,
   scm: OverviewPullRequest
@@ -103,8 +99,6 @@ function overlayPullRequest(
   };
 }
 
-// Merges each fetched window's SCM detail onto the poll's live PRs per run;
-// unfetched runs and uncovered PRs keep poll data, so no PR link is dropped.
 function mergeScmInfo(
   base: AutofixOverviewResponse,
   scmByRunId: Map<string, OverviewPullRequest[]>
@@ -134,8 +128,6 @@ function mergeScmInfo(
   return {...base, runsByMilestone};
 }
 
-// The status poll leaves count/userCount/lastSeen null; overlay them from the
-// issueStats query once it lands so cards paint fast and vitals fill in after.
 type IssueStats = {
   count: string | null;
   lastSeen: string | null;
@@ -200,8 +192,6 @@ export function useAutofixOverview({
     refetchInterval: POLL_INTERVAL,
   });
 
-  // Snuba vitals ride off the fast poll's path: fetched once, then refetched only
-  // when the poll surfaces a new run that could be missing counts.
   const issueStatsQuery = useQuery({
     ...overviewQuery({expand: ['issueStats']}),
     enabled,
@@ -234,8 +224,6 @@ export function useAutofixOverview({
     [organization.slug, selection.projects]
   );
 
-  // Requested ids (dedup) live in a ref so a window request never re-reads state
-  // during render; the shimmer clears off `settledRunIds`.
   const requestedRunIdsRef = useRef<Set<string>>(new Set());
   const [settledRunIds, setSettledRunIds] = useState<Set<string>>(() => new Set());
   const [scmByRunId, setScmByRunId] = useState<Map<string, OverviewPullRequest[]>>(
@@ -245,10 +233,12 @@ export function useAutofixOverview({
   // Ids we've already refetched issueStats for, so a run persistently missing
   // from the stats response can't loop the Snuba call every poll.
   const refetchedRunIdsRef = useRef<Set<string>>(new Set());
+  // Runs still absent from issueStats after their one refetch settled; drop their
+  // vitals shimmer so a deleted/inaccessible issue's card doesn't shimmer forever.
+  const [statsUnavailableRunIds, setStatsUnavailableRunIds] = useState<Set<string>>(
+    () => new Set()
+  );
 
-  // Fetches one positional window of PR-bearing runs (the caller partitions runs
-  // by render order). Any card in a window scrolling into view pulls the whole
-  // window, so the runs just below it are enriched before they are reached.
   const requestScmWindow = useCallback(
     (runIds: string[]) => {
       const fresh = runIds.filter(id => !requestedRunIdsRef.current.has(id));
@@ -260,8 +250,6 @@ export function useAutofixOverview({
       }
       // Snapshot the scope so a window landing after a scope change is dropped.
       const generation = scopeGenerationRef.current;
-      // Mark the window settled once its request finishes (success or failure);
-      // the shimmer is on by default for un-enriched cards until then.
       const settle = () => {
         if (scopeGenerationRef.current !== generation) {
           return;
@@ -297,13 +285,12 @@ export function useAutofixOverview({
   // so the reshown cards re-window instead of being deduped against the old scope.
   const scopeKey = JSON.stringify([selection.projects, selection.datetime, sort]);
   useEffect(() => {
-    // Bump the generation so an in-flight window from the old scope is ignored
-    // when it settles instead of writing stale data into the new scope.
     scopeGenerationRef.current += 1;
     requestedRunIdsRef.current.clear();
     refetchedRunIdsRef.current.clear();
     setScmByRunId(new Map());
     setSettledRunIds(new Set());
+    setStatsUnavailableRunIds(new Set());
   }, [scopeKey]);
 
   const isScmSettled = useCallback(
@@ -325,8 +312,6 @@ export function useAutofixOverview({
     return map;
   }, [issueStatsQuery.data]);
 
-  // Refetch vitals only when the poll brings in a run the issueStats response
-  // doesn't cover (a new run), and only once per run (guarded by the ref above).
   const issueStatsRefetch = issueStatsQuery.refetch;
   const issueStatsFetching = issueStatsQuery.isFetching;
   const hasIssueStats = Boolean(issueStatsQuery.data);
@@ -334,9 +319,16 @@ export function useAutofixOverview({
     if (!hasIssueStats || issueStatsFetching) {
       return;
     }
-    const fresh = runsMissingStats(statusPollQuery.data, issueStatsByRunId).filter(
-      id => !refetchedRunIdsRef.current.has(id)
-    );
+    const missing = runsMissingStats(statusPollQuery.data, issueStatsByRunId);
+    // A run still missing after its one refetch settled won't self-heal; mark it
+    // so its vitals stop shimmering instead of hanging on forever.
+    const exhausted = missing.filter(id => refetchedRunIdsRef.current.has(id));
+    if (exhausted.length > 0) {
+      setStatsUnavailableRunIds(prev =>
+        exhausted.every(id => prev.has(id)) ? prev : new Set([...prev, ...exhausted])
+      );
+    }
+    const fresh = missing.filter(id => !refetchedRunIdsRef.current.has(id));
     if (fresh.length === 0) {
       return;
     }
@@ -353,8 +345,11 @@ export function useAutofixOverview({
   ]);
 
   const isVitalsPending = useCallback(
-    (seerRunId: string) => !issueStatsByRunId.has(seerRunId) && !issueStatsQuery.isError,
-    [issueStatsByRunId, issueStatsQuery.isError]
+    (seerRunId: string) =>
+      !issueStatsByRunId.has(seerRunId) &&
+      !issueStatsQuery.isError &&
+      !statsUnavailableRunIds.has(seerRunId),
+    [issueStatsByRunId, issueStatsQuery.isError, statsUnavailableRunIds]
   );
 
   const data = useMemo(
@@ -374,9 +369,9 @@ export function useAutofixOverview({
     projectConfigPending: projectConfigQuery.isLoading,
     isPending: !data,
     isError: statusPollQuery.isError && !data,
-    // Poll-based: true once the sole source has painted, so milestone toasts
-    // baseline off a real payload.
-    dataSettled: !statusPollQuery.isPending && Boolean(statusPollQuery.data),
+    // isFetching, not isPending: a stale-cache remount must wait for the refetch
+    // so milestone toasts baseline off fresh data, not the stale snapshot.
+    dataSettled: !statusPollQuery.isFetching && Boolean(statusPollQuery.data),
     requestScmWindow,
     isScmSettled,
     isVitalsPending,

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -67,6 +67,26 @@ export function detectMilestoneAdvances(
   return advances;
 }
 
+// Poll run ids the issueStats response doesn't cover yet; a non-empty result
+// means a new run appeared and its vitals still need fetching.
+export function runsMissingStats(
+  poll: AutofixOverviewResponse | undefined,
+  statsByRunId: ReadonlyMap<string, unknown>
+): string[] {
+  if (!poll) {
+    return [];
+  }
+  const missing: string[] = [];
+  for (const runs of Object.values(poll.runsByMilestone)) {
+    for (const run of runs) {
+      if (!statsByRunId.has(run.seerRunId)) {
+        missing.push(run.seerRunId);
+      }
+    }
+  }
+  return missing;
+}
+
 // Overlays the window's SCM fields (checks/review/files) onto the matching poll
 // PR by id, so the poll's live PR identity/status isn't clobbered by a snapshot.
 function overlayPullRequest(
@@ -114,8 +134,35 @@ function mergeScmInfo(
   return {...base, runsByMilestone};
 }
 
-// Progressive load: the 10s status+Snuba poll paints cards fast; slow GitHub
-// PR/SCM detail is windowed lazily, only for cards scrolled into view.
+// The status poll leaves count/userCount/lastSeen null; overlay them from the
+// issueStats query once it lands so cards paint fast and vitals fill in after.
+type IssueStats = {
+  count: string | null;
+  lastSeen: string | null;
+  userCount: number | null;
+};
+
+function overlayIssueStats(
+  base: AutofixOverviewResponse,
+  statsByRunId: Map<string, IssueStats>
+): AutofixOverviewResponse {
+  if (statsByRunId.size === 0) {
+    return base;
+  }
+  const runsByMilestone = Object.fromEntries(
+    Object.entries(base.runsByMilestone).map(([milestone, runs]) => [
+      milestone,
+      runs.map(run => {
+        const stats = statsByRunId.get(run.seerRunId);
+        return stats ? {...run, issue: {...run.issue, ...stats}} : run;
+      }),
+    ])
+  ) as AutofixOverviewResponse['runsByMilestone'];
+  return {...base, runsByMilestone};
+}
+
+// Progressive load: the 10s status poll paints cards fast; slower Snuba vitals
+// and GitHub SCM detail fill in afterward without blocking the poll.
 export function useAutofixOverview({
   organization,
   selection,
@@ -148,9 +195,17 @@ export function useAutofixOverview({
     );
 
   const statusPollQuery = useQuery({
-    ...overviewQuery({expand: ['status', 'issueStats']}),
+    ...overviewQuery({expand: ['status']}),
     enabled,
     refetchInterval: POLL_INTERVAL,
+  });
+
+  // Snuba vitals ride off the fast poll's path: fetched once, then refetched only
+  // when the poll surfaces a new run that could be missing counts.
+  const issueStatsQuery = useQuery({
+    ...overviewQuery({expand: ['issueStats']}),
+    enabled,
+    retry: 1,
   });
 
   const projectConfigQuery = useQuery({
@@ -187,6 +242,9 @@ export function useAutofixOverview({
     () => new Map()
   );
   const scopeGenerationRef = useRef(0);
+  // Ids we've already refetched issueStats for, so a run persistently missing
+  // from the stats response can't loop the Snuba call every poll.
+  const refetchedRunIdsRef = useRef<Set<string>>(new Set());
 
   // Fetches one positional window of PR-bearing runs (the caller partitions runs
   // by render order). Any card in a window scrolling into view pulls the whole
@@ -243,6 +301,7 @@ export function useAutofixOverview({
     // when it settles instead of writing stale data into the new scope.
     scopeGenerationRef.current += 1;
     requestedRunIdsRef.current.clear();
+    refetchedRunIdsRef.current.clear();
     setScmByRunId(new Map());
     setSettledRunIds(new Set());
   }, [scopeKey]);
@@ -252,10 +311,61 @@ export function useAutofixOverview({
     [settledRunIds]
   );
 
+  const issueStatsByRunId = useMemo(() => {
+    const map = new Map<string, IssueStats>();
+    for (const runs of Object.values(issueStatsQuery.data?.runsByMilestone ?? {})) {
+      for (const run of runs) {
+        map.set(run.seerRunId, {
+          count: run.issue.count,
+          lastSeen: run.issue.lastSeen,
+          userCount: run.issue.userCount,
+        });
+      }
+    }
+    return map;
+  }, [issueStatsQuery.data]);
+
+  // Refetch vitals only when the poll brings in a run the issueStats response
+  // doesn't cover (a new run), and only once per run (guarded by the ref above).
+  const issueStatsRefetch = issueStatsQuery.refetch;
+  const issueStatsFetching = issueStatsQuery.isFetching;
+  const hasIssueStats = Boolean(issueStatsQuery.data);
+  useEffect(() => {
+    if (!hasIssueStats || issueStatsFetching) {
+      return;
+    }
+    const fresh = runsMissingStats(statusPollQuery.data, issueStatsByRunId).filter(
+      id => !refetchedRunIdsRef.current.has(id)
+    );
+    if (fresh.length === 0) {
+      return;
+    }
+    for (const id of fresh) {
+      refetchedRunIdsRef.current.add(id);
+    }
+    issueStatsRefetch();
+  }, [
+    statusPollQuery.data,
+    issueStatsByRunId,
+    hasIssueStats,
+    issueStatsFetching,
+    issueStatsRefetch,
+  ]);
+
+  const isVitalsPending = useCallback(
+    (seerRunId: string) => !issueStatsByRunId.has(seerRunId) && !issueStatsQuery.isError,
+    [issueStatsByRunId, issueStatsQuery.isError]
+  );
+
   const data = useMemo(
     () =>
-      statusPollQuery.data ? mergeScmInfo(statusPollQuery.data, scmByRunId) : undefined,
-    [statusPollQuery.data, scmByRunId]
+      statusPollQuery.data
+        ? mergeScmInfo(
+            overlayIssueStats(statusPollQuery.data, issueStatsByRunId),
+            scmByRunId
+          )
+        : undefined,
+    [statusPollQuery.data, issueStatsByRunId, scmByRunId]
   );
 
   return {
@@ -269,8 +379,10 @@ export function useAutofixOverview({
     dataSettled: !statusPollQuery.isPending && Boolean(statusPollQuery.data),
     requestScmWindow,
     isScmSettled,
+    isVitalsPending,
     refetch: () => {
       statusPollQuery.refetch();
+      issueStatsQuery.refetch();
       projectConfigQuery.refetch();
     },
   };

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -1,24 +1,22 @@
-import {useEffect, useMemo} from 'react';
-import {type QueryKey, useQuery} from '@tanstack/react-query';
-import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {CanonicalApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 
 import {
   type AutofixOverviewResponse,
+  type AutofixScmInfoResponse,
   type MilestoneKey,
+  type OverviewPullRequest,
   type OverviewRun,
   OVERVIEW_SECTIONS,
   type OverviewSort,
   PIPELINE,
   POLL_INTERVAL,
   QUERY_STALE_TIME,
-  type RunStatus,
 } from './types';
 
 export interface MilestoneAdvance {
@@ -69,87 +67,55 @@ export function detectMilestoneAdvances(
   return advances;
 }
 
-function statusByRunId(
-  data: AutofixOverviewResponse | undefined
-): Map<string, RunStatus | null> {
-  const map = new Map<string, RunStatus | null>();
-  for (const runs of Object.values(data?.runsByMilestone ?? {})) {
-    for (const run of runs) {
-      map.set(run.seerRunId, run.status);
-    }
-  }
-  return map;
+// Overlays the window's SCM fields (checks/review/files) onto the matching poll
+// PR by id, so the poll's live PR identity/status isn't clobbered by a snapshot.
+function overlayPullRequest(
+  base: OverviewPullRequest,
+  scm: OverviewPullRequest
+): OverviewPullRequest {
+  return {
+    ...base,
+    checksStatus: scm.checksStatus,
+    reviewStatus: scm.reviewStatus,
+    files: scm.files,
+    failedCheckDetails: scm.failedCheckDetails,
+    repoName: base.repoName ?? scm.repoName,
+  };
 }
 
-// Fingerprint of which run sits in which section; a change cues an enrichment refetch.
-export function sectionSignature(
-  data: AutofixOverviewResponse | undefined
-): string | null {
-  if (!data) {
-    return null;
-  }
-  const pairs: string[] = [];
-  for (const [milestone, runs] of Object.entries(data.runsByMilestone)) {
-    for (const run of runs) {
-      pairs.push(`${run.seerRunId}:${milestone}`);
-    }
-  }
-  return pairs.sort().join(',');
-}
-
-export function shouldRefetchEnriched(
-  pollData: AutofixOverviewResponse | undefined,
-  enrichedData: AutofixOverviewResponse | undefined
-): boolean {
-  const pollSignature = sectionSignature(pollData);
-  const enrichedSignature = sectionSignature(enrichedData);
-  return (
-    pollSignature !== null &&
-    enrichedSignature !== null &&
-    pollSignature !== enrichedSignature
-  );
-}
-
-type QueryParams = Record<string, unknown> | undefined;
-
-const SCOPE_FREE_PARAMS = ['expand'];
-
-export function isSameScope(previous: QueryParams, next: QueryParams): boolean {
-  return isEqual(omit(previous, SCOPE_FREE_PARAMS), omit(next, SCOPE_FREE_PARAMS));
-}
-
-function queryParamsOf(queryKey: QueryKey): QueryParams {
-  const [, options] = queryKey as CanonicalApiQueryKey;
-  return options?.query;
-}
-
-export function overlayStatus(
+// Merges each fetched window's SCM detail onto the poll's live PRs per run;
+// unfetched runs and uncovered PRs keep poll data, so no PR link is dropped.
+function mergeScmInfo(
   base: AutofixOverviewResponse,
-  poll: AutofixOverviewResponse | undefined
+  scmByRunId: Map<string, OverviewPullRequest[]>
 ): AutofixOverviewResponse {
-  const statuses = statusByRunId(poll);
-  if (statuses.size === 0) {
+  if (scmByRunId.size === 0) {
     return base;
   }
-  let changed = false;
   const runsByMilestone = Object.fromEntries(
     Object.entries(base.runsByMilestone).map(([milestone, runs]) => [
       milestone,
       runs.map(run => {
-        const next = statuses.get(run.seerRunId);
-        if (typeof next === 'string' && next !== run.status) {
-          changed = true;
-          return {...run, status: next};
+        const enriched = scmByRunId.get(run.seerRunId);
+        if (!enriched) {
+          return run;
         }
-        return run;
+        const scmById = new Map(enriched.map(pr => [pr.id, pr]));
+        return {
+          ...run,
+          pullRequests: run.pullRequests.map(pr => {
+            const scm = scmById.get(pr.id);
+            return scm ? overlayPullRequest(pr, scm) : pr;
+          }),
+        };
       }),
     ])
   ) as AutofixOverviewResponse['runsByMilestone'];
-  return changed ? {...base, runsByMilestone} : base;
+  return {...base, runsByMilestone};
 }
 
-// Progressive load: a light `status` poll paints cards fast and stays live every 10s;
-// the enriched `expand` request fills in Snuba/SCM detail and refetches on section change.
+// Progressive load: the 10s status+Snuba poll paints cards fast; slow GitHub
+// PR/SCM detail is windowed lazily, only for cards scrolled into view.
 export function useAutofixOverview({
   organization,
   selection,
@@ -161,10 +127,12 @@ export function useAutofixOverview({
   selection: PageFilters;
   sort: OverviewSort;
 }) {
+  const queryClient = useQueryClient();
+
   const overviewQuery = (query: {
-    expand?: Array<'scmInfo' | 'issueStats' | 'status' | 'projectConfig'>;
-  }) => {
-    const options = apiOptions.as<AutofixOverviewResponse>()(
+    expand?: Array<'issueStats' | 'status' | 'projectConfig'>;
+  }) =>
+    apiOptions.as<AutofixOverviewResponse>()(
       '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
       {
         path: {organizationIdOrSlug: organization.slug},
@@ -178,32 +146,9 @@ export function useAutofixOverview({
         staleTime: QUERY_STALE_TIME,
       }
     );
-    return {
-      ...options,
-      placeholderData: <T>(
-        previousData: T | undefined,
-        previousQuery: {queryKey: QueryKey} | undefined
-      ) =>
-        previousQuery &&
-        isSameScope(
-          queryParamsOf(previousQuery.queryKey),
-          queryParamsOf(options.queryKey)
-        )
-          ? previousData
-          : undefined,
-    };
-  };
-
-  const enrichedQuery = useQuery({
-    ...overviewQuery({expand: ['scmInfo', 'issueStats', 'status']}),
-    enabled,
-    // Enrichment is progressive polish: fail fast to empty slots rather than
-    // shimmering through the default retry backoff.
-    retry: 1,
-  });
 
   const statusPollQuery = useQuery({
-    ...overviewQuery({expand: ['status']}),
+    ...overviewQuery({expand: ['status', 'issueStats']}),
     enabled,
     refetchInterval: POLL_INTERVAL,
   });
@@ -213,17 +158,110 @@ export function useAutofixOverview({
     enabled,
   });
 
-  const enrichedRefetch = enrichedQuery.refetch;
-  useEffect(() => {
-    if (shouldRefetchEnriched(statusPollQuery.data, enrichedQuery.data)) {
-      enrichedRefetch();
-    }
-  }, [statusPollQuery.data, enrichedQuery.data, enrichedRefetch]);
+  const scmInfoQueryOptions = useCallback(
+    (runIds: string[]) =>
+      apiOptions.as<AutofixScmInfoResponse>()(
+        '/organizations/$organizationIdOrSlug/seer/autofix-scm-info/',
+        {
+          path: {organizationIdOrSlug: organization.slug},
+          query: {
+            // Same project scope as the poll so the endpoint resolves the same
+            // runs; otherwise All-Projects/extra-access runs stay un-enriched.
+            project: selection.projects,
+            // Sorted so concurrent identical windows share one request.
+            runIds: runIds.toSorted(),
+          },
+          // Within-scope dedup is handled by requestedRunIdsRef, so freshness is
+          // ours to manage: always hit the network so a scope reset re-fetches.
+          staleTime: 0,
+        }
+      ),
+    [organization.slug, selection.projects]
+  );
 
-  const source = enrichedQuery.data ?? statusPollQuery.data;
+  // Requested ids (dedup) live in a ref so a window request never re-reads state
+  // during render; the shimmer reads `pendingRunIds`.
+  const requestedRunIdsRef = useRef<Set<string>>(new Set());
+  const [pendingRunIds, setPendingRunIds] = useState<Set<string>>(() => new Set());
+  const [scmByRunId, setScmByRunId] = useState<Map<string, OverviewPullRequest[]>>(
+    () => new Map()
+  );
+  const scopeGenerationRef = useRef(0);
+
+  // Fetches one positional window of PR-bearing runs (the caller partitions runs
+  // by render order). Any card in a window scrolling into view pulls the whole
+  // window, so the runs just below it are enriched before they are reached.
+  const requestScmWindow = useCallback(
+    (runIds: string[]) => {
+      const fresh = runIds.filter(id => !requestedRunIdsRef.current.has(id));
+      if (fresh.length === 0) {
+        return;
+      }
+      for (const id of fresh) {
+        requestedRunIdsRef.current.add(id);
+      }
+      // Shimmer the whole window now, before the request resolves.
+      setPendingRunIds(prev => new Set([...prev, ...fresh]));
+      // Snapshot the scope so a window landing after a scope change is dropped.
+      const generation = scopeGenerationRef.current;
+      const settle = () => {
+        if (scopeGenerationRef.current !== generation) {
+          return;
+        }
+        setPendingRunIds(prev => {
+          const next = new Set(prev);
+          for (const id of fresh) {
+            next.delete(id);
+          }
+          return next;
+        });
+      };
+
+      queryClient
+        // Fail fast to un-enriched cards rather than shimmering through retries.
+        .fetchQuery({...scmInfoQueryOptions(fresh), retry: false})
+        .then(({json}) => {
+          if (scopeGenerationRef.current !== generation) {
+            return;
+          }
+          setScmByRunId(prev => {
+            const next = new Map(prev);
+            for (const id of fresh) {
+              const entry = json.scmInfoByRunId?.[id];
+              if (entry) {
+                next.set(id, entry.pullRequests);
+              }
+            }
+            return next;
+          });
+          settle();
+        })
+        .catch(settle);
+    },
+    [queryClient, scmInfoQueryOptions]
+  );
+
+  // A scope change (sort/project/date) remounts the cards; clear the SCM caches
+  // so the reshown cards re-window instead of being deduped against the old scope.
+  const scopeKey = JSON.stringify([selection.projects, selection.datetime, sort]);
+  useEffect(() => {
+    // Bump the generation so an in-flight window from the old scope is ignored
+    // when it settles instead of writing stale data into the new scope.
+    scopeGenerationRef.current += 1;
+    requestedRunIdsRef.current.clear();
+    setScmByRunId(new Map());
+    setPendingRunIds(new Set());
+  }, [scopeKey]);
+
+  const isScmPending = useCallback(
+    (seerRunId: string) => pendingRunIds.has(seerRunId),
+    [pendingRunIds]
+  );
+
   const data = useMemo(
-    () => (source ? overlayStatus(source, statusPollQuery.data) : undefined),
-    [source, statusPollQuery.data]
+    () =>
+      statusPollQuery.data ? mergeScmInfo(statusPollQuery.data, scmByRunId) : undefined,
+    [statusPollQuery.data, scmByRunId]
   );
 
   return {
@@ -231,15 +269,14 @@ export function useAutofixOverview({
     projectConfig: projectConfigQuery.data?.projectConfig,
     projectConfigPending: projectConfigQuery.isLoading,
     isPending: !data,
-    // Error only once both fail with nothing to show; the poll alone may still be
-    // recovered by an in-flight enriched call.
-    isError: statusPollQuery.isError && enrichedQuery.isError && !data,
-    // Cold-load shimmer only: the poll painted but no enriched payload yet.
-    enrichmentPending: Boolean(data) && !enrichedQuery.data && !enrichedQuery.isError,
-    enrichedSettled: !enrichedQuery.isFetching && Boolean(enrichedQuery.data),
+    isError: statusPollQuery.isError && !data,
+    // Poll-based: true once the sole source has painted, so milestone toasts
+    // baseline off a real payload.
+    dataSettled: !statusPollQuery.isPending && Boolean(statusPollQuery.data),
+    requestScmWindow,
+    isScmPending,
     refetch: () => {
       statusPollQuery.refetch();
-      enrichedQuery.refetch();
       projectConfigQuery.refetch();
     },
   };

--- a/static/app/views/seerWorkflows/overview/useIsInView.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/useIsInView.spec.tsx
@@ -1,0 +1,67 @@
+import {useRef} from 'react';
+
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {useIsInView} from './useIsInView';
+
+let triggerIntersect: ((isIntersecting: boolean) => void) | undefined;
+
+class MockIntersectionObserver {
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    triggerIntersect = isIntersecting =>
+      callback(
+        [{isIntersecting} as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver
+      );
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+function Harness() {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useIsInView(ref);
+  return <div ref={ref}>{inView ? 'in view' : 'not in view'}</div>;
+}
+
+describe('useIsInView', () => {
+  const original = window.IntersectionObserver;
+
+  beforeEach(() => {
+    triggerIntersect = undefined;
+    window.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    window.IntersectionObserver = original;
+  });
+
+  it('flips to true once the ref intersects', () => {
+    render(<Harness />);
+
+    expect(screen.getByText('not in view')).toBeInTheDocument();
+
+    act(() => triggerIntersect!(true));
+
+    expect(screen.getByText('in view')).toBeInTheDocument();
+  });
+
+  it('renders immediately when IntersectionObserver is unavailable', () => {
+    // @ts-expect-error deleting the global to exercise the fallback path
+    delete window.IntersectionObserver;
+
+    render(<Harness />);
+
+    expect(screen.getByText('in view')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerWorkflows/overview/useIsInView.ts
+++ b/static/app/views/seerWorkflows/overview/useIsInView.ts
@@ -1,0 +1,35 @@
+import {useEffect, useState} from 'react';
+
+import {ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS} from 'sentry/components/events/issueDetailsLazyRender';
+
+function supportsIntersectionObserver(): boolean {
+  return 'IntersectionObserver' in window;
+}
+
+// Reports whether `ref` has scrolled into view; latches true on first sight so
+// the windowed enrichment fires at most once per card and never thrashes.
+export function useIsInView(
+  ref: React.RefObject<Element | null>,
+  options: Partial<IntersectionObserverInit> = ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS
+): boolean {
+  const [inView, setInView] = useState(() => !supportsIntersectionObserver());
+
+  useEffect(() => {
+    if (inView) {
+      return;
+    }
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    const observer = new IntersectionObserver(entries => {
+      if (entries.some(entry => entry.isIntersecting)) {
+        setInView(true);
+      }
+    }, options);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref, inView, options]);
+
+  return inView;
+}


### PR DESCRIPTION
## Summary

The Autofix Overview page (`/issues/autofix/`) fetched GitHub PR/SCM detail for
**every** card up front via the enriched `expand=scmInfo` call. GitHub is the
page's latency bottleneck, so that call gated the whole page — even cards nobody
scrolls to. This fetches SCM detail **lazily, only for cards scrolled into
view**, from the windowed endpoint added in #122735.

## What changed

- **Poll paints cards.** The 10s `status` poll (Postgres-only) paints cards
  immediately; the `expand=scmInfo` call is gone. Snuba vitals (count/users/
  lastSeen) ride a separate one-shot `issueStats` call off the hot path,
  refetched only when a new run appears.
- **Windowed SCM fetch.** A per-card `IntersectionObserver` (`useIsInView`)
  batches visible, PR-bearing runs into windows of `SCM_WINDOW_SIZE` (5),
  fetches `autofix-scm-info`, and merges results onto the poll's live PRs per
  PR id (so an empty window never wipes a live PR).
- **Per-card shimmer.** The checks/review placeholder shimmers only while that
  window is in flight; an scm-info error degrades the card gracefully.
- **Fresh on scope change.** Re-sort or project/date change resets the SCM
  caches; hard refresh and re-sort are the only refetch triggers.
- **Eligibility from `projectConfig`.** Coding-agent flags now come from the
  DB-only `projectConfig`, so eligibility never waits on GitHub.

No new flag; ships as default within the existing `seer-night-shift-ui` gate.

## Testing

137 tests in `static/app/views/seerWorkflows/overview/` pass (windowed
batching, graceful degradation, re-window on sort, `useIsInView`); lint and
typecheck clean.

## Depends on / follow-ups

- Backend endpoint #122735 (merged).
- Follow-up: remove the now-dead `scmInfo` expand path after rollout.
