### PR TITLE
ref(seer): Add strongly typed AgentRunOptions and leverage from features

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -571,8 +571,8 @@ class SeerAgentClient:
         flush=False: leave the row for the async outbox runner to drain and
         retry. Use for background callers (e.g. night shift).
 
-        force_ce if set forces context engine on/off, force_frontend_code_search
-        likewise for frontend source code search.
+        Explicit agent_run_options override any options derived from organization
+        configuration.
         """
         user_id = (
             self.user.id
@@ -592,13 +592,9 @@ class SeerAgentClient:
             if on_run_created is not None:
                 on_run_created(run)
 
-        # Merging the default options from config with any provided options
-        resolved_agent_run_options = AgentRunOptions(
-            **{
-                **self._build_agent_run_options(),
-                **(agent_run_options or {}),
-            }
-        )
+        resolved_agent_run_options = self._build_agent_run_options()
+        if agent_run_options is not None:
+            resolved_agent_run_options.update(agent_run_options)
 
         return enqueue_seer_run(
             organization=self.organization,
@@ -649,45 +645,42 @@ class SeerAgentClient:
         likewise for frontend source code search.
         """
 
-        is_context_engine_enabled = False
+        opts = AgentRunOptions()
+
         if _has_context_engine(self.organization, self.user):
             if random.random() < options.get("seer.explorer.context-engine-rollout"):
-                is_context_engine_enabled = True
+                opts["is_context_engine_enabled"] = True
 
         if features.has(
             "organizations:seer-explorer-context-engine-allow-fe-override",
             self.organization,
             actor=self.user,
         ):
-            is_context_engine_enabled = override_ce_enable
+            opts["is_context_engine_enabled"] = override_ce_enable
 
         if force_ce is not None:
-            is_context_engine_enabled = force_ce
+            opts["is_context_engine_enabled"] = force_ce
 
-        enable_frontend_code_search = False
         if features.has(
             "organizations:seer-agent-source-code-search",
             self.organization,
             actor=self.user,
         ):
-            enable_frontend_code_search = True
+            opts["enable_frontend_code_search"] = True
 
         if force_frontend_code_search is not None:
-            enable_frontend_code_search = force_frontend_code_search
+            opts["enable_frontend_code_search"] = force_frontend_code_search
 
-        enable_tool_summary = False
         if features.has(
             "organizations:seer-explorer-thinking-summary",
             self.organization,
             actor=self.user,
         ):
-            enable_tool_summary = True
+            opts["enable_tool_summary"] = True
 
-        embed_widgets = None
         if self._embed_widgets_enabled():
-            embed_widgets = get_embed_widgets(self.organization, self.user)
+            opts["embed_widgets"] = get_embed_widgets(self.organization, self.user)
 
-        enable_streaming = False
         if self.enable_streaming is True or (
             self.enable_streaming is None
             and features.has(
@@ -696,24 +689,16 @@ class SeerAgentClient:
                 actor=self.user,
             )
         ):
-            enable_streaming = True
+            opts["enable_streaming"] = True
 
-        is_agentic_triage_sort = False
         if features.has(
             "organizations:agentic-triage-sort",
             self.organization,
             actor=self.user,
         ):
-            is_agentic_triage_sort = True
+            opts["is_agentic_triage_sort"] = True
 
