### PR TITLE
feat(deletions): Make event deletion task self-chaining idempotent

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -206,7 +206,7 @@ SENTRY_SESSION_STORE_REDIS_CLUSTER = "default"
 SENTRY_AUTH_IDPMIGRATION_REDIS_CLUSTER = "default"
 SENTRY_SNOWFLAKE_REDIS_CLUSTER = "default"
 SENTRY_SCM_REDIS_CLUSTER = "default"
-# Ephemeral dedup markers for self-chaining tasks (merge_groups / unmerge).
+# Ephemeral dedup markers for self-chaining tasks (e.g. merge_groups, unmerge).
 SENTRY_SELFCHAIN_IDEMPOTENCY_REDIS_CLUSTER = "default"
 
 # Hosts that are allowed to use system token authentication.

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -43,7 +43,7 @@ EVENT_CHUNK_SIZE = 10000
 ISSUE_PLATFORM_MAX_ROWS_TO_DELETE = 2000000
 
 # Identifies this task in the self-chain idempotency guard.
-_TASK_KEY = "delete_events_from_nodestore_and_eventstore"
+DELETE_EVENTS_TASK_KEY = "delete_events_from_nodestore_and_eventstore"
 
 
 class RetryTask(Exception):
@@ -114,7 +114,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
     # page and spawn another child.
     task_state = current_task()
     activation_id = task_state.id if task_state else None
-    if activation_id and already_spawned(_TASK_KEY, activation_id):
+    if activation_id and already_spawned(DELETE_EVENTS_TASK_KEY, activation_id):
         logger.info(
             "delete_events_for_groups_from_nodestore_and_eventstore.duplicate_redelivery.skipped",
             extra={
@@ -123,7 +123,9 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
                 "activation_id": activation_id,
             },
         )
-        metrics.incr("taskworker.selfchain.duplicate_skipped", tags={"task": _TASK_KEY})
+        metrics.incr(
+            "taskworker.selfchain.duplicate_skipped", tags={"task": DELETE_EVENTS_TASK_KEY}
+        )
         return
 
     kwargs_to_schedule_next_task = {
@@ -165,7 +167,7 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
                 },
             )
             if activation_id:
-                mark_spawned(_TASK_KEY, activation_id)
+                mark_spawned(DELETE_EVENTS_TASK_KEY, activation_id)
         else:
             logger.info(f"{prefix}.completed", extra=extra)
             # The fetch request for the nodestore uses the eventstore to determine what IDs to delete

--- a/src/sentry/deletions/tasks/nodestore.py
+++ b/src/sentry/deletions/tasks/nodestore.py
@@ -8,6 +8,7 @@ import sentry_sdk
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 from snuba_sdk import DeleteQuery, Request
 from taskbroker_client.retry import Retry
+from taskbroker_client.state import current_task
 
 from sentry import eventstream, nodestore, options
 from sentry.deletions.tasks.scheduled import MAX_RETRIES, logger
@@ -28,6 +29,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.taskworker.namespaces import deletion_tasks
+from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.utils import metrics
 from sentry.utils.snuba import UnqualifiedQueryError, bulk_snuba_queries
 from sentry.utils.snuba_rpc import (
@@ -39,6 +41,9 @@ from sentry.utils.snuba_rpc import (
 EVENT_CHUNK_SIZE = 10000
 # https://github.com/getsentry/snuba/blob/54feb15b7575142d4b3af7f50d2c2c865329f2db/snuba/datasets/configuration/issues/storages/search_issues.yaml#L139
 ISSUE_PLATFORM_MAX_ROWS_TO_DELETE = 2000000
+
+# Identifies this task in the self-chain idempotency guard.
+_TASK_KEY = "delete_events_from_nodestore_and_eventstore"
 
 
 class RetryTask(Exception):
@@ -105,6 +110,22 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
         )
         return
 
+    # A redelivered activation that already spawned its continuation must not process the same
+    # page and spawn another child.
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_TASK_KEY, activation_id):
+        logger.info(
+            "delete_events_for_groups_from_nodestore_and_eventstore.duplicate_redelivery.skipped",
+            extra={
+                "project_id": project_id,
+                "transaction_id": transaction_id,
+                "activation_id": activation_id,
+            },
+        )
+        metrics.incr("taskworker.selfchain.duplicate_skipped", tags={"task": _TASK_KEY})
+        return
+
     kwargs_to_schedule_next_task = {
         "organization_id": organization_id,
         "project_id": project_id,
@@ -143,6 +164,8 @@ def delete_events_for_groups_from_nodestore_and_eventstore(
                     "last_event_timestamp": last_event.timestamp,
                 },
             )
