### PR TITLE
feat(onboarding): Use dashed icon for pending agent stages

### DIFF
--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -13,6 +13,7 @@ import {
   IconBot,
   IconCircle,
   IconCircleCheckmark,
+  IconCircleDashed,
   IconFatal,
   IconNot,
   IconPieHalf,
@@ -83,7 +84,7 @@ function StageSymbol({status}: {status: AgenticProgressStageStatus | null}) {
     return <ActiveLoadingIndicator mini />;
   }
 
-  return <IconCircle size="md" variant="muted" />;
+  return <IconCircleDashed size="md" variant="muted" />;
 }
 
 const ActiveLoadingIndicator = styled(LoadingIndicator)`


### PR DESCRIPTION
## Summary

Uses the dashed circle status icon for agentic onboarding stages that have not started yet, visually distinguishing pending work from completed and active stages.

## Testing

- `.venv/bin/prek run -q --files static/app/views/onboarding/agenticProgress/agenticProgressList.tsx`
- `node scripts/test.js static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx --runInBand`