### PR TITLE
ref(objectstore): Consolidate session use cases

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -30,7 +30,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.profilechunkattachment import ProfileChunkAttachment
 from sentry.models.project import Project
 from sentry.models.release import Release
-from sentry.objectstore import get_profile_attachments_session, parse_accept_encoding
+from sentry.objectstore import UsecaseId, get_session, parse_accept_encoding
 from sentry.profiles.utils import get_from_profiling_service, proxy_profiling_service
 
 
@@ -229,7 +229,7 @@ class ProjectProfilingChunkAttachmentEndpoint(ProjectProfilingBaseEndpoint):
         name = posixpath.basename(" ".join(attachment.name.split()))
         accept_encoding = parse_accept_encoding(request.headers.get("Accept-Encoding", ""))
 
-        session = get_profile_attachments_session(project.organization_id, project.id)
+        session = get_session(UsecaseId.PROFILE_ATTACHMENTS, project)
         blob = session.get(attachment.stored_id, accept_encoding=accept_encoding or None)
         if blob is None:
             raise ResourceDoesNotExist

--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 
-from sentry.objectstore import get_attachments_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.imports import import_string
 from sentry.utils.tracing import trace
@@ -75,9 +75,7 @@ def delete_cached_and_ratelimited_attachments(
     for attachment in attachments:
         # deletes from objectstore if no long-term storage is desired
         if attachment.rate_limited and attachment.stored_id:
-            get_attachments_session(project.organization_id, project.id).delete(
-                attachment.stored_id
-            )
+            get_session(UsecaseId.ATTACHMENTS, project).delete(attachment.stored_id)
 
         # unconditionally deletes any payloads from the attachment cache
         attachment.delete()

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import zstandard
 from objectstore_client import TimeToLive
 
-from sentry.objectstore import default_attachment_retention, get_attachments_session
+from sentry.objectstore import UsecaseId, default_attachment_retention, get_session
 from sentry.utils import metrics
 from sentry.utils.json import prune_empty_keys
 
@@ -73,7 +73,7 @@ class CachedAttachment:
     def load_data(self, project: Project | None = None) -> bytes:
         if self.stored_id:
             assert project
-            session = get_attachments_session(project.organization_id, project.id)
+            session = get_session(UsecaseId.ATTACHMENTS, project)
             response = session.get(self.stored_id)
             if response is None:
                 raise FileNotFoundError("Attachment does not exist in objectstore")
@@ -145,7 +145,7 @@ class BaseAttachmentCache:
             # the attachment is stored, but has updated data, so we need to overwrite:
             if attachment.stored_id is not None and attachment._data is not UNINITIALIZED_DATA:
                 assert project
-                session = get_attachments_session(project.organization_id, project.id)
+                session = get_session(UsecaseId.ATTACHMENTS, project)
                 # A keyed `put` replaces the object wholesale, so metadata that is not
                 # sent here is lost rather than preserved from the previous write.
                 session.put(

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -21,7 +21,7 @@ from sentry.models.debugfile import (
 )
 from sentry.models.files.file import File
 from sentry.models.project import Project
-from sentry.objectstore import get_debug_files_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.utils.db import atomic_transaction
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 
@@ -194,7 +194,7 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
     except Project.DoesNotExist:
         return None
 
-    session = get_debug_files_session(project.organization_id, project.id)
+    session = get_session(UsecaseId.DEBUG_FILES, project)
 
     content_type = file.headers.get("Content-Type", "application/octet-stream")
     date_created = file.timestamp

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -18,7 +18,7 @@ from sentry.models.debugfile import ProguardArtifactRelease, ProjectDebugFile
 from sentry.models.files import FileBlobOwner
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.objectstore import get_debug_files_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import demomode_tasks
 from sentry.utils.db import atomic_transaction
@@ -246,9 +246,7 @@ def _sync_project_debug_file(
                     raise FileNotFoundError("Debug file does not exist in objectstore")
                 source_fileobj = response.payload
                 try:
-                    target_storage_path = get_debug_files_session(
-                        target_org.id, target_project.id
-                    ).put(
+                    target_storage_path = get_session(UsecaseId.DEBUG_FILES, target_project).put(
                         source_fileobj,
                         compression=(
                             "zstd"

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -27,10 +27,7 @@ from sentry.lang.native.sources import (
 from sentry.lang.native.utils import Backoff
 from sentry.models.project import Project
 from sentry.net.http import Session
-from sentry.objectstore import (
-    get_attachments_session,
-    get_internal_download_url,
-)
+from sentry.objectstore import UsecaseId, get_internal_download_url, get_session
 from sentry.utils import metrics
 
 MAX_ATTEMPTS = 3
@@ -237,7 +234,7 @@ class Symbolicator:
 
         if minidump.stored_id:
             stored_id = minidump.stored_id
-            session = get_attachments_session(self.project.organization_id, self.project.id)
+            session = get_session(UsecaseId.ATTACHMENTS, self.project)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,
@@ -281,7 +278,7 @@ class Symbolicator:
 
         if report.stored_id:
             stored_id = report.stored_id
-            session = get_attachments_session(self.project.organization_id, self.project.id)
+            session = get_session(UsecaseId.ATTACHMENTS, self.project)
             json: dict[str, Any] = {
                 "platform": platform,
                 "sources": sources,

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -43,7 +43,7 @@ from sentry.db.models.fields.jsonfield import LegacyTextJSONField
 from sentry.db.models.manager.base import BaseManager
 from sentry.models.files.file import File
 from sentry.models.files.utils import clear_cached_files
-from sentry.objectstore import get_debug_files_session, get_download_redirect_url
+from sentry.objectstore import UsecaseId, get_download_redirect_url, get_session
 from sentry.objectstore.metrics import measure_storage_operation
 from sentry.utils import json, metrics
 from sentry.utils.retries import ConditionalRetryPolicy
@@ -269,8 +269,8 @@ class ProjectDebugFile(Model):
         from sentry.models.project import Project
 
         try:
-            org_id = Project.objects.get_from_cache(id=self.project_id).organization_id
-            return get_debug_files_session(org=org_id, project=self.project_id)
+            project = Project.objects.get_from_cache(id=self.project_id)
+            return get_session(UsecaseId.DEBUG_FILES, project)
         except Project.DoesNotExist:
             logger.exception("Project doesn't exist, probably deleted")
             raise
@@ -524,7 +524,7 @@ def create_dif_from_file(
     session: Session | None = None
     storage_path: str | None = None
     if features.has("organizations:objectstore-debugfiles-write", project.organization):
-        session = get_debug_files_session(project.organization_id, project.id)
+        session = get_session(UsecaseId.DEBUG_FILES, project)
         try:
             with file.getfile() as source:
                 storage_path = session.put(
@@ -599,7 +599,7 @@ def create_dif_from_fileobj(
 
     object_name = _get_dif_object_name(meta)
     content_type = DIF_MIMETYPES[meta.file_format]
-    session = get_debug_files_session(project.organization_id, project.id)
+    session = get_session(UsecaseId.DEBUG_FILES, project)
     storage_path: str | None = None
 
     def upload() -> str:

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -24,9 +24,10 @@ from sentry.db.models.fields.bounded import BoundedIntegerField
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.models.files.utils import get_size_and_checksum, get_storage
 from sentry.objectstore import (
+    UsecaseId,
     default_attachment_retention,
-    get_attachments_session,
     get_download_redirect_url,
+    get_session,
 )
 from sentry.objectstore.metrics import measure_storage_operation
 from sentry.options.rollout import in_random_rollout
@@ -155,7 +156,7 @@ class EventAttachment(Model):
                 # explicit delete to avoid unnecessary load on the objectstore service.
                 if not os.environ.get("_SENTRY_CLEANUP"):
                     organization_id = _get_organization(self.project_id)
-                    get_attachments_session(organization_id, self.project_id).delete(
+                    get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(
                         self.blob_path.removeprefix(V2_PREFIX)
                     )
 
@@ -181,7 +182,7 @@ class EventAttachment(Model):
         assert self.blob_path is not None
 
         organization_id = _get_organization(self.project_id)
-        session = get_attachments_session(organization_id, self.project_id)
+        session = get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id)
         return get_download_redirect_url(
             request, session, organization_id, self.blob_path.removeprefix(V2_PREFIX)
         )
@@ -208,7 +209,9 @@ class EventAttachment(Model):
         elif self.blob_path.startswith(V2_PREFIX):
             key = self.blob_path.removeprefix(V2_PREFIX)
             organization_id = _get_organization(self.project_id)
-            response = get_attachments_session(organization_id, self.project_id).get(key)
+            response = get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).get(
+                key
+            )
             if response is None:
                 raise FileNotFoundError("Attachment does not exist in objectstore")
             return response.payload
@@ -225,7 +228,9 @@ class EventAttachment(Model):
         if self.uses_objectstore():
             assert self.blob_path is not None
             key = self.blob_path.removeprefix(V2_PREFIX)
-            session = get_attachments_session(_get_organization(self.project_id), self.project_id)
+            session = get_session(
+                UsecaseId.ATTACHMENTS, self.project_id, org=_get_organization(self.project_id)
+            )
             response = session.get(key, accept_encoding=accept_encoding or None)
             if response is None:
                 raise FileNotFoundError("Attachment does not exist in objectstore")
@@ -266,7 +271,7 @@ class EventAttachment(Model):
 
         else:
             organization_id = _get_organization(project_id)
-            session = get_attachments_session(organization_id, project_id)
+            session = get_session(UsecaseId.ATTACHMENTS, project_id, org=organization_id)
             key = session.put(
                 data,
                 content_type=content_type,

--- a/src/sentry/models/profilechunkattachment.py
+++ b/src/sentry/models/profilechunkattachment.py
@@ -40,7 +40,7 @@ class ProfileChunkAttachment(Model):
 
     # The Objectstore key the blob was stored under by Relay (under the
     # "profile_attachments" usecase). Read back via
-    # ``get_profile_attachments_session(org, project).get(stored_id)``.
+    # ``get_session(UsecaseId.PROFILE_ATTACHMENTS, project, org=org).get(stored_id)``.
     stored_id = models.TextField()
 
     date_added = models.DateTimeField(default=timezone.now)

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -78,6 +78,13 @@ class SentryMetricsBackend(MetricsBackend):
 
 
 class UsecaseId(Enum):
+    """Objectstore workloads and their default configuration.
+
+    Use this enum with ``get_session`` instead of constructing a client usecase
+    directly. This configures the correct expiration policy and other usecase
+    settings.
+    """
+
     ATTACHMENTS = "attachments"
     DEBUG_FILES = "debug_files"
     PROFILE_ATTACHMENTS = "profile_attachments"
@@ -108,7 +115,7 @@ class UsecaseId(Enum):
                 )
 
 
-def create_client() -> Client:
+def _create_client() -> Client:
     options = settings.SENTRY_OBJECTSTORE_CONFIG
 
     # Initialize the `TokenGenerator` if key parameters are found.
@@ -140,7 +147,7 @@ _CLIENT: Client | None = None
 def get_client() -> Client:
     global _CLIENT
     if not _CLIENT:
-        _CLIENT = create_client()
+        _CLIENT = _create_client()
     return _CLIENT
 
 
@@ -148,6 +155,15 @@ _USECASES: dict[UsecaseId, ObjectstoreClientUsecase] = {}
 
 
 def get_session(usecase: UsecaseId, project: Project | int, *, org: int | None = None) -> Session:
+    """Return an Objectstore session scoped to a project.
+
+    There are two ways to construct a session:
+    - Project model: ``get_session(UsecaseId.ATTACHMENTS, project)``
+    - Project and org IDs: ``get_session(UsecaseId.ATTACHMENTS, project_id, org=org_id)``
+
+    When passing a project model, ``org`` is optional and must match the
+    project's organization. It is required when passing a project ID.
+    """
     if isinstance(project, int):
         if org is None:
             raise TypeError("org is required when project is an ID")
@@ -170,23 +186,26 @@ def get_session(usecase: UsecaseId, project: Project | int, *, org: int | None =
 _IS_SYMBOLICATOR_CONTAINER: bool | None = None
 
 
-def maybe_rewrite_url_for_symbolicator(url: str) -> str:
+def _maybe_rewrite_internal_url(url: str) -> str:
     """
-    Rewrites a full Objectstore URL so that Symbolicator can reach it.
+    Rewrites a full Objectstore URL so that an internal service can reach it.
 
-    In prod, the URL is returned unchanged, as both Sentry and Symbolicator talk to Objectstore
-    using the same hostname.
+    In production, the URL is returned unchanged, as both Sentry and internal
+    services talk to Objectstore using the same hostname.
 
-    While in development or testing, we might need to replace the hostname, depending on how
-    Symbolicator is running. This function runs a `docker ps` to automatically return the correct
-    URL in the following 2 cases:
-        - Symbolicator running in Docker (possibly via `devservices`) -- this mirrors `sentry`'s CI.
-          If this is detected, we replace Objectstore's hostname with the one reachable in the Docker network.
+    While in development or testing, we might need to replace the hostname,
+    depending on how Symbolicator is running. This function runs a `docker ps`
+    to automatically return the correct URL in the following 2 cases:
+        - Symbolicator running in Docker (possibly via `devservices`) -- this
+          mirrors `sentry`'s CI. If this is detected, we replace Objectstore's
+          hostname with the one reachable in the Docker network.
 
-          Note that this approach doesn't work if Objectstore is running both locally and in Docker, as we'll always
-          rewrite the URL to the Docker one, so Sentry and Symbolicator might attempt to talk to 2 different Objectstores.
-        - Symbolicator running locally -- this mirrors `symbolicator`'s CI.
-          In this case, we don't need to rewrite the URL.
+          Note that this approach doesn't work if Objectstore is running both
+          locally and in Docker, as we'll always rewrite the URL to the Docker
+          one, so Sentry and Symbolicator might attempt to talk to 2 different
+          Objectstores.
+        - Symbolicator running locally -- this mirrors `symbolicator`'s CI. In
+          this case, we don't need to rewrite the URL.
     """
     global _IS_SYMBOLICATOR_CONTAINER  # Cached to avoid running `docker ps` multiple times
 
@@ -228,9 +247,7 @@ def get_internal_download_url(
     # instead, so we need to additionally wrap this with `maybe_rewrite_url_for_symbolicator`.
     # TODO(lcian): Find a more robust way to do this. Here we assume that the caller is Symbolicator,
     # which is currently the case in practice, but in theory it could be any other service.
-    return maybe_rewrite_url_for_symbolicator(
-        session.object_url(key, token_validity=token_validity)
-    )
+    return _maybe_rewrite_internal_url(session.object_url(key, token_validity=token_validity))
 
 
 def get_download_redirect_url(

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -144,7 +144,7 @@ def _create_client() -> Client:
 _CLIENT: Client | None = None
 
 
-def get_client() -> Client:
+def _get_client() -> Client:
     global _CLIENT
     if not _CLIENT:
         _CLIENT = _create_client()
@@ -180,7 +180,7 @@ def get_session(usecase: UsecaseId, project: Project | int, *, org: int | None =
         objectstore_usecase = usecase.create()
         _USECASES[usecase] = objectstore_usecase
 
-    return get_client().session(objectstore_usecase, org=org_id, project=project_id)
+    return _get_client().session(objectstore_usecase, org=org_id, project=project_id)
 
 
 _IS_SYMBOLICATOR_CONTAINER: bool | None = None

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import subprocess
 from datetime import timedelta
+from enum import Enum
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlsplit, urlunparse
 
 import urllib3
@@ -13,8 +17,10 @@ from objectstore_client import (
     TimeToIdle,
     TimeToLive,
     TokenGenerator,
-    Usecase,
     parse_accept_encoding,
+)
+from objectstore_client import (
+    Usecase as ObjectstoreClientUsecase,
 )
 from objectstore_client.metrics import Tags
 
@@ -22,7 +28,10 @@ from sentry import options
 from sentry.utils import metrics as sentry_metrics
 from sentry.utils.env import in_test_environment
 
-__all__ = ["get_attachments_session", "get_debug_files_session", "parse_accept_encoding"]
+if TYPE_CHECKING:
+    from sentry.models.project import Project
+
+__all__ = ["UsecaseId", "get_session", "parse_accept_encoding"]
 
 
 # Default validity of the token used for redirecting to Objectstore. This is a
@@ -69,12 +78,21 @@ class SentryMetricsBackend(MetricsBackend):
 
 
 _OBJECTSTORE_CLIENT: Client | None = None
-_ATTACHMENTS_USECASE: Usecase | None = None
-_DEBUG_FILES_USECASE = Usecase(
+_ATTACHMENTS_USECASE: ObjectstoreClientUsecase | None = None
+_DEBUG_FILES_USECASE = ObjectstoreClientUsecase(
     "debug_files", compression="none", expiration_policy=TimeToIdle(timedelta(days=90))
 )
-_PROFILE_ATTACHMENTS_USECASE: Usecase | None = None
-_PREPROD_USECASE = Usecase("preprod", expiration_policy=TimeToIdle(timedelta(days=30)))
+_PROFILE_ATTACHMENTS_USECASE: ObjectstoreClientUsecase | None = None
+_PREPROD_USECASE = ObjectstoreClientUsecase(
+    "preprod", expiration_policy=TimeToIdle(timedelta(days=30))
+)
+
+
+class UsecaseId(Enum):
+    ATTACHMENTS = "attachments"
+    DEBUG_FILES = "debug_files"
+    PROFILE_ATTACHMENTS = "profile_attachments"
+    PREPROD = "preprod"
 
 
 def create_client() -> Client:
@@ -110,42 +128,51 @@ def get_client() -> Client:
     return _OBJECTSTORE_CLIENT
 
 
-def get_attachments_usecase() -> Usecase:
+def _get_attachments_usecase() -> ObjectstoreClientUsecase:
     global _ATTACHMENTS_USECASE
     if not _ATTACHMENTS_USECASE:
         retention = default_attachment_retention()
-        _ATTACHMENTS_USECASE = Usecase(
+        _ATTACHMENTS_USECASE = ObjectstoreClientUsecase(
             "attachments", expiration_policy=TimeToLive(timedelta(days=retention))
         )
     return _ATTACHMENTS_USECASE
 
 
-def get_attachments_session(org: int, project: int) -> Session:
-    return get_client().session(get_attachments_usecase(), org=org, project=project)
-
-
-def get_debug_files_session(org: int, project: int) -> Session:
-    return get_client().session(_DEBUG_FILES_USECASE, org=org, project=project)
-
-
-def get_profile_attachments_usecase() -> Usecase:
+def _get_profile_attachments_usecase() -> ObjectstoreClientUsecase:
     # Relay stores raw profiles and their attachments (e.g. Perfetto traces) under
     # the "profile_attachments" usecase, so we must read them back with the same usecase.
     global _PROFILE_ATTACHMENTS_USECASE
     if not _PROFILE_ATTACHMENTS_USECASE:
         retention = default_attachment_retention()
-        _PROFILE_ATTACHMENTS_USECASE = Usecase(
+        _PROFILE_ATTACHMENTS_USECASE = ObjectstoreClientUsecase(
             "profile_attachments", expiration_policy=TimeToLive(timedelta(days=retention))
         )
     return _PROFILE_ATTACHMENTS_USECASE
 
 
-def get_profile_attachments_session(org: int, project: int) -> Session:
-    return get_client().session(get_profile_attachments_usecase(), org=org, project=project)
+def get_session(usecase: UsecaseId, project: Project | int, *, org: int | None = None) -> Session:
+    if isinstance(project, int):
+        if org is None:
+            raise TypeError("org is required when project is an ID")
+        project_id = project
+        org_id = org
+    else:
+        project_id = project.id
+        org_id = project.organization_id
+        if org is not None and org != org_id:
+            raise ValueError("project does not belong to org")
 
+    match usecase:
+        case UsecaseId.ATTACHMENTS:
+            objectstore_usecase = _get_attachments_usecase()
+        case UsecaseId.DEBUG_FILES:
+            objectstore_usecase = _DEBUG_FILES_USECASE
+        case UsecaseId.PROFILE_ATTACHMENTS:
+            objectstore_usecase = _get_profile_attachments_usecase()
+        case UsecaseId.PREPROD:
+            objectstore_usecase = _PREPROD_USECASE
 
-def get_preprod_session(org: int, project: int) -> Session:
-    return get_client().session(_PREPROD_USECASE, org=org, project=project)
+    return get_client().session(objectstore_usecase, org=org_id, project=project_id)
 
 
 _IS_SYMBOLICATOR_CONTAINER: bool | None = None

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -77,22 +77,35 @@ class SentryMetricsBackend(MetricsBackend):
         sentry_metrics.distribution(name, value, tags=tags, unit=unit)
 
 
-_OBJECTSTORE_CLIENT: Client | None = None
-_ATTACHMENTS_USECASE: ObjectstoreClientUsecase | None = None
-_DEBUG_FILES_USECASE = ObjectstoreClientUsecase(
-    "debug_files", compression="none", expiration_policy=TimeToIdle(timedelta(days=90))
-)
-_PROFILE_ATTACHMENTS_USECASE: ObjectstoreClientUsecase | None = None
-_PREPROD_USECASE = ObjectstoreClientUsecase(
-    "preprod", expiration_policy=TimeToIdle(timedelta(days=30))
-)
-
-
 class UsecaseId(Enum):
     ATTACHMENTS = "attachments"
     DEBUG_FILES = "debug_files"
     PROFILE_ATTACHMENTS = "profile_attachments"
     PREPROD = "preprod"
+
+    def create(self) -> ObjectstoreClientUsecase:
+        match self:
+            case UsecaseId.ATTACHMENTS:
+                return ObjectstoreClientUsecase(
+                    self.value,
+                    expiration_policy=TimeToLive(timedelta(days=default_attachment_retention())),
+                )
+            case UsecaseId.DEBUG_FILES:
+                return ObjectstoreClientUsecase(
+                    self.value,
+                    compression="none",
+                    expiration_policy=TimeToIdle(timedelta(days=90)),
+                )
+            case UsecaseId.PROFILE_ATTACHMENTS:
+                return ObjectstoreClientUsecase(
+                    self.value,
+                    expiration_policy=TimeToLive(timedelta(days=default_attachment_retention())),
+                )
+            case UsecaseId.PREPROD:
+                return ObjectstoreClientUsecase(
+                    self.value,
+                    expiration_policy=TimeToIdle(timedelta(days=30)),
+                )
 
 
 def create_client() -> Client:
@@ -121,33 +134,17 @@ def create_client() -> Client:
     )
 
 
+_CLIENT: Client | None = None
+
+
 def get_client() -> Client:
-    global _OBJECTSTORE_CLIENT
-    if not _OBJECTSTORE_CLIENT:
-        _OBJECTSTORE_CLIENT = create_client()
-    return _OBJECTSTORE_CLIENT
+    global _CLIENT
+    if not _CLIENT:
+        _CLIENT = create_client()
+    return _CLIENT
 
 
-def _get_attachments_usecase() -> ObjectstoreClientUsecase:
-    global _ATTACHMENTS_USECASE
-    if not _ATTACHMENTS_USECASE:
-        retention = default_attachment_retention()
-        _ATTACHMENTS_USECASE = ObjectstoreClientUsecase(
-            "attachments", expiration_policy=TimeToLive(timedelta(days=retention))
-        )
-    return _ATTACHMENTS_USECASE
-
-
-def _get_profile_attachments_usecase() -> ObjectstoreClientUsecase:
-    # Relay stores raw profiles and their attachments (e.g. Perfetto traces) under
-    # the "profile_attachments" usecase, so we must read them back with the same usecase.
-    global _PROFILE_ATTACHMENTS_USECASE
-    if not _PROFILE_ATTACHMENTS_USECASE:
-        retention = default_attachment_retention()
-        _PROFILE_ATTACHMENTS_USECASE = ObjectstoreClientUsecase(
-            "profile_attachments", expiration_policy=TimeToLive(timedelta(days=retention))
-        )
-    return _PROFILE_ATTACHMENTS_USECASE
+_USECASES: dict[UsecaseId, ObjectstoreClientUsecase] = {}
 
 
 def get_session(usecase: UsecaseId, project: Project | int, *, org: int | None = None) -> Session:
@@ -162,15 +159,10 @@ def get_session(usecase: UsecaseId, project: Project | int, *, org: int | None =
         if org is not None and org != org_id:
             raise ValueError("project does not belong to org")
 
-    match usecase:
-        case UsecaseId.ATTACHMENTS:
-            objectstore_usecase = _get_attachments_usecase()
-        case UsecaseId.DEBUG_FILES:
-            objectstore_usecase = _DEBUG_FILES_USECASE
-        case UsecaseId.PROFILE_ATTACHMENTS:
-            objectstore_usecase = _get_profile_attachments_usecase()
-        case UsecaseId.PREPROD:
-            objectstore_usecase = _PREPROD_USECASE
+    objectstore_usecase = _USECASES.get(usecase)
+    if objectstore_usecase is None:
+        objectstore_usecase = usecase.create()
+        _USECASES[usecase] = objectstore_usecase
 
     return get_client().session(objectstore_usecase, org=org_id, project=project_id)
 

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -14,7 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models.project import Project
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -69,7 +69,7 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
         project_id = project.id
 
         object_key = f"{organization_id}/{project_id}/{image_id}"
-        session = get_preprod_session(organization_id, project_id)
+        session = get_session(UsecaseId.PREPROD, project)
 
         try:
             result = session.get(object_key)

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -14,7 +14,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.utils import generate_locality_url
 from sentry.models.project import Project
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.objectstore.types import ObjectstoreUploadOptions
 from sentry.utils.http import absolute_uri
 
@@ -29,7 +29,7 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
 
     def get(self, request: Request, project: Project) -> Response:
         organization = project.organization
-        session = get_preprod_session(org=organization.id, project=project.id)
+        session = get_session(UsecaseId.PREPROD, project)
 
         path = reverse(
             "sentry-api-0-organization-objectstore",

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -34,7 +34,7 @@ from sentry.issues.action_log import resolve_action_source
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import (
     PreprodArtifactApiDeleteEvent,
     PreprodArtifactApiGetSnapshotDetailsEvent,
@@ -378,7 +378,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             return Response({"detail": "Manifest key not found"}, status=404)
 
         try:
-            session = get_preprod_session(organization.id, artifact.project_id)
+            session = get_session(UsecaseId.PREPROD, artifact.project)
             get_response = session.get(manifest_key)
             if get_response is None:
                 raise FileNotFoundError("Manifest does not exist in objectstore")
@@ -841,7 +841,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
             # Write manifest inside the transaction so that a failed objectstore
             # write rolls back the DB records, ensuring both succeed or neither does.
-            session = get_preprod_session(project.organization_id, project.id)
+            session = get_session(UsecaseId.PREPROD, project)
             manifest_bytes = manifest.json(exclude_none=True).encode()
             manifest_size_bytes = len(manifest_bytes)
             session.put(manifest_bytes, key=manifest_key)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_archive.py
@@ -18,7 +18,7 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationRele
 from sentry.auth.staff import is_active_staff
 from sentry.issues.action_log import resolve_action_source
 from sentry.models.organization import Organization
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodArtifactApiSnapshotArchiveDownloadEvent
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
@@ -87,7 +87,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         return artifact, metrics
 
     def _download(self, artifact: PreprodArtifact) -> HttpResponseBase:
-        session = get_preprod_session(artifact.project.organization_id, artifact.project_id)
+        session = get_session(UsecaseId.PREPROD, artifact.project)
         result = session.get(archive_object_key(artifact.id))
         if result is None:
             return Response({"detail": "Download not ready"}, status=409)
@@ -104,7 +104,7 @@ class OrganizationPreprodSnapshotArchiveEndpoint(OrganizationEndpoint):
         return response
 
     def _archive_exists(self, artifact: PreprodArtifact) -> bool:
-        session = get_preprod_session(artifact.project.organization_id, artifact.project_id)
+        session = get_session(UsecaseId.PREPROD, artifact.project)
         try:
             return archive_exists(session, archive_object_key(artifact.id))
         except RequestError:

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
@@ -24,7 +24,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.staff import is_active_staff
 from sentry.issues.action_log import resolve_action_source
 from sentry.models.organization import Organization
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodArtifactApiGetSnapshotImageEvent
 from sentry.preprod.api.models.public.snapshots import SnapshotImageDetailResponseDict
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
@@ -216,7 +216,7 @@ class OrganizationPreprodSnapshotImageDetailEndpoint(OrganizationEndpoint):
             return Response({"detail": "Manifest key not found"}, status=404)
 
         try:
-            session = get_preprod_session(organization.id, artifact.project_id)
+            session = get_session(UsecaseId.PREPROD, artifact.project)
             response = session.get(manifest_key)
             if response is None:
                 raise FileNotFoundError("Manifest does not exist in objectstore")

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -27,7 +27,7 @@ from sentry.auth.staff import is_active_staff
 from sentry.constants import ObjectStatus
 from sentry.issues.action_log import resolve_action_source
 from sentry.models.organization import Organization
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodArtifactApiGetLatestBaseSnapshotEvent
 from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot import (
     _strip_to_compact,
@@ -199,7 +199,7 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             return Response({"detail": "Manifest key not found"}, status=404)
 
         try:
-            session = get_preprod_session(organization.id, artifact.project_id)
+            session = get_session(UsecaseId.PREPROD, artifact.project)
             response = session.get(manifest_key)
             if response is None:
                 raise FileNotFoundError("Manifest does not exist in objectstore")

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -17,7 +17,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, Attrib
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
 from sentry.models.files.file import File
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.eap.constants import get_preprod_trace_id
 from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.preprod.snapshots.manifest import ComparisonManifest
@@ -151,7 +151,7 @@ def _collect_snapshot_objectstore_keys(
 
         keys.append((org_id, project_id, comparison_key))
         try:
-            session = get_preprod_session(org_id, project_id)
+            session = get_session(UsecaseId.PREPROD, project_id, org=org_id)
             response = session.get(comparison_key)
             if response is None:
                 raise FileNotFoundError("Comparison manifest does not exist in objectstore")
@@ -171,7 +171,7 @@ def _collect_snapshot_objectstore_keys(
 def _delete_objectstore_key(args: tuple[int, int, str]) -> bool:
     org_id, project_id, key = args
     try:
-        get_preprod_session(org_id, project_id).delete(key)
+        get_session(UsecaseId.PREPROD, project_id, org=org_id).delete(key)
         return True
     except Exception:
         logger.exception("preprod.cleanup.objectstore_delete_failed", extra={"key": key})

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ValidationError
 from taskbroker_client.retry import Retry
 
 from sentry import analytics
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.categorize import categorize_image_sets
@@ -747,7 +747,7 @@ def process_snapshot_comparison_chunk(
     base_artifact_id: int,
     **kwargs: Any,
 ) -> None:
-    session = get_preprod_session(org_id, project_id)
+    session = get_session(UsecaseId.PREPROD, project_id, org=org_id)
     plan_key = _plan_key(org_id, project_id, head_artifact_id, base_artifact_id)
 
     try:
@@ -944,7 +944,7 @@ def compare_snapshots(
             )
 
     try:
-        session = get_preprod_session(org_id, project_id)
+        session = get_session(UsecaseId.PREPROD, project_id, org=org_id)
 
         head_manifest_key = (head_metrics.extras or {}).get("manifest_key")
         base_manifest_key = (base_metrics.extras or {}).get("manifest_key")
@@ -1199,7 +1199,7 @@ def finalize_snapshot_comparison(
     ).update(date_updated=timezone.now())
 
     comparison.refresh_from_db(fields=["chunks_done_indices"])
-    session = get_preprod_session(org_id, project_id)
+    session = get_session(UsecaseId.PREPROD, project_id, org=org_id)
     plan_key = _plan_key(org_id, project_id, head_artifact_id, base_artifact_id)
     try:
         plan = _get_json(session, plan_key, ComparisonPlan)

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -12,7 +12,7 @@ from objectstore_client.multipart import CompletePart, MultipartUpload
 from urllib3.exceptions import HTTPError
 
 from sentry.models.organization import Organization
-from sentry.objectstore import get_preprod_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.preprod.snapshots.zip_builder import (
@@ -79,7 +79,7 @@ def _put_part_with_retry(upload: MultipartUpload, chunk: bytes, part_number: int
 
 def _archive_available(org_id: int, project_id: int, artifact_id: int) -> bool:
     try:
-        session = get_preprod_session(org_id, project_id)
+        session = get_session(UsecaseId.PREPROD, project_id, org=org_id)
         return archive_exists(session, archive_object_key(artifact_id))
     except Exception:
         return False
@@ -155,7 +155,7 @@ def build_snapshot_images_zip(
         if not manifest_key:
             raise SnapshotZipBuildError(f"missing manifest_key for artifact {artifact_id}")
 
-        session = get_preprod_session(org_id, project_id)
+        session = get_session(UsecaseId.PREPROD, project_id, org=org_id)
         key = archive_object_key(artifact_id)
 
         # Snapshot images for a given artifact are immutable, so a stored archive

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -104,7 +104,7 @@ from sentry.deletions.defaults.group import DIRECT_GROUP_RELATED_MODELS
 from sentry.models.eventattachment import V1_PREFIX, V2_PREFIX, EventAttachment
 from sentry.models.files.utils import get_storage
 from sentry.models.project import Project
-from sentry.objectstore import default_attachment_retention, get_attachments_session
+from sentry.objectstore import UsecaseId, default_attachment_retention, get_session
 from sentry.options.rollout import in_random_rollout
 from sentry.search.eap.occurrences.common_queries import count_occurrences
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
@@ -435,7 +435,7 @@ def _maybe_copy_attachment_into_cache(
         )
         # move the attachment into objectstore and update the record
         with attachment.getfile() as fp:
-            stored_id = get_attachments_session(project.organization_id, project.id).put(
+            stored_id = get_session(UsecaseId.ATTACHMENTS, project).put(
                 fp,
                 content_type=attachment.content_type,
                 filename=attachment.name,

--- a/tests/sentry/api/endpoints/test_project_profiling_profile.py
+++ b/tests/sentry/api/endpoints/test_project_profiling_profile.py
@@ -68,7 +68,7 @@ class ProjectProfilingChunkAttachmentTest(APITestCase):
         assert response.data["id"] == str(self.attachment.id)
         assert response.data["name"] == "trace.perfetto"
 
-    @patch("sentry.api.endpoints.project_profiling_profile.get_profile_attachments_session")
+    @patch("sentry.api.endpoints.project_profiling_profile.get_session")
     def test_downloads_blob(self, mock_session: MagicMock) -> None:
         blob = MagicMock()
         blob.payload = BytesIO(b"perfetto-bytes")
@@ -83,7 +83,7 @@ class ProjectProfilingChunkAttachmentTest(APITestCase):
         assert response["Content-Disposition"] == 'attachment; filename="trace.perfetto"'
         mock_session.return_value.get.assert_called_once()
 
-    @patch("sentry.api.endpoints.project_profiling_profile.get_profile_attachments_session")
+    @patch("sentry.api.endpoints.project_profiling_profile.get_session")
     def test_download_tolerates_expired_blob(self, mock_session: MagicMock) -> None:
         # The blob's Objectstore TTL and this row's cleanup are not perfectly
         # synchronized, so the blob may already be gone while the row lingers.

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -120,7 +120,7 @@ def test_zstd_chunks() -> None:
 
 
 @django_db_all
-@mock.patch("sentry.attachments.base.get_attachments_session")
+@mock.patch("sentry.attachments.base.get_session")
 def test_overwriting_stored_attachment_keeps_metadata(mock_get_session: mock.Mock) -> None:
     cache = BaseAttachmentCache(InMemoryCache())
     project = mock.Mock(id=42, organization_id=1)

--- a/tests/sentry/debug_files/objectstore_migration/test_utils.py
+++ b/tests/sentry/debug_files/objectstore_migration/test_utils.py
@@ -101,7 +101,7 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
 
         with (
             patch(
-                "sentry.debug_files.objectstore_migration.utils.get_debug_files_session",
+                "sentry.debug_files.objectstore_migration.utils.get_session",
                 return_value=session,
             ),
             patch("sentry.utils.retries.time.sleep"),
@@ -159,7 +159,7 @@ class DebugFileObjectstoreMigrationUtilsTest(TestCase):
 
         with (
             patch(
-                "sentry.debug_files.objectstore_migration.utils.get_debug_files_session",
+                "sentry.debug_files.objectstore_migration.utils.get_session",
                 return_value=session,
             ),
             self.captureOnCommitCallbacks(execute=True),

--- a/tests/sentry/demo_mode/test_tasks.py
+++ b/tests/sentry/demo_mode/test_tasks.py
@@ -19,7 +19,7 @@ from sentry.models.artifactbundle import (
 from sentry.models.debugfile import ProguardArtifactRelease, ProjectDebugFile
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.objectstore import get_debug_files_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.testutils.cases import TestCase
 from sentry.testutils.skips import requires_objectstore
 
@@ -251,9 +251,9 @@ class SyncArtifactBundlesTest(TestCase):
         content = b"objectstore-backed-debug-file"
         content_type = "application/x-mach-binary"
         date_created = timezone.now()
-        source_storage_path = get_debug_files_session(
-            self.source_org.id, self.source_proj_foo.id
-        ).put(content, compression="none", content_type=content_type)
+        source_storage_path = get_session(UsecaseId.DEBUG_FILES, self.source_proj_foo).put(
+            content, compression="none", content_type=content_type
+        )
         source_project_debug_file = ProjectDebugFile.objects.create(
             project_id=self.source_proj_foo.id,
             file=None,
@@ -288,7 +288,7 @@ class SyncArtifactBundlesTest(TestCase):
         assert target_project_debug_file.file_size == len(content)
         assert target_project_debug_file.date_created == date_created
         assert target_project_debug_file.get_file().read() == content
-        target_metadata = get_debug_files_session(self.target_org.id, self.target_proj_foo.id).head(
+        target_metadata = get_session(UsecaseId.DEBUG_FILES, self.target_proj_foo).head(
             target_project_debug_file.storage_path
         )
         assert target_metadata is not None
@@ -304,9 +304,9 @@ class SyncArtifactBundlesTest(TestCase):
     @requires_objectstore
     def test_sync_dual_written_project_debug_files(self) -> None:
         source_project_debug_file = self.create_dif_file(self.source_proj_foo)
-        source_storage_path = get_debug_files_session(
-            self.source_org.id, self.source_proj_foo.id
-        ).put(b"objectstore-backed-debug-file", compression="none")
+        source_storage_path = get_session(UsecaseId.DEBUG_FILES, self.source_proj_foo).put(
+            b"objectstore-backed-debug-file", compression="none"
+        )
         source_project_debug_file.update(
             storage_path=source_storage_path,
             content_type=source_project_debug_file.file.headers["Content-Type"],

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -35,7 +35,7 @@ from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models.debugfile import create_files_from_dif_zip
 from sentry.models.eventattachment import EventAttachment
 from sentry.models.userreport import UserReport
-from sentry.objectstore import get_attachments_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.services import eventstore
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.testutils.factories import get_fixture_path
@@ -602,7 +602,7 @@ def do_process_view_hierarchy(project, task_runner, use_objectstore=False):
         )
         attachment_metadata["chunks"] = 1
     else:
-        session = get_attachments_session(project.organization_id, project.id)
+        session = get_session(UsecaseId.ATTACHMENTS, project)
         stored_id = session.put(attachment_payload)
         attachment_metadata["stored_id"] = stored_id
 
@@ -667,9 +667,7 @@ def test_process_stored_attachment(
         with open(get_fixture_path("native", "threadnames.dmp"), "rb") as f:
             attachment_payload = f.read()
 
-        stored_id = get_attachments_session(default_project.organization_id, project_id).put(
-            attachment_payload
-        )
+        stored_id = get_session(UsecaseId.ATTACHMENTS, default_project).put(attachment_payload)
 
         with task_runner():
             process_event(

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -26,7 +26,7 @@ from sentry.models.debugfile import (
     get_debug_id_from_dif_request,
 )
 from sentry.models.files.file import File
-from sentry.objectstore import get_debug_files_session
+from sentry.objectstore import UsecaseId, get_session
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.objectstore import debug_files_test_both_backends
 from sentry.testutils.skips import requires_objectstore
@@ -249,7 +249,7 @@ class DebugFileObjectstoreTest(TestCase):
     """Tests for Objectstore-backed debug files."""
 
     def _get_session(self):
-        return get_debug_files_session(org=self.organization.id, project=self.project.id)
+        return get_session(UsecaseId.DEBUG_FILES, self.project)
 
     def _create_objectstore_dif(self, content=b"test-content", **kwargs):
         storage_path = self._get_session().put(content, compression="zstd")
@@ -422,7 +422,7 @@ class CreateDebugFileTest(APITestCase):
         assert dif.file_size == len(content)
         assert dif.get_file().read() == content
 
-    @patch("sentry.models.debugfile.get_debug_files_session")
+    @patch("sentry.models.debugfile.get_session")
     def test_exclusive_objectstore_dif_is_idempotent(self, get_session) -> None:
         content = b"objectstore-dif-content"
         get_session.return_value.put.return_value = "storage-path"
@@ -437,7 +437,7 @@ class CreateDebugFileTest(APITestCase):
         get_session.return_value.put.assert_called_once()
 
     @patch("sentry.models.debugfile.ProjectDebugFile.objects.create")
-    @patch("sentry.models.debugfile.get_debug_files_session")
+    @patch("sentry.models.debugfile.get_session")
     def test_exclusive_objectstore_dif_cleans_up_after_database_error(
         self, get_session, create
     ) -> None:
@@ -454,7 +454,7 @@ class CreateDebugFileTest(APITestCase):
 
     @requires_objectstore
     @patch("sentry.utils.retries.time.sleep")
-    @patch("sentry.models.debugfile.get_debug_files_session")
+    @patch("sentry.models.debugfile.get_session")
     def test_exclusive_objectstore_write_failure_does_not_create_file(
         self, get_session, sleep
     ) -> None:
@@ -504,7 +504,7 @@ class CreateDebugFileTest(APITestCase):
         with (
             self.feature("organizations:objectstore-debugfiles-write"),
             patch(
-                "sentry.models.debugfile.get_debug_files_session",
+                "sentry.models.debugfile.get_session",
                 return_value=MagicMock(put=MagicMock(side_effect=RuntimeError)),
             ),
         ):
@@ -530,7 +530,7 @@ class CreateDebugFileTest(APITestCase):
         dif.delete()
 
         assert not File.objects.filter(id=file_id).exists()
-        session = get_debug_files_session(self.organization.id, self.project.id)
+        session = get_session(UsecaseId.DEBUG_FILES, self.project)
         assert session.get(storage_path) is None
 
     @requires_objectstore
@@ -543,7 +543,7 @@ class CreateDebugFileTest(APITestCase):
         assert created
         storage_path = dif.storage_path
         assert storage_path is not None
-        session = get_debug_files_session(self.organization.id, self.project.id)
+        session = get_session(UsecaseId.DEBUG_FILES, self.project)
         session.delete(storage_path)
         replacement_storage_path = session.put(objectstore_content, compression="none")
         dif.storage_path = replacement_storage_path

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -20,7 +20,7 @@ class EventAttachmentDeleteTest(TestCase):
             blob_path="v2/some-key",
         )
 
-    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment.get_session")
     @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
     def test_v2_delete_calls_objectstore(
         self,
@@ -33,7 +33,7 @@ class EventAttachmentDeleteTest(TestCase):
 
         mock_get_session.return_value.delete.assert_called_once_with("some-key")
 
-    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment.get_session")
     @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
     def test_v2_delete_skips_objectstore_during_cleanup(
         self,
@@ -53,7 +53,7 @@ class EventAttachmentDeleteTest(TestCase):
 
 
 class EventAttachmentPutfileTest(TestCase):
-    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment.get_session")
     @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
     @override_options({"objectstore.enable_for.attachments": 1})
     def test_objectstore_upload_stores_filename(
@@ -73,7 +73,7 @@ class EventAttachmentPutfileTest(TestCase):
         assert mock_get_session.return_value.put.call_args.kwargs["filename"] == "hello.png"
         assert mock_get_session.return_value.put.call_args.kwargs["content_type"] == "image/png"
 
-    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment.get_session")
     @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
     @override_options({"objectstore.enable_for.attachments": 1})
     def test_objectstore_upload_stores_normalized_content_type(

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_archive.py
@@ -21,7 +21,7 @@ ENQUEUE_TARGET = (
     "preprod_artifact_snapshot_archive.build_snapshot_images_zip"
 )
 SESSION_TARGET = (
-    "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_archive.get_preprod_session"
+    "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_archive.get_session"
 )
 
 

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_image_detail.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_image_detail.py
@@ -9,7 +9,9 @@ from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSn
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 
-MOCK_TARGET = "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_image_detail.get_preprod_session"
+MOCK_TARGET = (
+    "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_image_detail.get_session"
+)
 
 
 class OrganizationPreprodSnapshotImageDetailTest(APITestCase):

--- a/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_latest_base.py
+++ b/tests/sentry/preprod/api/endpoints/snapshots/test_preprod_artifact_snapshot_latest_base.py
@@ -9,7 +9,9 @@ from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 
-MOCK_TARGET = "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+MOCK_TARGET = (
+    "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_session"
+)
 
 
 class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
+from sentry.objectstore import UsecaseId
 from sentry.testutils.cases import APITestCase
 
 
@@ -35,7 +36,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
 
         return mock_session
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_successful_image_retrieval_png(self, mock_get_session):
         png_data = b"\x89PNG\r\n\x1a\n" + b"fake png content" * 100
         mock_session = self._create_mock_session(png_data, "image/png")
@@ -49,10 +50,10 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response.content == png_data
         assert response["Content-Type"] == "image/png"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
         mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_successful_image_retrieval_jpeg(self, mock_get_session):
         jpeg_data = b"\xff\xd8\xff" + b"fake jpeg content" * 100
         mock_session = self._create_mock_session(jpeg_data, "image/jpeg")
@@ -66,10 +67,10 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response.content == jpeg_data
         assert response["Content-Type"] == "image/jpeg"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
         mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_successful_image_retrieval_webp(self, mock_get_session):
         webp_data = b"RIFF" + b"1234" + b"WEBP" + b"fake webp content" * 100
         mock_session = self._create_mock_session(webp_data, "image/webp")
@@ -83,10 +84,10 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response.content == webp_data
         assert response["Content-Type"] == "image/webp"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
         mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_unknown_image_format(self, mock_get_session):
         unknown_data = b"unknown binary data" * 50
         mock_session = self._create_mock_session(unknown_data, "application/octet-stream")
@@ -100,10 +101,10 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response.content == unknown_data
         assert response["Content-Type"] == "application/octet-stream"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
         mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_content_disposition_with_filename(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -119,7 +120,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response["Content-Disposition"] == 'inline; filename="alert-dark-danger-no-icon.png"'
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_no_content_disposition_without_filename_param(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -132,7 +133,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert not response.has_header("Content-Disposition")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_content_disposition_strips_path_traversal(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -148,7 +149,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response["Content-Disposition"] == 'inline; filename="alert-dark-danger-no-icon.png"'
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_content_disposition_strips_parent_dir_traversal(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -164,7 +165,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response["Content-Disposition"] == 'inline; filename="passwd"'
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_content_disposition_strips_header_injection(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -183,7 +184,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert "\n" not in cd
         assert not response.has_header("Set-Cookie")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_content_disposition_strips_quotes(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -199,7 +200,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert response["Content-Disposition"] == 'inline; filename="foo.png"'
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_no_content_disposition_when_filename_empties_out(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -215,7 +216,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 200
         assert not response.has_header("Content-Disposition")
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_content_disposition_non_ascii_filename(self, mock_get_session):
         mock_session = self._create_mock_session(b"\x89PNG\r\n\x1a\n", "image/png")
         mock_get_session.return_value = mock_session
@@ -246,7 +247,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         )
         assert response.status_code == 403
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_objectstore_404_returns_404(self, mock_get_session):
         mock_session = MagicMock()
         mock_session.get.return_value = None
@@ -260,7 +261,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.status_code == 404
         assert response.json() == {"detail": "Image not found"}
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_session")
     def test_error_handling_returns_json(self, mock_get_session):
         mock_session = MagicMock()
         mock_session.get.side_effect = Exception("Storage error")

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -5,6 +5,7 @@ import zstandard
 from django.urls import reverse
 
 from sentry.models.commitcomparison import CommitComparison
+from sentry.objectstore import UsecaseId
 from sentry.preprod.analytics import PreprodArtifactApiGetSnapshotDetailsEvent
 from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base import (
     LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS,
@@ -412,7 +413,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         response = self._post_selective()
         assert response.status_code == 200
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.compare_snapshots")
     def test_base_upload_triggers_comparison_for_waiting_head(
         self, mock_compare_snapshots, mock_get_session
@@ -498,7 +499,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             }
         )
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.compare_snapshots")
     def test_selective_base_is_matched_for_comparison(
         self, mock_compare_snapshots, mock_get_session
@@ -631,7 +632,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         mock_session.get.return_value = mock_result
         return mock_session
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details(self, mock_get_session):
         artifact, _, manifest_key, manifest_json, images = self._create_artifact_with_manifest()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
@@ -649,7 +650,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["images"][0]["image_file_name"] == "img1"
         assert response.data["images"][1]["key"] == "img2"
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_returns_canvas_theme(self, mock_get_session):
         images = {
             "img1": {
@@ -677,7 +678,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert themes == {"img1": "dark", "img2": "light"}
 
     @patch("sentry.analytics.record")
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_records_web_client(self, mock_get_session, mock_record):
         artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
@@ -697,7 +698,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         )
 
     @patch("sentry.analytics.record")
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_records_mcp_client(self, mock_get_session, mock_record):
         artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
@@ -720,7 +721,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
             ),
         )
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_with_vcs_info(self, mock_get_session):
         commit_comparison = CommitComparison.objects.create(
             organization_id=self.org.id,
@@ -748,7 +749,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert vcs_info["head_ref"] == "chore/cleanup"
         assert vcs_info["pr_number"] == 123
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_returns_all_images(self, mock_get_session):
         images = {
             f"img{i:03d}": {
@@ -771,7 +772,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["images"][0]["key"] == "img000"
         assert response.data["images"][9]["key"] == "img009"
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_diff_omits_images(self, mock_get_session):
         from sentry.preprod.snapshots.manifest import (
             ComparisonImageResult,
@@ -923,7 +924,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         assert response.status_code == 404
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_objectstore_error(self, mock_get_session):
         artifact, _, _, _, _ = self._create_artifact_with_manifest()
         mock_session = MagicMock()
@@ -964,7 +965,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         assert response.status_code == 404
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_flat_fields_solo_no_approval(self, mock_get_session):
         artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
         mock_get_session.return_value = self._create_mock_session(manifest_json)
@@ -979,7 +980,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["approvers"] == []
         assert response.data["comparison_type"] == "solo"
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_flat_fields_pending_comparison(self, mock_get_session):
         artifact, snapshot_metrics, _, manifest_json, _ = self._create_artifact_with_manifest(
             commit_comparison=CommitComparison.objects.create(
@@ -1014,7 +1015,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.status_code == 200
         assert response.data["comparison_state"] == "pending"
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_flat_fields_with_approval(self, mock_get_session):
         artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
         self.create_preprod_comparison_approval(
@@ -1032,7 +1033,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert len(response.data["approvers"]) == 1
         assert response.data["approvers"][0]["source"] == "sentry"
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_flat_fields_auto_approved(self, mock_get_session):
         artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
         self.create_preprod_comparison_approval(
@@ -1048,7 +1049,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.status_code == 200
         assert response.data["approval_status"] == "auto_approved"
 
-    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_flat_fields_waiting_for_base(self, mock_get_session):
         artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest(
             commit_comparison=CommitComparison.objects.create(
@@ -1126,7 +1127,7 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         }
 
     @patch(
-        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_session"
     )
     def test_get_latest_base_snapshot_scoped_by_project_slug(self, mock_get_session):
         artifact, manifest_key, manifest_json = self._create_base_snapshot()
@@ -1142,10 +1143,10 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.data["project_slug"] == "sausage"
         assert response.data["image_count"] == 1
         assert response.data["images"][0]["image_file_name"] == "components/button.png"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
 
     @patch(
-        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_session"
     )
     def test_get_latest_base_snapshot_scoped_by_project_param_slug(self, mock_get_session):
         artifact, _, manifest_json = self._create_base_snapshot()
@@ -1159,10 +1160,10 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
         assert response.data["project_slug"] == "sausage"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
 
     @patch(
-        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_session"
     )
     def test_get_latest_base_snapshot_scoped_by_project_param_id(self, mock_get_session):
         artifact, _, manifest_json = self._create_base_snapshot()
@@ -1176,10 +1177,10 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
         assert response.data["project_slug"] == "sausage"
-        mock_get_session.assert_called_once_with(self.org.id, self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
 
     @patch(
-        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_preprod_session"
+        "sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_base.get_session"
     )
     def test_get_latest_base_snapshot_project_slug_takes_precedence_over_project(
         self, mock_get_session
@@ -1201,7 +1202,7 @@ class OrganizationPreprodLatestBaseSnapshotTest(APITestCase):
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
         assert response.data["project_slug"] == "other-project"
-        mock_get_session.assert_called_once_with(self.org.id, other_project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, other_project)
 
     def test_get_latest_base_snapshot_rejects_all_project_id_sentinel(self):
         response = self.client.get(

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -5,6 +5,7 @@ from django.test import override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient
 
+from sentry.objectstore import UsecaseId
 from sentry.testutils.cases import APITestCase
 
 
@@ -19,7 +20,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
             args=[self.org.slug, self.project.slug],
         )
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_upload_options.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_upload_options.get_session")
     def test_returns_upload_options(self, mock_get_session) -> None:
         mock_session = MagicMock()
         mock_session.mint_token.return_value = "fake-token"
@@ -38,9 +39,9 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
 
         assert data["expirationPolicy"] == "tti:30 days"
 
-        mock_get_session.assert_called_once_with(org=self.org.id, project=self.project.id)
+        mock_get_session.assert_called_once_with(UsecaseId.PREPROD, self.project)
 
-    @patch("sentry.preprod.api.endpoints.project_preprod_upload_options.get_preprod_session")
+    @patch("sentry.preprod.api.endpoints.project_preprod_upload_options.get_session")
     def test_objectstore_url_uses_region_endpoint(self, mock_get_session) -> None:
         mock_session = MagicMock()
         mock_session.mint_token.return_value = "fake-token"

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -186,7 +186,7 @@ class ProcessChunkTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks._fetch_batch_images",
                 return_value=({"h": b"img", "b": b"img"}, set()),
@@ -289,7 +289,7 @@ class ProcessChunkTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks._fetch_batch_images",
                 return_value=({"h": b"img", "b": b"img"}, set()),
@@ -329,7 +329,7 @@ class ProcessChunkTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks._fetch_batch_images",
                 return_value=({"h": b"img", "b": b"img"}, set()),
@@ -381,7 +381,7 @@ class ProcessChunkTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks._fetch_batch_images",
                 return_value=({"h": b"img", "b": b"img"}, set()),
@@ -420,7 +420,7 @@ class ProcessChunkTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks._process_chunk",
                 side_effect=Exception("boom"),
@@ -456,7 +456,7 @@ class ProcessChunkTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks._process_chunk",
                 side_effect=ValueError("odiff exploded"),
@@ -553,7 +553,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         }
         session = _dict_backed_session(stored)
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot"),
             patch("sentry.preprod.snapshots.tasks.metrics") as mock_metrics,
         ):
@@ -581,7 +581,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
 
         comparison, h, b = self._comparison(1, state=PreprodSnapshotComparison.State.SUCCESS)
-        with patch("sentry.preprod.snapshots.tasks.get_preprod_session") as session:
+        with patch("sentry.preprod.snapshots.tasks.get_session") as session:
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
         assert not session.called
 
@@ -596,7 +596,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         }
         session = _dict_backed_session(stored)
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot") as mock_auto_approve,
         ):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
@@ -617,7 +617,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         prefix = f"{self.organization.id}/{self.project.id}/{h.id}/{b.id}"
         stored = {f"{prefix}/plan.json": orjson.dumps(self._single_chunk_plan(h, b).dict())}
         session = _dict_backed_session(stored)
-        with patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session):
+        with patch("sentry.preprod.snapshots.tasks.get_session", return_value=session):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
         comparison.refresh_from_db()
         assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
@@ -634,7 +634,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         }
         session = _dict_backed_session(stored)
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot") as mock_auto_approve,
         ):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
@@ -647,7 +647,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
 
         comparison, h, b = self._comparison(None)
-        with patch("sentry.preprod.snapshots.tasks.get_preprod_session") as session:
+        with patch("sentry.preprod.snapshots.tasks.get_session") as session:
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
         assert not session.called
         comparison.refresh_from_db()
@@ -657,7 +657,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
 
         comparison, h, b = self._comparison(3, done_indices=[0])
-        with patch("sentry.preprod.snapshots.tasks.get_preprod_session") as session:
+        with patch("sentry.preprod.snapshots.tasks.get_session") as session:
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
         assert not session.called
         comparison.refresh_from_db()
@@ -690,7 +690,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
             return session
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", side_effect=_capture),
+            patch("sentry.preprod.snapshots.tasks.get_session", side_effect=_capture),
             patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot"),
         ):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
@@ -705,7 +705,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         prefix = f"{self.organization.id}/{self.project.id}/{h.id}/{b.id}"
         stored = {f"{prefix}/plan.json": orjson.dumps(self._single_chunk_plan(h, b).dict())}
         session = _dict_backed_session(stored)
-        with patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session):
+        with patch("sentry.preprod.snapshots.tasks.get_session", return_value=session):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
         comparison.refresh_from_db()
         assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
@@ -720,7 +720,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         prefix = f"{self.organization.id}/{self.project.id}/{h.id}/{b.id}"
         stored = {f"{prefix}/plan.json": orjson.dumps(self._single_chunk_plan(h, b).dict())}
         session = _dict_backed_session(stored)
-        with patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session):
+        with patch("sentry.preprod.snapshots.tasks.get_session", return_value=session):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
         comparison.refresh_from_db()
         assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
@@ -734,7 +734,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
         comparison, h, b = self._comparison(1, done_indices=[0])
         session = _dict_backed_session({})
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs") as vcs,
         ):
             finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
@@ -781,7 +781,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"
             ) as dispatch,
@@ -827,7 +827,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"
             ) as dispatch,
@@ -887,7 +887,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch(
                 "sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"
             ) as dispatch,
@@ -945,7 +945,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
             patch(
                 "sentry.preprod.snapshots.tasks.finalize_snapshot_comparison.apply_async"
@@ -1002,7 +1002,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
         ):
@@ -1044,7 +1044,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.get.side_effect = _get
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs") as vcs,
         ):
             compare_snapshots(
@@ -1081,7 +1081,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.get.return_value = None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs") as vcs,
         ):
             compare_snapshots(
@@ -1118,7 +1118,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         comparison.save()
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session") as session_factory,
+            patch("sentry.preprod.snapshots.tasks.get_session") as session_factory,
             patch(
                 "sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"
             ) as dispatch,
@@ -1205,7 +1205,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
         ):
@@ -1262,7 +1262,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
         ):
@@ -1322,7 +1322,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs") as vcs,
         ):
@@ -1348,7 +1348,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs") as vcs,
         ):
@@ -1387,7 +1387,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.compare_snapshots.apply_async") as reschedule,
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
         ):
@@ -1444,7 +1444,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.compare_snapshots.apply_async") as reschedule,
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
         ):
@@ -1499,7 +1499,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.compare_snapshots.apply_async") as reschedule,
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs") as vcs,
         ):
@@ -1548,7 +1548,7 @@ class CompareSnapshotsOrchestratorTest(TestCase):
         session.put.side_effect = lambda *a, **k: None
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.compare_snapshots.apply_async") as reschedule,
             patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
         ):
@@ -1651,7 +1651,7 @@ class EndToEndFanoutTest(TestCase):
         )
 
         with (
-            patch("sentry.preprod.snapshots.tasks.get_preprod_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
             patch("sentry.preprod.snapshots.tasks.MAX_PIXELS_PER_BATCH", 1),
             patch(
                 "sentry.preprod.snapshots.tasks._fetch_batch_images", side_effect=self._fake_fetch

--- a/tests/sentry/preprod/snapshots/test_zip_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_zip_tasks.py
@@ -19,7 +19,7 @@ from sentry.preprod.snapshots.zip_tasks import (
 )
 from sentry.testutils.cases import TestCase
 
-SESSION_TARGET = "sentry.preprod.snapshots.zip_tasks.get_preprod_session"
+SESSION_TARGET = "sentry.preprod.snapshots.zip_tasks.get_session"
 
 
 def _manifest_bytes() -> bytes:

--- a/tests/sentry/test_reprocessing2.py
+++ b/tests/sentry/test_reprocessing2.py
@@ -20,7 +20,7 @@ class MaybeCopyAttachmentIntoCacheTest(TestCase):
             blob_path=":hello",
         )
 
-    @mock.patch("sentry.reprocessing2.get_attachments_session")
+    @mock.patch("sentry.reprocessing2.get_session")
     @override_options({"objectstore.enable_for.attachments": 1})
     def test_objectstore_upload_stores_content_type(self, mock_get_session: mock.Mock) -> None:
         mock_get_session.return_value.put.return_value = "some-key"


### PR DESCRIPTION
Replace per-usecase Objectstore session helpers with one `get_session` API and a `UsecaseId` selector.

The API accepts a project model where available and requires an explicit org for ID-only paths. This centralizes session configuration and validates supplied orgs for project calls.

Closes FS-391