+            if activation_id:
+                mark_spawned(_TASK_KEY, activation_id)
         else:
             logger.info(f"{prefix}.completed", extra=extra)
             # The fetch request for the nodestore uses the eventstore to determine what IDs to delete

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -369,7 +369,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Idempotency guard for self-chaining tasks (merge_groups / unmerge): dedupe the chain-step
+# Idempotency guard for self-chaining tasks (e.g. merge_groups, unmerge): dedupe the chain-step
 # spawn keyed on the broker activation id so a broker re-pend cannot fork the chain.
 register(
     "taskworker.selfchain_idempotency.enabled",

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -102,7 +102,7 @@ class NodestoreDeletionTaskTest(TestCase):
         )
 
     @patch("sentry.deletions.tasks.nodestore.current_task")
-    def test_selfchain_skips_when_already_spawned(self, mock_current_task) -> None:
+    def test_selfchain_skips_when_already_spawned(self, mock_current_task: MagicMock) -> None:
         activation_id = "nodestore-delete-act-skip"
         mock_current_task.return_value = SimpleNamespace(id=activation_id)
         mark_spawned(_TASK_KEY, activation_id)
@@ -121,7 +121,9 @@ class NodestoreDeletionTaskTest(TestCase):
         mock_apply_async.assert_not_called()
 
     @patch("sentry.deletions.tasks.nodestore.current_task")
-    def test_selfchain_marks_and_dedupes_across_deliveries(self, mock_current_task) -> None:
+    def test_selfchain_marks_and_dedupes_across_deliveries(
+        self, mock_current_task: MagicMock
+    ) -> None:
         activation_id = "nodestore-delete-act-dedupe"
         mock_current_task.return_value = SimpleNamespace(id=activation_id)
         events = [SimpleNamespace(event_id="event-id", timestamp="2025-01-01T00:00:00")]
@@ -149,7 +151,7 @@ class NodestoreDeletionTaskTest(TestCase):
     @patch("sentry.deletions.tasks.nodestore.mark_spawned")
     @patch("sentry.deletions.tasks.nodestore.current_task", return_value=None)
     def test_selfchain_is_inert_without_activation(
-        self, mock_current_task, mock_mark_spawned
+        self, mock_current_task: MagicMock, mock_mark_spawned: MagicMock
     ) -> None:
         events = [SimpleNamespace(event_id="event-id", timestamp="2025-01-01T00:00:00")]
 

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -10,9 +11,12 @@ from sentry.deletions.tasks.nodestore import (
 from sentry.services.eventstore.models import Event
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
+from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.utils.snuba import UnqualifiedQueryError
+
+_TASK_KEY = "delete_events_from_nodestore_and_eventstore"
 
 
 class NodestoreDeletionTaskTest(TestCase):
@@ -45,8 +49,18 @@ class NodestoreDeletionTaskTest(TestCase):
             last_event_timestamp=last_event_timestamp,
         )
 
+    def run_deletion_task(self) -> None:
+        delete_events_for_groups_from_nodestore_and_eventstore(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            group_ids=[1],
+            times_seen=[1],
+            transaction_id="transaction-id",
+            dataset_str=Dataset.Events.value,
+            referrer=Referrer.DELETIONS_GROUP.value,
+        )
+
     def test_project_killswitch_stops_deletion_chain(self) -> None:
-        transaction_id = uuid4().hex
         with (
             override_options({"deletions.nodestore.killswitch-projects": [self.project.id]}),
             patch(
@@ -59,15 +73,7 @@ class NodestoreDeletionTaskTest(TestCase):
                 delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
             ) as mock_apply_async,
         ):
-            delete_events_for_groups_from_nodestore_and_eventstore(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                group_ids=[1],
-                times_seen=[1],
-                transaction_id=transaction_id,
-                dataset_str=Dataset.Events.value,
-                referrer=Referrer.DELETIONS_GROUP.value,
-            )
+            self.run_deletion_task()
 
         mock_fetch_events.assert_not_called()
         mock_delete_events.assert_not_called()
@@ -75,7 +81,6 @@ class NodestoreDeletionTaskTest(TestCase):
 
     def test_project_killswitch_does_not_stop_other_projects(self) -> None:
         other_project = self.create_project()
