### PR TITLE
feat(investigations): Support all metric detector types

### DIFF
--- a/src/sentry/investigations/services/breached_metrics.py
+++ b/src/sentry/investigations/services/breached_metrics.py
@@ -18,6 +18,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.workflow_engine.models import DataCondition, DataSourceDetector, DetectorGroup
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 MAX_BREACH_WINDOW = timedelta(days=45)
 
@@ -62,7 +63,11 @@ def _direction(conditions: list[dict[str, Any]]) -> str:
             AlertRuleThresholdType.BELOW.value: "below",
             AlertRuleThresholdType.ABOVE_AND_BELOW.value: "both",
         }.get(threshold_type, "comparison")
-    condition_types = {condition["type"] for condition in conditions}
+    condition_types = {
+        condition["type"]
+        for condition in conditions
+        if condition["result"] != DetectorPriorityLevel.OK
+    }
     if condition_types & {Condition.GREATER, Condition.GREATER_OR_EQUAL}:
         return "above"
     if condition_types & {Condition.LESS, Condition.LESS_OR_EQUAL}:
@@ -82,10 +87,13 @@ def _condition_snapshot(
         condition.comparison, (int, float)
     ):
         return snapshot
-    if condition.type in {Condition.GREATER, Condition.GREATER_OR_EQUAL}:
-        snapshot["thresholdChangePercent"] = float(condition.comparison) - 100
-    elif condition.type in {Condition.LESS, Condition.LESS_OR_EQUAL}:
-        snapshot["thresholdChangePercent"] = 100 - float(condition.comparison)
+    if condition.type in {
+        Condition.GREATER,
+        Condition.GREATER_OR_EQUAL,
+        Condition.LESS,
+        Condition.LESS_OR_EQUAL,
+    }:
+        snapshot["thresholdChangePercent"] = abs(float(condition.comparison) - 100)
     return snapshot
 
 
