### PR TITLE
feat(derived data): Allow experimental Pipelines in DebugGroupDerivedDataEndpoint

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -35,6 +35,7 @@ from sentry.issues.derived.features import (
     IS_ASSIGNED,
     LAST_COMPLETED_AUTOFIX_STEP,
     LAST_PROGRESSED_AT,
+    MERGE_AWARE_STATUS,
     PROGRESS,
     STATUS,
     VIEW_COUNT,
@@ -92,6 +93,47 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
             current == IssueStatus.CLOSED
         ):
             return emit(STATUS.value(IssueStatus.OPEN))
+
+    return None
+
+
+@aggregator(
+    (MERGE_AWARE_STATUS,),
+    scope=(
+        ResolveAction,
+        SetResolvedInReleaseAction,
+        SetResolvedByAgeAction,
+        SetResolvedInCommitAction,
+        ArchiveAction,
+        UnresolveAction,
+        SetEscalatingAction,
+        SetRegressedAction,
+        ReconcileStatusAction,
+    ),
+)
+def track_merge_aware_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    if entry.original_group_id is not None:
+        return None
+
+    current = state[MERGE_AWARE_STATUS]
+
+    match entry.action:
+        case ReconcileStatusAction(status=raw_status):
+            new_status = IssueStatus(raw_status)
+            if new_status != current:
+                return emit(MERGE_AWARE_STATUS.value(new_status))
+        case (
+            ResolveAction()
+            | SetResolvedInReleaseAction()
+            | SetResolvedByAgeAction()
+            | SetResolvedInCommitAction()
+            | ArchiveAction()
+        ) if current == IssueStatus.OPEN:
+            return emit(MERGE_AWARE_STATUS.value(IssueStatus.CLOSED))
+        case UnresolveAction() | SetRegressedAction() | SetEscalatingAction() if (
+            current == IssueStatus.CLOSED
+        ):
+            return emit(MERGE_AWARE_STATUS.value(IssueStatus.OPEN))
 
     return None
 

--- a/src/sentry/issues/derived/features.py
+++ b/src/sentry/issues/derived/features.py
@@ -19,6 +19,11 @@ STATUS = Feature[IssueStatus](
     "status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus), version=1
 )
 
+# Alternate status computation used by the merge-aware debug pipeline.
+MERGE_AWARE_STATUS = Feature[IssueStatus](
+    "merge_aware_status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus)
+)
+
 # The current Progress of the issue.
 PROGRESS = Feature[IssueProgressState | None](
     "progress",

--- a/src/sentry/issues/endpoints/debug_group_derived_data.py
+++ b/src/sentry/issues/endpoints/debug_group_derived_data.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
+from sentry.issues.derived.aggregators import track_merge_aware_status
 from sentry.issues.derived.framework import Pipeline, State
 from sentry.issues.derived.processing import PIPELINE
 from sentry.issues.derived.store import GroupDerivedDataStore
@@ -16,6 +17,12 @@ from sentry.models.group import Group
 
 DEFAULT_LIMIT = 1000
 MAX_LIMIT = 10000
+
+_MERGE_AWARE_PIPELINE = Pipeline((*PIPELINE.aggregators, track_merge_aware_status))
+_PIPELINES = {
+    "live": PIPELINE,
+    "merge_aware": _MERGE_AWARE_PIPELINE,
+}
 
 
 def _state_to_dict(pipeline: Pipeline[Any], state: State) -> dict[str, Any]:
@@ -30,6 +37,17 @@ class DebugGroupDerivedDataEndpoint(GroupEndpoint):
     }
 
     def get(self, request: Request, group: Group) -> Response:
+        pipeline_name = request.GET.get("pipeline", "live")
+        pipeline = _PIPELINES.get(pipeline_name)
+        if pipeline is None:
+            available = ", ".join(_PIPELINES)
+            return Response(
+                {
+                    "detail": f"Invalid pipeline: {pipeline_name!r}. Available pipelines: {available}"
+                },
+                status=400,
+            )
+
         raw_limit = request.GET.get("limit", str(DEFAULT_LIMIT))
         try:
             limit = int(raw_limit)
@@ -65,15 +83,16 @@ class DebugGroupDerivedDataEndpoint(GroupEndpoint):
             entry_count = None
             truncated = True
         else:
