### PR TITLE
feat(seer): Render dashboards in block embeds

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -66,7 +66,7 @@
   },
   {
     "name": "dashboard",
-    "description": "The ONLY way to reference a saved Sentry dashboard. Use the dashboard ID exactly as returned by the dashboard API. Include the API-provided title when available. Inline: renders a compact link. Block: renders a standalone dashboard reference. Never use a markdown link for dashboard references.",
+    "description": "The ONLY way to reference a saved Sentry dashboard. Use the dashboard ID exactly as returned by the dashboard API. Include the API-provided title when available. Inline: renders a compact link. Block: renders a live preview of the dashboard widgets. Do not duplicate the widget titles, queries, visualizations, or values as text. Never use a markdown link for dashboard references.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/app/components/seer/markdown/__stories__/dashboardEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/dashboardEmbedStory.tsx
@@ -1,0 +1,38 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {dashboardsApiOptions} from 'sentry/utils/dashboards/dashboardsApiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {EmbedStory, EmbedVariant} from './embedStory';
+
+export function DashboardEmbedStory() {
+  const organization = useOrganization();
+  const {
+    data: dashboards,
+    isError,
+    isPending,
+  } = useQuery(dashboardsApiOptions(organization, {query: {per_page: 100}}));
+  const dashboard = dashboards?.find(candidate => candidate.widgetDisplay.length > 0);
+
+  return (
+    <EmbedStory name="dashboard">
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <Text variant="muted">Unable to load a dashboard example.</Text>
+      ) : dashboard ? (
+        <EmbedVariant
+          name="dashboard"
+          label="Dashboard"
+          data={{id: dashboard.id, title: dashboard.title}}
+          demoProps={{minHeight: undefined, maxHeight: undefined, overflow: undefined}}
+        />
+      ) : (
+        <Text variant="muted">No dashboard is available for this organization.</Text>
+      )}
+    </EmbedStory>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/README.md
+++ b/static/app/components/seer/markdown/embeds/README.md
@@ -9,6 +9,6 @@ navigation history, or shareable state.
 - Disable widget actions that the embed does not handle locally.
 - Explicit resource links may navigate away from the embed.
 
-For dashboard widget legends, use `LocalWidgetLegendSelectionState` instead of
+For dashboard widget legends, use `useLocalWidgetLegendSelectionState` instead of
 `WidgetLegendSelectionState`. When introducing a new interactive widget embed, add coverage
 that verifies its interaction state stays local to the embed.

--- a/static/app/components/seer/markdown/embeds/README.md
+++ b/static/app/components/seer/markdown/embeds/README.md
@@ -1,0 +1,14 @@
+# Seer Markdown Embeds
+
+Embeds render inside host surfaces such as Seer conversations. Keep widget actions and
+interaction state local to the embed so an interaction cannot change the host page URL,
+navigation history, or shareable state.
+
+- Do not pass the host router's `location` or `navigate` into embedded widgets.
+- Store legend selections, sorts, column sizes, and similar UI state inside the embed.
+- Disable widget actions that the embed does not handle locally.
+- Explicit resource links may navigate away from the embed.
+
+For dashboard widget legends, use `LocalWidgetLegendSelectionState` instead of
+`WidgetLegendSelectionState`. When introducing a new interactive widget embed, add coverage
+that verifies its interaction state stays local to the embed.

--- a/static/app/components/seer/markdown/embeds/components/dashboard.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboard.tsx
@@ -1,3 +1,6 @@
+import {lazy} from 'react';
+
+import {LazyLoad} from 'sentry/components/lazyLoad';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {
   defineSeerEmbed,
@@ -7,6 +10,8 @@ import {IconDashboard} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
+
+const LazyDashboardBlock = lazy(() => import('./dashboardBlock'));
 
 function DashboardLink({id, title}: EmbedOutput<'dashboard'>) {
   const organization = useOrganization();
@@ -23,7 +28,10 @@ function DashboardLink({id, title}: EmbedOutput<'dashboard'>) {
 
 export const Dashboard = defineSeerEmbed({
   name: 'dashboard',
-  render(props) {
+  render(props, level) {
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazyDashboardBlock} {...props} />;
+    }
     return <DashboardLink {...props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -164,7 +165,7 @@ export default function DashboardBlock({id, title}: EmbedOutput<'dashboard'>) {
     ...dashboardDetailsApiOptions(organization, id),
     retry: false,
   });
-  const dashboard = data ? getDashboardPreview(data) : undefined;
+  const dashboard = useMemo(() => (data ? getDashboardPreview(data) : undefined), [data]);
 
   return (
     <Container

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -96,7 +96,7 @@ function DashboardWidgetPreview({
   );
 }
 
-export function DashboardPreview({
+function DashboardPreview({
   dashboard,
   href,
 }: {

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -10,6 +10,7 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {LocalWidgetLegendSelectionState} from 'sentry/components/seer/markdown/embeds/localWidgetLegendSelectionState';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {IconDashboard} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -18,8 +19,6 @@ import {dashboardDetailsApiOptions} from 'sentry/utils/dashboards/dashboardsApiO
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {mergeGlobalFilters} from 'sentry/views/dashboards/globalFilter/utils';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
@@ -31,7 +30,6 @@ import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs
 import {WidgetQueryQueueProvider} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
-import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
 
 // Keep the embed compact by showing at most a 2x2 widget grid.
 const MAX_PREVIEW_WIDGETS = 4;
@@ -76,7 +74,7 @@ function DashboardWidgetPreview({
   dashboard: DashboardDetails;
   selection: PageFilters;
   widget: Widget;
-  widgetLegendState: WidgetLegendSelectionState;
+  widgetLegendState: LocalWidgetLegendSelectionState;
 }) {
   return (
     <Container minHeight="240px">
@@ -110,8 +108,6 @@ function DashboardPreview({
   dashboard: DashboardDetails;
   href: string;
 }) {
-  const location = useLocation();
-  const navigate = useNavigate();
   const organization = useOrganization();
   const {selection: currentSelection} = usePageFilters();
   const previewWidgets = dashboard.widgets.slice(0, MAX_PREVIEW_WIDGETS);
@@ -121,13 +117,11 @@ function DashboardPreview({
     : currentSelection;
   const widgetLegendState = useMemo(
     () =>
-      new WidgetLegendSelectionState({
+      new LocalWidgetLegendSelectionState({
         dashboard,
-        location,
-        navigate,
         organization,
       }),
-    [dashboard, location, navigate, organization]
+    [dashboard, organization]
   );
 
   if (dashboard.widgets.length === 0) {

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -10,7 +9,10 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {LocalWidgetLegendSelectionState} from 'sentry/components/seer/markdown/embeds/localWidgetLegendSelectionState';
+import {
+  LocalWidgetLegendSelectionState,
+  useLocalWidgetLegendSelectionState,
+} from 'sentry/components/seer/markdown/embeds/localWidgetLegendSelectionState';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {IconDashboard} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -115,14 +117,10 @@ function DashboardPreview({
   const selection = hasSavedPageFilters(dashboard)
     ? getSavedFiltersAsPageFilters(dashboard)
     : currentSelection;
-  const widgetLegendState = useMemo(
-    () =>
-      new LocalWidgetLegendSelectionState({
-        dashboard,
-        organization,
-      }),
-    [dashboard, organization]
-  );
+  const widgetLegendState = useLocalWidgetLegendSelectionState({
+    dashboard,
+    organization,
+  });
 
   if (dashboard.widgets.length === 0) {
     return <Text variant="muted">{t('This dashboard has no widgets.')}</Text>;

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
+import type {Location} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
@@ -8,6 +9,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {
@@ -19,10 +21,15 @@ import {IconDashboard} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import {dashboardDetailsApiOptions} from 'sentry/utils/dashboards/dashboardsApiOptions';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {getIntervalOptionsForPageFilter} from 'sentry/utils/useChartInterval';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
 import {mergeGlobalFilters} from 'sentry/views/dashboards/globalFilter/utils';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {
@@ -33,6 +40,7 @@ import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs
 import {WidgetQueryQueueProvider} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
+import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
 // Keep the embed compact by showing at most a 2x2 widget grid.
 const MAX_PREVIEW_WIDGETS = 4;
@@ -72,11 +80,13 @@ function DashboardWidgetPreview({
   dashboard,
   selection,
   widget,
+  widgetInterval,
   widgetLegendState,
 }: {
   dashboard: DashboardDetails;
   selection: PageFilters;
   widget: Widget;
+  widgetInterval: string;
   widgetLegendState: LocalWidgetLegendSelectionState;
 }) {
   return (
@@ -95,12 +105,33 @@ function DashboardWidgetPreview({
               MAX_PREVIEW_ITEMS_PER_WIDGET
             )}
             widget={{...widget}}
+            widgetInterval={widgetInterval}
             widgetLegendState={widgetLegendState}
             widgetLimitReached={false}
           />
         </DashboardsMEPProvider>
       </ErrorBoundary>
     </Container>
+  );
+}
+
+function getDashboardLocation(location: Location, selection: PageFilters): Location {
+  return {
+    ...location,
+    query: {
+      ...normalizeDateTimeParams(selection.datetime),
+      environment: selection.environments,
+      project: selection.projects.map(String),
+    },
+  };
+}
+
+function getDashboardWidgetInterval(selection: PageFilters): string {
+  const intervalOptions = getIntervalOptionsForPageFilter(selection.datetime);
+  return (
+    intervalOptions[intervalOptions.length - 2]?.value ??
+    intervalOptions[intervalOptions.length - 1]?.value ??
+    '1m'
   );
 }
 
@@ -112,12 +143,25 @@ function DashboardPreview({
   href: string;
 }) {
   const organization = useOrganization();
+  const location = useLocation();
   const {selection: currentSelection} = usePageFilters();
   const previewWidgets = dashboard.widgets.slice(0, MAX_PREVIEW_WIDGETS);
   const remainingWidgets = dashboard.widgets.length - previewWidgets.length;
-  const selection = hasSavedPageFilters(dashboard)
-    ? getSavedFiltersAsPageFilters(dashboard)
-    : currentSelection;
+  const selection = useMemo(
+    () =>
+      hasSavedPageFilters(dashboard)
+        ? getSavedFiltersAsPageFilters(dashboard)
+        : currentSelection,
+    [currentSelection, dashboard]
+  );
+  const dashboardLocation = useMemo(
+    () => getDashboardLocation(location, selection),
+    [location, selection]
+  );
+  const widgetInterval = useMemo(
+    () => getDashboardWidgetInterval(selection),
+    [selection]
+  );
   const widgetLegendState = useLocalWidgetLegendSelectionState({
     dashboard,
     organization,
@@ -129,26 +173,46 @@ function DashboardPreview({
 
   return (
     <Stack gap="md">
-      <MetricsResultsMetaProvider>
-        <MEPSettingProvider forceTransactions={false}>
-          <WidgetQueryQueueProvider>
-            <Grid
-              columns={{'2xs': 'minmax(0, 1fr)', md: 'repeat(2, minmax(0, 1fr))'}}
-              gap="md"
-            >
-              {previewWidgets.map((widget, index) => (
-                <DashboardWidgetPreview
-                  key={widget.id ?? `${widget.title}-${index}`}
-                  dashboard={dashboard}
-                  selection={selection}
-                  widget={widget}
-                  widgetLegendState={widgetLegendState}
-                />
-              ))}
-            </Grid>
-          </WidgetQueryQueueProvider>
-        </MEPSettingProvider>
-      </MetricsResultsMetaProvider>
+      <OnDemandControlProvider location={dashboardLocation}>
+        <MetricsResultsMetaProvider>
+          <MetricsCardinalityProvider
+            organization={organization}
+            location={dashboardLocation}
+          >
+            <MetricsDataSwitcher location={dashboardLocation}>
+              {metricsDataSide => (
+                <MEPSettingProvider
+                  location={dashboardLocation}
+                  forceTransactions={metricsDataSide.forceTransactionsOnly}
+                >
+                  <WidgetQueryQueueProvider>
+                    <WidgetSyncContextProvider>
+                      <Grid
+                        columns={{
+                          '2xs': 'minmax(0, 1fr)',
+                          md: 'repeat(2, minmax(0, 1fr))',
+                        }}
+                        gap="md"
+                      >
+                        {previewWidgets.map((widget, index) => (
+                          <DashboardWidgetPreview
+                            key={widget.id ?? `${widget.title}-${index}`}
+                            dashboard={dashboard}
+                            selection={selection}
+                            widget={widget}
+                            widgetInterval={widgetInterval}
+                            widgetLegendState={widgetLegendState}
+                          />
+                        ))}
+                      </Grid>
+                    </WidgetSyncContextProvider>
+                  </WidgetQueryQueueProvider>
+                </MEPSettingProvider>
+              )}
+            </MetricsDataSwitcher>
+          </MetricsCardinalityProvider>
+        </MetricsResultsMetaProvider>
+      </OnDemandControlProvider>
       {remainingWidgets > 0 ? (
         <Link to={href}>
           {tn('View %s more widget', 'View %s more widgets', remainingWidgets)}

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -1,0 +1,201 @@
+import {useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconDashboard} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
+import {dashboardDetailsApiOptions} from 'sentry/utils/dashboards/dashboardsApiOptions';
+import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
+import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {mergeGlobalFilters} from 'sentry/views/dashboards/globalFilter/utils';
+import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
+import {
+  getSavedFiltersAsPageFilters,
+  hasSavedPageFilters,
+} from 'sentry/views/dashboards/utils';
+import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {WidgetQueryQueueProvider} from 'sentry/views/dashboards/utils/widgetQueryQueue';
+import WidgetCard from 'sentry/views/dashboards/widgetCard';
+import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
+import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
+
+const MAX_PREVIEW_WIDGETS = 4;
+
+function getDashboardPreview(dashboard: DashboardDetails): DashboardDetails {
+  if (!dashboard.prebuiltId) {
+    return dashboard;
+  }
+
+  const prebuiltDashboard = PREBUILT_DASHBOARDS[dashboard.prebuiltId];
+  if (!prebuiltDashboard) {
+    return dashboard;
+  }
+
+  const globalFilter = mergeGlobalFilters(
+    prebuiltDashboard.filters?.globalFilter ?? [],
+    dashboard.filters?.globalFilter ?? []
+  );
+
+  return {
+    ...dashboard,
+    ...prebuiltDashboard,
+    id: dashboard.id,
+    filters: {...dashboard.filters, globalFilter},
+    projects: dashboard.projects,
+    environment: dashboard.environment,
+    period: dashboard.period,
+    start: dashboard.start,
+    end: dashboard.end,
+    utc: dashboard.utc,
+  };
+}
+
+function DashboardWidgetPreview({
+  dashboard,
+  selection,
+  widget,
+  widgetLegendState,
+}: {
+  dashboard: DashboardDetails;
+  selection: PageFilters;
+  widget: Widget;
+  widgetLegendState: WidgetLegendSelectionState;
+}) {
+  return (
+    <Container minHeight="240px">
+      <ErrorBoundary mini>
+        <DashboardsMEPProvider>
+          <WidgetCard
+            disableFullscreen
+            disableTableActions
+            disableZoom
+            dashboardFilters={dashboard.filters}
+            selection={selection}
+            showContextMenu={false}
+            tableItemLimit={Math.min(widget.limit ?? 5, 5)}
+            widget={{...widget}}
+            widgetLegendState={widgetLegendState}
+            widgetLimitReached={false}
+          />
+        </DashboardsMEPProvider>
+      </ErrorBoundary>
+    </Container>
+  );
+}
+
+export function DashboardPreview({
+  dashboard,
+  href,
+}: {
+  dashboard: DashboardDetails;
+  href: string;
+}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const {selection: currentSelection} = usePageFilters();
+  const previewWidgets = dashboard.widgets.slice(0, MAX_PREVIEW_WIDGETS);
+  const remainingWidgets = dashboard.widgets.length - previewWidgets.length;
+  const selection = hasSavedPageFilters(dashboard)
+    ? getSavedFiltersAsPageFilters(dashboard)
+    : currentSelection;
+  const widgetLegendState = useMemo(
+    () =>
+      new WidgetLegendSelectionState({
+        dashboard,
+        location,
+        navigate,
+        organization,
+      }),
+    [dashboard, location, navigate, organization]
+  );
+
+  if (dashboard.widgets.length === 0) {
+    return <Text variant="muted">{t('This dashboard has no widgets.')}</Text>;
+  }
+
+  return (
+    <Stack gap="md">
+      <MetricsResultsMetaProvider>
+        <MEPSettingProvider forceTransactions={false}>
+          <WidgetQueryQueueProvider>
+            <Grid
+              columns={{'2xs': 'minmax(0, 1fr)', md: 'repeat(2, minmax(0, 1fr))'}}
+              gap="md"
+            >
+              {previewWidgets.map((widget, index) => (
+                <DashboardWidgetPreview
+                  key={widget.id ?? `${widget.title}-${index}`}
+                  dashboard={dashboard}
+                  selection={selection}
+                  widget={widget}
+                  widgetLegendState={widgetLegendState}
+                />
+              ))}
+            </Grid>
+          </WidgetQueryQueueProvider>
+        </MEPSettingProvider>
+      </MetricsResultsMetaProvider>
+      {remainingWidgets > 0 ? (
+        <Link to={href}>
+          {tn('View %s more widget', 'View %s more widgets', remainingWidgets)}
+        </Link>
+      ) : null}
+    </Stack>
+  );
+}
+
+export default function DashboardBlock({id, title}: EmbedOutput<'dashboard'>) {
+  const organization = useOrganization();
+  const href = normalizeUrl(`/organizations/${organization.slug}/dashboard/${id}/`);
+  const {data, isError, isPending} = useQuery({
+    ...dashboardDetailsApiOptions(organization, id),
+    retry: false,
+  });
+  const dashboard = data ? getDashboardPreview(data) : undefined;
+
+  return (
+    <Container
+      background="primary"
+      border="primary"
+      containerType="inline-size"
+      padding="md"
+      radius="md"
+    >
+      <Stack gap="md">
+        <Flex align="center" justify="between" gap="md" wrap="wrap">
+          <ResourceLink
+            icon={IconDashboard}
+            href={href}
+            title={dashboard?.title ?? title ?? t('Dashboard %s', id)}
+          />
+          {dashboard ? (
+            <Text size="sm" variant="muted">
+              {tn('%s widget', '%s widgets', dashboard.widgets.length)}
+            </Text>
+          ) : null}
+        </Flex>
+        {isPending ? (
+          <LoadingIndicator />
+        ) : isError || !dashboard ? (
+          <Text variant="muted">{t('Unable to load dashboard details.')}</Text>
+        ) : (
+          <DashboardPreview dashboard={dashboard} href={href} />
+        )}
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
@@ -32,7 +33,10 @@ import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
 
+// Keep the embed compact by showing at most a 2x2 widget grid.
 const MAX_PREVIEW_WIDGETS = 4;
+// Limit the rows or series fetched inside each previewed widget.
+const MAX_PREVIEW_ITEMS_PER_WIDGET = 5;
 
 function getDashboardPreview(dashboard: DashboardDetails): DashboardDetails {
   if (!dashboard.prebuiltId) {
@@ -85,7 +89,10 @@ function DashboardWidgetPreview({
             dashboardFilters={dashboard.filters}
             selection={selection}
             showContextMenu={false}
-            tableItemLimit={Math.min(widget.limit ?? 5, 5)}
+            tableItemLimit={Math.min(
+              widget.limit ?? MAX_PREVIEW_ITEMS_PER_WIDGET,
+              MAX_PREVIEW_ITEMS_PER_WIDGET
+            )}
             widget={{...widget}}
             widgetLegendState={widgetLegendState}
             widgetLimitReached={false}
@@ -191,7 +198,9 @@ export default function DashboardBlock({id, title}: EmbedOutput<'dashboard'>) {
         {isPending ? (
           <LoadingIndicator />
         ) : isError || !dashboard ? (
-          <Text variant="muted">{t('Unable to load dashboard details.')}</Text>
+          <Alert role="alert" variant="danger">
+            {t('Unable to load dashboard details.')}
+          </Alert>
         ) : (
           <DashboardPreview dashboard={dashboard} href={href} />
         )}

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -94,7 +94,6 @@ describe('Seer resource embeds', () => {
     const {unmount} = renderEmbed({
       name: 'dashboard',
       data: {id: '123'},
-      level: 'block',
     });
 
     expect(

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -80,7 +80,13 @@ describe('Seer resource embeds', () => {
     );
     const dashboardRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/123/',
-      body: DashboardFixture(widgets, {id: '123', title: 'Application health'}),
+      body: DashboardFixture(widgets, {
+        environment: ['production'],
+        id: '123',
+        projects: [1],
+        title: 'Application health',
+        utc: true,
+      }),
     });
     const widgetDataRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
@@ -110,7 +116,19 @@ describe('Seer resource embeds', () => {
       '/organizations/org-slug/dashboard/123/'
     );
     expect(dashboardRequest).toHaveBeenCalled();
-    await waitFor(() => expect(widgetDataRequest).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(widgetDataRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: ['production'],
+            interval: '10m',
+            project: [1],
+            statsPeriod: '24h',
+          }),
+        })
+      )
+    );
     unmount();
   });
 

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -97,7 +97,10 @@ describe('Seer resource embeds', () => {
       level: 'block',
     });
 
-    expect(await screen.findByText('Errors')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', {name: 'Application health'}, {timeout: 5_000})
+    ).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
     expect(screen.getByText('Latency')).toBeInTheDocument();
     expect(screen.getByText('Users')).toBeInTheDocument();
     expect(screen.getByText('Throughput')).toBeInTheDocument();

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -1,8 +1,13 @@
+import {DashboardFixture} from 'sentry-fixture/dashboard';
+import {EventsStatsFixture} from 'sentry-fixture/events';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 
 interface RenderEmbedOptions {
   data: Record<string, unknown>;
@@ -35,6 +40,7 @@ describe('Seer resource embeds', () => {
   it('links a dashboard title to the dashboard in the current organization', async () => {
     const {router} = renderEmbed({
       name: 'dashboard',
+      level: 'inline',
       data: {
         id: '123',
         title: 'Application health',
@@ -53,12 +59,57 @@ describe('Seer resource embeds', () => {
       sentryUrl: 'https://sentry.io',
     });
 
-    renderEmbed({name: 'dashboard', data: {id: '456'}});
+    renderEmbed({name: 'dashboard', data: {id: '456'}, level: 'inline'});
 
     expect(screen.getByRole('link', {name: 'Dashboard 456'})).toHaveAttribute(
       'href',
       '/dashboard/456/'
     );
+  });
+
+  it('renders a live preview of the first four dashboard widgets', async () => {
+    const widgets = ['Errors', 'Latency', 'Users', 'Throughput', 'Slow spans'].map(
+      (title, index) =>
+        WidgetFixture({
+          id: String(index + 1),
+          title,
+          displayType: index === 0 ? DisplayType.LINE : DisplayType.TEXT,
+          widgetType: index === 0 ? WidgetType.ERRORS : undefined,
+          description: `${title} details`,
+        })
+    );
+    const dashboardRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/123/',
+      body: DashboardFixture(widgets, {id: '123', title: 'Application health'}),
+    });
+    const widgetDataRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: EventsStatsFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+
+    const {unmount} = renderEmbed({
+      name: 'dashboard',
+      data: {id: '123'},
+      level: 'block',
+    });
+
+    expect(await screen.findByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Latency')).toBeInTheDocument();
+    expect(screen.getByText('Users')).toBeInTheDocument();
+    expect(screen.getByText('Throughput')).toBeInTheDocument();
+    expect(screen.queryByText('Slow spans')).not.toBeInTheDocument();
+    expect(screen.getByText('5 widgets')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'View 1 more widget'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/dashboard/123/'
+    );
+    expect(dashboardRequest).toHaveBeenCalled();
+    await waitFor(() => expect(widgetDataRequest).toHaveBeenCalled());
+    unmount();
   });
 
   it('links a replay to the relevant event timestamp (inline)', async () => {

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -114,6 +114,19 @@ describe('Seer resource embeds', () => {
     unmount();
   });
 
+  it('shows an error notice when dashboard details fail to load', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/123/',
+      statusCode: 500,
+    });
+
+    renderEmbed({name: 'dashboard', data: {id: '123'}});
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Unable to load dashboard details.'
+    );
+  });
+
   it('links a replay to the relevant event timestamp (inline)', async () => {
     const {router} = renderEmbed({
       name: 'replay',

--- a/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.spec.ts
+++ b/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.spec.ts
@@ -1,0 +1,27 @@
+import {DashboardFixture} from 'sentry-fixture/dashboard';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
+
+import {LocalWidgetLegendSelectionState} from './localWidgetLegendSelectionState';
+
+describe('LocalWidgetLegendSelectionState', () => {
+  it('stores legend selection without changing URL query state', () => {
+    const widget = WidgetFixture({id: '123', displayType: DisplayType.BAR});
+    const legendState = new LocalWidgetLegendSelectionState({
+      dashboard: DashboardFixture([widget]),
+      organization: OrganizationFixture(),
+    });
+    const selection = {
+      [WidgetLegendNameEncoderDecoder.encodeSeriesNameForLegend('count()', widget.id)]:
+        false,
+    };
+
+    legendState.setWidgetSelectionState(selection, widget);
+
+    expect(legendState.getWidgetSelectionState(widget)).toEqual(selection);
+    expect(legendState.location.query).toEqual({});
+  });
+});

--- a/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.spec.ts
+++ b/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.spec.ts
@@ -2,26 +2,38 @@ import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {WidgetLegendNameEncoderDecoder} from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 
-import {LocalWidgetLegendSelectionState} from './localWidgetLegendSelectionState';
+import {useLocalWidgetLegendSelectionState} from './localWidgetLegendSelectionState';
 
 describe('LocalWidgetLegendSelectionState', () => {
-  it('stores legend selection without changing URL query state', () => {
+  it('stores legend selection locally and rerenders the consumer', () => {
     const widget = WidgetFixture({id: '123', displayType: DisplayType.BAR});
-    const legendState = new LocalWidgetLegendSelectionState({
-      dashboard: DashboardFixture([widget]),
-      organization: OrganizationFixture(),
+    const dashboard = DashboardFixture([widget]);
+    const organization = OrganizationFixture();
+    const renderSpy = jest.fn();
+    const {result} = renderHook(() => {
+      renderSpy();
+      return useLocalWidgetLegendSelectionState({
+        dashboard,
+        organization,
+      });
     });
+    const legendState = result.current;
     const selection = {
       [WidgetLegendNameEncoderDecoder.encodeSeriesNameForLegend('count()', widget.id)]:
         false,
     };
+    const initialRenderCount = renderSpy.mock.calls.length;
 
-    legendState.setWidgetSelectionState(selection, widget);
+    act(() => legendState.setWidgetSelectionState(selection, widget));
 
-    expect(legendState.getWidgetSelectionState(widget)).toEqual(selection);
+    expect(result.current).toBe(legendState);
+    expect(result.current.getWidgetSelectionState(widget)).toEqual(selection);
+    expect(renderSpy).toHaveBeenCalledTimes(initialRenderCount + 1);
     expect(legendState.location.query).toEqual({});
   });
 });

--- a/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.ts
+++ b/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.ts
@@ -1,3 +1,4 @@
+import {useMemo, useReducer} from 'react';
 import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
@@ -11,10 +12,15 @@ type Props = {
   organization: Organization;
 };
 
+type StateProps = Props & {
+  onChange: () => void;
+};
+
 export class LocalWidgetLegendSelectionState extends WidgetLegendSelectionState {
   private readonly selectionByWidget = new Map<string, LegendSelection>();
+  private readonly onChange: () => void;
 
-  constructor({dashboard, organization}: Props) {
+  constructor({dashboard, onChange, organization}: StateProps) {
     super({
       dashboard,
       organization,
@@ -28,10 +34,12 @@ export class LocalWidgetLegendSelectionState extends WidgetLegendSelectionState 
       } as Location,
       navigate: () => {},
     });
+    this.onChange = onChange;
   }
 
   override setWidgetSelectionState(selected: LegendSelection, widget: Widget) {
     this.selectionByWidget.set(this.getWidgetKey(widget), selected);
+    this.onChange();
   }
 
   override getWidgetSelectionState(widget: Widget): LegendSelection {
@@ -44,4 +52,18 @@ export class LocalWidgetLegendSelectionState extends WidgetLegendSelectionState 
   private getWidgetKey(widget: Widget): string {
     return widget.id ?? widget.tempId ?? widget.title;
   }
+}
+
+export function useLocalWidgetLegendSelectionState({dashboard, organization}: Props) {
+  const [, rerender] = useReducer(count => count + 1, 0);
+
+  return useMemo(
+    () =>
+      new LocalWidgetLegendSelectionState({
+        dashboard,
+        onChange: rerender,
+        organization,
+      }),
+    [dashboard, organization]
+  );
 }

--- a/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.ts
+++ b/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.ts
@@ -1,0 +1,47 @@
+import type {Location} from 'history';
+
+import type {Organization} from 'sentry/types/organization';
+import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
+import {WidgetLegendSelectionState} from 'sentry/views/dashboards/widgetLegendSelectionState';
+
+type LegendSelection = Record<string, boolean>;
+
+type Props = {
+  dashboard: DashboardDetails;
+  organization: Organization;
+};
+
+export class LocalWidgetLegendSelectionState extends WidgetLegendSelectionState {
+  private readonly selectionByWidget = new Map<string, LegendSelection>();
+
+  constructor({dashboard, organization}: Props) {
+    super({
+      dashboard,
+      organization,
+      location: {
+        hash: '',
+        key: 'seer-embed',
+        pathname: '',
+        query: {},
+        search: '',
+        state: undefined,
+      } as Location,
+      navigate: () => {},
+    });
+  }
+
+  override setWidgetSelectionState(selected: LegendSelection, widget: Widget) {
+    this.selectionByWidget.set(this.getWidgetKey(widget), selected);
+  }
+
+  override getWidgetSelectionState(widget: Widget): LegendSelection {
+    return (
+      this.selectionByWidget.get(this.getWidgetKey(widget)) ??
+      super.getWidgetSelectionState(widget)
+    );
+  }
+
+  private getWidgetKey(widget: Widget): string {
+    return widget.id ?? widget.tempId ?? widget.title;
+  }
+}

--- a/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.ts
+++ b/static/app/components/seer/markdown/embeds/localWidgetLegendSelectionState.ts
@@ -1,5 +1,4 @@
 import {useMemo, useReducer} from 'react';
-import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
@@ -25,13 +24,14 @@ export class LocalWidgetLegendSelectionState extends WidgetLegendSelectionState 
       dashboard,
       organization,
       location: {
+        action: 'POP',
         hash: '',
         key: 'seer-embed',
         pathname: '',
         query: {},
         search: '',
         state: undefined,
-      } as Location,
+      },
       navigate: () => {},
     });
     this.onChange = onChange;

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -120,7 +120,8 @@ export const SEER_EMBED_SCHEMAS = {
       'Use the dashboard ID exactly as returned by the dashboard API. ' +
       'Include the API-provided title when available. ' +
       'Inline: renders a compact link. ' +
-      'Block: renders a standalone dashboard reference. ' +
+      'Block: renders a live preview of the dashboard widgets. Do not duplicate ' +
+      'the widget titles, queries, visualizations, or values as text. ' +
       'Never use a markdown link for dashboard references.',
     level: ['inline', 'block'],
     schema: z.object({

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -9,6 +9,7 @@ resources:
 import * as Storybook from 'sentry/stories';
 
 import {BasicDemo, LinkifyDemo, StreamingEmbedExamples} from './__stories__/components';
+import {DashboardEmbedStory} from './__stories__/dashboardEmbedStory';
 import {EmbedStory} from './__stories__/embedStory';
 import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
 
@@ -48,7 +49,7 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 
 ### dashboard
 
-<EmbedStory name="dashboard" />
+<DashboardEmbedStory />
 
 ### dsn
 

--- a/static/app/utils/dashboards/dashboardsApiOptions.tsx
+++ b/static/app/utils/dashboards/dashboardsApiOptions.tsx
@@ -1,7 +1,7 @@
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {QueryParamValue} from 'sentry/utils/useLocation';
-import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import type {DashboardDetails, DashboardListItem} from 'sentry/views/dashboards/types';
 
 const MAX_STARRED_DASHBOARDS_IN_NAV = 20;
 
@@ -36,6 +36,19 @@ export function dashboardsApiOptions(
       path: {organizationIdOrSlug: organization.slug},
       staleTime: 0,
       ...(query ? {query} : {}),
+    }
+  );
+}
+
+export function dashboardDetailsApiOptions(
+  organization: Organization,
+  dashboardId: string
+) {
+  return apiOptions.as<DashboardDetails>()(
+    '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/',
+    {
+      path: {organizationIdOrSlug: organization.slug, dashboardId},
+      staleTime: 30_000,
     }
   );
 }

--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -1,3 +1,4 @@
+import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
@@ -9,6 +10,7 @@ import {
   getCurrentPageFilters,
   getFieldsFromEquations,
   getNumEquations,
+  getSavedFiltersAsPageFilters,
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
   hasUnsavedFilterChanges,
@@ -50,6 +52,46 @@ describe('Dashboards util', () => {
       const eventView = eventViewFromWidget(widget.title, query, selection);
       expect(eventView.fields[0]!.field).toBe('count()');
       expect(eventView.sorts).toEqual([{field: 'count', kind: 'desc'}]);
+    });
+  });
+
+  describe('getSavedFiltersAsPageFilters', () => {
+    it('uses the dashboard default when no datetime is saved', () => {
+      expect(
+        getSavedFiltersAsPageFilters(
+          DashboardFixture([], {
+            environment: ['production'],
+            projects: [1],
+            utc: false,
+          })
+        )
+      ).toEqual({
+        datetime: {
+          end: null,
+          period: '24h',
+          start: null,
+          utc: false,
+        },
+        environments: ['production'],
+        projects: [1],
+      });
+    });
+
+    it('preserves a saved absolute datetime and UTC setting', () => {
+      expect(
+        getSavedFiltersAsPageFilters(
+          DashboardFixture([], {
+            end: '2026-08-31T14:00:00',
+            start: '2026-08-31T12:00:00',
+            utc: true,
+          })
+        ).datetime
+      ).toEqual({
+        end: '2026-08-31T14:00:00',
+        period: null,
+        start: '2026-08-31T12:00:00',
+        utc: true,
+      });
     });
   });
 

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -34,6 +34,7 @@ import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import {decodeList} from 'sentry/utils/queryString';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {DEFAULT_STATS_PERIOD} from 'sentry/views/dashboards/data';
 import type {
   DashboardDetails,
   DashboardFilters,
@@ -416,12 +417,14 @@ export function hasUnsavedFilterChanges(
 }
 
 export function getSavedFiltersAsPageFilters(dashboard: DashboardDetails): PageFilters {
+  const hasSavedDatetime = Boolean(dashboard.period || dashboard.start || dashboard.end);
+
   return {
     datetime: {
       end: dashboard.end || null,
-      period: dashboard.period || null,
+      period: dashboard.period || (hasSavedDatetime ? null : DEFAULT_STATS_PERIOD),
       start: dashboard.start || null,
-      utc: null,
+      utc: dashboard.utc ?? false,
     },
     environments: dashboard.environment || [],
     projects: dashboard.projects || [],


### PR DESCRIPTION
Dashboard embeds now render a live block preview of the saved dashboard while preserving the existing compact inline link. The preview shows up to four real dashboard widgets and links to the full dashboard when more widgets are available, keeping large dashboards from overwhelming a Seer response.

Block previews fetch dashboard details by ID, apply saved page and global filters, and hydrate prebuilt dashboard definitions before rendering existing widget cards. The heavier dashboard code is lazy-loaded, Storybook selects an available dashboard for its example, and the generated Seer schema directs the agent not to duplicate widget content in surrounding text.