-        return AgentRunOptions(
-            is_context_engine_enabled=is_context_engine_enabled,
-            enable_frontend_code_search=enable_frontend_code_search,
-            enable_tool_summary=enable_tool_summary,
-            embed_widgets=embed_widgets,
-            enable_streaming=enable_streaming,
-            is_agentic_triage_sort=is_agentic_triage_sort,
-        )
+        return opts
 
     def continue_run(
         self,

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -29,6 +29,7 @@ from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.agent.client_utils import (
     AgentChatRequest,
     AgentReposRequest,
+    AgentRunOptions,
     AgentUpdateRequest,
     SeerFeatureRunRequest,
     collect_user_org_context,
@@ -552,9 +553,7 @@ class SeerAgentClient:
         extras: dict[str, Any] | None = None,
         on_run_created: Callable[[SeerRun], None] | None = None,
         referrer: str | None = None,
-        force_ce: bool | None = None,  # Deprecated, use agent_run_options instead
-        force_frontend_code_search: bool | None = None,  # Deprecated, use agent_run_options instead
-        agent_run_options: dict[str, Any] | None = None,
+        agent_run_options: AgentRunOptions | None = None,
     ) -> SeerRun:
         """Dispatch a run to a registered Seer feature by feature_id via the
         SEER_RUN_CREATE outbox. The feature builds its own agent run from
@@ -593,6 +592,14 @@ class SeerAgentClient:
             if on_run_created is not None:
                 on_run_created(run)
 
+        # Merging the default options from config with any provided options
+        resolved_agent_run_options = AgentRunOptions(
+            **{
+                **self._build_agent_run_options(),
+                **(agent_run_options or {}),
+            }
+        )
+
         return enqueue_seer_run(
             organization=self.organization,
             run_type=SeerRunType.FEATURE_RUN,
@@ -600,10 +607,7 @@ class SeerAgentClient:
             body=SeerFeatureRunRequest(
                 feature_id=feature_id,
                 payload=payload,
-                agent_run_options=self._build_agent_run_options(
-                    force_ce=force_ce,
-                    force_frontend_code_search=force_frontend_code_search,
-                ),
+                agent_run_options=resolved_agent_run_options,
             ),
             viewer_context=self.viewer_context,
             user_id=user_id,
@@ -638,48 +642,52 @@ class SeerAgentClient:
         override_ce_enable: bool = True,
         force_ce: bool | None = None,
         force_frontend_code_search: bool | None = None,
-    ) -> dict[str, Any]:
+    ) -> AgentRunOptions:
         """Resolve org-flag-driven agent run options, shared by start_run and start_feature_run.
 
         force_ce if set forces context engine on/off, force_frontend_code_search
         likewise for frontend source code search.
         """
-        opts: dict[str, Any] = {}
 
+        is_context_engine_enabled = False
         if _has_context_engine(self.organization, self.user):
             if random.random() < options.get("seer.explorer.context-engine-rollout"):
-                opts["is_context_engine_enabled"] = True
+                is_context_engine_enabled = True
 
         if features.has(
             "organizations:seer-explorer-context-engine-allow-fe-override",
             self.organization,
             actor=self.user,
         ):
-            opts["is_context_engine_enabled"] = override_ce_enable
+            is_context_engine_enabled = override_ce_enable
 
         if force_ce is not None:
-            opts["is_context_engine_enabled"] = force_ce
+            is_context_engine_enabled = force_ce
 
+        enable_frontend_code_search = False
         if features.has(
             "organizations:seer-agent-source-code-search",
             self.organization,
             actor=self.user,
         ):
-            opts["enable_frontend_code_search"] = True
+            enable_frontend_code_search = True
 
         if force_frontend_code_search is not None:
-            opts["enable_frontend_code_search"] = force_frontend_code_search
+            enable_frontend_code_search = force_frontend_code_search
 
+        enable_tool_summary = False
         if features.has(
             "organizations:seer-explorer-thinking-summary",
             self.organization,
             actor=self.user,
         ):
-            opts["enable_tool_summary"] = True
+            enable_tool_summary = True
 
+        embed_widgets = None
         if self._embed_widgets_enabled():
-            opts["embed_widgets"] = get_embed_widgets(self.organization, self.user)
+            embed_widgets = get_embed_widgets(self.organization, self.user)
 
+        enable_streaming = False
         if self.enable_streaming is True or (
             self.enable_streaming is None
             and features.has(
@@ -688,16 +696,24 @@ class SeerAgentClient:
                 actor=self.user,
             )
         ):
-            opts["enable_streaming"] = True
+            enable_streaming = True
 
+        is_agentic_triage_sort = False
         if features.has(
             "organizations:agentic-triage-sort",
             self.organization,
             actor=self.user,
         ):
-            opts["is_agentic_triage_sort"] = True
+            is_agentic_triage_sort = True
 
-        return opts
+        return AgentRunOptions(
+            is_context_engine_enabled=is_context_engine_enabled,
+            enable_frontend_code_search=enable_frontend_code_search,
+            enable_tool_summary=enable_tool_summary,
+            embed_widgets=embed_widgets,
+            enable_streaming=enable_streaming,
+            is_agentic_triage_sort=is_agentic_triage_sort,
+        )
 
     def continue_run(
         self,

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -552,8 +552,9 @@ class SeerAgentClient:
         extras: dict[str, Any] | None = None,
         on_run_created: Callable[[SeerRun], None] | None = None,
         referrer: str | None = None,
-        force_ce: bool | None = None,
-        force_frontend_code_search: bool | None = None,
+        force_ce: bool | None = None,  # Deprecated, use agent_run_options instead
+        force_frontend_code_search: bool | None = None,  # Deprecated, use agent_run_options instead
+        agent_run_options: dict[str, Any] | None = None,
     ) -> SeerRun:
         """Dispatch a run to a registered Seer feature by feature_id via the
         SEER_RUN_CREATE outbox. The feature builds its own agent run from

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -108,12 +108,20 @@ class AgentPrStateRequest(TypedDict):
     pr_id: int
 
 
-class SeerFeatureRunRequest(TypedDict):
-    """The feature-run body as enqueued onto the SEER_RUN_CREATE outbox."""
+class AgentRunOptions(TypedDict):
+    enable_frontend_code_search: bool | None
+    is_context_engine_enabled: bool = False
+    enable_coding: bool = False
+    enable_tool_summary: bool = False
+    embed_widgets: list[dict[str, Any]] | None = None
+    enable_streaming: bool = False
+    is_agentic_triage_sort: bool = False
 
+
+class SeerFeatureRunRequest(TypedDict):
     feature_id: str
     payload: dict[str, Any]
-    agent_run_options: NotRequired[dict[str, Any]]
+    agent_run_options: NotRequired[AgentRunOptions]
 
 
 class SeerFeatureRunWireRequest(SeerFeatureRunRequest):

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -109,13 +109,13 @@ class AgentPrStateRequest(TypedDict):
 
 
 class AgentRunOptions(TypedDict):
-    enable_frontend_code_search: bool | None
-    is_context_engine_enabled: bool = False
-    enable_coding: bool = False
-    enable_tool_summary: bool = False
-    embed_widgets: list[dict[str, Any]] | None = None
-    enable_streaming: bool = False
-    is_agentic_triage_sort: bool = False
+    enable_frontend_code_search: NotRequired[bool | None]
+    is_context_engine_enabled: NotRequired[bool]
+    enable_coding: NotRequired[bool]
+    enable_tool_summary: NotRequired[bool]
+    embed_widgets: NotRequired[list[dict[str, Any]] | None]
+    enable_streaming: NotRequired[bool]
+    is_agentic_triage_sort: NotRequired[bool]
 
 
 class SeerFeatureRunRequest(TypedDict):

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -7,6 +7,7 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.client_utils import AgentRunOptions
 from sentry.seer.agent.on_completion_hook import extract_hook_definition
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -74,8 +75,10 @@ def trigger_autofix_rca_feature(
         flush=flush,
         extras=extras,
         referrer=referrer.value,
-        force_ce=False,
-        force_frontend_code_search=False,
+        agent_run_options=AgentRunOptions(
+            is_context_engine_enabled=False,
+            enable_frontend_code_search=False,
+        ),
     )
 
     quotas.backend.record_seer_run(


### PR DESCRIPTION
Adds a AgentRunOptions type and wires up to start_feature_run. Leverages from RCA feature triggering.

This gives us more strong typing rather than a dict. Also ensures we leverage the "default" options from config using _build_agent_run_options, merged with any passed agent_run_options passed to the run function.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>