### PR TITLE
feat(auth): Add new login toggle to help menu

### DIFF
--- a/static/app/utils/useEnableAuthV2.ts
+++ b/static/app/utils/useEnableAuthV2.ts
@@ -1,0 +1,44 @@
+import {useCallback, useState} from 'react';
+import Cookies from 'js-cookie';
+
+const REACT_AUTH_COOKIE = 'sentry_react_auth';
+
+function getCookieDomain() {
+  const {hostname} = window.location;
+
+  if (hostname === 'sentry.io' || hostname.endsWith('.sentry.io')) {
+    return '.sentry.io';
+  }
+
+  if (hostname === 'dev.getsentry.net' || hostname.endsWith('.dev.getsentry.net')) {
+    return '.dev.getsentry.net';
+  }
+
+  return;
+}
+
+export function useEnableAuthV2() {
+  const [isAuthV2Enabled, setIsAuthV2Enabled] = useState(
+    () => Cookies.get(REACT_AUTH_COOKIE) === '1'
+  );
+
+  const setAuthV2Enabled = useCallback((enabled: boolean) => {
+    const domain = getCookieDomain();
+    const options = {
+      path: '/',
+      sameSite: 'lax' as const,
+      ...(domain ? {domain} : {}),
+    };
+
+    if (enabled) {
+      Cookies.set(REACT_AUTH_COOKIE, '1', options);
+    } else {
+      Cookies.remove(REACT_AUTH_COOKIE, options);
+      Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});
+    }
+
+    setIsAuthV2Enabled(enabled);
+  }, []);
+
+  return {isAuthV2Enabled, setAuthV2Enabled};
+}

--- a/static/app/views/navigation/primary/helpMenu.spec.tsx
+++ b/static/app/views/navigation/primary/helpMenu.spec.tsx
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import {BroadcastFixture} from 'sentry-fixture/broadcast';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
@@ -35,6 +36,33 @@ describe('PrimaryNavigationHelpMenu', () => {
     jest.clearAllMocks();
     ModalStore.reset();
     ConfigStore.set('supportEmail', 'support@sentry.io');
+    Cookies.remove('sentry_react_auth', {path: '/'});
+  });
+
+  it('toggles the new login cookie when the feature is enabled', async () => {
+    const organization = OrganizationFixture({features: ['authv2-enable-toggle']});
+
+    render(<PrimaryNavigationHelpMenu />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Help'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Enable new login'}));
+
+    expect(Cookies.get('sentry_react_auth')).toBe('1');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Help'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Disable new login'}));
+
+    expect(Cookies.get('sentry_react_auth')).toBeUndefined();
+  });
+
+  it('hides the new login toggle when the feature is disabled', async () => {
+    render(<PrimaryNavigationHelpMenu />, {organization: OrganizationFixture()});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Help'}));
+
+    expect(
+      screen.queryByRole('menuitemradio', {name: 'Enable new login'})
+    ).not.toBeInTheDocument();
   });
 
   it('opens Intercom when contacting support', async () => {

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -13,6 +13,7 @@ import {
   IconEllipsis,
   IconGithub,
   IconGroup,
+  IconLab,
   IconMegaphone,
   IconOpen,
   IconQuestion,
@@ -26,6 +27,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {showIntercom} from 'sentry/utils/intercom';
+import {useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {PrimaryNavigation} from 'sentry/views/navigation/primary/components';
@@ -47,6 +49,7 @@ export function PrimaryNavigationHelpMenu({
   const contactSupportItem = getContactSupportItem(organization);
   const openForm = useFeedbackForm();
   const {privacyUrl, termsUrl} = useLegacyStore(ConfigStore);
+  const {isAuthV2Enabled, setAuthV2Enabled} = useEnableAuthV2();
 
   useEffect(() => {
     trackAnalytics('intercom_link.viewed', {organization, source: 'sidebar'});
@@ -181,6 +184,24 @@ export function PrimaryNavigationHelpMenu({
               <IconOpen />
             </MenuIcon>
           ),
+        },
+      ],
+    },
+    {
+      key: 'auth-v2',
+      hidden: !organization.features.includes('authv2-enable-toggle'),
+      children: [
+        {
+          key: 'toggle-auth-v2',
+          label: isAuthV2Enabled ? t('Disable new login') : t('Enable new login'),
+          leadingItems: (
+            <MenuIcon>
+              <IconLab isSolid />
+            </MenuIcon>
+          ),
+          onAction() {
+            setAuthV2Enabled(!isAuthV2Enabled);
+          },
         },
       ],
     },


### PR DESCRIPTION
Adds a feature-gated help-menu action that enables or disables the new login experience through a shared cookie helper. The action reflects the current cookie state and keeps the experiment cookie behavior in one reusable utility.

Depends on #122862 for the `authv2-enable-toggle` feature registration.