### PR TITLE
fix(gitlab): Bound the receipt failure counter's error tag

### DIFF
--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -56,7 +56,7 @@ class GitlabRequestParser(BaseRequestParser):
                 self._METRIC_CONTROL_PATH_FAILURE_KEY,
                 tags={"integration": self.provider, "error": type(e).__name__},
             )
-            logger.warning("Failed to get integration from request")
+            logger.exception("Failed to get integration from request")
 
         return None
 

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -52,11 +52,14 @@ class GitlabRequestParser(BaseRequestParser):
                 ).first()
                 return self._integration
         except Exception as e:
+            # The class name, not the message: a message carries the external id,
+            # the instance URL and other per-request detail, so every distinct one
+            # would open its own time series.
             metrics.incr(
                 self._METRIC_CONTROL_PATH_FAILURE_KEY,
-                tags={"integration": self.provider, "error": str(e)},
+                tags={"integration": self.provider, "error": type(e).__name__},
             )
-            logger.warning("Failed to get integration from request")
+            logger.exception("gitlab.get_integration_from_request.failure")
 
         return None
 

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -52,14 +52,11 @@ class GitlabRequestParser(BaseRequestParser):
                 ).first()
                 return self._integration
         except Exception as e:
-            # The class name, not the message: a message carries the external id,
-            # the instance URL and other per-request detail, so every distinct one
-            # would open its own time series.
             metrics.incr(
                 self._METRIC_CONTROL_PATH_FAILURE_KEY,
                 tags={"integration": self.provider, "error": type(e).__name__},
             )
-            logger.exception("gitlab.get_integration_from_request.failure")
+            logger.warning("Failed to get integration from request")
 
         return None
 

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -232,6 +232,39 @@ class GitlabRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
+    def test_get_integration_from_request_failure_tag_is_bounded(self) -> None:
+        """The failure counter must not tag per-request exception text.
+
+        Tag values open a time series each, so the message — which carries the
+        external id and instance URL — would make this counter unbounded.
+        """
+        self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+
+        with mock.patch.object(
+            parser,
+            "_resolve_external_id",
+            side_effect=ValueError(f"no integration for {EXTERNAL_ID} at example.gitlab.com"),
+        ):
+            with mock.patch(
+                "sentry.middleware.integrations.parsers.gitlab.metrics"
+            ) as mock_metrics:
+                assert parser.get_integration_from_request() is None
+
+        mock_metrics.incr.assert_called_once_with(
+            GitlabRequestParser._METRIC_CONTROL_PATH_FAILURE_KEY,
+            tags={"integration": "gitlab", "error": "ValueError"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
     @responses.activate
     def test_webhook_outbox_creation(self) -> None:
         request = self.factory.post(

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -232,39 +232,6 @@ class GitlabRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
-    def test_get_integration_from_request_failure_tag_is_bounded(self) -> None:
-        """The failure counter must not tag per-request exception text.
-
-        Tag values open a time series each, so the message — which carries the
-        external id and instance URL — would make this counter unbounded.
-        """
-        self.get_integration()
-        request = self.factory.post(
-            self.path,
-            data=PUSH_EVENT,
-            content_type="application/json",
-            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-            HTTP_X_GITLAB_EVENT="Push Hook",
-        )
-        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
-
-        with mock.patch.object(
-            parser,
-            "_resolve_external_id",
-            side_effect=ValueError(f"no integration for {EXTERNAL_ID} at example.gitlab.com"),
-        ):
-            with mock.patch(
-                "sentry.middleware.integrations.parsers.gitlab.metrics"
-            ) as mock_metrics:
-                assert parser.get_integration_from_request() is None
-
-        mock_metrics.incr.assert_called_once_with(
-            GitlabRequestParser._METRIC_CONTROL_PATH_FAILURE_KEY,
-            tags={"integration": "gitlab", "error": "ValueError"},
-        )
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_cells(cell_config)
     @responses.activate
     def test_webhook_outbox_creation(self) -> None:
         request = self.factory.post(


### PR DESCRIPTION
### Problem

`GitlabRequestParser.get_integration_from_request` tags
`integrations.gitlab.get_integration_from_request.failure` with `str(e)`:

Every distinct tag value is its own time series, and this one is free text assembled from whatever raised — external ids, instance URLs, database driver messages. `src/sentry/metrics/middleware.py` denylists tag *keys* that look like identifiers, but nothing bounds a *value*, so this passes review and lint and only bites in production.

It has not bitten yet for an unlucky reason: this metric has never been emitted, so Datadog holds no tag configuration for it. The first emission creates one in exclude-tags mode, which indexes every tag present — meaning the first sustained GitLab receipt failure is also the moment the cardinality lands.
