### PR TITLE
feat(onboarding): Refine agentic progress display

### DIFF
--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
@@ -6,6 +6,12 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 import {AgenticProgress, AgenticProgressList} from './agenticProgressList';
 
 describe('AgenticProgressList', () => {
+  it('renders header content', () => {
+    render(<AgenticProgressList stages={[]} header="Progress header" />);
+
+    expect(screen.getByText('Progress header')).toBeInTheDocument();
+  });
+
   it('renders every visible stage status and its notes', () => {
     render(
       <AgenticProgressList
@@ -128,6 +134,14 @@ describe('AgenticProgressList', () => {
     );
 
     expect(screen.getByText('Created 2 projects')).toBeInTheDocument();
+    expect(screen.getByText('Agent Connected')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Your agent is setting up Sentry in your application. For now, you’re off the hook. Sit back and let it do the work.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Last update/)).toBeInTheDocument();
+    expect(screen.getByText('ID:Lg1iSt2qeQ')).toBeInTheDocument();
     await waitFor(() => expect(projectsRequest).toHaveBeenCalled());
   });
 });

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -2,19 +2,22 @@ import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ProjectList} from 'sentry/components/projectList';
+import {TimeSince} from 'sentry/components/timeSince';
 import {
+  IconBot,
   IconCircle,
   IconCircleCheckmark,
   IconFatal,
   IconNot,
   IconPieHalf,
 } from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 
 import type {AgenticProgressRun} from './types';
 
@@ -251,13 +254,20 @@ function ProgressItem({
 
 export function AgenticProgressList({
   extraContentByStage,
+  header,
   stages,
 }: {
   stages: AgenticProgressStageState[];
   extraContentByStage?: Partial<Record<AgenticProgressStage, React.ReactNode>>;
+  header?: React.ReactNode;
 }) {
   return (
     <Stack width="100%" border="muted" radius="lg" overflow="hidden" gap="0">
+      {header ? (
+        <Container padding="lg" borderBottom="muted">
+          {header}
+        </Container>
+      ) : null}
       {stages.map((stage, index) => (
         <ProgressItem
           key={stage.stage}
@@ -270,6 +280,57 @@ export function AgenticProgressList({
   );
 }
 
+function AgenticProgressHeader({
+  onboardingCode,
+  updatedAt,
+}: {
+  onboardingCode: string | undefined;
+  updatedAt: string;
+}) {
+  return (
+    <Stack gap="md">
+      <Flex align="center" gap="sm">
+        <IconBot size="md" variant="secondary" />
+        <Text variant="muted" size="sm" bold uppercase>
+          {t('Agent Connected')}
+        </Text>
+      </Flex>
+      <Text variant="muted" density="comfortable">
+        {t(
+          'Your agent is setting up Sentry in your application. For now, you’re off the hook. Sit back and let it do the work.'
+        )}
+      </Text>
+      <Flex align="center" justify="between" gap="md" marginTop="sm">
+        <Flex align="center" gap="sm">
+          <Flex width="16px" align="center" justify="center" flexShrink={0}>
+            <StatusIndicator variant="accent" />
+          </Flex>
+          <Text size="sm" variant="muted">
+            {tct('Last update [time]', {
+              time: (
+                <TimeSince
+                  date={updatedAt}
+                  disabledAbsoluteTooltip
+                  liveUpdateInterval="second"
+                />
+              ),
+            })}
+          </Text>
+        </Flex>
+        {onboardingCode ? (
+          <RunId size="sm" variant="muted" monospace>
+            {t('ID:%s', onboardingCode)}
+          </RunId>
+        ) : null}
+      </Flex>
+    </Stack>
+  );
+}
+
+const RunId = styled(Text)`
+  opacity: 0.6;
+`;
+
 function CreatedProjects({projectSlugs}: {projectSlugs: string[]}) {
   return (
     <Grid columns="max-content max-content" align="center" gap="md">
@@ -281,12 +342,24 @@ function CreatedProjects({projectSlugs}: {projectSlugs: string[]}) {
   );
 }
 
-export function AgenticProgress({run}: {run: AgenticProgressRun}) {
+export function AgenticProgress({
+  run,
+  onboardingCode = run.onboardingCode,
+}: {
+  run: AgenticProgressRun;
+  onboardingCode?: string;
+}) {
   const createProjectStage = run.stages.find(stage => stage.stage === 'create_project');
   const projectSlugs = createProjectStage?.extra?.projectSlugs ?? [];
 
   return (
     <AgenticProgressList
+      header={
+        <AgenticProgressHeader
+          onboardingCode={onboardingCode}
+          updatedAt={run.updatedAt}
+        />
+      }
       stages={run.stages}
       extraContentByStage={
         projectSlugs.length


### PR DESCRIPTION
Adds a reusable header slot to the agentic progress list and uses it to show the connected-agent state, live last-update time, and onboarding identifier above stage progress. This keeps run context visible while the agent works without coupling the reusable list to the welcome-screen layout.