### PR TITLE
fix(agents): Show span ID in AI span details

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -9,6 +9,7 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {TabList, TabPanels, TabStateProvider} from '@sentry/scraps/tabs';
 import {Text} from '@sentry/scraps/text';
 
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -237,15 +238,30 @@ function SpanMetadata({
   attributes: SpanAttributes;
   node: AITraceSpanNode;
 }) {
-  const rows = getHighlightedSpanAttributes({
-    op: node.op,
-    spanId: node.id,
-    attributes: attributes ?? node.attributes,
-  });
-
-  if (rows.length === 0) {
-    return null;
-  }
+  const rows: Array<{name: string; value: React.ReactNode}> = [
+    {
+      name: t('Span ID'),
+      value: (
+        <Flex align="center" gap="xs" minWidth="0">
+          <Text size="md" monospace ellipsis>
+            {node.id}
+          </Text>
+          <CopyToClipboardButton
+            variant="transparent"
+            size="zero"
+            text={node.id}
+            aria-label={t('Copy span ID to clipboard')}
+            tooltipProps={{disabled: true}}
+          />
+        </Flex>
+      ),
+    },
+    ...getHighlightedSpanAttributes({
+      op: node.op,
+      spanId: node.id,
+      attributes: attributes ?? node.attributes,
+    }),
+  ];
 
   return (
     <Grid columns="max-content minmax(0, 1fr)" gap="lg" align="center">

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -136,15 +136,9 @@ export function ConversationSpanDetail({
       <Flex align="center" gap="lg" flexShrink={0}>
         <Flex flex="1" minWidth="0" align="center" gap="md">
           <AiSpanStatusIcon node={node} />
-          <Stack flex="1" minWidth="0">
-            <InfoText title={title} mode="overflowOnly" size="lg" bold>
-              {title}
-            </InfoText>
-            <TraceDrawerComponents.SubtitleWithCopyButton
-              subTitle={`ID: ${node.id}`}
-              clipboardText={node.id}
-            />
-          </Stack>
+          <InfoText title={title} mode="overflowOnly" size="lg" bold>
+            {title}
+          </InfoText>
         </Flex>
         {onClose ? (
           <Button
@@ -156,6 +150,13 @@ export function ConversationSpanDetail({
           />
         ) : null}
       </Flex>
+
+      <Container flexShrink={0} minWidth="0">
+        <TraceDrawerComponents.SubtitleWithCopyButton
+          subTitle={`ID: ${node.id}`}
+          clipboardText={node.id}
+        />
+      </Container>
 
       <Stack gap="lg" flexShrink={0}>
         <Flex align="center" gap="sm" wrap="wrap">
@@ -495,13 +496,11 @@ function EmptyTab({message}: {message: string}) {
 function SpanDetailSkeleton({embedded}: {embedded?: boolean}) {
   return (
     <SpanDetailCard embedded={embedded}>
-      <Flex align="center" gap="md" flexShrink={0}>
+      <Flex align="center" gap="lg" flexShrink={0}>
         <Placeholder height="16px" width="16px" />
-        <Stack gap="xs">
-          <Placeholder height="16px" width="180px" />
-          <Placeholder height="12px" width="120px" />
-        </Stack>
+        <Placeholder height="16px" width="180px" />
       </Flex>
+      <Placeholder height="14px" width="160px" />
       <Stack gap="md" flexShrink={0}>
         <Placeholder height="16px" width="60px" />
         <SpanMetadataSkeleton />

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -133,25 +133,24 @@ export function ConversationSpanDetail({
 
   return (
     <SpanDetailCard ref={scrollContainerRef} embedded={embedded}>
-      <Flex align="center" gap="lg" flexShrink={0}>
-        <Flex flex="1" minWidth="0" align="center" gap="md">
-          <AiSpanStatusIcon node={node} />
-          <InfoText title={title} mode="overflowOnly" size="lg" bold>
-            {title}
-          </InfoText>
+      <Container flexShrink={0}>
+        <Flex align="center" gap="lg">
+          <Flex flex="1" minWidth="0" align="center" gap="md">
+            <AiSpanStatusIcon node={node} />
+            <InfoText title={title} mode="overflowOnly" size="lg" bold>
+              {title}
+            </InfoText>
+          </Flex>
+          {onClose ? (
+            <Button
+              size="sm"
+              variant="transparent"
+              icon={<IconClose />}
+              aria-label={t('Close')}
+              onClick={onClose}
+            />
+          ) : null}
         </Flex>
-        {onClose ? (
-          <Button
-            size="sm"
-            variant="transparent"
-            icon={<IconClose />}
-            aria-label={t('Close')}
-            onClick={onClose}
-          />
-        ) : null}
-      </Flex>
-
-      <Container flexShrink={0} minWidth="0">
         <TraceDrawerComponents.SubtitleWithCopyButton
           subTitle={`ID: ${node.id}`}
           clipboardText={node.id}

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -495,11 +495,13 @@ function EmptyTab({message}: {message: string}) {
 function SpanDetailSkeleton({embedded}: {embedded?: boolean}) {
   return (
     <SpanDetailCard embedded={embedded}>
-      <Flex align="center" gap="lg" flexShrink={0}>
-        <Placeholder height="16px" width="16px" />
-        <Placeholder height="16px" width="180px" />
-      </Flex>
-      <Placeholder height="14px" width="160px" />
+      <Container flexShrink={0}>
+        <Flex align="center" gap="lg">
+          <Placeholder height="16px" width="16px" />
+          <Placeholder height="16px" width="180px" />
+        </Flex>
+        <Placeholder height="14px" width="160px" />
+      </Container>
       <Stack gap="md" flexShrink={0}>
         <Placeholder height="16px" width="60px" />
         <SpanMetadataSkeleton />

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -9,7 +9,6 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {TabList, TabPanels, TabStateProvider} from '@sentry/scraps/tabs';
 import {Text} from '@sentry/scraps/text';
 
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -137,9 +136,15 @@ export function ConversationSpanDetail({
       <Flex align="center" gap="lg" flexShrink={0}>
         <Flex flex="1" minWidth="0" align="center" gap="md">
           <AiSpanStatusIcon node={node} />
-          <InfoText title={title} mode="overflowOnly" size="lg" bold>
-            {title}
-          </InfoText>
+          <Stack flex="1" minWidth="0">
+            <InfoText title={title} mode="overflowOnly" size="lg" bold>
+              {title}
+            </InfoText>
+            <TraceDrawerComponents.SubtitleWithCopyButton
+              subTitle={`ID: ${node.id}`}
+              clipboardText={node.id}
+            />
+          </Stack>
         </Flex>
         {onClose ? (
           <Button
@@ -238,30 +243,15 @@ function SpanMetadata({
   attributes: SpanAttributes;
   node: AITraceSpanNode;
 }) {
-  const rows: Array<{name: string; value: React.ReactNode}> = [
-    {
-      name: t('Span ID'),
-      value: (
-        <Flex align="center" gap="xs" minWidth="0">
-          <Text size="md" monospace ellipsis>
-            {node.id}
-          </Text>
-          <CopyToClipboardButton
-            variant="transparent"
-            size="zero"
-            text={node.id}
-            aria-label={t('Copy span ID to clipboard')}
-            tooltipProps={{disabled: true}}
-          />
-        </Flex>
-      ),
-    },
-    ...getHighlightedSpanAttributes({
-      op: node.op,
-      spanId: node.id,
-      attributes: attributes ?? node.attributes,
-    }),
-  ];
+  const rows = getHighlightedSpanAttributes({
+    op: node.op,
+    spanId: node.id,
+    attributes: attributes ?? node.attributes,
+  });
+
+  if (rows.length === 0) {
+    return null;
+  }
 
   return (
     <Grid columns="max-content minmax(0, 1fr)" gap="lg" align="center">
@@ -505,9 +495,12 @@ function EmptyTab({message}: {message: string}) {
 function SpanDetailSkeleton({embedded}: {embedded?: boolean}) {
   return (
     <SpanDetailCard embedded={embedded}>
-      <Flex align="center" gap="lg" flexShrink={0}>
+      <Flex align="center" gap="md" flexShrink={0}>
         <Placeholder height="16px" width="16px" />
-        <Placeholder height="16px" width="180px" />
+        <Stack gap="xs">
+          <Placeholder height="16px" width="180px" />
+          <Placeholder height="12px" width="120px" />
+        </Stack>
       </Flex>
       <Stack gap="md" flexShrink={0}>
         <Placeholder height="16px" width="60px" />

--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -115,6 +115,18 @@ describe('ConversationViewContent', () => {
     expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
   });
 
+  it('shows the span ID of the open span', async () => {
+    renderView({activeTab: 'transcript', selectedSpanId: 'span-a'});
+
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+
+    expect(screen.getByText('Span ID')).toBeInTheDocument();
+    expect(screen.getByText('span-a')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Copy span ID to clipboard'})
+    ).toBeInTheDocument();
+  });
+
   it('writes a sticky selection when the user picks a span', async () => {
     const onSelectSpan = jest.fn();
     renderView({activeTab: 'transcript', onSelectSpan});

--- a/static/app/views/explore/conversations/components/conversationView.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.spec.tsx
@@ -120,11 +120,8 @@ describe('ConversationViewContent', () => {
 
     expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
 
-    expect(screen.getByText('Span ID')).toBeInTheDocument();
-    expect(screen.getByText('span-a')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Copy span ID to clipboard'})
-    ).toBeInTheDocument();
+    expect(screen.getByText('ID: span-a')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Copy to clipboard'})).toBeInTheDocument();
   });
 
   it('writes a sticky selection when the user picks a span', async () => {


### PR DESCRIPTION
Makes a span's ID readable and copyable from the AI span detail panel, so a span seen in the trace waterfall, the conversation transcript, or the trace AI spans tab can be correlated with logs, queries, and support threads. All three surfaces share the same panel, so they all pick this up.

It renders directly under the span heading as an `ID: …` subtitle with a copy button, the same way the rest of the trace drawer presents a span's ID.

Closes TET-2848