### PR TITLE
fix(dashboards): fix ai agent overview trace table widget type

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -217,6 +217,7 @@ const AGENTS_TRACES_TABLE: PrebuiltWidget = {
   title: t('Traces'),
   description: t('Agent traces with duration, token, cost, and tool usage.'),
   displayType: DisplayType.AGENTS_TRACES_TABLE,
+  widgetType: WidgetType.SPANS,
   interval: '1h',
   tableWidths: DEFAULT_TRACES_TABLE_WIDTHS,
   limit: MAX_TABLE_LIMIT,


### PR DESCRIPTION
Properly set missing widget type to spans.