### PR TITLE
fix(dashboards): widget builder not respecting navbar width

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -103,8 +103,8 @@ export function WidgetBuilderV2({
     }
 
     const navigationElement = document.querySelector(
-      'nav[aria-label="Primary Navigation"]'
-    )?.parentElement;
+      '[data-navigation-component="navigation-layout"]'
+    );
     if (navigationElement) {
       navigationElementRef.current = navigationElement as HTMLDivElement;
     }

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -107,6 +107,7 @@ function NavigationLayout({
 
   return (
     <Flex
+      data-navigation-component="navigation-layout"
       top={barTop}
       left={0}
       position={currentStepId ? undefined : 'sticky'}


### PR DESCRIPTION
new `registerLLMContext` on the navbar messed with the widget builder's position calculations. probably not the best thing that we relied on the parent component of the primary nav so i've added in a proper css data field so we can keep track like that. Now the widget builder will respect the Nav boundaries so they don't overlap.

<img width="1509" height="709" alt="image" src="https://github.com/user-attachments/assets/36e815e8-ec3a-4884-aef5-c6e106873dac" />
