### PR TITLE
feat(onboarding): Track agentic stage completion

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -1,4 +1,5 @@
 from .advanced_search_feature_gated import *  # noqa: F401,F403
+from .agentic_onboarding import *  # noqa: F401,F403
 from .ai_autofix_pr_events import *  # noqa: F401,F403
 from .alert_created import *  # noqa: F401,F403
 from .alert_edited import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/agentic_onboarding.py
+++ b/src/sentry/analytics/events/agentic_onboarding.py
@@ -1,0 +1,13 @@
+from sentry import analytics
+
+
+@analytics.eventclass("agentic_onboarding.stage_completed")
+class AgenticOnboardingStageCompletedEvent(analytics.Event):
+    user_id: int
+    organization_id: int
+    run_id: str
+    stage: str
+    status: str
+
+
+analytics.register(AgenticOnboardingStageCompletedEvent)

--- a/src/sentry/api/endpoints/organization_agentic_onboarding.py
+++ b/src/sentry/api/endpoints/organization_agentic_onboarding.py
@@ -7,6 +7,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from sentry import analytics
+from sentry.analytics.events.agentic_onboarding import AgenticOnboardingStageCompletedEvent
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -205,7 +207,7 @@ class OrganizationAgenticOnboardingStatusEndpoint(OrganizationEndpoint):
         assert user_id is not None
 
         try:
-            run, _ = get_onboarding_progress_service().update(
+            run, _, stage_status_changed = get_onboarding_progress_service().update(
                 token=values["run_token"],
                 user_id=user_id,
                 organization_id=organization.id,
@@ -219,6 +221,18 @@ class OrganizationAgenticOnboardingStatusEndpoint(OrganizationEndpoint):
             return Response({"detail": "Onboarding run is terminal"}, status=409)
         except ValueError:
             return Response({"detail": INVALID_PROGRESS_UPDATE_DETAIL}, status=400)
+
+        if stage_status_changed:
+            if values["update"].status is StageStatus.COMPLETED:
+                analytics.record(
+                    AgenticOnboardingStageCompletedEvent(
+                        user_id=user_id,
+                        organization_id=organization.id,
+                        run_id=run.run_id,
+                        stage=values["update"].stage.value,
+                        status=values["update"].status.value,
+                    )
+                )
 
         snapshot = serialize(run, request.user, AgenticOnboardingRunSerializer())
         return Response(snapshot)

--- a/src/sentry/onboarding/agentic_progress/service.py
+++ b/src/sentry/onboarding/agentic_progress/service.py
@@ -16,6 +16,7 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 from sentry.utils import json, redis
 
 from .model import (
+    STAGE_INDEX,
     InvalidOnboardingRun,
     OnboardingRun,
     OnboardingRunTerminal,
@@ -49,6 +50,12 @@ class RegisteredRun(NamedTuple):
 class UpdatedRun(NamedTuple):
     run: OnboardingRun
     changed: bool
+
+
+class ProgressUpdatedRun(NamedTuple):
+    run: OnboardingRun
+    changed: bool
+    stage_status_changed: bool
 
 
 class ClientRunClaim(NamedTuple):
@@ -131,7 +138,7 @@ class OnboardingProgressService:
         user_id: int,
         organization_id: int,
         update: ProgressUpdate[Any],
-    ) -> UpdatedRun:
+    ) -> ProgressUpdatedRun:
         if len(token) != TOKEN_LENGTH or not token.isalnum():
             raise RunNotFound
         token_hash = self._hash_token(token)
@@ -139,14 +146,22 @@ class OnboardingProgressService:
         if run_id is None:
             raise RunNotFound
 
+        stage_status_changed = False
+
         def mutate(run: OnboardingRun) -> OnboardingRun:
+            nonlocal stage_status_changed
             if run.token_hash != token_hash:
                 raise RunNotFound
             if run.user_id != user_id or run.organization_id != organization_id:
                 raise RunOwnershipMismatch
-            return apply_update(run, update, datetime.now(timezone.utc))
+            stage_index = STAGE_INDEX[update.stage]
+            previous_status = run.stages[stage_index].status
+            updated = apply_update(run, update, datetime.now(timezone.utc))
+            stage_status_changed = previous_status is not updated.stages[stage_index].status
+            return updated
 
-        return self._atomic_update(run_id, mutate)
+        run, changed = self._atomic_update(run_id, mutate)
+        return ProgressUpdatedRun(run, changed, stage_status_changed)
 
     def cancel(self, *, run_id: str, user_id: int, organization_id: int) -> OnboardingRun:
         def mutate(run: OnboardingRun) -> OnboardingRun:

--- a/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
+++ b/tests/sentry/api/endpoints/test_organization_agentic_onboarding.py
@@ -271,3 +271,47 @@ class OrganizationAgenticOnboardingEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data == {"detail": "Invalid onboarding progress update"}
+
+    def test_records_completed_stage_once(self) -> None:
+        run, token = self.service.create_or_resume(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            client_run_id=str(uuid4()),
+            onboarding_code="abcdefghij",
+        )
+        path = reverse(
+            "sentry-api-0-organization-agentic-onboarding-status",
+            args=[self.organization.slug],
+        )
+        service_path = (
+            "sentry.api.endpoints.organization_agentic_onboarding.get_onboarding_progress_service"
+        )
+        payload = {
+            "schemaVersion": 1,
+            "runToken": token,
+            "stage": "create_project",
+            "status": "completed",
+            "extra": {"projectSlugs": ["frontend"]},
+        }
+        extra_update = {**payload, "extra": {"projectSlugs": ["backend"]}}
+
+        with (
+            patch(service_path, return_value=self.service),
+            patch("sentry.analytics.record") as record_analytics,
+        ):
+            response = self.client.post(path, payload)
+            extra_response = self.client.post(path, extra_update)
+
+        assert response.status_code == 200
+        assert extra_response.status_code == 200
+        assert extra_response.data["sequence"] == 2
+        record_analytics.assert_called_once()
+        event = record_analytics.call_args.args[0]
+        assert event.type == "agentic_onboarding.stage_completed"
+        assert event.serialize() == {
+            "user_id": self.user.id,
+            "organization_id": self.organization.id,
+            "run_id": run.run_id,
+            "stage": "create_project",
+            "status": "completed",
+        }

--- a/tests/sentry/onboarding/agentic_progress/test_service.py
+++ b/tests/sentry/onboarding/agentic_progress/test_service.py
@@ -106,7 +106,7 @@ def test_update_uses_canonical_state_key(service: OnboardingProgressService) -> 
         service, user_id=1, organization_id=2, client_run_id="browser-session"
     )
 
-    updated, changed = service.update(
+    updated, changed, _ = service.update(
         token=token,
         user_id=1,
         organization_id=2,
@@ -121,13 +121,13 @@ def test_update_uses_canonical_state_key(service: OnboardingProgressService) -> 
 
 def test_duplicate_update_is_idempotent(service: OnboardingProgressService) -> None:
     _, token = create_run(service, user_id=1, organization_id=2, client_run_id="browser-session")
-    first, first_changed = service.update(
+    first, first_changed, _ = service.update(
         token=token,
         user_id=1,
         organization_id=2,
         update=ProgressUpdate(stage=Stage.CONNECT_MCP, status=StageStatus.COMPLETED),
     )
-    duplicate, duplicate_changed = service.update(
+    duplicate, duplicate_changed, _ = service.update(
         token=token,
         user_id=1,
         organization_id=2,


### PR DESCRIPTION
Agentic onboarding now records an analytics event whenever a stage first completes. The event includes the user, organization, onboarding run, and stage, while idempotent update retries remain deduplicated by the persisted progress change boundary.