-        transaction_id = uuid4().hex
         with (
             override_options({"deletions.nodestore.killswitch-projects": [other_project.id]}),
             patch(
@@ -85,15 +90,7 @@ class NodestoreDeletionTaskTest(TestCase):
                 "sentry.deletions.tasks.nodestore.delete_events_from_eventstore"
             ) as mock_delete_events,
         ):
-            delete_events_for_groups_from_nodestore_and_eventstore(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                group_ids=[1],
-                times_seen=[1],
-                transaction_id=transaction_id,
-                dataset_str=Dataset.Events.value,
-                referrer=Referrer.DELETIONS_GROUP.value,
-            )
+            self.run_deletion_task()
 
         mock_fetch_events.assert_called_once()
         mock_delete_events.assert_called_once_with(
@@ -103,6 +100,74 @@ class NodestoreDeletionTaskTest(TestCase):
             [1],
             Dataset.Events,
         )
+
+    @patch("sentry.deletions.tasks.nodestore.current_task")
+    def test_selfchain_skips_when_already_spawned(self, mock_current_task) -> None:
+        activation_id = "nodestore-delete-act-skip"
+        mock_current_task.return_value = SimpleNamespace(id=activation_id)
+        mark_spawned(_TASK_KEY, activation_id)
+
+        with (
+            patch(
+                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore"
+            ) as mock_fetch_events,
+            patch.object(
+                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
+            ) as mock_apply_async,
+        ):
+            self.run_deletion_task()
+
+        mock_fetch_events.assert_not_called()
+        mock_apply_async.assert_not_called()
+
+    @patch("sentry.deletions.tasks.nodestore.current_task")
+    def test_selfchain_marks_and_dedupes_across_deliveries(self, mock_current_task) -> None:
+        activation_id = "nodestore-delete-act-dedupe"
+        mock_current_task.return_value = SimpleNamespace(id=activation_id)
+        events = [SimpleNamespace(event_id="event-id", timestamp="2025-01-01T00:00:00")]
+
+        with (
+            patch(
+                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore",
+                return_value=events,
+            ) as mock_fetch_events,
+            patch("sentry.deletions.tasks.nodestore.delete_events_from_nodestore"),
+            patch("sentry.deletions.tasks.nodestore.delete_dangling_attachments_and_user_reports"),
+            patch.object(
+                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
+            ) as mock_apply_async,
+        ):
+            self.run_deletion_task()
+            assert mock_apply_async.call_count == 1
+            assert already_spawned(_TASK_KEY, activation_id) is True
+
+            self.run_deletion_task()
+
+        assert mock_fetch_events.call_count == 1
+        assert mock_apply_async.call_count == 1
+
+    @patch("sentry.deletions.tasks.nodestore.mark_spawned")
+    @patch("sentry.deletions.tasks.nodestore.current_task", return_value=None)
+    def test_selfchain_is_inert_without_activation(
+        self, mock_current_task, mock_mark_spawned
+    ) -> None:
+        events = [SimpleNamespace(event_id="event-id", timestamp="2025-01-01T00:00:00")]
+
+        with (
+            patch(
+                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore",
+                return_value=events,
+            ),
+            patch("sentry.deletions.tasks.nodestore.delete_events_from_nodestore"),
+            patch("sentry.deletions.tasks.nodestore.delete_dangling_attachments_and_user_reports"),
+            patch.object(
+                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
+            ) as mock_apply_async,
+        ):
+            self.run_deletion_task()
+
+        assert mock_apply_async.call_count == 1
+        mock_mark_spawned.assert_not_called()
 
     def test_simple_deletion_with_events(self) -> None:
         """Test nodestore deletion when events are found."""

--- a/tests/sentry/deletions/tasks/test_nodestore.py
+++ b/tests/sentry/deletions/tasks/test_nodestore.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from sentry.deletions.tasks.nodestore import (
+    DELETE_EVENTS_TASK_KEY,
     delete_events_for_groups_from_nodestore_and_eventstore,
     fetch_events_from_eventstore,
 )
@@ -15,8 +16,6 @@ from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawne
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.utils.snuba import UnqualifiedQueryError
-
-_TASK_KEY = "delete_events_from_nodestore_and_eventstore"
 
 
 class NodestoreDeletionTaskTest(TestCase):
@@ -49,11 +48,11 @@ class NodestoreDeletionTaskTest(TestCase):
             last_event_timestamp=last_event_timestamp,
         )
 
