### PR TITLE
perf(seer): Skip off-screen autofix cards with content-visibility

### DIFF
--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -688,6 +688,11 @@ export function OverviewCard({
   );
 }
 
+const CardContainer = styled(Container)`
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
+`;
+
 function CardFrame({
   aside,
   children,
@@ -698,7 +703,7 @@ function CardFrame({
   containerRef?: React.Ref<HTMLDivElement>;
 }) {
   return (
-    <Container
+    <CardContainer
       ref={containerRef}
       background="primary"
       border="primary"
@@ -723,7 +728,7 @@ function CardFrame({
           </Stack>
         </Flex>
       </Stack>
-    </Container>
+    </CardContainer>
   );
 }
 


### PR DESCRIPTION
## Summary

Apply `content-visibility: auto` to the Autofix Overview card container so the
browser skips layout and paint for off-screen cards. The overview can render
hundreds of cards in one list; laying them all out on initial load is a
measurable up-front cost. This lets the browser do that work only for cards
near the viewport.

## Why

The overview renders every run as a card in a single long list (250+ in busy
orgs). We looked at full list virtualization but it's a heavier change (DOM
windowing, scroll math, a library, and interaction with the per-card
IntersectionObserver enrichment). `content-visibility: auto` gets most of the
off-screen savings for ~7 lines of CSS and near-zero risk — no changes to the
DOM, data flow, or tests.

- `content-visibility: auto` — the browser skips layout/paint for cards outside
  the viewport and renders them as they scroll in.
- `contain-intrinsic-size: auto 240px` — reserves an estimated height so the
  scrollbar and layout stay stable before a card is rendered; `auto` remembers
  each card's real height after first render, so the scrollbar barely shifts.

Split out from #122755 (merged) so its rendering impact can be measured and
shipped independently.

## Testing

CSS-only — no DOM or behavior change. The existing overview test suite passes.
