### PR TITLE
fix(feature-flags): Add more platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -833,8 +833,18 @@ const platformKeys = platforms.map(p => p.id);
 // Feature flag platforms with gettingStartedDocs. Note backend js platforms start with 'node-'.
 export const featureFlagOnboardingPlatforms: readonly PlatformKey[] = [
   ...platformKeys.filter(
+    id => id.startsWith('javascript') || id.startsWith('node') || id.startsWith('python')
+  ),
+  'bun',
+  'deno',
+];
+
+// Feature flag platforms to show the issue details distribution drawer for.
+export const featureFlagDrawerPlatforms: readonly PlatformKey[] = [
+  ...platformKeys.filter(
     id =>
       id.startsWith('apple') ||
+      // Matches 'javascript*' as well as 'java*'.
       id.startsWith('java') ||
       id.startsWith('node') ||
       id.startsWith('python')
@@ -844,15 +854,6 @@ export const featureFlagOnboardingPlatforms: readonly PlatformKey[] = [
   'dart',
   'deno',
   'react-native',
-];
-
-// Feature flag platforms to show the issue details distribution drawer for.
-export const featureFlagDrawerPlatforms: readonly PlatformKey[] = [
-  ...platformKeys.filter(
-    id => id.startsWith('javascript') || id.startsWith('node') || id.startsWith('python')
-  ),
-  'bun',
-  'deno',
 ];
 
 export const agentMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -833,10 +833,17 @@ const platformKeys = platforms.map(p => p.id);
 // Feature flag platforms with gettingStartedDocs. Note backend js platforms start with 'node-'.
 export const featureFlagOnboardingPlatforms: readonly PlatformKey[] = [
   ...platformKeys.filter(
-    id => id.startsWith('javascript') || id.startsWith('node') || id.startsWith('python')
+    id =>
+      id.startsWith('apple') ||
+      id.startsWith('java') ||
+      id.startsWith('node') ||
+      id.startsWith('python')
   ),
+  'android',
   'bun',
+  'dart',
   'deno',
+  'react-native',
 ];
 
 // Feature flag platforms to show the issue details distribution drawer for.


### PR DESCRIPTION
The feature flag flyout forces loading tags instead of feature flags when attempting to view flag details for an event with a platform not in this list. This adds the missing ones listed in our public docs:

https://docs.sentry.io/product/issues/issue-details/feature-flags/#set-up-evaluation-tracking

This manual configuration isn't particularly sustainable in the longer term but for now this unblocks.

Fixes #122803