### PR TITLE
feat(autofix): Require nightshift for autofix-should-run-repo-checks

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -583,8 +583,9 @@ def trigger_autofix_agent(
 
     # If autofix-should-run-repo-checks is enabled,
     # we should force bash tools on as it is dependent on bash tools
-    enable_bash_tools = enable_bash_tools or features.has(
-        "organizations:autofix-should-run-repo-checks", group.organization
+    enable_bash_tools = enable_bash_tools or (
+        referrer == AutofixReferrer.NIGHT_SHIFT
+        and features.has("organizations:autofix-should-run-repo-checks", group.organization)
     )
 
     client = get_autofix_agent_client(


### PR DESCRIPTION
Require that nightshift is the referrer for autofix-should-run-repo-checks. The manual flow should set the enable_bash_tools directly.