### PR TITLE
fix(dashboards): Enforce min height when duplicating dashboard

### DIFF
--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -16,6 +16,7 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {
   assignDefaultLayout,
+  assignTempId,
   getInitialColumnDepths,
 } from 'sentry/views/dashboards/layoutUtils';
 import {enforceLayoutMinHeight} from 'sentry/views/dashboards/utils/enforceLayoutMinHeight';
@@ -75,7 +76,10 @@ function ImportDashboardFromFileModal({
       const newDashboard = await createDashboard(api, organization.slug, {
         ...dashboard,
         widgets: enforceLayoutMinHeight(
-          assignDefaultLayout(dashboard.widgets, getInitialColumnDepths())
+          assignDefaultLayout(
+            dashboard.widgets.map(assignTempId),
+            getInitialColumnDepths()
+          )
         ),
       });
 

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -18,6 +18,7 @@ import {
   assignDefaultLayout,
   getInitialColumnDepths,
 } from 'sentry/views/dashboards/layoutUtils';
+import {enforceLayoutMinHeight} from 'sentry/views/dashboards/utils/enforceLayoutMinHeight';
 import {Wrapper} from 'sentry/views/discover/table/quickContext/styles';
 
 export interface ImportDashboardFromFileModalProps {
@@ -73,7 +74,9 @@ function ImportDashboardFromFileModal({
     try {
       const newDashboard = await createDashboard(api, organization.slug, {
         ...dashboard,
-        widgets: assignDefaultLayout(dashboard.widgets, getInitialColumnDepths()),
+        widgets: enforceLayoutMinHeight(
+          assignDefaultLayout(dashboard.widgets, getInitialColumnDepths())
+        ),
       });
 
       addSuccessMessage(`${dashboard.title} dashboard template successfully added`);

--- a/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDuplicateDashboard.tsx
@@ -10,6 +10,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {mergeGlobalFilters} from 'sentry/views/dashboards/globalFilter/utils';
 import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 import {cloneDashboard} from 'sentry/views/dashboards/utils';
+import {enforceLayoutMinHeight} from 'sentry/views/dashboards/utils/enforceLayoutMinHeight';
 import {
   PREBUILT_DASHBOARDS,
   type PrebuiltDashboardId,
@@ -52,6 +53,7 @@ export function useDuplicateDashboard({onSuccess}: UseDuplicateDashboardProps) {
           }
         } else {
           dashboardDetail = await fetchDashboard(api, organization.slug, dashboard.id);
+          dashboardDetail.widgets = enforceLayoutMinHeight(dashboardDetail.widgets);
         }
 
         const newDashboard = cloneDashboard(dashboardDetail);

--- a/static/app/views/dashboards/utils/enforceLayoutMinHeight.spec.tsx
+++ b/static/app/views/dashboards/utils/enforceLayoutMinHeight.spec.tsx
@@ -1,0 +1,218 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {enforceLayoutMinHeight} from 'sentry/views/dashboards/utils/enforceLayoutMinHeight';
+
+describe('enforceLayoutMinHeight', () => {
+  it('expands undersized widgets and compacts widgets affected directly and indirectly', () => {
+    // Initial 6-column grid (E grows from one row to two):
+    //      0 1 2 3 4 5
+    // y=0: E E A A . .
+    // y=1: S S . . . .
+    // y=2: . P P . . .
+    // y=3: I I . . . .
+    // E=expanded, S=same-columns, A=separate-columns, P=partial-overlap, I=indirectly-below
+    const widgets = [
+      WidgetFixture({
+        id: 'expanded',
+        layout: {x: 0, y: 0, w: 2, h: 1, minH: 1},
+      }),
+      // Directly below the expanded widget in the same columns.
+      WidgetFixture({
+        id: 'same-columns',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 0, y: 1, w: 2, h: 1, minH: 1},
+      }),
+      // In separate columns and does not need adjustment, so it should not be impacted.
+      WidgetFixture({
+        id: 'separate-columns',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 2, y: 0, w: 2, h: 1, minH: 1},
+      }),
+      // Overlaps only half of the expanded widget's columns.
+      WidgetFixture({
+        id: 'partial-overlap',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 1, y: 2, w: 2, h: 1, minH: 1},
+      }),
+      // Is displaced indirectly by the widget directly below the expanded one.
+      WidgetFixture({
+        id: 'indirectly-below',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 0, y: 3, w: 2, h: 1, minH: 1},
+      }),
+    ];
+
+    const result = enforceLayoutMinHeight(widgets);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'expanded',
+        layout: expect.objectContaining({x: 0, y: 0, w: 2, h: 2, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'same-columns',
+        layout: expect.objectContaining({x: 0, y: 2, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'separate-columns',
+        layout: expect.objectContaining({x: 2, y: 0, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'partial-overlap',
+        layout: expect.objectContaining({x: 1, y: 3, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'indirectly-below',
+        layout: expect.objectContaining({x: 0, y: 4, w: 2, h: 1, minH: 1}),
+      }),
+    ]);
+  });
+
+  it('expands and compacts multiple undersized widgets', () => {
+    // Initial 6-column grid (E grows from one row to two):
+    //      0 1 2 3 4 5
+    // y=0: E E A A . .
+    // y=1: S S B B . .
+    // y=2: . P P . . .
+    // y=3: I I . . . .
+    // E=expanded-left, B=expanded-right, S=same-columns, A=separate-columns, P=partial-overlap, I=indirectly-below
+    const widgets = [
+      WidgetFixture({
+        id: 'expanded-left',
+        layout: {x: 0, y: 0, w: 2, h: 1, minH: 1},
+      }),
+      WidgetFixture({
+        id: 'expanded-right',
+        layout: {x: 2, y: 1, w: 2, h: 1, minH: 1},
+      }),
+      // Directly below the expanded-left widget in the same columns.
+      WidgetFixture({
+        id: 'same-columns',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 0, y: 1, w: 2, h: 1, minH: 1},
+      }),
+      // In separate columns and does not need adjustment, so it should not be impacted.
+      WidgetFixture({
+        id: 'separate-columns',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 2, y: 0, w: 2, h: 1, minH: 1},
+      }),
+      // Overlaps only half of the expanded widget's columns, shifted down one after adjustment
+      WidgetFixture({
+        id: 'partial-overlap',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 1, y: 2, w: 2, h: 1, minH: 1},
+      }),
+      // Is displaced indirectly by the partial overlap widget's shift
+      WidgetFixture({
+        id: 'indirectly-below',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 0, y: 3, w: 2, h: 1, minH: 1},
+      }),
+    ];
+
+    const result = enforceLayoutMinHeight(widgets);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'expanded-left',
+        layout: expect.objectContaining({x: 0, y: 0, w: 2, h: 2, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'expanded-right',
+        layout: expect.objectContaining({x: 2, y: 1, w: 2, h: 2, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'same-columns',
+        layout: expect.objectContaining({x: 0, y: 2, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'separate-columns',
+        layout: expect.objectContaining({x: 2, y: 0, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'partial-overlap',
+        layout: expect.objectContaining({x: 1, y: 3, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'indirectly-below',
+        layout: expect.objectContaining({x: 0, y: 4, w: 2, h: 1, minH: 1}),
+      }),
+    ]);
+  });
+
+  it('expands and compacts multiple stacked undersized widgets', () => {
+    // Initial 6-column grid (E grows from one row to two):
+    //      0 1 2 3 4 5
+    // y=0: E E A A . .
+    // y=1: S S . . . .
+    // y=2: . B B . . .
+    // y=3: . P P . . .
+    // y=4: I I . . . .
+    // E=expanded-left, B=expanded-right, S=same-columns, A=separate-columns, P=partial-overlap, I=indirectly-below
+    const widgets = [
+      WidgetFixture({
+        id: 'expanded-left',
+        layout: {x: 0, y: 0, w: 2, h: 1, minH: 1},
+      }),
+      WidgetFixture({
+        id: 'expanded-right',
+        layout: {x: 1, y: 2, w: 2, h: 1, minH: 1},
+      }),
+      // Directly below the expanded-left widget in the same columns, shifts one down after expanded-left adjustment
+      WidgetFixture({
+        id: 'same-columns',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 0, y: 1, w: 2, h: 1, minH: 1},
+      }),
+      // In separate columns and does not need adjustment, so it should not be impacted.
+      WidgetFixture({
+        id: 'separate-columns',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 2, y: 0, w: 2, h: 1, minH: 1},
+      }),
+      // Overlaps half of expanded-left's columns and all of expanded-right's columns. Shifts down 2 after adjustment, one for each adjusted widget
+      WidgetFixture({
+        id: 'partial-overlap',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 1, y: 3, w: 2, h: 1, minH: 1},
+      }),
+      // Is displaced indirectly by the partial overlap widget's shift, will shift down 2
+      WidgetFixture({
+        id: 'indirectly-below',
+        displayType: DisplayType.BIG_NUMBER,
+        layout: {x: 0, y: 4, w: 2, h: 1, minH: 1},
+      }),
+    ];
+
+    const result = enforceLayoutMinHeight(widgets);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'expanded-left',
+        layout: expect.objectContaining({x: 0, y: 0, w: 2, h: 2, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'expanded-right',
+        layout: expect.objectContaining({x: 1, y: 3, w: 2, h: 2, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'same-columns',
+        layout: expect.objectContaining({x: 0, y: 2, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'separate-columns',
+        layout: expect.objectContaining({x: 2, y: 0, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'partial-overlap',
+        layout: expect.objectContaining({x: 1, y: 5, w: 2, h: 1, minH: 1}),
+      }),
+      expect.objectContaining({
+        id: 'indirectly-below',
+        layout: expect.objectContaining({x: 0, y: 6, w: 2, h: 1, minH: 1}),
+      }),
+    ]);
+  });
+});

--- a/static/app/views/dashboards/utils/enforceLayoutMinHeight.tsx
+++ b/static/app/views/dashboards/utils/enforceLayoutMinHeight.tsx
@@ -1,3 +1,4 @@
+import {defined} from 'sentry/utils/defined';
 import {
   generateWidgetsAfterCompaction,
   getDefaultWidgetHeight,
@@ -10,7 +11,7 @@ import type {Widget} from 'sentry/views/dashboards/types';
 export function enforceLayoutMinHeight(widgets: Widget[]): Widget[] {
   for (const widget of widgets) {
     const minWidgetHeight = getDefaultWidgetHeight(widget.displayType);
-    if (widget.layout?.h && widget.layout.h < minWidgetHeight) {
+    if (defined(widget.layout?.h) && widget.layout.h < minWidgetHeight) {
       widget.layout.h = minWidgetHeight;
     }
   }

--- a/static/app/views/dashboards/utils/enforceLayoutMinHeight.tsx
+++ b/static/app/views/dashboards/utils/enforceLayoutMinHeight.tsx
@@ -1,0 +1,18 @@
+import {
+  generateWidgetsAfterCompaction,
+  getDefaultWidgetHeight,
+} from 'sentry/views/dashboards/layoutUtils';
+import type {Widget} from 'sentry/views/dashboards/types';
+
+/**
+ * Takes a series of widgets and ensures that the height assigned to each widget is the proper minimum height.
+ */
+export function enforceLayoutMinHeight(widgets: Widget[]): Widget[] {
+  for (const widget of widgets) {
+    const minWidgetHeight = getDefaultWidgetHeight(widget.displayType);
+    if (widget.layout?.h && widget.layout.h < minWidgetHeight) {
+      widget.layout.h = minWidgetHeight;
+    }
+  }
+  return generateWidgetsAfterCompaction(widgets);
+}


### PR DESCRIPTION
Enforces the min height when duplicating dashboards. This iterates through the widgets, sets the height to the min height if `h<minH` for the display type, then runs a compaction util to assign the layout information to each of the widgets.

This ensures that if we block invalid height layouts on POST, that duplication can still be made for dashboards with widgets that are not the proper height. This only applies to custom dashboards, not prebuilt ones since those should be valid layouts.

Should be merged in before #122601