### PR TITLE
ref(onboarding): Share the integration action resolver across flows

### DIFF
--- a/static/app/components/onboarding/scm/useScmProjectCreation.ts
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.ts
@@ -13,12 +13,10 @@ import type {Project} from 'sentry/types/project';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
-import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import type {useIntegrationActionResolver} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 
-type GetIntegrationAction = ReturnType<
-  typeof useCreateNotificationAction
->['getIntegrationAction'];
+type GetIntegrationAction = ReturnType<typeof useIntegrationActionResolver>;
 
 export interface ScmProjectCreationResult {
   project: Project;

--- a/static/app/components/onboarding/scm/useScmProjectDetails.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.spec.tsx
@@ -93,7 +93,7 @@ describe('useScmProjectDetails', () => {
   }
 
   beforeEach(() => {
-    // useCreateNotificationAction queries messaging integrations on mount.
+    // The notification picker queries messaging integrations on mount.
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/`,
       body: [],

--- a/static/app/components/onboarding/useCreateProjectAndRules.ts
+++ b/static/app/components/onboarding/useCreateProjectAndRules.ts
@@ -13,15 +13,13 @@ import type {Project} from 'sentry/types/project';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import type {useIntegrationActionResolver} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 const MUTATION_KEY = 'create-project-and-rules';
 
 type Variables = {
   alertRuleConfig: Partial<RequestDataFragment>;
-  getIntegrationAction: ReturnType<
-    typeof useCreateNotificationAction
-  >['getIntegrationAction'];
+  getIntegrationAction: ReturnType<typeof useIntegrationActionResolver>;
   platform: OnboardingSelectedSDK;
   projectName: string;
   team?: string;

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useState} from 'react';
 import {AnimatePresence, LayoutGroup, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -28,13 +28,10 @@ import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 import {
-  buildIntegrationAction,
   providerDetails,
+  useIntegrationActionResolver,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
-import {
-  getRequestDataFragment,
-  type RequestDataFragment,
-} from 'sentry/views/projectInstall/issueAlertOptions';
+import {getRequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import type {StepProps} from './types';
 
@@ -93,21 +90,18 @@ export function ScmMessaging({
 
   const validatedActiveRow = validateActiveRow(activeRow, providers, messagingSetup);
   const visibleProviders = listedProviders(providers, validatedActiveRow, messagingSetup);
-  const getIntegrationAction = useCallback(
-    ({shouldCreateRule}: Partial<RequestDataFragment>) => {
-      if (!shouldCreateRule || messagingSetup.mode !== 'selected') {
-        return;
-      }
-
-      const channelTargetedBy =
-        providerDetails[messagingSetup.providerKey].channelTargetedBy;
-      return buildIntegrationAction({
-        provider: messagingSetup.providerKey,
-        integrationId: messagingSetup.integrationId,
-        channel: messagingSetup[channelTargetedBy],
-      });
-    },
-    [messagingSetup]
+  // This step stores its selection in messagingSetup rather than in the
+  // notification-picker state the create-project flow uses, so map it onto the
+  // shared resolver directly.
+  const getIntegrationAction = useIntegrationActionResolver(
+    messagingSetup.mode === 'selected'
+      ? {
+          provider: messagingSetup.providerKey,
+          integrationId: messagingSetup.integrationId,
+          channel:
+            messagingSetup[providerDetails[messagingSetup.providerKey].channelTargetedBy],
+        }
+      : undefined
   );
 
   const isSubmitting = isCreating || submissionMode !== undefined;

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -45,7 +45,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeams} from 'sentry/utils/useTeams';
 import {
   MultipleCheckboxOptions,
-  useCreateNotificationAction,
+  useNotificationAction,
   type IntegrationChannel,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import type {
@@ -167,7 +167,7 @@ export function CreateProject() {
       : undefined;
   }, [autoFill, createdProject?.notificationRule?.actions]);
 
-  const {getIntegrationAction, notificationProps} = useCreateNotificationAction(
+  const {getIntegrationAction, notificationProps} = useNotificationAction(
     notificationActionParam
   );
 

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -21,7 +21,7 @@ import {
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
-  useCreateNotificationAction,
+  useNotificationAction,
   useScmNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
@@ -145,7 +145,7 @@ describe('MessagingIntegrationAlertRule', () => {
   });
 });
 
-describe('useCreateNotificationAction', () => {
+describe('useNotificationAction', () => {
   const organization = OrganizationFixture();
 
   const slackIntegration = OrganizationIntegrationsFixture({
@@ -181,7 +181,7 @@ describe('useCreateNotificationAction', () => {
   it('defaults provider and integration from the first result on load', async () => {
     addIntegrationsResponse([slackIntegration]);
 
-    const {result} = renderHookWithProviders(() => useCreateNotificationAction(), {
+    const {result} = renderHookWithProviders(() => useNotificationAction(), {
       organization,
     });
 
@@ -205,10 +205,9 @@ describe('useCreateNotificationAction', () => {
     // Initial load returns one integration.
     addIntegrationsResponse([slackIntegration]);
 
-    const {result, rerender} = renderHookWithProviders(
-      () => useCreateNotificationAction(),
-      {organization}
-    );
+    const {result, rerender} = renderHookWithProviders(() => useNotificationAction(), {
+      organization,
+    });
 
     await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
 
@@ -237,7 +236,7 @@ describe('useCreateNotificationAction', () => {
     focusManager.setFocused(false);
     addIntegrationsResponse([]);
 
-    const {result} = renderHookWithProviders(() => useCreateNotificationAction(), {
+    const {result} = renderHookWithProviders(() => useNotificationAction(), {
       organization,
     });
 
@@ -276,7 +275,7 @@ describe('useCreateNotificationAction', () => {
     ];
 
     const {result} = renderHookWithProviders(
-      () => useCreateNotificationAction({actions: defaultActions}),
+      () => useNotificationAction({actions: defaultActions}),
       {organization}
     );
 
@@ -328,7 +327,7 @@ describe('useCreateNotificationAction', () => {
     ];
 
     const {result} = renderHookWithProviders(
-      () => useCreateNotificationAction({actions: defaultActions}),
+      () => useNotificationAction({actions: defaultActions}),
       {organization}
     );
 
@@ -360,7 +359,7 @@ describe('useCreateNotificationAction', () => {
     ];
 
     const {result} = renderHookWithProviders(
-      () => useCreateNotificationAction({actions: defaultActions}),
+      () => useNotificationAction({actions: defaultActions}),
       {organization}
     );
 
@@ -398,7 +397,7 @@ describe('useCreateNotificationAction', () => {
     ];
 
     const {result} = renderHookWithProviders(
-      () => useCreateNotificationAction({actions: defaultActions}),
+      () => useNotificationAction({actions: defaultActions}),
       {organization}
     );
 

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -208,6 +208,27 @@ export function buildNotificationSelection({
 }
 
 /**
+ * Returns the integration-action resolver for a messaging selection: a
+ * callback that yields the action to include in the workflow created
+ * alongside the project, and no-ops when rule creation is off or the
+ * selection is incomplete. Callers supply the selection from wherever their
+ * flow stores it (picker state, the SCM wizard's session state, etc).
+ */
+export function useIntegrationActionResolver(
+  selection: Partial<NotificationSelection> | undefined
+) {
+  return useCallback(
+    ({shouldCreateRule}: Partial<RequestDataFragment>) => {
+      if (!shouldCreateRule) {
+        return;
+      }
+      return buildIntegrationAction(selection ?? {});
+    },
+    [selection]
+  );
+}
+
+/**
  * Result of resolving the initial notification-picker selection, computed
  * from whatever restore source a caller-specific hook uses (a persisted
  * rule action, a raw stored selection, etc).
@@ -323,28 +344,16 @@ function useNotificationPicker(resolveRestore: RestoreResolver) {
     setShouldRenderSetupButton(false);
   }, [messagingIntegrationsQuery.isSuccess, providersToIntegrations, resolveRestore]);
 
-  const getIntegrationAction = useCallback(
-    ({shouldCreateRule}: Partial<RequestDataFragment>) => {
-      const isCreatingIntegrationNotification = actions.find(
-        action => action === MultipleCheckboxOptions.INTEGRATION
-      );
-      if (!shouldCreateRule || !isCreatingIntegrationNotification) {
-        return;
-      }
-
-      const integrationAction = buildIntegrationAction({
-        provider,
-        integrationId: integration?.id,
-        channel: channel?.value,
-      });
-      if (!integrationAction) {
-        return;
-      }
-
-      return integrationAction;
-    },
+  // Memoized so the resolver (and anything depending on it) only changes
+  // when the picker selection actually changes.
+  const selection = useMemo(
+    () =>
+      actions.includes(MultipleCheckboxOptions.INTEGRATION)
+        ? buildNotificationSelection({provider, integration, channel})
+        : undefined,
     [actions, provider, integration, channel]
   );
+  const getIntegrationAction = useIntegrationActionResolver(selection);
 
   return {
     getIntegrationAction,
@@ -379,12 +388,12 @@ function getIntegrationId(action: IssueAlertRuleAction): string | undefined {
 }
 
 /**
- * Classic notification-picker adapter: restores the selection by decoding a
+ * Default notification-picker adapter: restores the selection by decoding a
  * persisted `IssueAlertRuleAction` (e.g. from a previously created rule, in
  * the API's flattened action shape). Used by the standalone Create Project
  * page, whose only restore source is a real created rule.
  */
-export function useCreateNotificationAction({
+export function useNotificationAction({
   actions: defaultActions,
 }: Partial<Pick<RequestDataFragment, 'actions'>> = {}) {
   const resolveRestore = useCallback<RestoreResolver>(
@@ -461,7 +470,7 @@ export function useScmNotificationAction({
 
       // Named integration not (yet) in the query response: show the setup CTA
       // and don't latch, so this re-resolves after a refetch delivers it
-      // (mirrors the classic decode resolver's guard).
+      // (mirrors the decode resolver's guard in `useNotificationAction`).
       if (!matchedIntegration) {
         return {kind: 'wait'};
       }


### PR DESCRIPTION
The notification picker and the SCM messaging step each had a getIntegrationAction callback with the same shouldCreateRule gate and buildIntegrationAction call, differing only in where the selection comes from. This extracts that shell into useIntegrationActionResolver, which takes a selection and returns the callback. The picker feeds it the current picker selection via buildNotificationSelection, and the messaging step feeds it the selection stored in messagingSetup.

Also renames useCreateNotificationAction to useNotificationAction. Since the useNotificationPicker extraction the hook is only the default restore adapter alongside useScmNotificationAction, and after #123074 it no longer creates anything: workflow creation lives in useCreateProjectAndRules.

The GetIntegrationAction type aliases in useScmProjectCreation and useCreateProjectAndRules simplify to ReturnType<typeof useIntegrationActionResolver>, which is the callback type directly.

No behavior change.

Refs VDY-141
