### PR TITLE
fix(conversations): Stop the trace link looking external

### DIFF
--- a/static/app/components/core/link/link.mdx
+++ b/static/app/components/core/link/link.mdx
@@ -25,7 +25,7 @@ The Link component provides context-aware navigation within the Sentry applicati
 
 Use `<Link>` for navigation within the Sentry application. The component uses React Router under the hood and falls back to a standard anchor tag when no router context is available.
 
-Internal links should always navigate in the same tab. Do not open internal destinations in a new tab (for example with `target="_blank"` or `openInNewTab`). Opening an internal destination in a new tab is unexpected, and the open-in-new icon that usually accompanies it conventionally signals that a link leaves Sentry. It also takes the choice away from the reader: cmd/ctrl+click already forces a new tab for anyone who wants one, but there is no established way to do the opposite and keep a `target="_blank"` link in the current tab. Same-tab navigation is usually faster too, since it stays within the single-page app rather than reloading it.
+Internal links should always navigate in the same tab. Do not open internal destinations in a new tab (for example with `target="_blank"` or `openInNewTab`). Opening an internal destination in a new tab is unexpected. It also takes the choice away from the reader: cmd/ctrl+click already forces a new tab for anyone who wants one, but there is no established way to do the opposite and keep a `target="_blank"` link in the current tab. Same-tab navigation is usually faster too, since it stays within the single-page app rather than reloading it.
 
 <Storybook.Demo>
   <Link to="/organizations/sentry/issues/">Navigate to Issues</Link>

--- a/static/app/components/core/link/link.mdx
+++ b/static/app/components/core/link/link.mdx
@@ -25,7 +25,7 @@ The Link component provides context-aware navigation within the Sentry applicati
 
 Use `<Link>` for navigation within the Sentry application. The component uses React Router under the hood and falls back to a standard anchor tag when no router context is available.
 
-Internal links should always navigate in the same tab. Do not open internal destinations in a new tab (for example with `target="_blank"` or `openInNewTab`).
+Internal links should always navigate in the same tab. Do not open internal destinations in a new tab (for example with `target="_blank"` or `openInNewTab`). Opening an internal destination in a new tab is unexpected, and the open-in-new icon that usually accompanies it conventionally signals that a link leaves Sentry. It also takes the choice away from the reader: cmd/ctrl+click already forces a new tab for anyone who wants one, but there is no established way to do the opposite and keep a `target="_blank"` link in the current tab. Same-tab navigation is usually faster too, since it stays within the single-page app rather than reloading it.
 
 <Storybook.Demo>
   <Link to="/organizations/sentry/issues/">Navigate to Issues</Link>

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -15,7 +15,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconFire, IconOpen, IconUser} from 'sentry/icons';
+import {IconFire, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import type {AvatarProject} from 'sentry/types/project';
 import {escapeDoubleQuotes} from 'sentry/utils';
@@ -195,12 +195,9 @@ export function ConversationSummary({
                     })
                   }
                 >
-                  <Flex align="center" gap="xs">
-                    <IconOpen size="xs" />
-                    <Text size="sm" variant="inherit" wrap="nowrap">
-                      {tn('Trace', 'Traces', traces.length)}
-                    </Text>
-                  </Flex>
+                  <Text size="sm" variant="inherit" wrap="nowrap">
+                    {tn('Trace', 'Traces', traces.length)}
+                  </Text>
                 </Link>
               )}
               {aggregates.toolNames.length > 0 && (

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -231,30 +231,3 @@ describe('ConversationDetailPage summary errors', () => {
     expect(screen.queryByTestId('conversation-error-icon')).not.toBeInTheDocument();
   });
 });
-
-describe('ConversationDetailPage summary trace link', () => {
-  beforeEach(() => {
-    Element.prototype.scrollTo = jest.fn();
-    Element.prototype.scrollIntoView = jest.fn();
-    MockApiClient.clearMockResponses();
-    act(() => {
-      PageFiltersStore.reset();
-      PageFiltersStore.init();
-    });
-    mockApis();
-  });
-
-  it('deep-links to the trace and navigates in the same tab', async () => {
-    renderPage();
-
-    // Every fixture span shares a trace, so the link targets that trace's
-    // waterfall rather than the traces explorer.
-    const link = await screen.findByRole('link', {name: 'Trace'});
-    expect(link).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/explore/traces/trace/trace-1/?node=span-span-a'
-    );
-    // The link stays in-tab, so it must not signal itself as external.
-    expect(link).not.toHaveAttribute('target');
-  });
-});

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -231,3 +231,30 @@ describe('ConversationDetailPage summary errors', () => {
     expect(screen.queryByTestId('conversation-error-icon')).not.toBeInTheDocument();
   });
 });
+
+describe('ConversationDetailPage summary trace link', () => {
+  beforeEach(() => {
+    Element.prototype.scrollTo = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
+    MockApiClient.clearMockResponses();
+    act(() => {
+      PageFiltersStore.reset();
+      PageFiltersStore.init();
+    });
+    mockApis();
+  });
+
+  it('deep-links to the trace and navigates in the same tab', async () => {
+    renderPage();
+
+    // Every fixture span shares a trace, so the link targets that trace's
+    // waterfall rather than the traces explorer.
+    const link = await screen.findByRole('link', {name: 'Trace'});
+    expect(link).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/traces/trace/trace-1/?node=span-span-a'
+    );
+    // The link stays in-tab, so it must not signal itself as external.
+    expect(link).not.toHaveAttribute('target');
+  });
+});


### PR DESCRIPTION
The `Trace`/`Traces` link in the conversation header rendered an open-in-new icon next to it while navigating in the same tab. The mismatched affordance is what people actually noticed - the link reads as though it will leave Sentry, then doesn't. Dropping the icon leaves a plain text link that matches what it does.

Closes TET-2816