### PR TITLE
feat(seer): Make Recommended the default autofix overview sort

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1873,25 +1873,49 @@ describe('AutofixOverview', () => {
     expect(screen.queryByText('Code Changes')).not.toBeInTheDocument();
   });
 
-  it('defaults to Recent Seer Activity and omits the sort param', async () => {
+  it('defaults to Recommended and keeps the sort param out of the URL', async () => {
     const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
 
-    renderPage();
+    const {router} = renderPage();
 
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: /Sort/})).toHaveTextContent(
-      'Recent Seer Activity'
-    );
+    expect(screen.getByRole('button', {name: /Sort/})).toHaveTextContent('Recommended');
     expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
-        query: expect.not.objectContaining({sort: expect.anything()}),
+        query: expect.objectContaining({sort: 'recommended'}),
       })
     );
+    expect(router.location.query.sort).toBeUndefined();
+  });
+
+  it('omits the sort param for the Recent Seer Activity backend default', async () => {
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    const {router} = renderPage();
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /Sort/}));
+    await userEvent.click(screen.getByRole('option', {name: 'Recent Seer Activity'}));
+
+    await waitFor(() =>
+      expect(statusPollRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/seer/autofix-overview/`,
+        expect.objectContaining({
+          query: expect.not.objectContaining({sort: expect.anything()}),
+        })
+      )
+    );
+    expect(router.location.query.sort).toBe('seer');
   });
 
   it.each([

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -95,6 +95,7 @@ const FilterBar = styled(Flex)`
 `;
 
 const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
+  {value: 'recommended', label: t('Recommended')},
   {value: 'seer', label: t('Recent Seer Activity')},
   {value: 'issue', label: t('Recent Issue Activity')},
   {value: 'events', label: t('Most events')},
@@ -171,7 +172,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
 
   const sort: OverviewSort =
     SORT_OPTIONS.find(option => option.value === decodeScalar(location.query.sort))
-      ?.value ?? 'seer';
+      ?.value ?? 'recommended';
   const assignee = decodeScalar(location.query.assignee) ?? null;
   const view =
     decodeScalar(location.query.view) === 'in_progress' ? 'in_progress' : 'all';
@@ -383,7 +384,10 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
           options={SORT_OPTIONS}
           onChange={selected => {
             trackFilterChanged('sort', selected.value);
-            setQueryParam('sort', selected.value === 'seer' ? undefined : selected.value);
+            setQueryParam(
+              'sort',
+              selected.value === 'recommended' ? undefined : selected.value
+            );
           }}
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -111,7 +111,7 @@ export interface OverviewIssue {
   owners?: Group['owners'];
 }
 
-export type OverviewSort = 'seer' | 'issue' | 'events' | 'users';
+export type OverviewSort = 'recommended' | 'seer' | 'issue' | 'events' | 'users';
 
 // The milestone a run reached, as keyed in the endpoint's `runsByMilestone`.
 export type MilestoneKey =

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -178,7 +178,7 @@ export function useAutofixOverview({
         query: {
           project: selection.projects,
           ...normalizeDateTimeParams(selection.datetime),
-          // Default sort keeps the URL clean and adds no backend Snuba work.
+          // 'seer' is the backend's default order, so it needs no sort param.
           ...(sort === 'seer' ? {} : {sort}),
           ...query,
         },


### PR DESCRIPTION
Adds a Recommended option to the Autofix Overview sort dropdown and makes it the default.

The default sends `sort=recommended` to the endpoint explicitly while keeping the URL clean (no `?sort` param); picking Recent Seer Activity puts `?sort=seer` in the URL and omits the API param, since that's the backend's default order. Everything else rides the existing sort plumbing — scope reset, SCM re-windowing, and analytics all key off the same `sort` value.

Stacked on #122879 (backend, now merged), which adds `sort=recommended` to the endpoint. Hold merging until that backend change deploys; until then an unknown sort value falls back to the endpoint's default order, so nothing breaks either way.

Refs AIML-3417
