### PR TITLE
fix(replays): handle replays missing their initial snapshot

### DIFF
--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -357,11 +357,14 @@ def mock_segment_fullsnapshot(
         childNodes=[bodyNode],
     )
 
+    timestamp_ms = ms(timestamp)  # rrweb timestamps are in ms
+
     return [
         {
             "type": EventType.FullSnapshot,
+            "timestamp": timestamp_ms,
             "data": {
-                "timestamp": ms(timestamp),  # rrweb timestamps are in ms
+                "timestamp": timestamp_ms,
                 "node": {
                     "type": EventType.DomContentLoaded,
                     "childNodes": [htmlNode],

--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -1,9 +1,13 @@
 import {duration} from 'moment-timezone';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
+import {
+  RRWebFullSnapshotFrameEventFixture,
+  RRWebInitFrameEventsFixture,
+} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
+import {stubIframeScrollTo} from 'sentry-test/iframeScrollTo';
 import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {ResponseMeta} from 'sentry/types/api';
@@ -51,9 +55,14 @@ const mockReplay = ReplayReader.factory({
   }),
   errors: [],
   fetching: false,
-  attachments: RRWebInitFrameEventsFixture({
-    timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
-  }),
+  attachments: [
+    ...RRWebInitFrameEventsFixture({
+      timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+    }),
+    RRWebFullSnapshotFrameEventFixture({
+      timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+    }),
+  ],
   clipWindow: {
     startTimestampMs: mockEventTimestampMs - 5_000,
     endTimestampMs: mockEventTimestampMs + 5_000,
@@ -109,6 +118,8 @@ jest.mock('screenfull', () => ({
 }));
 
 describe('ReplayClipPreview', () => {
+  beforeAll(stubIframeScrollTo);
+
   beforeEach(() => {
     mockIsFullscreen.mockReturnValue(false);
 

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -18,6 +18,7 @@ import {
   RRWebDOMFrameFixture,
   RRWebFullSnapshotFrameEventFixture,
   RRWebIncrementalSnapshotFrameEventFixture,
+  RRWebInitFrameEventsFixture,
 } from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
@@ -410,6 +411,60 @@ describe('ReplayReader', () => {
     });
 
     expect(replay?.hasCanvasElementInReplay()).toBe(true);
+  });
+
+  describe('processingErrors', () => {
+    const timestamp = new Date('2023-12-25T00:02:00');
+
+    it('reports no errors when the replay has both a meta frame and a full snapshot', () => {
+      const replay = ReplayReader.factory({
+        attachments: [
+          ...RRWebInitFrameEventsFixture({timestamp}),
+          RRWebFullSnapshotFrameEventFixture({timestamp}),
+        ],
+        errors: [],
+        fetching: false,
+        replayRecord,
+      });
+
+      expect(replay?.processingErrors()).toEqual([]);
+    });
+
+    it('reports a missing full snapshot when the replay only has a meta frame', () => {
+      const replay = ReplayReader.factory({
+        attachments: RRWebInitFrameEventsFixture({timestamp}),
+        errors: [],
+        fetching: false,
+        replayRecord,
+      });
+
+      expect(replay?.processingErrors()).toEqual(['Missing Full Snapshot Frame']);
+    });
+
+    it('reports no missing full snapshot when the replay is a video replay', () => {
+      const replay = ReplayReader.factory({
+        attachments: [
+          ...RRWebInitFrameEventsFixture({timestamp}),
+          {
+            type: EventType.Custom,
+            timestamp: timestamp.getTime(),
+            data: {
+              tag: 'video',
+              payload: {
+                duration: 5000,
+                segmentId: 0,
+                timestamp: timestamp.getTime(),
+              },
+            },
+          },
+        ],
+        errors: [],
+        fetching: false,
+        replayRecord,
+      });
+
+      expect(replay?.processingErrors()).toEqual([]);
+    });
   });
 
   describe('clip window', () => {

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -466,6 +466,10 @@ export class ReplayReader {
       this.getRRWebFrames().some(frame => frame.type === EventType.Meta)
         ? null
         : 'Missing Meta Frame',
+      this.isVideoReplay() ||
+      this.getRRWebFrames().some(frame => frame.type === EventType.FullSnapshot)
+        ? null
+        : 'Missing Full Snapshot Frame',
     ].filter(defined);
   });
   hasProcessingErrors = () => {

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -3,11 +3,15 @@ import {duration} from 'moment-timezone';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
+import {
+  RRWebFullSnapshotFrameEventFixture,
+  RRWebInitFrameEventsFixture,
+} from 'sentry-fixture/replay/rrweb';
 import {ReplayListFixture} from 'sentry-fixture/replayList';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 import {UserFixture} from 'sentry-fixture/user';
 
+import {stubIframeScrollTo} from 'sentry-test/iframeScrollTo';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
@@ -49,9 +53,14 @@ const mockReplay = ReplayReader.factory({
   }),
   errors: [],
   fetching: false,
-  attachments: RRWebInitFrameEventsFixture({
-    timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
-  }),
+  attachments: [
+    ...RRWebInitFrameEventsFixture({
+      timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+    }),
+    RRWebFullSnapshotFrameEventFixture({
+      timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+    }),
+  ],
   clipWindow: {
     startTimestampMs: mockEventTimestampMs - 5_000,
     endTimestampMs: mockEventTimestampMs + 5_000,
@@ -80,6 +89,8 @@ type InitializeOrgProps = {
 };
 
 describe('GroupReplays', () => {
+  beforeAll(stubIframeScrollTo);
+
   const mockGroup = GroupFixture();
   const user = UserFixture({id: '1'});
 

--- a/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplaysPlayer.spec.tsx
@@ -1,7 +1,10 @@
 import {duration} from 'moment-timezone';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
+import {
+  RRWebFullSnapshotFrameEventFixture,
+  RRWebInitFrameEventsFixture,
+} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -35,9 +38,14 @@ const mockReplay = ReplayReader.factory({
   }),
   errors: [],
   fetching: false,
-  attachments: RRWebInitFrameEventsFixture({
-    timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
-  }),
+  attachments: [
+    ...RRWebInitFrameEventsFixture({
+      timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+    }),
+    RRWebFullSnapshotFrameEventFixture({
+      timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+    }),
+  ],
   clipWindow: {
     startTimestampMs: mockEventTimestampMs - 5_000,
     endTimestampMs: mockEventTimestampMs + 5_000,

--- a/tests/js/sentry-test/iframeScrollTo.ts
+++ b/tests/js/sentry-test/iframeScrollTo.ts
@@ -1,0 +1,24 @@
+/**
+ * jsdom does not implement `scrollTo`, and rrweb calls it on the replay
+ * iframe's own window when it applies a snapshot's initial offset. jsdom
+ * reports that as an error, which fails the test. Call this from a `beforeAll`
+ * in specs that render a player over a replay with a full snapshot.
+ */
+export function stubIframeScrollTo() {
+  const getContentWindow = Object.getOwnPropertyDescriptor(
+    HTMLIFrameElement.prototype,
+    'contentWindow'
+  )!.get!;
+
+  jest
+    .spyOn(HTMLIFrameElement.prototype, 'contentWindow', 'get')
+    .mockImplementation(function (this: HTMLIFrameElement): Window | null {
+      const contentWindow: Window | null = getContentWindow.call(this);
+
+      if (contentWindow) {
+        contentWindow.scrollTo = jest.fn();
+      }
+
+      return contentWindow;
+    });
+}


### PR DESCRIPTION
Recreation of #122506 since I merged it into the wrong branch by accident...

---

A replay whose payload is missing its initial `FullSnapshot` would still mount the player. rrweb's mirror starts empty, so no add ever resolves and no DOM is ever built. That's the dreaded white screen with a bunch of `console.warn` spew from REPLAY-892.

This updates the `ReplayReader`'s `processingErrors()` to check for missing `FullSnapshot`s.

### Before

The player mounts and plays, but the iframe never receives a DOM and the console floods:

<img width="1656" height="809" alt="replay-892-before" src="https://github.com/user-attachments/assets/4065627a-7f67-4ef0-8651-bc2a79681189" />

### After

The existing processing-error state renders instead:

<img width="1656" height="230" alt="replay-892-after" src="https://github.com/user-attachments/assets/19c104af-6b62-4001-88c1-14412e145e50" />

Closes REPLAY-892.

