### PR TITLE
feat(seer): Show generated headline as autofix overview card title

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -83,6 +83,7 @@ describe('AutofixOverview', () => {
     shortId: 'PROJ-1',
     title: 'TypeError in checkout cart',
     rootCause: {
+      headline: null,
       oneLineDescription: 'The cart total is read before it is set.',
     },
     proposedFix: null,
@@ -97,7 +98,10 @@ describe('AutofixOverview', () => {
     groupId: '3',
     shortId: 'PROJ-2',
     title: 'KeyError in proxy handler',
-    rootCause: {oneLineDescription: 'The Authorization header is dropped.'},
+    rootCause: {
+      headline: null,
+      oneLineDescription: 'The Authorization header is dropped.',
+    },
     proposedFix: {
       oneLineSummary: 'Restore the Authorization header as a fallback.',
     },
@@ -715,6 +719,39 @@ describe('AutofixOverview', () => {
     expect(screen.getAllByText('Plan')).toHaveLength(1);
   });
 
+  it('uses the root cause headline as the card title with the issue title beneath', async () => {
+    mockOverview({
+      base: {
+        autofix_root_cause: [
+          {
+            ...rootCauseRun,
+            rootCause: {
+              headline: 'Checkout crashes on an empty cart',
+              oneLineDescription: 'The cart total is read before it is set.',
+            },
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    // The generated headline becomes the linked card title.
+    const titleLink = await screen.findByRole('link', {
+      name: 'Checkout crashes on an empty cart',
+    });
+    expect(titleLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/2/`
+    );
+    // The raw issue title still shows, beneath the headline.
+    expect(screen.getByText('TypeError in checkout cart')).toBeInTheDocument();
+    // The issue title is not itself a link (only the headline links out).
+    expect(
+      screen.queryByRole('link', {name: 'TypeError in checkout cart'})
+    ).not.toBeInTheDocument();
+  });
+
   it('shows "0 users" for a card with events but zero affected users', async () => {
     mockOverview({
       base: {
@@ -803,6 +840,7 @@ describe('AutofixOverview', () => {
           {
             ...solutionRun,
             rootCause: {
+              headline: null,
               oneLineDescription: 'The request is passed to `dateutil.parse()`.',
             },
             proposedFix: {

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -560,6 +560,7 @@ export const OverviewCard = memo(function OverviewCardComponent({
       }
     }
   }, [inView, scmWindows, requestScmWindow]);
+  const headline = run.rootCause?.headline;
   const rootCause = run.rootCause?.oneLineDescription;
   const proposedFix = run.proposedFix?.oneLineSummary;
   const issueUrl = `/organizations/${orgSlug}/issues/${run.groupId}/`;
@@ -616,9 +617,14 @@ export const OverviewCard = memo(function OverviewCardComponent({
                   })
                 }
               >
-                {run.title}
+                {headline || run.title}
               </TitleLink>
             </Text>
+            {headline && (
+              <Text size="sm" variant="muted" ellipsis>
+                {run.title}
+              </Text>
+            )}
             <Flex wrap="wrap" gap="md" align="center">
               <Flex gap="xs" align="center">
                 <ProjectAvatar

--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -33,7 +33,10 @@ describe('OverviewCardAction', () => {
       groupId: '2',
       shortId: 'PROJ-1',
       title: 'TypeError in checkout cart',
-      rootCause: {oneLineDescription: 'The cart total is read before it is set.'},
+      rootCause: {
+        headline: null,
+        oneLineDescription: 'The cart total is read before it is set.',
+      },
       proposedFix: null,
       seerRunId: 'run-1',
       lastTriggeredAt: '2026-07-14T09:00:00Z',

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -204,7 +204,7 @@ export interface OverviewRun {
   lastTriggeredAt: string;
   proposedFix: {oneLineSummary: string | null} | null;
   pullRequests: OverviewPullRequest[];
-  rootCause: {oneLineDescription: string | null} | null;
+  rootCause: {headline: string | null; oneLineDescription: string | null} | null;
   seerRunId: string;
   shortId: string;
   status: RunStatus | null;


### PR DESCRIPTION
Renders the LLM-generated root cause `headline` as the bold, linked title on each Autofix overview card, with the raw issue title kept beneath it, abridged to a single line — matching the design mock.

Runs without a headline fall back to the issue title as the title, exactly as today, so pre-existing runs render unchanged. Depends on the backend exposing `rootCause.headline` in the overview API (frontend and backend ship as separate PRs and don't deploy atomically).

Refs AIML-3415