### PR TITLE
fix(issue-progress): clear fix applied when issue reopens

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -197,9 +197,15 @@ def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorRe
 
     if state[STATUS] != IssueStatus.OPEN:
         new_progress = None
-    elif (
+    elif entry.type == PullRequestMergedAction.get_type() or (
         current_progress == IssueProgressState.FIX_APPLIED
-        or entry.type == PullRequestMergedAction.get_type()
+        and entry.type
+        # Usually an issue will first close before it regresses, but there are cases where a regression action
+        #  is seen without a resolution action. This handles that case and clears the FIX_APPLIED progress.
+        not in (
+            UnresolveAction.get_type(),
+            SetRegressedAction.get_type(),
+        )
     ):
         new_progress = IssueProgressState.FIX_APPLIED
     elif state[HAS_OPEN_FIX_PR]:

--- a/src/sentry/issues/derived/features.py
+++ b/src/sentry/issues/derived/features.py
@@ -24,7 +24,7 @@ PROGRESS = Feature[IssueProgressState | None](
     "progress",
     default=IssueProgressState.IDENTIFIED,
     codec=OptionalCodec(EnumCodec(IssueProgressState)),
-    version=1,
+    version=2,
 )
 
 # The last time the progress was advanced.

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -787,6 +787,29 @@ def test_merged_fix_persists_across_unrelated_actions() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "action_type",
+    [
+        GroupActionType.UNRESOLVE,
+        GroupActionType.SET_REGRESSED,
+    ],
+)
+def test_merged_fix_resets_when_issue_reopens(action_type: GroupActionType) -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(
+                    type=GroupActionType.PULL_REQUEST_MERGED,
+                    data={"pull_request": 101, "has_other_open_prs": False},
+                ),
+                FakeEntry(type=action_type),
+            ],
+        )
+        == IssueProgressState.IDENTIFIED
+    )
+
+
 def test_merged_fix_resets_after_closed_issue_regresses() -> None:
     p = _pipeline(targets=(PROGRESS,))
     state = p.initial_state()


### PR DESCRIPTION
Fixes ISWF-3372

Issue progress could remain in `FIX_APPLIED` when a pull request merge was followed directly by a regression action. The current code assumes that issues follow a logical flow of "pull request merged" (fix applied) -> "issue resolved" (progress cleared) -> "issue regressed". But it appears that some issues do not have a resolution action before regressing. This might be something we need to track down at some point, but it's easy enough to account for this case in the aggregator.