### PR TITLE
ref(hybridcloud): Stop building the retired github_event_and_action tag

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -803,39 +803,6 @@ def _discard_if_stale(
     return True
 
 
-def _get_github_delivery_time_tags(payload: WebhookPayload) -> dict[str, str]:
-    """Extract GitHub event and action from payload for delivery_time_ms metric tags.
-
-    Returns a single tag github_event_and_action as "<event>.<action>", using "unknown"
-    when the request body has no action (e.g. push, ping).
-    """
-    if payload.provider != "github":
-        return {}
-    event_type: str | None = None
-    try:
-        headers = orjson.loads(payload.request_headers)
-    except orjson.JSONDecodeError:
-        return {}
-    if isinstance(headers, dict):
-        for key, value in headers.items():
-            if key.upper() == "X-GITHUB-EVENT" and isinstance(value, str) and value:
-                event_type = value
-                break
-    if not event_type:
-        return {}
-    action = "unknown"
-    try:
-        body = orjson.loads(payload.request_body)
-    except orjson.JSONDecodeError:
-        pass
-    else:
-        if isinstance(body, dict):
-            body_action = body.get("action")
-            if isinstance(body_action, str) and body_action:
-                action = body_action
-    return {"github_event_and_action": f"{event_type}.{action}"}
-
-
 def _record_delivery_time_metrics(
     payload: WebhookPayload, *, dispatch_tags: Mapping[str, str]
 ) -> None:
@@ -852,10 +819,9 @@ def _record_delivery_time_metrics(
         **dispatch_tags,
         "region_sent_to": payload.cell_name,
         "provider": provider,
-        # Bounded, and the unit delivery queues by — unlike github_event_and_action,
-        # which slices below the mailbox and grows with every action GitHub adds.
+        # The unit delivery queues by, and bounded to one value per mailbox shape.
         "event_type": event_type_from_mailbox(provider, payload.mailbox_name),
-    } | _get_github_delivery_time_tags(payload)
+    }
     metrics.distribution(
         "hybridcloud.deliver_webhooks.delivery_time_ms",
         # e.g. 0.123 seconds → 123 milliseconds

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, PropertyMock, patch
 
-import orjson
 import pytest
 import responses
 from django.core.cache import cache
@@ -1585,7 +1584,7 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_delivery_time_metrics_github_event_and_action(self, mock_metrics: MagicMock) -> None:
+    def test_delivery_time_metrics_github_event_type(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -1596,10 +1595,6 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123:0:pull_request",
             cell_name="us",
             provider="github",
-            request_headers=orjson.dumps(
-                {"X-GitHub-Event": "pull_request", "Content-Type": "application/json"}
-            ).decode(),
-            request_body=orjson.dumps({"action": "opened", "repository": {}}).decode(),
         )
         drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
@@ -1609,41 +1604,11 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
         assert tags.get("region_sent_to") == "us"
         assert tags.get("provider") == "github"
         assert tags.get("event_type") == "pull_request"
-        # Both tags emit while consumers migrate off the unbounded one.
-        assert tags.get("github_event_and_action") == "pull_request.opened"
 
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_delivery_time_metrics_github_event_only(self, mock_metrics: MagicMock) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123:0:push",
-            cell_name="us",
-            provider="github",
-            request_headers=orjson.dumps(
-                {"X-GitHub-Event": "push", "Content-Type": "application/json"}
-            ).decode(),
-            request_body=orjson.dumps({"repository": {}}).decode(),
-        )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
-        assert len(delivery_time_tags) == 1
-        tags = delivery_time_tags[0]
-        assert tags.get("region_sent_to") == "us"
-        assert tags.get("event_type") == "push"
-        assert tags.get("github_event_and_action") == "push.unknown"
-
-    @responses.activate
-    @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_delivery_time_metrics_non_github_no_github_tags(self, mock_metrics: MagicMock) -> None:
+    def test_delivery_time_metrics_non_github_event_type(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -1663,7 +1628,6 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
         assert tags.get("region_sent_to") == "us"
         assert tags.get("provider") == "stripe"
         assert tags.get("event_type") == "none"
-        assert "github_event_and_action" not in tags
 
     @responses.activate
     @override_cells(cell_config)


### PR DESCRIPTION
### Problem

`github_event_and_action` was never needed in datadog, dashbboards & monitor now use event_type itself. 