### PR TITLE
feat(onboarding): Preload agentic run initialization

### DIFF
--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressInit.ts
@@ -1,6 +1,6 @@
 import {useEffect, useRef, useState} from 'react';
 import {uuid4} from '@sentry/core';
-import {useMutation} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -28,7 +28,7 @@ export function useAgenticProgressInit({enabled}: UseAgenticProgressInitOptions)
   const [initialOnboardingCode] = useState(createOnboardingCode);
   const clientRunId = agenticProgressClientRunId ?? initialClientRunId;
   const onboardingCode = agenticProgressOnboardingCode ?? initialOnboardingCode;
-  const startedForClientRunId = useRef<string | null>(null);
+  const onboardingCodeRef = useRef(onboardingCode);
 
   const initializeRun = (nextClientRunId: string, nextOnboardingCode: string) =>
     fetchMutation<InitializedAgenticProgressRun>({
@@ -42,23 +42,29 @@ export function useAgenticProgressInit({enabled}: UseAgenticProgressInitOptions)
       },
     });
 
-  const mutation = useMutation({
-    mutationFn: async () => {
+  // A conflicting onboarding code is replaced without changing the run's cache identity.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
+  const query = useQuery({
+    queryKey: ['agentic-progress-init', organization.slug, clientRunId],
+    queryFn: async () => {
       try {
-        return await initializeRun(clientRunId, onboardingCode);
+        return await initializeRun(clientRunId, onboardingCodeRef.current);
       } catch (error) {
         if (!(error instanceof RequestError) || error.status !== 409) {
           throw error;
         }
 
         const replacementOnboardingCode = createOnboardingCode();
+        onboardingCodeRef.current = replacementOnboardingCode;
         setAgenticProgressOnboardingCode(replacementOnboardingCode);
 
         return initializeRun(clientRunId, replacementOnboardingCode);
       }
     },
+    enabled,
+    retry: false,
+    staleTime: Infinity,
   });
-  const {mutate} = mutation;
 
   useEffect(() => {
     if (!agenticProgressClientRunId) {
@@ -77,19 +83,5 @@ export function useAgenticProgressInit({enabled}: UseAgenticProgressInitOptions)
     setAgenticProgressOnboardingCode,
   ]);
 
-  useEffect(() => {
-    if (!enabled) {
-      startedForClientRunId.current = null;
-      return;
-    }
-
-    if (startedForClientRunId.current === clientRunId) {
-      return;
-    }
-
-    startedForClientRunId.current = clientRunId;
-    mutate();
-  }, [clientRunId, enabled, mutate]);
-
-  return mutation;
+  return query;
 }

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -22,6 +22,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useAgenticProgressInit} from 'sentry/views/onboarding/agenticProgress/useAgenticProgressInit';
 import {GenericFooter} from 'sentry/views/onboarding/components/genericFooter';
 import {
   NewWelcomeProductCard,
@@ -129,6 +130,8 @@ export function NewWelcomeUI(props: StepProps) {
   });
   const hasAgenticSetup = organization.features.includes('onboarding-agentic-setup');
   const [showAgentSetup, setShowAgentSetup] = useState(false);
+
+  useAgenticProgressInit({enabled: hasScmOnboarding && hasAgenticSetup});
 
   useWelcomeAnalyticsEffect();
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -121,7 +121,9 @@ describe('Onboarding', () => {
       );
 
       await waitFor(() => {
-        expect(sessionStorage.getItem('onboarding')).toBeNull();
+        expect(
+          JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')
+        ).not.toHaveProperty('selectedPlatform');
       });
 
       expect(
@@ -570,6 +572,8 @@ describe('Onboarding', () => {
       channelName: '#alerts',
     } as const satisfies ScmMessagingSetup;
 
+    let agenticRunRequestMock: ReturnType<typeof MockApiClient.addMockResponse>;
+
     beforeEach(() => {
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/config/integrations/`,
@@ -587,6 +591,11 @@ describe('Onboarding', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/projects/`,
         body: [],
+      });
+      agenticRunRequestMock = MockApiClient.addMockResponse({
+        url: `/organizations/${scmOrganization.slug}/onboarding/agent/runs/`,
+        method: 'POST',
+        body: {},
       });
     });
 
@@ -697,6 +706,12 @@ describe('Onboarding', () => {
       );
     });
 
+    it('preloads agent setup while the welcome screen is visible', async () => {
+      renderOnboarding('welcome');
+
+      await waitFor(() => expect(agenticRunRequestMock).toHaveBeenCalledTimes(1));
+    });
+
     it('fires scm_welcome_step_viewed on welcome mount and not the legacy event', () => {
       renderOnboarding('welcome');
 
@@ -710,7 +725,7 @@ describe('Onboarding', () => {
       );
     });
 
-    it('clears the whole session when returning to the welcome step', async () => {
+    it('clears prior setup state when returning to the welcome step', async () => {
       // Returning to welcome restarts the flow, so nothing is carried over —
       // including messagingSetup, which only has to survive local repository
       // and platform changes.
@@ -734,7 +749,10 @@ describe('Onboarding', () => {
       renderOnboarding('welcome');
 
       await waitFor(() => {
-        expect(sessionStorage.getItem('onboarding')).toBeNull();
+        expect(JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')).toEqual({
+          agenticProgressClientRunId: expect.any(String),
+          agenticProgressOnboardingCode: expect.any(String),
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

Agentic setup currently starts run initialization only after the user opens the setup interstitial, leaving that screen blocked on a loading state.

This change starts initialization on the welcome screen and stores it in the TanStack Query cache by organization and client run ID. The setup interstitial reuses the same result without issuing a duplicate request. Conflicting onboarding codes are still replaced within the same run cache identity.

## Testing

Verified by cherry-picking this commit onto current `origin/master`, then running:

- `node scripts/test.js static/app/views/onboarding/agenticProgress/useAgenticProgressInit.spec.tsx static/app/views/onboarding/onboarding.spec.tsx --runInBand`
- `node_modules/.bin/knip`
- `node_modules/.bin/knip --production --exclude dependencies`