### PR TITLE
ref(autofix): Default RCAs to run through seer

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -540,11 +540,7 @@ def trigger_autofix_agent(
         and features.has("organizations:autofix-should-run-repo-checks", group.organization)
     )
 
-    # TODO: we want to support bash tools under the autofix-rca-in-seer feature
-    use_seer_rca_feature = not enable_bash_tools and features.has(
-        "organizations:autofix-rca-in-seer", group.organization, actor=user
-    )
-    if step == AutofixStep.ROOT_CAUSE and run_id is None and use_seer_rca_feature:
+    if step == AutofixStep.ROOT_CAUSE and run_id is None:
         # Local import avoids a circular import (dispatch imports this module).
         from sentry.seer.autofix_rca.dispatch import trigger_autofix_rca_feature
 

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -100,8 +100,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         # True only when a run exists (so they see results), False otherwise (shows paywall).
         is_free_cohort = is_free_cohort_org(org)
         if is_free_cohort:
-            # Night shift can go through either the regular autofix path (source="autofix") or
-            # the RCA feature path (source="autofix_rca") depending on the organizations:autofix-rca-in-seer.
+            # Existing runs can use either the legacy autofix source or the RCA feature source.
             has_autofix_quota = (
                 runs_for_group(group.id, "autofix").exists()
                 or runs_for_group(group.id, "autofix_rca").exists()

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -449,10 +449,12 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.seer.autofix.autofix_agent.SeerAutofixOperator.has_access", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.process_autofix_updates.apply_async")
+    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_autofix_agent_sends_started_webhook_for_all_steps(
         self,
         mock_client_class,
+        mock_feature,
         mock_process_autofix_updates,
         mock_broadcast,
         mock_has_access,
@@ -463,6 +465,9 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=12345)
+        mock_feature.return_value = self.create_seer_run(
+            organization=self.group.organization, type="feature_run", seer_run_state_id=12345
+        )
 
         step_to_action = {
             AutofixStep.ROOT_CAUSE: (
@@ -549,7 +554,7 @@ class TestTriggerAutofixAgent(TestCase):
 
         trigger_autofix_agent(
             group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
+            step=AutofixStep.SOLUTION,
             referrer=AutofixReferrer.UNKNOWN,
             run_id=None,
         )
@@ -564,29 +569,27 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_root_cause_routes_to_rca_feature_when_flagged(
+    def test_root_cause_routes_to_rca_feature(
         self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        """With the flag on, a new root-cause run dispatches the autofix_rca feature
-        instead of a legacy explorer run, still emits the started webhook, and
-        returns the feature run."""
+        """A new root-cause run dispatches the autofix_rca feature, emits the
+        started webhook, and returns the feature run."""
         feature_run = self.create_seer_run(
             organization=self.group.organization, type="feature_run", seer_run_state_id=777
         )
         mock_feature.return_value = feature_run
 
-        with self.feature("organizations:autofix-rca-in-seer"):
-            result = trigger_autofix_agent(
-                group=self.group,
-                step=AutofixStep.ROOT_CAUSE,
-                referrer=AutofixReferrer.UNKNOWN,
-                run_id=None,
-            )
+        result = trigger_autofix_agent(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
 
         assert result == feature_run
         mock_feature.assert_called_once()
         assert mock_feature.call_args.args[0] == self.group
-        # legacy explorer run is not started for a flagged root-cause kickoff
+        # The legacy explorer run is not started for a root-cause kickoff.
         mock_client_class.return_value.start_run.assert_not_called()
         # the started webhook still fires, pointing at the feature run
         mock_broadcast.assert_called_once()
@@ -611,14 +614,13 @@ class TestTriggerAutofixAgent(TestCase):
             organization=self.group.organization, type="feature_run", seer_run_state_id=777
         )
 
-        with self.feature("organizations:autofix-rca-in-seer"):
-            trigger_autofix_agent(
-                group=self.group,
-                step=AutofixStep.ROOT_CAUSE,
-                referrer=AutofixReferrer.UNKNOWN,
-                run_id=None,
-                stopping_point=AutofixStoppingPoint.CODE_CHANGES,
-            )
+        trigger_autofix_agent(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+            stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+        )
 
         assert mock_feature.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
 
@@ -636,56 +638,30 @@ class TestTriggerAutofixAgent(TestCase):
             organization=self.group.organization, seer_run_state_id=5
         )
 
-        with self.feature("organizations:autofix-rca-in-seer"):
-            trigger_autofix_agent(
-                group=self.group,
-                step=AutofixStep.SOLUTION,
-                referrer=AutofixReferrer.UNKNOWN,
-                run_id=None,
-            )
-
-        mock_feature.assert_not_called()
-        mock_client.start_run.assert_called_once()
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_root_cause_uses_legacy_flow_without_flag(
-        self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
-    ):
-        """Without the flag, root-cause kickoffs use the legacy explorer run."""
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        seer_run = self.create_seer_run(organization=self.group.organization, seer_run_state_id=9)
-        mock_client.start_run.return_value = seer_run
-
-        result = trigger_autofix_agent(
+        trigger_autofix_agent(
             group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
+            step=AutofixStep.SOLUTION,
             referrer=AutofixReferrer.UNKNOWN,
             run_id=None,
         )
 
-        assert result == seer_run
         mock_feature.assert_not_called()
         mock_client.start_run.assert_called_once()
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_flagged_root_cause_still_enforces_quota(
+    def test_root_cause_still_enforces_quota(
         self, mock_client_class, mock_feature, mock_check_quota
     ):
         """The upstream quota check runs before routing to the feature."""
-        with self.feature("organizations:autofix-rca-in-seer"):
-            with pytest.raises(NoSeerQuotaException):
-                trigger_autofix_agent(
-                    group=self.group,
-                    step=AutofixStep.ROOT_CAUSE,
-                    referrer=AutofixReferrer.UNKNOWN,
-                    run_id=None,
-                )
+        with pytest.raises(NoSeerQuotaException):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
 
         mock_feature.assert_not_called()
 
@@ -703,7 +679,7 @@ class TestTriggerAutofixAgent(TestCase):
 
         trigger_autofix_agent(
             group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
+            step=AutofixStep.SOLUTION,
             referrer=AutofixReferrer.UNKNOWN,
             run_id=None,
         )
@@ -849,7 +825,7 @@ class TestTriggerAutofixAgent(TestCase):
 
         trigger_autofix_agent(
             group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
+            step=AutofixStep.SOLUTION,
             referrer=AutofixReferrer.UNKNOWN,
             run_id=None,
         )
@@ -957,7 +933,7 @@ class TestTriggerAutofixAgent(TestCase):
 
         trigger_autofix_agent(
             group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
+            step=AutofixStep.SOLUTION,
             referrer=AutofixReferrer.UNKNOWN,
             run_id=None,
         )
@@ -1063,7 +1039,8 @@ class TestTriggerAutofixAgent(TestCase):
     ):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
+        mock_client.get_run.return_value = self._make_run_state()
+        mock_client.continue_run.return_value = MagicMock(seer_run_state_id=123)
         self._make_repo_and_projectrepo()
 
         mock_scm = _make_scm_mock(
@@ -1077,10 +1054,10 @@ class TestTriggerAutofixAgent(TestCase):
                 group=self.group,
                 step=AutofixStep.ROOT_CAUSE,
                 referrer=AutofixReferrer.UNKNOWN,
-                run_id=None,
+                run_id=67890,
             )
 
-        prompt_metadata = mock_client.start_run.call_args.kwargs["prompt_metadata"]
+        prompt_metadata = mock_client.continue_run.call_args.kwargs["prompt_metadata"]
         assert json.loads(prompt_metadata["base_shas"]) == {
             "owner/repo": {"base_sha": "abc123", "base_branch": "main"}
         }


### PR DESCRIPTION
Removes the gating that moved RCA into Seer and makes that the default path for RCA now. Deleting actual RCA code in stacked PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>