### PR TITLE
feat(deletions): Add project-level event deletion task killswitch

### DIFF
--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -13,6 +13,7 @@ from sentry import eventstream, nodestore, options
 from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
 from sentry.eventstream.eap import delete_groups_from_eap_rpc
 from sentry.exceptions import DeleteAborted
+from sentry.killswitches import killswitch_matches_context
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.userreport import UserReport
 from sentry.search.eap.occurrences.query_utils import (
@@ -90,6 +91,19 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
     prefix = "deletions.nodestore"
     if not group_ids:
         raise DeleteAborted("delete_events_from_nodestore.empty_group_ids")
+
+    if killswitch_matches_context(
+        "deletions.nodestore.killswitch-projects", {"project_id": project_id}
+    ):
+        logger.warning(
+            "deletions.nodestore.halted_by_killswitch",
+            extra={
+                "project_id": project_id,
+                "transaction_id": transaction_id,
+                "dataset": dataset_str,
+            },
+        )
+        return
 
     kwargs_to_schedule_next_task = {
         "organization_id": organization_id,

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -218,6 +218,17 @@ ALL_KILLSWITCH_OPTIONS = {
             "org_id": "An organization ID to filter segments by.",
         },
     ),
+    "deletions.nodestore.killswitch-projects": KillswitchInfo(
+        description="""
+        Halt the self-chaining nodestore group-event deletion task for the given projects.
+
+        Note that this leaves partial cleanup: remaining nodestore, eventstore, and EAP
+        data will not be deleted and must be cleaned up manually.
+        """,
+        fields={
+            "project_id": "A project ID to halt nodestore group-event deletion for.",
+        },
+    ),
     "unmerge.killswitch-projects": KillswitchInfo(
         description="""
         Halt the self-chaining unmerge task for the given projects.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -349,6 +349,13 @@ register(
 )
 
 register(
+    "deletions.nodestore.killswitch-projects",
+    default=[],
+    type=Any,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "unmerge.killswitch-projects",
     default=[],
     type=Any,

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -10,6 +11,7 @@ from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.utils.snuba import UnqualifiedQueryError
 
 
@@ -41,6 +43,65 @@ class NodestoreDeletionTaskTest(TestCase):
             },
             last_event_id=last_event_id,
             last_event_timestamp=last_event_timestamp,
+        )
+
+    def test_project_killswitch_stops_deletion_chain(self) -> None:
+        transaction_id = uuid4().hex
+        with (
+            override_options({"deletions.nodestore.killswitch-projects": [self.project.id]}),
+            patch(
+                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore"
+            ) as mock_fetch_events,
+            patch(
+                "sentry.deletions.tasks.nodestore.delete_events_from_eventstore"
+            ) as mock_delete_events,
+            patch.object(
+                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
+            ) as mock_apply_async,
+        ):
+            delete_events_for_groups_from_nodestore_and_eventstore(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_ids=[1],
+                times_seen=[1],
+                transaction_id=transaction_id,
+                dataset_str=Dataset.Events.value,
+                referrer=Referrer.DELETIONS_GROUP.value,
+            )
+
+        mock_fetch_events.assert_not_called()
+        mock_delete_events.assert_not_called()
+        mock_apply_async.assert_not_called()
+
+    def test_project_killswitch_does_not_stop_other_projects(self) -> None:
+        other_project = self.create_project()
+        transaction_id = uuid4().hex
+        with (
+            override_options({"deletions.nodestore.killswitch-projects": [other_project.id]}),
+            patch(
+                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore", return_value=[]
+            ) as mock_fetch_events,
+            patch(
+                "sentry.deletions.tasks.nodestore.delete_events_from_eventstore"
+            ) as mock_delete_events,
+        ):
+            delete_events_for_groups_from_nodestore_and_eventstore(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_ids=[1],
+                times_seen=[1],
+                transaction_id=transaction_id,
+                dataset_str=Dataset.Events.value,
+                referrer=Referrer.DELETIONS_GROUP.value,
+            )
+
+        mock_fetch_events.assert_called_once()
+        mock_delete_events.assert_called_once_with(
+            self.organization.id,
+            self.project.id,
+            [1],
+            [1],
+            Dataset.Events,
         )
 
     def test_simple_deletion_with_events(self) -> None:


### PR DESCRIPTION
For INC-2476.

Adds a project-level killswitch for the self-chaining event deletion task. Matching task activations stop before querying Snuba, deleting event data, or scheduling the next chain step, while other projects continue normally.

Modeled after https://github.com/getsentry/sentry/pull/118611.