### PR TITLE
fix(onboarding): Establish query containers for SCM steps

### DIFF
--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -70,7 +70,10 @@ export function ScmConnect({
   const effectiveIntegration = selectedIntegration ?? activeIntegrationExisting;
 
   return (
-    <Stack align="center" gap="3xl" flexGrow={1}>
+    // The onboarding flow has no page-level query container (project creation
+    // resolves against `#main`), and the flow's fixed footers preclude one
+    // higher up, so each SCM step declares its own.
+    <Stack align="center" gap="3xl" flexGrow={1} containerType="inline-size">
       <ScmStepHeader
         heading={t('Connect your code')}
         subtitle={t(

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -97,7 +97,10 @@ export function ScmMessaging({
   const hasValidationAlert = !!validation.staleReason || validation.isError;
 
   return (
-    <Stack align="center" gap="2xl" flexGrow={1}>
+    // The onboarding flow has no page-level query container (project creation
+    // resolves against `#main`), and the flow's fixed footers preclude one
+    // higher up, so each SCM step declares its own.
+    <Stack align="center" gap="2xl" flexGrow={1} containerType="inline-size">
       <Stack gap="2xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`} width="100%">
         <Stack gap="lg">
           <Heading as="h2" size="3xl">

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -116,7 +116,10 @@ export function ScmPlatformFeatures({
   }
 
   return (
-    <Stack align="center" gap="2xl" flexGrow={1}>
+    // The onboarding flow has no page-level query container (project creation
+    // resolves against `#main`), and the flow's fixed footers preclude one
+    // higher up, so each SCM step declares its own.
+    <Stack align="center" gap="2xl" flexGrow={1} containerType="inline-size">
       <Stack gap="3xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`}>
         <Heading as="h2" size="4xl">
           {t('Create your first project')}


### PR DESCRIPTION
Since #122712 replaced the SCM components' screen-prefixed responsive props with bare container keys, none of their `@container` rules could match in the onboarding flow: bare keys resolve against the nearest query container, which the project creation flow provides via the org layout's `#main` content stack, but the onboarding route renders outside that layout. Every SCM step was stuck at its mobile base layout at any width, affecting the provider pills, the integration connect footer, the alert frequency grid, the project details grid, and the platform features layout.

A flow-wide container in `onboarding.tsx` is not an option because `container-type` implies layout containment, which would re-anchor the fixed footers rendered by the welcome and setup-docs steps (the same constraint #120638 worked around with local containers), so each SCM step root declares its own `containerType="inline-size"` instead. The step roots span the page width minus the flow padding, so the `3xl` (1024px) flip lands close to the old `screen:md` (992px) viewport breakpoint.
