### PR TITLE
feat(onboarding): Use code blocks for setup commands

### DIFF
--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@sentry/scraps/button';
+import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -6,8 +7,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {Hovercard} from 'sentry/components/hovercard';
 import {List} from 'sentry/components/list';
 import {ListItem} from 'sentry/components/list/listItem';
-import {TextCopyInput} from 'sentry/components/textCopyInput';
-import {IconBot, IconChat, IconCheckmark, IconInfo, IconTerminal} from 'sentry/icons';
+import {IconBot, IconCheckmark, IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 export type AgentSetupCopySource = 'install_command' | 'prompt';
@@ -57,14 +57,13 @@ export function AgentSetupCard({onCopyCommand, prompt}: AgentSetupCardProps) {
           <ListItem>
             <Stack gap="md" paddingBottom="xl">
               <StepLabel>{t('Install Sentry plugin')}</StepLabel>
-              <TextCopyInput
-                size="sm"
-                monospace
-                icon={<IconTerminal size="xs" variant="secondary" />}
+              <CodeBlock
+                alwaysShowCopyButton
                 onCopy={() => onCopyCommand('install_command')}
+                wrapMode="wrap"
               >
                 {INSTALL_PLUGIN_COMMAND}
-              </TextCopyInput>
+              </CodeBlock>
             </Stack>
           </ListItem>
           <ListItem>
@@ -72,14 +71,13 @@ export function AgentSetupCard({onCopyCommand, prompt}: AgentSetupCardProps) {
               <Stack gap="md">
                 <StepLabel>{t('Then open your agent in your project and ask')}</StepLabel>
                 <Stack gap="sm">
-                  <TextCopyInput
-                    size="sm"
-                    monospace
-                    icon={<IconChat size="xs" variant="secondary" />}
+                  <CodeBlock
+                    alwaysShowCopyButton
                     onCopy={() => onCopyCommand('prompt')}
+                    wrapMode="wrap"
                   >
                     {prompt}
-                  </TextCopyInput>
+                  </CodeBlock>
                   <Flex>
                     <Hovercard
                       position="top"

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -691,7 +691,7 @@ describe('Onboarding', () => {
       await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
 
       expect(
-        await screen.findByDisplayValue('npx @sentry/agent-plugin install')
+        await screen.findByText('npx @sentry/agent-plugin install')
       ).toBeInTheDocument();
       expect(screen.getByText('Connect your repository')).toBeInTheDocument();
       expect(screen.getByText('Choose your platform')).toBeInTheDocument();
@@ -721,7 +721,7 @@ describe('Onboarding', () => {
       await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
 
       expect(
-        await screen.findByDisplayValue('npx @sentry/agent-plugin install')
+        await screen.findByText('npx @sentry/agent-plugin install')
       ).toBeInTheDocument();
 
       act(resolveAgenticRunRequest);
@@ -729,7 +729,7 @@ describe('Onboarding', () => {
       expect(await screen.findByText('Agent Connected')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Switch to Manual'})).toBeInTheDocument();
       expect(
-        screen.queryByDisplayValue('npx @sentry/agent-plugin install')
+        screen.queryByText('npx @sentry/agent-plugin install')
       ).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary

- replace the installation command input with a wrapping `CodeBlock`
- replace the agent prompt input with a wrapping `CodeBlock`
- keep copy actions persistently visible for both setup snippets
- update onboarding assertions for rendered code content

Depends on the reusable CodeBlock behavior added in #122780.

## Testing

- `.venv/bin/prek run -q --files static/app/views/onboarding/components/agentSetupCard.tsx static/app/views/onboarding/onboarding.spec.tsx`
- `node scripts/test.js --ci --maxWorkers=75% --colors static/app/views/onboarding/onboarding.spec.tsx` (39 tests)