### PR TITLE
fix(taskworker): expire the retry_state example's redis key

### DIFF
--- a/src/sentry/taskworker/tasks/examples.py
+++ b/src/sentry/taskworker/tasks/examples.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
+from datetime import timedelta
 from functools import cache
 from time import sleep
 from typing import Any
@@ -17,6 +18,8 @@ from sentry.utils.arroyo_producer import get_future_tracking_producer
 from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger(__name__)
+
+NO_RETRIES_REMAINING_TTL = timedelta(days=1)
 
 
 @cache
@@ -49,7 +52,7 @@ def retry_state() -> None:
         retry_task_helper()
     except NoRetriesRemainingError:
         redis = redis_clusters.get("default")
-        redis.set("no-retries-remaining", 1)
+        redis.set("no-retries-remaining", 1, ex=NO_RETRIES_REMAINING_TTL)
 
 
 @exampletasks.register(

--- a/tests/sentry/taskworker/tasks/test_examples.py
+++ b/tests/sentry/taskworker/tasks/test_examples.py
@@ -1,0 +1,19 @@
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import RetryState, TaskActivation
+from taskbroker_client.state import clear_current_task, set_current_task
+
+from sentry.taskworker.tasks.examples import retry_state
+from sentry.testutils.cases import TestCase
+from sentry.utils.redis import redis_clusters
+
+
+class RetryStateTest(TestCase):
+    def test_marker_key_expires(self) -> None:
+        # An attempt one below max_attempts is the terminal one, so the retry helper
+        # raises NoRetriesRemainingError instead of asking for another attempt.
+        set_current_task(TaskActivation(retry_state=RetryState(attempts=1, max_attempts=2)))
+        self.addCleanup(clear_current_task)
+
+        retry_state()
+
+        redis = redis_clusters.get("default")
+        assert redis.ttl("no-retries-remaining") > 0


### PR DESCRIPTION
[INFRENG-503](https://linear.app/getsentry/issue/INFRENG-503/add-a-ttl-to-the-retry-state-example-tasks-redis-write)
