### PR TITLE
feat(investigations): Record terminal lifecycle outcomes

### DIFF
--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -33,10 +33,12 @@ from sentry.investigations.services.investigations import (
     mark_downstream_blocks_stale,
 )
 from sentry.investigations.telemetry import (
+    record_execution_cancelled,
     record_execution_completed,
     record_execution_failed,
     record_execution_started,
     record_investigation_completed,
+    record_investigation_failed,
     record_title_generation_completed,
     record_title_generation_failed,
 )
@@ -651,6 +653,12 @@ def cancel_investigation_executions_after_failure(
         ):
             return
 
+        failure_reason = str((failed_execution.error or {}).get("code") or "execution_failed")
+        transaction.on_commit(
+            partial(record_investigation_failed, investigation, reason=failure_reason),
+            using=database,
+        )
+
         active_executions = list(
             InvestigationBlockExecution.objects.select_for_update(of=("self",))
             .filter(
@@ -658,7 +666,7 @@ def cancel_investigation_executions_after_failure(
                 status__in=ACTIVE_BLOCK_EXECUTION_STATUSES,
             )
             .exclude(id=failed_execution.id)
-            .select_related("seer_run")
+            .select_related("block__investigation", "seer_run")
             .order_by("id")
         )
         completed_at = timezone.now()
@@ -675,6 +683,14 @@ def cancel_investigation_executions_after_failure(
         )
 
         for execution in active_executions:
+            transaction.on_commit(
+                partial(
+                    record_execution_cancelled,
+                    execution,
+                    reason="investigation_execution_failed",
+                ),
+                using=database,
+            )
             if execution.seer_run is None or execution.seer_run.seer_run_state_id is None:
                 continue
             transaction.on_commit(
@@ -995,7 +1011,6 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
         ):
             return
         locked.update(title_generation_status=TitleGenerationStatus.PENDING)
-    record_investigation_completed(locked)
 
     title_seer_run_state_id: int | None = None
 
@@ -1066,6 +1081,7 @@ def synchronize_title(investigation: Investigation, state: SeerRunState) -> None
     investigation.update(**updates)
     if metadata is not None:
         record_title_generation_completed(investigation)
+        record_investigation_completed(investigation)
     else:
         record_title_generation_failed(
             investigation,

--- a/src/sentry/investigations/services/executions.py
+++ b/src/sentry/investigations/services/executions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime, timedelta
+from functools import partial
 from typing import Any
 from uuid import UUID
 
@@ -32,6 +33,7 @@ from sentry.investigations.services.parameters import (
     ParameterValidationError,
     validate_parameter_value,
 )
+from sentry.investigations.telemetry import record_execution_cancelled
 from sentry.models.project import Project
 from sentry.utils import json
 
@@ -539,12 +541,19 @@ def mark_block_execution_stopping(execution: InvestigationBlockExecution) -> boo
     return updated == 1
 
 
-def mark_block_execution_cancelled(execution: InvestigationBlockExecution) -> bool:
+def mark_block_execution_cancelled(
+    execution: InvestigationBlockExecution, *, reason: str = "user_requested"
+) -> bool:
     updated = (
         InvestigationBlockExecution.objects.filter(id=execution.id)
         .exclude(status__in=TERMINAL_BLOCK_EXECUTION_STATUSES)
         .update(status=InvestigationBlockExecutionStatus.CANCELLED, completed_at=timezone.now())
     )
+    if updated:
+        transaction.on_commit(
+            partial(record_execution_cancelled, execution, reason=reason),
+            using=router.db_for_write(InvestigationBlockExecution),
+        )
     return updated == 1
 
 

--- a/src/sentry/investigations/telemetry.py
+++ b/src/sentry/investigations/telemetry.py
@@ -6,8 +6,14 @@ import sentry_sdk
 from django.utils import timezone
 
 from sentry.investigations.models import Investigation, InvestigationBlockExecution
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
+
+
+def _record_count(name: str, attributes: dict[str, str]) -> None:
+    sentry_sdk.metrics.count(name, 1, attributes=attributes)
+    metrics.incr(name, tags=attributes, sample_rate=1.0)
 
 
 def _investigation_attributes(investigation: Investigation) -> dict[str, str]:
@@ -26,16 +32,12 @@ def _execution_attributes(execution: InvestigationBlockExecution) -> dict[str, s
 
 
 def record_investigation_started(investigation: Investigation) -> None:
-    sentry_sdk.metrics.count(
-        "investigations.started",
-        1,
-        attributes=_investigation_attributes(investigation),
-    )
+    _record_count("investigations.started", _investigation_attributes(investigation))
 
 
 def record_investigation_completed(investigation: Investigation) -> None:
     attributes = _investigation_attributes(investigation)
-    sentry_sdk.metrics.count("investigations.completed", 1, attributes=attributes)
+    _record_count("investigations.completed", attributes)
     sentry_sdk.metrics.distribution(
         "investigations.duration",
         (timezone.now() - investigation.date_added).total_seconds(),
@@ -44,17 +46,20 @@ def record_investigation_completed(investigation: Investigation) -> None:
     )
 
 
-def record_execution_started(execution: InvestigationBlockExecution) -> None:
-    sentry_sdk.metrics.count(
-        "investigations.execution.started",
-        1,
-        attributes=_execution_attributes(execution),
+def record_investigation_failed(investigation: Investigation, *, reason: str) -> None:
+    _record_count(
+        "investigations.failed",
+        {**_investigation_attributes(investigation), "reason": reason},
     )
+
+
+def record_execution_started(execution: InvestigationBlockExecution) -> None:
+    _record_count("investigations.execution.started", _execution_attributes(execution))
 
 
 def record_execution_completed(execution: InvestigationBlockExecution) -> None:
     attributes = _execution_attributes(execution)
-    sentry_sdk.metrics.count("investigations.execution.completed", 1, attributes=attributes)
+    _record_count("investigations.execution.completed", attributes)
     if execution.completed_at is not None:
         sentry_sdk.metrics.distribution(
             "investigations.execution.duration",
@@ -65,13 +70,12 @@ def record_execution_completed(execution: InvestigationBlockExecution) -> None:
 
 
 def record_execution_failed(
-    execution: InvestigationBlockExecution, *, reason: str, seer_run_id: int
+    execution: InvestigationBlockExecution, *, reason: str, seer_run_id: int | None
 ) -> None:
     attributes = _execution_attributes(execution)
-    sentry_sdk.metrics.count(
+    _record_count(
         "investigations.execution.failed",
-        1,
-        attributes={**attributes, "reason": reason},
+        {**attributes, "reason": reason},
     )
     if execution.completed_at is not None:
         sentry_sdk.metrics.distribution(
@@ -93,22 +97,27 @@ def record_execution_failed(
     )
 
 
+def record_execution_cancelled(execution: InvestigationBlockExecution, *, reason: str) -> None:
+    _record_count(
+        "investigations.execution.cancelled",
+        {**_execution_attributes(execution), "reason": reason},
+    )
+
+
 def record_title_generation_completed(investigation: Investigation) -> None:
-    sentry_sdk.metrics.count(
-        "investigations.title_generation.completed",
-        1,
-        attributes=_investigation_attributes(investigation),
+    _record_count(
+        "investigations.title_generation.completed", _investigation_attributes(investigation)
     )
 
 
 def record_title_generation_failed(
     investigation: Investigation, *, reason: str, seer_run_id: int | None
 ) -> None:
-    sentry_sdk.metrics.count(
+    _record_count(
         "investigations.title_generation.failed",
-        1,
-        attributes={**_investigation_attributes(investigation), "reason": reason},
+        {**_investigation_attributes(investigation), "reason": reason},
     )
+    record_investigation_failed(investigation, reason=reason)
     logger.warning(
         "investigations.title_generation.failed",
         extra={

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -11,6 +11,7 @@ from sentry.investigations.services import (
     mark_block_execution_dispatch_failed,
     mark_block_execution_dispatch_started,
 )
+from sentry.investigations.telemetry import record_execution_failed
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.users.services.user.service import user_service
@@ -48,4 +49,6 @@ def dispatch_investigation_execution(execution_id: int) -> None:
     except Exception:
         logger.exception("investigations.execution.dispatch_failed")
         if mark_block_execution_dispatch_failed(execution, dispatch_claimed_at=dispatch_claimed_at):
+            execution.refresh_from_db(fields=["completed_at"])
+            record_execution_failed(execution, reason="dispatch_failed", seer_run_id=None)
             cancel_investigation_executions_after_failure(execution)

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_block_execution_details.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_block_execution_details.py
@@ -121,7 +121,10 @@ class InvestigationBlockExecutionDetailsEndpointTest(APITestCase):
         assert execution.status == InvestigationBlockExecutionStatus.CANCELLED
         assert execution.completed_at is not None
 
-    def test_stop_closes_a_pending_execution_that_never_reached_seer(self) -> None:
+    @patch("sentry.investigations.services.executions.record_execution_cancelled")
+    def test_stop_closes_a_pending_execution_that_never_reached_seer(
+        self, record_cancelled: MagicMock
+    ) -> None:
         execution = self.create_investigation_block_execution(
             block=self.block,
             executor="code_mode",
@@ -130,11 +133,13 @@ class InvestigationBlockExecutionDetailsEndpointTest(APITestCase):
             input_snapshot={"projectIds": [self.project.id]},
         )
 
-        response = self.client.delete(self.execution_url(execution))
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(self.execution_url(execution))
 
         assert response.status_code == 204
         execution.refresh_from_db()
         assert execution.status == InvestigationBlockExecutionStatus.CANCELLED
+        record_cancelled.assert_called_once_with(execution, reason="user_requested")
 
     def test_resume_does_not_revive_a_finished_execution(self) -> None:
         execution = self.awaiting_input_execution()

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -201,7 +201,10 @@ class InvestigationAutoRunTest(TestCase):
         "sentry.tasks.seer.investigation.start_execution_run",
         side_effect=RuntimeError("Seer unavailable"),
     )
-    def test_dispatch_failure_cancels_other_active_cells(self, start_run: mock.Mock) -> None:
+    @mock.patch("sentry.tasks.seer.investigation.record_execution_failed")
+    def test_dispatch_failure_cancels_other_active_cells(
+        self, record_failed: mock.Mock, start_run: mock.Mock
+    ) -> None:
         failed_execution = self.create_investigation_block_execution(
             block=self.root,
             executor="code_mode",
@@ -229,4 +232,7 @@ class InvestigationAutoRunTest(TestCase):
             "code": "investigation_execution_failed",
             "message": "Cancelled because another cell in this investigation failed.",
         }
+        record_failed.assert_called_once_with(
+            failed_execution, reason="dispatch_failed", seer_run_id=None
+        )
         start_run.assert_called_once()

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -441,8 +441,15 @@ class InvestigationAgentTest(TestCase):
             "message": "The agent returned malformed or unsupported result JSON.",
         }
 
+    @patch("sentry.investigations.agent.record_investigation_failed")
+    @patch("sentry.investigations.agent.record_execution_cancelled")
     @patch("sentry.investigations.agent.interrupt_run")
-    def test_failed_execution_cancels_other_active_cells(self, interrupt_run: MagicMock) -> None:
+    def test_failed_execution_cancels_other_active_cells(
+        self,
+        interrupt_run: MagicMock,
+        record_cancelled: MagicMock,
+        record_investigation_failed: MagicMock,
+    ) -> None:
         sibling_block = self.create_investigation_block(
             investigation=self.investigation,
             kind="text",
@@ -476,28 +483,53 @@ class InvestigationAgentTest(TestCase):
             "message": "Cancelled because another cell in this investigation failed.",
         }
         assert sibling_execution.completed_at is not None
+        record_cancelled.assert_called_once_with(
+            sibling_execution, reason="investigation_execution_failed"
+        )
+        record_investigation_failed.assert_called_once_with(
+            self.investigation, reason="seer_execution_failed"
+        )
         interrupt_run.assert_called_once_with(self.organization, 43)
 
+    @patch("sentry.investigations.telemetry.metrics.incr")
     @patch("sentry.investigations.telemetry.sentry_sdk.metrics.count")
-    def test_failed_execution_records_sentry_metric(self, metrics_count: MagicMock) -> None:
+    def test_failed_execution_records_metrics(
+        self, metrics_count: MagicMock, metrics_incr: MagicMock
+    ) -> None:
         with self.captureOnCommitCallbacks(execute=True):
             synchronize_execution(self.execution, state(status="error", blocks=[]))
 
-        metrics_count.assert_called_once_with(
-            "investigations.execution.failed",
-            1,
-            attributes={
-                "reason": "seer_execution_failed",
-                "source_type": "manual",
-                "template": "manual",
-                "block_kind": "query",
-                "executor": "code_mode",
-            },
-        )
+        execution_attributes = {
+            "reason": "seer_execution_failed",
+            "source_type": "manual",
+            "template": "manual",
+            "block_kind": "query",
+            "executor": "code_mode",
+        }
+        investigation_attributes = {
+            "reason": "seer_execution_failed",
+            "source_type": "manual",
+            "template": "manual",
+        }
+        assert metrics_count.call_args_list == [
+            (("investigations.execution.failed", 1), {"attributes": execution_attributes}),
+            (("investigations.failed", 1), {"attributes": investigation_attributes}),
+        ]
+        assert metrics_incr.call_args_list == [
+            (
+                ("investigations.execution.failed",),
+                {"tags": execution_attributes, "sample_rate": 1.0},
+            ),
+            (
+                ("investigations.failed",),
+                {"tags": investigation_attributes, "sample_rate": 1.0},
+            ),
+        ]
 
+    @patch("sentry.investigations.agent.record_investigation_failed")
     @patch("sentry.investigations.agent.interrupt_run")
     def test_superseded_execution_failure_does_not_cancel_current_run(
-        self, interrupt_run: MagicMock
+        self, interrupt_run: MagicMock, record_investigation_failed: MagicMock
     ) -> None:
         current_run = self.create_seer_run(
             organization=self.organization,
@@ -521,6 +553,7 @@ class InvestigationAgentTest(TestCase):
         current_execution.refresh_from_db()
         assert self.execution.status == InvestigationBlockExecutionStatus.FAILED
         assert current_execution.status == InvestigationBlockExecutionStatus.RUNNING
+        record_investigation_failed.assert_not_called()
         interrupt_run.assert_not_called()
 
     @patch("sentry.investigations.agent.interrupt_run")
@@ -1026,8 +1059,11 @@ class InvestigationAgentTest(TestCase):
         assert set(link["params"]) == {"dataset", "query", "project_slugs"}
         assert len(link["params"]["query"]) == 2000
 
+    @patch("sentry.investigations.agent.record_investigation_completed")
     @patch("sentry.investigations.agent.record_title_generation_completed")
-    def test_title_uses_the_final_assistant_message(self, record_completed: MagicMock) -> None:
+    def test_title_uses_the_final_assistant_message(
+        self, record_title_completed: MagicMock, record_investigation_completed: MagicMock
+    ) -> None:
         self.investigation.title = "Untitled investigation"
         self.investigation.title_generation_status = "running"
         self.investigation.save(update_fields=["title", "title_generation_status"])
@@ -1050,7 +1086,8 @@ class InvestigationAgentTest(TestCase):
             "One endpoint drove most errors.\nRoll back the latest endpoint change."
         )
         assert self.investigation.title_generation_status == "completed"
-        record_completed.assert_called_once_with(self.investigation)
+        record_title_completed.assert_called_once_with(self.investigation)
+        record_investigation_completed.assert_called_once_with(self.investigation)
 
     def test_title_accepts_metadata_in_a_json_code_fence(self) -> None:
         self.investigation.update(
@@ -1076,8 +1113,11 @@ class InvestigationAgentTest(TestCase):
         assert self.investigation.summary == "Error volume crossed threshold"
         assert self.investigation.title_generation_status == "completed"
 
+    @patch("sentry.investigations.telemetry.metrics.incr")
     @patch("sentry.investigations.telemetry.sentry_sdk.metrics.count")
-    def test_invalid_title_records_sentry_metric(self, metrics_count: MagicMock) -> None:
+    def test_invalid_title_records_failure_metrics(
+        self, metrics_count: MagicMock, metrics_incr: MagicMock
+    ) -> None:
         self.investigation.update(
             title=DEFAULT_INVESTIGATION_TITLE, title_generation_status="running"
         )
@@ -1093,15 +1133,22 @@ class InvestigationAgentTest(TestCase):
 
         synchronize_title(self.investigation, run_state)
 
-        metrics_count.assert_called_once_with(
-            "investigations.title_generation.failed",
-            1,
-            attributes={
-                "source_type": "manual",
-                "template": "manual",
-                "reason": "invalid_result",
-            },
-        )
+        attributes = {
+            "source_type": "manual",
+            "template": "manual",
+            "reason": "invalid_result",
+        }
+        assert metrics_count.call_args_list == [
+            (("investigations.title_generation.failed", 1), {"attributes": attributes}),
+            (("investigations.failed", 1), {"attributes": attributes}),
+        ]
+        assert metrics_incr.call_args_list == [
+            (
+                ("investigations.title_generation.failed",),
+                {"tags": attributes, "sample_rate": 1.0},
+            ),
+            (("investigations.failed",), {"tags": attributes, "sample_rate": 1.0}),
+        ]
 
     @patch("sentry.investigations.agent.SeerAgentClient")
     def test_title_prompt_uses_specific_incident_source_context(
@@ -1151,7 +1198,7 @@ class InvestigationAgentTest(TestCase):
         _maybe_start_title_generation(self.investigation, None)
 
         mock_client.return_value.start_run.assert_called_once()
-        record_completed.assert_called_once()
+        record_completed.assert_not_called()
 
     @patch("sentry.investigations.agent.SeerAgentClient")
     def test_title_generation_skips_an_in_flight_run(self, mock_client: MagicMock) -> None:


### PR DESCRIPTION
Investigation telemetry now distinguishes terminal success from block completion, reports current execution and title-generation failures at the investigation level, and records dispatch failures and cancellations. Every lifecycle counter is emitted to both Sentry SDK metrics for dimensional analysis and unsampled StatsD for exact operational totals.

Superseded execution failures remain execution-level events and do not mark the active investigation as failed. This PR contains no schema, API, frontend, or migration changes.

Tested with the complete `tests/sentry/investigations` suite (300 passed, 2 subtests passed), strict mypy on the changed source files, and the full staged hook suite.