-    def run_deletion_task(self) -> None:
+    def run_deletion_task(self, group_id: int = 1) -> None:
         delete_events_for_groups_from_nodestore_and_eventstore(
             organization_id=self.organization.id,
             project_id=self.project.id,
-            group_ids=[1],
+            group_ids=[group_id],
             times_seen=[1],
             transaction_id="transaction-id",
             dataset_str=Dataset.Events.value,
@@ -105,20 +104,15 @@ class NodestoreDeletionTaskTest(TestCase):
     def test_selfchain_skips_when_already_spawned(self, mock_current_task: MagicMock) -> None:
         activation_id = "nodestore-delete-act-skip"
         mock_current_task.return_value = SimpleNamespace(id=activation_id)
-        mark_spawned(_TASK_KEY, activation_id)
+        mark_spawned(DELETE_EVENTS_TASK_KEY, activation_id)
 
-        with (
-            patch(
-                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore"
-            ) as mock_fetch_events,
-            patch.object(
-                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
-            ) as mock_apply_async,
-        ):
+        with patch(
+            "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore",
+            side_effect=AssertionError("duplicate activation should not fetch events"),
+        ) as mock_fetch_events:
             self.run_deletion_task()
 
         mock_fetch_events.assert_not_called()
-        mock_apply_async.assert_not_called()
 
     @patch("sentry.deletions.tasks.nodestore.current_task")
     def test_selfchain_marks_and_dedupes_across_deliveries(
@@ -126,26 +120,18 @@ class NodestoreDeletionTaskTest(TestCase):
     ) -> None:
         activation_id = "nodestore-delete-act-dedupe"
         mock_current_task.return_value = SimpleNamespace(id=activation_id)
-        events = [SimpleNamespace(event_id="event-id", timestamp="2025-01-01T00:00:00")]
+        event = self.create_n_events_with_group(n_events=1)[0]
+        assert event.group_id is not None
 
-        with (
-            patch(
-                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore",
-                return_value=events,
-            ) as mock_fetch_events,
-            patch("sentry.deletions.tasks.nodestore.delete_events_from_nodestore"),
-            patch("sentry.deletions.tasks.nodestore.delete_dangling_attachments_and_user_reports"),
-            patch.object(
-                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
-            ) as mock_apply_async,
-        ):
-            self.run_deletion_task()
+        with patch.object(
+            delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
+        ) as mock_apply_async:
+            self.run_deletion_task(event.group_id)
             assert mock_apply_async.call_count == 1
-            assert already_spawned(_TASK_KEY, activation_id) is True
+            assert already_spawned(DELETE_EVENTS_TASK_KEY, activation_id) is True
 
-            self.run_deletion_task()
+            self.run_deletion_task(event.group_id)
 
-        assert mock_fetch_events.call_count == 1
         assert mock_apply_async.call_count == 1
 
     @patch("sentry.deletions.tasks.nodestore.mark_spawned")
@@ -153,20 +139,13 @@ class NodestoreDeletionTaskTest(TestCase):
     def test_selfchain_is_inert_without_activation(
         self, mock_current_task: MagicMock, mock_mark_spawned: MagicMock
     ) -> None:
-        events = [SimpleNamespace(event_id="event-id", timestamp="2025-01-01T00:00:00")]
+        event = self.create_n_events_with_group(n_events=1)[0]
+        assert event.group_id is not None
 
-        with (
-            patch(
-                "sentry.deletions.tasks.nodestore.fetch_events_from_eventstore",
-                return_value=events,
-            ),
-            patch("sentry.deletions.tasks.nodestore.delete_events_from_nodestore"),
-            patch("sentry.deletions.tasks.nodestore.delete_dangling_attachments_and_user_reports"),
-            patch.object(
-                delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
-            ) as mock_apply_async,
-        ):
-            self.run_deletion_task()
+        with patch.object(
+            delete_events_for_groups_from_nodestore_and_eventstore, "apply_async"
+        ) as mock_apply_async:
+            self.run_deletion_task(event.group_id)
 
         assert mock_apply_async.call_count == 1
         mock_mark_spawned.assert_not_called()


### PR DESCRIPTION
For INC-2476.

Modeled after https://github.com/getsentry/sentry/pull/118966.

The nodestore deletion task (`delete_events_for_groups_from_nodestore_and_eventstore`) self-chains while paging through events. Because taskbroker provides at-least-once delivery, a re-pended activation could previously enqueue another continuation and fork the chain, amplifying deletion and Snuba traffic.

This PR reuses the merge/unmerge self-chain guard: each activation checks a Redis marker keyed by its taskbroker activation ID and records the marker immediately after dispatching its continuation.

The project-level killswitch added in https://github.com/getsentry/sentry/pull/122770 remains active.