### PR TITLE
fix(seer): Make Autofix Overview responsive on narrow widths

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -78,6 +79,20 @@ import {useOverviewSeerDrawer} from './useOverviewSeerDrawer';
 const SeerTrialCTA = OverrideOrDefault({
   overrideName: 'component:seer-trial-cta',
 });
+
+const FilterBar = styled(Flex)`
+  @container (width < ${p => p.theme.container.sm}) {
+    > * {
+      flex: 1 1 calc(50% - ${p => p.theme.space.md});
+      min-width: 0;
+    }
+
+    > * > button {
+      width: 100%;
+      min-width: 0;
+    }
+  }
+`;
 
 const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
   {value: 'seer', label: t('Recent Seer Activity')},
@@ -334,8 +349,8 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   }
 
   return (
-    <Stack gap="lg" padding="lg xl">
-      <Flex gap="md" align="center" wrap="wrap">
+    <Stack gap="lg" padding={{xs: 'lg md', sm: 'lg xl'}}>
+      <FilterBar gap="md" align="center" wrap="wrap">
         {pageFiltersReady && projectsLoaded ? (
           <PageFilterBar condensed>
             <ProjectPageFilter />
@@ -373,7 +388,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
         />
-      </Flex>
+      </FilterBar>
       {isError ? (
         <LoadingError onRetry={refetch} />
       ) : resultsPending ? (

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Tag, type TagProps} from '@sentry/scraps/badge';
-import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
@@ -44,7 +44,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {CodeChanges} from './codeChanges';
 import {OpenSeerButton} from './openSeerButton';
 import {getProcessingLabel} from './overviewActions';
-import {ButtonSpinner, OverviewCardAction} from './overviewCardAction';
+import {ActionButtonBar, ButtonSpinner, OverviewCardAction} from './overviewCardAction';
 import {OverviewIssueAssignee} from './overviewIssueAssignee';
 import {
   OverviewIssuePriority,
@@ -162,7 +162,7 @@ function OverviewAction({
     });
   if (status === 'processing') {
     return (
-      <ButtonBar>
+      <ActionButtonBar>
         <Button
           size="sm"
           variant="secondary"
@@ -173,14 +173,14 @@ function OverviewAction({
           {getProcessingLabel(sectionKey)}
         </Button>
         <OpenSeerButton run={run} section={sectionKey} size="sm" variant="secondary" />
-      </ButtonBar>
+      </ActionButtonBar>
     );
   }
 
   if (sectionKey === 'merged') {
     if (pullRequests.length > 0) {
       return (
-        <Stack gap="xs" align="end">
+        <Stack gap="xs" align={{xs: 'start', sm: 'end'}} width="100%">
           {pullRequests.map(pullRequest => {
             const label = t('Merged #%s', pullRequest.number);
             const title = t('The pull request for this fix was merged.');
@@ -194,7 +194,7 @@ function OverviewAction({
               );
             }
             return (
-              <ButtonBar key={pullRequest.id}>
+              <ActionButtonBar key={pullRequest.id}>
                 <Tooltip title={title} skipWrapper>
                   <LinkButton
                     size="sm"
@@ -213,7 +213,7 @@ function OverviewAction({
                   size="sm"
                   variant="secondary"
                 />
-              </ButtonBar>
+              </ActionButtonBar>
             );
           })}
         </Stack>
@@ -241,8 +241,8 @@ function OverviewAction({
         : [];
 
     return (
-      <Stack align="end" gap="xs">
-        <ButtonBar>
+      <Stack align={{xs: 'start', sm: 'end'}} gap="xs" width="100%">
+        <ActionButtonBar>
           <LinkButton
             size="sm"
             variant="primary"
@@ -256,7 +256,7 @@ function OverviewAction({
             </Flex>
           </LinkButton>
           <OpenSeerButton run={run} section={sectionKey} size="sm" variant="primary" />
-        </ButtonBar>
+        </ActionButtonBar>
         {reviewStatusTag && (
           <Tag variant={reviewStatusTag.variant} icon={reviewStatusTag.icon}>
             {reviewStatusTag.label}
@@ -304,16 +304,18 @@ function OverviewAction({
 
   if (sectionKey === 'review_pr') {
     return (
-      <Tooltip title={REVIEW_PR_META.description} skipWrapper>
-        <LinkButton
-          size="sm"
-          variant="secondary"
-          icon={<REVIEW_PR_META.Icon />}
-          to={issueUrl}
-        >
-          {REVIEW_PR_META.label}
-        </LinkButton>
-      </Tooltip>
+      <ActionButtonBar>
+        <Tooltip title={REVIEW_PR_META.description} skipWrapper>
+          <LinkButton
+            size="sm"
+            variant="secondary"
+            icon={<REVIEW_PR_META.Icon />}
+            to={issueUrl}
+          >
+            {REVIEW_PR_META.label}
+          </LinkButton>
+        </Tooltip>
+      </ActionButtonBar>
     );
   }
 
@@ -579,108 +581,133 @@ export function OverviewCard({
       section: sectionKey,
     });
 
+  const showCodeChanges = Boolean(
+    sectionKey === 'code_changes_ready' && run.codeChanges?.length
+  );
+  const showEnrichmentPlaceholder = enrichmentPending && Boolean(reviewPullRequest?.url);
+  const showPullRequestFiles =
+    !showEnrichmentPlaceholder && Boolean(reviewPullRequest) && changedFiles.length > 0;
+  const hasBody = Boolean(
+    rootCause ||
+    proposedFix ||
+    showCodeChanges ||
+    showEnrichmentPlaceholder ||
+    showPullRequestFiles
+  );
+
   return (
     <CardFrame
       containerRef={cardRef}
-      aside={
-        <Fragment>
-          <OverviewAction
-            sectionKey={sectionKey}
-            run={run}
-            reviewPullRequest={reviewPullRequest}
-            issueUrl={issueUrl}
-            projectConfig={projectConfig}
-          />
-          <PriorityAndAssignee
-            run={run}
-            memberList={memberList}
-            assigneeReady={assigneeReady}
-          />
-        </Fragment>
-      }
-    >
-      {/* Grid, not flex: items stretch by default, so the level bar spans
-          every wrapped title line and the text cell can't escape the row */}
-      <Grid columns="max-content minmax(0, 1fr)" gap="sm">
-        <LevelBar level={run.issue.level ?? undefined} />
-        <Stack minWidth="0" gap="xs">
-          <Text bold display="block" textWrap="pretty" wordBreak="break-word" size="lg">
-            <TitleLink
-              to={issueUrl}
-              onClick={() =>
-                trackAnalytics('autofix.overview.issue_clicked', {
-                  organization,
-                  group_id: run.groupId,
-                  run_id: run.seerRunId,
-                  section: sectionKey,
-                })
-              }
-            >
-              {run.title}
-            </TitleLink>
-          </Text>
-          <Flex wrap="wrap" gap="md" align="center">
-            <Flex gap="xs" align="center">
-              <ProjectAvatar
-                project={run.issue.project}
-                size={12}
-                hasTooltip
-                tooltip={run.issue.project.slug}
+      title={
+        // Grid, not flex: items stretch by default, so the level bar spans
+        // every wrapped title line and the text cell can't escape the row
+        <Grid columns="max-content minmax(0, 1fr)" gap="sm">
+          <LevelBar level={run.issue.level ?? undefined} />
+          <Stack minWidth="0" gap="xs">
+            <Text bold display="block" textWrap="pretty" wordBreak="break-word" size="lg">
+              <TitleLink
+                to={issueUrl}
+                onClick={() =>
+                  trackAnalytics('autofix.overview.issue_clicked', {
+                    organization,
+                    group_id: run.groupId,
+                    run_id: run.seerRunId,
+                    section: sectionKey,
+                  })
+                }
+              >
+                {run.title}
+              </TitleLink>
+            </Text>
+            <Flex wrap="wrap" gap="md" align="center">
+              <Flex gap="xs" align="center">
+                <ProjectAvatar
+                  project={run.issue.project}
+                  size={12}
+                  hasTooltip
+                  tooltip={run.issue.project.slug}
+                />
+                <Text size="sm" monospace variant="muted">
+                  {run.shortId}
+                </Text>
+              </Flex>
+              <IssueVitals
+                run={run}
+                statsPeriod={statsPeriod}
+                vitalsPending={vitalsPending}
               />
-              <Text size="sm" monospace variant="muted">
-                {run.shortId}
-              </Text>
             </Flex>
-            <IssueVitals
-              run={run}
-              statsPeriod={statsPeriod}
-              vitalsPending={vitalsPending}
-            />
-          </Flex>
-        </Stack>
-      </Grid>
-      {rootCause && (
-        <NarrativeBlock
-          icon={<IconBug size="xs" variant="secondary" aria-hidden />}
-          label={t('Root Cause')}
-        >
-          {rootCause}
-        </NarrativeBlock>
-      )}
-      {proposedFix && (
-        <NarrativeBlock
-          icon={<IconCommit size="xs" variant="secondary" aria-hidden />}
-          label={t('Plan')}
-        >
-          {proposedFix}
-        </NarrativeBlock>
-      )}
-      {sectionKey === 'code_changes_ready' && run.codeChanges?.length ? (
-        <CodeChanges
-          codeChanges={run.codeChanges}
-          onFirstExpand={trackCodeChangesExpanded}
+          </Stack>
+        </Grid>
+      }
+      meta={
+        <PriorityAndAssignee
+          run={run}
+          memberList={memberList}
+          assigneeReady={assigneeReady}
         />
-      ) : null}
-      {enrichmentPending && reviewPullRequest?.url ? (
-        <Placeholder height="3rem" />
-      ) : reviewPullRequest && changedFiles.length > 0 ? (
-        <PullRequestFiles
-          orgSlug={orgSlug}
-          pullRequest={reviewPullRequest}
-          onFirstExpand={trackCodeChangesExpanded}
+      }
+      actions={
+        <OverviewAction
+          sectionKey={sectionKey}
+          run={run}
+          reviewPullRequest={reviewPullRequest}
+          issueUrl={issueUrl}
+          projectConfig={projectConfig}
         />
-      ) : null}
-    </CardFrame>
+      }
+      body={
+        hasBody ? (
+          <Fragment>
+            {rootCause && (
+              <NarrativeBlock
+                icon={<IconBug size="xs" variant="secondary" aria-hidden />}
+                label={t('Root Cause')}
+              >
+                {rootCause}
+              </NarrativeBlock>
+            )}
+            {proposedFix && (
+              <NarrativeBlock
+                icon={<IconCommit size="xs" variant="secondary" aria-hidden />}
+                label={t('Plan')}
+              >
+                {proposedFix}
+              </NarrativeBlock>
+            )}
+            {showCodeChanges && run.codeChanges ? (
+              <CodeChanges
+                codeChanges={run.codeChanges}
+                onFirstExpand={trackCodeChangesExpanded}
+              />
+            ) : null}
+            {showEnrichmentPlaceholder ? (
+              <Placeholder height="3rem" />
+            ) : showPullRequestFiles && reviewPullRequest ? (
+              <PullRequestFiles
+                orgSlug={orgSlug}
+                pullRequest={reviewPullRequest}
+                onFirstExpand={trackCodeChangesExpanded}
+              />
+            ) : null}
+          </Fragment>
+        ) : undefined
+      }
+    />
   );
 }
 
 function CardFrame({
-  aside,
-  children,
+  actions,
+  body,
+  meta,
+  title,
   containerRef,
 }: {
-  aside: React.ReactNode;
-  children: React.ReactNode;
+  actions: React.ReactNode;
+  meta: React.ReactNode;
+  title: React.ReactNode;
+  body?: React.ReactNode;
   containerRef?: React.Ref<HTMLDivElement>;
 }) {
   return (
@@ -691,27 +718,45 @@ function CardFrame({
       radius="md"
       padding="xl"
     >
-      <Stack gap="xl">
-        <Flex
-          gap={{xs: 'xl', sm: '3xl'}}
-          align="stretch"
-          justify="between"
-          direction={{xs: 'column-reverse', sm: 'row'}}
-        >
-          <Stack gap="lg" minWidth="0" flex="1">
-            {children}
+      <Grid
+        areas={{
+          xs: body ? `"title" "meta" "body" "actions"` : `"title" "meta" "actions"`,
+          sm: body ? `"title aside" "body aside"` : `"title aside"`,
+        }}
+        columns={{xs: 'minmax(0, 1fr)', sm: 'minmax(0, 1fr) max-content'}}
+        rows={{xs: 'auto', sm: body ? 'auto 1fr' : 'auto'}}
+        gap={{xs: 'lg', sm: 'lg 3xl'}}
+      >
+        <Container area="title" minWidth="0">
+          {title}
+        </Container>
+        {body ? (
+          <Stack area="body" gap="lg" minWidth="0">
+            {body}
           </Stack>
-
-          {/* justify=between + parent align=stretch pins the action to the top
-              and the priority/assignee controls to the bottom-right */}
-          <Stack gap="lg" align="end" justify="between" flexShrink={0} minWidth="0">
-            {aside}
+        ) : null}
+        <Aside gap="lg" align="end" justify="between">
+          <Stack area="actions" align={{xs: 'start', sm: 'end'}}>
+            {actions}
           </Stack>
-        </Flex>
-      </Stack>
+          <Flex area="meta" align="center">
+            {meta}
+          </Flex>
+        </Aside>
+      </Grid>
     </Container>
   );
 }
+
+const Aside = styled(Stack)`
+  grid-area: aside;
+
+  @container (width < ${p => p.theme.container.sm}) {
+    && {
+      display: contents;
+    }
+  }
+`;
 
 export function TextLineSkeleton({
   size,
@@ -731,34 +776,37 @@ export function OverviewCardSkeleton() {
   const theme = useTheme();
   return (
     <CardFrame
-      aside={
+      title={
+        <Grid columns="max-content minmax(0, 1fr)" gap="sm">
+          <LevelBar />
+          <Stack minWidth="0" gap="xs">
+            <TextLineSkeleton size="lg" width="70%" />
+            <Flex wrap="wrap" gap="md" align="center">
+              {['4.5rem', '4rem', '4rem', '5rem', '5rem'].map((width, index) => (
+                <TextLineSkeleton key={index} size="sm" width={width} />
+              ))}
+            </Flex>
+          </Stack>
+        </Grid>
+      }
+      meta={
+        <Flex gap="xs">
+          <Placeholder height={theme.form.xs.height} width={theme.form.xs.height} />
+          <Placeholder height={theme.form.xs.height} width={theme.form.xs.height} />
+        </Flex>
+      }
+      actions={<Placeholder height={theme.form.sm.height} width="9rem" />}
+      body={
         <Fragment>
-          <Placeholder height={theme.form.sm.height} width="9rem" />
-          <Flex gap="xs">
-            <Placeholder height={theme.form.xs.height} width={theme.form.xs.height} />
-            <Placeholder height={theme.form.xs.height} width={theme.form.xs.height} />
-          </Flex>
+          {['90%', '75%'].map((width, index) => (
+            <Stack key={index} gap="xs">
+              <TextLineSkeleton size="xs" width="4rem" />
+              <TextLineSkeleton size="sm" width={width} />
+            </Stack>
+          ))}
+          <Placeholder />
         </Fragment>
       }
-    >
-      <Grid columns="max-content minmax(0, 1fr)" gap="sm">
-        <LevelBar />
-        <Stack minWidth="0" gap="xs">
-          <TextLineSkeleton size="lg" width="70%" />
-          <Flex wrap="wrap" gap="md" align="center">
-            {['4.5rem', '4rem', '4rem', '5rem', '5rem'].map((width, index) => (
-              <TextLineSkeleton key={index} size="sm" width={width} />
-            ))}
-          </Flex>
-        </Stack>
-      </Grid>
-      {['90%', '75%'].map((width, index) => (
-        <Stack key={index} gap="xs">
-          <TextLineSkeleton size="xs" width="4rem" />
-          <TextLineSkeleton size="sm" width={width} />
-        </Stack>
-      ))}
-      <Placeholder />
-    </CardFrame>
+    />
   );
 }

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.tsx
@@ -127,9 +127,11 @@ export function OverviewCardAction({
 
   if (isDispatched) {
     return (
-      <Button size="sm" variant="secondary" disabled icon={<ButtonSpinner size={14} />}>
-        {config.busyLabel}
-      </Button>
+      <ActionButtonBar>
+        <Button size="sm" variant="secondary" disabled icon={<ButtonSpinner size={14} />}>
+          {config.busyLabel}
+        </Button>
+      </ActionButtonBar>
     );
   }
 
@@ -154,7 +156,7 @@ export function OverviewCardAction({
   ) : null;
 
   return (
-    <ButtonBar>
+    <ActionButtonBar>
       {permissionsButton ?? (
         <Tooltip title={config.description} skipWrapper>
           <Button
@@ -193,10 +195,17 @@ export function OverviewCardAction({
           </DropdownMenuFooter>
         }
       />
-    </ButtonBar>
+    </ActionButtonBar>
   );
 }
 
 export const ButtonSpinner = styled(LoadingIndicator)`
   margin: 0;
+`;
+
+export const ActionButtonBar = styled(ButtonBar)`
+  @container (width < ${p => p.theme.container.sm}) {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
+  }
 `;

--- a/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
+++ b/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
@@ -3,6 +3,7 @@ import {Link} from '@sentry/scraps/link';
 
 import {t, tct, tn} from 'sentry/locale';
 import {oxfordizeArray} from 'sentry/utils/oxfordizeArray';
+import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 
 import type {ProjectConfig} from './types';
 
@@ -25,7 +26,10 @@ function formatProjectNames(slugs: string[]) {
 }
 
 export function ProjectSetupWarning({unconfiguredProjects, orgSlug}: Props) {
-  const names = formatProjectNames(unconfiguredProjects.map(project => project.slug));
+  const breakpoints = useBreakpoints();
+  const names = breakpoints.xs
+    ? formatProjectNames(unconfiguredProjects.map(project => project.slug))
+    : tn('%s project', '%s projects', unconfiguredProjects.length);
 
   return (
     <Alert variant="warning" showIcon>


### PR DESCRIPTION
The Autofix Overview page assumed a wide content column. On phones and in squeezed columns (e.g. the Seer drawer open at 80% width) the filter bar wrapped raggedly, card action buttons overflowed, and the project setup warning listed every unconfigured project slug.

## Cards

Cards now use a grid with named areas instead of a `column-reverse` flex. Below the `sm` container width a card reads top-to-bottom (title → priority/assignee → root cause/plan/code changes → actions at the bottom); wider containers keep the existing layout with actions pinned top-right and priority/assignee bottom-right. The body area only renders when a card has narrative or code-change content, so sparse cards don't leave a phantom gap.

## Action buttons

Card action buttons share a new `ActionButtonBar` that spans the full card below the `sm` container width, letting the label button absorb the width while trailing icon buttons (Open Seer, the options dropdown) stay fixed. PR status tags left-align under the button on narrow widths.

## Filter bar

The filter bar's `CompactSelect` triggers are `width: max-content`, so they couldn't shrink and the row wrapped unevenly. Below the `sm` container width each filter is now a stretchable half-row cell.

## Project setup warning

Shows a project count ("Seer isn't set up for 182 projects.") instead of naming every slug below the `xs` viewport breakpoint.

Breakpoints are container-based (resolved against the main content column, which `organizationLayout` marks as a query container), so a card squeezed by the Seer drawer gets the narrow treatment too — not just phones. The setup warning is the one viewport-based check, matching the existing `breakpoints.xs` pattern on this page.

Frontend-only.