### PR TITLE
fix(api): Complete generated query parameters

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -169,6 +169,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.END,
             GlobalParams.ENVIRONMENT,
             GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.REFERRER,
             OrganizationParams.PROJECT,
             GlobalParams.START,
             GlobalParams.STATS_PERIOD,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -676,6 +676,8 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             GlobalParams.STATS_PERIOD,
             GlobalParams.START,
             GlobalParams.END,
+            GlobalParams.ENVIRONMENT,
+            OrganizationParams.PROJECT,
             DATASET_QUERY_PARAM,
             ITEM_TYPE_QUERY_PARAM,
             ATTRIBUTE_TYPE_QUERY_PARAM,

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -101,6 +101,13 @@ For example, `24h`, to mean query data starting from 24 hours ago to now.""",
         type=str,
         description="The name of environments to filter by.",
     )
+    REFERRER = OpenApiParameter(
+        name="referrer",
+        location="query",
+        required=False,
+        type=str,
+        description="Internal referrer identifier used for query tracing. Most clients can omit this.",
+    )
     EVENT_ID = OpenApiParameter(
         name="event_id",
         location="path",
@@ -556,6 +563,15 @@ class WorkflowParams:
         required=True,
         type=int,
         description="The ID of the alert you'd like to query.",
+    )
+
+    DETECTOR = OpenApiParameter(
+        name="detector",
+        location="query",
+        required=False,
+        type=int,
+        many=True,
+        description="The IDs of monitors connected to the alerts you'd like to query.",
     )
 
     QUERY = OpenApiParameter(
@@ -1214,6 +1230,58 @@ class DashboardParams:
         required=True,
         type=int,
         description="""The ID of the dashboard you'd like to retrieve.""",
+    )
+
+    FILTER = OpenApiParameter(
+        name="filter",
+        location="query",
+        required=False,
+        many=True,
+        type=str,
+        enum=[
+            "excludeFavorites",
+            "excludePrebuilt",
+            "onlyFavorites",
+            "onlyPrebuilt",
+            "owned",
+            "shared",
+            "showHidden",
+        ],
+        description="Filter the dashboards returned. Repeat this parameter to apply multiple filters.",
+    )
+
+    PIN = OpenApiParameter(
+        name="pin",
+        location="query",
+        required=False,
+        type=str,
+        enum=["favorites"],
+        description="Pin favorited dashboards to the top of the results.",
+    )
+
+    QUERY = OpenApiParameter(
+        name="query",
+        location="query",
+        required=False,
+        type=str,
+        description="Filter dashboards by title.",
+    )
+
+    SORT = OpenApiParameter(
+        name="sort",
+        location="query",
+        required=False,
+        type=str,
+        description="""The property to sort results by. Prefix the value with `-` to sort in descending order.
+
+Available fields are:
+- `title`
+- `dateCreated`
+- `mostPopular`
+- `recentlyViewed`
+- `mydashboards`
+- `myDashboardsAndRecentlyViewed`
+""",
     )
 
 

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -43,7 +43,12 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
 )
 from sentry.apidocs.examples.dashboard_examples import DashboardExamples
-from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, VisibilityParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    DashboardParams,
+    GlobalParams,
+    VisibilityParams,
+)
 from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import is_active_superuser
@@ -416,7 +421,15 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
     @extend_schema(
         operation_id="listOrganizationDashboards",
         summary="List an Organization's Custom Dashboards",
-        parameters=[GlobalParams.ORG_ID_OR_SLUG, VisibilityParams.PER_PAGE, CursorQueryParam],
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            DashboardParams.FILTER,
+            DashboardParams.QUERY,
+            DashboardParams.SORT,
+            DashboardParams.PIN,
+            VisibilityParams.PER_PAGE,
+            CursorQueryParam,
+        ],
         request=None,
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -78,12 +78,19 @@ UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
         child=serializers.CharField(),
         help_text=("A list of project slugs to filter your results by."),
     )
-    environment = serializers.CharField(help_text="The environment to filter by.", required=False)
+    environment = serializers.ListField(
+        help_text="The environments to filter by.",
+        required=False,
+        child=serializers.CharField(),
+    )
     sort = serializers.CharField(help_text="The field to sort the output by.", required=False)
     sortBy = serializers.CharField(help_text="The field to sort the output by.", required=False)
     orderBy = serializers.CharField(help_text="The field to sort the output by.", required=False)
     query = serializers.CharField(
         help_text="A structured query string to filter the output by.", required=False
+    )
+    queryReferrer = serializers.CharField(
+        help_text="Internal referrer identifier used for query tracing.", required=False
     )
     per_page = serializers.IntegerField(
         help_text="Limit the number of rows to return in the result.", required=False

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -31,7 +31,13 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
-from sentry.apidocs.parameters import DetectorParams, GlobalParams, OrganizationParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    DetectorParams,
+    GlobalParams,
+    OrganizationParams,
+    VisibilityParams,
+)
 from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
@@ -261,6 +267,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             DetectorParams.QUERY,
             DetectorParams.SORT,
             DetectorParams.ID,
+            VisibilityParams.PER_PAGE,
+            CursorQueryParam,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -43,7 +43,13 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.workflow_engine_examples import WorkflowEngineExamples
-from sentry.apidocs.parameters import GlobalParams, OrganizationParams, WorkflowParams
+from sentry.apidocs.parameters import (
+    CursorQueryParam,
+    GlobalParams,
+    OrganizationParams,
+    VisibilityParams,
+    WorkflowParams,
+)
 from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
@@ -243,7 +249,10 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
             WorkflowParams.SORT_BY,
             WorkflowParams.QUERY,
             WorkflowParams.ID,
