### PR TITLE
ref(tags): Remove unused DS_DENYLIST and onlySamplingTags parameter

### DIFF
--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -15,7 +15,7 @@ from sentry.api.utils import clamp_date_range, default_start_end_dates
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import DS_DENYLIST, PROTECTED_TAG_KEYS
+from sentry.constants import PROTECTED_TAG_KEYS
 from sentry.models.environment import Environment
 
 
@@ -48,13 +48,6 @@ class ProjectTagsEndpoint(ProjectEndpoint):
                 description="Set to `0` to omit the `uniqueValues` count for each tag key.",
             ),
             OpenApiParameter(
-                name="onlySamplingTags",
-                location="query",
-                required=False,
-                type=str,
-                description="Set to `1` to only return tag keys relevant to dynamic sampling.",
-            ),
-            OpenApiParameter(
                 name="useFlagsBackend",
                 location="query",
                 required=False,
@@ -81,8 +74,6 @@ class ProjectTagsEndpoint(ProjectEndpoint):
             tag_keys = []
         else:
             kwargs: dict = {}
-            if request.GET.get("onlySamplingTags") == "1":
-                kwargs["denylist"] = DS_DENYLIST
 
             # Flags are stored on the same table as tags but on a different column. Ideally both
             # could be queried in a single request. But at present we're not sure if we want to

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -765,50 +765,6 @@ DataCategory = sentry_relay.consts.DataCategory
 CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"
 CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"
 
-# Dynamic sampling denylist composed manually from
-# 1. `src/sentry/event_manager.py:save`. We have function
-# `_derive_interface_tags_many(jobs)` which iterates across all interfaces
-# and execute `iter_tags`, so i've searched usage of `iter_tags`.
-# 2. `src/sentry/event_manager.py:_pull_out_data` we have `set_tag`.
-# 3. `src/sentry/event_manager.py:_get_event_user_many` we have `set_tag`.
-# 4. `src/sentry/event_manager.py:_get_or_create_release_many` we have `set_tag`.
-# 5. `src/sentry/interfaces/exception.py:Mechanism` we have `iter_tags`.
-# 6. `src/sentry/event_manager_auto_tags.py:UrlTagDeriver`.
-# 7. `src/sentry/event_manager_auto_tags.py:InterfaceTypeTagDeriver`.
-# 8. `src/sentry/event_manager_auto_tags.py:BrowserTagDeriver` (and OsTagDeriver, DeviceTagDeriver).
-# Note:
-# should be sorted alphabetically so that it is easy to maintain in future
-# if you update this list please add explanation or source of it
-DS_DENYLIST = frozenset(
-    [
-        "app.device",
-        "browser",
-        "browser.name",
-        "device",
-        "device.family",
-        "environment",
-        "gpu.name",
-        "gpu.vendor",
-        "handled",
-        "interface_type",
-        "level",
-        "logger",
-        "mechanism",
-        "monitor.id",
-        "os",
-        "os.name",
-        "os.rooted",
-        "runtime",
-        "runtime.name",
-        "sentry:dist",
-        "sentry:release",
-        "sentry:user",
-        "transaction",
-        "url",
-    ]
-)
-
-
 # DESCRIBES the globs used to check if a transaction is for a healthcheck endpoint
 # https://kubernetes.io/docs/reference/using-api/health-checks/
 # Also it covers: livez, readyz

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -116,7 +116,6 @@ class TagStorage(Service):
         environment_id,
         status=TagKeyStatus.ACTIVE,
         include_values_seen=False,
-        denylist=None,
         tenant_ids=None,
     ):
         """

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -531,7 +531,6 @@ class SnubaTagStorage(TagStorage):
         keys: list[str] | None = None,
         include_values_seen: bool = True,
         dataset: Dataset = Dataset.Events,
-        denylist: frozenset[int | str] | None = None,
         tenant_ids=None,
         **kwargs: Any,
     ) -> set[TagKey | GroupTagKey]:
@@ -553,7 +552,6 @@ class SnubaTagStorage(TagStorage):
             keys,
             include_values_seen=include_values_seen,
             dataset=dataset,
-            denylist=denylist,
             tenant_ids=tenant_ids,
             **optimize_kwargs,
         )
@@ -569,7 +567,6 @@ class SnubaTagStorage(TagStorage):
         keys: list[str] | None = None,
         include_values_seen: bool = True,
         use_cache=False,
-        denylist: frozenset[int | str] | None = None,
         dataset: Dataset = Dataset.Discover,
         **kwargs,
     ) -> set[TagKey | GroupTagKey]:
@@ -672,10 +669,6 @@ class SnubaTagStorage(TagStorage):
         results: set[TagKey | GroupTagKey] = set()
 
         for key, data in result.items():
-            # Ignore key (skip interaction) if it's in denylist
-            if denylist is not None and key in denylist:
-                continue
-
             params = {"key": key}
             if include_values_seen:
                 params["values_seen"] = data["values_seen"]
@@ -708,7 +701,6 @@ class SnubaTagStorage(TagStorage):
         environment_id: int | None,
         status: int = TagKeyStatus.ACTIVE,
         include_values_seen: bool = False,
-        denylist: frozenset[int | str] | None = None,
         tenant_ids=None,
         **kwargs,
     ) -> set[TagKey | GroupTagKey]:
@@ -729,7 +721,6 @@ class SnubaTagStorage(TagStorage):
             project_id,
             None,
             environment_id if environment_id is None else [environment_id],
-            denylist=denylist,
             tenant_ids=tenant_ids,
             include_values_seen=include_values_seen,
             **optimize_kwargs,

--- a/tests/snuba/api/endpoints/test_project_tags.py
+++ b/tests/snuba/api/endpoints/test_project_tags.py
@@ -1,4 +1,3 @@
-from sentry.constants import DS_DENYLIST
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -98,43 +97,3 @@ class ProjectTagsTest(APITestCase, SnubaTestCase):
         assert data["def"]["uniqueValues"] == 1
         assert data["abc"]["canDelete"] is False
         assert data["abc"]["uniqueValues"] == 2
-
-    def test_simple_remove_tags_in_denylist(self) -> None:
-        self.store_event(
-            data={
-                # "browser" and "sentry:dist" are in denylist sentry.constants.DS_DENYLIST
-                "tags": {"browser": "chrome", "bar": "rab", "sentry:dist": "test_dist"},
-                "timestamp": before_now(minutes=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"tags": {"bar": "rab2"}, "timestamp": before_now(minutes=1).isoformat()},
-            project_id=self.project.id,
-        )
-
-        response = self.get_success_response(
-            self.project.organization.slug, self.project.slug, onlySamplingTags=1
-        )
-
-        data = {v["key"]: v for v in response.data}
-        assert len(data) == 1
-
-        assert data["bar"]["canDelete"]
-        assert data["bar"]["uniqueValues"] == 2
-
-    def test_simple_remove_tags_in_denylist_remove_all_tags(self) -> None:
-        self.store_event(
-            data={
-                "tags": {deny_tag: "value_{deny_tag}" for deny_tag in DS_DENYLIST},
-                "timestamp": before_now(minutes=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
-        response = self.get_success_response(
-            self.project.organization.slug, self.project.slug, onlySamplingTags=1
-        )
-
-        data = {v["key"]: v for v in response.data}
-        assert len(data) == 0
-        assert data == {}

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -462,37 +462,6 @@ class TagStorageTest(TestCase, SnubaTestCase, SearchIssueTestMixin, PerformanceI
         }
         assert set(keys) == expected_keys
 
-    def test_get_tag_keys_removed_from_denylist(self) -> None:
-        denylist_keys = frozenset(["browser", "sentry:release"])
-        expected_keys = {
-            "baz",
-            "environment",
-            "foo",
-            "sentry:user",
-            "level",
-            "interface_type",
-        }
-        keys = {
-            k.key: k
-            for k in self.ts.get_tag_keys(
-                project_id=self.proj1.id,
-                environment_id=self.proj1env1.id,
-                denylist=denylist_keys,
-                tenant_ids={"referrer": "r", "organization_id": 1234},
-            )
-        }
-        assert set(keys) == expected_keys
-        keys = {
-            k.key: k
-            for k in self.ts.get_tag_keys(
-                project_id=self.proj1.id,
-                environment_id=self.proj1env1.id,
-                tenant_ids={"referrer": "r", "organization_id": 1234},
-            )
-        }
-        expected_keys |= {"browser", "sentry:release"}
-        assert set(keys) == expected_keys
-
     def test_get_group_tag_key(self) -> None:
         with pytest.raises(GroupTagKeyNotFound):
             self.ts.get_group_tag_key(


### PR DESCRIPTION
- `DS_DENYLIST` was used to prevent people from creating custom transaction sampling rules - see https://github.com/getsentry/sentry/pull/35183
- The frontend caller was removed in #36504. Nothing in `static/`, getsentry, or the backend passes the parameter anymore.