### PR TITLE
fix(seer): name the install that owns the repo on handoff 403s

### DIFF
--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -35,6 +35,28 @@ from sentry.shared_integrations.exceptions import ApiError
 logger = logging.getLogger(__name__)
 
 
+def _github_installation_for_repo(
+    organization: Organization, repo: SeerRepoDefinition
+) -> tuple[str | None, str | None]:
+    if repo.integration_id is None:
+        return None, None
+
+    integration = integration_service.get_integration(
+        integration_id=int(repo.integration_id),
+        organization_id=organization.id,
+        provider="github",
+    )
+    if integration is None:
+        return None, None
+
+    installation_id = str(integration.external_id)
+    return installation_id, get_github_permissions_update_url(
+        installation_id,
+        integration.metadata.get("account_type"),
+        integration.name,
+    )
+
+
 def _resolve_client(
     organization: Organization,
     integration_id: int | None,
@@ -160,18 +182,9 @@ def launch_coding_agents(
                         failure_type = "github_app_permissions"
                         error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
                         try:
-                            github_integrations = integration_service.get_integrations(
-                                organization_id=organization.id,
-                                providers=["github"],
+                            github_installation_id, github_installation_url = (
+                                _github_installation_for_repo(organization, repo)
                             )
-                            if github_integrations:
-                                github_integration = github_integrations[0]
-                                github_installation_id = github_integration.external_id
-                                github_installation_url = get_github_permissions_update_url(
-                                    str(github_integration.external_id),
-                                    github_integration.metadata.get("account_type"),
-                                    github_integration.name,
-                                )
                         except Exception:
                             sentry_sdk.capture_exception(level="warning")
                 elif (

--- a/tests/sentry/seer/agent/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/agent/test_coding_agent_handoff.py
@@ -15,13 +15,14 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 
 
-def _repo(owner: str, name: str) -> SeerRepoDefinition:
+def _repo(owner: str, name: str, integration_id: str | None = None) -> SeerRepoDefinition:
     """Minimal SeerRepoDefinition for tests."""
     return SeerRepoDefinition(
         provider="github",
         owner=owner,
         name=name,
         external_id="123",
+        integration_id=integration_id,
     )
 
 
@@ -262,6 +263,146 @@ class TestLaunchCodingAgents(TestCase):
         failure = result["failures"][0]
         assert failure["failure_type"] == "github_copilot_not_licensed"
         assert "Copilot license" in failure["error_message"]
+
+    def _copilot_permissions_failure(self, mock_copilot_client_class, mock_identity_service, repo):
+        mock_identity_service.get_access_token_for_user.return_value = "test-token"
+        mock_client_instance = MagicMock()
+        mock_copilot_client_class.return_value = mock_client_instance
+        mock_client_instance.launch.side_effect = ApiError(
+            "Resource not accessible by integration", code=403
+        )
+
+        result = launch_coding_agents(
+            organization=self.organization,
+            integration_id=None,
+            run_id=self.run_id,
+            prompt="Fix the bug",
+            repos=[repo],
+            provider="github_copilot",
+            user_id=1,
+        )
+
+        assert len(result["failures"]) == 1
+        failure = result["failures"][0]
+        assert failure["failure_type"] == "github_app_permissions"
+        return failure
+
+    @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.agent.coding_agent_handoff.GithubCopilotAgentClient")
+    @patch("sentry.seer.agent.coding_agent_handoff.github_copilot_identity_service")
+    def test_permissions_403_names_the_installation_that_owns_the_repo(
+        self,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_store,
+    ):
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="1111",
+            name="other-gh-org",
+            metadata={"account_type": "Organization"},
+        )
+        owning = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="2222",
+            name="owning-gh-org",
+            metadata={"account_type": "Organization"},
+        )
+
+        failure = self._copilot_permissions_failure(
+            mock_copilot_client_class,
+            mock_identity_service,
+            _repo("owning-gh-org", "repo", integration_id=str(owning.id)),
+        )
+
+        assert failure["github_installation_id"] == "2222"
+        assert failure["github_installation_url"] == (
+            "https://github.com/organizations/owning-gh-org"
+            "/settings/installations/2222/permissions/update"
+        )
+
+    @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.agent.coding_agent_handoff.GithubCopilotAgentClient")
+    @patch("sentry.seer.agent.coding_agent_handoff.github_copilot_identity_service")
+    def test_permissions_403_uses_personal_namespace_for_user_installations(
+        self,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_store,
+    ):
+        owning = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="3333",
+            name="some-user",
+            metadata={"account_type": "User"},
+        )
+
+        failure = self._copilot_permissions_failure(
+            mock_copilot_client_class,
+            mock_identity_service,
+            _repo("some-user", "repo", integration_id=str(owning.id)),
+        )
+
+        assert failure["github_installation_id"] == "3333"
+        assert failure["github_installation_url"] == (
+            "https://github.com/settings/installations/3333/permissions/update"
+        )
+
+    @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.agent.coding_agent_handoff.GithubCopilotAgentClient")
+    @patch("sentry.seer.agent.coding_agent_handoff.github_copilot_identity_service")
+    def test_permissions_403_omits_installation_when_repo_has_no_integration(
+        self,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_store,
+    ):
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="4444",
+            name="unrelated-gh-org",
+            metadata={"account_type": "Organization"},
+        )
+
+        failure = self._copilot_permissions_failure(
+            mock_copilot_client_class,
+            mock_identity_service,
+            _repo("owner", "repo"),
+        )
+
+        assert "github_installation_id" not in failure
+        assert "github_installation_url" not in failure
+
+    @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.agent.coding_agent_handoff.GithubCopilotAgentClient")
+    @patch("sentry.seer.agent.coding_agent_handoff.github_copilot_identity_service")
+    def test_permissions_403_omits_installation_from_another_organization(
+        self,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_store,
+    ):
+        other_org = self.create_organization()
+        foreign = self.create_integration(
+            organization=other_org,
+            provider="github",
+            external_id="5555",
+            name="foreign-gh-org",
+            metadata={"account_type": "Organization"},
+        )
+
+        failure = self._copilot_permissions_failure(
+            mock_copilot_client_class,
+            mock_identity_service,
+            _repo("foreign-gh-org", "repo", integration_id=str(foreign.id)),
+        )
+
+        assert "github_installation_id" not in failure
+        assert "github_installation_url" not in failure
 
     @patch("sentry.seer.agent.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.agent.coding_agent_handoff.validate_and_get_integration")


### PR DESCRIPTION
when a coding agent handoff fails with a github app permissions error,
launch_coding_agents resolved the installation by taking the first
entry from the org's github integrations

an org can have the app installed on many github accounts — one
Integration row per account — so that first entry is frequently not
the install that failed

the repo is already in scope and carries integration_id, populated
from repo.integration_id, so we can resolve the install that actually
owns it and derive the installation id and permissions URL from that

Fixes CW-1934.
