### PR TITLE
fix(auth): Exempt invited SSO signups from required email verification

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -353,6 +353,54 @@ class AuthIdentityHandler:
 
         return om
 
+    def _email_verified_via_pending_invite(self) -> bool:
+        """
+        A valid, approved invite token for this org in the session proves the user clicked a
+        link mailed to the invited address, treat that as sufficient proof of email ownership.
+        Not literally the same guarantee as completing the signup verification flow:
+        the invite token's own trust window (INVITE_DAYS_VALID) can outlive a single pipeline session,
+        so a click from days earlier still qualifies.
+
+        Best-effort: this only ever relaxes the verification requirement, so any failure here must fall back to
+        requiring verification as usual rather than block account creation.
+        """
+        if self.request.user.is_authenticated:
+            # An existing (logged in) user that is invited to a new org and declines to link to the existing account
+            # ends up here.
+            # In a more complicated scenario (ex: user A is a member of org 1, user B is invited to org 1.
+            # User A's session is still active and they try to accept user B's invite - edge case but possible),
+            # if the existing (logged in) user is already a member of the org that is on the invitation,
+            # _get_invite() looks up the invite by request.user_id first, which returns the membership
+            # for the logged in user, not the invite that is in the session.
+            # To prevent this mix-up, bail if there is an auth'd user AND that user is already
+            # a member of the org on the invitation.
+            already_a_member = (
+                organization_service.check_membership_by_id(
+                    user_id=self.request.user.id, organization_id=self.organization.id
+                )
+                is not None
+            )
+            if already_a_member:
+                return False
+        try:
+            invite_helper = ApiInviteHelper.from_session_or_email(
+                request=self.request,
+                organization_id=self.organization.id,
+                email=self.identity["email"],
+                logger=logger,
+            )
+            if (
+                invite_helper is None
+                or not invite_helper.valid_token
+                or not invite_helper.invite_approved
+            ):
+                return False
+            member = invite_helper.invite_context.member
+            return member is not None and member.email.lower() == self.identity["email"].lower()
+        except Exception:
+            logger.exception("sso.login-pipeline.invite-verification-check-failed")
+            return False
+
     def _get_auth_identity(self, **params: Any) -> AuthIdentity | None:
         try:
             return AuthIdentity.objects.get(auth_provider_id=self.auth_provider.id, **params)
@@ -704,7 +752,10 @@ class AuthIdentityHandler:
                 messages.add_message(self.request, messages.ERROR, ERR_MERGE_FAILED)
                 return self._build_confirmation_response(is_new_account)
             elif op == "newuser":
