### PR TITLE
perf(tasks): Filter GAL options in indexed query

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -635,12 +635,13 @@ def backfill_group_action_log_for_all_projects(
     project_options = list(
         ProjectOption.objects.filter(
             key=GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION,
+            value=False,
             id__gt=last_project_option_id,
         )
         .order_by("id")
-        .values_list("id", "project_id", "value")[:batch_size]
+        .values_list("id", "project_id")[:batch_size]
     )
-    incomplete_option_count = sum(value is False for _, _, value in project_options)
+    incomplete_option_count = len(project_options)
     logger.info(
         "backfill_group_action_log.coordinator.query_completed",
         extra={
@@ -662,9 +663,7 @@ def backfill_group_action_log_for_all_projects(
         extra={"project_count": incomplete_option_count},
     )
     dispatched_project_count = 0
-    for _, project_id, value in project_options:
-        if value is not False:
-            continue
+    for _, project_id in project_options:
         backfill_group_action_log_for_project.apply_async(
             kwargs={
                 "project_id": project_id,

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -740,16 +740,16 @@ class BackfillGroupActionLogForAllProjectsTest(TestCase):
         assert project_without_option.get_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION) is None
         mock_coordinator_apply.assert_not_called()
 
-    def test_complete_options_still_advance_cursor(self) -> None:
+    def test_complete_options_are_filtered_before_pagination(self) -> None:
         complete_project_1 = self.create_project(organization=self.organization)
         complete_project_2 = self.create_project(organization=self.organization)
         incomplete_project = self.create_project(organization=self.organization)
         self._set_backfill_complete(complete_project_1, True)
-        complete_option_2 = self._set_backfill_complete(complete_project_2, True)
-        self._set_backfill_complete(incomplete_project, False)
+        self._set_backfill_complete(complete_project_2, True)
+        incomplete_option = self._set_backfill_complete(incomplete_project, False)
 
         with (
-            override_options({"issues.backfill_group_action_log.coordinator_batch_size": 2}),
+            override_options({"issues.backfill_group_action_log.coordinator_batch_size": 1}),
             patch.object(
                 backfill_group_action_log_for_project, "apply_async"
             ) as mock_project_apply,
@@ -759,9 +759,9 @@ class BackfillGroupActionLogForAllProjectsTest(TestCase):
         ):
             backfill_group_action_log_for_all_projects()
 
-        mock_project_apply.assert_not_called()
+        assert mock_project_apply.call_args.kwargs["kwargs"]["project_id"] == incomplete_project.id
         assert mock_coordinator_apply.call_args.kwargs["kwargs"]["last_project_option_id"] == (
-            complete_option_2.id
+            incomplete_option.id
         )
 
     def test_logs_coordinator_phases(self) -> None:


### PR DESCRIPTION
The group action log coordinator now filters `ProjectOption.value=False` in PostgreSQL before applying its batch limit. Each returned row is actionable, so completed options no longer consume coordinator batches or require in-memory filtering.

This query is supported by the partial `(value, id)` index added in #122782. Its post-deployment migration must be run and validated in production before this change deploys.
