### PR TITLE
feat(conversations): Default the chart to conversation count

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -22,7 +22,7 @@ describe('ConversationsChart', () => {
       body: {
         timeSeries: [
           TimeSeriesFixture({
-            yAxis: 'sum(gen_ai.cost.total_tokens)',
+            yAxis: 'count_unique(gen_ai.conversation.id)',
             meta: {valueType: 'number', valueUnit: null, interval: 1_800_000},
           }),
         ],
@@ -30,37 +30,8 @@ describe('ConversationsChart', () => {
     });
   });
 
-  it('fetches the cost timeseries by default', async () => {
+  it('fetches the conversation count timeseries by default', async () => {
     render(<ConversationsChart />, {organization});
-
-    await waitFor(() => {
-      expect(timeseriesRequest).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/events-timeseries/`,
-        expect.objectContaining({
-          query: expect.objectContaining({
-            yAxis: ['sum(gen_ai.cost.total_tokens)'],
-            query: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
-          }),
-        })
-      );
-    });
-
-    expect(screen.getByRole('button', {name: 'Cost'})).toBeInTheDocument();
-  });
-
-  it('switches the visualization via the title dropdown', async () => {
-    const {router} = render(<ConversationsChart />, {organization});
-
-    await userEvent.click(screen.getByRole('button', {name: 'Cost'}));
-    await userEvent.click(screen.getByRole('option', {name: 'Individual Chats'}));
-
-    await waitFor(() => {
-      expect(router.location.query.chartVisualization).toBe('chats');
-    });
-
-    expect(
-      await screen.findByRole('button', {name: 'Individual Chats'})
-    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(timeseriesRequest).toHaveBeenCalledWith(
@@ -73,12 +44,39 @@ describe('ConversationsChart', () => {
         })
       );
     });
+
+    expect(screen.getByRole('button', {name: 'Conversation Count'})).toBeInTheDocument();
+  });
+
+  it('switches the visualization via the title dropdown', async () => {
+    const {router} = render(<ConversationsChart />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Conversation Count'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Cost'}));
+
+    await waitFor(() => {
+      expect(router.location.query.chartVisualization).toBe('cost');
+    });
+
+    expect(await screen.findByRole('button', {name: 'Cost'})).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(timeseriesRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events-timeseries/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            yAxis: ['sum(gen_ai.cost.total_tokens)'],
+            query: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
+          }),
+        })
+      );
+    });
   });
 
   it('fetches the total messages timeseries', async () => {
     render(<ConversationsChart />, {organization});
 
-    await userEvent.click(screen.getByRole('button', {name: 'Cost'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Conversation Count'}));
     await userEvent.click(screen.getByRole('option', {name: 'Total Messages'}));
 
     await waitFor(() => {
@@ -136,8 +134,7 @@ describe('ConversationsChart', () => {
         `/organizations/${organization.slug}/events-timeseries/`,
         expect.objectContaining({
           query: expect.objectContaining({
-            query:
-              '(has:gen_ai.conversation.id gen_ai.operation.type:ai_client) and (gen_ai.agent.name:my-agent)',
+            query: '(has:gen_ai.conversation.id) and (gen_ai.agent.name:my-agent)',
           }),
         })
       );
@@ -208,8 +205,8 @@ describe('ConversationsChart', () => {
     const href = alertItem.getAttribute('href') ?? '';
     expect(href).toContain('/monitors/new/settings');
     expect(href).toContain('detectorType=metric_issue');
-    expect(href).toContain('aggregate=sum');
-    expect(href).toContain('gen_ai.cost.total_tokens');
+    expect(href).toContain('aggregate=count_unique');
+    expect(href).toContain('gen_ai.conversation.id');
   });
 
   it('disables "Add to Dashboard" without the dashboards-edit feature', async () => {
@@ -242,8 +239,8 @@ describe('ConversationsChart', () => {
             widgetType: WidgetType.SPANS,
             queries: [
               expect.objectContaining({
-                aggregates: ['sum(gen_ai.cost.total_tokens)'],
-                conditions: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
+                aggregates: ['count_unique(gen_ai.conversation.id)'],
+                conditions: 'has:gen_ai.conversation.id',
               }),
             ],
           }),

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -52,6 +52,11 @@ const CONVERSATION_SPANS_FILTER = `has:${SpanFields.GEN_AI_CONVERSATION_ID}`;
 const AI_CLIENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
 
 const CHART_VISUALIZATIONS = {
+  chats: {
+    label: t('Conversation Count'),
+    yAxis: `count_unique(${SpanFields.GEN_AI_CONVERSATION_ID})`,
+    filter: CONVERSATION_SPANS_FILTER,
+  },
   cost: {
     label: t('Cost'),
     yAxis: `sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`,
@@ -61,11 +66,6 @@ const CHART_VISUALIZATIONS = {
     label: t('Total Messages'),
     yAxis: `count(${SpanFields.SPAN_DURATION})`,
     filter: `${CONVERSATION_SPANS_FILTER} ${AI_CLIENT_FILTER}`,
-  },
-  chats: {
-    label: t('Individual Chats'),
-    yAxis: `count_unique(${SpanFields.GEN_AI_CONVERSATION_ID})`,
-    filter: CONVERSATION_SPANS_FILTER,
   },
 } as const satisfies Record<string, {filter: string; label: string; yAxis: string}>;
 
@@ -91,7 +91,7 @@ const CHART_TYPE_TO_DISPLAY_TYPE: Record<ChartTypeKey, DisplayType> = {
 
 const visualizationParser = parseAsStringLiteral(
   Object.keys(CHART_VISUALIZATIONS) as ChartVisualizationKey[]
-).withDefault('cost');
+).withDefault('chats');
 
 const chartTypeParser = parseAsStringLiteral([
   'line',


### PR DESCRIPTION
The conversations chart opens on Conversation Count instead of Cost, and the option previously labelled "Individual Chats" is now "Conversation Count".

Cost is a narrower question than how many conversations are happening, so it is a poor first thing to show. The rename drops a second term for a concept the rest of the UI already calls a conversation.

The URL value stays `chartVisualization=chats` so existing shared links keep working — only the label and the default changed. Conversation Count also moves to the top of the dropdown so the default leads the list.

Closes TET-2810