### PR TITLE
build(ui): Lazy load js-beautify

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -1,17 +1,23 @@
 import {Fragment, useCallback, useMemo, useState} from 'react';
 import {createPortal} from 'react-dom';
-import beautify from 'js-beautify';
 
 import {CodeBlock} from '@sentry/scraps/code';
 
 import {AuthTokenGenerator} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {useRegisteredTabSelection} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {PACKAGE_LOADING_PLACEHOLDER} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+import {useFormattedCode} from 'sentry/utils/useFormattedCode';
 
 interface OnboardingCodeSnippetProps extends Omit<
   React.ComponentProps<typeof CodeBlock>,
   'onAfterHighlight'
 > {}
+
+const JAVASCRIPT_FORMAT_OPTIONS = {
+  indent_size: 2,
+  e4x: true,
+  brace_style: 'preserve-inline',
+} as const;
 
 /**
  * Replaces tokens in a DOM element with a span element.
@@ -49,6 +55,12 @@ export function OnboardingCodeSnippet({
     [children]
   );
 
+  const {formattedCode} = useFormattedCode({
+    code: children,
+    language: language === 'javascript' ? 'javascript' : null,
+    options: JAVASCRIPT_FORMAT_OPTIONS,
+  });
+
   return (
     <Fragment>
       <CodeBlock
@@ -59,14 +71,7 @@ export function OnboardingCodeSnippet({
         {...props}
         onAfterHighlight={handleAfterHighlight}
       >
-        {/* Trim whitespace from code snippets and beautify javascript code */}
-        {language === 'javascript'
-          ? beautify.js(children, {
-              indent_size: 2,
-              e4x: true,
-              brace_style: 'preserve-inline',
-            })
-          : children.trim()}
+        {formattedCode}
       </CodeBlock>
       {authTokenNodes.map(node => createPortal(<AuthTokenGenerator />, node))}
     </Fragment>

--- a/static/app/components/replays/breadcrumbs/breadcrumbCodeSnippet.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbCodeSnippet.tsx
@@ -1,5 +1,3 @@
-import beautify from 'js-beautify';
-
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container} from '@sentry/scraps/layout';
 
