### PR TITLE
fix(seer): Make code changes file-row hover and diff border full-width

### DIFF
--- a/static/app/views/seerWorkflows/overview/changedFileRow.tsx
+++ b/static/app/views/seerWorkflows/overview/changedFileRow.tsx
@@ -31,7 +31,7 @@ export function ChangedFileRow({
   path: string;
 }) {
   return (
-    <FileRow padding="0 xs">
+    <FileRow>
       <Disclosure size="sm" expanded={expanded} onExpandedChange={onExpandedChange}>
         <Disclosure.Title
           trailingItems={
@@ -63,6 +63,14 @@ export function ChangedFileRow({
 const FileRow = styled(Container)`
   & + & {
     border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+
+  [data-disclosure] > *:first-child {
+    border-radius: 0;
+  }
+
+  [data-disclosure] > *:last-child {
+    padding: 0;
   }
 `;
 


### PR DESCRIPTION
Fixes two visual defects in the "Code Changes" file list on the Seer Workflows overview card.

Each file row was wrapped in a container with horizontal padding, so the row hover was inset from the card edges and — because the hover background lives on the core `Disclosure` title — showed rounded corners. Expanding a row also left the separator between the file header and its diff indented and a lighter color than the full-width `border.primary` separators between rows.

The fix drops the row's horizontal inset (hover now spans the full width), squares off the Disclosure title's hover background, and zeroes the content panel's indent so the expanded diff is full-bleed. The diff's top border now lines up with the between-row separators.

Scoped to `changedFileRow.tsx` only — no changes to the shared `Disclosure` component or `FileDiffViewer`. This is a CSS-only change inside a `styled` template.

Note: the Jest harness can't run locally right now — `jest.config.ts` fails to parse under ts-node (`import.meta`/top-level-await vs the repo's `module: "preserve"` tsconfig), which reproduces on unrelated specs too. Worth a visual check on review: hover a file row (full-width, square corners) and expand a row (the line above the diff reaches both edges).