### PR TITLE
fix(workflow_engine): Add workflow/query metrics tagged with retry state

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -11,7 +11,7 @@ import sentry_sdk
 from django.utils import timezone
 from pydantic import BaseModel, validator
 from taskbroker_client.retry import retry_task
-from taskbroker_client.state import current_task
+from taskbroker_client.state import CurrentTaskState, current_task
 
 from sentry import features, nodestore
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -64,6 +64,10 @@ logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workf
 
 EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
+
+
+def is_retry(task: CurrentTaskState | None) -> bool:
+    return task is not None and task.attempt > 0
 
 
 class EventInstance(BaseModel):
@@ -452,9 +456,9 @@ def get_condition_group_results(
         )
     )
 
-    last_try = False
-    if task := current_task():
-        last_try = not task.retries_remaining
+    task = current_task()
+    last_try = task is not None and not task.retries_remaining
+    retry = is_retry(task)
 
     for unique_condition, time_and_groups in queries_to_groups.items():
         handler = unique_condition.handler()
@@ -471,6 +475,10 @@ def get_condition_group_results(
             )
 
         try:
+            metrics.incr(
+                "workflow_engine.delayed_workflow.condition_query",
+                tags={"is_retry": retry},
+            )
             result = handler.get_rate_bulk(
                 duration=duration,
                 groups=groups_to_query,
@@ -1036,7 +1044,9 @@ def _process_workflows_for_project(project: Project, event_data: EventRedisData)
 
 @trace
 def process_delayed_workflows(
-    batch_client: DelayedWorkflowClient, project_id: int, batch_key: str | None = None
+    batch_client: DelayedWorkflowClient,
+    project_id: int,
+    batch_key: str | None = None,
 ) -> None:
     """
     Grab workflows, groups, and data condition groups from the Redis buffer, evaluate the "slow" conditions in a bulk snuba query, and fire them if they pass
@@ -1049,6 +1059,7 @@ def process_delayed_workflows(
     metrics.incr(
         "workflow_engine.delayed_workflow",
         amount=len(event_data.events),
+        tags={"is_retry": is_retry(current_task())},
     )
 
     project = fetch_project(project_id)

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -55,6 +55,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     get_condition_query_groups,
     get_group_to_groupevent,
     get_groups_to_fire,
+    is_retry,
 )
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
@@ -537,6 +538,41 @@ class TestGetSnubaResults(BaseWorkflowTest):
     def test_empty_condition_groups(self) -> None:
         assert get_condition_group_results({}) == {}
 
+    def test_is_retry(self) -> None:
+        task = Mock(spec=CurrentTaskState)
+        task.attempt = 0
+
+        assert not is_retry(None)
+        assert not is_retry(task)
+
+        task.attempt = 1
+        assert is_retry(task)
+
+    @patch("sentry.workflow_engine.processors.delayed_workflow.metrics.incr")
+    @patch("sentry.workflow_engine.processors.delayed_workflow.current_task")
+    def test_condition_query_metric_tracks_retry_load(
+        self, mock_current_task: MagicMock, mock_incr: MagicMock
+    ) -> None:
+        task = Mock(spec=CurrentTaskState)
+        task.attempt = 1
+        task.retries_remaining = True
+        mock_current_task.return_value = task
+        mock_handler = Mock(spec=BaseEventFrequencyQueryHandler)
+        mock_handler.get_rate_bulk.return_value = {}
+        mock_handler.intervals = {"1h": ("fake", timedelta(seconds=1))}
+        unique_query = UniqueConditionQuery(
+            handler=lambda: mock_handler,  # type: ignore[arg-type]
+            interval="1h",
+            environment_id=None,
+        )
+
+        get_condition_group_results({unique_query: GroupQueryParams(group_ids={1}, timestamp=None)})
+
+        mock_incr.assert_called_once_with(
+            "workflow_engine.delayed_workflow.condition_query",
+            tags={"is_retry": True},
+        )
+
     def test_count_comparison_condition(self) -> None:
         dc = self.create_event_frequency_condition()
         condition_groups, group_id, unique_queries = self.create_condition_groups([dc])
@@ -620,6 +656,7 @@ class TestGetSnubaResults(BaseWorkflowTest):
         self, mock_current_task: MagicMock
     ) -> None:
         mock_task = Mock(spec=CurrentTaskState)
+        mock_task.attempt = 1
         mock_task.retries_remaining = False
         mock_current_task.return_value = mock_task
 

--- a/tests/sentry/workflow_engine/tasks/test_delayed_workflows.py
+++ b/tests/sentry/workflow_engine/tasks/test_delayed_workflows.py
@@ -184,6 +184,27 @@ class TestDelayedWorkflowTaskBase(BaseWorkflowTest, BaseEventFrequencyPercentTes
 
 
 class TestDelayedWorkflowTaskIntegration(TestDelayedWorkflowTaskBase):
+    @patch("sentry.workflow_engine.processors.delayed_workflow.metrics.incr")
+    def test_metric_tracks_retry_workload(self, mock_incr: MagicMock) -> None:
+        self._push_base_events()
+
+        with (
+            patch(
+                "sentry.workflow_engine.processors.delayed_workflow._process_workflows_for_project"
+            ),
+            patch(
+                "sentry.workflow_engine.processors.delayed_workflow.current_task"
+            ) as mock_current_task,
+        ):
+            mock_current_task.return_value.attempt = 1
+            process_delayed_workflows(self.batch_client, self.project.id)
+
+        mock_incr.assert_any_call(
+            "workflow_engine.delayed_workflow",
+            amount=2,
+            tags={"is_retry": True},
+        )
+
     @override_options({"delayed_processing.batch_size": 1})
     @patch("sentry.workflow_engine.tasks.delayed_workflows.process_delayed_workflows.apply_async")
     def test_batched_cleanup(self, mock_process_delayed: MagicMock) -> None:


### PR DESCRIPTION
We have general volume metrics, but little indication of how much our of workload is due to retries.
This tries to fix that by tagging our delayed workflow counts and a new condition query counter with whether they were generated by a retry.