@@ -7,6 +5,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 import {isSpanFrame} from 'sentry/utils/replays/types';
+import {useFormattedCode} from 'sentry/utils/useFormattedCode';
 
 interface Props {
   frame: ReplayFrame;
@@ -14,6 +13,8 @@ interface Props {
   showSnippet: boolean;
   extraction?: Extraction;
 }
+
+const HTML_FORMAT_OPTIONS = {indent_size: 2} as const;
 
 export function BreadcrumbCodeSnippet({
   frame,
@@ -33,11 +34,21 @@ export function BreadcrumbCodeSnippet({
     return null;
   }
 
-  return extraction?.html?.map(html => (
-    <Container maxWidth="100%" maxHeight="400px" overflow="auto" key={html}>
+  return extraction?.html?.map(html => <FormattedHtmlSnippet html={html} key={html} />);
+}
+
+function FormattedHtmlSnippet({html}: {html: string}) {
+  const {formattedCode} = useFormattedCode({
+    code: html,
+    language: 'html',
+    options: HTML_FORMAT_OPTIONS,
+  });
+
+  return (
+    <Container maxWidth="100%" maxHeight="400px" overflow="auto">
       <CodeBlock language="html" hideCopyButton>
-        {beautify.html(html, {indent_size: 2})}
+        {formattedCode}
       </CodeBlock>
     </Container>
-  ));
+  );
 }

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -1,6 +1,3 @@
-import {useMemo} from 'react';
-import beautify from 'js-beautify';
-
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
@@ -11,6 +8,9 @@ import {After, Before} from 'sentry/components/replays/diff/utils';
 import SplitDiff from 'sentry/components/splitDiff';
 import {t} from 'sentry/locale';
 import {useExtractPageHtml} from 'sentry/utils/replays/hooks/useExtractPageHtml';
+import {useFormattedCode} from 'sentry/utils/useFormattedCode';
+
+const HTML_FORMAT_OPTIONS = {indent_size: 2} as const;
 
 export function ReplayTextDiff() {
   const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
@@ -23,18 +23,29 @@ export function ReplayTextDiff() {
     offsetMsToStopAt: [leftOffsetMs + 1, rightOffsetMs + 1],
   });
 
-  const [leftBody, rightBody] = useMemo(
-    () => data?.map(([_, html]) => beautify.html(html, {indent_size: 2})) ?? [],
-    [data]
-  );
+  const [leftBodySource = '', rightBodySource = ''] =
+    data?.map(([_, html]) => html) ?? [];
+  const {formattedCode: leftBody, isPending: isLeftBodyPending} = useFormattedCode({
+    code: leftBodySource,
+    language: 'html',
+    options: HTML_FORMAT_OPTIONS,
+  });
+  const {formattedCode: rightBody, isPending: isRightBodyPending} = useFormattedCode({
+    code: rightBodySource,
+    language: 'html',
+    options: HTML_FORMAT_OPTIONS,
+  });
+  const isFormatting = isLeftBodyPending || isRightBodyPending;
 
   return (
     <Stack flexGrow={1} gap="md" height="0">
-      {!isLoading && leftBody === rightBody ? <DiffFeedbackBanner /> : null}
+      {!isLoading && !isFormatting && leftBody === rightBody ? (
+        <DiffFeedbackBanner />
+      ) : null}
       <ContentSliderDiff.Header>
         <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs}>
           <CopyToClipboardButton
-            text={leftBody ?? ''}
+            text={leftBody}
             size="xs"
             variant="transparent"
             aria-label={t('Copy Before')}
@@ -42,7 +53,7 @@ export function ReplayTextDiff() {
         </Before>
         <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs}>
           <CopyToClipboardButton
-            text={rightBody ?? ''}
+            text={rightBody}
             size="xs"
             variant="transparent"
             aria-label={t('Copy After')}
@@ -50,7 +61,7 @@ export function ReplayTextDiff() {
         </After>
       </ContentSliderDiff.Header>
       <Flex flexGrow={1} height="0" overflow="auto">
-        <SplitDiff base={leftBody ?? ''} target={rightBody ?? ''} type="lines" />
+        <SplitDiff base={leftBody} target={rightBody} type="lines" />
       </Flex>
     </Stack>
   );

--- a/static/app/gettingStartedDocs/javascript/jsLoader.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader.tsx
@@ -1,5 +1,3 @@
-import beautify from 'js-beautify';
-
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {tracePropagationBlock} from 'sentry/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage';
@@ -39,10 +37,10 @@ export const feedbackOnboardingJsLoader: OnboardingConfig = {
         {
           type: 'code',
           language: 'html',
-          code: beautify.html(
-            `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,
-            {indent_size: 2, wrap_attributes: 'force-expand-multiline'}
-          ),
+          code: `<script
+  src="${params.dsn.cdn}"
+  crossorigin="anonymous"
+></script>`,
         },
       ],
     },
@@ -113,10 +111,10 @@ export const replayOnboardingJsLoader: OnboardingConfig = {
         {
           type: 'code',
           language: 'html',
-          code: beautify.html(
-            `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,
-            {indent_size: 2, wrap_attributes: 'force-expand-multiline'}
-          ),
+          code: `<script
+  src="${params.dsn.cdn}"
+  crossorigin="anonymous"
+></script>`,
         },
         {
           type: 'alert',

--- a/static/app/utils/useFormattedCode.spec.tsx
+++ b/static/app/utils/useFormattedCode.spec.tsx
@@ -1,0 +1,67 @@
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useFormattedCode} from 'sentry/utils/useFormattedCode';
+
+describe('useFormattedCode', () => {
+  it('returns trimmed code without loading a formatter when disabled', () => {
+    const {result} = renderHookWithProviders(() =>
+      useFormattedCode({
+        code: '\n  plain text  \n',
+        language: null,
+      })
+    );
+
+    expect(result.current).toEqual({
+      formattedCode: 'plain text',
+      isPending: false,
+    });
+  });
+
+  it('uses the source as a fallback while lazily formatting JavaScript', async () => {
+    const {result} = renderHookWithProviders(() =>
+      useFormattedCode({
+        code: 'function x(){return 1;}',
+        language: 'javascript',
+        options: {
+          indent_size: 2,
+          e4x: true,
+          brace_style: 'preserve-inline',
+        },
+      })
+    );
+
+    expect(result.current).toEqual({
+      formattedCode: 'function x(){return 1;}',
+      isPending: true,
+    });
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        formattedCode: 'function x() { return 1; }',
+        isPending: false,
+      })
+    );
+  });
+
+  it('formats HTML and embedded JavaScript', async () => {
+    const {result} = renderHookWithProviders(() =>
+      useFormattedCode({
+        code: '<main><script>function x(){return 1;}</script></main>',
+        language: 'html',
+        options: {indent_size: 2},
+      })
+    );
+
+    await waitFor(() =>
+      expect(result.current.formattedCode).toBe(
+        '<main>\n' +
+          '  <script>\n' +
+          '    function x() {\n' +
+          '      return 1;\n' +
+          '    }\n' +
+          '  </script>\n' +
+          '</main>'
+      )
+    );
+  });
+});

--- a/static/app/utils/useFormattedCode.tsx
+++ b/static/app/utils/useFormattedCode.tsx
@@ -1,0 +1,57 @@
+import {useMemo} from 'react';
+import {queryOptions, skipToken, useQuery} from '@tanstack/react-query';
+import type jsBeautify from 'js-beautify';
+
+type FormatterLanguage = 'html' | 'javascript';
+type FormatterOptions = jsBeautify.HTMLBeautifyOptions | jsBeautify.JSBeautifyOptions;
+
+interface UseFormattedCodeOptions {
+  code: string;
+  language: FormatterLanguage | null;
+  options?: FormatterOptions;
+}
+
+/**
+ * `js-beautify` is roughly 25 KiB gzip. Keep the public package entry point behind
+ * one named dynamic import so consumers do not download it until formatting is needed
+ * and Rspack emits a recognizable `js-beautify.<contenthash>.js` chunk.
+ */
+async function loadBeautifier() {
+  const {default: beautify} = await import(
+    /* webpackChunkName: "js-beautify" */ 'js-beautify'
+  );
+  return beautify;
+}
+
+function beautifierQueryOptions(enabled: boolean) {
+  return queryOptions({
+    queryKey: ['js-beautify'],
+    queryFn: enabled ? loadBeautifier : skipToken,
+    staleTime: Infinity,
+  });
+}
+
+/**
+ * Formats code after the shared beautifier chunk loads. Until then, return trimmed
+ * source so code remains readable and copyable instead of showing an empty state.
+ * Pass `language: null` to skip loading the formatter and only trim the source.
+ */
+export function useFormattedCode(options: UseFormattedCodeOptions) {
+  const {data: beautify, isPending} = useQuery(
+    beautifierQueryOptions(options.language !== null)
+  );
+  const formattedCode = useMemo(() => {
+    if (!beautify || !options.language) {
+      return options.code.trim();
+    }
+
+    return options.language === 'html'
+      ? beautify.html(options.code, options.options)
+      : beautify.js(options.code, options.options);
+  }, [beautify, options.code, options.language, options.options]);
+
+  return {
+    formattedCode,
+    isPending: options.language ? isPending : false,
+  };
+}

--- a/static/app/utils/useFormattedCode.tsx
+++ b/static/app/utils/useFormattedCode.tsx
@@ -18,7 +18,7 @@ interface UseFormattedCodeOptions {
  */
 async function loadBeautifier() {
   const {default: beautify} = await import(
-    /* webpackChunkName: "js-beautify" */ 'js-beautify'
+    /* rspackChunkName: "js-beautify" */ 'js-beautify'
   );
   return beautify;
 }


### PR DESCRIPTION
Lazy loads js-beautify through a shared formatter hook so it only downloads when formatted code is rendered, while keeping trimmed source visible during the load.

The production build emits a dedicated `js-beautify.986e0eea1e04bc96.js` chunk containing only js-beautify. It is 98.2 KiB raw / 24.4 KiB gzip.

Two consecutive production builds emitted the same filename and identical output, confirming the content hash is stable when the package content does not change. The source map for the chunk contains 24 sources, all from js-beautify.