### PR TITLE
fix(investigations): Route details through Explore

### DIFF
--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -136,6 +136,26 @@ describe('buildRoutes()', () => {
   });
 
   describe('explore route catch-all', () => {
+    it('matches investigation details before the catch-all', () => {
+      const spy = jest.spyOn(constants, 'USING_CUSTOMER_DOMAIN', 'get');
+
+      spy.mockReturnValue(true);
+      let matchedPaths = getMatchedPaths(
+        buildRoutes(),
+        '/explore/investigations/investigation-1/'
+      );
+      expect(matchedPaths).toContain('investigations/:investigationId/');
+      expect(matchedPaths).not.toContain('*');
+
+      spy.mockReturnValue(false);
+      matchedPaths = getMatchedPaths(
+        buildRoutes(),
+        '/organizations/test-org/explore/investigations/investigation-1/'
+      );
+      expect(matchedPaths).toContain('investigations/:investigationId/');
+      expect(matchedPaths).not.toContain('*');
+    });
+
     it('catches unknown subpaths under /explore/', () => {
       const spy = jest.spyOn(constants, 'USING_CUSTOMER_DOMAIN', 'get');
 

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2324,6 +2324,10 @@ function buildRoutes(): RouteObject[] {
       path: 'investigations/',
       component: make(() => import('sentry/views/investigations')),
     },
+    {
+      path: 'investigations/:investigationId/',
+      component: make(() => import('sentry/views/investigations/detail')),
+    },
     // Unknown /explore/ subpaths redirect to the default explore view, rather
     // than falling through to the `/:orgId/:projectId/` legacy redirect and
     // rendering "The project you were looking for was not found".
@@ -2347,12 +2351,6 @@ function buildRoutes(): RouteObject[] {
     path: '/explore/',
     withOrgPath: true,
     children: exploreChildren,
-  };
-
-  const investigationRoutes: SentryRouteObject = {
-    path: '/seer/investigation/:investigationId/',
-    withOrgPath: true,
-    component: make(() => import('sentry/views/investigations/detail')),
   };
 
   const preprodChildren: SentryRouteObject[] = [
@@ -2831,7 +2829,6 @@ function buildRoutes(): RouteObject[] {
       domainViewRoutes,
       tracesRoutes,
       exploreRoutes,
-      investigationRoutes,
       llmMonitoringRedirects,
       profilingRoutes,
       gettingStartedRoutes,

--- a/static/app/views/investigations/detail/index.spec.tsx
+++ b/static/app/views/investigations/detail/index.spec.tsx
@@ -16,6 +16,7 @@ import {
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {FeedbackIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
+import {ConfigStore} from 'sentry/stores/configStore';
 import {GlobalFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {
   AsyncSDKIntegrationContextProvider,
@@ -154,9 +155,9 @@ function renderView(
     organization: renderOrganization,
     initialRouterConfig: {
       location: {
-        pathname: '/organizations/org-slug/seer/investigation/investigation-1/',
+        pathname: '/organizations/org-slug/explore/investigations/investigation-1/',
       },
-      route: '/organizations/:orgId/seer/investigation/:investigationId/',
+      route: '/organizations/:orgId/explore/investigations/:investigationId/',
     },
   });
 
@@ -178,6 +179,7 @@ describe('Investigation detail', () => {
     jest.spyOn(indicators, 'addSuccessMessage').mockImplementation();
     jest.spyOn(indicators, 'addErrorMessage').mockImplementation();
     createFeedbackForm.mockClear();
+    ConfigStore.set('customerDomain', null);
   });
 
   it('loads and renders the complete investigation response', async () => {
@@ -1679,12 +1681,17 @@ describe('Investigation detail', () => {
 
     await waitFor(() =>
       expect(router.location.pathname).toBe(
-        '/organizations/org-slug/seer/investigation/investigation-2/'
+        '/organizations/org-slug/explore/investigations/investigation-2/'
       )
     );
   });
 
   it('copies the link from the title menu', async () => {
+    ConfigStore.set('customerDomain', {
+      subdomain: 'org-slug',
+      organizationUrl: 'https://org-slug.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
     const writeText = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, 'clipboard', {
       value: {writeText},
@@ -1701,7 +1708,7 @@ describe('Investigation detail', () => {
 
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        `${window.location.origin}/organizations/org-slug/seer/investigation/investigation-1/`
+        `${window.location.origin}/explore/investigations/investigation-1/`
       )
     );
   });

--- a/static/app/views/investigations/detail/index.tsx
+++ b/static/app/views/investigations/detail/index.tsx
@@ -540,7 +540,7 @@ function isTitleGenerationActive(status: string | null | undefined) {
 
 function getInvestigationPath(organizationSlug: string, investigationId: string) {
   return normalizeUrl(
-    `/organizations/${organizationSlug}/seer/investigation/${investigationId}/`
+    `/organizations/${organizationSlug}/explore/investigations/${investigationId}/`
   );
 }
 

--- a/static/app/views/investigations/index.spec.tsx
+++ b/static/app/views/investigations/index.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
+import {ConfigStore} from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
 import InvestigationsView from 'sentry/views/investigations';
 import {
@@ -76,6 +77,7 @@ describe('Explore Investigations', () => {
   beforeEach(() => {
     jest.spyOn(indicators, 'addSuccessMessage').mockImplementation();
     jest.spyOn(indicators, 'addErrorMessage').mockImplementation();
+    ConfigStore.set('customerDomain', null);
   });
 
   it('shows the standard feature-disabled state without the feature', () => {
@@ -110,6 +112,11 @@ describe('Explore Investigations', () => {
   });
 
   it('renders loading and populated table states without unsupported controls', async () => {
+    ConfigStore.set('customerDomain', {
+      subdomain: 'org-slug',
+      organizationUrl: 'https://org-slug.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
     MockApiClient.addMockResponse({
       url: listUrl,
       body: [InvestigationFixture()],
@@ -120,7 +127,7 @@ describe('Explore Investigations', () => {
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(
       await screen.findByRole('link', {name: 'Database latency investigation'})
-    ).toHaveAttribute('href', '/organizations/org-slug/seer/investigation/1/');
+    ).toHaveAttribute('href', '/explore/investigations/1/');
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
@@ -252,7 +259,7 @@ describe('Explore Investigations', () => {
     );
     expect(await screen.findByText('Untitled investigation')).toBeInTheDocument();
     expect(router.location.pathname).toBe(
-      '/organizations/org-slug/seer/investigation/1/'
+      '/organizations/org-slug/explore/investigations/1/'
     );
     expect(queryClient.getQueryData(unrelatedOptions.queryKey)?.json).toBe(
       unrelatedDetail
@@ -434,7 +441,7 @@ describe('Explore Investigations', () => {
 
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        `${window.location.origin}/organizations/org-slug/seer/investigation/1/`
+        `${window.location.origin}/organizations/org-slug/explore/investigations/1/`
       )
     );
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith(

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -72,7 +72,7 @@ const TableWrapper = styled('div')`
 
 function getInvestigationPath(organizationSlug: string, investigationId: string) {
   return normalizeUrl(
-    `/organizations/${organizationSlug}/seer/investigation/${investigationId}/`
+    `/organizations/${organizationSlug}/explore/investigations/${investigationId}/`
   );
 }
 

--- a/static/app/views/issueDetails/groupOpenPeriods.spec.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.spec.tsx
@@ -134,7 +134,7 @@ describe('GroupOpenPeriods', () => {
     expect(await screen.findByText('Investigation')).toBeInTheDocument();
     expect(await screen.findByRole('link', {name: '4567'})).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/seer/investigation/4567/`
+      `/organizations/${organization.slug}/explore/investigations/4567/`
     );
     expect(candidatesMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/static/app/views/issueDetails/groupOpenPeriods.tsx
+++ b/static/app/views/issueDetails/groupOpenPeriods.tsx
@@ -113,7 +113,7 @@ function IssueOpenPeriodsList() {
         investigation:
           activity.type === 'opened' && candidate?.status === 'view' ? (
             <Link
-              to={`/organizations/${organization.slug}/seer/investigation/${candidate.investigationId}/`}
+              to={`/organizations/${organization.slug}/explore/investigations/${candidate.investigationId}/`}
             >
               <Flex as="span" align="center" gap="xs">
                 <IconSeer size="xs" />

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -6,6 +6,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ConfigStore} from 'sentry/stores/configStore';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import {
   DataConditionType,
@@ -58,6 +59,7 @@ describe('MetricDetectorTriggeredSection', () => {
   };
 
   beforeEach(() => {
+    ConfigStore.set('customerDomain', null);
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
@@ -91,6 +93,11 @@ describe('MetricDetectorTriggeredSection', () => {
   });
 
   it('links to an existing investigation for the selected open period', async () => {
+    ConfigStore.set('customerDomain', {
+      subdomain: 'org-slug',
+      organizationUrl: 'https://org-slug.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
     const organization = OrganizationFixture({
       slug: 'org-slug',
       features: ['investigations'],
@@ -122,7 +129,7 @@ describe('MetricDetectorTriggeredSection', () => {
     ).toBeInTheDocument();
     expect(
       await screen.findByRole('button', {name: 'View Investigation'})
-    ).toHaveAttribute('href', '/organizations/org-slug/seer/investigation/4567/');
+    ).toHaveAttribute('href', '/explore/investigations/4567/');
   });
 
   it('hides an existing investigation summary until all summary fields are ready', async () => {
@@ -247,6 +254,11 @@ describe('MetricDetectorTriggeredSection', () => {
   });
 
   it('launches an investigation for the selected open period', async () => {
+    ConfigStore.set('customerDomain', {
+      subdomain: 'org-slug',
+      organizationUrl: 'https://org-slug.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
     const organization = OrganizationFixture({
       slug: 'org-slug',
       features: ['investigations'],
@@ -262,7 +274,7 @@ describe('MetricDetectorTriggeredSection', () => {
       body: {id: '4567'},
     });
 
-    render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
+    const {router} = render(<MetricIssueSeerInvestigationSection {...defaultProps} />, {
       organization,
     });
 
@@ -292,6 +304,7 @@ describe('MetricDetectorTriggeredSection', () => {
         })
       );
     });
+    expect(router.location.pathname).toBe('/explore/investigations/4567/');
   });
 
   it('uses the latest open period when the displayed event is not linked to one', async () => {

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -673,7 +673,7 @@ function SeerInvestigationSection({
       );
       navigate(
         normalizeUrl(
-          `/organizations/${organization.slug}/seer/investigation/${launchedInvestigation.id}/`
+          `/organizations/${organization.slug}/explore/investigations/${launchedInvestigation.id}/`
         )
       );
     },
@@ -683,7 +683,7 @@ function SeerInvestigationSection({
   const investigationPath =
     candidate?.status === 'view'
       ? normalizeUrl(
-          `/organizations/${organization.slug}/seer/investigation/${candidate.investigationId}/`
+          `/organizations/${organization.slug}/explore/investigations/${candidate.investigationId}/`
         )
       : null;
 

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -192,7 +192,7 @@ export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {
                 makeNavigationItemProps(
                   'explore',
                   `/${prefix}/explore/${getDefaultExploreRoute(organization)}/`,
-                  [`/${prefix}/explore`, `/${prefix}/seer/investigation/`]
+                  [`/${prefix}/explore`]
                 ),
                 tourProps
               )}

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -110,7 +110,7 @@ describe('ExploreSecondaryNavigation', () => {
         organization: investigationsOrganization,
         initialRouterConfig: {
           location: {
-            pathname: '/organizations/org-slug/seer/investigation/investigation-1/',
+            pathname: '/organizations/org-slug/explore/investigations/investigation-1/',
           },
         },
       }

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -223,10 +223,7 @@ function ExploreSecondaryNavigationImpl() {
                 <SecondaryNavigation.ListItem>
                   <SecondaryNavigation.Link
                     to={`${baseUrl}/investigations/`}
-                    activeTo={[
-                      `${baseUrl}/investigations/`,
-                      `/organizations/${organization.slug}/seer/investigation/`,
-                    ]}
+                    activeTo={`${baseUrl}/investigations/`}
                     analyticsItemName="explore_investigations"
                     trailingItems={<FeatureBadge type="beta" />}
                   >


### PR DESCRIPTION
Investigation detail pages now live beneath the existing Explore investigations route at `/explore/investigations/:id/`. This reuses the established Explore React shell for cold loads, avoids the conflicting top-level `/seer/` path, and updates investigation links and navigation state to the new location.
