### PR TITLE
fix(replay): Hide duplicate installation mode dropdown in onboarding

### DIFF
--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -300,7 +300,9 @@ function OnboardingContent({
                     })}
                     {jsFrameworkDocs?.platformOptions && (
                       <PlatformOptionDropdown
-                        platformOptions={jsFrameworkDocs?.platformOptions}
+                        platformOptions={pickPlatformOptions(
+                          jsFrameworkDocs.platformOptions
+                        )}
                         disabled={setupMode === 'jsLoader'}
                       />
                     )}

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -1,6 +1,7 @@
 import type {ReactNode} from 'react';
 import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import omit from 'lodash/omit';
 import {parseAsStringLiteral, useQueryState} from 'nuqs';
 import {PlatformIcon} from 'platformicons';
 
@@ -300,8 +301,9 @@ function OnboardingContent({
                     })}
                     {jsFrameworkDocs?.platformOptions && (
                       <PlatformOptionDropdown
-                        platformOptions={pickPlatformOptions(
-                          jsFrameworkDocs.platformOptions
+                        platformOptions={omit(
+                          jsFrameworkDocs.platformOptions,
+                          'installationMode'
                         )}
                         disabled={setupMode === 'jsLoader'}
                       />


### PR DESCRIPTION
On backend projects, the JS framework selector rendered a Loader Script vs Npm/Yarn dropdown that duplicated the radio group right below it. Only the radio group drives which docs render, so changing the dropdown did nothing.

## Before
<img width="722" height="305" alt="image" src="https://github.com/user-attachments/assets/4dcf67d8-8132-48db-adad-89b815060b1a" />

## After
<img width="722" height="418" alt="image" src="https://github.com/user-attachments/assets/308c9934-75f2-45ac-a709-974e68b525ff" />


Fixes REPLAY-872