### PR TITLE
fix(seer): Gate autofix overview cards on the issueStats query

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -174,6 +174,12 @@ describe('AutofixOverview', () => {
     return {promise, resolve};
   }
 
+  // Flush pending microtasks so already-resolved mock responses apply and render.
+  async function tick() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
   const originalIntersectionObserver = window.IntersectionObserver;
   function makeCardsVisible({
     deferred = false,
@@ -739,23 +745,44 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText('0 users')).not.toBeInTheDocument();
   });
 
-  it('shimmers the Snuba vitals until the issueStats call resolves', async () => {
+  it('holds the skeleton until the issueStats call resolves, then shows vitals', async () => {
     const issueStats = deferredResponse();
-    mockOverview({
+    const {statusPollRequest, projectConfigRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
       issueStatsAsyncDelay: issueStats.promise,
     });
 
     renderPage();
 
-    expect(await screen.findByText('TypeError in checkout cart')).toBeInTheDocument();
+    // Let the status + projectConfig responses land and render; only the vitals
+    // stay pending. Cards must not paint yet, so events/users never shimmer.
+    await waitFor(() => expect(statusPollRequest).toHaveBeenCalled());
+    await waitFor(() => expect(projectConfigRequest).toHaveBeenCalled());
+    await act(tick);
+    expect(screen.queryByText('TypeError in checkout cart')).not.toBeInTheDocument();
     expect(screen.getAllByTestId('loading-placeholder').length).toBeGreaterThan(0);
-    expect(screen.queryByText('1.2K events')).not.toBeInTheDocument();
 
     issueStats.resolve();
 
-    expect(await screen.findByText('1.2K events')).toBeInTheDocument();
+    expect(await screen.findByText('TypeError in checkout cart')).toBeInTheDocument();
+    expect(screen.getByText('1.2K events')).toBeInTheDocument();
     expect(screen.getByText('5 users')).toBeInTheDocument();
+  });
+
+  it('shows the cards when the issueStats call fails instead of blocking forever', async () => {
+    mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+      issueStatsStatusCode: 500,
+    });
+
+    renderPage();
+
+    // A failed vitals call must not withhold the cards forever; once the query
+    // settles (after its one retry) the cards render. The timeout covers the
+    // issueStats retry backoff.
+    expect(
+      await screen.findByText('TypeError in checkout cart', undefined, {timeout: 5000})
+    ).toBeInTheDocument();
   });
 
   it('fetches the vitals once for a stable run set, without looping', async () => {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -181,6 +181,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     data,
     projectConfig,
     projectConfigPending,
+    issueStatsPending,
     isPending,
     isError,
     dataSettled,
@@ -296,7 +297,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     );
   };
 
-  const resultsPending = isPending || projectConfigPending;
+  const resultsPending = isPending || projectConfigPending || issueStatsPending;
   const populatedKeys = populatedSections.map(section => section.key);
   const allCollapsed =
     populatedKeys.length > 0 && populatedKeys.every(key => collapsedGroups.includes(key));

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -367,6 +367,7 @@ export function useAutofixOverview({
     data,
     projectConfig: projectConfigQuery.data?.projectConfig,
     projectConfigPending: projectConfigQuery.isLoading,
+    issueStatsPending: issueStatsQuery.isLoading,
     isPending: !data,
     isError: statusPollQuery.isError && !data,
     // isFetching, not isPending: a stale-cache remount must wait for the refetch


### PR DESCRIPTION
On the autofix overview page, the card list painted as soon as the status poll and projectConfig resolved, without waiting for the separate `issueStats` (Snuba vitals) query. Whenever status won the race, cards appeared with their events/users fields shimmering until the slower vitals query landed. This folds the `issueStats` initial-load state into the top-level pending gate, so cards paint only once vitals are available and the events/users fields never shimmer in on first load.

The gate uses `issueStatsQuery.isLoading` rather than `isPending`, so it blocks only the first fetch and releases on error — it does not re-trigger on the later background or per-run vitals refetches. On a vitals error the cards still render (without vitals) after the query's one retry settles, so a failed Snuba call never withholds the list. The tradeoff is that first cards now appear slightly later, gated on the slower query, which is the intent here. The per-card shimmer is preserved for the genuine late-arrival case where a run is present in the status poll but missing from issueStats.