-                is_trusted = is_email_verified_by_trusted_provider(self.provider.key, self.identity)
+                is_trusted = (
+                    is_email_verified_by_trusted_provider(self.provider.key, self.identity)
+                    or self._email_verified_via_pending_invite()
+                )
                 if not is_trusted and _sso_verification_required(self.identity["email"]):
                     return self._send_sso_verification_email_and_redirect(
                         self.identity["email"], state

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -364,25 +364,26 @@ class AuthIdentityHandler:
         Best-effort: this only ever relaxes the verification requirement, so any failure here must fall back to
         requiring verification as usual rather than block account creation.
         """
-        if self.request.user.is_authenticated:
-            # An existing (logged in) user that is invited to a new org and declines to link to the existing account
-            # ends up here.
-            # In a more complicated scenario (ex: user A is a member of org 1, user B is invited to org 1.
-            # User A's session is still active and they try to accept user B's invite - edge case but possible),
-            # if the existing (logged in) user is already a member of the org that is on the invitation,
-            # _get_invite() looks up the invite by request.user_id first, which returns the membership
-            # for the logged in user, not the invite that is in the session.
-            # To prevent this mix-up, bail if there is an auth'd user AND that user is already
-            # a member of the org on the invitation.
-            already_a_member = (
-                organization_service.check_membership_by_id(
-                    user_id=self.request.user.id, organization_id=self.organization.id
-                )
-                is not None
-            )
-            if already_a_member:
-                return False
         try:
+            if self.request.user.is_authenticated:
+                # An existing (logged in) user that is invited to a new org and declines to link to the existing account
+                # ends up here.
+                # In a more complicated scenario (ex: user A is a member of org 1, user B is invited to org 1.
+                # User A's session is still active and they try to accept user B's invite - edge case but possible),
+                # if the existing (logged in) user is already a member of the org that is on the invitation,
+                # _get_invite() (used by invite_helper) looks up the invite by request.user_id first, which returns
+                # the membership for the logged-in user, not the invite that is in the session.
+                # To prevent this mix-up, bail if there is an auth'd user AND that user is already
+                # a member of the org on the invitation.
+                already_a_member = (
+                    organization_service.check_membership_by_id(
+                        user_id=self.request.user.id, organization_id=self.organization.id
+                    )
+                    is not None
+                )
+                if already_a_member:
+                    return False
+
             invite_helper = ApiInviteHelper.from_session_or_email(
                 request=self.request,
                 organization_id=self.organization.id,

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -126,7 +126,7 @@ def _sso_verification_required(email: str) -> bool:
     force_emails = options.get("auth.email-verification-at-signup.force-in-experiment") or []
     in_allowlist = any(glob_star_match(p, email) for p in force_emails)
 
-    return features.has("auth:email-verification-at-sso-signup") or in_allowlist
+    return options.get("auth.email-verification-at-signup.sso-enabled") or in_allowlist
 
 
 def _sso_verification_send_rate_limited(email: str) -> bool:

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -168,8 +168,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
     permanent_system_features = {
         # Enables user registration.
         "auth:register": True,
-        # Require email verification during SSO signup.
-        "auth:email-verification-at-sso-signup": False,
         # Enable support for multiple regions, and org slug subdomains (customer-domains).
         "system:multi-region": False,
     }

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -263,6 +263,12 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "auth.email-verification-at-signup.sso-enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # User Settings
 register(

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1506,6 +1506,129 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         assert not User.objects.filter(email=self.email).exists()
         assert self.request.session[PENDING_VERIFICATION_SESSION_KEY] == self.email
 
+    def test_valid_invite_token_exempts_from_verification(self) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = OrganizationMember.objects.create(
+                organization=self.organization, email=self.email, token="abc"
+            )
+        self.request.session["invite_member_id"] = member.id
+        self.request.session["invite_token"] = member.token
+        self.save_session()
+
+        self.request.POST = {"op": "newuser"}
+        with self.feature({"auth:email-verification-at-sso-signup": True}):
+            with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
+                self.handler.handle_unknown_identity(self.state)
+
+        mock_send.assert_not_called()
+        user = User.objects.get(email=self.email)
+        assert UserEmail.objects.get(user=user, email=self.email).is_verified is True
+
+    def test_invite_token_email_mismatch_still_requires_verification(self) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = OrganizationMember.objects.create(
+                organization=self.organization, email="someone-else@example.com", token="abc"
+            )
+        self.request.session["invite_member_id"] = member.id
+        self.request.session["invite_token"] = member.token
+        self.save_session()
+
+        self.request.POST = {"op": "newuser"}
+        with self.feature({"auth:email-verification-at-sso-signup": True}):
+            with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
+                response = self.handler.handle_unknown_identity(self.state)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == reverse("sentry-signup-verify-email-pending")
+        mock_send.assert_called_once()
+        assert not User.objects.filter(email=self.email).exists()
+
+    def test_invite_without_session_token_still_requires_verification(self) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            OrganizationMember.objects.create(organization=self.organization, email=self.email)
+
+        self.request.POST = {"op": "newuser"}
+        with self.feature({"auth:email-verification-at-sso-signup": True}):
+            with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
+                response = self.handler.handle_unknown_identity(self.state)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == reverse("sentry-signup-verify-email-pending")
+        mock_send.assert_called_once()
+        assert not User.objects.filter(email=self.email).exists()
+
+    def test_authenticated_user_without_org_membership_still_gets_invite_exemption(self) -> None:
+        # an existing user invited to a different org who declines to merge accounts
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = OrganizationMember.objects.create(
+                organization=self.organization, email=self.email, token="abc"
+            )
+        self.request.session["invite_member_id"] = member.id
+        self.request.session["invite_token"] = member.token
+        self.save_session()
+        self.set_up_user()
+
+        self.request.POST = {"op": "newuser"}
+        with self.feature({"auth:email-verification-at-sso-signup": True}):
+            with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
+                self.handler.handle_unknown_identity(self.state)
+
+        mock_send.assert_not_called()
+        user = User.objects.get(email=self.email)
+        assert UserEmail.objects.get(user=user, email=self.email).is_verified is True
+
+    def test_authenticated_member_of_org_does_not_get_invite_exemption(self) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = OrganizationMember.objects.create(
+                organization=self.organization, email=self.email, token="abc"
+            )
+        self.request.session["invite_member_id"] = member.id
+        self.request.session["invite_token"] = member.token
+        self.save_session()
+        user = self.set_up_user()
+        self.create_member(organization=self.organization, user=user)
+
+        assert self.handler._email_verified_via_pending_invite() is False
+
+    def test_unapproved_invite_does_not_grant_verification_exemption(self) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = self.create_member(
+                organization=self.organization,
+                email=self.email,
+                invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+            )
+            member.token = "abc"
+            member.save()
+        self.request.session["invite_member_id"] = member.id
+        self.request.session["invite_token"] = member.token
+        self.save_session()
+
+        self.request.POST = {"op": "newuser"}
+        with self.feature({"auth:email-verification-at-sso-signup": True}):
+            with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
+                response = self.handler.handle_unknown_identity(self.state)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == reverse("sentry-signup-verify-email-pending")
+        mock_send.assert_called_once()
+
+    @mock.patch("sentry.auth.helper.send_signup_verification_email")
+    def test_invite_check_failure_falls_back_to_requiring_verification(
+        self, mock_send: mock.MagicMock
+    ) -> None:
+        self.request.POST = {"op": "newuser"}
+        with self.feature({"auth:email-verification-at-sso-signup": True}):
+            with mock.patch(
+                "sentry.auth.helper.ApiInviteHelper.from_session_or_email",
+                side_effect=Exception("boom"),
+            ):
+                response = self.handler.handle_unknown_identity(self.state)
+
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == reverse("sentry-signup-verify-email-pending")
+        mock_send.assert_called_once()
+        assert not User.objects.filter(email=self.email).exists()
+
     @mock.patch("sentry.auth.helper.render_to_response")
     @mock.patch("sentry.auth.helper.messages")
     def test_transaction_rollback_after_verification_allows_resend(

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1392,7 +1392,7 @@ class HandleNewUserTransactionRollbackTest(AuthIdentityHandlerTest):
 class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
     def test_flag_off_creates_user_immediately(self) -> None:
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": False}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": False}):
             self.handler.handle_unknown_identity(self.state)
 
         assert AuthIdentity.objects.filter(
@@ -1415,7 +1415,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
 
         handler = self._handler_with(identity)
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch.object(handler, "provider") as mock_provider:
                 mock_provider.key = "google"
                 handler.handle_unknown_identity(self.state)
@@ -1477,7 +1477,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self, mock_send: mock.MagicMock
     ) -> None:
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             response = self.handler.handle_unknown_identity(self.state)
 
         assert isinstance(response, HttpResponseRedirect)
@@ -1491,14 +1491,18 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         assert self.request.session[PENDING_VERIFICATION_SESSION_KEY] == self.email
         assert self.request.session[PENDING_EXPIRY_TEXT_SESSION_KEY] == PIPELINE_STATE_TTL // 60
 
-    @override_options({"auth.email-verification-at-signup.force-in-experiment": ["*@example.com"]})
+    @override_options(
+        {
+            "auth.email-verification-at-signup.force-in-experiment": ["*@example.com"],
+            "auth.email-verification-at-signup.sso-enabled": False,
+        }
+    )
     @mock.patch("sentry.auth.helper.send_signup_verification_email")
-    def test_allowlist_forces_verification_even_without_flag(
+    def test_allowlist_forces_verification_even_without_sso_enabled(
         self, mock_send: mock.MagicMock
     ) -> None:
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": False}):
-            response = self.handler.handle_unknown_identity(self.state)
+        response = self.handler.handle_unknown_identity(self.state)
 
         assert isinstance(response, HttpResponseRedirect)
         assert response.url == reverse("sentry-signup-verify-email-pending")
@@ -1516,7 +1520,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self.save_session()
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
                 self.handler.handle_unknown_identity(self.state)
 
@@ -1534,7 +1538,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self.save_session()
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
                 response = self.handler.handle_unknown_identity(self.state)
 
@@ -1548,7 +1552,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
             OrganizationMember.objects.create(organization=self.organization, email=self.email)
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
                 response = self.handler.handle_unknown_identity(self.state)
 
@@ -1569,7 +1573,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self.set_up_user()
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
                 self.handler.handle_unknown_identity(self.state)
 
@@ -1604,7 +1608,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self.save_session()
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
                 response = self.handler.handle_unknown_identity(self.state)
 
@@ -1617,7 +1621,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self, mock_send: mock.MagicMock
     ) -> None:
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch(
                 "sentry.auth.helper.ApiInviteHelper.from_session_or_email",
                 side_effect=Exception("boom"),
@@ -1648,7 +1652,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         assert not User.objects.filter(email=self.email).exists()
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             with mock.patch("sentry.auth.helper.send_signup_verification_email") as mock_send:
                 handler.handle_unknown_identity(self.state)
         mock_send.assert_called_once()
@@ -1700,7 +1704,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         assert client.ttl(self.state.redis_key) <= 5
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             self.handler.handle_unknown_identity(self.state)
 
         assert client.ttl(self.state.redis_key) > 5
@@ -1712,7 +1716,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         self.state.regenerate({"flow": FLOW_LOGIN})
         self.request.POST = {"op": "newuser"}
 
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             for _ in range(3):
                 response = self.handler.handle_unknown_identity(self.state)
                 assert isinstance(response, HttpResponseRedirect)
@@ -1728,7 +1732,7 @@ class SSOEmailVerificationRequiredTest(AuthIdentityHandlerTest, HybridCloudTestM
         mock_ratelimiter.backend.is_limited.return_value = True
 
         self.request.POST = {"op": "newuser"}
-        with self.feature({"auth:email-verification-at-sso-signup": True}):
+        with override_options({"auth.email-verification-at-signup.sso-enabled": True}):
             response = self.handler.handle_unknown_identity(self.state)
 
         assert not isinstance(response, HttpResponseRedirect)


### PR DESCRIPTION
Clicking an org invite link already proves the user owns that inbox, but the `auth:email-verification-at-sso-signup` gate didn't know about invites: it ran before the invite was ever looked up, so an invited user got forced through a second, redundant verification email.

`AuthIdentityHandler._email_verified_via_pending_invite()` now folds into the existing `is_trusted` check: exempt only if the session carries a valid, approved, unexpired invite token (not merely "an invite exists for this email") for a member whose email matches the SSO identity.

Bails if `request.user` is authenticated and already a member of this org, since `ApiInviteHelper`'s lookup checks membership before the invite cookie and could otherwise resolve the wrong row. An authenticated user who isn't yet a member (an existing Sentry user invited to a different org, declining to merge accounts) still gets the exemption. Fails open on any error, falling back to requiring verification rather than blocking signup.

Note: this duplicates a read `_handle_membership()` already does later to accept the invite. Left as is (cheap, read only) rather than threading an `invite_helper` param through three methods for a bounded fix.