### PR TITLE
ref(seer): Centralize product client construction

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -15,11 +15,10 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
 from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashboard
-from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
 from sentry.models.dashboard import Dashboard
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.factory import create_dashboard_generation_client
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -195,14 +194,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
             on_page_context = CREATE_ON_PAGE_CONTEXT
 
         try:
-            client = SeerAgentClient(
-                organization,
-                request.user,
-                on_completion_hook=DashboardOnCompletionHook,
-                category_key="dashboard_generate",
-                category_value=str(organization.id),
-                reasoning_effort="medium",
-            )
+            client = create_dashboard_generation_client(organization, request.user)
             run = client.start_run(
                 prompt=prompt,
                 on_page_context=on_page_context,

--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -47,6 +47,10 @@ from sentry.models.project import Project
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import MemoryBlock, SeerRunState
 from sentry.seer.agent.client_utils import AgentUpdateRequest, make_agent_update_request
+from sentry.seer.agent.factory import (
+    create_investigation_execution_client,
+    create_investigation_title_client,
+)
 from sentry.seer.agent.on_completion_hook import AgentOnCompletionHook
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
@@ -174,15 +178,7 @@ def start_execution_run(
 ) -> None:
     is_query = execution.block.kind == InvestigationBlockKind.QUERY
     if client is None:
-        client = SeerAgentClient(organization, user)
-    client.on_completion_hook = InvestigationAgentCompletionHook
-    client.is_interactive = is_query
-    client.enable_code_mode_tools = "only" if is_query else "off"
-    client.enable_coding = False
-    client.enable_bash_tools = False
-    client.enable_embeds = is_query
-    client.enable_streaming = True
-    client.max_iterations = 20 if is_query else 5
+        client = create_investigation_execution_client(organization, user, is_query=is_query)
     dispatch_won: bool | None = None
 
     def mark_dispatched(run: Any) -> None:
@@ -977,17 +973,7 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
     if investigation.summary is not None and investigation.summary_description is not None:
         return
     user = user_service.get_user(user_id=user_id) if user_id else None
-    client = SeerAgentClient(
-        investigation.organization,
-        user,
-        on_completion_hook=InvestigationAgentCompletionHook,
-        enable_code_mode_tools="only",
-        enable_coding=False,
-        enable_bash_tools=False,
-        enable_embeds=False,
-        enable_streaming=True,
-        max_iterations=3,
-    )
+    client = create_investigation_title_client(investigation.organization, user)
     block_context = "\n".join(_completion_block_context(block) for block in blocks)
     prompt = (
         "Describe a completed Sentry investigation. Do not use tools. Return exactly one raw JSON "

--- a/src/sentry/investigations/endpoints/organization_investigation_block_executions.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_block_executions.py
@@ -28,7 +28,7 @@ from sentry.investigations.services import (
     mark_block_execution_dispatch_failed,
 )
 from sentry.models.organization import Organization
-from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.agent.factory import create_investigation_execution_client
 from sentry.utils import metrics
 
 
@@ -65,7 +65,11 @@ class OrganizationInvestigationBlockExecutionsEndpoint(OrganizationInvestigation
         else:
             project_ids = []
 
-        client = SeerAgentClient(organization, request.user)
+        client = create_investigation_execution_client(
+            organization,
+            request.user,
+            is_query=block.kind == InvestigationBlockKind.QUERY,
+        )
         try:
             execution, created = create_block_execution(
                 block=block,

--- a/src/sentry/seer/agent/factory.py
+++ b/src/sentry/seer/agent/factory.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from sentry.seer.agent.client import SeerAgentClient
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
+
+    from sentry.models.group import Group
+    from sentry.users.models.user import User
+    from sentry.users.services.user import RpcUser
+
+
+def create_autofix_client(
+    group: Group,
+    *,
+    intelligence_level: Literal["low", "medium", "high"] = "medium",
+    reasoning_effort: Literal["low", "medium", "high"] | None = None,
+    enable_coding: bool = False,
+    code_review_enabled: bool = False,
+    enable_bash_tools: bool = False,
+    enable_pr_context_tools: bool = False,
+    user: User | RpcUser | AnonymousUser | None = None,
+) -> SeerAgentClient:
+    """Create a client for Autofix runs.
+
+    Referrers describe individual runs and should be passed when dispatching them.
+    """
+    from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+
+    return SeerAgentClient(
+        organization=group.organization,
+        project=group.project,
+        group=group,
+        user=user,
+        category_key="autofix",
+        category_value=str(group.id),
+        intelligence_level=intelligence_level,
+        reasoning_effort=reasoning_effort,
+        on_completion_hook=AutofixOnCompletionHook,
+        enable_coding=enable_coding,
+        code_review_enabled=code_review_enabled,
+        enable_bash_tools=enable_bash_tools,
+        enable_pr_context_tools=enable_pr_context_tools,
+    )

--- a/src/sentry/seer/agent/factory.py
+++ b/src/sentry/seer/agent/factory.py
@@ -1,3 +1,5 @@
+"""Configured Seer agent clients for product integrations."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
@@ -8,10 +10,12 @@ if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser
 
     from sentry.models.group import Group
+    from sentry.models.organization import Organization
     from sentry.users.models.user import User
     from sentry.users.services.user import RpcUser
 
 
+# Product hook modules import their callers, so load hooks only when a factory is invoked.
 def create_autofix_client(
     group: Group,
     *,
@@ -43,4 +47,84 @@ def create_autofix_client(
         code_review_enabled=code_review_enabled,
         enable_bash_tools=enable_bash_tools,
         enable_pr_context_tools=enable_pr_context_tools,
+    )
+
+
+def create_dashboard_generation_client(
+    organization: Organization,
+    user: User | RpcUser | AnonymousUser,
+) -> SeerAgentClient:
+    from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
+
+    return SeerAgentClient(
+        organization,
+        user,
+        on_completion_hook=DashboardOnCompletionHook,
+        category_key="dashboard_generate",
+        category_value=str(organization.id),
+        reasoning_effort="medium",
+    )
+
+
+def create_operator_client(
+    organization: Organization,
+    user: User | RpcUser | None,
+    *,
+    category_key: str,
+    category_value: str,
+    enable_code_mode_tools: str = "off",
+) -> SeerAgentClient:
+    from sentry.seer.entrypoints.operator import SeerOperatorCompletionHook
+
+    return SeerAgentClient(
+        organization=organization,
+        user=user,
+        category_key=category_key,
+        category_value=category_value,
+        on_completion_hook=SeerOperatorCompletionHook,
+        is_interactive=True,
+        enable_coding=False,
+        enable_code_mode_tools=enable_code_mode_tools,
+        enable_embeds=False,
+    )
+
+
+def create_investigation_execution_client(
+    organization: Organization,
+    user: User | RpcUser | AnonymousUser | None,
+    *,
+    is_query: bool,
+) -> SeerAgentClient:
+    from sentry.investigations.agent import InvestigationAgentCompletionHook
+
+    return SeerAgentClient(
+        organization,
+        user,
+        on_completion_hook=InvestigationAgentCompletionHook,
+        is_interactive=is_query,
+        enable_code_mode_tools="only" if is_query else "off",
+        enable_coding=False,
+        enable_bash_tools=False,
+        enable_embeds=is_query,
+        enable_streaming=True,
+        max_iterations=20 if is_query else 5,
+    )
+
+
+def create_investigation_title_client(
+    organization: Organization,
+    user: User | RpcUser | AnonymousUser | None,
+) -> SeerAgentClient:
+    from sentry.investigations.agent import InvestigationAgentCompletionHook
+
+    return SeerAgentClient(
+        organization,
+        user,
+        on_completion_hook=InvestigationAgentCompletionHook,
+        enable_code_mode_tools="only",
+        enable_coding=False,
+        enable_bash_tools=False,
+        enable_embeds=False,
+        enable_streaming=True,
+        max_iterations=3,
     )

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -30,6 +30,7 @@ from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.agent.factory import create_autofix_client
 from sentry.seer.autofix.artifact_schemas import (
     RootCauseArtifact,
     SolutionArtifact,
@@ -381,39 +382,8 @@ def get_iteration_for_insert_index(state: SeerRunState, insert_index: int) -> in
     return int(metadata["iteration_index"])
 
 
-def get_autofix_agent_client(
-    group: Group,
-    intelligence_level: Literal["low", "medium", "high"] = "medium",
-    reasoning_effort: Literal["low", "medium", "high"] | None = None,
-    enable_coding: bool = False,
-    code_review_enabled: bool = False,
-    enable_bash_tools: bool = False,
-    enable_pr_context_tools: bool = False,
-    user: User | RpcUser | AnonymousUser | None = None,
-) -> SeerAgentClient:
-    from sentry.seer.autofix.on_completion_hook import (
-        AutofixOnCompletionHook,  # nested to avoid circular import
-    )
-
-    return SeerAgentClient(
-        organization=group.organization,
-        project=group.project,
-        group=group,
-        user=user,
-        category_key="autofix",
-        category_value=str(group.id),
-        intelligence_level=intelligence_level,
-        reasoning_effort=reasoning_effort,
-        on_completion_hook=AutofixOnCompletionHook,
-        enable_coding=enable_coding,
-        code_review_enabled=code_review_enabled,
-        enable_bash_tools=enable_bash_tools,
-        enable_pr_context_tools=enable_pr_context_tools,
-    )
-
-
 def get_autofix_run_state(group: Group, run_id: int) -> SeerRunState:
-    client = get_autofix_agent_client(group)
+    client = create_autofix_client(group)
     return _get_group_run_state(client, group, run_id)
 
 
@@ -588,7 +558,7 @@ def trigger_autofix_agent(
         and features.has("organizations:autofix-should-run-repo-checks", group.organization)
     )
 
-    client = get_autofix_agent_client(
+    client = create_autofix_client(
         group,
         enable_bash_tools=enable_bash_tools,
         enable_coding=config.enable_coding,
@@ -873,7 +843,7 @@ def trigger_coding_agent_handoff(
             "failures": [{"error_message": "No repositories configured in project preferences"}],
         }
 
-    client = get_autofix_agent_client(group)
+    client = create_autofix_client(group)
     state = _get_group_run_state(client, group, run_id)
 
     repo = _get_relevant_repo(state, repo_definitions, run_id, group)
@@ -946,7 +916,7 @@ def trigger_push_changes(
     ):
         raise PermissionDenied("Code generation is disabled for this organization")
 
-    client = get_autofix_agent_client(group)
+    client = create_autofix_client(group)
 
     if state is None:
         state = _get_group_run_state(client, group, run_id)

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -9,9 +9,9 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcOrganization
-from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import CodingAgentState, SeerRunState
 from sentry.seer.agent.client_utils import fetch_run_status
+from sentry.seer.agent.factory import create_operator_client
 from sentry.seer.agent.on_completion_hook import AgentOnCompletionHook
 from sentry.seer.autofix.commit_author import commit_author_for_user
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -521,20 +521,12 @@ class SeerAgentOperator[CachePayloadT]:
                 enable_code_mode_tools = "only"
 
             try:
-                # RpcUser is not in SeerAgentClient's type signature but works at runtime
-                client = SeerAgentClient(
+                client = create_operator_client(
                     organization=organization,
                     user=user,
                     category_key=category_key,
                     category_value=category_value,
-                    on_completion_hook=SeerOperatorCompletionHook,
-                    is_interactive=True,
-                    enable_coding=False,
                     enable_code_mode_tools=enable_code_mode_tools,
-                    # Entrypoints (e.g. Slack) render responses as plain markdown and
-                    # can't display embed widgets, so the raw Markdoc tags would leak as
-                    # text. Don't ask the agent to emit them in the first place.
-                    enable_embeds=False,
                 )
             except SeerPermissionError as e:
                 with SeerOperatorEventLifecycleMetric(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -4,7 +4,6 @@ import uuid
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
-from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
 from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -29,7 +28,9 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         response = self.client.post(self.url, data, format="json")
         assert response.status_code == 400
 
-    @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerAgentClient")
+    @patch(
+        "sentry.dashboards.endpoints.organization_dashboard_generate.create_dashboard_generation_client"
+    )
     def test_post_starts_run_and_returns_run_id(self, mock_client_class: MagicMock) -> None:
         run_uuid = uuid.uuid4()
         mock_client = MagicMock()
@@ -42,14 +43,7 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 789, "sentry_run_id": str(run_uuid)}
 
-        mock_client_class.assert_called_once_with(
-            self.organization,
-            ANY,
-            on_completion_hook=DashboardOnCompletionHook,
-            category_key="dashboard_generate",
-            category_value=str(self.organization.id),
-            reasoning_effort="medium",
-        )
+        mock_client_class.assert_called_once_with(self.organization, ANY)
         call_kwargs = mock_client.start_run.call_args[1]
         assert "Show me error rates by project" in call_kwargs["prompt"]
         assert call_kwargs["artifact_key"] == "dashboard"
@@ -66,7 +60,9 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         response = self.client.post(self.url, data, format="json")
         assert response.status_code == 403
 
-    @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerAgentClient")
+    @patch(
+        "sentry.dashboards.endpoints.organization_dashboard_generate.create_dashboard_generation_client"
+    )
     def test_post_seer_permission_error_returns_403(self, mock_client_class: MagicMock) -> None:
         mock_client = MagicMock()
         mock_client.start_run.side_effect = SeerPermissionError("Forbidden")
@@ -95,7 +91,9 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         response = self.client.post(self.url, data, format="json")
         assert response.status_code == 400
 
-    @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerAgentClient")
+    @patch(
+        "sentry.dashboards.endpoints.organization_dashboard_generate.create_dashboard_generation_client"
+    )
     def test_post_with_current_dashboard_uses_edit_context(
         self, mock_client_class: MagicMock
     ) -> None:
@@ -135,14 +133,7 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data == {"run_id": 123, "sentry_run_id": str(run_uuid)}
 
-        mock_client_class.assert_called_once_with(
-            self.organization,
-            ANY,
-            on_completion_hook=DashboardOnCompletionHook,
-            category_key="dashboard_generate",
-            category_value=str(self.organization.id),
-            reasoning_effort="medium",
-        )
+        mock_client_class.assert_called_once_with(self.organization, ANY)
 
         # Verify on_page_context includes the current dashboard JSON
         call_kwargs = mock_client.start_run.call_args[1]

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_block_executions.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_block_executions.py
@@ -54,7 +54,7 @@ class InvestigationQueryExecutionEndpointTest(APITestCase):
         )
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_starts_and_persists_an_immutable_execution(self, mock_client: MagicMock) -> None:
         self.investigation.filters = {
@@ -95,7 +95,7 @@ class InvestigationQueryExecutionEndpointTest(APITestCase):
         assert mock_client.return_value.start_run.call_args.kwargs["record_in_history"] is False
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_retry_while_running_returns_the_same_execution(self, mock_client: MagicMock) -> None:
         run = self.create_seer_run(organization=self.organization, type=SeerRunType.FEATURE_RUN)
@@ -118,7 +118,7 @@ class InvestigationQueryExecutionEndpointTest(APITestCase):
         assert mock_client.return_value.start_run.call_count == 1
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_new_run_request_supersedes_an_identical_running_execution(
         self, mock_client: MagicMock
@@ -148,7 +148,7 @@ class InvestigationQueryExecutionEndpointTest(APITestCase):
         assert str(self.block.current_execution.id) == second.data["id"]
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_hidden_template_hint_is_forwarded_without_a_request_dataset(
         self, mock_client: MagicMock
@@ -176,7 +176,7 @@ class InvestigationQueryExecutionEndpointTest(APITestCase):
         assert '"datasetHint":"metrics"' in prompt
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_sends_actual_upstream_block_content_as_query_context(
         self, mock_client: MagicMock
@@ -209,7 +209,7 @@ class InvestigationQueryExecutionEndpointTest(APITestCase):
         assert "Focus on the checkout regression." in prompt
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_dispatch_failure_cancels_other_active_cells(self, mock_client: MagicMock) -> None:
         sibling_block = self.create_investigation_block(
@@ -295,7 +295,7 @@ class InvestigationTextExecutionEndpointTest(APITestCase):
         )
 
     @patch(
-        "sentry.investigations.endpoints.organization_investigation_block_executions.SeerAgentClient"
+        "sentry.investigations.endpoints.organization_investigation_block_executions.create_investigation_execution_client"
     )
     def test_starts_text_generation_with_typed_context(self, mock_client: MagicMock) -> None:
         sibling_text = self.create_investigation_block(

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -1150,7 +1150,7 @@ class InvestigationAgentTest(TestCase):
             (("investigations.failed",), {"tags": attributes, "sample_rate": 1.0}),
         ]
 
-    @patch("sentry.investigations.agent.SeerAgentClient")
+    @patch("sentry.investigations.agent.create_investigation_title_client")
     def test_title_prompt_uses_specific_incident_source_context(
         self, mock_client: MagicMock
     ) -> None:
@@ -1178,7 +1178,7 @@ class InvestigationAgentTest(TestCase):
         assert "Avoid headings and jargon" in prompt
 
     @patch("sentry.investigations.agent.record_investigation_completed")
-    @patch("sentry.investigations.agent.SeerAgentClient")
+    @patch("sentry.investigations.agent.create_investigation_title_client")
     def test_title_generation_waits_for_every_auto_run_block(
         self, mock_client: MagicMock, record_completed: MagicMock
     ) -> None:
@@ -1200,7 +1200,7 @@ class InvestigationAgentTest(TestCase):
         mock_client.return_value.start_run.assert_called_once()
         record_completed.assert_not_called()
 
-    @patch("sentry.investigations.agent.SeerAgentClient")
+    @patch("sentry.investigations.agent.create_investigation_title_client")
     def test_title_generation_skips_an_in_flight_run(self, mock_client: MagicMock) -> None:
         self.investigation.update(
             title=DEFAULT_INVESTIGATION_TITLE, title_generation_status="running"
@@ -1212,7 +1212,7 @@ class InvestigationAgentTest(TestCase):
         self.investigation.refresh_from_db()
         assert self.investigation.title_generation_status == "running"
 
-    @patch("sentry.investigations.agent.SeerAgentClient")
+    @patch("sentry.investigations.agent.create_investigation_title_client")
     def test_title_generation_does_not_retry_a_failed_run(self, mock_client: MagicMock) -> None:
         self.investigation.update(
             title=DEFAULT_INVESTIGATION_TITLE, title_generation_status="failed"
@@ -1224,7 +1224,7 @@ class InvestigationAgentTest(TestCase):
         self.investigation.refresh_from_db()
         assert self.investigation.title_generation_status == "failed"
 
-    @patch("sentry.investigations.agent.SeerAgentClient")
+    @patch("sentry.investigations.agent.create_investigation_title_client")
     def test_title_generation_does_not_retry_a_legacy_completed_run(
         self, mock_client: MagicMock
     ) -> None:
@@ -1239,7 +1239,7 @@ class InvestigationAgentTest(TestCase):
 
         mock_client.assert_not_called()
 
-    @patch("sentry.investigations.agent.SeerAgentClient")
+    @patch("sentry.investigations.agent.create_investigation_title_client")
     def test_title_dispatch_failure_releases_the_in_flight_status(
         self, mock_client: MagicMock
     ) -> None:

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -20,6 +20,7 @@ from sentry.seer.agent.client_models import (
     RepoPRState,
     SeerRunState,
 )
+from sentry.seer.agent.factory import create_autofix_client
 from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
@@ -59,6 +60,40 @@ class TestSeerAgentClient(TestCase):
         client = SeerAgentClient(self.organization, self.user)
         assert client.organization == self.organization
         assert client.user == self.user
+
+    @patch("sentry.seer.agent.factory.SeerAgentClient")
+    def test_create_autofix_client_configures_client(self, mock_client_class):
+        from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+
+        group = self.create_group(organization=self.organization)
+
+        client = create_autofix_client(
+            group,
+            user=self.user,
+            intelligence_level="high",
+            reasoning_effort="low",
+            enable_coding=True,
+            code_review_enabled=True,
+            enable_bash_tools=True,
+            enable_pr_context_tools=True,
+        )
+
+        assert client == mock_client_class.return_value
+        mock_client_class.assert_called_once_with(
+            organization=self.organization,
+            project=group.project,
+            group=group,
+            user=self.user,
+            category_key="autofix",
+            category_value=str(group.id),
+            intelligence_level="high",
+            reasoning_effort="low",
+            on_completion_hook=AutofixOnCompletionHook,
+            enable_coding=True,
+            code_review_enabled=True,
+            enable_bash_tools=True,
+            enable_pr_context_tools=True,
+        )
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     def test_client_init_raises_when_coding_option_disabled(self, mock_access):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -20,7 +20,13 @@ from sentry.seer.agent.client_models import (
     RepoPRState,
     SeerRunState,
 )
-from sentry.seer.agent.factory import create_autofix_client
+from sentry.seer.agent.factory import (
+    create_autofix_client,
+    create_dashboard_generation_client,
+    create_investigation_execution_client,
+    create_investigation_title_client,
+    create_operator_client,
+)
 from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
@@ -93,6 +99,106 @@ class TestSeerAgentClient(TestCase):
             code_review_enabled=True,
             enable_bash_tools=True,
             enable_pr_context_tools=True,
+        )
+
+    @patch("sentry.seer.agent.factory.SeerAgentClient")
+    def test_create_dashboard_generation_client_configures_client(self, mock_client_class):
+        from sentry.dashboards.on_completion_hook import DashboardOnCompletionHook
+
+        client = create_dashboard_generation_client(self.organization, self.user)
+
+        assert client == mock_client_class.return_value
+        mock_client_class.assert_called_once_with(
+            self.organization,
+            self.user,
+            on_completion_hook=DashboardOnCompletionHook,
+            category_key="dashboard_generate",
+            category_value=str(self.organization.id),
+            reasoning_effort="medium",
+        )
+
+    @patch("sentry.seer.agent.factory.SeerAgentClient")
+    def test_create_operator_client_configures_client(self, mock_client_class):
+        from sentry.seer.entrypoints.operator import SeerOperatorCompletionHook
+
+        client = create_operator_client(
+            self.organization,
+            self.user,
+            category_key="slack_thread",
+            category_value="thread-123",
+            enable_code_mode_tools="only",
+        )
+
+        assert client == mock_client_class.return_value
+        mock_client_class.assert_called_once_with(
+            organization=self.organization,
+            user=self.user,
+            category_key="slack_thread",
+            category_value="thread-123",
+            on_completion_hook=SeerOperatorCompletionHook,
+            is_interactive=True,
+            enable_coding=False,
+            enable_code_mode_tools="only",
+            enable_embeds=False,
+        )
+
+    @patch("sentry.seer.agent.factory.SeerAgentClient")
+    def test_create_investigation_query_client_configures_client(self, mock_client_class):
+        from sentry.investigations.agent import InvestigationAgentCompletionHook
+
+        client = create_investigation_execution_client(self.organization, self.user, is_query=True)
+
+        assert client == mock_client_class.return_value
+        mock_client_class.assert_called_once_with(
+            self.organization,
+            self.user,
+            on_completion_hook=InvestigationAgentCompletionHook,
+            is_interactive=True,
+            enable_code_mode_tools="only",
+            enable_coding=False,
+            enable_bash_tools=False,
+            enable_embeds=True,
+            enable_streaming=True,
+            max_iterations=20,
+        )
+
+    @patch("sentry.seer.agent.factory.SeerAgentClient")
+    def test_create_investigation_text_client_configures_client(self, mock_client_class):
+        from sentry.investigations.agent import InvestigationAgentCompletionHook
+
+        client = create_investigation_execution_client(self.organization, self.user, is_query=False)
+
+        assert client == mock_client_class.return_value
+        mock_client_class.assert_called_once_with(
+            self.organization,
+            self.user,
+            on_completion_hook=InvestigationAgentCompletionHook,
+            is_interactive=False,
+            enable_code_mode_tools="off",
+            enable_coding=False,
+            enable_bash_tools=False,
+            enable_embeds=False,
+            enable_streaming=True,
+            max_iterations=5,
+        )
+
+    @patch("sentry.seer.agent.factory.SeerAgentClient")
+    def test_create_investigation_title_client_configures_client(self, mock_client_class):
+        from sentry.investigations.agent import InvestigationAgentCompletionHook
+
+        client = create_investigation_title_client(self.organization, self.user)
+
+        assert client == mock_client_class.return_value
+        mock_client_class.assert_called_once_with(
+            self.organization,
+            self.user,
+            on_completion_hook=InvestigationAgentCompletionHook,
+            enable_code_mode_tools="only",
+            enable_coding=False,
+            enable_bash_tools=False,
+            enable_embeds=False,
+            enable_streaming=True,
+            max_iterations=3,
         )
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -449,7 +449,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.seer.autofix.autofix_agent.SeerAutofixOperator.has_access", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.process_autofix_updates.apply_async")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_autofix_agent_sends_started_webhook_for_all_steps(
         self,
         mock_client_class,
@@ -507,7 +507,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_autofix_agent_sends_started_webhook_for_continued_run(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -538,11 +538,10 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_trigger_autofix_agent_passes_project_and_group_to_client(
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
+    def test_trigger_autofix_agent_uses_autofix_client_factory(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        """SeerAgentClient is constructed with project and group from the group."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
@@ -554,16 +553,19 @@ class TestTriggerAutofixAgent(TestCase):
             run_id=None,
         )
 
-        mock_client_class.assert_called_once()
-        call_kwargs = mock_client_class.call_args.kwargs
-        assert call_kwargs["project"] == self.group.project
-        assert call_kwargs["group"] == self.group
+        mock_client_class.assert_called_once_with(
+            self.group,
+            enable_bash_tools=False,
+            enable_coding=False,
+            enable_pr_context_tools=False,
+            user=None,
+        )
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_root_cause_routes_to_rca_feature_when_flagged(
         self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -601,7 +603,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_rca_feature_receives_stopping_point(
         self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -625,7 +627,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_solution_step_does_not_route_to_rca_feature(
         self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
     ):
@@ -650,7 +652,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_root_cause_uses_legacy_flow_without_flag(
         self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
     ):
@@ -673,7 +675,7 @@ class TestTriggerAutofixAgent(TestCase):
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
     @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_flagged_root_cause_still_enforces_quota(
         self, mock_client_class, mock_feature, mock_check_quota
     ):
@@ -692,7 +694,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_autofix_agent_metadata_omits_group_id(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -718,7 +720,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_pr_iteration_continued_run_increments_iteration_index(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -752,7 +754,7 @@ class TestTriggerAutofixAgent(TestCase):
         assert "referrer" not in call_kwargs["payload"]
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_pr_iteration_requires_existing_pr(self, mock_client_class, mock_broadcast):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -775,7 +777,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_pr_iteration_enabled_by_either_flag(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -820,7 +822,7 @@ class TestTriggerAutofixAgent(TestCase):
             trigger()
         assert mock_client.continue_run.call_count == 2
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
     def test_when_no_quota(self, mock_check_quota, mock_client_class):
         with pytest.raises(NoSeerQuotaException):
@@ -839,7 +841,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_records_seer_run_for_new_run(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -861,7 +863,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_does_not_record_seer_run_for_continued_run(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -884,7 +886,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_continued_run_permitted_with_no_remaining_budget(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -906,7 +908,7 @@ class TestTriggerAutofixAgent(TestCase):
         assert run == seer_run
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_continued_run_requires_matching_group(self, mock_client_class, mock_broadcast):
         other_group = self.create_group(project=self.project)
         mock_client = MagicMock()
@@ -927,7 +929,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_code_review_always_disabled(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -947,7 +949,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_pr_context_tools_disabled_on_non_pr_iteration_step(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -967,7 +969,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_pr_context_tools_enabled_on_pr_iteration_step(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -999,7 +1001,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_commit_author_serialized_into_iteration_metadata(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
@@ -1057,7 +1059,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_root_cause_includes_base_shas(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run, mock_scm_new
     ):
@@ -1089,7 +1091,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_code_changes_omits_base_shas_when_pr_iteration_disabled(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run, mock_scm_new
     ):
@@ -1113,7 +1115,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_non_root_cause_step_omits_base_shas(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run, mock_scm_new
     ):
@@ -1292,7 +1294,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         self.project.update_option("sentry:seer_automation_handoff_integration_id", 456)
         self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", auto_create_pr)
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_success(self, mock_client_class):
         """Test successful coding agent handoff."""
         mock_client = MagicMock()
@@ -1331,7 +1333,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert call_kwargs["issue_short_id"] == self.group.qualified_short_id
 
     @patch("sentry.seer.autofix.autofix_agent.analytics.record")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_records_referrer(self, mock_client_class, mock_record):
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -1352,7 +1354,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         event = mock_record.call_args.args[0]
         assert event.referrer == AutofixReferrer.SLACK.value
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_no_repos(self, mock_client_class):
         """Test handoff with no repositories in preferences returns failure."""
         mock_client = MagicMock()
@@ -1369,7 +1371,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert "No repositories configured" in result["failures"][0]["error_message"]
         mock_client.launch_coding_agents.assert_not_called()
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_rejects_run_from_different_group(self, mock_client_class):
         other_group = self.create_group(project=self.project)
         mock_client = MagicMock()
@@ -1387,7 +1389,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
 
         mock_client.launch_coding_agents.assert_not_called()
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_generates_prompt_from_artifacts(self, mock_client_class):
         """Test that prompt is generated from run state artifacts."""
         mock_client = MagicMock()
@@ -1425,7 +1427,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert "Memory leak in cache" in prompt
         assert "Add TTL to cache" in prompt
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_uses_group_title_for_branch(self, mock_client_class):
         """Test that branch_name_base is the group title behind a seer/ prefix."""
         mock_client = MagicMock()
@@ -1451,7 +1453,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["branch_name_base"] == f"seer/{self.group.title}"
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_fetches_auto_create_pr_from_preferences(
         self, mock_client_class
     ):
@@ -1476,7 +1478,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["auto_create_pr"] is True
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_defaults_auto_create_pr_false(self, mock_client_class):
         """Test that auto_create_pr defaults to False when automation_handoff not configured."""
         mock_client = MagicMock()
@@ -1499,7 +1501,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["auto_create_pr"] is False
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_uses_auto_create_pr_override(self, mock_client_class):
         """Test that manual handoff can force PR creation independent of automation settings."""
         mock_client = MagicMock()
@@ -1523,7 +1525,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         call_kwargs = mock_client.launch_coding_agents.call_args.kwargs
         assert call_kwargs["auto_create_pr"] is True
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_filters_to_relevant_repo(self, mock_client_class):
         """Test that only the repo named in relevant_repo is passed to launch_coding_agents."""
         mock_client = MagicMock()
@@ -1553,7 +1555,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert repos[0].name == "relevant-repo"
 
     @patch("sentry.seer.autofix.autofix_agent.logger")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_falls_back_to_first_repo_when_no_relevant_repo(
         self, mock_client_class, mock_logger
     ):
@@ -1587,7 +1589,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         )
 
     @patch("sentry.seer.autofix.autofix_agent.logger")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_falls_back_when_relevant_repo_doesnt_match(
         self, mock_client_class, mock_logger
     ):
@@ -1638,7 +1640,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
                 integration_id=456,
             )
 
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_keeps_branch_name_from_preferences_when_set(
         self, mock_client_class
     ):
@@ -1660,7 +1662,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert repos[0].branch_name == "release/v2"
 
     @patch("sentry.seer.autofix.autofix_agent._resolve_default_branch", return_value="main")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    @patch("sentry.seer.autofix.autofix_agent.create_autofix_client")
     def test_trigger_coding_agent_handoff_resolves_default_branch_when_empty(
         self, mock_client_class, mock_resolve
     ):

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -1184,7 +1184,7 @@ class TestSeerAgentOperatorCodeMode(TestCase):
         self.entrypoint = MockAgentEntrypoint()
         self.operator = SeerAgentOperator(self.entrypoint)
 
-    @patch("sentry.seer.entrypoints.operator.SeerAgentClient")
+    @patch("sentry.seer.entrypoints.operator.create_operator_client")
     def test_slack_code_mode_enabled(self, mock_client_cls):
         mock_client = Mock()
         mock_client.start_run.return_value = Mock(seer_run_state_id=1)
@@ -1203,7 +1203,7 @@ class TestSeerAgentOperatorCodeMode(TestCase):
         mock_client_cls.assert_called_once()
         assert mock_client_cls.call_args.kwargs["enable_code_mode_tools"] == "only"
 
-    @patch("sentry.seer.entrypoints.operator.SeerAgentClient")
+    @patch("sentry.seer.entrypoints.operator.create_operator_client")
     def test_slack_code_mode_disabled(self, mock_client_cls):
         mock_client = Mock()
         mock_client.start_run.return_value = Mock(seer_run_state_id=1)
@@ -1222,7 +1222,7 @@ class TestSeerAgentOperatorCodeMode(TestCase):
         assert mock_client_cls.call_args.kwargs["enable_code_mode_tools"] == "off"
         mock_client.latest_run.assert_called_once_with(only_current_user=False)
 
-    @patch("sentry.seer.entrypoints.operator.SeerAgentClient")
+    @patch("sentry.seer.entrypoints.operator.create_operator_client")
     def test_non_slack_category_ignores_flag(self, mock_client_cls):
         mock_client = Mock()
         mock_client.start_run.return_value = Mock(seer_run_state_id=1)


### PR DESCRIPTION
Adds a central `sentry.seer.agent.factory` composition point for discoverable, product-specific `SeerAgentClient` presets. Autofix, dashboard generation, operator entrypoints, investigation execution, and investigation title generation now use named factories that consistently apply their category, completion-hook, interaction, and tool configuration.

Generic lookups and simple feature-run clients remain direct so the catalog represents meaningful product configurations rather than wrapping every constructor. Referrer attribution also remains scoped to individual run dispatches instead of becoming client state.

Pre-commit lint and type hooks pass, and all 208 affected tests collect successfully. Local test execution was blocked by the Redis development container continuously restarting and refusing connections.