@@ -185,6 +193,11 @@ def resolve_breached_metric_sources(
             detection_type = AlertRuleDetectionType(detector.config.get("detection_type"))
         except (TypeError, ValueError):
             continue
+        if (
+            detection_type == AlertRuleDetectionType.STATIC
+            and detector.config.get("comparison_delta") is not None
+        ):
+            detection_type = AlertRuleDetectionType.PERCENT
         data_source_link = data_source_links.get(detector.id)
         if data_source_link is None:
             continue

--- a/src/sentry/investigations/services/breached_metrics.py
+++ b/src/sentry/investigations/services/breached_metrics.py
@@ -9,14 +9,14 @@ from django.utils import timezone
 
 from sentry.constants import ObjectStatus
 from sentry.incidents.grouptype import MetricIssue
-from sentry.incidents.models.alert_rule import AlertRuleDetectionType
+from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.models.group import Group
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
-from sentry.workflow_engine.models import DataSourceDetector, DetectorGroup
+from sentry.workflow_engine.models import DataCondition, DataSourceDetector, DetectorGroup
 from sentry.workflow_engine.models.data_condition import Condition
 
 MAX_BREACH_WINDOW = timedelta(days=45)
@@ -49,12 +49,44 @@ def _code_mode_dataset(
 
 
 def _direction(conditions: list[dict[str, Any]]) -> str:
+    anomaly_condition = next(
+        (condition for condition in conditions if condition["type"] == Condition.ANOMALY_DETECTION),
+        None,
+    )
+    if anomaly_condition is not None and isinstance(anomaly_condition["comparison"], dict):
+        threshold_type = anomaly_condition["comparison"].get("threshold_type")
+        if not isinstance(threshold_type, int):
+            return "comparison"
+        return {
+            AlertRuleThresholdType.ABOVE.value: "above",
+            AlertRuleThresholdType.BELOW.value: "below",
+            AlertRuleThresholdType.ABOVE_AND_BELOW.value: "both",
+        }.get(threshold_type, "comparison")
     condition_types = {condition["type"] for condition in conditions}
     if condition_types & {Condition.GREATER, Condition.GREATER_OR_EQUAL}:
         return "above"
     if condition_types & {Condition.LESS, Condition.LESS_OR_EQUAL}:
         return "below"
     return "comparison"
+
+
+def _condition_snapshot(
+    condition: DataCondition, detection_type: AlertRuleDetectionType
+) -> dict[str, Any]:
+    snapshot = {
+        "type": condition.type,
+        "comparison": condition.comparison,
+        "result": condition.condition_result,
+    }
+    if detection_type != AlertRuleDetectionType.PERCENT or not isinstance(
+        condition.comparison, (int, float)
+    ):
+        return snapshot
+    if condition.type in {Condition.GREATER, Condition.GREATER_OR_EQUAL}:
+        snapshot["thresholdChangePercent"] = float(condition.comparison) - 100
+    elif condition.type in {Condition.LESS, Condition.LESS_OR_EQUAL}:
+        snapshot["thresholdChangePercent"] = 100 - float(condition.comparison)
+    return snapshot
 
 
 def _analysis_window(open_period: GroupOpenPeriod, now: datetime) -> dict[str, str]:
@@ -147,11 +179,11 @@ def resolve_breached_metric_sources(
         ):
             continue
         detector = detector_group.detector
-        if (
-            detector.type != "metric_issue"
-            or detector.project_id != group.project_id
-            or detector.config.get("detection_type") != AlertRuleDetectionType.STATIC
-        ):
+        if detector.type != "metric_issue" or detector.project_id != group.project_id:
+            continue
+        try:
+            detection_type = AlertRuleDetectionType(detector.config.get("detection_type"))
+        except (TypeError, ValueError):
             continue
         data_source_link = data_source_links.get(detector.id)
         if data_source_link is None:
@@ -175,11 +207,7 @@ def resolve_breached_metric_sources(
         if condition_group is None:
             continue
         conditions = [
-            {
-                "type": condition.type,
-                "comparison": condition.comparison,
-                "result": condition.condition_result,
-            }
+            _condition_snapshot(condition, detection_type)
             for condition in condition_group.conditions.all()
         ]
         if not conditions:
@@ -196,6 +224,7 @@ def resolve_breached_metric_sources(
                 "aggregate": snuba_query.aggregate,
                 "groupBy": snuba_query.group_by or [],
                 "timeWindowSeconds": snuba_query.time_window,
+                "detectionType": detection_type.value,
                 "comparisonDeltaSeconds": detector.config.get("comparison_delta"),
                 "direction": _direction(conditions),
                 "conditions": conditions,

--- a/src/sentry/investigations/templates/breached_metric.py
+++ b/src/sentry/investigations/templates/breached_metric.py
@@ -24,9 +24,12 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
             title="Monitor context",
             generation_prompt=(
                 "Summarize only the Monitor details evidence for a human responder. State the "
-                "monitor name and query, affected project and environment when known, threshold "
-                "and breach direction, and supplied open-period time range. Do not speculate about "
-                "the cause. " + SHORT_LINKED_SUMMARY_INSTRUCTIONS
+                "monitor name and query, affected project and environment when known, detection "
+                "type, breach criteria and direction, and supplied open-period time range. For a "
+                "static monitor, report its fixed threshold. For a percent monitor, report the "
+                "percentage-change threshold and comparison period. For a dynamic monitor, report "
+                "its sensitivity, seasonality, and anomaly direction without describing a fixed "
+                "threshold. Do not speculate about the cause. " + SHORT_LINKED_SUMMARY_INSTRUCTIONS
             ),
             config={"autoRun": True},
             display={"type": "markdown"},
@@ -38,11 +41,15 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
             title="Monitor details",
             generation_prompt=(
                 "Use the supplied metric issue, monitor definition, project, open-period window, "
-                "threshold, and direction. Query the exact supplied monitor definition over the "
-                "open period and an equal pre-breach baseline. Return a compact table of the "
-                "monitor facts and the most useful baseline and open-period values. Preserve the "
-                "exact query and time range; do not infer missing monitor configuration. "
-                + LINKED_EVIDENCE_INSTRUCTIONS
+                "detection type, conditions, and direction. Query the exact supplied monitor "
+                "definition over the open period and an equal pre-breach baseline. Return a compact "
+                "table of the monitor facts and the most useful baseline and open-period values. "
+                "For static detection, use the fixed condition threshold. For percent detection, "
+                "use thresholdChangePercent and comparisonDeltaSeconds rather than treating the "
+                "internal condition comparison as a raw metric threshold. For dynamic detection, "
+                "use the supplied sensitivity, seasonality, and anomaly direction; do not claim it "
+                "has a fixed numeric threshold. Preserve the exact query and time range, and do not "
+                "infer missing monitor configuration. " + LINKED_EVIDENCE_INSTRUCTIONS
             ),
             config={"autoRun": True},
             display={"version": 1, "type": "table", "defaultView": "table"},
@@ -52,10 +59,11 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
             kind=InvestigationBlockKind.TEXT,
             title="What happened",
             generation_prompt=(
-                "Summarize only the Metric spike evidence. Describe when the ramp-up began, the "
-                "peak value and time, how long the breach lasted, and whether the signal recovered "
-                "or remained elevated. State uncertainty when sparse telemetry does not establish "
-                "one of those facts. " + SHORT_LINKED_SUMMARY_INSTRUCTIONS
+                "Summarize only the Metric change evidence. Describe when the deviation began, its "
+                "largest observed value or deviation and time, how long the breach lasted, and "
+                "whether the signal recovered. Describe whether the change was upward, downward, "
+                "or outside a dynamic expected range. State uncertainty when sparse telemetry does "
+                "not establish one of those facts. " + SHORT_LINKED_SUMMARY_INSTRUCTIONS
             ),
             config={"autoRun": True},
             display={"type": "markdown"},
@@ -64,13 +72,17 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
         TemplateBlockSpec(
             key="spike_evidence",
             kind=InvestigationBlockKind.QUERY,
-            title="Metric spike",
+            title="Metric change",
             generation_prompt=(
                 "Query the exact supplied monitor definition over the supplied open period and an "
-                "equal pre-breach baseline. Make the ramp-up, peak, and ramp-down or recovery "
-                "visible in a time-series chart. Plot the observed metric and supplied threshold "
-                "or comparison as separate series so the crossing is clear. Use the monitor time "
-                "window for the chart interval when supported, and do not invent missing points. "
+                "equal pre-breach baseline. Make the onset, largest deviation, and recovery visible "
+                "in a time-series chart. For static detection, plot the observed metric and fixed "
+                "threshold. For percent detection, compare the observed metric with the specified "
+                "historical period and show the percentage-change boundary. For dynamic detection, "
+                "plot modeled expected bounds only when the available telemetry supplies them; "
+                "otherwise plot the observed metric and state that modeled bounds are unavailable. "
+                "Never invent a fixed threshold or expected range. Use the monitor time window for "
+                "the chart interval when supported, and do not invent missing points. "
                 + LINKED_EVIDENCE_INSTRUCTIONS
             ),
             config={"autoRun": True, "preferChart": True},
@@ -80,11 +92,11 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
         TemplateBlockSpec(
             key="issues_summary",
             kind=InvestigationBlockKind.TEXT,
-            title="What caused the spike",
+            title="What contributed to the change",
             generation_prompt=(
                 "Summarize only the Contributing issues evidence. Identify the issue groups that "
-                "best account for the spike, including their counts, change from baseline, and "
-                "relative contribution when available. If no issue groups convincingly explain "
+                "best account for the metric change, including their counts, change from baseline, "
+                "and relative contribution when available. If no issue groups convincingly explain "
                 "the metric change, say that clearly. " + SHORT_LINKED_SUMMARY_INSTRUCTIONS
             ),
             config={"autoRun": True},
@@ -96,13 +108,13 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
             kind=InvestigationBlockKind.QUERY,
             title="Contributing issues",
             generation_prompt=(
-                "Using the Metric spike evidence to preserve the spike window, compare issue-group "
-                "telemetry during the open period with the equal pre-breach baseline. Rank issue "
-                "groups by the strongest supported contribution using absolute counts, change "
-                "from baseline, and share of the spike. Prefer a bar chart with a compact table "
-                "when useful, and include issue links only when the telemetry provides valid ones. "
-                "Treat no supporting issue groups as a valid result; never fabricate attribution. "
-                + LINKED_EVIDENCE_INSTRUCTIONS
+                "Using the Metric change evidence to preserve the breach window, compare "
+                "issue-group telemetry during the open period with the equal pre-breach baseline. "
+                "Rank issue groups by the strongest supported contribution using absolute counts, "
+                "change from baseline, and share of the metric change. Prefer a bar chart with a "
+                "compact table when useful, and include issue links only when the telemetry provides "
+                "valid ones. Treat no supporting issue groups as a valid result; never fabricate "
+                "attribution. " + LINKED_EVIDENCE_INSTRUCTIONS
             ),
             config={"autoRun": True, "preferChart": True},
             display={"version": 1, "type": "table", "defaultView": "chart"},
@@ -111,10 +123,10 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
         TemplateBlockSpec(
             key="tags_summary",
             kind=InvestigationBlockKind.TEXT,
-            title="Why those issues spiked",
+            title="Why the metric changed",
             generation_prompt=(
                 "Summarize only the Issue tag changes evidence. Explain which dimensions changed "
-                "most during the spike and what explanation, if any, those distribution changes "
+                "most during the breach and what explanation, if any, those distribution changes "
                 "support. Distinguish evidence from hypotheses and say when the slices do not "
                 "establish a convincing explanation. " + SHORT_LINKED_SUMMARY_INSTRUCTIONS
             ),
@@ -130,7 +142,7 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
                 "Slice the contributing issue groups by supported dimensions that can explain the "
                 "change, such as release, transaction, environment, region, browser, device, or "
                 "other useful tags. Compare each distribution during the open period with the "
-                "equal pre-breach baseline; do not rank raw spike volume without that comparison. "
+                "equal pre-breach baseline; do not rank raw breach volume without that comparison. "
                 "Chart the strongest supported distribution changes and retain a compact table "
                 "when useful. Do not invent unavailable tags or claim causation from correlation. "
                 + LINKED_EVIDENCE_INSTRUCTIONS
@@ -159,7 +171,7 @@ BREACHED_METRIC_TEMPLATE = InvestigationTemplateSpec(
             kind=InvestigationBlockKind.QUERY,
             title="Release and infrastructure signals",
             generation_prompt=(
-                "Use the supplied spike window together with the contributing issue and tag "
+                "Use the supplied breach window together with the contributing issue and tag "
                 "evidence. Check supported Sentry telemetry for releases, deployments, affected "
                 "services or transactions, and infrastructure-like patterns correlated with the "
                 "change. Return a compact evidence table containing only observed signals and "

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
@@ -24,6 +24,7 @@ from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscrip
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 FEATURE = "organizations:investigations"
 
@@ -78,8 +79,20 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
             condition_group=condition_group,
             type=condition_type,
             comparison=condition_comparison,
-            condition_result=2,
+            condition_result=DetectorPriorityLevel.HIGH,
         )
+        if condition_type != Condition.ANOMALY_DETECTION:
+            resolve_condition_type = (
+                Condition.LESS_OR_EQUAL
+                if condition_type in {Condition.GREATER, Condition.GREATER_OR_EQUAL}
+                else Condition.GREATER_OR_EQUAL
+            )
+            self.create_data_condition(
+                condition_group=condition_group,
+                type=resolve_condition_type,
+                comparison=condition_comparison,
+                condition_result=DetectorPriorityLevel.OK,
+            )
         detector = self.create_detector(
             project=self.project,
             type=MetricIssue.slug,
@@ -186,10 +199,86 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
             {
                 "type": Condition.GREATER,
                 "comparison": 150,
-                "result": 2,
+                "result": DetectorPriorityLevel.HIGH,
                 "thresholdChangePercent": 50.0,
-            }
+            },
+            {
+                "type": Condition.LESS_OR_EQUAL,
+                "comparison": 150,
+                "result": DetectorPriorityLevel.OK,
+                "thresholdChangePercent": 50.0,
+            },
         ]
+        schedule_auto_run.assert_called_once()
+
+    @mock.patch(
+        "sentry.investigations.endpoints.organization_investigation_index.schedule_eligible_auto_run_blocks"
+    )
+    def test_below_percent_detector_snapshot(self, schedule_auto_run: mock.Mock) -> None:
+        group, open_period = self.create_metric_open_period(
+            detection_type=AlertRuleDetectionType.PERCENT,
+            condition_type=Condition.LESS,
+            condition_comparison=60,
+            comparison_delta=86_400,
+        )
+        source = {
+            "type": "metric_open_period",
+            "ref": {"groupId": str(group.id), "openPeriodId": str(open_period.id)},
+        }
+
+        launched = self.client.post(
+            self.collection_url,
+            {"templateKey": "breached_metric", "templateVersion": 1, "source": source},
+            format="json",
+        )
+
+        assert launched.status_code == 201
+        monitor = launched.data["source"]["snapshot"]["monitor"]
+        assert monitor["detectionType"] == "percent"
+        assert monitor["direction"] == "below"
+        assert monitor["conditions"] == [
+            {
+                "type": Condition.LESS,
+                "comparison": 60,
+                "result": DetectorPriorityLevel.HIGH,
+                "thresholdChangePercent": 40.0,
+            },
+            {
+                "type": Condition.GREATER_OR_EQUAL,
+                "comparison": 60,
+                "result": DetectorPriorityLevel.OK,
+                "thresholdChangePercent": 40.0,
+            },
+        ]
+        schedule_auto_run.assert_called_once()
+
+    @mock.patch(
+        "sentry.investigations.endpoints.organization_investigation_index.schedule_eligible_auto_run_blocks"
+    )
+    def test_migrated_percent_detector_snapshot(self, schedule_auto_run: mock.Mock) -> None:
+        group, open_period = self.create_metric_open_period(
+            detection_type=AlertRuleDetectionType.STATIC,
+            condition_comparison=150,
+            comparison_delta=86_400,
+        )
+        source = {
+            "type": "metric_open_period",
+            "ref": {"groupId": str(group.id), "openPeriodId": str(open_period.id)},
+        }
+
+        launched = self.client.post(
+            self.collection_url,
+            {"templateKey": "breached_metric", "templateVersion": 1, "source": source},
+            format="json",
+        )
+
+        assert launched.status_code == 201
+        monitor = launched.data["source"]["snapshot"]["monitor"]
+        assert monitor["detectionType"] == "percent"
+        assert monitor["comparisonDeltaSeconds"] == 86_400
+        assert all(
+            condition["thresholdChangePercent"] == 50.0 for condition in monitor["conditions"]
+        )
         schedule_auto_run.assert_called_once()
 
     @mock.patch(
@@ -237,7 +326,7 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
             {
                 "type": Condition.ANOMALY_DETECTION,
                 "comparison": comparison,
-                "result": 2,
+                "result": DetectorPriorityLevel.HIGH,
             }
         ]
         schedule_auto_run.assert_called_once()

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
@@ -13,6 +13,11 @@ from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.investigations.models import Investigation, InvestigationSourceType
 from sentry.investigations.services import investigation_legacy_source_key
 from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.seer.anomaly_detection.types import (
+    AnomalyDetectionSeasonality,
+    AnomalyDetectionSensitivity,
+    AnomalyDetectionThresholdType,
+)
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
@@ -37,7 +42,14 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    def create_metric_open_period(self) -> tuple[Any, GroupOpenPeriod]:
+    def create_metric_open_period(
+        self,
+        *,
+        detection_type: AlertRuleDetectionType = AlertRuleDetectionType.STATIC,
+        condition_type: str = Condition.GREATER,
+        condition_comparison: Any = 100,
+        comparison_delta: int | None = None,
+    ) -> tuple[Any, GroupOpenPeriod]:
         group = self.create_group(
             project=self.project,
             type=MetricIssue.type_id,
@@ -64,14 +76,17 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         condition_group = self.create_data_condition_group(organization=self.organization)
         self.create_data_condition(
             condition_group=condition_group,
-            type=Condition.GREATER,
-            comparison=100,
+            type=condition_type,
+            comparison=condition_comparison,
             condition_result=2,
         )
         detector = self.create_detector(
             project=self.project,
             type=MetricIssue.slug,
-            config={"detection_type": AlertRuleDetectionType.STATIC.value},
+            config={
+                "detection_type": detection_type.value,
+                "comparison_delta": comparison_delta,
+            },
             workflow_condition_group=condition_group,
             name="Checkout errors",
         )
@@ -112,6 +127,7 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         assert launched.status_code == 201, launched.data
         assert launched.data["source"]["ref"] == source["ref"]
         assert launched.data["source"]["snapshot"]["analysisWindow"]["end"] == ended_at.isoformat()
+        assert launched.data["source"]["snapshot"]["monitor"]["detectionType"] == "static"
         assert launched.data["filters"] == {}
         investigation = Investigation.objects.get(id=launched.data["id"])
         assert investigation.source_type == InvestigationSourceType.BREACHED_METRIC
@@ -129,6 +145,102 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         assert response.data == {
             "items": [{"status": "view", "investigationId": launched.data["id"]}]
         }
+
+    @mock.patch(
+        "sentry.investigations.endpoints.organization_investigation_index.schedule_eligible_auto_run_blocks"
+    )
+    def test_percent_detector_is_available(self, schedule_auto_run: mock.Mock) -> None:
+        group, open_period = self.create_metric_open_period(
+            detection_type=AlertRuleDetectionType.PERCENT,
+            condition_comparison=150,
+            comparison_delta=86_400,
+        )
+        source = {
+            "type": "metric_open_period",
+            "ref": {"groupId": str(group.id), "openPeriodId": str(open_period.id)},
+        }
+
+        candidate = self.client.post(
+            self.candidates_url,
+            {
+                "templateKey": "breached_metric",
+                "templateVersion": 1,
+                "sources": [source],
+            },
+            format="json",
+        )
+        assert candidate.status_code == 200
+        assert candidate.data == {"items": [{"status": "investigate"}]}
+
+        launched = self.client.post(
+            self.collection_url,
+            {"templateKey": "breached_metric", "templateVersion": 1, "source": source},
+            format="json",
+        )
+        assert launched.status_code == 201
+        monitor = launched.data["source"]["snapshot"]["monitor"]
+        assert monitor["detectionType"] == "percent"
+        assert monitor["comparisonDeltaSeconds"] == 86_400
+        assert monitor["direction"] == "above"
+        assert monitor["conditions"] == [
+            {
+                "type": Condition.GREATER,
+                "comparison": 150,
+                "result": 2,
+                "thresholdChangePercent": 50.0,
+            }
+        ]
+        schedule_auto_run.assert_called_once()
+
+    @mock.patch(
+        "sentry.investigations.endpoints.organization_investigation_index.schedule_eligible_auto_run_blocks"
+    )
+    def test_dynamic_detector_is_available(self, schedule_auto_run: mock.Mock) -> None:
+        comparison = {
+            "sensitivity": AnomalyDetectionSensitivity.HIGH,
+            "seasonality": AnomalyDetectionSeasonality.AUTO,
+            "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
+        }
+        group, open_period = self.create_metric_open_period(
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+            condition_type=Condition.ANOMALY_DETECTION,
+            condition_comparison=comparison,
+        )
+        source = {
+            "type": "metric_open_period",
+            "ref": {"groupId": str(group.id), "openPeriodId": str(open_period.id)},
+        }
+
+        candidate = self.client.post(
+            self.candidates_url,
+            {
+                "templateKey": "breached_metric",
+                "templateVersion": 1,
+                "sources": [source],
+            },
+            format="json",
+        )
+        assert candidate.status_code == 200
+        assert candidate.data == {"items": [{"status": "investigate"}]}
+
+        launched = self.client.post(
+            self.collection_url,
+            {"templateKey": "breached_metric", "templateVersion": 1, "source": source},
+            format="json",
+        )
+        assert launched.status_code == 201
+        monitor = launched.data["source"]["snapshot"]["monitor"]
+        assert monitor["detectionType"] == "dynamic"
+        assert monitor["comparisonDeltaSeconds"] is None
+        assert monitor["direction"] == "both"
+        assert monitor["conditions"] == [
+            {
+                "type": Condition.ANOMALY_DETECTION,
+                "comparison": comparison,
+                "result": 2,
+            }
+        ]
+        schedule_auto_run.assert_called_once()
 
     def test_inaccessible_source_is_unavailable(self) -> None:
         other_organization = self.create_organization()


### PR DESCRIPTION
Breached-metric investigations can now launch for static, percent-change, and dynamic metric detectors. Source snapshots identify the detection type, expose normalized percentage-change thresholds, and translate anomaly directions so investigation cells receive the detector semantics they need.

The existing `breached_metric` v1 block graph remains unchanged, while its prompts now describe generic metric changes and select the correct fixed-threshold, historical-comparison, or modeled-range behavior. Existing investigations keep their persisted prompts and blocks; this only changes newly created investigations and requires no migration or frontend update.
