### PR TITLE
feat(seer): Register the organizations:seer-xray feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -329,6 +329,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-disable-coding-setting", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GitLab as a supported SCM provider for Seer
     manager.add("organizations:seer-gitlab-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Seer XRay Mode, the overlay that highlights LLM-context-registered DOM nodes
+    manager.add("organizations:seer-xray", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Append a "text" summary to SentryApp webhooks sent to Claude Code routine fire URLs
     manager.add("organizations:sentry-apps-claude-routine-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable prefill templates on the internal integration creation page


### PR DESCRIPTION
Registers `organizations:seer-xray` as a FlagPole organization feature so Seer XRay Mode can be rolled out independently of the code that consumes it. Nothing behaves differently on merge — with no FlagPole config yet, the flag is off for every organization.

`api_expose=True` is required here rather than incidental. XRay Mode gates entirely on the client side: both the command palette toggle and the overlay itself read `organization.features.includes('seer-xray')`, so the flag has to reach the organization serializer or it can never turn the feature on.

This is the backend half of Seer XRay Mode, split out of the frontend PR so the flag exists before the UI that depends on it merges.

Rollout config lives in `sentry-options-automator` and is not part of this PR.


Related to https://github.com/getsentry/sentry/pull/122143
Needed for https://github.com/getsentry/sentry-options-automator/pull/9323