### PR TITLE
fix(eap): Expose internal convention attributes to staff

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -114,6 +114,7 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
             rpc_response = snuba_rpc.attribute_names_rpc(rpc_request)
 
         include_internal = is_active_superuser(request) or is_active_staff(request)
+        include_internal_convention_attributes = request.user.is_staff
 
         paginator = ChainPaginator(
             [
@@ -125,6 +126,7 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
                         attribute.name,
                         SupportedTraceItemType.SPANS,
                         include_internal=include_internal,
+                        include_internal_convention_attributes=include_internal_convention_attributes,
                     )
                 ],
             ],

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -621,15 +621,18 @@ def can_expose_trace_item_attribute_to_api(
     attribute_key: TraceItemAttributeKey,
     item_type: SupportedTraceItemType,
     include_internal: bool = False,
+    include_internal_convention_attributes: bool = False,
 ) -> bool:
     return can_expose_attribute_to_api(
         attribute_key["key"],
         item_type,
         include_internal=include_internal,
+        include_internal_convention_attributes=include_internal_convention_attributes,
     ) and can_expose_attribute_to_api(
         attribute_key["name"],
         item_type,
         include_internal=include_internal,
+        include_internal_convention_attributes=include_internal_convention_attributes,
     )
 
 
@@ -638,6 +641,7 @@ def _can_expose_data_attribute_to_api(
     attribute_key: TraceItemAttributeKey,
     item_type: SupportedTraceItemType,
     include_internal: bool = False,
+    include_internal_convention_attributes: bool = False,
 ) -> bool:
     """Whether an attribute found in a customer's data may be exposed.
 
@@ -646,18 +650,31 @@ def _can_expose_data_attribute_to_api(
     column. Its exposure is gated on the attribute's own name, so a private
     reserved *column* it merely shadows doesn't suppress it (e.g. a customer's
     ``organization.id``, which shadows the private ``sentry.organization_id``).
-    Internal sentry *conventions* are still hidden unless ``include_internal``.
+    Internal sentry *conventions* are still hidden unless
+    ``include_internal_convention_attributes``.
     """
     if attribute_key["attributeSource"]["source_type"] == AttributeSourceType.USER.value:
-        if not can_expose_attribute(name, item_type, include_internal=include_internal):
+        is_internal_convention_attribute = is_internal_sentry_convention_attribute(name, item_type)
+        if not can_expose_attribute(
+            name,
+            item_type,
+            include_internal=include_internal
+            or (include_internal_convention_attributes and is_internal_convention_attribute),
+        ):
             return False
-        if include_internal:
+        if include_internal or include_internal_convention_attributes:
             return True
-        return not is_internal_sentry_convention_attribute(name, item_type)
+        return not is_internal_convention_attribute
     return can_expose_attribute_to_api(
-        name, item_type, include_internal=include_internal
+        name,
+        item_type,
+        include_internal=include_internal,
+        include_internal_convention_attributes=include_internal_convention_attributes,
     ) and can_expose_trace_item_attribute_to_api(
-        attribute_key, item_type, include_internal=include_internal
+        attribute_key,
+        item_type,
+        include_internal=include_internal,
+        include_internal_convention_attributes=include_internal_convention_attributes,
     )
 
 
@@ -763,6 +780,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         snuba_params.end = adjusted_end_date
 
         include_internal = is_active_superuser(request) or is_active_staff(request)
+        include_internal_convention_attributes = request.user.is_staff
         debug = request.user.is_superuser and request.GET.get("debug", False)
         debug_infos: list[dict] = []
 
@@ -797,6 +815,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                             trace_item_type,
                             include_internal,
                             include_context,
+                            include_internal_convention_attributes=include_internal_convention_attributes,
                             debug=debug,
                         )
                     )
@@ -839,6 +858,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         trace_item_type: SupportedTraceItemType,
         include_internal: bool,
         include_context: bool = False,
+        include_internal_convention_attributes: bool = False,
         debug: str | bool = False,
     ) -> tuple[list[TraceItemAttributeKey], dict | None]:
         debug_info: dict | None = None
@@ -945,6 +965,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 aliased_attributes,
                 all_aliased_attributes,
                 include_context,
+                include_internal_convention_attributes,
             )
 
             sentry_sdk.set_context("api_response", {"attributes": attributes})
