### PR TITLE
ref(performance): Drop project tags from span-status inconsistency metric

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -897,8 +897,6 @@ def query_trace_data(
                             "sdk_name": span.get("sdk.name", ""),
                             "sdk_version": span.get("sdk.version", ""),
                             "origin": span.get("origin", ""),
-                            "project_id": str(span.get("project.id", "")),
-                            "project_slug": span.get("project.slug", ""),
                         },
                     )
             if span["id"] in id_to_occurrence:

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -495,11 +495,15 @@ class OrganizationEventsTraceEndpointTest(
             )
         assert response.status_code == 200, response.content
 
-        mock_metrics.incr.assert_any_call(
-            "performance.trace.span_with_errors_ok_status",
-            sample_rate=mock.ANY,
-            tags=mock.ANY,
-        )
+        tags = [
+            call.kwargs["tags"]
+            for call in mock_metrics.incr.call_args_list
+            if call.args[0] == "performance.trace.span_with_errors_ok_status"
+        ]
+        assert tags, "expected the span.status inconsistency metric to be emitted"
+        # Project identifiers are unbounded and would explode the stored series count.
+        for tag in tags:
+            assert set(tag) == {"sdk_name", "sdk_version", "origin"}
 
     def test_with_performance_issues(self) -> None:
         self.load_trace()


### PR DESCRIPTION
`performance.trace.span_with_errors_ok_status` fires whenever a span reports `span.status: ok` while carrying errors — a signal for [TET-2102](https://linear.app/getsentry/issue/TET-2102/detect-spanstatus-inconsistencies-and-report-to-sdk-teams), meant to surface SDK inconsistencies to the SDK teams.

It tagged every emission with `project_slug` **and** `project_id`. Those are unbounded, and they multiply across `sdk_name` × `sdk_version`, so they inflate the stored series count in Datadog for no consumer — nothing queries this metric by project today. Spotted while auditing input-derived tags on Datadog metrics.

The SDK team confirmed `sdk_name` + `sdk_version` + `origin` is the tag set they need to act on the signal, so this keeps those three and drops both project identifiers.

### Changes

- Remove the `project_slug` and `project_id` tags from the metric in `src/sentry/snuba/trace.py`.
- Pin the expected tag set in the existing test rather than matching `tags=mock.ANY`, so re-adding a project identifier fails CI.

No behavior change beyond the tags: the metric and its `performance.trace.span_with_errors_ok_status.sample_rate` option are untouched, and it keeps emitting at the current rate.