### PR TITLE
fix(control) Move integration reads to replicas

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -201,3 +201,9 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "integration_service.get_integration.using_replica",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -18,7 +18,7 @@ from django.forms import ValidationError
 from django.utils import timezone as django_timezone
 from snuba_sdk import Column, Condition, Limit, Op
 
-from sentry import analytics, audit_log, features, quotas
+from sentry import analytics, audit_log, features, options, quotas
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.auth.access import SystemAccess
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, ObjectStatus
@@ -1611,7 +1611,9 @@ def _get_alert_rule_trigger_action_discord_channel_id(name: str, integration_id:
     from sentry.integrations.discord.utils.channel import validate_channel_id
 
     integration = integration_service.get_integration(
-        integration_id=integration_id, status=ObjectStatus.ACTIVE
+        integration_id=integration_id,
+        status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if integration is None:
         raise InvalidTriggerActionError("Discord integration not found.")

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -7,6 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -107,7 +108,8 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     def validate_default_branch(self, default_branch):
         # Get the integration to check if it's Perforce
         integration = integration_service.get_integration(
-            integration_id=self.org_integration.integration_id
+            integration_id=self.org_integration.integration_id,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
 
         # For Perforce, allow empty branch (streams are part of depot path)

--- a/src/sentry/integrations/api/serializers/models/external_issue.py
+++ b/src/sentry/integrations/api/serializers/models/external_issue.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
 
+from sentry import options
 from sentry.api.serializers import register
 from sentry.api.serializers.base import Serializer
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -26,7 +27,10 @@ class ExternalIssueSerializer(Serializer):
         result = {}
         for item in item_list:
             # Get the integration (e.g. Jira, GitHub, etc) associated with that issue
-            integration = integration_service.get_integration(integration_id=item.integration_id)
+            integration = integration_service.get_integration(
+                integration_id=item.integration_id,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
+            )
             if integration is None:
                 continue
             installation = integration.get_installation(organization_id=item.organization.id)

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -14,6 +14,7 @@ from django.http import Http404, HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
@@ -246,7 +247,10 @@ class BitbucketWebhookEndpoint(Endpoint):
         except Repository.DoesNotExist:
             raise Http404()
 
-        integration = integration_service.get_integration(integration_id=repo.integration_id)
+        integration = integration_service.get_integration(
+            integration_id=repo.integration_id,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
+        )
         if integration and "webhook_secret" in integration.metadata:
             secret = integration.metadata["webhook_secret"]
             try:

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -103,6 +103,7 @@ def get_installation_metadata(event, host):
         external_id=external_id,
         provider=IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
         status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if integration is None:
         metrics.incr("integrations.github_enterprise.does_not_exist")

--- a/src/sentry/integrations/gitlab/tasks.py
+++ b/src/sentry/integrations/gitlab/tasks.py
@@ -6,6 +6,7 @@ import logging
 from rest_framework import status
 from taskbroker_client.retry import Retry
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_WEBHOOK_VERSION_KEY
 from sentry.integrations.gitlab.metrics import (
@@ -50,7 +51,9 @@ def update_project_webhook(integration_id: int, organization_id: int, repository
     This task is spawned by update_all_project_webhooks for each repository.
     """
     integration = integration_service.get_integration(
-        integration_id=integration_id, status=ObjectStatus.ACTIVE
+        integration_id=integration_id,
+        status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if not integration:
         logger.warning(
@@ -135,7 +138,9 @@ def update_all_project_webhooks(integration_id: int, organization_id: int) -> No
     This is triggered when sync settings are changed to ensure all webhooks have the correct permissions.
     """
     integration = integration_service.get_integration(
-        integration_id=integration_id, status=ObjectStatus.ACTIVE
+        integration_id=integration_id,
+        status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if not integration:
         logger.warning(

--- a/src/sentry/integrations/jira/actions/form.py
+++ b/src/sentry/integrations/jira/actions/form.py
@@ -5,6 +5,7 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from sentry import options
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import IntegrationNotifyServiceForm
@@ -19,9 +20,10 @@ class JiraNotifyServiceForm(IntegrationNotifyServiceForm):
             return None
 
         integration_id = cleaned_data.get("integration")
-        # TODO(mark) Add using_replica here
         integration = integration_service.get_integration(
-            integration_id=integration_id, provider=self.provider
+            integration_id=integration_id,
+            provider=self.provider,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
 
         if not integration:

--- a/src/sentry/integrations/jira_server/actions/form.py
+++ b/src/sentry/integrations/jira_server/actions/form.py
@@ -5,6 +5,7 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from sentry import options
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import IntegrationNotifyServiceForm
@@ -18,7 +19,9 @@ class JiraServerNotifyServiceForm(IntegrationNotifyServiceForm):
 
         integration_id = cleaned_data.get("integration")
         integration = integration_service.get_integration(
-            integration_id=integration_id, provider=self.provider
+            integration_id=integration_id,
+            provider=self.provider,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
 
         if not integration:

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -8,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
@@ -44,7 +45,9 @@ def get_integration_from_token(token: str | None) -> RpcIntegration:
     # (provider, external_id) unique index, so an external_id-only lookup does a
     # sequential scan of the whole table on every inbound Jira Server webhook.
     integration = integration_service.get_integration(
-        provider=IntegrationProviderSlug.JIRA_SERVER.value, external_id=unvalidated["id"]
+        provider=IntegrationProviderSlug.JIRA_SERVER.value,
+        external_id=unvalidated["id"],
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if not integration:
         raise ValueError("Could not find integration for token")

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -575,7 +575,9 @@ class MsTeamsWebhookEndpoint(Endpoint):
         group = Group.objects.select_related("project__organization").filter(id=group_id).first()
         if group:
             integration = integration_service.get_integration(
-                integration_id=integration.id, status=ObjectStatus.ACTIVE
+                integration_id=integration.id,
+                status=ObjectStatus.ACTIVE,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
             )
             if integration is None:
                 group = None

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -593,7 +593,6 @@ class DatabaseBackedIntegrationService(IntegrationService):
         from sentry.identity.services.identity.service import identity_service
         from sentry.users.services.user.service import user_service
 
-        # TODO(mark) Add using_replica here
         integration = self.get_integration(
             provider=integration_provider,
             external_id=integration_external_id,

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from django.utils import timezone
 from taskbroker_client.retry import Retry
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user
@@ -32,7 +33,9 @@ def link_slack_user_identities(
     organization_id: int,
 ) -> None:
     integration = integration_service.get_integration(
-        integration_id=integration_id, status=ObjectStatus.ACTIVE
+        integration_id=integration_id,
+        status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     organization_context = organization_service.get_organization_by_id(id=organization_id)
     organization = organization_context.organization if organization_context else None

--- a/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
+++ b/src/sentry/integrations/slack/tasks/link_slack_user_identities.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from django.utils import timezone
 from taskbroker_client.retry import Retry
 
-from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.utils.users import SlackUserData, get_slack_data_by_user
@@ -33,9 +32,7 @@ def link_slack_user_identities(
     organization_id: int,
 ) -> None:
     integration = integration_service.get_integration(
-        integration_id=integration_id,
-        status=ObjectStatus.ACTIVE,
-        using_replica=options.get("integration_service.get_integration.using_replica"),
+        integration_id=integration_id, status=ObjectStatus.ACTIVE
     )
     organization_context = organization_service.get_organization_by_id(id=organization_id)
     organization = organization_context.organization if organization_context else None

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from django.db.models import Prefetch
 from django.http.request import QueryDict
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.api import client
 from sentry.api.endpoints.timeseries import TimeSeries
 from sentry.api.serializers import serialize
@@ -118,9 +118,9 @@ def _unfurl_dashboards(
     links: list[UnfurlableUrl],
     user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
-    # TODO(mark) Add using_replica here
     org_integrations = integration_service.get_organization_integrations(
-        integration_id=integration.id
+        integration_id=integration.id,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     organizations = Organization.objects.filter(
         id__in=[oi.organization_id for oi in org_integrations]

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 from django.http.request import QueryDict
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.api import client
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartType
@@ -134,9 +134,9 @@ def _unfurl_discover(
     links: list[UnfurlableUrl],
     user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
-    # TODO(mark) Add using_replica here
     org_integrations = integration_service.get_organization_integrations(
-        integration_id=integration.id
+        integration_id=integration.id,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     organizations = Organization.objects.filter(
         id__in=[oi.organization_id for oi in org_integrations]

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 from django.http.request import QueryDict
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.api import client
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
@@ -541,9 +541,9 @@ def _unfurl_explore(
     links: list[UnfurlableUrl],
     user: User | RpcUser | None = None,
 ) -> UnfurledUrl:
-    # TODO(mark) Add using_replica here
     org_integrations = integration_service.get_organization_integrations(
-        integration_id=integration.id
+        integration_id=integration.id,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     organizations = Organization.objects.filter(
         id__in=[oi.organization_id for oi in org_integrations]

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -16,7 +16,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.models.views import View
 from slack_sdk.webhook import WebhookClient
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.api import client
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -554,9 +554,10 @@ class SlackActionEndpoint(Endpoint):
         return self.respond(response)
 
     def handle_unfurl(self, slack_request: SlackActionRequest, action: str) -> Response:
-        # TODO(mark) Add using_replica here
         organization_integrations = integration_service.get_organization_integrations(
-            integration_id=slack_request.integration.id, limit=1
+            integration_id=slack_request.integration.id,
+            limit=1,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
         if len(organization_integrations) > 0:
             analytics.record(

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -303,9 +303,10 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
         data = slack_request.data.get("event", {})
 
-        # TODO(mark) Add using_replica here
         ois = integration_service.get_organization_integrations(
-            integration_id=slack_request.integration.id, limit=1
+            integration_id=slack_request.integration.id,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
+            limit=1,
         )
         organization_id = ois[0].organization_id if len(ois) > 0 else None
         organization_context = (

--- a/src/sentry/integrations/slack/workspace.py
+++ b/src/sentry/integrations/slack/workspace.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from slack_sdk.errors import SlackApiError
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.metrics import translate_slack_api_error
@@ -67,7 +68,9 @@ def has_history_scope(
     """
     if scopes is None:
         integration = integration_service.get_integration(
-            integration_id=integration_id, status=ObjectStatus.ACTIVE
+            integration_id=integration_id,
+            status=ObjectStatus.ACTIVE,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
         if integration is None:
             return False

--- a/src/sentry/integrations/tasks/migrate_repo.py
+++ b/src/sentry/integrations/tasks/migrate_repo.py
@@ -1,5 +1,6 @@
 from taskbroker_client.retry import Retry
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
@@ -31,7 +32,10 @@ from sentry.taskworker.namespaces import integrations_control_tasks
     ),
 )
 def migrate_repo(repo_id: int, integration_id: int, organization_id: int) -> None:
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
+    )
     if integration is None:
         raise Integration.DoesNotExist
     installation = integration.get_installation(organization_id=organization_id)

--- a/src/sentry/integrations/tasks/migrate_repo.py
+++ b/src/sentry/integrations/tasks/migrate_repo.py
@@ -1,6 +1,5 @@
 from taskbroker_client.retry import Retry
 
-from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
@@ -32,10 +31,7 @@ from sentry.taskworker.namespaces import integrations_control_tasks
     ),
 )
 def migrate_repo(repo_id: int, integration_id: int, organization_id: int) -> None:
-    integration = integration_service.get_integration(
-        integration_id=integration_id,
-        using_replica=options.get("integration_service.get_integration.using_replica"),
-    )
+    integration = integration_service.get_integration(integration_id=integration_id)
     if integration is None:
         raise Integration.DoesNotExist
     installation = integration.get_installation(organization_id=organization_id)

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from taskbroker_client.retry import Retry
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.constants import ObjectStatus
 from sentry.integrations.analytics import IntegrationIssueAssigneeSyncedEvent
 from sentry.integrations.errors import OrganizationIntegrationNotFound
@@ -68,7 +68,9 @@ def sync_assignee_outbound(
     if not has_issue_sync:
         return
     integration = integration_service.get_integration(
-        integration_id=external_issue.integration_id, status=ObjectStatus.ACTIVE
+        integration_id=external_issue.integration_id,
+        status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if not integration:
         return

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.utils import timezone as django_timezone
 from taskbroker_client.retry import Retry
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.analytics.events.issue_resolved import IssueResolvedEvent
 from sentry.api.helpers.group_index.update import get_current_release_version_of_group
 from sentry.constants import ObjectStatus
@@ -204,7 +204,10 @@ def sync_status_inbound(
 ) -> None:
     from sentry.integrations.mixins import ResolveSyncAction
 
-    integration = integration_service.get_integration(integration_id=integration_id)
+    integration = integration_service.get_integration(
+        integration_id=integration_id,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
+    )
     if integration is None:
         raise Integration.DoesNotExist
     elif integration.status != ObjectStatus.ACTIVE:

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -1,6 +1,6 @@
 from taskbroker_client.retry import Retry
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.integrations.analytics import IntegrationIssueStatusSyncedEvent
@@ -47,7 +47,9 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
         return None
 
     integration = integration_service.get_integration(
-        integration_id=external_issue.integration_id, status=ObjectStatus.ACTIVE
+        integration_id=external_issue.integration_id,
+        status=ObjectStatus.ACTIVE,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
     )
     if not integration:
         return None

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -7,7 +7,6 @@ import requests
 from django.http import HttpRequest
 from jwt import ExpiredSignatureError, InvalidAlgorithmError, InvalidSignatureError
 
-from sentry import options
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
@@ -79,11 +78,7 @@ def get_integration_from_jwt(
     issuer = claims.get("iss")
     # Look up the sharedSecret for the clientKey, as stored
     # by the add-on during the installation handshake
-    integration = integration_service.get_integration(
-        provider=provider,
-        external_id=issuer,
-        using_replica=options.get("integration_service.get_integration.using_replica"),
-    )
+    integration = integration_service.get_integration(provider=provider, external_id=issuer)
     if not integration:
         raise AtlassianConnectValidationError("No integration found")
     # Verify the signature with the sharedSecret and the algorithm specified in the header's

--- a/src/sentry/integrations/utils/atlassian_connect.py
+++ b/src/sentry/integrations/utils/atlassian_connect.py
@@ -7,6 +7,7 @@ import requests
 from django.http import HttpRequest
 from jwt import ExpiredSignatureError, InvalidAlgorithmError, InvalidSignatureError
 
+from sentry import options
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
@@ -78,8 +79,11 @@ def get_integration_from_jwt(
     issuer = claims.get("iss")
     # Look up the sharedSecret for the clientKey, as stored
     # by the add-on during the installation handshake
-    # TODO(mark) Add using_replica here
-    integration = integration_service.get_integration(provider=provider, external_id=issuer)
+    integration = integration_service.get_integration(
+        provider=provider,
+        external_id=issuer,
+        using_replica=options.get("integration_service.get_integration.using_replica"),
+    )
     if not integration:
         raise AtlassianConnectValidationError("No integration found")
     # Verify the signature with the sharedSecret and the algorithm specified in the header's

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 from requests import PreparedRequest
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.integrations.client import ApiClient
@@ -198,7 +199,9 @@ class VstsApiClient(IntegrationProxyClient, RepositoryClient):
             from sentry.integrations.vsts.integration import VstsIntegrationProvider
 
             integration = integration_service.get_integration(
-                organization_integration_id=self.org_integration_id, status=ObjectStatus.ACTIVE
+                organization_integration_id=self.org_integration_id,
+                status=ObjectStatus.ACTIVE,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
             )
             if integration is None:
                 return

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 from mistune import markdown
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IntegrationSyncTargetNotFound, IssueSyncIntegration
@@ -424,7 +425,9 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
         client = self.get_client()
 
         integration = integration_service.get_integration(
-            integration_id=self.org_integration.integration_id, status=ObjectStatus.ACTIVE
+            integration_id=self.org_integration.integration_id,
+            status=ObjectStatus.ACTIVE,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
         if not integration:
             raise IntegrationError("Azure DevOps integration not found")

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
@@ -77,6 +78,7 @@ class WorkItemWebhook(Endpoint):
                 provider=IntegrationProviderSlug.AZURE_DEVOPS.value,
                 external_id=external_id,
                 status=ObjectStatus.ACTIVE,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
             )
             if integration is None:
                 logger.info(

--- a/src/sentry/issues/endpoints/group_integrations.py
+++ b/src/sentry/issues/endpoints/group_integrations.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -56,7 +56,10 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         issues_by_integration = defaultdict(list)
         for ei in external_issues:
             # TODO(jess): move into an external issue serializer?
-            integration = integration_service.get_integration(integration_id=ei.integration_id)
+            integration = integration_service.get_integration(
+                integration_id=ei.integration_id,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
+            )
             if integration is None:
                 continue
             installation = integration.get_installation(organization_id=self.group.organization.id)

--- a/src/sentry/issues/services/issue/impl.py
+++ b/src/sentry/issues/services/issue/impl.py
@@ -6,6 +6,7 @@
 
 from django.db.models import Max
 
+from sentry import options
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.services.issue.model import RpcExternalIssueGroupMetadata, RpcGroupShareMetadata
 from sentry.issues.services.issue.service import IssueService
@@ -31,9 +32,12 @@ class DatabaseBackedIssueService(IssueService):
         if not external_issues.exists():
             return None
 
-        if integration_service.get_integration(integration_id=integration_id) is None:
+        integration = integration_service.get_integration(
+            integration_id=integration_id,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
+        )
+        if integration is None:
             return None
-
         if (
             organization_integrations := integration_service.get_organization_integrations(
                 organization_ids={

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/discord_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/discord_issue_alert_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -34,6 +35,7 @@ class DiscordIssueAlertHandler(BaseIssueAlertHandler):
                 integration_id=integration_id,
                 organization_id=organization_id,
                 status=ObjectStatus.ACTIVE,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
             )
         if not integration:
             return ""

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/msteams_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/msteams_issue_alert_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -24,6 +25,7 @@ class MSTeamsIssueAlertHandler(BaseIssueAlertHandler):
                 integration_id=integration_id,
                 organization_id=organization_id,
                 status=ObjectStatus.ACTIVE,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
             )
         if not integration:
             return ""

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from taskbroker_client.retry import RetryTaskError
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
 from sentry.incidents.models.incident import TriggerStatus
@@ -400,6 +401,7 @@ class TicketingIssueAlertHandler(BaseIssueAlertHandler):
                 integration_id=integration_id,
                 organization_id=organization_id,
                 status=ObjectStatus.ACTIVE,
+                using_replica=options.get("integration_service.get_integration.using_replica"),
             )
         integration_name = integration.name if integration else "[removed]"
         return cls.label_template.format(integration=integration_name)

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import quotas
+from sentry import options, quotas
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -45,7 +45,9 @@ def get_autofix_integration_setup_problems(
     # Iterate through all organization integrations to find one with an active integration
     for organization_integration in organization_integrations:
         integration = integration_service.get_integration(
-            organization_integration_id=organization_integration.id, status=ObjectStatus.ACTIVE
+            organization_integration_id=organization_integration.id,
+            status=ObjectStatus.ACTIVE,
+            using_replica=options.get("integration_service.get_integration.using_replica"),
         )
         if integration:
             installation = integration.get_installation(organization_id=organization.id)


### PR DESCRIPTION
Move a bunch of integration reads to replicas. I've focused on paths where we're handling webhooks, or using integrations in tasks as these flows are far away from any writes and I don't want to introduce replicas in places where we could be exposed to read-after-write. For this reason, I've also tried to avoid paths where the read integration is used to construct a client.