@@ -963,6 +984,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         aliased_attributes: list[ResolvedAttribute | ProxyResolvedAttribute],
         exclude_attributes: list[ResolvedAttribute | ProxyResolvedAttribute],
         include_context: bool = False,
+        include_internal_convention_attributes: bool = False,
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         present_names = {attribute.name for attribute in rpc_response.attributes if attribute.name}
@@ -987,6 +1009,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                     attr_key,
                     trace_item_type,
                     include_internal=include_internal,
+                    include_internal_convention_attributes=include_internal_convention_attributes,
                 )
                 and not _replacement_superseded_by_present_source(
                     attr_key["name"], trace_item_type, present_names
@@ -1013,6 +1036,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                 aliased_attr.public_alias,
                 trace_item_type,
                 include_internal=include_internal,
+                include_internal_convention_attributes=include_internal_convention_attributes,
             ):
                 attr_key = as_attribute_key(
                     aliased_attr.internal_name,
@@ -1025,8 +1049,12 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                     aliased_attr.internal_name,
                     trace_item_type,
                     include_internal=include_internal,
+                    include_internal_convention_attributes=include_internal_convention_attributes,
                 ) and can_expose_trace_item_attribute_to_api(
-                    attr_key, trace_item_type, include_internal=include_internal
+                    attr_key,
+                    trace_item_type,
+                    include_internal=include_internal,
+                    include_internal_convention_attributes=include_internal_convention_attributes,
                 ):
                     attribute_keys[attr_key["key"]] = attr_key
         attributes = list(attribute_keys.values())

--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -248,6 +248,7 @@ class OrganizationTraceItemStatsEndpoint(OrganizationEventsEndpointBase):
 
         max_attributes = options.get("explore.trace-items.keys.max")
         include_internal = is_active_superuser(request) or is_active_staff(request)
+        include_internal_convention_attributes = request.user.is_staff
 
         def get_table_results():
             with handle_query_errors():
@@ -321,6 +322,7 @@ class OrganizationTraceItemStatsEndpoint(OrganizationEventsEndpointBase):
                     public_alias,
                     stats_config.visibility_item_type,
                     include_internal=include_internal,
+                    include_internal_convention_attributes=include_internal_convention_attributes,
                 ):
                     continue
 

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -113,6 +113,7 @@ def convert_rpc_attribute_to_json(
     attributes: list[dict],
     trace_item_type: SupportedTraceItemType,
     include_internal: bool = False,
+    include_internal_convention_attributes: bool = False,
     include_arrays: bool = False,
 ) -> list[TraceItemAttribute]:
     result: list[TraceItemAttribute] = []
@@ -122,7 +123,10 @@ def convert_rpc_attribute_to_json(
         internal_name = attribute["name"]
 
         if not can_expose_attribute_to_api(
-            internal_name, trace_item_type, include_internal=include_internal
+            internal_name,
+            trace_item_type,
+            include_internal=include_internal,
+            include_internal_convention_attributes=include_internal_convention_attributes,
         ):
             continue
 
@@ -483,6 +487,7 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
         )
 
         include_internal = is_active_superuser(request) or is_active_staff(request)
+        include_internal_convention_attributes = request.user.is_staff
 
         resp_dict = {
             "itemId": serialize_item_id(resp["itemId"], item_type),
@@ -491,6 +496,7 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
                 resp["attributes"],
                 item_type,
                 include_internal=include_internal,
+                include_internal_convention_attributes=include_internal_convention_attributes,
                 include_arrays=include_arrays,
             ),
             "meta": serialize_meta(resp["attributes"], item_type),

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1104,6 +1104,7 @@ class SearchResolver:
             visibility_attribute,
             item_type,
             include_internal=self.config.api_attribute_visibility_include_internal,
