### PR TITLE
feat(seer): Add recommended sort to the autofix overview endpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -374,10 +374,10 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         include_project_config = "projectConfig" in expand
         environments = self.get_environments(request, organization)
 
-        sort = request.GET.get("sort")
+        sort = request.GET.get("sort", "")
 
         latest_run_per_group = self._latest_run_per_group(organization, project_ids, start, end)
-        sort_by = _ISSUE_SORT_TO_SEARCH.get(sort) if sort is not None else None
+        sort_by = _ISSUE_SORT_TO_SEARCH.get(sort)
         if sort_by == "recommended" and features.has(
             "organizations:issue-stream-recommended-sort-experimental",
             organization,

--- a/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
+++ b/src/sentry/seer/endpoints/organization_seer_autofix_overview.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple, cast
 from uuid import UUID
 
 from django.db.models import Exists, OuterRef, Q
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import search
+from sentry import features, search
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -93,9 +93,14 @@ _VISIBLE_PULL_REQUEST_FILTER = Q(pull_request__state__isnull=True) | ~Q(
 # writes; removable from these filters by 2026-11-11 (data retention).
 _AUTOFIX_AGENT_SOURCES = ("autofix", "autofix_rca")
 
-# The three issue-based sort params, mapped to their search-backend names.
+# The issue-based sort params, mapped to their search-backend names.
 # Any other value (seer default, empty, unknown) keeps the default order.
-_ISSUE_SORT_TO_SEARCH = {"issue": "date", "events": "freq", "users": "user"}
+_ISSUE_SORT_TO_SEARCH = {
+    "issue": "date",
+    "events": "freq",
+    "users": "user",
+    "recommended": "recommended",
+}
 
 
 @dataclass
@@ -372,14 +377,22 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         sort = request.GET.get("sort")
 
         latest_run_per_group = self._latest_run_per_group(organization, project_ids, start, end)
-        if sort in _ISSUE_SORT_TO_SEARCH:
+        sort_by = _ISSUE_SORT_TO_SEARCH.get(sort) if sort is not None else None
+        if sort_by == "recommended" and features.has(
+            "organizations:issue-stream-recommended-sort-experimental",
+            organization,
+            actor=request.user,
+        ):
+            sort_by = "recommended_v2"
+        if sort_by is not None:
             latest_run_per_group = self._reorder_by_issue_sort(
                 latest_run_per_group,
-                _ISSUE_SORT_TO_SEARCH[sort],
+                sort_by,
                 projects,
                 environments,
                 start,
                 end,
+                request.user,
             )
 
         # Classify into milestones and cap before the expensive serialize, so the
@@ -547,6 +560,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
         environments: Sequence[Environment],
         start: datetime,
         end: datetime,
+        actor: Any,
     ) -> dict[int, _RunMilestones]:
         candidate_ids = list(latest_run_per_group)
         if not candidate_ids:
@@ -561,6 +575,7 @@ class OrganizationSeerAutofixOverviewEndpoint(OrganizationEndpoint):
             search_filters=[SearchFilter(SearchKey("issue.id"), "IN", SearchValue(candidate_ids))],
             date_from=start,
             date_to=end,
+            actor=actor,
             referrer="seer.autofix-overview",
         )
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -215,6 +215,25 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
             plain.qualified_short_id,
         ]
 
+    def test_sort_recommended_keeps_candidates_without_window_events_sorted_last(self):
+        # `stale` has no events inside the requested window, so it is absent from
+        # the scored search results and must be appended last rather than dropped.
+        stale = self._group_with_events("stale", events=1, minutes_ago=120)
+        active = self._group_with_events("active", events=1)
+        self._run_for_group(stale, "stale")
+        self._run_for_group(active, "active")
+
+        with self.feature("organizations:issue-stream-recommended-sort-experimental"):
+            resp = self.get_success_response(
+                self.organization.slug,
+                qs_params={"sort": "recommended", "statsPeriod": "1h"},
+            )
+
+        assert self._root_cause_short_ids(resp) == [
+            active.qualified_short_id,
+            stale.qualified_short_id,
+        ]
+
     def test_sort_recommended_uses_v2_scorer_and_viewer_actor(self):
         group = self._group_with_events("boom", events=1)
         self._run_for_group(group, "boom")

--- a/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_autofix_overview.py
@@ -198,6 +198,53 @@ class OrganizationSeerAutofixOverviewTest(APITestCase, SnubaTestCase):
 
         assert self._root_cause_short_ids(resp) == [high.qualified_short_id]
 
+    def test_sort_recommended_orders_by_fixability_boost(self):
+        plain = self._group_with_events("plain", events=1)
+        fixable = self._group_with_events("fixable", events=1)
+        fixable.update(seer_fixability_score=1.0)
+        self._run_for_group(plain, "plain")
+        self._run_for_group(fixable, "fixable")
+
+        with self.feature("organizations:issue-stream-recommended-sort-experimental"):
+            resp = self.get_success_response(
+                self.organization.slug, qs_params={"sort": "recommended"}
+            )
+
+        assert self._root_cause_short_ids(resp) == [
+            fixable.qualified_short_id,
+            plain.qualified_short_id,
+        ]
+
+    def test_sort_recommended_uses_v2_scorer_and_viewer_actor(self):
+        group = self._group_with_events("boom", events=1)
+        self._run_for_group(group, "boom")
+
+        with (
+            self.feature("organizations:issue-stream-recommended-sort-experimental"),
+            mock.patch(
+                "sentry.seer.endpoints.organization_seer_autofix_overview.search.backend.query",
+                wraps=search.backend.query,
+            ) as mock_query,
+        ):
+            self.get_success_response(self.organization.slug, qs_params={"sort": "recommended"})
+
+        assert mock_query.call_count == 1
+        assert mock_query.call_args.kwargs["sort_by"] == "recommended_v2"
+        assert mock_query.call_args.kwargs["actor"].id == self.user.id
+
+    def test_sort_recommended_without_experimental_flag_uses_v1_scorer(self):
+        group = self._group_with_events("boom", events=1)
+        self._run_for_group(group, "boom")
+
+        with mock.patch(
+            "sentry.seer.endpoints.organization_seer_autofix_overview.search.backend.query",
+            wraps=search.backend.query,
+        ) as mock_query:
+            self.get_success_response(self.organization.slug, qs_params={"sort": "recommended"})
+
+        assert mock_query.call_count == 1
+        assert mock_query.call_args.kwargs["sort_by"] == "recommended"
+
     def test_issue_sort_raises_paginator_cap_to_candidate_count(self):
         # Without the max_limit override the paginator silently caps at 100 and
         # candidates beyond it would sort last; assert the endpoint raises it.


### PR DESCRIPTION
Adds `sort=recommended` to the autofix overview endpoint, reordering runs with the same scorer that ranks the issue stream's Recommended sort.

The overview today only has single-field sorts (`issue`, `events`, `users`); this restores the attention-based ordering the page's issue-stream predecessor inherited for free. The sort param joins the existing `_ISSUE_SORT_TO_SEARCH` map and flows through the existing `_reorder_by_issue_sort` → `search.backend.query` path, so within-section order and the per-milestone cap both follow it.

Two details mirror `organization_group_index.py`: `recommended` is translated to `recommended_v2` behind `organizations:issue-stream-recommended-sort-experimental` (fully rolled out, so clients only ever see the plain `recommended` key), and the viewer is passed as `actor` so the scorer's assignment and suspect-commit boosts apply. Candidates with no in-window events are already appended at the end by the existing fallback, which also covers the v2 path's Snuba narrowing.

Frontend follow-up (stacked): #122880

Refs AIML-3417
