### PR TITLE
fix(explore): export with highest accuracy sampling

### DIFF
--- a/static/app/components/exports/useDataExport.ts
+++ b/static/app/components/exports/useDataExport.ts
@@ -33,7 +33,7 @@ interface IssuesByTagQueryInfo {
 
 export type DiscoverQueryInfo = EventQuery & LocationQuery;
 
-type EventsQuerySamplingMode =
+export type EventsQuerySamplingMode =
   | 'NORMAL'
   | 'HIGHEST_ACCURACY'
   | 'HIGHEST_ACCURACY_FLEX_TIME';

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
@@ -123,7 +123,14 @@ describe('LogsAggregateExportModalButton', () => {
     await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
 
     await waitFor(() => {
-      expect(exportRequest).toHaveBeenCalled();
+      expect(exportRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/data-export/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            query_info: expect.objectContaining({sampling: 'HIGHEST_ACCURACY'}),
+          }),
+        })
+      );
     });
   });
 

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.spec.tsx
@@ -1,0 +1,113 @@
+import {LogFixture} from 'sentry-fixture/log';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {
+  LOGS_FIELDS_KEY,
+  LOGS_QUERY_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LogsDirectExportModalButton} from 'sentry/views/explore/logs/exports/logsDirectExportModalButton';
+import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+describe('LogsDirectExportModalButton', () => {
+  const {organization, project} = initializeOrg({
+    organization: {features: ['ourlogs-enabled']},
+  });
+
+  const tableData = [
+    LogFixture({
+      id: 'log-1',
+      [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    }),
+  ];
+
+  ProjectsStore.loadInitialData([project]);
+  PageFiltersStore.init();
+  PageFiltersStore.onInitializeUrlState({
+    projects: [parseInt(project.id, 10)],
+    environments: [],
+    datetime: {period: '14d', start: null, end: null, utc: null},
+  });
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/explore/logs/`,
+      query: {
+        project: project.id,
+        [LOGS_QUERY_KEY]: '',
+        [LOGS_FIELDS_KEY]: ['timestamp', 'message'],
+      },
+    },
+    route: '/organizations/:orgId/explore/logs/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+    // A sample count well above the loaded rows, so the modal offers row counts
+    // the browser can't serve and the export goes to the server.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      body: {
+        timeSeries: [
+          {
+            yAxis: 'count(message)',
+            values: [{timestamp: 1508208080000, value: 5000, sampleCount: 5000}],
+            meta: {valueType: 'integer', valueUnit: null, interval: 3600000},
+          },
+        ],
+      },
+    });
+  });
+
+  it('asks the server export for the highest accuracy without flex-time windows', async () => {
+    const exportRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/data-export/`,
+      method: 'POST',
+      body: {},
+    });
+
+    render(
+      <LogsQueryParamsProvider
+        analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+        source="location"
+      >
+        <LogsDirectExportModalButton
+          error={null}
+          isLoading={false}
+          tableData={tableData}
+        />
+      </LogsQueryParamsProvider>,
+      {initialRouterConfig}
+    );
+    renderGlobalModal();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+
+    await waitFor(() => {
+      expect(exportRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/data-export/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            query_info: expect.objectContaining({
+              sampling: 'HIGHEST_ACCURACY',
+            }),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
@@ -28,12 +28,6 @@ export function LogsDirectExportModalButton({
 
   const queryInfo = useLogsQueryInfo({
     field: [...fields],
-    // Without this the server export falls back to normal sampling and can hand
-    // back a downsampled set of the rows on screen. Not the table's flex-time
-    // mode though: this export paginates by offset and stops on the first short
-    // page, and flex-time returns short pages as it walks its time windows. Only
-    // the "All Columns" export can afford flex-time, because it continues on a
-    // page token rather than an offset.
     sampling: SAMPLING_MODE.HIGH_ACCURACY,
     sort: sortBys.map(formatExportSort),
   });

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
@@ -1,6 +1,5 @@
 import {t} from 'sentry/locale';
 import {formatExportSort} from 'sentry/views/explore/components/exports/formatExportSort';
-import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
   LogsExportModalButton,
   useLogsQueryInfo,
@@ -28,7 +27,6 @@ export function LogsDirectExportModalButton({
 
   const queryInfo = useLogsQueryInfo({
     field: [...fields],
-    sampling: SAMPLING_MODE.HIGH_ACCURACY,
     sort: sortBys.map(formatExportSort),
   });
   const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length);

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import {formatExportSort} from 'sentry/views/explore/components/exports/formatExportSort';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
   LogsExportModalButton,
   useLogsQueryInfo,
@@ -27,6 +28,13 @@ export function LogsDirectExportModalButton({
 
   const queryInfo = useLogsQueryInfo({
     field: [...fields],
+    // Without this the server export falls back to normal sampling and can hand
+    // back a downsampled set of the rows on screen. Not the table's flex-time
+    // mode though: this export paginates by offset and stops on the first short
+    // page, and flex-time returns short pages as it walks its time windows. Only
+    // the "All Columns" export can afford flex-time, because it continues on a
+    // page token rather than an offset.
+    sampling: SAMPLING_MODE.HIGH_ACCURACY,
     sort: sortBys.map(formatExportSort),
   });
   const estimatedRowCount = useLogsExportEstimatedRowCount(tableData.length);

--- a/static/app/views/explore/logs/exports/logsExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.spec.tsx
@@ -37,6 +37,7 @@ describe('LogsExportModalButton', () => {
     field: ['message'],
     project: [1],
     query: '',
+    sampling: 'HIGHEST_ACCURACY',
     sort: ['-timestamp'],
   };
 

--- a/static/app/views/explore/logs/exports/logsExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.tsx
@@ -9,6 +9,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExploreExportModalButton} from 'sentry/views/explore/components/exports/exploreExportModalButton';
 import {trackExploreTableExported} from 'sentry/views/explore/components/exports/trackExploreTableExported';
 import type {ExploreExportConfig} from 'sentry/views/explore/components/exports/types';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import type {
   OurLogsAggregateResponseItem,
   OurLogsResponseItem,
@@ -21,10 +22,10 @@ export interface LogsQueryInfo {
   field: string[];
   project: number[];
   query: string;
+  sampling: EventsQuerySamplingMode;
   sort: string[];
   end?: string;
   environment?: string[];
-  sampling?: EventsQuerySamplingMode;
   start?: string;
   statsPeriod?: string;
 }
@@ -41,12 +42,10 @@ type LogsExportModalButtonProps = {
 
 export function useLogsQueryInfo({
   field,
-  sampling,
   sort,
 }: {
   field: string[];
   sort: string[];
-  sampling?: EventsQuerySamplingMode;
 }): LogsQueryInfo {
   const {selection} = usePageFilters();
   const logsSearch = useQueryParamsSearch();
@@ -58,7 +57,7 @@ export function useLogsQueryInfo({
     field,
     query: logsSearch.formatString(),
     project: projects,
-    sampling,
+    sampling: SAMPLING_MODE.HIGH_ACCURACY,
     sort,
     start: start ? new Date(start).toISOString() : undefined,
     end: end ? new Date(end).toISOString() : undefined,

--- a/static/app/views/explore/logs/exports/logsExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.tsx
@@ -1,5 +1,8 @@
 import {downloadRows} from 'sentry/components/exports/downloadRows';
-import {ExportQueryType} from 'sentry/components/exports/useDataExport';
+import {
+  ExportQueryType,
+  type EventsQuerySamplingMode,
+} from 'sentry/components/exports/useDataExport';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -21,6 +24,7 @@ export interface LogsQueryInfo {
   sort: string[];
   end?: string;
   environment?: string[];
+  sampling?: EventsQuerySamplingMode;
   start?: string;
   statsPeriod?: string;
 }
@@ -37,10 +41,12 @@ type LogsExportModalButtonProps = {
 
 export function useLogsQueryInfo({
   field,
+  sampling,
   sort,
 }: {
   field: string[];
   sort: string[];
+  sampling?: EventsQuerySamplingMode;
 }): LogsQueryInfo {
   const {selection} = usePageFilters();
   const logsSearch = useQueryParamsSearch();
@@ -52,6 +58,7 @@ export function useLogsQueryInfo({
     field,
     query: logsSearch.formatString(),
     project: projects,
+    sampling,
     sort,
     start: start ? new Date(start).toISOString() : undefined,
     end: end ? new Date(end).toISOString() : undefined,

--- a/static/app/views/explore/metrics/exports/metricsExportModalButton.tsx
+++ b/static/app/views/explore/metrics/exports/metricsExportModalButton.tsx
@@ -1,5 +1,8 @@
 import {downloadRows, type ExportableRow} from 'sentry/components/exports/downloadRows';
-import {ExportQueryType} from 'sentry/components/exports/useDataExport';
+import {
+  ExportQueryType,
+  type EventsQuerySamplingMode,
+} from 'sentry/components/exports/useDataExport';
 import type {StatsPeriodRange} from 'sentry/components/pageFilters/types';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -7,6 +10,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExploreExportModalButton} from 'sentry/views/explore/components/exports/exploreExportModalButton';
 import {trackExploreTableExported} from 'sentry/views/explore/components/exports/trackExploreTableExported';
 import type {ExploreExportConfig} from 'sentry/views/explore/components/exports/types';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export interface MetricsQueryInfo {
@@ -14,6 +18,7 @@ export interface MetricsQueryInfo {
   field: string[];
   project: number[];
   query: string;
+  sampling: EventsQuerySamplingMode;
   sort: string[];
   end?: string;
   environment?: string[];
@@ -50,6 +55,7 @@ export function useMetricsQueryInfo({
     field,
     query,
     project: projects,
+    sampling: SAMPLING_MODE.HIGH_ACCURACY,
     sort,
     environment: environments,
     ...(statsPeriodRange

--- a/static/app/views/explore/metrics/exports/metricsSamplesExportModalButton.spec.tsx
+++ b/static/app/views/explore/metrics/exports/metricsSamplesExportModalButton.spec.tsx
@@ -129,6 +129,12 @@ describe('MetricsSamplesExportModalButton', () => {
     });
   });
 
+  it('asks the server export for the accuracy the table escalates to', async () => {
+    const queryInfo = await submitExport();
+
+    expect(queryInfo.sampling).toBe('HIGHEST_ACCURACY');
+  });
+
   it('counts rows with the export query when the user has narrowed the search', async () => {
     renderButton();
 

--- a/static/app/views/explore/spans/tracesExportModalButton.spec.tsx
+++ b/static/app/views/explore/spans/tracesExportModalButton.spec.tsx
@@ -222,7 +222,11 @@ describe('TracesExportModalButton', () => {
       expect(dataExportMock).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/data-export/`,
         expect.objectContaining({
-          data: expect.objectContaining({query_type: 'Explore', limit: 500}),
+          data: expect.objectContaining({
+            query_type: 'Explore',
+            limit: 500,
+            query_info: expect.objectContaining({sampling: 'HIGHEST_ACCURACY'}),
+          }),
         })
       );
     });

--- a/static/app/views/explore/spans/tracesExportModalButton.tsx
+++ b/static/app/views/explore/spans/tracesExportModalButton.tsx
@@ -16,6 +16,7 @@ import type {ExploreExportConfig} from 'sentry/views/explore/components/exports/
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {RawCounts} from 'sentry/views/explore/useRawCounts';
@@ -65,6 +66,7 @@ export function TracesExportModalButton({
     field: payload.field,
     project: decodeList(payload.project).map(Number),
     query: payload.query,
+    sampling: SAMPLING_MODE.HIGH_ACCURACY,
     sort: decodeList(payload.sort),
     environment: payload.environment,
     start: decodeScalar(payload.start),


### PR DESCRIPTION
Every selected-columns explore export sent no `sampling` key, so `ExploreProcessor.get_sampling_mode` returned `None` and the RPC fell back to `MODE_NORMAL`. Meanwhile the tables people export from all read more accurately than that:

- Logs themselves: requests `sampling=HIGHEST_ACCURACY_FLEX_TIME` (high fidelity needs only the default `-timestamp` desc sort, so it is on for most sessions).
- Log aggregates, spans, and traces: run `useProgressiveQuery`, which starts at normal sampling and escalates to `HIGHEST_ACCURACY` when the cheap read comes back thin. Exports have no such escalation.

...so a download could contain a downsampled set of the rows the user was looking at when they clicked Export. 

This sets `HIGHEST_ACCURACY` on all four export surfaces.

Closes LOGS-949.