+            WorkflowParams.DETECTOR,
             OrganizationParams.PROJECT,
+            VisibilityParams.PER_PAGE,
+            CursorQueryParam,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -1,6 +1,19 @@
+import pytest
 from drf_spectacular.utils import extend_schema
 
 from sentry.api.base import Endpoint
+from sentry.api.endpoints.organization_events import OrganizationEventsEndpoint
+from sentry.api.endpoints.organization_trace_item_attributes import (
+    OrganizationTraceItemAttributesEndpoint,
+)
+from sentry.dashboards.endpoints.organization_dashboards import OrganizationDashboardsEndpoint
+from sentry.replays.endpoints.organization_replay_index import OrganizationReplayIndexEndpoint
+from sentry.workflow_engine.endpoints.organization_detector_index import (
+    OrganizationDetectorIndexEndpoint,
+)
+from sentry.workflow_engine.endpoints.organization_workflow_index import (
+    OrganizationWorkflowIndexEndpoint,
+)
 from tests.sentry.apidocs import generate_schema
 
 
@@ -65,3 +78,80 @@ def test_description() -> None:
 
     assert schema["paths"]["/foo"]["put"]["operationId"] != "Autoschema Description"
     assert schema["paths"]["/foo"]["put"]["description"] == "Autoschema Description"
+
+
+@pytest.mark.parametrize(
+    ("path", "view", "operation_id", "expected_names", "array_names"),
+    [
+        pytest.param(
+            "/api/0/organizations/{organization_id_or_slug}/events/",
+            OrganizationEventsEndpoint,
+            "listOrganizationEvents",
+            {"referrer"},
+            set(),
+            id="events",
+        ),
+        pytest.param(
+            "/api/0/organizations/{organization_id_or_slug}/replays/",
+            OrganizationReplayIndexEndpoint,
+            "listOrganizationReplays",
+            {"environment", "queryReferrer"},
+            {"environment"},
+            id="replays",
+        ),
+        pytest.param(
+            "/api/0/organizations/{organization_id_or_slug}/detectors/",
+            OrganizationDetectorIndexEndpoint,
+            "listOrganizationDetectors",
+            {"cursor", "per_page"},
+            set(),
+            id="detectors",
+        ),
+        pytest.param(
+            "/api/0/organizations/{organization_id_or_slug}/dashboards/",
+            OrganizationDashboardsEndpoint,
+            "listOrganizationDashboards",
+            {"filter", "pin", "query", "sort"},
+            {"filter"},
+            id="dashboards",
+        ),
+        pytest.param(
+            "/api/0/organizations/{organization_id_or_slug}/workflows/",
+            OrganizationWorkflowIndexEndpoint,
+            "listOrganizationWorkflows",
+            {"cursor", "detector", "per_page"},
+            {"detector"},
+            id="workflows",
+        ),
+        pytest.param(
+            "/api/0/organizations/{organization_id_or_slug}/trace-items/attributes/",
+            OrganizationTraceItemAttributesEndpoint,
+            "listOrganizationTraceItemAttributes",
+            {"environment", "project"},
+            {"environment", "project"},
+            id="trace-item-attributes",
+        ),
+    ],
+)
+def test_public_endpoint_query_parameters(
+    path: str,
+    view: type[Endpoint],
+    operation_id: str,
+    expected_names: set[str],
+    array_names: set[str],
+) -> None:
+    route = path.removeprefix("/").replace(
+        "{organization_id_or_slug}", "<str:organization_id_or_slug>"
+    )
+    schema = generate_schema(route, view=view)
+    operation = schema["paths"][path]["get"]
+
+    assert operation["operationId"] == operation_id
+    query_parameters = {
+        parameter["name"]: parameter
+        for parameter in operation["parameters"]
+        if parameter["in"] == "query"
+    }
+    assert expected_names <= query_parameters.keys()
+    for name in array_names:
+        assert query_parameters[name]["schema"]["type"] == "array"

--- a/tests/sentry/replays/endpoints/test_organization_replay_index.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_index.py
@@ -31,12 +31,20 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
     def features(self) -> dict[str, bool]:
         return {"organizations:session-replay": True}
 
-    def test_replay_validators_accept_project_slugs(self) -> None:
-        replay_validator = ReplayValidator(data={"project": ["my-project"]})
+    def test_replay_validators_accept_query_parameters(self) -> None:
+        replay_validator = ReplayValidator(
+            data={
+                "environment": ["production", "staging"],
+                "project": ["my-project"],
+                "queryReferrer": "replayList",
+            }
+        )
         selector_validator = ReplaySelectorValidator(data={"project": ["my-project"]})
 
         assert replay_validator.is_valid(), replay_validator.errors
         assert selector_validator.is_valid(), selector_validator.errors
+        assert replay_validator.validated_data["environment"] == ["production", "staging"]
+        assert replay_validator.validated_data["queryReferrer"] == "replayList"
 
     def test_get_replays_empty_project_uses_project_slug_filter(self) -> None:
         project = self.create_project(teams=[self.team], slug="replay-project")


### PR DESCRIPTION
This completes the "Incomplete operations" section of getsentry/sentry-api-schema#91. Generated API clients now expose the runtime-supported referrer, filter, and pagination parameters for organization events, replays, detectors, dashboards, workflows, and trace-item attributes. Repeated replay environments and trace-item project/environment filters are represented as arrays.

Shared parameter definitions keep the dashboard and workflow schemas consistent, while regression coverage verifies the generated parameter names and array shapes. The missing routes tracked separately in the issue are outside this PR's scope.
