### PR TITLE
feat(onboarding): Compare the messaging destination on project reuse

### DIFF
--- a/static/app/components/onboarding/onboardingContext.spec.tsx
+++ b/static/app/components/onboarding/onboardingContext.spec.tsx
@@ -29,6 +29,7 @@ const selectedMessagingSetup = {
 
 function StateConsumer() {
   const {
+    createdProject,
     messagingSetup,
     selectedRepository,
     selectedPlatform,
@@ -43,6 +44,7 @@ function StateConsumer() {
       <div>
         {selectedFeatures ? `features:${selectedFeatures.length}` : 'no-features'}
       </div>
+      <div>{createdProject ? `project:${createdProject.slug}` : 'no-project'}</div>
       <div>{`messaging:${messagingSetup.mode}`}</div>
       <button onClick={() => setSelectedPlatform(undefined)}>Clear platform</button>
       <button onClick={() => resetOnboarding()}>Reset onboarding</button>
@@ -128,6 +130,57 @@ describe('OnboardingContextProvider', () => {
     expect(screen.getByText('platform:javascript-nextjs')).toBeInTheDocument();
     expect(screen.getByText('features:1')).toBeInTheDocument();
     expect(screen.getByText('messaging:selected')).toBeInTheDocument();
+  });
+
+  it('lifts a legacy createdProjectSlug into createdProject on load', async () => {
+    // Sessions written before createdProject existed hold only the slug. The
+    // destination is unknown for them, so it lifts as undefined, and the legacy
+    // key is dropped so the lift runs once.
+    sessionStorage.setItem(
+      'onboarding',
+      JSON.stringify({
+        selectedRepository: RepositoryFixture({id: '42'}),
+        selectedPlatform: platform,
+        createdProjectSlug: 'javascript-nextjs',
+      })
+    );
+
+    render(
+      <OnboardingContextProvider>
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+
+    expect(await screen.findByText('project:javascript-nextjs')).toBeInTheDocument();
+    expect(screen.getByText('repo:42')).toBeInTheDocument();
+    const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
+    expect(stored.createdProject).toEqual({slug: 'javascript-nextjs'});
+    expect(stored).not.toHaveProperty('createdProjectSlug');
+  });
+
+  it('does not lift a legacy createdProjectSlug past a stale repository clear', async () => {
+    // The stale-repo guard clears repo-derived state, and the created project
+    // is derived. The lift is ordered before it so the clear wins.
+    sessionStorage.setItem(
+      'onboarding',
+      JSON.stringify({
+        selectedRepository: RepositoryFixture({id: ''}),
+        selectedPlatform: platform,
+        createdProjectSlug: 'javascript-nextjs',
+      })
+    );
+
+    render(
+      <OnboardingContextProvider>
+        <StateConsumer />
+      </OnboardingContextProvider>
+    );
+
+    expect(await screen.findByText('no-repo')).toBeInTheDocument();
+    expect(screen.getByText('no-project')).toBeInTheDocument();
+    expect(JSON.parse(sessionStorage.getItem('onboarding') ?? '{}')).not.toHaveProperty(
+      'createdProjectSlug'
+    );
   });
 
   it('restores messaging setup from session storage after a remount', () => {

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext, useEffect, useMemo, useRef} from 'react';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
+  type CreatedProject,
   type ScmMessagingSetup,
   UNCONFIGURED_SCM_MESSAGING_SETUP,
 } from 'sentry/components/onboarding/scm/scmMessagingSetup';
@@ -19,7 +20,7 @@ type OnboardingContextProps = {
   ) => void;
   setAgenticProgressClientRunId: (clientRunId?: string) => void;
   setAgenticProgressOnboardingCode: (onboardingCode?: string) => void;
-  setCreatedProjectSlug: (slug?: string) => void;
+  setCreatedProject: (createdProject?: CreatedProject) => void;
   setMessagingSetup: (messagingSetup: ScmMessagingSetup) => void;
   setSelectedFeatures: (features?: ProductSolution[]) => void;
   setSelectedIntegration: (integration?: Integration) => void;
@@ -28,7 +29,7 @@ type OnboardingContextProps = {
   agentSetupProjectBaseline?: OnboardingSessionState['agentSetupProjectBaseline'];
   agenticProgressClientRunId?: string;
   agenticProgressOnboardingCode?: string;
-  createdProjectSlug?: string;
+  createdProject?: CreatedProject;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
   selectedPlatform?: OnboardingSelectedSDK;
@@ -44,7 +45,7 @@ type OnboardingSessionState = {
   };
   agenticProgressClientRunId?: string;
   agenticProgressOnboardingCode?: string;
-  createdProjectSlug?: string;
+  createdProject?: CreatedProject;
   messagingSetup?: ScmMessagingSetup;
   selectedFeatures?: ProductSolution[];
   selectedIntegration?: Integration;
@@ -64,8 +65,8 @@ const OnboardingContext = createContext<OnboardingContextProps>({
   setSelectedRepository: () => {},
   selectedFeatures: undefined,
   setSelectedFeatures: () => {},
-  createdProjectSlug: undefined,
-  setCreatedProjectSlug: () => {},
+  createdProject: undefined,
+  setCreatedProject: () => {},
   messagingSetup: UNCONFIGURED_SCM_MESSAGING_SETUP,
   setMessagingSetup: () => {},
   agentSetupProjectBaseline: undefined,
@@ -111,7 +112,7 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
         selectedRepository: undefined,
         selectedPlatform: undefined,
         selectedFeatures: undefined,
-        createdProjectSlug: undefined,
+        createdProject: undefined,
       }));
     }
   }, [setOnboarding]);
@@ -134,9 +135,9 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
       setSelectedFeatures: (selectedFeatures?: ProductSolution[]) => {
         setOnboarding(prev => ({...prev, selectedFeatures}));
       },
-      createdProjectSlug: onboarding?.createdProjectSlug,
-      setCreatedProjectSlug: (createdProjectSlug?: string) => {
-        setOnboarding(prev => ({...prev, createdProjectSlug}));
+      createdProject: onboarding?.createdProject,
+      setCreatedProject: (createdProject?: CreatedProject) => {
+        setOnboarding(prev => ({...prev, createdProject}));
       },
       messagingSetup: onboarding?.messagingSetup ?? UNCONFIGURED_SCM_MESSAGING_SETUP,
       setMessagingSetup: (messagingSetup: ScmMessagingSetup) => {
@@ -164,7 +165,7 @@ export function OnboardingContextProvider({children, initialValue}: ProviderProp
           ...prev,
           selectedPlatform: undefined,
           selectedFeatures: undefined,
-          createdProjectSlug: undefined,
+          createdProject: undefined,
         }));
       },
       // Full-flow exits should clear every staged choice explicitly. Do not use

--- a/static/app/components/onboarding/onboardingContext.tsx
+++ b/static/app/components/onboarding/onboardingContext.tsx
@@ -54,6 +54,14 @@ type OnboardingSessionState = {
 };
 
 /**
+ * Session shape from before the created project carried its messaging
+ * destination. Read once on load to lift the slug; never written.
+ */
+type LegacyOnboardingSessionState = OnboardingSessionState & {
+  createdProjectSlug?: string;
+};
+
+/**
  * Prefer using `useOnboardingContext` hook instead of directly using this context.
  */
 const OnboardingContext = createContext<OnboardingContextProps>({
@@ -90,10 +98,34 @@ type ProviderProps = {
 };
 
 export function OnboardingContextProvider({children, initialValue}: ProviderProps) {
-  const [onboarding, setOnboarding, removeOnboarding] = useSessionStorage(
-    ONBOARDING_SESSION_KEY,
-    initialValue
-  );
+  const [onboarding, setOnboarding, removeOnboarding] = useSessionStorage<
+    LegacyOnboardingSessionState | undefined
+  >(ONBOARDING_SESSION_KEY, initialValue);
+
+  // A session written before createdProject existed holds only the slug under
+  // createdProjectSlug. Lift it once on load so the docs step still resolves
+  // the real slug and the reuse check still finds the project. Those sessions
+  // never recorded the destination, so it lifts as undefined: a submission
+  // that stages a destination then creates a fresh project rather than
+  // reusing one whose workflow may target another channel. Declared before
+  // the stale-repo guard so that guard's clear of the derived state wins.
+  // Drop this once sessions written before it shipped are gone.
+  const hadLegacyCreatedProjectSlug = useRef(!!onboarding?.createdProjectSlug);
+  useEffect(() => {
+    if (hadLegacyCreatedProjectSlug.current) {
+      hadLegacyCreatedProjectSlug.current = false;
+      setOnboarding(prev => {
+        const {createdProjectSlug, ...rest}: LegacyOnboardingSessionState = prev ?? {};
+        if (rest.createdProject || !createdProjectSlug) {
+          return rest;
+        }
+        return {
+          ...rest,
+          createdProject: {slug: createdProjectSlug, messagingSelection: undefined},
+        };
+      });
+    }
+  }, [setOnboarding]);
 
   // An optimistic repo (empty id, see useScmRepoSelection) persisted by a
   // refresh mid-resolution can never fetch detection and would hold the

--- a/static/app/components/onboarding/scm/scmMessagingSetup.ts
+++ b/static/app/components/onboarding/scm/scmMessagingSetup.ts
@@ -1,4 +1,21 @@
 import type {ScmMessagingProviderKey} from 'sentry/components/onboarding/scm/messagingProviders';
+import type {NotificationSelection} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+
+/**
+ * The project created by this onboarding session, with the messaging
+ * destination it was created for. Both live in one value so a persisted slug
+ * can never be restored without its destination: the messaging step's reuse
+ * check compares the staged destination against this snapshot.
+ */
+export type CreatedProject = {
+  /**
+   * The destination the project's workflow was created for. `channel` holds
+   * the action-target value (`channelTargetedBy`), so equality means the same
+   * workflow would be created. Undefined = created email-only (Set up later).
+   */
+  messagingSelection: NotificationSelection | undefined;
+  slug: string;
+};
 
 export type ScmMessagingActiveRow = {
   mode: 'configuring' | 'removing';

--- a/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
@@ -31,8 +31,8 @@ describe('useScmProjectCreation', () => {
     return renderHookWithProviders(
       () =>
         useScmProjectCreation({
-          createdProjectSlug: undefined,
-          onProjectCreated: jest.fn(),
+          createdProject: undefined,
+          onCreatedProjectChange: jest.fn(),
           selectedRepository: undefined,
           ...overrides,
         }),
@@ -72,11 +72,11 @@ describe('useScmProjectCreation', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('creates the project with default rules and persists the slug before completing', async () => {
+  it('creates the project with default rules and persists it before completing', async () => {
     const createRequest = mockCreateProject();
-    const onProjectCreated = jest.fn();
+    const onCreatedProjectChange = jest.fn();
     const onSuccess = jest.fn();
-    const {result} = renderCreation({onProjectCreated});
+    const {result} = renderCreation({onCreatedProjectChange});
 
     await act(() =>
       result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
@@ -93,13 +93,19 @@ describe('useScmProjectCreation', () => {
         }),
       })
     );
-    expect(onProjectCreated).toHaveBeenCalledWith('python');
+    // Slug and destination are persisted in one update, so a later reuse
+    // check never sees a slug without the destination it was created for.
+    expect(onCreatedProjectChange).toHaveBeenCalledWith({
+      slug: 'python',
+      messagingSelection: undefined,
+    });
     expect(onSuccess).toHaveBeenCalledWith(
       expect.objectContaining({project: createdProject, reused: false, workflowIds: []})
     );
-    // The slug must be persisted before completion so the duplicate-prevention
-    // handoff to SDK setup survives a failure later in the sequence.
-    expect(onProjectCreated.mock.invocationCallOrder[0]).toBeLessThan(
+    // The created project must be persisted before completion so the
+    // duplicate-prevention handoff to SDK setup survives a failure later in
+    // the sequence.
+    expect(onCreatedProjectChange.mock.invocationCallOrder[0]).toBeLessThan(
       onSuccess.mock.invocationCallOrder[0]!
     );
   });
@@ -108,7 +114,12 @@ describe('useScmProjectCreation', () => {
     const createRequest = mockCreateProject();
     ProjectsStore.loadInitialData([createdProject]);
     const onSuccess = jest.fn();
-    const {result} = renderCreation({createdProjectSlug: createdProject.slug});
+    const {result} = renderCreation({
+      createdProject: {
+        slug: createdProject.slug,
+        messagingSelection: undefined,
+      },
+    });
 
     await act(() =>
       result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
@@ -125,7 +136,12 @@ describe('useScmProjectCreation', () => {
     ProjectsStore.loadInitialData([
       ProjectFixture({slug: 'old-project', platform: 'javascript'}),
     ]);
-    const {result} = renderCreation({createdProjectSlug: 'old-project'});
+    const {result} = renderCreation({
+      createdProject: {
+        slug: 'old-project',
+        messagingSelection: undefined,
+      },
+    });
 
     await act(() =>
       result.current.createOrReuseProject({
@@ -166,8 +182,12 @@ describe('useScmProjectCreation', () => {
       statusCode: 500,
       body: {},
     });
+    const onCreatedProjectChange = jest.fn();
     const onSuccess = jest.fn();
-    const {result} = renderCreation({selectedRepository: repository});
+    const {result} = renderCreation({
+      onCreatedProjectChange,
+      selectedRepository: repository,
+    });
 
     await act(() =>
       result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
@@ -176,6 +196,11 @@ describe('useScmProjectCreation', () => {
     expect(repoLinkRequest).toHaveBeenCalledWith(
       `/projects/${organization.slug}/${createdProject.slug}/repo/`,
       expect.objectContaining({method: 'POST', data: {repositoryId: '42'}})
+    );
+    // Persisted before the linking await: a reload during linking restores
+    // the slug together with its destination.
+    expect(onCreatedProjectChange.mock.invocationCallOrder[0]).toBeLessThan(
+      repoLinkRequest.mock.invocationCallOrder[0]!
     );
     expect(onSuccess).toHaveBeenCalled();
   });
@@ -187,9 +212,9 @@ describe('useScmProjectCreation', () => {
       statusCode: 400,
       body: {},
     });
-    const onProjectCreated = jest.fn();
+    const onCreatedProjectChange = jest.fn();
     const onSuccess = jest.fn();
-    const {result} = renderCreation({onProjectCreated});
+    const {result} = renderCreation({onCreatedProjectChange});
 
     let outcome: unknown;
     await act(async () => {
@@ -200,7 +225,77 @@ describe('useScmProjectCreation', () => {
     });
 
     expect(outcome).toBeUndefined();
-    expect(onProjectCreated).not.toHaveBeenCalled();
+    expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  describe('messaging destination on reuse', () => {
+    const savedSelection = {provider: 'slack', integrationId: '15', channel: '#alerts'};
+    const reusableProject = {
+      slug: createdProject.slug,
+      messagingSelection: savedSelection,
+    };
+
+    beforeEach(() => {
+      ProjectsStore.loadInitialData([createdProject]);
+    });
+
+    it('reuses the project when the staged destination is the one it was created for', async () => {
+      const createRequest = mockCreateProject();
+      const onSuccess = jest.fn();
+      const {result} = renderCreation({createdProject: reusableProject});
+
+      await act(() =>
+        result.current.createOrReuseProject({
+          platform: pythonPlatform,
+          stagedSelection: savedSelection,
+          onSuccess,
+        })
+      );
+
+      expect(createRequest).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({project: createdProject, reused: true})
+      );
+    });
+
+    it('creates a new project when the staged destination changed', async () => {
+      const createRequest = mockCreateProject();
+      const onCreatedProjectChange = jest.fn();
+      const onSuccess = jest.fn();
+      const {result} = renderCreation({
+        createdProject: reusableProject,
+        onCreatedProjectChange,
+      });
+      const stagedSelection = {...savedSelection, channel: '#ops'};
+
+      await act(() =>
+        result.current.createOrReuseProject({
+          platform: pythonPlatform,
+          stagedSelection,
+          onSuccess,
+        })
+      );
+
+      expect(createRequest).toHaveBeenCalledTimes(1);
+      expect(onCreatedProjectChange).toHaveBeenCalledWith({
+        slug: createdProject.slug,
+        messagingSelection: stagedSelection,
+      });
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({reused: false}));
+    });
+
+    it('Set up later reuses the project whatever destination it was created for', async () => {
+      const createRequest = mockCreateProject();
+      const onSuccess = jest.fn();
+      const {result} = renderCreation({createdProject: reusableProject});
+
+      await act(() =>
+        result.current.createOrReuseProject({platform: pythonPlatform, onSuccess})
+      );
+
+      expect(createRequest).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({reused: true}));
+    });
   });
 });

--- a/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
@@ -93,8 +93,6 @@ describe('useScmProjectCreation', () => {
         }),
       })
     );
-    // Slug and destination are persisted in one update, so a later reuse
-    // check never sees a slug without the destination it was created for.
     expect(onCreatedProjectChange).toHaveBeenCalledWith({
       slug: 'python',
       messagingSelection: undefined,
@@ -281,6 +279,31 @@ describe('useScmProjectCreation', () => {
       expect(onCreatedProjectChange).toHaveBeenCalledWith({
         slug: createdProject.slug,
         messagingSelection: stagedSelection,
+      });
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({reused: false}));
+    });
+
+    it('creates a new project when a destination is staged after Set up later', async () => {
+      const createRequest = mockCreateProject();
+      const onCreatedProjectChange = jest.fn();
+      const onSuccess = jest.fn();
+      const {result} = renderCreation({
+        createdProject: {slug: createdProject.slug, messagingSelection: undefined},
+        onCreatedProjectChange,
+      });
+
+      await act(() =>
+        result.current.createOrReuseProject({
+          platform: pythonPlatform,
+          stagedSelection: savedSelection,
+          onSuccess,
+        })
+      );
+
+      expect(createRequest).toHaveBeenCalledTimes(1);
+      expect(onCreatedProjectChange).toHaveBeenCalledWith({
+        slug: createdProject.slug,
+        messagingSelection: savedSelection,
       });
       expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({reused: false}));
     });

--- a/static/app/components/onboarding/scm/useScmProjectCreation.ts
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.ts
@@ -43,11 +43,10 @@ interface UseScmProjectCreationOptions {
    */
   createdProject: CreatedProject | undefined;
   /**
-   * Persists the created project: slug and destination in one update, so a
-   * reload can never restore one without the other. Called immediately after
-   * the project POST succeeds and before repository linking or completion, so
-   * the duplicate-prevention handoff to SDK setup is never skipped by a later
-   * failure.
+   * Persists the created project (onboarding session state). Called
+   * immediately after the project POST succeeds and before repository linking
+   * or completion, so the duplicate-prevention handoff to SDK setup is never
+   * skipped by a later failure.
    */
   onCreatedProjectChange: (createdProject: CreatedProject) => void;
   selectedRepository: Repository | undefined;

--- a/static/app/components/onboarding/scm/useScmProjectCreation.ts
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {linkProjectToRepository} from 'sentry/components/onboarding/scm/linkProjectToRepository';
+import type {CreatedProject} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import type {CreatedProjectRule} from 'sentry/components/onboarding/useCreateProjectRules';
 import {t} from 'sentry/locale';
@@ -13,7 +14,10 @@ import type {Project} from 'sentry/types/project';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
-import type {useCreateNotificationAction} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
+import type {
+  NotificationSelection,
+  useCreateNotificationAction,
+} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 
 type GetIntegrationAction = ReturnType<
@@ -24,7 +28,7 @@ export interface ScmProjectCreationResult {
   project: Project;
   /**
    * True when an already-created project was reused (back-nav with an
-   * unchanged platform) instead of creating a new one.
+   * unchanged platform and destination) instead of creating a new one.
    */
   reused: boolean;
   workflowIds: string[];
@@ -33,17 +37,19 @@ export interface ScmProjectCreationResult {
 
 interface UseScmProjectCreationOptions {
   /**
-   * Slug of a project created earlier in this onboarding session, used for the
-   * reuse-on-back check. Persisted via onProjectCreated.
+   * The project created earlier in this onboarding session, with the
+   * messaging destination it was created for. Drives the reuse-on-back check.
+   * Persisted via onCreatedProjectChange.
    */
-  createdProjectSlug: string | undefined;
+  createdProject: CreatedProject | undefined;
   /**
-   * Persists the created project slug (onboarding session state). Called
-   * immediately after the project POST succeeds and before repository linking
-   * or completion, so the duplicate-prevention handoff to SDK setup is never
-   * skipped by a later failure.
+   * Persists the created project: slug and destination in one update, so a
+   * reload can never restore one without the other. Called immediately after
+   * the project POST succeeds and before repository linking or completion, so
+   * the duplicate-prevention handoff to SDK setup is never skipped by a later
+   * failure.
    */
-  onProjectCreated: (slug: string) => void;
+  onCreatedProjectChange: (createdProject: CreatedProject) => void;
   selectedRepository: Repository | undefined;
 }
 
@@ -51,7 +57,7 @@ interface CreateOrReuseProjectOptions {
   /**
    * Runs after creation (or reuse) succeeds, while the duplicate-submit guard
    * is still held. Completion must happen inside the guarded window: the
-   * projects store and session slug update asynchronously, so a second click
+   * projects store and session state update asynchronously, so a second click
    * after the guard released but before the re-render could pass the reuse
    * check with stale data and create a duplicate.
    */
@@ -67,6 +73,13 @@ interface CreateOrReuseProjectOptions {
    * Defaults to a no-op (email-only creation).
    */
   getIntegrationAction?: GetIntegrationAction;
+  /**
+   * The messaging destination this submission would create a workflow for;
+   * undefined for an email-only submission (Set up later). Compared against
+   * the created project's destination on reuse: "Set up later" means "change
+   * nothing now", so undefined never abandons a created project.
+   */
+  stagedSelection?: NotificationSelection;
 }
 
 const noopIntegrationAction: GetIntegrationAction = () => {};
@@ -79,12 +92,12 @@ const noopIntegrationAction: GetIntegrationAction = () => {};
  *
  * Owns the onboarding-specific concerns around useCreateProjectAndRules:
  * synchronous duplicate-submit protection, reuse of an unchanged project on
- * back-navigation, slug persistence ordering, default team/name resolution,
- * and best-effort repository linking.
+ * back-navigation, created-project persistence ordering, default team/name
+ * resolution, and best-effort repository linking.
  */
 export function useScmProjectCreation({
-  createdProjectSlug,
-  onProjectCreated,
+  createdProject,
+  onCreatedProjectChange,
   selectedRepository,
 }: UseScmProjectCreationOptions) {
   const organization = useOrganization();
@@ -106,20 +119,28 @@ export function useScmProjectCreation({
       platform,
       alertRuleConfig,
       getIntegrationAction,
+      stagedSelection,
       onSuccess,
     }: CreateOrReuseProjectOptions): Promise<ScmProjectCreationResult | undefined> => {
       if (isCreatingRef.current) {
         return undefined;
       }
 
-      // If a project was already created for this platform (e.g. the user
-      // went back after the project received its first event), reuse it.
-      // If the platform changed, abandon the old project and create a new
-      // one — matching legacy onboarding behavior.
-      const existingProject = createdProjectSlug
-        ? projects.find(p => p.slug === createdProjectSlug)
+      // Reuse the project created earlier in this session (e.g. the user went
+      // back after it received its first event) when nothing that shaped it
+      // changed: the same platform and, for a submission that stages a
+      // destination, the same destination it was created for. Any other
+      // change abandons the old project and creates a new one, matching the
+      // unchanged-return check in useScmProjectDetails.
+      const existingProject = createdProject
+        ? projects.find(p => p.slug === createdProject.slug)
         : undefined;
-      if (existingProject?.platform === platform.key) {
+      if (
+        createdProject &&
+        existingProject?.platform === platform.key &&
+        (stagedSelection === undefined ||
+          isSameSelection(stagedSelection, createdProject.messagingSelection))
+      ) {
         const result: ScmProjectCreationResult = {
           project: existingProject,
           reused: true,
@@ -153,7 +174,13 @@ export function useScmProjectCreation({
           return undefined;
         }
 
-        onProjectCreated(creation.project.slug);
+        // Slug and destination in one update, before the linking await below:
+        // a reload during linking restores both together, so the reuse check
+        // can never see a slug without its destination.
+        onCreatedProjectChange({
+          slug: creation.project.slug,
+          messagingSelection: stagedSelection,
+        });
 
         if (selectedRepository?.id) {
           await linkProjectToRepository({
@@ -178,8 +205,8 @@ export function useScmProjectCreation({
     },
     [
       createProjectAndRules,
-      createdProjectSlug,
-      onProjectCreated,
+      createdProject,
+      onCreatedProjectChange,
       organization.slug,
       projects,
       selectedRepository,
@@ -188,4 +215,18 @@ export function useScmProjectCreation({
   );
 
   return {createOrReuseProject, isCreating, isDataPending};
+}
+
+function isSameSelection(
+  staged: NotificationSelection,
+  saved: NotificationSelection | undefined
+) {
+  if (!saved) {
+    return false;
+  }
+  return (
+    staged.provider === saved.provider &&
+    staged.integrationId === saved.integrationId &&
+    staged.channel === saved.channel
+  );
 }

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -752,7 +752,10 @@ describe('Onboarding', () => {
         JSON.stringify({
           selectedPlatform: nextJsPlatform,
           selectedFeatures: [ProductSolution.ERROR_MONITORING],
-          createdProjectSlug: 'javascript-nextjs',
+          createdProject: {
+            slug: 'javascript-nextjs',
+            messagingSelection: undefined,
+          },
           messagingSetup: selectedMessagingSetup,
           agentSetupProjectBaseline: {
             organizationId: scmOrganization.id,
@@ -1135,7 +1138,10 @@ describe('Onboarding', () => {
           JSON.stringify({
             selectedPlatform: nextJsPlatform,
             selectedFeatures: [ProductSolution.ERROR_MONITORING],
-            createdProjectSlug: nextJsProject.slug,
+            createdProject: {
+              slug: nextJsProject.slug,
+              messagingSelection: undefined,
+            },
           })
         );
 
@@ -1188,6 +1194,10 @@ describe('Onboarding', () => {
       const initialContext = {
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
+        createdProject: {
+          slug: nextJsProject.slug,
+          messagingSelection: undefined,
+        },
         messagingSetup: selectedMessagingSetup,
       };
 
@@ -1219,8 +1229,8 @@ describe('Onboarding', () => {
       const stored = JSON.parse(sessionStorage.getItem('onboarding') ?? '{}');
       expect(stored.selectedPlatform).toBeDefined();
       expect(stored.selectedFeatures).toBeDefined();
-      // createdProjectSlug should be cleared so the user can re-create
-      expect(stored.createdProjectSlug).toBeUndefined();
+      // createdProject should be cleared so the user can re-create
+      expect(stored.createdProject).toBeUndefined();
       expect(stored.messagingSetup).toEqual(initialContext.messagingSetup);
     });
 
@@ -1311,7 +1321,10 @@ describe('Onboarding', () => {
         }),
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
-        createdProjectSlug: 'javascript-nextjs',
+        createdProject: {
+          slug: 'javascript-nextjs',
+          messagingSelection: undefined,
+        },
         messagingSetup: selectedMessagingSetup,
       };
 
@@ -1334,7 +1347,7 @@ describe('Onboarding', () => {
       // Derived state should be cleared
       expect(stored.selectedPlatform).toBeUndefined();
       expect(stored.selectedFeatures).toBeUndefined();
-      expect(stored.createdProjectSlug).toBeUndefined();
+      expect(stored.createdProject).toBeUndefined();
       // Integration and repo should be preserved
       expect(stored.selectedIntegration).toBeDefined();
       expect(stored.selectedRepository).toBeDefined();

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -111,8 +111,8 @@ function ScmPlatformFeaturesAdapter({
     setSelectedPlatform,
     selectedFeatures,
     setSelectedFeatures,
-    createdProjectSlug,
-    setCreatedProjectSlug,
+    createdProject,
+    setCreatedProject,
   } = useOnboardingContext();
 
   return (
@@ -120,11 +120,11 @@ function ScmPlatformFeaturesAdapter({
       selectedRepository={selectedRepository}
       selectedPlatform={selectedPlatform}
       selectedFeatures={selectedFeatures}
-      createdProjectSlug={createdProjectSlug}
+      createdProject={createdProject}
       deferProjectCreation={deferProjectCreation}
       onPlatformChange={setSelectedPlatform}
       onFeaturesChange={setSelectedFeatures}
-      onProjectCreated={setCreatedProjectSlug}
+      onCreatedProjectChange={setCreatedProject}
       onComplete={onComplete}
       genBackButton={genBackButton}
     />
@@ -141,12 +141,12 @@ function ScmPlatformFeaturesTreatmentAdapter(props: StepProps) {
 
 function ScmMessagingAdapter({genBackButton, onComplete}: StepProps) {
   const {
-    createdProjectSlug,
+    createdProject,
     messagingSetup,
     selectedFeatures,
     selectedPlatform,
     selectedRepository,
-    setCreatedProjectSlug,
+    setCreatedProject,
     setMessagingSetup,
   } = useOnboardingContext();
 
@@ -159,10 +159,10 @@ function ScmMessagingAdapter({genBackButton, onComplete}: StepProps) {
 
   return (
     <ScmMessaging
-      createdProjectSlug={createdProjectSlug}
+      createdProject={createdProject}
       messagingSetup={messagingSetup}
+      onCreatedProjectChange={setCreatedProject}
       onMessagingSetupChange={setMessagingSetup}
-      onProjectCreated={setCreatedProjectSlug}
       onComplete={onComplete}
       selectedFeatures={selectedFeatures}
       selectedPlatform={selectedPlatform}
@@ -301,7 +301,7 @@ export function OnboardingWithoutContext() {
   const organization = useOrganization();
   const onboardingContext = useOnboardingContext();
   const selectedProjectSlug =
-    onboardingContext.createdProjectSlug ?? onboardingContext.selectedPlatform?.key;
+    onboardingContext.createdProject?.slug ?? onboardingContext.selectedPlatform?.key;
 
   // Only report experiment exposure for genuine new-org onboarding. Existing
   // orgs can land on /onboarding via stale links, which would

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -137,18 +137,19 @@ function mockProviderQueries(integrations: OrganizationIntegration[] = []) {
   }
 }
 
-function renderMessaging(
-  onMessagingSetupChange = jest.fn(),
-  messagingSetup: ScmMessagingSetup = selectedMessagingSetup,
+function renderMessaging({
+  createdProject: existingProject,
+  messagingSetup = selectedMessagingSetup,
   onComplete = jest.fn(),
-  onProjectCreated = jest.fn()
-) {
+  onCreatedProjectChange = jest.fn(),
+  onMessagingSetupChange = jest.fn(),
+}: Partial<React.ComponentProps<typeof ScmMessaging>> = {}) {
   return render(
     <ScmMessaging
-      createdProjectSlug={undefined}
+      createdProject={existingProject}
       messagingSetup={messagingSetup}
+      onCreatedProjectChange={onCreatedProjectChange}
       onMessagingSetupChange={onMessagingSetupChange}
-      onProjectCreated={onProjectCreated}
       selectedFeatures={selectedFeatures}
       selectedPlatform={selectedPlatform}
       selectedRepository={undefined}
@@ -192,7 +193,7 @@ describe('ScmMessaging', () => {
     mockChannelValidate(true);
     const onMessagingSetupChange = jest.fn();
 
-    renderMessaging(onMessagingSetupChange);
+    renderMessaging({onMessagingSetupChange});
 
     await waitFor(() =>
       expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
@@ -209,7 +210,7 @@ describe('ScmMessaging', () => {
     });
     const onMessagingSetupChange = jest.fn();
 
-    renderMessaging(onMessagingSetupChange);
+    renderMessaging({onMessagingSetupChange});
 
     expect(
       await screen.findByText(
@@ -224,7 +225,7 @@ describe('ScmMessaging', () => {
     mockIntegration({organizationIntegrationStatus: 'disabled'});
     const onMessagingSetupChange = jest.fn();
 
-    renderMessaging(onMessagingSetupChange);
+    renderMessaging({onMessagingSetupChange});
 
     expect(
       await screen.findByText(
@@ -243,10 +244,10 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
-          createdProjectSlug={undefined}
+          createdProject={undefined}
           messagingSetup={selectedMessagingSetup}
+          onCreatedProjectChange={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          onProjectCreated={jest.fn()}
           selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
           selectedRepository={undefined}
@@ -277,10 +278,10 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
-          createdProjectSlug={undefined}
+          createdProject={undefined}
           messagingSetup={selectedMessagingSetup}
+          onCreatedProjectChange={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          onProjectCreated={jest.fn()}
           selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
           selectedRepository={undefined}
@@ -325,10 +326,10 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
-          createdProjectSlug={undefined}
+          createdProject={undefined}
           messagingSetup={selectedMessagingSetup}
+          onCreatedProjectChange={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          onProjectCreated={jest.fn()}
           selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
           selectedRepository={undefined}
@@ -381,7 +382,7 @@ describe('ScmMessaging', () => {
     const validateRequest = mockChannelValidate(false);
     const onMessagingSetupChange = jest.fn();
 
-    renderMessaging(onMessagingSetupChange);
+    renderMessaging({onMessagingSetupChange});
 
     await waitFor(() => expect(validateRequest).toHaveBeenCalled());
     expect(
@@ -415,7 +416,7 @@ describe('ScmMessaging', () => {
       match: [MockApiClient.matchQuery({channel: '1234567890'})],
     });
 
-    renderMessaging(jest.fn(), discordSetup);
+    renderMessaging({messagingSetup: discordSetup});
 
     await waitFor(() =>
       expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
@@ -459,10 +460,10 @@ describe('ScmMessaging', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ScmMessaging
-          createdProjectSlug={undefined}
+          createdProject={undefined}
           messagingSetup={selectedMessagingSetup}
+          onCreatedProjectChange={jest.fn()}
           onMessagingSetupChange={onMessagingSetupChange}
-          onProjectCreated={jest.fn()}
           selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
           selectedRepository={undefined}
@@ -495,10 +496,10 @@ describe('ScmMessaging', () => {
             Touch context
           </button>
           <ScmMessaging
-            createdProjectSlug={undefined}
+            createdProject={undefined}
             messagingSetup={messagingSetup}
+            onCreatedProjectChange={jest.fn()}
             onMessagingSetupChange={setMessagingSetup}
-            onProjectCreated={jest.fn()}
             selectedFeatures={selectedFeatures}
             selectedPlatform={selectedPlatform}
             selectedRepository={undefined}
@@ -535,10 +536,10 @@ describe('ScmMessaging', () => {
             New reference
           </button>
           <ScmMessaging
-            createdProjectSlug={undefined}
+            createdProject={undefined}
             messagingSetup={messagingSetup}
+            onCreatedProjectChange={jest.fn()}
             onMessagingSetupChange={setMessagingSetup}
-            onProjectCreated={jest.fn()}
             selectedFeatures={selectedFeatures}
             selectedPlatform={selectedPlatform}
             selectedRepository={undefined}
@@ -569,7 +570,7 @@ describe('ScmMessaging', () => {
       }),
     ]);
 
-    renderMessaging(jest.fn(), {mode: 'unconfigured'});
+    renderMessaging({messagingSetup: {mode: 'unconfigured'}});
 
     expect(await screen.findByText('slack')).toBeInTheDocument();
     expect(screen.getByText('discord')).toBeInTheDocument();
@@ -577,14 +578,14 @@ describe('ScmMessaging', () => {
   });
 
   it('Continue is not rendered when no destination is configured', () => {
-    renderMessaging(jest.fn(), {mode: 'unconfigured'});
+    renderMessaging({messagingSetup: {mode: 'unconfigured'}});
     expect(screen.queryByRole('button', {name: 'Continue'})).not.toBeInTheDocument();
   });
 
   it('Continue is disabled while revalidation is in flight', async () => {
     mockIntegration();
     mockChannelValidate(true);
-    renderMessaging(jest.fn(), selectedMessagingSetup);
+    renderMessaging();
 
     // Revalidation is still in flight on first paint — Continue is visible but disabled.
     expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
@@ -598,7 +599,7 @@ describe('ScmMessaging', () => {
   it('Continue is disabled while the saved channel is stale', async () => {
     mockIntegration();
     mockChannelValidate(false);
-    renderMessaging(jest.fn(), selectedMessagingSetup);
+    renderMessaging();
 
     expect(
       await screen.findByText(
@@ -613,7 +614,7 @@ describe('ScmMessaging', () => {
       url: '/organizations/org-slug/integrations/15/',
       statusCode: 500,
     });
-    renderMessaging(jest.fn(), selectedMessagingSetup);
+    renderMessaging();
 
     expect(
       await screen.findByText(
@@ -641,8 +642,8 @@ describe('ScmMessaging', () => {
       body: AutomationFixture({id: 'workflow-id'}),
     });
     const onComplete = jest.fn();
-    const onProjectCreated = jest.fn();
-    renderMessaging(jest.fn(), selectedMessagingSetup, onComplete, onProjectCreated);
+    const onCreatedProjectChange = jest.fn();
+    renderMessaging({onComplete, onCreatedProjectChange});
 
     // Continue is visible immediately but disabled until revalidation succeeds.
     const continueButton = screen.getByRole('button', {name: 'Continue'});
@@ -691,8 +692,11 @@ describe('ScmMessaging', () => {
         }),
       })
     );
-    expect(onProjectCreated).toHaveBeenCalledWith(createdProject.slug);
-    expect(onProjectCreated.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(onCreatedProjectChange).toHaveBeenCalledWith({
+      slug: createdProject.slug,
+      messagingSelection: {provider: 'slack', integrationId: '15', channel: '#alerts'},
+    });
+    expect(onCreatedProjectChange.mock.invocationCallOrder[0]).toBeLessThan(
       onComplete.mock.invocationCallOrder[0]!
     );
   });
@@ -710,13 +714,13 @@ describe('ScmMessaging', () => {
     });
     const onMessagingSetupChange = jest.fn();
     const onComplete = jest.fn();
-    const onProjectCreated = jest.fn();
-    renderMessaging(
+    const onCreatedProjectChange = jest.fn();
+    renderMessaging({
       onMessagingSetupChange,
-      {mode: 'unconfigured'},
+      messagingSetup: {mode: 'unconfigured'},
       onComplete,
-      onProjectCreated
-    );
+      onCreatedProjectChange,
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'Set up later'}));
 
@@ -734,7 +738,10 @@ describe('ScmMessaging', () => {
       })
     );
     expect(createWorkflowRequest).not.toHaveBeenCalled();
-    expect(onProjectCreated).toHaveBeenCalledWith(createdProject.slug);
+    expect(onCreatedProjectChange).toHaveBeenCalledWith({
+      slug: createdProject.slug,
+      messagingSelection: undefined,
+    });
   });
 
   it('stays on the step with the destination staged when project creation fails', async () => {
@@ -748,13 +755,8 @@ describe('ScmMessaging', () => {
     });
     const onMessagingSetupChange = jest.fn();
     const onComplete = jest.fn();
-    const onProjectCreated = jest.fn();
-    renderMessaging(
-      onMessagingSetupChange,
-      selectedMessagingSetup,
-      onComplete,
-      onProjectCreated
-    );
+    const onCreatedProjectChange = jest.fn();
+    renderMessaging({onMessagingSetupChange, onComplete, onCreatedProjectChange});
 
     const continueButton = await screen.findByRole('button', {name: 'Continue'});
     await waitFor(() => expect(continueButton).toBeEnabled());
@@ -763,7 +765,7 @@ describe('ScmMessaging', () => {
     await waitFor(() => expect(createProjectRequest).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(continueButton).toBeEnabled());
     expect(onMessagingSetupChange).not.toHaveBeenCalled();
-    expect(onProjectCreated).not.toHaveBeenCalled();
+    expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
   });
 
@@ -778,7 +780,7 @@ describe('ScmMessaging', () => {
     });
     const onMessagingSetupChange = jest.fn();
     const onComplete = jest.fn();
-    renderMessaging(onMessagingSetupChange, selectedMessagingSetup, onComplete);
+    renderMessaging({onMessagingSetupChange, onComplete});
 
     const setupLaterButton = screen.getByRole('button', {name: 'Set up later'});
     await waitFor(() => expect(setupLaterButton).toBeEnabled());
@@ -815,8 +817,8 @@ describe('ScmMessaging', () => {
       method: 'DELETE',
     });
     const onComplete = jest.fn();
-    const onProjectCreated = jest.fn();
-    renderMessaging(jest.fn(), selectedMessagingSetup, onComplete, onProjectCreated);
+    const onCreatedProjectChange = jest.fn();
+    renderMessaging({onComplete, onCreatedProjectChange});
 
     const continueButton = await screen.findByRole('button', {name: 'Continue'});
     await waitFor(() => expect(continueButton).toBeEnabled());
@@ -824,8 +826,122 @@ describe('ScmMessaging', () => {
 
     await waitFor(() => expect(rollbackRequest).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(continueButton).toBeEnabled());
-    expect(onProjectCreated).not.toHaveBeenCalled();
+    expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  describe('project reuse on back-navigation', () => {
+    // The destination selectedMessagingSetup stages, as the snapshot records it.
+    const stagedSelection = {provider: 'slack', integrationId: '15', channel: '#alerts'};
+
+    function mockCreateProject() {
+      return MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+    }
+
+    function mockCreateWorkflow() {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/`,
+        body: [IssueStreamDetectorFixture({projectId: createdProject.id})],
+      });
+      return MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/workflows/`,
+        method: 'POST',
+        body: AutomationFixture({id: 'new-workflow'}),
+      });
+    }
+
+    beforeEach(() => {
+      ProjectsStore.loadInitialData([createdProject]);
+    });
+
+    it('completes without any requests when the destination is unchanged', async () => {
+      mockIntegration();
+      mockChannelValidate(true);
+      const createProjectRequest = mockCreateProject();
+      const createWorkflowRequest = mockCreateWorkflow();
+      const onComplete = jest.fn();
+      const onCreatedProjectChange = jest.fn();
+      renderMessaging({
+        createdProject: {slug: createdProject.slug, messagingSelection: stagedSelection},
+        onComplete,
+        onCreatedProjectChange,
+      });
+
+      const continueButton = screen.getByRole('button', {name: 'Continue'});
+      await waitFor(() => expect(continueButton).toBeEnabled());
+      await userEvent.click(continueButton);
+
+      await waitFor(() =>
+        expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
+          product: selectedFeatures,
+        })
+      );
+      expect(createProjectRequest).not.toHaveBeenCalled();
+      expect(createWorkflowRequest).not.toHaveBeenCalled();
+      expect(onCreatedProjectChange).not.toHaveBeenCalled();
+    });
+
+    it('creates a new project when a destination is added after Set up later', async () => {
+      mockIntegration();
+      mockChannelValidate(true);
+      const createProjectRequest = mockCreateProject();
+      const createWorkflowRequest = mockCreateWorkflow();
+      const onComplete = jest.fn();
+      const onCreatedProjectChange = jest.fn();
+      renderMessaging({
+        createdProject: {slug: createdProject.slug, messagingSelection: undefined},
+        onComplete,
+        onCreatedProjectChange,
+      });
+
+      const continueButton = screen.getByRole('button', {name: 'Continue'});
+      await waitFor(() => expect(continueButton).toBeEnabled());
+      await userEvent.click(continueButton);
+
+      await waitFor(() =>
+        expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
+          product: selectedFeatures,
+        })
+      );
+      expect(createProjectRequest).toHaveBeenCalledTimes(1);
+      expect(createWorkflowRequest).toHaveBeenCalledTimes(1);
+      expect(onCreatedProjectChange).toHaveBeenCalledWith({
+        slug: createdProject.slug,
+        messagingSelection: stagedSelection,
+      });
+    });
+
+    it('Set up later completes without any requests whatever the project was created for', async () => {
+      mockIntegration();
+      mockChannelValidate(true);
+      const createProjectRequest = mockCreateProject();
+      const createWorkflowRequest = mockCreateWorkflow();
+      const onComplete = jest.fn();
+      const onCreatedProjectChange = jest.fn();
+      renderMessaging({
+        createdProject: {
+          slug: createdProject.slug,
+          messagingSelection: {...stagedSelection, channel: '#ops'},
+        },
+        onComplete,
+        onCreatedProjectChange,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Set up later'}));
+
+      await waitFor(() =>
+        expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
+          product: selectedFeatures,
+        })
+      );
+      expect(createProjectRequest).not.toHaveBeenCalled();
+      expect(createWorkflowRequest).not.toHaveBeenCalled();
+      expect(onCreatedProjectChange).not.toHaveBeenCalled();
+    });
   });
 
   it('clears an ineligible destination with an explanation', async () => {
@@ -849,7 +965,7 @@ describe('ScmMessaging', () => {
     });
     const onMessagingSetupChange = jest.fn();
 
-    renderMessaging(onMessagingSetupChange, msteamsSetup);
+    renderMessaging({onMessagingSetupChange, messagingSetup: msteamsSetup});
 
     expect(
       await screen.findByText(
@@ -893,10 +1009,10 @@ describe('ScmMessaging', () => {
       const [setup, setSetup] = useState(initial);
       return (
         <ScmMessaging
-          createdProjectSlug={undefined}
+          createdProject={undefined}
           messagingSetup={setup}
+          onCreatedProjectChange={jest.fn()}
           onMessagingSetupChange={setSetup}
-          onProjectCreated={jest.fn()}
           selectedFeatures={selectedFeatures}
           selectedPlatform={selectedPlatform}
           selectedRepository={undefined}
@@ -912,7 +1028,7 @@ describe('ScmMessaging', () => {
         body: {results: []},
       });
 
-      renderMessaging(jest.fn(), {mode: 'unconfigured'});
+      renderMessaging({messagingSetup: {mode: 'unconfigured'}});
 
       // All three rows visible initially.
       expect(await screen.findByText('slack')).toBeInTheDocument();
@@ -941,7 +1057,7 @@ describe('ScmMessaging', () => {
 
     it('a saved destination hides sibling rows and keeps the footer', async () => {
       mockExclusiveSlackProviders();
-      renderMessaging(jest.fn(), exclusiveSlackSetup);
+      renderMessaging({messagingSetup: exclusiveSlackSetup});
 
       expect(await screen.findByText('slack')).toBeInTheDocument();
       expect(screen.queryByText('discord')).not.toBeInTheDocument();
@@ -1065,7 +1181,7 @@ describe('ScmMessaging', () => {
 
     it('Cancel from removing keeps siblings hidden and restores the footer', async () => {
       mockExclusiveSlackProviders();
-      renderMessaging(jest.fn(), exclusiveSlackSetup);
+      renderMessaging({messagingSetup: exclusiveSlackSetup});
 
       expect(await screen.findByText('slack')).toBeInTheDocument();
       expect(screen.queryByText('discord')).not.toBeInTheDocument();
@@ -1127,10 +1243,10 @@ describe('ScmMessaging', () => {
               Clear destination
             </button>
             <ScmMessaging
-              createdProjectSlug={undefined}
+              createdProject={undefined}
               messagingSetup={setup}
+              onCreatedProjectChange={jest.fn()}
               onMessagingSetupChange={setSetup}
-              onProjectCreated={jest.fn()}
               selectedFeatures={selectedFeatures}
               selectedPlatform={selectedPlatform}
               selectedRepository={undefined}
@@ -1171,7 +1287,7 @@ describe('ScmMessaging', () => {
         body: {results: []},
       });
 
-      renderMessaging(jest.fn(), {mode: 'unconfigured'});
+      renderMessaging({messagingSetup: {mode: 'unconfigured'}});
 
       expect(
         await screen.findByRole('button', {name: /Connect slack/i})

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -885,36 +885,6 @@ describe('ScmMessaging', () => {
       expect(onCreatedProjectChange).not.toHaveBeenCalled();
     });
 
-    it('creates a new project when a destination is added after Set up later', async () => {
-      mockIntegration();
-      mockChannelValidate(true);
-      const createProjectRequest = mockCreateProject();
-      const createWorkflowRequest = mockCreateWorkflow();
-      const onComplete = jest.fn();
-      const onCreatedProjectChange = jest.fn();
-      renderMessaging({
-        createdProject: {slug: createdProject.slug, messagingSelection: undefined},
-        onComplete,
-        onCreatedProjectChange,
-      });
-
-      const continueButton = screen.getByRole('button', {name: 'Continue'});
-      await waitFor(() => expect(continueButton).toBeEnabled());
-      await userEvent.click(continueButton);
-
-      await waitFor(() =>
-        expect(onComplete).toHaveBeenCalledWith(selectedPlatform, {
-          product: selectedFeatures,
-        })
-      );
-      expect(createProjectRequest).toHaveBeenCalledTimes(1);
-      expect(createWorkflowRequest).toHaveBeenCalledTimes(1);
-      expect(onCreatedProjectChange).toHaveBeenCalledWith({
-        slug: createdProject.slug,
-        messagingSelection: stagedSelection,
-      });
-    });
-
     it('Set up later completes without any requests whatever the project was created for', async () => {
       mockIntegration();
       mockChannelValidate(true);

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useEffectEvent, useState} from 'react';
+import {useCallback, useEffect, useEffectEvent, useMemo, useState} from 'react';
 import {AnimatePresence, LayoutGroup, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -11,6 +11,7 @@ import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedD
 import type {ScmMessagingProviderKey} from 'sentry/components/onboarding/scm/messagingProviders';
 import {ScmMessagingProviderRow} from 'sentry/components/onboarding/scm/scmMessagingProviderRow';
 import type {
+  CreatedProject,
   ScmMessagingActiveRow,
   ScmMessagingSetup,
 } from 'sentry/components/onboarding/scm/scmMessagingSetup';
@@ -47,11 +48,11 @@ export const SCM_MESSAGING_TITLE = t('Get alerts where your team works');
 type MessagingProviderList = ReturnType<typeof useScmMessagingProviders>['providers'];
 
 interface ScmMessagingProps {
-  createdProjectSlug: string | undefined;
+  createdProject: CreatedProject | undefined;
   messagingSetup: ScmMessagingSetup;
   onComplete: StepProps['onComplete'];
+  onCreatedProjectChange: (createdProject: CreatedProject) => void;
   onMessagingSetupChange: (messagingSetup: ScmMessagingSetup) => void;
-  onProjectCreated: (slug: string) => void;
   selectedFeatures: ProductSolution[] | undefined;
   selectedPlatform: OnboardingSelectedSDK;
   selectedRepository: Repository | undefined;
@@ -59,19 +60,19 @@ interface ScmMessagingProps {
 }
 
 export function ScmMessaging({
-  createdProjectSlug,
+  createdProject,
   genBackButton,
   messagingSetup,
+  onCreatedProjectChange,
   onMessagingSetupChange,
-  onProjectCreated,
   onComplete,
   selectedFeatures,
   selectedPlatform,
   selectedRepository,
 }: ScmMessagingProps) {
   const {createOrReuseProject, isCreating, isDataPending} = useScmProjectCreation({
-    createdProjectSlug,
-    onProjectCreated,
+    createdProject,
+    onCreatedProjectChange,
     selectedRepository,
   });
   const [submissionMode, setSubmissionMode] = useState<'continue' | 'setup-later'>();
@@ -97,21 +98,30 @@ export function ScmMessaging({
 
   const validatedActiveRow = validateActiveRow(activeRow, providers, messagingSetup);
   const visibleProviders = listedProviders(providers, validatedActiveRow, messagingSetup);
+  // The destination as the creation snapshot records it, so the reuse check
+  // can compare it against what the project was created with.
+  const selection = useMemo(
+    () =>
+      messagingSetup.mode === 'selected'
+        ? {
+            provider: messagingSetup.providerKey,
+            integrationId: messagingSetup.integrationId,
+            channel:
+              messagingSetup[
+                providerDetails[messagingSetup.providerKey].channelTargetedBy
+              ],
+          }
+        : undefined,
+    [messagingSetup]
+  );
   const getIntegrationAction = useCallback(
     ({shouldCreateRule}: Partial<RequestDataFragment>) => {
-      if (!shouldCreateRule || messagingSetup.mode !== 'selected') {
+      if (!shouldCreateRule) {
         return;
       }
-
-      const channelTargetedBy =
-        providerDetails[messagingSetup.providerKey].channelTargetedBy;
-      return buildIntegrationAction({
-        provider: messagingSetup.providerKey,
-        integrationId: messagingSetup.integrationId,
-        channel: messagingSetup[channelTargetedBy],
-      });
+      return buildIntegrationAction(selection ?? {});
     },
-    [messagingSetup]
+    [selection]
   );
 
   const isSubmitting = isCreating || submissionMode !== undefined;
@@ -127,12 +137,19 @@ export function ScmMessaging({
   }: {
     includeMessagingRule: boolean;
   }) => {
+    // Gated on the submission intent, not on the selection alone: Set up
+    // later can submit with a staged destination still in the closure, which
+    // must read as undefined — the same subtlety the includeMessagingRule
+    // split guards.
+    const stagedSelection = includeMessagingRule ? selection : undefined;
+
     await createOrReuseProject({
       platform: selectedPlatform,
       alertRuleConfig: includeMessagingRule
         ? getRequestDataFragment()
         : {defaultRules: true},
       getIntegrationAction: includeMessagingRule ? getIntegrationAction : undefined,
+      stagedSelection,
       onSuccess: () => {
         // Record the skip only on success: a failed creation keeps the staged
         // destination (and the Continue button) intact on the step.

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -15,6 +15,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {CreatedProject} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {Repository} from 'sentry/types/integrations';
@@ -58,7 +59,7 @@ jest.mock('sentry/data/platforms', () => {
 });
 
 interface StateOverrides {
-  createdProjectSlug?: string;
+  createdProject?: CreatedProject;
   selectedFeatures?: ProductSolution[];
   selectedPlatform?: OnboardingSelectedSDK;
   selectedRepository?: Repository;
@@ -69,12 +70,7 @@ function defaultProps(state: StateOverrides = {}) {
     selectedRepository: state.selectedRepository,
     selectedPlatform: state.selectedPlatform,
     selectedFeatures: state.selectedFeatures,
-    createdProject: state.createdProjectSlug
-      ? {
-          slug: state.createdProjectSlug,
-          messagingSelection: undefined,
-        }
-      : undefined,
+    createdProject: state.createdProject,
     deferProjectCreation: false,
     onPlatformChange: jest.fn(),
     onFeaturesChange: jest.fn(),
@@ -815,7 +811,7 @@ describe('ScmPlatformFeatures', () => {
       const props = defaultProps({
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
-        createdProjectSlug: existingProject.slug,
+        createdProject: {slug: existingProject.slug, messagingSelection: undefined},
       });
       render(<ScmPlatformFeatures {...props} />, {organization});
 
@@ -851,7 +847,7 @@ describe('ScmPlatformFeatures', () => {
       const props = defaultProps({
         selectedPlatform: nextJsPlatform,
         selectedFeatures: [ProductSolution.ERROR_MONITORING],
-        createdProjectSlug: stalePythonProject.slug,
+        createdProject: {slug: stalePythonProject.slug, messagingSelection: undefined},
       });
       render(<ScmPlatformFeatures {...props} />, {organization});
 

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -69,11 +69,16 @@ function defaultProps(state: StateOverrides = {}) {
     selectedRepository: state.selectedRepository,
     selectedPlatform: state.selectedPlatform,
     selectedFeatures: state.selectedFeatures,
-    createdProjectSlug: state.createdProjectSlug,
+    createdProject: state.createdProjectSlug
+      ? {
+          slug: state.createdProjectSlug,
+          messagingSelection: undefined,
+        }
+      : undefined,
     deferProjectCreation: false,
     onPlatformChange: jest.fn(),
     onFeaturesChange: jest.fn(),
-    onProjectCreated: jest.fn(),
+    onCreatedProjectChange: jest.fn(),
     onComplete: jest.fn(),
   };
 }
@@ -647,7 +652,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       expect(createRequest).not.toHaveBeenCalled();
-      expect(props.onProjectCreated).not.toHaveBeenCalled();
+      expect(props.onCreatedProjectChange).not.toHaveBeenCalled();
       expect(props.onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
       });
@@ -691,7 +696,10 @@ describe('ScmPlatformFeatures', () => {
       expect(props.onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
       });
-      expect(props.onProjectCreated).toHaveBeenCalledWith(createdProject.slug);
+      expect(props.onCreatedProjectChange).toHaveBeenCalledWith({
+        slug: createdProject.slug,
+        messagingSelection: undefined,
+      });
     });
 
     it('links selected repository to project after creation', async () => {

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -6,6 +6,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {ScmFeatureSelectionPanel} from 'sentry/components/onboarding/scm/scmFeatureSelectionPanel';
+import type {CreatedProject} from 'sentry/components/onboarding/scm/scmMessagingSetup';
 import {ScmPlatformFeaturesCore} from 'sentry/components/onboarding/scm/scmPlatformFeaturesCore';
 import {
   DEFAULT_SCM_FEATURES,
@@ -22,12 +23,12 @@ import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 import type {StepProps} from './types';
 
 interface ScmPlatformFeaturesProps {
-  createdProjectSlug: string | undefined;
+  createdProject: CreatedProject | undefined;
   deferProjectCreation: boolean;
   onComplete: StepProps['onComplete'];
+  onCreatedProjectChange: (createdProject: CreatedProject) => void;
   onFeaturesChange: (features: ProductSolution[] | undefined) => void;
   onPlatformChange: (platform: OnboardingSelectedSDK | undefined) => void;
-  onProjectCreated: (slug: string | undefined) => void;
   selectedFeatures: ProductSolution[] | undefined;
   selectedPlatform: OnboardingSelectedSDK | undefined;
   selectedRepository: Repository | undefined;
@@ -35,20 +36,20 @@ interface ScmPlatformFeaturesProps {
 }
 
 export function ScmPlatformFeatures({
-  createdProjectSlug,
+  createdProject,
   deferProjectCreation,
   onComplete,
+  onCreatedProjectChange,
   onFeaturesChange,
   onPlatformChange,
-  onProjectCreated,
   selectedFeatures,
   selectedPlatform,
   selectedRepository,
   genBackButton,
 }: ScmPlatformFeaturesProps) {
   const {createOrReuseProject, isCreating, isDataPending} = useScmProjectCreation({
-    createdProjectSlug,
-    onProjectCreated,
+    createdProject,
+    onCreatedProjectChange,
     selectedRepository,
   });
 

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -47,7 +47,7 @@ export function useBackActions({
       }
 
       if (preserveOnboardingState) {
-        onboardingContext.setCreatedProjectSlug(undefined);
+        onboardingContext.setCreatedProject(undefined);
       } else {
         onboardingContext.resetOnboarding();
       }


### PR DESCRIPTION
On back-navigation to the messaging step, `createOrReuseProject` reused an already-created project on a platform-only check, so a changed messaging destination was silently dropped: Continue with a different channel completed without any workflow request, and a destination configured after a Set up later creation was never created at all.

The messaging step now records the destination the project was created for next to its slug in the onboarding session state (`createdProject.messagingSelection`, cleared wherever the slug is cleared). On return, a submission that stages the same destination reuses the project untouched. One that stages a different destination creates a new project with its own workflow and abandons the old one. This is the rule `useScmProjectDetails` already applies on the SCM project-creation page: an unchanged resubmit reuses, any change creates a new project. Set up later stages no destination, so it always reuses. The control arm passes no destination and keeps the platform-only check.

The old project is not deleted or modified. Back-navigation deletes an inactive project before this step is reached again, so an abandoned project is one that has received data or is more than an hour old. Replacing the workflow on the existing project instead was considered and dropped to keep one reuse rule across project creation; multi-project creation is expected to change this area.

Refs VDY-141