-            state = PIPELINE.run(entries)
-            computed = _state_to_dict(PIPELINE, state)
+            state = pipeline.run(entries)
+            computed = _state_to_dict(pipeline, state)
             entry_count = len(entries)
             truncated = False
 
         return Response(
             {
                 "groupId": str(group.id),
-                "pipelineHash": PIPELINE.pipeline_hash,
+                "pipeline": pipeline_name,
+                "pipelineHash": pipeline.pipeline_hash,
                 "stored": stored,
                 "computed": computed,
                 "entryCount": entry_count,

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -19,11 +19,12 @@ from sentry.issues.action_log.types import (
     GroupActorType,
     ReconcileStatusAction,
 )
-from sentry.issues.derived.aggregators import AGGREGATORS
+from sentry.issues.derived.aggregators import AGGREGATORS, track_merge_aware_status
 from sentry.issues.derived.features import (
     BLOCKER,
     LAST_COMPLETED_AUTOFIX_STEP,
     LAST_PROGRESSED_AT,
+    MERGE_AWARE_STATUS,
     PROGRESS,
     STATUS,
     VIEW_COUNT,
@@ -64,6 +65,7 @@ class FakeEntry:
     date_added: datetime = datetime(2025, 1, 1, tzinfo=UTC)
     actor_type: int = GroupActorType.SYSTEM
     actor_id: int = 0
+    original_group_id: int | None = None
     data: dict[str, object] = field(default_factory=dict)
 
     @property
@@ -144,6 +146,15 @@ def test_view_ignores_non_view() -> None:
 
 def test_starts_open() -> None:
     assert _run_for_feature(STATUS, []) == IssueStatus.OPEN
+
+
+def test_merge_aware_status_ignores_entries_from_merged_groups() -> None:
+    pipeline = _pipeline([*AGGREGATORS, track_merge_aware_status])
+
+    state = pipeline.run([FakeEntry(type=GroupActionType.RESOLVE, original_group_id=123)])
+
+    assert state[STATUS] == IssueStatus.CLOSED
+    assert state[MERGE_AWARE_STATUS] == IssueStatus.OPEN
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/issues/endpoints/test_debug_group_derived_data.py
+++ b/tests/sentry/issues/endpoints/test_debug_group_derived_data.py
@@ -8,6 +8,7 @@ from sentry.issues.action_log.types import (
     ViewAction,
 )
 from sentry.issues.derived.processing import PIPELINE, process_group_log
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -42,6 +43,7 @@ class DebugGroupDerivedDataEndpointTest(APITestCase):
         assert response.data["computed"] is not None
         assert response.data["entryCount"] == 0
         assert response.data["truncated"] is False
+        assert response.data["pipeline"] == "live"
 
     def test_with_stored_and_computed(self) -> None:
         _publish(group=self.group, action=ViewAction())
@@ -58,6 +60,35 @@ class DebugGroupDerivedDataEndpointTest(APITestCase):
         assert response.data["computed"]["status"] == "closed"
         assert response.data["entryCount"] == 3
         assert response.data["pipelineHash"] == PIPELINE.pipeline_hash
+
+    def test_merge_aware_pipeline_ignores_status_from_merged_group(self) -> None:
+        _publish(group=self.group, action=ResolveAction())
+        GroupActionLogEntry.objects.filter(group_id=self.group.id).update(original_group_id=123)
+        process_group_log(self.group.id)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.group.id,
+            qs_params={"pipeline": "merge_aware"},
+            status_code=200,
+        )
+
+        assert response.data["pipeline"] == "merge_aware"
+        assert response.data["stored"]["state"]["status"] == "closed"
+        assert response.data["computed"]["status"] == "closed"
+        assert response.data["computed"]["merge_aware_status"] == "open"
+
+    def test_invalid_pipeline(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            self.group.id,
+            qs_params={"pipeline": "unknown"},
+            status_code=400,
+        )
+
+        assert response.data == {
+            "detail": "Invalid pipeline: 'unknown'. Available pipelines: live, merge_aware"
+        }
 
     def test_truncated_when_over_limit(self) -> None:
         for _ in range(3):


### PR DESCRIPTION
Rolling out new Features or modified features can be expensive; we need to reprocess the world before we can see them in action.
Unit test coverage is expected for key scenarios, but it's useful to be able to specify non-live Pipelines for processing in non-live contexts to see their impact on known problem groups.
This extends our debug endpoint to allow arbitrary PIpelines to added and requested for evaluation. 
By itself, this isn't terribly high impact, but it can be useful for spot-checking fixes against real data, and it starts moving us away from a world of single pipeline assumption. We can apply a similar pattern of pipeline choice to background validation tasks, running them with a potential new pipeline, tagging metrics with the pipeline name, and using comparison of correctness over a significant project or set of groups to inform choices.


Note that in thise case, we're not replacing STATUS, just adding a peer. I plan to follow up to support a "use this new Feature wherever we use STATUS currently" approach which'll be much more interesting; the code was interesting enough to merit independent review.