+            include_internal_convention_attributes=self.config.api_attribute_visibility_include_internal_convention_attributes,
         )
 
     def _raise_if_hidden_api_attribute(

--- a/src/sentry/search/eap/types.py
+++ b/src/sentry/search/eap/types.py
@@ -43,6 +43,7 @@ class SearchResolverConfig:
     # so backend resolution semantics remain unchanged.
     api_attribute_visibility_item_type: str | None = None
     api_attribute_visibility_include_internal: bool = False
+    api_attribute_visibility_include_internal_convention_attributes: bool = False
 
     def extra_conditions(
         self,

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -297,31 +297,40 @@ def is_internal_sentry_convention_attribute(
 
 
 def can_expose_attribute_to_api(
-    attribute: str, item_type: SupportedTraceItemType, include_internal: bool = False
+    attribute: str,
+    item_type: SupportedTraceItemType,
+    include_internal: bool = False,
+    include_internal_convention_attributes: bool = False,
 ) -> bool:
     """Return whether an attribute may be exposed by public API surfaces.
 
     The visibility check expands the requested attribute to its related public
     aliases, internal names, and replacement attributes because any of those may
     carry the metadata that marks the underlying convention as internal.
-    `include_internal` only allows those Sentry-owned internal convention
-    attributes. It does not bypass `can_expose_attribute`, which still filters
-    private attributes first.
+    `include_internal_convention_attributes` allows Sentry-owned attributes
+    marked internal by conventions without exposing unrelated internal
+    attributes. It does not bypass private attribute filtering.
     """
     candidates = _get_sentry_convention_visibility_candidates(attribute, item_type)
-
-    for candidate in candidates:
-        if not can_expose_attribute(candidate, item_type, include_internal=include_internal):
-            return False
-
-    # Private attributes are rejected above before this internal-only override
-    # is applied.
-    if include_internal:
-        return True
-
-    return not any(
+    is_internal_convention_attribute = any(
         is_internal_sentry_convention_attribute(candidate, item_type) for candidate in candidates
     )
+    include_internal_for_visibility = include_internal or (
+        include_internal_convention_attributes and is_internal_convention_attribute
+    )
+
+    for candidate in candidates:
+        if not can_expose_attribute(
+            candidate,
+            item_type,
+            include_internal=include_internal_for_visibility,
+        ):
+            return False
+
+    if include_internal or include_internal_convention_attributes:
+        return True
+
+    return not is_internal_convention_attribute
 
 
 def is_sentry_convention_replacement_attribute(

--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -169,6 +169,10 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, SpanTestCase, APITest
 
     @mock.patch("sentry.api.endpoints.organization_spans_fields.snuba_rpc.attribute_names_rpc")
     def test_internal_sentry_convention_attributes_are_hidden(self, mock_attribute_names) -> None:
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, teams=[self.team])
+        self.login_as(user=user)
+
         self.create_span(start_ts=before_now(days=0, minutes=10))
         mock_attribute_names.return_value = TraceItemAttributeNamesResponse(
             attributes=[
@@ -187,3 +191,18 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, SpanTestCase, APITest
 
         assert response.status_code == 200, response.data
         assert response.data == [{"key": "public.attribute", "name": "public.attribute"}]
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization, teams=[self.team])
+        self.login_as(user=staff_user)
+
+        response = self.do_request()
+
+        assert response.status_code == 200, response.data
+        assert response.data == [
+            {"key": "public.attribute", "name": "public.attribute"},
+            {
+                "key": "sentry.dsc.environment",
+                "name": "sentry.dsc.environment",
+            },
+        ]

--- a/tests/sentry/api/endpoints/test_project_trace_item_details.py
+++ b/tests/sentry/api/endpoints/test_project_trace_item_details.py
@@ -234,11 +234,11 @@ class TestInternalConventionVisibilityFiltering:
         assert "sentry.dsc.environment" not in names
         assert "dsc.environment" not in names
 
-    def test_convert_rpc_shows_internal_convention_attributes_when_include_internal(self) -> None:
+    def test_convert_rpc_shows_internal_convention_attributes_for_staff(self) -> None:
         result = convert_rpc_attribute_to_json(
             [self.INTERNAL_ATTR, self.PUBLIC_ATTR],
             SupportedTraceItemType.SPANS,
-            include_internal=True,
+            include_internal_convention_attributes=True,
         )
 
         names = [r["name"] for r in result]

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -76,6 +76,20 @@ class AttributeVisibilityTest(TestCase):
             include_internal=True,
         )
 
+    def test_internal_convention_attribute_visible_with_convention_access(self) -> None:
+        assert can_expose_attribute_to_api(
+            ATTRIBUTE_NAMES.SENTRY_DSC_ENVIRONMENT,
+            SupportedTraceItemType.SPANS,
+            include_internal_convention_attributes=True,
+        )
+
+    def test_convention_access_does_not_expose_unrelated_internal_attributes(self) -> None:
+        assert not can_expose_attribute_to_api(
+            "__sentry_internal_test",
+            SupportedTraceItemType.SPANS,
+            include_internal_convention_attributes=True,
+        )
+
     def test_internal_convention_public_alias_is_hidden(self) -> None:
         with mock.patch.dict(
             eap_utils.PUBLIC_ALIAS_TO_INTERNAL_MAPPING[SupportedTraceItemType.SPANS],
@@ -985,7 +999,7 @@ class SearchResolverColumnTest(TestCase):
             params=SnubaParams(projects=[self.project]),
             config=SearchResolverConfig(
                 api_attribute_visibility_item_type=SupportedTraceItemType.SPANS,
-                api_attribute_visibility_include_internal=True,
+                api_attribute_visibility_include_internal_convention_attributes=True,
             ),
             definitions=SPAN_DEFINITIONS,
         )

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -1501,6 +1501,10 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert "__sentry_internal_test" in attribute_names
 
     def test_internal_convention_attributes_are_hidden(self) -> None:
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, teams=[self.team])
+        self.login_as(user=user)
+
         self.store_segment(
             self.project.id,
             uuid4().hex,
@@ -1537,8 +1541,8 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert ("tags[dsc.sample_rate,number]", "dsc.sample_rate") not in number_attributes
 
         staff_user = self.create_user(is_staff=True)
-        self.create_member(user=staff_user, organization=self.organization)
-        self.login_as(user=staff_user, staff=True)
+        self.create_member(user=staff_user, organization=self.organization, teams=[self.team])
+        self.login_as(user=staff_user)
 
         response = self.do_request(query={"attributeType": "number"})
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -157,14 +157,26 @@ class OrganizationTraceItemStatsEndpointTest(
         assert "device" not in attribute_distribution
 
     def test_hidden_api_attributes_filtered(self) -> None:
+        user = self.create_user()
+        self.create_member(user=user, organization=self.organization, teams=[self.team])
+        self.login_as(user=user)
+
         for tag in [
             {"browser": "chrome", "device": "desktop"},
             {"browser": "firefox", "device": "mobile"},
         ]:
             self._store_span(sentry_tags=tag)
 
-        def can_expose_attribute_to_api(attribute, item_type, include_internal=False):
-            return attribute not in {"device", "sentry.device"}
+        def can_expose_attribute_to_api(
+            attribute,
+            item_type,
+            include_internal=False,
+            include_internal_convention_attributes=False,
+        ):
+            return include_internal_convention_attributes or attribute not in {
+                "device",
+                "sentry.device",
+            }
 
         with mock.patch(
             "sentry.api.endpoints.organization_trace_item_stats.can_expose_attribute_to_api",
@@ -184,6 +196,25 @@ class OrganizationTraceItemStatsEndpointTest(
         assert "browser" in attribute_distribution
         assert "device" not in attribute_distribution
         assert "sentry.device" not in attribute_distribution
+
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(user=staff_user, organization=self.organization, teams=[self.team])
+        self.login_as(user=staff_user)
+
+        with mock.patch(
+            "sentry.api.endpoints.organization_trace_item_stats.can_expose_attribute_to_api",
+            can_expose_attribute_to_api,
+        ):
+            response = self.do_request(
+                query={
+                    "statsType": ["attributeDistributions"],
+                    "itemType": "spans",
+                }
+            )
+
+        assert response.status_code == 200, response.data
+        attribute_distribution = response.data["data"][0]["attributeDistributions"]["data"]
+        assert "sentry.device" in attribute_distribution
 
     def test_substring_match_returns_known_public_aliases(self) -> None:
         # Store spans with known sentry attributes (op, description)


### PR DESCRIPTION
Internal attributes identified through sentry-conventions visibility metadata should be available to staff users without requiring active staff or superuser mode.

This separates convention visibility from the existing internal-attribute gate, passes staff-account status through the affected APIs, and preserves the elevated-mode requirement for unrelated legacy internal prefixes and the existing private-attribute filtering.

The affected surfaces are trace item details, trace item attributes, trace item stats, span fields, and SearchResolver API visibility configuration.

Closes EXP-997