### PR TITLE
ref(seer): Make embed stories composable

### DIFF
--- a/static/app/components/seer/markdown/__stories__/components.tsx
+++ b/static/app/components/seer/markdown/__stories__/components.tsx
@@ -1,16 +1,9 @@
 import {useRef, useState} from 'react';
-import {useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
-import {CodeBlock} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
-import {SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
-import {Demo} from 'sentry/stories';
-import {replayListApiOptions} from 'sentry/utils/replays/replayListApiOptions';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 const BASIC_MD = `## Root Cause
 
@@ -99,97 +92,6 @@ export function StreamingEmbedExamples() {
         </Button>
       </Flex>
       <SeerMarkdown raw={text} variant="streaming" />
-    </Stack>
-  );
-}
-
-function formatTag(name: string, data: unknown): string {
-  return `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
-}
-
-function useReplayExampleData(): Record<string, unknown> | undefined {
-  const organization = useOrganization();
-  const {data} = useQuery(
-    replayListApiOptions({
-      options: {query: {sort: '-started_at'}},
-      organization,
-      queryReferrer: 'replayList',
-    })
-  );
-
-  const replay = data?.data?.[0];
-  if (!replay?.started_at) {
-    return undefined;
-  }
-
-  return {
-    id: replay.id,
-    eventTimestamp: String(replay.started_at),
-  };
-}
-
-function LevelDemo({
-  name,
-  level,
-  exampleData,
-  isLargeBlock,
-}: {
-  exampleData: Record<string, unknown>;
-  level: string;
-  name: string;
-  isLargeBlock?: boolean;
-}) {
-  const tag = formatTag(name, exampleData);
-  const md = level === 'inline' ? `Lorem ipsum ${tag} dolor sit amet.` : tag;
-
-  return (
-    <Stack gap="sm">
-      <Text size="sm" bold>
-        {level}
-      </Text>
-      <Demo maxHeight={isLargeBlock ? '900px' : undefined}>
-        <SeerMarkdown raw={md} />
-      </Demo>
-      <CodeBlock language="markdown" dark>
-        {md}
-      </CodeBlock>
-    </Stack>
-  );
-}
-
-export function EmbedExamples({name}: {name: string}) {
-  const schema = SEER_EMBED_SCHEMAS[name as keyof typeof SEER_EMBED_SCHEMAS];
-  const replayData = useReplayExampleData();
-
-  if (!schema) {
-    return null;
-  }
-
-  const exampleData =
-    name === 'replay' && replayData ? replayData : (schema.examples?.[0]?.data ?? {});
-
-  const isLargeBlock = name === 'replay';
-
-  return (
-    <Stack gap="md">
-      <Text size="sm" variant="muted">
-        Level: {schema.level.join(', ')}
-        {'featureFlag' in schema ? ` · Flag: ${schema.featureFlag}` : null}
-      </Text>
-      <Text size="sm" variant="muted">
-        {schema.description}
-      </Text>
-      <Stack gap="lg">
-        {schema.level.map(level => (
-          <LevelDemo
-            key={level}
-            name={name}
-            level={level}
-            exampleData={exampleData}
-            isLargeBlock={isLargeBlock && level === 'block'}
-          />
-        ))}
-      </Stack>
     </Stack>
   );
 }

--- a/static/app/components/seer/markdown/__stories__/embedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/embedStory.tsx
@@ -1,0 +1,117 @@
+import type {ComponentProps, ReactNode} from 'react';
+
+import {CodeBlock} from '@sentry/scraps/code';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import type {SeerEmbedExample} from 'sentry/components/seer/markdown/embeds/schemas';
+import {SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
+import {Demo} from 'sentry/stories';
+
+type EmbedName = keyof typeof SEER_EMBED_SCHEMAS;
+type EmbedLevel = (typeof SEER_EMBED_SCHEMAS)[EmbedName]['level'][number];
+
+function formatTag(name: EmbedName, data: Record<string, unknown>): string {
+  return `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
+}
+
+function formatEmbedLabel(name: EmbedName): string {
+  const label = name.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function getStoryExamples(
+  name: EmbedName,
+  examples: readonly SeerEmbedExample[]
+): SeerEmbedExample[] {
+  const seenLevelExamples = new Set<string>();
+
+  return examples.flatMap(example => {
+    if (!example.level) {
+      return example;
+    }
+
+    const key = JSON.stringify(example.data);
+    if (seenLevelExamples.has(key)) {
+      return [];
+    }
+
+    seenLevelExamples.add(key);
+    return {...example, label: formatEmbedLabel(name)};
+  });
+}
+
+function formatVariant(
+  name: EmbedName,
+  levels: readonly EmbedLevel[],
+  data: Record<string, unknown>
+): string {
+  const tag = formatTag(name, data);
+
+  return levels
+    .map(level =>
+      level === 'inline'
+        ? `Inline: Lorem ipsum ${tag} dolor sit amet.`
+        : `Block:\n\n${tag}`
+    )
+    .join('\n\n');
+}
+
+interface EmbedVariantProps {
+  data: Record<string, unknown>;
+  label: string;
+  name: EmbedName;
+  demoProps?: Omit<ComponentProps<typeof Demo>, 'children'>;
+}
+
+export function EmbedVariant({data, demoProps, label, name}: EmbedVariantProps) {
+  const markdown = formatVariant(name, SEER_EMBED_SCHEMAS[name].level, data);
+
+  return (
+    <Stack gap="sm">
+      <Text size="sm" bold>
+        {label}
+      </Text>
+      <Demo {...demoProps}>
+        <SeerMarkdown raw={markdown} />
+      </Demo>
+      <CodeBlock language="markdown" dark>
+        {markdown}
+      </CodeBlock>
+    </Stack>
+  );
+}
+
+interface EmbedStoryProps {
+  name: EmbedName;
+  children?: ReactNode;
+}
+
+export function EmbedStory({children, name}: EmbedStoryProps) {
+  const schema = SEER_EMBED_SCHEMAS[name];
+  const examples = getStoryExamples(name, schema.examples);
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" variant="muted">
+        Level: {schema.level.join(', ')}
+        {'featureFlag' in schema ? ` · Flag: ${schema.featureFlag}` : null}
+      </Text>
+      <Text size="sm" variant="muted">
+        {schema.description}
+      </Text>
+      <Stack gap="lg">
+        {children ??
+          examples.map(example => (
+            <EmbedVariant
+              key={example.label}
+              name={name}
+              label={example.label}
+              data={example.data}
+            />
+          ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/static/app/components/seer/markdown/__stories__/replayEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/replayEmbedStory.tsx
@@ -1,0 +1,44 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {replayListApiOptions} from 'sentry/utils/replays/replayListApiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {EmbedStory, EmbedVariant} from './embedStory';
+
+export function ReplayEmbedStory() {
+  const organization = useOrganization();
+  const {data, isError, isPending} = useQuery(
+    replayListApiOptions({
+      options: {query: {sort: '-started_at'}},
+      organization,
+      queryReferrer: 'replayList',
+    })
+  );
+
+  const replay = data?.data?.[0];
+
+  return (
+    <EmbedStory name="replay">
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <Text variant="muted">Unable to load a replay example.</Text>
+      ) : replay?.started_at ? (
+        <EmbedVariant
+          name="replay"
+          label="Replay"
+          data={{
+            id: replay.id,
+            eventTimestamp: String(replay.started_at),
+          }}
+          demoProps={{maxHeight: '900px'}}
+        />
+      ) : (
+        <Text variant="muted">No replay is available for this organization.</Text>
+      )}
+    </EmbedStory>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -4,18 +4,20 @@ import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 
-function renderEmbed(
-  name: string,
-  data: Record<string, unknown>,
-  level: 'block' | 'inline' = 'block'
-) {
+interface RenderEmbedOptions {
+  data: Record<string, unknown>;
+  name: string;
+  level?: 'block' | 'inline';
+}
+
+function renderEmbed({name, data, level = 'block'}: RenderEmbedOptions) {
   const tag = `{% ${name} %}${JSON.stringify(data)}{% /${name} %}`;
   const raw = level === 'inline' ? `text ${tag} text` : tag;
   return render(<SeerMarkdown raw={raw} />);
 }
 
 function hrefFor(name: string, label: string, data: Record<string, unknown>) {
-  renderEmbed(name, data, 'inline');
+  renderEmbed({name, data, level: 'inline'});
   return screen.getByRole('link', {name: label}).getAttribute('href') ?? '';
 }
 
@@ -31,9 +33,12 @@ describe('Seer resource embeds', () => {
   });
 
   it('links a dashboard title to the dashboard in the current organization', async () => {
-    const {router} = renderEmbed('dashboard', {
-      id: '123',
-      title: 'Application health',
+    const {router} = renderEmbed({
+      name: 'dashboard',
+      data: {
+        id: '123',
+        title: 'Application health',
+      },
     });
 
     await userEvent.click(screen.getByRole('link', {name: 'Application health'}));
@@ -48,7 +53,7 @@ describe('Seer resource embeds', () => {
       sentryUrl: 'https://sentry.io',
     });
 
-    renderEmbed('dashboard', {id: '456'});
+    renderEmbed({name: 'dashboard', data: {id: '456'}});
 
     expect(screen.getByRole('link', {name: 'Dashboard 456'})).toHaveAttribute(
       'href',
@@ -57,14 +62,14 @@ describe('Seer resource embeds', () => {
   });
 
   it('links a replay to the relevant event timestamp (inline)', async () => {
-    const {router} = renderEmbed(
-      'replay',
-      {
+    const {router} = renderEmbed({
+      name: 'replay',
+      data: {
         id: '4c1f2e3d1234567890',
         eventTimestamp: '2026-08-25T16:37:12Z',
       },
-      'inline'
-    );
+      level: 'inline',
+    });
 
     await userEvent.click(screen.getByRole('link', {name: 'Replay 4c1f2e3d'}));
 
@@ -75,7 +80,11 @@ describe('Seer resource embeds', () => {
   });
 
   it('links a replay without a timestamp to the beginning (inline)', () => {
-    renderEmbed('replay', {id: 'abcdef1234567890'}, 'inline');
+    renderEmbed({
+      name: 'replay',
+      data: {id: 'abcdef1234567890'},
+      level: 'inline',
+    });
 
     expect(screen.getByRole('link', {name: 'Replay abcdef12'})).toHaveAttribute(
       'href',
@@ -86,14 +95,14 @@ describe('Seer resource embeds', () => {
   it('renders a replay player preview at block level with a timestamp', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    renderEmbed(
-      'replay',
-      {
+    renderEmbed({
+      name: 'replay',
+      data: {
         id: '4c1f2e3d1234567890',
         eventTimestamp: '2026-08-25T16:37:12Z',
       },
-      'block'
-    );
+      level: 'block',
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('replay-loading-placeholder')).toBeInTheDocument();
@@ -101,7 +110,11 @@ describe('Seer resource embeds', () => {
   });
 
   it('falls back to a link at block level without a timestamp', () => {
-    renderEmbed('replay', {id: 'abcdef1234567890'}, 'block');
+    renderEmbed({
+      name: 'replay',
+      data: {id: 'abcdef1234567890'},
+      level: 'block',
+    });
 
     expect(screen.getByRole('link', {name: 'Replay abcdef12'})).toHaveAttribute(
       'href',
@@ -127,7 +140,7 @@ describe('Seer resource embeds', () => {
     });
 
     it('falls back to an id-based label when the API name is missing', () => {
-      renderEmbed('alert', {id: '4521', kind: 'metric'});
+      renderEmbed({name: 'alert', data: {id: '4521', kind: 'metric'}});
       expect(screen.getByRole('link', {name: 'Alert 4521'})).toBeInTheDocument();
     });
   });
@@ -207,7 +220,7 @@ describe('Seer resource embeds', () => {
     });
 
     it('uses a generic label when Seer supplies no title', () => {
-      renderEmbed('issuesQuery', {query: 'is:unresolved'});
+      renderEmbed({name: 'issuesQuery', data: {query: 'is:unresolved'}});
       expect(screen.getByRole('link', {name: 'Issue search'})).toBeInTheDocument();
     });
   });

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -8,12 +8,9 @@ resources:
 
 import * as Storybook from 'sentry/stories';
 
-import {
-  BasicDemo,
-  EmbedExamples,
-  LinkifyDemo,
-  StreamingEmbedExamples,
-} from './__stories__/components';
+import {BasicDemo, LinkifyDemo, StreamingEmbedExamples} from './__stories__/components';
+import {EmbedStory} from './__stories__/embedStory';
+import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
 
@@ -43,91 +40,91 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 
 ### timestamp
 
-<EmbedExamples name="timestamp" />
+<EmbedStory name="timestamp" />
 
 ### docs
 
-<EmbedExamples name="docs" />
+<EmbedStory name="docs" />
 
 ### dashboard
 
-<EmbedExamples name="dashboard" />
+<EmbedStory name="dashboard" />
 
 ### dsn
 
-<EmbedExamples name="dsn" />
+<EmbedStory name="dsn" />
 
 ### user
 
-<EmbedExamples name="user" />
+<EmbedStory name="user" />
 
 ### issue
 
-<EmbedExamples name="issue" />
+<EmbedStory name="issue" />
 
 ### issues
 
-<EmbedExamples name="issues" />
+<EmbedStory name="issues" />
 
 ### replay
 
-<EmbedExamples name="replay" />
+<ReplayEmbedStory />
 
 ### chart
 
-<EmbedExamples name="chart" />
+<EmbedStory name="chart" />
 
 ### autofix
 
-<EmbedExamples name="autofix" />
+<EmbedStory name="autofix" />
 
 ### alert
 
-<EmbedExamples name="alert" />
+<EmbedStory name="alert" />
 
 ### monitor
 
-<EmbedExamples name="monitor" />
+<EmbedStory name="monitor" />
 
 ### savedIssueView
 
-<EmbedExamples name="savedIssueView" />
+<EmbedStory name="savedIssueView" />
 
 ### savedQuery
 
-<EmbedExamples name="savedQuery" />
+<EmbedStory name="savedQuery" />
 
 ### trace
 
-<EmbedExamples name="trace" />
+<EmbedStory name="trace" />
 
 ### profile
 
-<EmbedExamples name="profile" />
+<EmbedStory name="profile" />
 
 ### issuesQuery
 
-<EmbedExamples name="issuesQuery" />
+<EmbedStory name="issuesQuery" />
 
 ### errorsQuery
 
-<EmbedExamples name="errorsQuery" />
+<EmbedStory name="errorsQuery" />
 
 ### spansQuery
 
-<EmbedExamples name="spansQuery" />
+<EmbedStory name="spansQuery" />
 
 ### logsQuery
 
-<EmbedExamples name="logsQuery" />
+<EmbedStory name="logsQuery" />
 
 ### replaysQuery
 
-<EmbedExamples name="replaysQuery" />
+<EmbedStory name="replaysQuery" />
 
 ### metricsQuery
 
-<EmbedExamples name="metricsQuery" />
+<EmbedStory name="metricsQuery" />
 
 ## Embed Architecture
 


### PR DESCRIPTION
Seer embed documentation now renders each payload variant once with all supported levels together, instead of creating separate demos for inline and block. The shared `EmbedStory` and `EmbedVariant` components remain schema-driven, while embeds that need live data or controls can compose their own story component.

`ReplayEmbedStory` is the first specialized story: it owns replay querying and loading, error, and empty states, removing replay-specific branching and query subscriptions from every generic embed section. Schema examples now describe payload variants only, and the generated agent schema no longer contains duplicate level-specific examples.

Follow-up to #122711.
