### PR TITLE
fix(dashboards): Support Trace Metrics equation state

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -37,7 +37,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {useTraceMetricMultiMetricSelection} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricMultiMetricSelection';
 import {
   extractTraceMetricFromColumn,
-  getTraceMetricAggregateSource,
+  getTraceMetricDisplayFields,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {hasMultipleMetricsSelected} from 'sentry/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected';
 import {
@@ -220,13 +220,13 @@ function useTraceMetricsSearchScope() {
   const {state: widgetBuilderState} = useWidgetBuilderContext();
   const hasMultiMetricSelection = useTraceMetricMultiMetricSelection();
 
-  const aggregateSource = getTraceMetricAggregateSource(
+  const displayFields = getTraceMetricDisplayFields(
     widgetBuilderState.displayType,
     widgetBuilderState.yAxis,
     widgetBuilderState.fields
   );
   const traceMetrics =
-    aggregateSource?.map(extractTraceMetricFromColumn).filter(defined) ?? [];
+    displayFields?.map(extractTraceMetricFromColumn).filter(defined) ?? [];
   const hasMultipleMetrics = hasMultipleMetricsSelected(
     traceMetrics,
     hasMultiMetricSelection

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -14,15 +14,18 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {useDisableTransactionWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/useDisableTransactionWidget';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {HiddenTraceMetricGroupByFields} from 'sentry/views/explore/metrics/constants';
 
 interface WidgetBuilderGroupBySelectorProps {
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
+  preserveAggregateFields?: boolean;
 }
 
 export function WidgetBuilderGroupBySelector({
+  preserveAggregateFields = false,
   validatedWidgetResponse,
 }: WidgetBuilderGroupBySelectorProps) {
   const {state, dispatch} = useWidgetBuilderContext();
@@ -87,8 +90,18 @@ export function WidgetBuilderGroupBySelector({
     tags,
   ]);
 
+  const groupByColumns = preserveAggregateFields
+    ? state.fields?.filter(field => field.kind === FieldValueKind.FIELD)
+    : state.fields;
+
   const handleGroupByChange = (newValue: QueryFieldValue[]) => {
-    dispatch({type: BuilderStateAction.SET_FIELDS, payload: newValue});
+    const fields = preserveAggregateFields
+      ? [
+          ...newValue,
+          ...(state.fields?.filter(field => field.kind !== FieldValueKind.FIELD) ?? []),
+        ]
+      : newValue;
+    dispatch({type: BuilderStateAction.SET_FIELDS, payload: fields});
   };
 
   return (
@@ -102,7 +115,7 @@ export function WidgetBuilderGroupBySelector({
       />
 
       <GroupBySelector
-        columns={state.fields}
+        columns={groupByColumns}
         fieldOptions={groupByOptions}
         onChange={handleGroupByChange}
         validatedWidgetResponse={validatedWidgetResponse}

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -51,7 +51,7 @@ import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {getTraceMetricAggregates} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {hasUnresolvedTraceMetric} from 'sentry/views/dashboards/widgetBuilder/utils/hasUnresolvedTraceMetric';
 import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
@@ -280,7 +280,7 @@ export function WidgetPreviewContainer({
     widget.widgetType === WidgetType.TRACEMETRICS &&
     widget.queries.every(query => query.aggregates.length === 0) &&
     Boolean(
-      getTraceMetricAggregateSource(state.displayType, state.yAxis, state.fields)?.some(
+      getTraceMetricAggregates(state.displayType, state.yAxis, state.fields)?.some(
         aggregate =>
           aggregate.kind === FieldValueKind.EQUATION && aggregate.field.trim() === ''
       )

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/aggregateSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/aggregateSelector.tsx
@@ -14,7 +14,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {
   buildTraceMetricAggregate,
   getTraceMetricAggregateActionType,
-  getTraceMetricAggregateSource,
+  getTraceMetricDisplayFields,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
@@ -32,7 +32,7 @@ export function AggregateSelector({
 }) {
   const {state, dispatch} = useWidgetBuilderContext();
 
-  const aggregateSource = getTraceMetricAggregateSource(
+  const displayFields = getTraceMetricDisplayFields(
     state.displayType,
     state.yAxis,
     state.fields
@@ -45,10 +45,10 @@ export function AggregateSelector({
   );
 
   const aggregateValue = useMemo(() => {
-    return aggregateSource?.[index]?.kind === 'function'
-      ? (aggregateSource?.[index]?.function?.[0] ?? '')
+    return displayFields?.[index]?.kind === 'function'
+      ? (displayFields?.[index]?.function?.[0] ?? '')
       : '';
-  }, [aggregateSource, index]);
+  }, [displayFields, index]);
 
   return (
     <AggregateCompactSelect
@@ -60,7 +60,7 @@ export function AggregateSelector({
       position="bottom-start"
       onChange={option => {
         if (field.kind === 'function') {
-          const newAggregates = cloneDeep(aggregateSource) ?? [];
+          const newAggregates = cloneDeep(displayFields) ?? [];
           newAggregates[index] = buildTraceMetricAggregate(
             option.value as AggregationKeyWithAlias,
             traceMetric

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.spec.tsx
@@ -7,7 +7,10 @@ import type {
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {MetricSelectRow} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow';
-import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {
+  useWidgetBuilderContext,
+  WidgetBuilderProvider,
+} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {serializeFields} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
@@ -178,6 +181,55 @@ describe('MetricSelectRow', () => {
     // Both metrics should be selected
     expect(screen.getByRole('button', {name: 'beta_metric'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'alpha_metric'})).toBeInTheDocument();
+  });
+
+  it('preserves table grouping fields when updating an aggregate', async () => {
+    let fields: QueryFieldValue[] | undefined;
+
+    function MetricSelectRows() {
+      const {state} = useWidgetBuilderContext();
+      fields = state.fields;
+
+      return state.fields?.map((field, index) => (
+        <MetricSelectRow key={index} field={field} index={index} disabled={false} />
+      ));
+    }
+
+    render(
+      <WidgetBuilderProvider>
+        <MetricSelectRows />
+      </WidgetBuilderProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+            query: {
+              dataset: WidgetType.TRACEMETRICS,
+              displayType: DisplayType.TABLE,
+              field: [
+                'span.op',
+                'span.description',
+                'sum(value,alpha_metric,counter,none)',
+                'count(value,alpha_metric,counter,none)',
+              ],
+            },
+          },
+        },
+      }
+    );
+
+    const metricSelectors = await screen.findAllByRole('button', {name: 'alpha_metric'});
+    await userEvent.click(metricSelectors[0]!);
+    await userEvent.click(await screen.findByRole('option', {name: 'beta_metric'}));
+
+    await waitFor(() => {
+      expect(serializeFields(fields ?? [])).toEqual([
+        'span.op',
+        'span.description',
+        'sum(value,beta_metric,counter,none)',
+        'sum(value,beta_metric,counter,none)',
+      ]);
+    });
   });
 
   it('replaces invalid aggregates when changing to an incompatible metric type', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
@@ -17,7 +17,7 @@ import {
   buildTraceMetricAggregate,
   extractTraceMetricFromColumn,
   getTraceMetricAggregateActionType,
-  getTraceMetricAggregateSource,
+  getTraceMetricDisplayFields,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {
@@ -102,13 +102,14 @@ export function MetricSelectRow({
   const hasMultiMetricSelection = useTraceMetricMultiMetricSelection();
   const [shouldAutoSelectFirstColumn, setShouldAutoSelectFirstColumn] = useState(false);
 
-  const aggregateSource = getTraceMetricAggregateSource(
+  const displayFields = getTraceMetricDisplayFields(
     state.displayType,
     state.yAxis,
     state.fields
   );
-  const traceMetric = (aggregateSource?.[index]
-    ? extractTraceMetricFromColumn(aggregateSource[index])
+
+  const traceMetric = (displayFields?.[index]
+    ? extractTraceMetricFromColumn(displayFields[index])
     : undefined) ?? {name: '', type: ''};
 
   // Dashboards is visualization-first: once Heat Map is chosen, restrict the
@@ -135,19 +136,15 @@ export function MetricSelectRow({
       if (hasMultiMetricSelection) {
         updatedAggregates =
           field.kind === FieldValueKind.FUNCTION
-            ? getUpdatedAggregatesMultiMetric(
-                aggregateSource ?? [],
-                index,
-                newTraceMetric
-              )
+            ? getUpdatedAggregatesMultiMetric(displayFields ?? [], index, newTraceMetric)
             : replaceFieldWithDefaultAggregate(
-                aggregateSource ?? [],
+                displayFields ?? [],
                 index,
                 newTraceMetric
               );
       } else {
         const validAggregateOptions = OPTIONS_BY_TYPE[newTraceMetric.type] ?? [];
-        updatedAggregates = (aggregateSource ?? []).map((f, aggregateIndex) => {
+        updatedAggregates = (displayFields ?? []).map((f, aggregateIndex) => {
           if (f.kind === 'function' && f.function?.[0]) {
             const aggregate = f.function[0];
             const isValid = validAggregateOptions.some(opt => opt.value === aggregate);
@@ -182,7 +179,7 @@ export function MetricSelectRow({
         payload: updatedAggregates,
       });
     },
-    [aggregateSource, dispatch, field, hasMultiMetricSelection, index, state.displayType]
+    [displayFields, dispatch, field, hasMultiMetricSelection, index, state.displayType]
   );
 
   const onSelectField = useCallback(() => {
@@ -191,13 +188,13 @@ export function MetricSelectRow({
     }
 
     setShouldAutoSelectFirstColumn(true);
-    const newFields = [...(aggregateSource ?? [])];
+    const newFields = [...(displayFields ?? [])];
     newFields[index] = {kind: FieldValueKind.FIELD, field: ''};
     dispatch({
       type: getTraceMetricAggregateActionType(state.displayType),
       payload: newFields,
     });
-  }, [aggregateSource, dispatch, index, state.displayType]);
+  }, [displayFields, dispatch, index, state.displayType]);
 
   useEffect(() => {
     if (field.kind !== FieldValueKind.FIELD) {
@@ -206,7 +203,7 @@ export function MetricSelectRow({
   }, [field.kind]);
 
   const hasOnlyAggregate =
-    aggregateSource?.filter(
+    displayFields?.filter(
       aggregate => aggregate.kind === 'function' || aggregate.kind === 'equation'
     ).length === 1;
   const renderedFieldSelector = fieldSelector?.(shouldAutoSelectFirstColumn);

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricSelectRow.tsx
@@ -107,7 +107,6 @@ export function MetricSelectRow({
     state.yAxis,
     state.fields
   );
-
   const traceMetric = (aggregateSource?.[index]
     ? extractTraceMetricFromColumn(aggregateSource[index])
     : undefined) ?? {name: '', type: ''};

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/builderStateMetricsQueryParamsProvider.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/builderStateMetricsQueryParamsProvider.tsx
@@ -4,7 +4,7 @@ import {generateFieldAsString} from 'sentry/utils/discover/fields';
 import {dispatchYAxisUpdate} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {getTraceMetricAggregates} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {
   DEFAULT_YAXIS_BY_TYPE,
   OPTIONS_BY_TYPE,
@@ -40,7 +40,7 @@ export function BuilderStateMetricsQueryParamsProvider({
 }: BuilderStateMetricsQueryParamsProviderProps) {
   const {state, dispatch} = useWidgetBuilderContext();
 
-  const aggregateSource = getTraceMetricAggregateSource(
+  const aggregateSource = getTraceMetricAggregates(
     state.displayType,
     state.yAxis,
     state.fields

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.tsx
@@ -6,7 +6,7 @@ import {MetricQueryRows} from 'sentry/views/dashboards/widgetBuilder/components/
 import {prepareQueriesForEquationMode} from 'sentry/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import type {EquationModeSnapshot} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState';
-import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {getTraceMetricAggregates} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {assignSequentialLabels} from 'sentry/views/explore/metrics/hooks/useStableLabels';
 import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
@@ -33,7 +33,7 @@ export function MetricsEquationVisualize({
 }: MetricsEquationVisualizeProps) {
   const {state} = useWidgetBuilderContext();
 
-  const aggregateSource = getTraceMetricAggregateSource(
+  const aggregateSource = getTraceMetricAggregates(
     state.displayType,
     state.yAxis,
     state.fields

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
@@ -14,7 +14,7 @@ import {dispatchYAxisUpdate} from 'sentry/views/dashboards/widgetBuilder/compone
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import type {EquationModeSnapshot} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {getTraceMetricAggregateSource} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
+import {getTraceMetricAggregates} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {MAX_METRIC_ALLOWED_LABEL_VALUE} from 'sentry/views/explore/metrics/constants';
 import {
   extractReferenceLabels,
@@ -76,7 +76,7 @@ export function MetricQueryRows({
   const referenceMap = useMetricReferences(metricQueries);
   const addAggregate = useAddMetricQuery({});
 
-  const aggregateSource = getTraceMetricAggregateSource(
+  const aggregateSource = getTraceMetricAggregates(
     state.displayType,
     state.yAxis,
     state.fields

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -835,6 +835,42 @@ describe('WidgetBuilderSlideout', () => {
     });
   });
 
+  it('shows the optional group by selector for Trace Metrics equations', async () => {
+    render(
+      <WidgetBuilderSlideout
+        dashboard={DashboardFixture([])}
+        dashboardFilters={{release: undefined}}
+        onClose={jest.fn()}
+        onQueryConditionChange={jest.fn()}
+        onSave={jest.fn()}
+        setIsPreviewDraggable={jest.fn()}
+        openWidgetTemplates={false}
+        setOpenWidgetTemplates={jest.fn()}
+      />,
+      {
+        organization: OrganizationFixture({
+          features: ['tracemetrics-enabled'],
+        }),
+        initialRouterConfig: {
+          location: {
+            pathname: '/dashboards/',
+            query: {
+              dataset: WidgetType.TRACEMETRICS,
+              displayType: DisplayType.TABLE,
+              field: [
+                'equation|sum(value,alpha_metric,counter,none) + avg(value,beta_metric,counter,none)',
+              ],
+            },
+          },
+        },
+        additionalWrapper: WidgetBuilderProvider,
+      }
+    );
+
+    expect(await screen.findByText('Group by')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Add Group'})).toBeInTheDocument();
+  });
+
   it('should not show the group by selector if the widget is an issue and a chart display type', async () => {
     render(
       <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -188,9 +188,12 @@ function WidgetBuilderSlideoutInner({
   // - Issue widgets: don't support Group By (issues have their own grouping)
   // - Categorical Bar widgets: group by is not supported yet, but may be in the future
   // - Text widgets: don't support Group By (no data visualization)
+  // - Trace Metrics equations with tables: no other way for selecting columns to group by
   const showGroupBySelector =
     (isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE) && !isTextWidget) ||
-    (state.dataset === WidgetType.TRACEMETRICS && isInEquationMode);
+    (state.dataset === WidgetType.TRACEMETRICS &&
+      isInEquationMode &&
+      state.displayType === DisplayType.TABLE);
 
   // X-Axis selector is only for Categorical Bar widgets, other chart widgets
   // always use time as the X-axis

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -182,13 +182,15 @@ function WidgetBuilderSlideoutInner({
     !(state.dataset === WidgetType.TRACEMETRICS && isInEquationMode) &&
     !(state.dataset === WidgetType.ISSUE && usesTimeSeriesData(state.displayType));
 
-  // Group By is used by time-series chart widgets to break down data by a field.
+  // Group By is used by time-series chart widgets and Trace Metrics equations
+  // to break down data by a field.
   // - Time-series widgets: show Group By to allow breaking down by fields
   // - Issue widgets: don't support Group By (issues have their own grouping)
   // - Categorical Bar widgets: group by is not supported yet, but may be in the future
   // - Text widgets: don't support Group By (no data visualization)
   const showGroupBySelector =
-    isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE) && !isTextWidget;
+    (isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE) && !isTextWidget) ||
+    (state.dataset === WidgetType.TRACEMETRICS && isInEquationMode);
 
   // X-Axis selector is only for Categorical Bar widgets, other chart widgets
   // always use time as the X-axis
@@ -514,6 +516,9 @@ function WidgetBuilderSlideoutInner({
                     {showGroupBySelector && (
                       <Section>
                         <WidgetBuilderGroupBySelector
+                          preserveAggregateFields={
+                            state.dataset === WidgetType.TRACEMETRICS && isInEquationMode
+                          }
                           validatedWidgetResponse={validatedWidgetResponse}
                         />
                       </Section>

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
@@ -141,6 +141,28 @@ describe('useTraceMetricsVisualizeModeState', () => {
     expect(result.current.isEquationMode).toBe(true);
   });
 
+  it('starts in equation mode when table grouping fields precede the equation', () => {
+    const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
+      organization: OrganizationFixture({features: EQUATION_FEATURES}),
+      additionalWrapper: WidgetBuilderProvider,
+      initialRouterConfig: {
+        location: {
+          pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+          query: {
+            dataset: WidgetType.TRACEMETRICS,
+            displayType: DisplayType.TABLE,
+            field: [
+              'span.op',
+              'equation|sum(value,alpha_metric,counter,none) + avg(value,beta_metric,counter,none)',
+            ],
+          },
+        },
+      },
+    });
+
+    expect(result.current.isEquationMode).toBe(true);
+  });
+
   it('toggles to equation mode', () => {
     const {result} = renderHookWithProviders(useTraceMetricsVisualizeModeState, {
       organization: OrganizationFixture({features: EQUATION_FEATURES}),
@@ -162,6 +184,44 @@ describe('useTraceMetricsVisualizeModeState', () => {
     });
 
     expect(result.current.isEquationMode).toBe(true);
+  });
+
+  it('preserves table grouping fields when switching between series and equation mode', () => {
+    function useCombinedStateHooks() {
+      const visualizeModeState = useTraceMetricsVisualizeModeState();
+      const {state} = useWidgetBuilderContext();
+      return {visualizeModeState, widgetBuilderState: state};
+    }
+
+    const {result} = renderHookWithProviders(useCombinedStateHooks, {
+      organization: OrganizationFixture({features: EQUATION_FEATURES}),
+      additionalWrapper: WidgetBuilderProvider,
+      initialRouterConfig: {
+        location: {
+          pathname: DASHBOARD_WIDGET_BUILDER_PATHNAME,
+          query: {
+            dataset: WidgetType.TRACEMETRICS,
+            displayType: DisplayType.TABLE,
+            field: [
+              'span.op',
+              'span.description',
+              'sum(value,alpha_metric,counter,none)',
+            ],
+          },
+        },
+      },
+    });
+
+    act(() => {
+      result.current.visualizeModeState.handleModeToggle(true);
+      result.current.visualizeModeState.handleModeToggle(false);
+    });
+
+    expect(serializeFields(result.current.widgetBuilderState.fields ?? [])).toEqual([
+      'span.op',
+      'span.description',
+      'sum(value,alpha_metric,counter,none)',
+    ]);
   });
 
   it('toggles to series mode', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.tsx
@@ -22,7 +22,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {
   getTraceMetricAggregateActionType,
-  getTraceMetricAggregateSource,
+  getTraceMetricAggregates,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {assignSequentialLabels} from 'sentry/views/explore/metrics/hooks/useStableLabels';
@@ -69,7 +69,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
     if (state.dataset !== WidgetType.TRACEMETRICS) {
       return false;
     }
-    const aggregateSource = getTraceMetricAggregateSource(
+    const aggregateSource = getTraceMetricAggregates(
       state.displayType,
       state.yAxis,
       state.fields
@@ -84,7 +84,17 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
   const restoreSeriesState = useCallback(() => {
     if (seriesSnapshot.current) {
       const actionType = getTraceMetricAggregateActionType(state.displayType);
-      dispatch({type: actionType, payload: seriesSnapshot.current.fields});
+      const fields =
+        actionType === BuilderStateAction.SET_FIELDS
+          ? [
+              ...(state.fields?.filter(field => field.kind === FieldValueKind.FIELD) ??
+                []),
+              ...seriesSnapshot.current.fields.filter(
+                field => field.kind !== FieldValueKind.FIELD
+              ),
+            ]
+          : seriesSnapshot.current.fields;
+      dispatch({type: actionType, payload: fields});
       dispatch({
         type: BuilderStateAction.SET_QUERY,
         payload: seriesSnapshot.current.query,
@@ -119,9 +129,16 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       derivedFields = [getDatasetConfig(WidgetType.TRACEMETRICS).defaultField];
     }
 
-    seriesSnapshot.current = {fields: derivedFields, legendAlias: [], query: []};
     const actionType = getTraceMetricAggregateActionType(state.displayType);
-    dispatch({type: actionType, payload: derivedFields});
+    const fields =
+      actionType === BuilderStateAction.SET_FIELDS
+        ? [
+            ...(state.fields?.filter(field => field.kind === FieldValueKind.FIELD) ?? []),
+            ...derivedFields,
+          ]
+        : derivedFields;
+    seriesSnapshot.current = {fields, legendAlias: [], query: []};
+    dispatch({type: actionType, payload: fields});
     dispatch({
       type: BuilderStateAction.SET_QUERY,
       payload: [],
@@ -130,7 +147,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       type: BuilderStateAction.SET_LEGEND_ALIAS,
       payload: [],
     });
-  }, [state.displayType, dispatch]);
+  }, [state.displayType, state.fields, dispatch]);
 
   const restoreEquationState = useCallback(() => {
     let snapshot = equationSnapshot.current;
@@ -138,7 +155,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
     if (!snapshot) {
       // If no equation snapshot state, then we need to derive the first state to
       // update the widget builder
-      const aggregateSource = getTraceMetricAggregateSource(
+      const aggregateSource = getTraceMetricAggregates(
         state.displayType,
         state.yAxis,
         state.fields
@@ -204,7 +221,7 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
   // Detect an equation yAxis and restore the cached equation mode if
   // the user was in equation mode when they left.
   const onChangeDatasetToTraceMetrics = useEffectEvent(() => {
-    const aggregateSource = getTraceMetricAggregateSource(
+    const aggregateSource = getTraceMetricAggregates(
       state.displayType,
       state.yAxis,
       state.fields
@@ -236,11 +253,11 @@ export function useTraceMetricsVisualizeModeState(): TraceMetricsVisualizeModeSt
       const currentLegendAlias = state.legendAlias ? [...state.legendAlias] : [];
 
       if (nextIsEquation) {
-        const currentFields = getTraceMetricAggregateSource(
-          state.displayType,
-          state.yAxis,
-          state.fields
-        );
+        const actionType = getTraceMetricAggregateActionType(state.displayType);
+        const currentFields =
+          actionType === BuilderStateAction.SET_FIELDS
+            ? state.fields
+            : getTraceMetricAggregates(state.displayType, state.yAxis, state.fields);
         seriesSnapshot.current = {
           fields: currentFields ? structuredClone(currentFields) : [],
           legendAlias: currentLegendAlias,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.ts
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.ts
@@ -5,7 +5,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {useTraceMetricMultiMetricSelection} from 'sentry/views/dashboards/widgetBuilder/hooks/useTraceMetricMultiMetricSelection';
 import {
   extractTraceMetricFromColumn,
-  getTraceMetricAggregateSource,
+  getTraceMetricAggregates,
 } from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {hasMultipleMetricsSelected} from 'sentry/views/dashboards/widgetBuilder/utils/hasMultipleMetricsSelected';
 import type {TraceItemAttributeConfig} from 'sentry/views/explore/hooks/useTraceItemAttributes';
@@ -33,7 +33,7 @@ export function useWidgetBuilderTraceItemConfig(): TraceItemAttributeConfig {
   }
 
   if (state.dataset === WidgetType.TRACEMETRICS) {
-    const aggregateSource = getTraceMetricAggregateSource(
+    const aggregateSource = getTraceMetricAggregates(
       state.displayType,
       state.yAxis,
       state.fields

--- a/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
@@ -46,11 +46,16 @@ export function extractTraceMetricFromColumn(column: Column): TraceMetric | unde
 }
 
 /**
- * Returns the aggregate columns for trace metric widgets based on display type.
- * Time-series uses yAxis, categorical bar filters to aggregate fields only,
- * and all other display types use fields directly.
+ * Returns the fields used to define a trace metric visualization's plotted data.
+ *
+ * Time-series visualizations plot their `yAxis` fields, while categorical bars
+ * plot only aggregate and equation `fields`. All other display types use
+ * `fields` directly; this deliberately includes table grouping fields alongside
+ * aggregates so callers can preserve the complete table column configuration.
+ *
+ * Categorical bar visualizations use `fields` directly, but filter out grouping fields.
  */
-export function getTraceMetricAggregateSource(
+export function getTraceMetricDisplayFields(
   displayType: DisplayType | undefined,
   yAxis: Column[] | undefined,
   fields: Column[] | undefined
@@ -77,7 +82,7 @@ export function getTraceMetricAggregates(
   yAxis: Column[] | undefined,
   fields: Column[] | undefined
 ): Column[] | undefined {
-  return getTraceMetricAggregateSource(displayType, yAxis, fields)?.filter(
+  return getTraceMetricDisplayFields(displayType, yAxis, fields)?.filter(
     field =>
       field.kind === FieldValueKind.FUNCTION || field.kind === FieldValueKind.EQUATION
   );

--- a/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate.ts
@@ -47,7 +47,7 @@ export function extractTraceMetricFromColumn(column: Column): TraceMetric | unde
 
 /**
  * Returns the aggregate columns for trace metric widgets based on display type.
- * Time-series uses yAxis, categorical bar filters to FUNCTION fields only,
+ * Time-series uses yAxis, categorical bar filters to aggregate fields only,
  * and all other display types use fields directly.
  */
 export function getTraceMetricAggregateSource(
@@ -64,6 +64,23 @@ export function getTraceMetricAggregateSource(
     );
   }
   return fields;
+}
+
+/**
+ * Returns only aggregate and equation columns for Trace Metrics widgets.
+ *
+ * Tables store grouping fields alongside aggregates, while equation mode only
+ * operates on aggregate columns.
+ */
+export function getTraceMetricAggregates(
+  displayType: DisplayType | undefined,
+  yAxis: Column[] | undefined,
+  fields: Column[] | undefined
+): Column[] | undefined {
+  return getTraceMetricAggregateSource(displayType, yAxis, fields)?.filter(
+    field =>
+      field.kind === FieldValueKind.FUNCTION || field.kind === FieldValueKind.EQUATION
+  );
 }
 
 /**


### PR DESCRIPTION
Supports the equation mode for table widgets

- users can select group by fields when setting up an equation
- group by fields are persisted when switching between series and equation modes
- aggregates in either mode are stored as separate state (i.e. when you switch to equations, it'll initialize equation state, but that state is independent now of the series view)


https://github.com/user-attachments/assets/fba7293c-6200-4f49-9bb8-328022a63e94

