### PR TITLE
feat(tracemetrics): Allow saving Table in dashboards with flag

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -459,11 +459,9 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 config is not None
                 and display_type_id not in config["supported_display_types"]
                 # Existing tracemetrics table widgets (those sent with an ``id``)
-                # are allowed to save. The Widget Builder doesn't offer table for
-                # tracemetrics, but some widgets were created with this combo
-                # before display-type validation existed, and those dashboards
-                # must still be saveable. New widgets are still rejected.
-                and not self._is_existing_tracemetrics_table(widget_type_id, display_type_id)
+                # are allowed to save. New tracemetrics table widgets are enabled
+                # by the feature flag.
+                and not self._allows_tracemetrics_table(widget_type_id, display_type_id)
             ):
                 supported_names = sorted(
                     DashboardWidgetDisplayTypes.get_type_name(d) or str(d)
@@ -477,11 +475,17 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
         return display_type_id
 
-    def _is_existing_tracemetrics_table(self, widget_type_id, display_type_id):
-        return (
-            self.context.get("widget_id") is not None
-            and widget_type_id == DashboardWidgetTypes.TRACEMETRICS
-            and display_type_id == DashboardWidgetDisplayTypes.TABLE
+    def _allows_tracemetrics_table(self, widget_type_id, display_type_id):
+        if (
+            widget_type_id != DashboardWidgetTypes.TRACEMETRICS
+            or display_type_id != DashboardWidgetDisplayTypes.TABLE
+        ):
+            return False
+
+        return self.context.get("widget_id") is not None or features.has(
+            "organizations:tracemetrics-dashboard-table",
+            self.context["organization"],
+            actor=self.context["request"].user,
         )
 
     def _validate_widget_type(self, data):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1965,7 +1965,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
 
         assert response.status_code == 200, response.data
 
-    def test_widget_type_tracemetrics_allows_existing_table(self) -> None:
+    def test_widget_type_tracemetrics_allows_existing_table_without_feature_flag(self) -> None:
         # Tracemetrics tables can't be created in the UI, but some existing
         # widgets predate display-type validation and must still be saveable.
         # Existing widgets are identified by the presence of an ``id``.

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1940,6 +1940,31 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
 
+    def test_widget_type_tracemetrics_allows_table_with_feature_flag(self) -> None:
+        data = {
+            "title": "Test Metrics Query",
+            "widgetType": "tracemetrics",
+            "displayType": "table",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "metric.name:foo",
+                    "fields": ["sum(value)"],
+                    "columns": [],
+                    "aggregates": ["sum(value)"],
+                },
+            ],
+        }
+
+        with self.feature("organizations:tracemetrics-dashboard-table"):
+            response = self.do_request(
+                "post",
+                self.url(),
+                data=data,
+            )
+
+        assert response.status_code == 200, response.data
+
     def test_widget_type_tracemetrics_allows_existing_table(self) -> None:
         # Tracemetrics tables can't be created in the UI, but some existing
         # widgets predate display-type validation and must still be saveable.


### PR DESCRIPTION
Originally tables were unsupported for the metrics dataset in dashboards. This feature flags it so we allow it. Also, existing widgets should continue to be allowed to be saved for backwards compatibility where we let some table widgets through before we started enforcing it.