### PR TITLE
fix(hybridcloud): Bound drains by their claim's deadline; merge the drains

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -57,20 +57,28 @@ slow forwarding yields to other tasks
 """
 
 
-RELEASE_MARGIN = datetime.timedelta(seconds=30)
+CELL_REQUEST_TIMEOUT = 12
+"""Connect and read timeout, each, for one delivery request to a cell."""
+
+REQUEST_BOUND = datetime.timedelta(seconds=2 * CELL_REQUEST_TIMEOUT + 2)
 """
-How long before its claim's deadline a drain stops delivering and releases the
-unworked tail back to the mailbox. Covers the requests still in flight at the
-stop (each bounded by CELL_REQUEST_TIMEOUT for connect and read) plus the final
-delete flush, so the release lands while the claim still holds.
+The longest a delivery request can take and still come back: the connect and
+read timeouts back to back, plus slack for the thread to hand the result over.
+A request still in flight past it is stuck — the read timeout is per socket
+read, so a cell that keeps trickling bytes outruns it — and is not waited for.
 """
 
-CELL_REQUEST_TIMEOUT = 12
+SETTLE_ALLOWANCE = datetime.timedelta(seconds=4)
 """
-Connect and read timeout, each, for one delivery request to a cell. Twice this
-must stay under RELEASE_MARGIN, or a request started just ahead of the
-soft-stop carries the drain past its claim's deadline into rows another
-dispatcher may already own.
+What a drain keeps back from its claim's deadline for the delete flush and the
+release UPDATE once it has stopped waiting on requests.
+"""
+
+RELEASE_MARGIN = REQUEST_BOUND + SETTLE_ALLOWANCE
+"""
+How long before its claim's deadline a drain stops delivering and releases the
+unworked tail back to the mailbox: long enough to wait out the requests in
+flight at the stop, then settle, so the release lands while the claim holds.
 """
 
 
@@ -981,6 +989,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
         deleter,
         worker_threads=worker_threads,
         delivery_tags=delivery_tags,
+        settle_by=claim.valid_until - SETTLE_ALLOWANCE,
         # A drain killed mid-request leaves no result to reschedule on, so the
         # record would be retried at every claim horizon until it is stale. A
         # strict provider's record head-blocks its mailbox all that while, so
@@ -1039,7 +1048,17 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                 else:
                     logger.debug("deliver_webhook.delivery_complete", extra=extra)
                 break
-            pool.wait_one()
+            if not pool.wait_one():
+                # Every request in flight has outrun REQUEST_BOUND: the cell is
+                # not answering. Stop rather than feed it more, and leave the
+                # tail parked under the claim instead of releasing it — a
+                # dispatcher would only send the next drain into the same cell.
+                logger.warning(
+                    "deliver_webhook.cell_unresponsive",
+                    extra={**extra, "in_flight": pool.in_flight},
+                )
+                pool.wind_down(reason="stuck", patience=0)
+                break
             if pool.unexpected is not None:
                 pool.wind_down(reason="error")
                 break
@@ -1070,10 +1089,12 @@ class _DeliveryPool:
         *,
         worker_threads: int,
         delivery_tags: Mapping[str, str],
+        settle_by: datetime.datetime,
         spends_attempt_on_submit: bool,
     ) -> None:
         self._deleter = deleter
         self._delivery_tags = delivery_tags
+        self._settle_by = settle_by
         self._spends_attempt_on_submit = spends_attempt_on_submit
         self._capacity = worker_threads
         self._executor = ContextPropagatingThreadPoolExecutor(max_workers=worker_threads)
@@ -1095,17 +1116,28 @@ class _DeliveryPool:
     def idle(self) -> bool:
         return not self._in_flight
 
+    @property
+    def in_flight(self) -> int:
+        return len(self._in_flight)
+
     def submit(self, record: WebhookPayload) -> None:
         if self._spends_attempt_on_submit:
             record.schedule_next_attempt()
         self._in_flight[self._executor.submit(deliver_message, record)] = record
 
-    def wait_one(self) -> None:
-        """Block until at least one request finishes, then handle every result that is in."""
-        done, _ = wait(self._in_flight, return_when=FIRST_COMPLETED)
+    def wait_one(self) -> bool:
+        """
+        Block until a request finishes, then handle every result that is in.
+        False when none finished inside REQUEST_BOUND: every request in flight
+        was already running when the wait began, so all of them are now stuck.
+        """
+        done, _ = wait(
+            self._in_flight, timeout=REQUEST_BOUND.total_seconds(), return_when=FIRST_COMPLETED
+        )
         self._handle(done)
+        return bool(done)
 
-    def wind_down(self, *, reason: str) -> int | None:
+    def wind_down(self, *, reason: str, patience: float | None = None) -> int | None:
         """
         Stop delivering: cancel the requests that have not started, wait out the
         ones that have, and handle their results. Returns the lowest cancelled id
@@ -1117,22 +1149,50 @@ class _DeliveryPool:
         cancelled id is below them all. Rows above it that were worked are
         settled by then, so the release's `schedule_for` match passes them by.
 
-        The wait is what RELEASE_MARGIN has to cover, so its length is recorded
-        under `reason` whenever there was something to wait for.
+        The wait lasts at most `patience` seconds — by default REQUEST_BOUND,
+        or what is left before `settle_by`, whichever is shorter — and is
+        recorded under `reason` whenever there was something to wait for.
+        Requests still running after that are abandoned (`_abandon`), and the
+        executor is shut down without joining their threads.
         """
         cancelled_ids = [record.id for future, record in self._in_flight.items() if future.cancel()]
         self._in_flight = {
             future: record for future, record in self._in_flight.items() if not future.cancelled()
         }
         if self._in_flight:
+            if patience is None:
+                remaining = (self._settle_by - timezone.now()).total_seconds()
+                patience = max(0.0, min(REQUEST_BOUND.total_seconds(), remaining))
             with metrics.timer(
                 "hybridcloud.deliver_webhooks.drain.wind_down",
                 tags={**self._delivery_tags, "reason": reason},
             ):
-                done, _ = wait(self._in_flight)
+                done, stuck = wait(self._in_flight, timeout=patience)
             self._handle(done)
-        self._executor.shutdown()
+            self._abandon(stuck)
+        self._executor.shutdown(wait=False)
         return min(cancelled_ids, default=None)
+
+    def _abandon(self, stuck: Iterable[Future[tuple[WebhookPayload, Exception | None]]]) -> None:
+        """
+        Give up on requests the drain will not wait for. Each counts as a failed
+        attempt: the record goes into its retry backoff, so a request that never
+        answers cannot be retried at every claim horizon until the record is
+        stale. Its thread finishes on its own; nothing reads the result, so a
+        late success is redelivered once after the backoff.
+        """
+        for future in stuck:
+            record = self._in_flight.pop(future)
+            self.failed += 1
+            # Unsampled: rare, and each one is a request the cell never answered.
+            metrics.incr(
+                "hybridcloud.deliver_webhooks.delivery",
+                tags={**self._delivery_tags, "outcome": "abandoned"},
+                sample_rate=1.0,
+            )
+            logger.warning("deliver_webhook.abandoned", extra=record.as_dict())
+            if not self._spends_attempt_on_submit:
+                record.schedule_next_attempt()
 
     def _handle(self, done: Iterable[Future[tuple[WebhookPayload, Exception | None]]]) -> None:
         for future in done:

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -996,13 +996,23 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
         while True:
             extra = {**claim.log_context, "delivered": pool.delivered}
             if claim.lapsed(log_key="deliver_webhook.delivery_deadline", extra=extra):
+                pool.wind_down(reason="lapsed")
                 break
             if claim.nearing_deadline():
                 # Settle and flush before releasing, so a request that completes
                 # late cannot land on a row another dispatcher has since claimed,
                 # and no delivered row is released ahead of its delete.
-                lowest_cancelled = pool.wind_down()
+                lowest_cancelled = pool.wind_down(reason="deadline")
                 deleter.flush()
+                overshoot = (timezone.now() - claim.valid_until).total_seconds()
+                if overshoot >= 0:
+                    # The in-flight requests outran RELEASE_MARGIN: the rows have
+                    # been claimable again since the deadline, so anything settled
+                    # after it may have been delivered twice.
+                    logger.warning(
+                        "deliver_webhook.release_overshoot",
+                        extra={**claim.log_context, "overshoot_seconds": overshoot},
+                    )
                 claim.release_remainder(
                     frontier if lowest_cancelled is None else lowest_cancelled,
                     extra={**claim.log_context, "delivered": pool.delivered},
@@ -1031,6 +1041,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                 break
             pool.wait_one()
             if pool.unexpected is not None:
+                pool.wind_down(reason="error")
                 break
             if pool.failed > 0 and not skip_on_failure:
                 # For providers that require strict ordering, stop on the first
@@ -1038,7 +1049,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                 # The failed record has already been rescheduled.
                 break
     finally:
-        pool.wind_down()
+        pool.wind_down(reason="exception")
         deleter.flush()
     if pool.unexpected is not None:
         raise pool.unexpected
@@ -1094,7 +1105,7 @@ class _DeliveryPool:
         done, _ = wait(self._in_flight, return_when=FIRST_COMPLETED)
         self._handle(done)
 
-    def wind_down(self) -> int | None:
+    def wind_down(self, *, reason: str) -> int | None:
         """
         Stop delivering: cancel the requests that have not started, wait out the
         ones that have, and handle their results. Returns the lowest cancelled id
@@ -1105,13 +1116,21 @@ class _DeliveryPool:
         the unsubmitted ones sit past everything submitted, so the lowest
         cancelled id is below them all. Rows above it that were worked are
         settled by then, so the release's `schedule_for` match passes them by.
+
+        The wait is what RELEASE_MARGIN has to cover, so its length is recorded
+        under `reason` whenever there was something to wait for.
         """
         cancelled_ids = [record.id for future, record in self._in_flight.items() if future.cancel()]
         self._in_flight = {
             future: record for future, record in self._in_flight.items() if not future.cancelled()
         }
-        done, _ = wait(self._in_flight)
-        self._handle(done)
+        if self._in_flight:
+            with metrics.timer(
+                "hybridcloud.deliver_webhooks.drain.wind_down",
+                tags={**self._delivery_tags, "reason": reason},
+            ):
+                done, _ = wait(self._in_flight)
+            self._handle(done)
         self._executor.shutdown()
         return min(cancelled_ids, default=None)
 

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -2,10 +2,9 @@ import dataclasses
 import datetime
 import enum
 import logging
-import math
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
-from concurrent.futures import as_completed
+from collections.abc import Iterable, Mapping, Sequence
+from concurrent.futures import FIRST_COMPLETED, Future, wait
 from typing import Any
 
 import orjson
@@ -58,21 +57,12 @@ slow forwarding yields to other tasks
 """
 
 
-MIN_RECORDS_PER_THREAD = 5
-"""
-Records a claim must hold per delivery thread before another thread is added.
-
-Bounds each drain's thread and connection burst for small claims; full
-concurrency is reached by ~worker_threads times this many records, where the
-worker-slot time a lone thread would spend dominates the burst cost.
-"""
-
 RELEASE_MARGIN = datetime.timedelta(seconds=30)
 """
 How long before its claim's deadline a drain stops delivering and releases the
-unworked tail back to the mailbox. Covers a worst-case delivery wave (bounded
-by CELL_REQUEST_TIMEOUT for connect and read each) plus the final delete
-flush, so the release lands while the claim still holds.
+unworked tail back to the mailbox. Covers the requests still in flight at the
+stop (each bounded by CELL_REQUEST_TIMEOUT for connect and read) plus the final
+delete flush, so the release lands while the claim still holds.
 """
 
 CELL_REQUEST_TIMEOUT = 12
@@ -118,8 +108,7 @@ actions that have been made to the relevant resources.
 
 DELETE_BATCH_SIZE = 100
 """
-How many finished rows a batching drain accumulates before removing them.
-Sized to the drain's read slice so a flush lands roughly per slice, and small
+How many finished rows a batching drain accumulates before removing them. Small
 enough that a crash strands at most this many rows until the claim horizon
 passes.
 """
@@ -296,17 +285,8 @@ class _MailboxClaim:
         return self.provider in allowlist
 
     @property
-    def threaded(self) -> bool:
-        """
-        Whether this claim's drain starts out delivering in concurrent waves; the
-        dispatch `drain` tag. Only providers that may skip failed records qualify:
-        concurrent requests complete in arbitrary order, so threading a
-        strict-ordering provider would deliver out of order exactly when its
-        mailbox is deep.
-        """
-        if not self.skip_on_failure or self.claimed <= MIN_RECORDS_PER_THREAD:
-            return False
-        return options.get("hybridcloud.webhookpayload.worker_threads") > 1
+    def log_context(self) -> dict[str, Any]:
+        return {"id": self.head_id, "mailbox_name": self.mailbox_name, "provider": self.provider}
 
     def task_args(self) -> dict[str, Any]:
         """
@@ -347,7 +327,7 @@ class _MailboxClaim:
         return True
 
     def nearing_deadline(self) -> bool:
-        """Whether to stop delivering and release, rather than run into the deadline mid-wave."""
+        """Whether to stop delivering and release, rather than run into the deadline mid-request."""
         return timezone.now() >= self.valid_until - RELEASE_MARGIN
 
     def release_remainder(self, next_id: int, *, extra: Mapping[str, Any]) -> None:
@@ -375,21 +355,23 @@ class _MailboxClaim:
             )
         logger.info("deliver_webhook.deadline_release", extra={**extra, "released": released})
 
-    def next_slice(self, start_id: int, size: int) -> list[WebhookPayload] | None:
+    def records(self) -> list[WebhookPayload] | None:
         """
-        The next `size` records this drain may deliver, or None when it must stand
-        down: its head is gone, so whoever claimed the mailbox next is delivering
-        these. An empty list is the ordinary end of a claim, not a stand-down.
+        The records this drain may deliver, or None when it must stand down: its
+        head is gone, so whoever claimed the mailbox next is delivering these.
 
-        The drain reads through here to keep that check ahead of delivery — a
-        wave that delivers first duplicates every row it sends.
+        Bounded to the claim: rows past it belong to whichever dispatcher claims
+        them next, and delivering them here would race a drain that dispatcher
+        may have started. The drain reads through here to keep the head check
+        ahead of delivery — a drain that delivers first duplicates every row it
+        sends.
         """
         records = list(
             WebhookPayload.objects.filter(
-                id__gte=start_id, mailbox_name=self.mailbox_name
-            ).order_by("id")[:size]
+                id__gte=self.head_id, mailbox_name=self.mailbox_name
+            ).order_by("id")[: self.claimed]
         )
-        if start_id == self.head_id and (not records or records[0].id != self.head_id):
+        if not records or records[0].id != self.head_id:
             _record_lost_head(
                 self.head_id,
                 dispatcher=self.dispatcher,
@@ -398,6 +380,46 @@ class _MailboxClaim:
             )
             return None
         return records
+
+
+class _PayloadDeleter:
+    """
+    Removes the rows a drain is finished with, whether they were delivered,
+    discarded for exhausted attempts, or discarded as stale.
+
+    Batching drains accumulate ids and remove them DELETE_BATCH_SIZE at a time
+    rather than issuing one statement per row, which is most of the write
+    traffic a drain generates on this delete-heavy table. Only the drain thread
+    ever calls a deleter: parallel workers perform requests and hand their
+    results back to the drain loop, so no locking is needed.
+
+    Batching is safe because every drain is bounded to a claim its dispatcher
+    owns: nothing else can touch a row between the drain finishing with it and
+    deleting it. A worker that dies before flushing reprocesses at most one batch
+    once the claim horizon passes — redelivering its delivered rows and
+    re-discarding the rest — the same window a claim-then-crash already has.
+    """
+
+    def __init__(self, *, batched: bool) -> None:
+        self._batched = batched
+        self._pending: list[int] = []
+
+    def delete(self, payload: WebhookPayload) -> None:
+        """Remove the payload's row, either now or at the next flush."""
+        if not self._batched:
+            payload.delete()
+            return
+        self._pending.append(payload.id)
+        if len(self._pending) >= DELETE_BATCH_SIZE:
+            self.flush()
+
+    def flush(self) -> None:
+        """Remove every row accumulated since the last flush."""
+        if not self._pending:
+            return
+        metrics.distribution("hybridcloud.deliver_webhooks.drain.delete_batch", len(self._pending))
+        WebhookPayload.objects.filter(id__in=self._pending).delete()
+        self._pending.clear()
 
 
 def _begin_drain(
@@ -503,14 +525,6 @@ def _claim_mailbox_batch(
     )
 
 
-class DispatchOutcome(enum.StrEnum):
-    """What `_claim_and_dispatch` did for a mailbox; doubles as a metric tag."""
-
-    NOT_DUE = "not_due"
-    SEQUENTIAL = "sequential"
-    PARALLEL = "parallel"
-
-
 def _delivery_tags(dispatcher: str | None, provider: str) -> dict[str, str]:
     """
     The tags every delivery outcome carries: who dispatched the drain, and whose
@@ -522,13 +536,7 @@ def _delivery_tags(dispatcher: str | None, provider: str) -> dict[str, str]:
     return {"dispatcher": dispatcher or "unknown", "provider": provider}
 
 
-def _record_dispatch(
-    *,
-    dispatcher: Dispatcher,
-    drain: DispatchOutcome,
-    mailbox_name: str,
-    claimed: int,
-) -> None:
+def _record_dispatch(*, dispatcher: Dispatcher, mailbox_name: str, claimed: int) -> None:
     """
     Record a drain enqueue so push- and scheduler-dispatched work stay comparable.
 
@@ -536,25 +544,21 @@ def _record_dispatch(
     one. A scheduler drain can claim up to MAX_MAILBOX_DRAIN records where a push
     drain typically claims one or two, so the two shares are different numbers.
     """
-    tags = {
-        "dispatcher": dispatcher,
-        "drain": drain,
-        "provider": _provider_from_mailbox(mailbox_name),
-    }
+    tags = {"dispatcher": dispatcher, "provider": _provider_from_mailbox(mailbox_name)}
     metrics.incr("hybridcloud.deliver_webhooks.dispatch", tags=tags)
     metrics.distribution("hybridcloud.deliver_webhooks.dispatch.claimed", claimed, tags=tags)
 
 
 def _claim_and_dispatch(
     head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
-) -> DispatchOutcome:
+) -> _MailboxClaim | None:
     """
     Claim a batch for the mailbox and dispatch its drain.
     Callers must hold the mailbox's drain lock so concurrent dispatchers cannot
     interleave around the claim.
 
-    Returns the dispatched drain's mode, or NOT_DUE when the head has already
-    been claimed, delivered, or moved into a retry backoff. Dispatchers discover
+    Returns the dispatched claim, or None when the head has already been
+    claimed, delivered, or moved into a retry backoff. Dispatchers discover
     mailbox heads outside the drain lock, so the due-gate inside the claim is
     what stops two of them from double-dispatching the same head.
 
@@ -568,7 +572,7 @@ def _claim_and_dispatch(
     """
     claim = _claim_mailbox_batch(head_id, mailbox_name, dispatcher=dispatcher)
     if claim is None:
-        return DispatchOutcome.NOT_DUE
+        return None
     # Only the arguments workers from the previous deploy bind: an unknown kwarg
     # is a TypeError the taskbroker discards without retry. The drain recovers
     # the mailbox and deadline from its head row; the full claim shape
@@ -578,14 +582,8 @@ def _claim_and_dispatch(
         claimed_count=claim.claimed,
         dispatcher=claim.dispatcher,
     )
-    outcome = DispatchOutcome.PARALLEL if claim.threaded else DispatchOutcome.SEQUENTIAL
-    _record_dispatch(
-        dispatcher=dispatcher,
-        drain=outcome,
-        mailbox_name=mailbox_name,
-        claimed=claim.claimed,
-    )
-    return outcome
+    _record_dispatch(dispatcher=dispatcher, mailbox_name=mailbox_name, claimed=claim.claimed)
+    return claim
 
 
 def maybe_trigger_drain(mailbox_name: str) -> None:
@@ -628,16 +626,13 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
             # backoff — the scheduler covers it when schedule_for comes due.
             metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff", tags=trigger_tags)
             return
-        outcome = _claim_and_dispatch(head[0], mailbox_name, dispatcher=Dispatcher.PUSH)
-        if outcome is DispatchOutcome.NOT_DUE:
+        claim = _claim_and_dispatch(head[0], mailbox_name, dispatcher=Dispatcher.PUSH)
+        if claim is None:
             # The head moved between our read and the claim; whoever moved it has
             # the mailbox covered.
             metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff", tags=trigger_tags)
             return
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.push_trigger.success",
-            tags={**trigger_tags, "drain": outcome},
-        )
+        metrics.incr("hybridcloud.deliver_webhooks.push_trigger.success", tags=trigger_tags)
     except Exception:
         metrics.incr(
             "hybridcloud.deliver_webhooks.push_trigger.error",
@@ -908,13 +903,11 @@ def schedule_webhook_delivery() -> None:
         # A None guard is a cache outage. Claims still keep dispatchers apart across
         # cycles, so proceed — just unserialized against push triggers.
         try:
-            outcome = _claim_and_dispatch(
-                record["id"], mailbox_name, dispatcher=Dispatcher.SCHEDULER
-            )
+            claim = _claim_and_dispatch(record["id"], mailbox_name, dispatcher=Dispatcher.SCHEDULER)
         finally:
             if guard:
                 _release_drain_lock(mailbox_name)
-        if outcome is DispatchOutcome.NOT_DUE:
+        if claim is None:
             # Claimed out of the list between discovery and here, usually by a
             # push trigger.
             metrics.incr(
@@ -951,8 +944,7 @@ def drain_mailbox(
     chain_depth: int = 1,
 ) -> None:
     """
-    Deliver webhooks from the mailbox that `payload_id` is the head of — in order,
-    or in concurrent waves when the claim qualifies (`_MailboxClaim.threaded`).
+    Deliver webhooks from the mailbox that `payload_id` is the head of.
 
     The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
     each defaults so a rolling deploy can bind drains the previous version sent.
@@ -967,147 +959,180 @@ def drain_mailbox(
 def _drain_mailbox(claim: _MailboxClaim) -> None:
     """
     Deliver the claimed records until a strict provider's record fails, the claim
-    nears its deadline, or all of them have been processed. Skip-on-failure claims
-    deliver in concurrent waves sized to the work left, falling back to one record
-    at a time as the tail shrinks; strict claims always deliver in order.
+    nears its deadline, or all of them have been processed.
 
-    The drain holds no lock, so it must not deliver past the records its dispatcher
-    claimed: beyond them the mailbox head is due again and another dispatcher may
-    already be draining it.
+    Skip-on-failure claims deliver on `worker_threads` threads. Strict claims
+    deliver on one: concurrent requests complete in arbitrary order, so a
+    strict-ordering provider would be delivered out of order exactly when its
+    mailbox is deep.
     """
-    delivery_tags = claim.delivery_tags
+    records = claim.records()
+    if records is None:
+        return
     skip_on_failure = claim.skip_on_failure
-    worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
+    delivery_tags = claim.delivery_tags
+    worker_threads = 1
+    if skip_on_failure:
+        worker_threads = max(
+            1, min(options.get("hybridcloud.webhookpayload.worker_threads"), len(records))
+        )
     deleter = _PayloadDeleter(batched=options.get("hybridcloud.webhookpayload.drain_batch_deletes"))
-
-    delivered = 0
-    failed = 0
-    remaining = claim.claimed
-    current_id = claim.head_id
-    records: list[WebhookPayload] = []
-    index = 0
-    log_context = {
-        "id": claim.head_id,
-        "mailbox_name": claim.mailbox_name,
-        "provider": claim.provider,
-    }
+    pool = _DeliveryPool(
+        deleter,
+        worker_threads=worker_threads,
+        delivery_tags=delivery_tags,
+        # A drain killed mid-request leaves no result to reschedule on, so the
+        # record would be retried at every claim horizon until it is stale. A
+        # strict provider's record head-blocks its mailbox all that while, so
+        # its attempt is spent before the request goes out — one extra write per
+        # record, which the high-volume skip-on-failure providers are spared:
+        # due-head dispatch simply passes over such a record.
+        spends_attempt_on_submit=not skip_on_failure,
+    )
+    walk = iter(records)
+    # The first id not yet handed to the pool: where a release starts.
+    frontier = claim.head_id
     try:
         while True:
-            extra = {**log_context, "delivered": delivered}
+            extra = {**claim.log_context, "delivered": pool.delivered}
             if claim.lapsed(log_key="deliver_webhook.delivery_deadline", extra=extra):
                 break
             if claim.nearing_deadline():
-                claim.release_remainder(current_id, extra=extra)
+                # Settle and flush before releasing, so a request that completes
+                # late cannot land on a row another dispatcher has since claimed,
+                # and no delivered row is released ahead of its delete.
+                lowest_cancelled = pool.wind_down()
+                deleter.flush()
+                claim.release_remainder(
+                    frontier if lowest_cancelled is None else lowest_cancelled,
+                    extra={**claim.log_context, "delivered": pool.delivered},
+                )
                 break
-
-            if index >= len(records):
-                # Slices of 100 keep query duration down and avoid reading records
-                # a failure earlier in the claim means we never get to.
-                fetched = claim.next_slice(current_id, min(100, remaining))
-                if fetched is None:
-                    return
-                if not fetched:
-                    if failed > 0:
-                        logger.info(
-                            "deliver_webhook.delivery_complete_with_failures",
-                            extra={**extra, "failed": failed},
-                        )
-                    else:
-                        logger.debug("deliver_webhook.delivery_complete", extra=extra)
-                    return
-                records = fetched
-                index = 0
-
-            concurrency = 1
-            if skip_on_failure:
-                concurrency = min(worker_threads, math.ceil(remaining / MIN_RECORDS_PER_THREAD))
-            if concurrency > 1:
-                wave = records[index : index + concurrency]
-                # Advance past the whole wave before delivery: a delete clears pk
-                # on the in-memory instance, and failed rows — left with a future
-                # schedule_for — must not be re-attempted here. A failed request
-                # never stops the drain: threading requires skip_on_failure.
-                current_id = wave[-1].id + 1
-                index += len(wave)
-                remaining -= len(wave)
-                delivered += _run_parallel_delivery_batch(
-                    wave, deleter, delivery_tags=delivery_tags
-                )
-            else:
-                record = records[index]
-                # Advance past this record regardless of outcome so that failed
-                # messages are not re-attempted later in this drain.
-                current_id = record.id + 1
-                index += 1
-                remaining -= 1
-                try:
-                    if deliver_message(record, deleter, delivery_tags=delivery_tags):
-                        delivered += 1
-                except DeliveryFailed:
-                    failed += 1
-                    metrics.incr(
-                        "hybridcloud.deliver_webhooks.delivery",
-                        tags={**delivery_tags, "outcome": "retry"},
+            while pool.has_room and (record := next(walk, None)) is not None:
+                # Advance past the record before it is delivered: a delete clears
+                # pk on the in-memory instance, and a failed record — left with a
+                # future schedule_for — must not be re-attempted by this drain.
+                frontier = record.id + 1
+                # Stale and attempts-exhausted rows are discarded in place of
+                # delivery, consuming claim budget like any delivered row rather
+                # than being swept out from under the claim.
+                if not _discard_if_exhausted(
+                    record, deleter, delivery_tags=delivery_tags
+                ) and not _discard_if_stale(record, deleter, delivery_tags=delivery_tags):
+                    pool.submit(record)
+            if pool.idle:
+                if pool.failed > 0:
+                    logger.info(
+                        "deliver_webhook.delivery_complete_with_failures",
+                        extra={**extra, "failed": pool.failed},
                     )
-                    if not skip_on_failure:
-                        # For providers that require strict ordering, stop on the
-                        # first failure so subsequent messages are not delivered
-                        # out of order.
-                        return
-                    # For allowlisted providers: skip the failed message and
-                    # continue. It has already been rescheduled by deliver_message.
-
-            if remaining <= 0:
-                # Claim exhausted. Rows past this point belong to whichever
-                # dispatcher claims them next; delivering them here would race
-                # a drain that dispatcher may have started.
-                logger.debug(
-                    "deliver_webhook.claim_exhausted",
-                    extra={**log_context, "delivered": delivered},
-                )
-                return
+                else:
+                    logger.debug("deliver_webhook.delivery_complete", extra=extra)
+                break
+            pool.wait_one()
+            if pool.unexpected is not None:
+                break
+            if pool.failed > 0 and not skip_on_failure:
+                # For providers that require strict ordering, stop on the first
+                # failure so subsequent messages are not delivered out of order.
+                # The failed record has already been rescheduled.
+                break
     finally:
+        pool.wind_down()
         deleter.flush()
+    if pool.unexpected is not None:
+        raise pool.unexpected
 
 
-class _PayloadDeleter:
+class _DeliveryPool:
     """
-    Removes the rows a drain is finished with, whether they were delivered,
-    discarded for exhausted attempts, or discarded as stale.
+    Delivery for one drain: a fixed set of threads, each handed the next record as
+    soon as it finishes its last, so a slow request holds up only its own thread.
 
-    Batching drains accumulate ids and remove them DELETE_BATCH_SIZE at a time
-    rather than issuing one statement per row, which is most of the write
-    traffic a drain generates on this delete-heavy table. Only the drain thread
-    ever calls a deleter: parallel workers perform requests and hand their
-    results back to the drain loop, so no locking is needed.
-
-    Batching is safe because every drain is bounded to a claim its dispatcher
-    owns: nothing else can touch a row between the drain finishing with it and
-    deleting it. A worker that dies before flushing reprocesses at most one batch
-    once the claim horizon passes — redelivering its delivered rows and
-    re-discarding the rest — the same window a claim-then-crash already has.
+    Workers only perform requests. Every result is handled on the drain thread,
+    which is what lets `_PayloadDeleter` go unlocked.
     """
 
-    def __init__(self, *, batched: bool) -> None:
-        self._batched = batched
-        self._pending: list[int] = []
+    def __init__(
+        self,
+        deleter: _PayloadDeleter,
+        *,
+        worker_threads: int,
+        delivery_tags: Mapping[str, str],
+        spends_attempt_on_submit: bool,
+    ) -> None:
+        self._deleter = deleter
+        self._delivery_tags = delivery_tags
+        self._spends_attempt_on_submit = spends_attempt_on_submit
+        self._capacity = worker_threads
+        self._executor = ContextPropagatingThreadPoolExecutor(max_workers=worker_threads)
+        self._in_flight: dict[Future[tuple[WebhookPayload, Exception | None]], WebhookPayload] = {}
+        self.delivered = 0
+        self.failed = 0
+        self.unexpected: Exception | None = None
+        """
+        The first error a result handler raised. The drain winds down and then
+        re-raises it rather than raising mid-stream: rows other threads already
+        delivered would never be deleted, then be redelivered under a later claim.
+        """
 
-    def delete(self, payload: WebhookPayload) -> None:
-        """Remove the payload's row, either now or at the next flush."""
-        if not self._batched:
-            payload.delete()
-            return
-        self._pending.append(payload.id)
-        if len(self._pending) >= DELETE_BATCH_SIZE:
-            self.flush()
+    @property
+    def has_room(self) -> bool:
+        return len(self._in_flight) < self._capacity
 
-    def flush(self) -> None:
-        """Remove every row accumulated since the last flush."""
-        if not self._pending:
-            return
-        metrics.distribution("hybridcloud.deliver_webhooks.drain.delete_batch", len(self._pending))
-        WebhookPayload.objects.filter(id__in=self._pending).delete()
-        self._pending.clear()
+    @property
+    def idle(self) -> bool:
+        return not self._in_flight
+
+    def submit(self, record: WebhookPayload) -> None:
+        if self._spends_attempt_on_submit:
+            record.schedule_next_attempt()
+        self._in_flight[self._executor.submit(deliver_message, record)] = record
+
+    def wait_one(self) -> None:
+        """Block until at least one request finishes, then handle every result that is in."""
+        done, _ = wait(self._in_flight, return_when=FIRST_COMPLETED)
+        self._handle(done)
+
+    def wind_down(self) -> int | None:
+        """
+        Stop delivering: cancel the requests that have not started, wait out the
+        ones that have, and handle their results. Returns the lowest cancelled id
+        — a cancelled record was never attempted, so a release must start there —
+        or None when every submitted request ran.
+
+        Every unworked record was either cancelled here or never submitted, and
+        the unsubmitted ones sit past everything submitted, so the lowest
+        cancelled id is below them all. Rows above it that were worked are
+        settled by then, so the release's `schedule_for` match passes them by.
+        """
+        cancelled_ids = [record.id for future, record in self._in_flight.items() if future.cancel()]
+        self._in_flight = {
+            future: record for future, record in self._in_flight.items() if not future.cancelled()
+        }
+        done, _ = wait(self._in_flight)
+        self._handle(done)
+        self._executor.shutdown()
+        return min(cancelled_ids, default=None)
+
+    def _handle(self, done: Iterable[Future[tuple[WebhookPayload, Exception | None]]]) -> None:
+        for future in done:
+            del self._in_flight[future]
+            payload_record, err = future.result()
+            if isinstance(err, DeliveryFailed):
+                self.failed += 1
+            try:
+                if _handle_delivery_result(
+                    payload_record,
+                    err,
+                    self._deleter,
+                    delivery_tags=self._delivery_tags,
+                    attempt_spent=self._spends_attempt_on_submit,
+                ):
+                    self.delivered += 1
+            except Exception as handler_err:
+                if self.unexpected is None:
+                    self.unexpected = handler_err
 
 
 def _discard_if_stale(
@@ -1199,17 +1224,22 @@ def _finish_delivered(
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
 
 
-def _handle_parallel_delivery_result(
+def _handle_delivery_result(
     payload_record: WebhookPayload,
     err: Exception | None,
     deleter: _PayloadDeleter,
     *,
     delivery_tags: Mapping[str, str],
+    attempt_spent: bool,
 ) -> bool:
     """
-    Process one result from the parallel delivery threadpool; returns whether the
-    payload was delivered. An unexpected `err` is re-raised, after the reschedule
-    so its record keeps a retry.
+    Process one result from the delivery pool; returns whether the payload was
+    delivered. An unexpected `err` is re-raised, after the reschedule so its
+    record keeps a retry.
+
+    A failed record is rescheduled into its retry backoff unless `attempt_spent`
+    says the pool already did so on submission (`_DeliveryPool`) — until one or
+    the other, the record still carries its claim's schedule_for.
     """
     if isinstance(err, DeliveryDropped):
         # Permanently rejected, so it is neither a delivery nor a retryable failure:
@@ -1217,10 +1247,7 @@ def _handle_parallel_delivery_result(
         deleter.delete(payload_record)
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={
-                **delivery_tags,
-                "outcome": err.outcome,
-            },
+            tags={**delivery_tags, "outcome": err.outcome},
         )
         return False
     if err:
@@ -1228,66 +1255,15 @@ def _handle_parallel_delivery_result(
         # always has a retry left; the reschedule spends it.
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={
-                **delivery_tags,
-                "outcome": "retry",
-            },
+            tags={**delivery_tags, "outcome": "retry"},
         )
-        payload_record.schedule_next_attempt()
+        if not attempt_spent:
+            payload_record.schedule_next_attempt()
         if not isinstance(err, DeliveryFailed):
             raise err
         return False
     _finish_delivered(payload_record, deleter, delivery_tags=delivery_tags)
     return True
-
-
-def _run_parallel_delivery_batch(
-    records: Sequence[WebhookPayload],
-    deleter: _PayloadDeleter,
-    *,
-    delivery_tags: Mapping[str, str],
-) -> int:
-    """
-    Deliver one batch of already-fetched records in parallel; returns how many
-    were delivered. Failed records are rescheduled with a backoff and skipped —
-    only skip-on-failure claims deliver in waves (`_MailboxClaim.threaded`).
-
-    The caller fetches so that it can inspect the batch before any of it is
-    delivered — see the head check in `_MailboxClaim.next_slice`.
-    """
-    # Stale and attempts-exhausted rows are discarded in place of delivery,
-    # consuming claim budget like any delivered row rather than being swept out
-    # from under the claim.
-    fresh_records = [
-        record
-        for record in records
-        if not _discard_if_exhausted(record, deleter, delivery_tags=delivery_tags)
-        and not _discard_if_stale(record, deleter, delivery_tags=delivery_tags)
-    ]
-
-    delivered = 0
-    unexpected: Exception | None = None
-    if fresh_records:
-        with ContextPropagatingThreadPoolExecutor(max_workers=len(fresh_records)) as threadpool:
-            futures = {
-                threadpool.submit(deliver_message_parallel, record) for record in fresh_records
-            }
-            for future in as_completed(futures):
-                payload_record, err = future.result()
-                try:
-                    if _handle_parallel_delivery_result(
-                        payload_record, err, deleter, delivery_tags=delivery_tags
-                    ):
-                        delivered += 1
-                except Exception as handler_err:
-                    # Raising mid-wave would abandon the sibling results: rows
-                    # their threads already delivered would never be deleted,
-                    # then redelivered under a later claim.
-                    if unexpected is None:
-                        unexpected = handler_err
-    if unexpected is not None:
-        raise unexpected
-    return delivered
 
 
 @instrumented_task(
@@ -1307,52 +1283,24 @@ def drain_mailbox_parallel(
 ) -> None:
     """
     Transitional alias from when sequential and parallel delivery were separate
-    tasks; `drain_mailbox` now runs both modes. Dispatch no longer enqueues this,
-    so it is deletable once no drains from the previous deploy are left in flight.
+    tasks. Dispatch no longer enqueues this, so it is deletable once no drains
+    from the previous deploy are left in flight.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
     if claim is not None:
         _drain_mailbox(claim)
 
 
-def deliver_message_parallel(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+def deliver_message(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+    """
+    Deliver one payload on a pool thread, handing any error back with it: the
+    result is processed on the drain thread (`_handle_delivery_result`).
+    """
     try:
         perform_request(payload)
         return (payload, None)
     except Exception as err:
         return (payload, err)
-
-
-def deliver_message(
-    payload: WebhookPayload, deleter: _PayloadDeleter, *, delivery_tags: Mapping[str, str]
-) -> bool:
-    """
-    Deliver a message if it still has delivery attempts remaining and is not stale.
-
-    Returns whether the payload actually reached the cell. A payload that was
-    discarded — attempts exhausted, too old, or permanently rejected — returns
-    False even though it was removed from the mailbox.
-    """
-    if _discard_if_exhausted(payload, deleter, delivery_tags=delivery_tags):
-        return False
-
-    if _discard_if_stale(payload, deleter, delivery_tags=delivery_tags):
-        return False
-
-    payload.schedule_next_attempt()
-    try:
-        perform_request(payload)
-    except DeliveryDropped as err:
-        # The cell rejected the payload permanently. Delete it like a delivery, but
-        # don't record delivery time or count it as one — it never arrived.
-        deleter.delete(payload)
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.delivery",
-            tags={**delivery_tags, "outcome": err.outcome},
-        )
-        return False
-    _finish_delivered(payload, deleter, delivery_tags=delivery_tags)
-    return True
 
 
 def perform_request(payload: WebhookPayload) -> None:

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime
 import enum
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, wait
@@ -64,8 +65,10 @@ REQUEST_BOUND = datetime.timedelta(seconds=2 * CELL_REQUEST_TIMEOUT + 2)
 """
 The longest a delivery request can take and still come back: the connect and
 read timeouts back to back, plus slack for the thread to hand the result over.
-A request still in flight past it is stuck — the read timeout is per socket
-read, so a cell that keeps trickling bytes outruns it — and is not waited for.
+A request still in flight past it is stuck and is not waited for. Two things
+the timeouts do not cover can put a request there: name resolution runs ahead
+of the connect timeout, and the read timeout is per socket read, so a cell
+that keeps trickling bytes outruns it.
 """
 
 SETTLE_ALLOWANCE = datetime.timedelta(seconds=4)
@@ -989,7 +992,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
         deleter,
         worker_threads=worker_threads,
         delivery_tags=delivery_tags,
-        settle_by=claim.valid_until - SETTLE_ALLOWANCE,
+        valid_until=claim.valid_until,
         # A drain killed mid-request leaves no result to reschedule on, so the
         # record would be retried at every claim horizon until it is stale. A
         # strict provider's record head-blocks its mailbox all that while, so
@@ -1068,7 +1071,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                 # The failed record has already been rescheduled.
                 break
     finally:
-        pool.wind_down(reason="exception")
+        pool.wind_down(reason="cleanup")
         deleter.flush()
     if pool.unexpected is not None:
         raise pool.unexpected
@@ -1089,12 +1092,13 @@ class _DeliveryPool:
         *,
         worker_threads: int,
         delivery_tags: Mapping[str, str],
-        settle_by: datetime.datetime,
+        valid_until: datetime.datetime,
         spends_attempt_on_submit: bool,
     ) -> None:
         self._deleter = deleter
         self._delivery_tags = delivery_tags
-        self._settle_by = settle_by
+        self._valid_until = valid_until
+        self._settle_by = valid_until - SETTLE_ALLOWANCE
         self._spends_attempt_on_submit = spends_attempt_on_submit
         self._capacity = worker_threads
         self._executor = ContextPropagatingThreadPoolExecutor(max_workers=worker_threads)
@@ -1129,8 +1133,10 @@ class _DeliveryPool:
         """
         Block until a request finishes, then handle every result that is in.
         False when none finished inside REQUEST_BOUND: every request in flight
-        was already running when the wait began, so all of them are now stuck.
+        has then been out for at least that long, so all of them are stuck.
         """
+        if not self._in_flight:
+            return True
         done, _ = wait(
             self._in_flight, timeout=REQUEST_BOUND.total_seconds(), return_when=FIRST_COMPLETED
         )
@@ -1150,8 +1156,8 @@ class _DeliveryPool:
         settled by then, so the release's `schedule_for` match passes them by.
 
         The wait lasts at most `patience` seconds — by default REQUEST_BOUND,
-        or what is left before `settle_by`, whichever is shorter — and is
-        recorded under `reason` whenever there was something to wait for.
+        or what is left before the settle deadline, whichever is shorter — and
+        is recorded under `reason` whenever there was something to wait for.
         Requests still running after that are abandoned (`_abandon`), and the
         executor is shut down without joining their threads.
         """
@@ -1163,11 +1169,14 @@ class _DeliveryPool:
             if patience is None:
                 remaining = (self._settle_by - timezone.now()).total_seconds()
                 patience = max(0.0, min(REQUEST_BOUND.total_seconds(), remaining))
-            with metrics.timer(
-                "hybridcloud.deliver_webhooks.drain.wind_down",
+            started = time.monotonic()
+            done, stuck = wait(self._in_flight, timeout=patience)
+            metrics.distribution(
+                "hybridcloud.deliver_webhooks.drain.wind_down_ms",
+                (time.monotonic() - started) * 1000,
                 tags={**self._delivery_tags, "reason": reason},
-            ):
-                done, stuck = wait(self._in_flight, timeout=patience)
+                unit="millisecond",
+            )
             self._handle(done)
             self._abandon(stuck)
         self._executor.shutdown(wait=False)
@@ -1178,10 +1187,19 @@ class _DeliveryPool:
         Give up on requests the drain will not wait for. Each counts as a failed
         attempt: the record goes into its retry backoff, so a request that never
         answers cannot be retried at every claim horizon until the record is
-        stale. Its thread finishes on its own; nothing reads the result, so a
-        late success is redelivered once after the backoff.
+        stale. Nothing reads the result, so a late success is redelivered once
+        after the backoff. The thread finishes when its socket does — or, for a
+        cell that keeps trickling bytes, when the worker process does.
+
+        Once the claim has lapsed the rows are due, and possibly another
+        dispatcher's already, so they are left as they are.
         """
+        lapsed = timezone.now() >= self._valid_until
         for future in stuck:
+            if future.done():
+                # It came back while the results ahead of it were being handled.
+                self._handle([future])
+                continue
             record = self._in_flight.pop(future)
             self.failed += 1
             # Unsampled: rare, and each one is a request the cell never answered.
@@ -1191,7 +1209,7 @@ class _DeliveryPool:
                 sample_rate=1.0,
             )
             logger.warning("deliver_webhook.abandoned", extra=record.as_dict())
-            if not self._spends_attempt_on_submit:
+            if not self._spends_attempt_on_submit and not lapsed:
                 record.schedule_next_attempt()
 
     def _handle(self, done: Iterable[Future[tuple[WebhookPayload, Exception | None]]]) -> None:

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -437,7 +437,12 @@ def _begin_drain(
             )
             return None
         mailbox = mailbox if mailbox is not None else head[0]
-        deadline = deadline if deadline is not None else head[1]
+        if deadline is None:
+            # The head's schedule_for is normally the claim's own deadline, but
+            # a failed attempt rewrites it to a retry backoff that passes the
+            # deadline (the first backoff already does). Cap what a redelivered
+            # drain adopts at the widest horizon its claim could have written.
+            deadline = min(head[1], timezone.now() + BATCH_SCHEDULE_OFFSET)
     _set_webhook_delivery_sentry_context(mailbox, _provider_from_mailbox(mailbox))
     claim = _MailboxClaim(
         claimed=claimed_count,

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -130,10 +130,9 @@ def _provider_tag(payload: WebhookPayload) -> str:
 
 def _provider_from_mailbox(mailbox_name: str | None) -> str:
     """
-    Recover the provider where only the mailbox name is in hand.
-
-    Mailboxes are named `<provider>:<identifier>`, and it is the identifier that later
-    gains bucket and event-type suffixes, so the first segment stays the provider.
+    Mailboxes are named `<provider>:<identifier>`, and it is the identifier that
+    later gains bucket and event-type suffixes, so the first segment stays the
+    provider.
     """
     provider, separator, _ = (mailbox_name or "").partition(":")
     return provider if separator and provider else UNKNOWN_PROVIDER
@@ -154,12 +153,7 @@ def _record_lost_head(
 
 
 def _set_webhook_delivery_sentry_context(mailbox_name: str | None, provider: str) -> None:
-    """
-    Set Sentry context at the delivery entrypoint for easier debugging.
-
-    Takes what the task args carry rather than a row, so it also covers a drain
-    that finds its head already gone.
-    """
+    """Set Sentry context at the delivery entrypoint for easier debugging."""
     sentry_sdk.set_tag("mailbox_name", mailbox_name)
     sentry_sdk.set_attribute("mailbox_name", mailbox_name)
     context: dict[str, Any] = {"mailbox_name": mailbox_name, "provider": provider}
@@ -303,10 +297,10 @@ class _MailboxClaim:
         """
         Whether this claim has lapsed, recording the stand-down when it has.
 
-        The deadline bounds a drain at both ends — it must not start past its
-        claim, and must not keep delivering past it — so both checks report one
-        outcome; `log_key` is what separates them in logs. At the deadline exactly
-        the claim is already lapsed, since the due gates are `schedule_for__lte=now`.
+        The deadline bounds a drain at both ends — it must not start past its claim,
+        nor keep delivering past it — so both report one outcome and `log_key`
+        separates them. At the deadline exactly the claim is already lapsed: the due
+        gates are `schedule_for__lte=now`.
         """
         if timezone.now() < self.valid_until:
             return False
@@ -322,6 +316,25 @@ class _MailboxClaim:
             },
         )
         return True
+
+    def next_slice(self, start_id: int, size: int) -> list[WebhookPayload] | None:
+        """
+        The next `size` records this drain may deliver, or None when it must stand
+        down: its head is gone, so whoever claimed the mailbox next is delivering
+        these. An empty list is the ordinary end of a claim, not a stand-down.
+
+        Both drains read through here to keep that check ahead of delivery — a
+        parallel batch that delivers first duplicates every row it sends.
+        """
+        records = list(
+            WebhookPayload.objects.filter(
+                id__gte=start_id, mailbox_name=self.mailbox_name
+            ).order_by("id")[:size]
+        )
+        if start_id == self.head_id and (not records or records[0].id != self.head_id):
+            self.record_lost_head("deliver_webhook.potential_race")
+            return None
+        return records
 
     def record_lost_head(self, log_key: str) -> None:
         """This drain's head row is already gone — see `_record_lost_head`."""
@@ -384,17 +397,13 @@ def _claim_mailbox_batch(
 ) -> _MailboxClaim | None:
     """
     Claim up to MAX_MAILBOX_DRAIN records at the head of the mailbox by scheduling
-    them past the drain deadline, keeping other dispatchers off the mailbox while
-    the drain runs. The claim is gated on the head still being due via the
-    UPDATE's WHERE clause, so a lost race claims nothing and returns None.
+    them past the drain deadline. The UPDATE gates on the head still being due, so
+    a lost race claims nothing and returns None.
 
-    In due-head mode the claim stops at the first not-due record. That stop keeps
-    concurrent drains apart: an in-flight drain's records carry a future
+    In due-head mode the claim stops at the first not-due record, which is what
+    keeps concurrent drains apart: an in-flight drain's records carry a future
     schedule_for, so a claim starting behind it ends before its range, and a
-    backoff record keeps its backoff. As a prefix, the drain's (head, count) walk
-    covers exactly the claimed records.
-
-    `claimed` doubles as the depth signal that picks the drain mode.
+    backoff record keeps its backoff.
     """
     valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
     window = WebhookPayload.objects.filter(id__gte=head_id, mailbox_name=mailbox_name).order_by(
@@ -887,9 +896,9 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
     Deliver the claimed records in order until one fails, the claim's deadline
     passes, or all of them have been processed.
 
-    This drain holds no lock while it runs, so it must not deliver past the records
-    its dispatcher claimed — beyond them the mailbox head is due again and another
-    dispatcher may have started a drain of its own.
+    The drain holds no lock, so it must not deliver past the records its dispatcher
+    claimed: beyond them the mailbox head is due again and another dispatcher may
+    already be draining it.
     """
     dispatch_tags = claim.dispatch_tags
     mailbox = claim.mailbox_name
@@ -911,18 +920,10 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
             ):
                 break
 
-            # Fetch records from the batch in slices of 100. This avoids reading
-            # redundant data should we hit an error and should help keep query duration low.
-            query = WebhookPayload.objects.filter(
-                id__gte=current_id, mailbox_name=mailbox
-            ).order_by("id")
-
-            slice_size = min(100, remaining)
-            records = list(query[:slice_size])
-            if current_id == claim.head_id and (not records or records[0].id != claim.head_id):
-                # First slice, and the head is not at its front: it has been
-                # delivered by whoever claimed it next.
-                claim.record_lost_head("deliver_webhook.potential_race")
+            # Slices of 100 keep query duration down and avoid reading records a
+            # failure earlier in the claim means we never get to.
+            records = claim.next_slice(current_id, min(100, remaining))
+            if records is None:
                 return
             batch_count = 0
             for record in records:
@@ -1269,17 +1270,8 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
             ):
                 break
 
-            batch_size = min(worker_threads, remaining)
-            records = list(
-                WebhookPayload.objects.filter(id__gte=current_id, mailbox_name=mailbox).order_by(
-                    "id"
-                )[:batch_size]
-            )
-            if current_id == claim.head_id and (not records or records[0].id != claim.head_id):
-                # First batch, and the head is not at its front: it has been
-                # delivered by whoever claimed it next. Checked before delivering
-                # any of them, since they are that drain's to deliver.
-                claim.record_lost_head("deliver_webhook.potential_race")
+            records = claim.next_slice(current_id, min(worker_threads, remaining))
+            if records is None:
                 return
             batch = _run_parallel_delivery_batch(records, deleter, dispatch_tags=dispatch_tags)
             attempted, delivered_batch, request_failed, next_id = (

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1153,18 +1153,10 @@ def _handle_parallel_delivery_result(
 
 
 class _ParallelBatch(NamedTuple):
-    """
-    What one parallel batch did.
+    """What one parallel batch delivered, and whether any request needs a retry."""
 
-    `next_start_id` is one past the highest id attempted so callers can advance
-    past failed rows (e.g. skip-on-failure providers), None when the batch was
-    empty.
-    """
-
-    attempted: int
     delivered: int
     request_failed: bool
-    next_start_id: int | None
 
 
 def _run_parallel_delivery_batch(
@@ -1179,14 +1171,6 @@ def _run_parallel_delivery_batch(
     The caller fetches so that it can inspect the batch before any of it is
     delivered — see the head check in `_drain_in_parallel`.
     """
-    if not records:
-        return _ParallelBatch(0, 0, False, None)
-
-    # Capture before delivery/discard — an immediate delete clears pk on the
-    # in-memory instance.
-    next_start_id = records[-1].id + 1
-    attempted = len(records)
-
     # Stale rows are discarded in place of delivery, consuming claim budget
     # like any delivered row rather than being swept out from under the claim.
     fresh_records = [
@@ -1198,7 +1182,7 @@ def _run_parallel_delivery_batch(
     delivered = 0
     request_failed = False
     if fresh_records:
-        with ContextPropagatingThreadPoolExecutor(max_workers=attempted) as threadpool:
+        with ContextPropagatingThreadPoolExecutor(max_workers=len(fresh_records)) as threadpool:
             futures = {
                 threadpool.submit(deliver_message_parallel, record) for record in fresh_records
             }
@@ -1212,7 +1196,7 @@ def _run_parallel_delivery_batch(
                     raise err
                 if err is None:
                     delivered += 1
-    return _ParallelBatch(attempted, delivered, request_failed, next_start_id)
+    return _ParallelBatch(delivered, request_failed)
 
 
 @instrumented_task(
@@ -1273,22 +1257,19 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
             records = claim.next_slice(current_id, min(worker_threads, remaining))
             if records is None:
                 return
-            batch = _run_parallel_delivery_batch(records, deleter, dispatch_tags=dispatch_tags)
-            attempted, delivered_batch, request_failed, next_id = (
-                batch.attempted,
-                batch.delivered,
-                batch.request_failed,
-                batch.next_start_id,
-            )
-            delivered += delivered_batch
-            extra["delivered"] = delivered
-
-            if next_id is None:
+            if not records:
                 logger.info("deliver_webhook.task_complete", extra=extra)
                 break
 
-            # Advance past this batch so failed rows (left with a future
-            # schedule_for) are not immediately re-attempted when we continue.
+            # Read before delivery: an immediate delete clears pk on the in-memory
+            # instance. Advancing past the whole batch is also what keeps failed
+            # rows, left with a future schedule_for, from being re-attempted here.
+            next_id = records[-1].id + 1
+            attempted = len(records)
+
+            batch = _run_parallel_delivery_batch(records, deleter, dispatch_tags=dispatch_tags)
+            delivered += batch.delivered
+            extra["delivered"] = delivered
             current_id = next_id
 
             remaining -= attempted
@@ -1303,7 +1284,7 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
                 )
                 return
 
-            if request_failed and not skip_on_failure:
+            if batch.request_failed and not skip_on_failure:
                 # For providers that require stricter mailbox behavior, stop on
                 # the first batch that had a retryable failure.
                 logger.info("deliver_webhook.delivery_request_failed", extra=extra)

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1036,10 +1036,6 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                     "deliver_webhook.claim_exhausted",
                     extra={**log_context, "delivered": delivered},
                 )
-                metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery",
-                    tags={**delivery_tags, "outcome": "claim_exhausted"},
-                )
                 return
     finally:
         deleter.flush()

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -2,10 +2,11 @@ import dataclasses
 import datetime
 import enum
 import logging
+import math
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from concurrent.futures import as_completed
-from typing import Any, NamedTuple
+from typing import Any
 
 import orjson
 import sentry_sdk
@@ -21,6 +22,7 @@ from sentry.exceptions import RestrictedIPAddress
 from sentry.hybridcloud.models.webhookpayload import (
     BACKOFF_INTERVAL,
     MAX_ATTEMPTS,
+    THE_PAST,
     DestinationType,
     WebhookPayload,
 )
@@ -56,10 +58,20 @@ slow forwarding yields to other tasks
 """
 
 
-PARALLEL_DRAIN_THRESHOLD = MAX_MAILBOX_DRAIN // 5
+MIN_RECORDS_PER_THREAD = 5
 """
-Mailbox depth at which delivery switches from sequential to parallel: past it the
-mailbox is behind, and parallel throughput is worth the loss of strict ordering.
+Records a claim must hold per delivery thread before another thread is added.
+
+Bounds each drain's thread and connection burst for small claims; full
+concurrency is reached by ~worker_threads times this many records, where the
+worker-slot time a lone thread would spend dominates the burst cost.
+"""
+
+RELEASE_MARGIN = datetime.timedelta(seconds=30)
+"""
+How long before its claim's deadline a drain stops delivering and releases the
+unworked tail back to the mailbox. Sized to cover a worst-case delivery wave
+plus the final delete flush, so the release lands while the claim still holds.
 """
 
 
@@ -274,6 +286,16 @@ class _MailboxClaim:
         allowlist = options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
         return self.provider in allowlist
 
+    @property
+    def threaded(self) -> bool:
+        """
+        Whether this claim's drain delivers in concurrent waves. Only providers
+        that may skip failed records qualify: concurrent requests complete in
+        arbitrary order, so threading a strict-ordering provider would deliver
+        out of order exactly when its mailbox is deep.
+        """
+        return self.skip_on_failure and self.claimed > MIN_RECORDS_PER_THREAD
+
     def task_args(self) -> dict[str, Any]:
         """
         This claim as a drain's task arguments; `_begin_drain` rebuilds it.
@@ -312,14 +334,41 @@ class _MailboxClaim:
         )
         return True
 
+    def nearing_deadline(self) -> bool:
+        """Whether to stop delivering and release, rather than run into the deadline mid-wave."""
+        return timezone.now() >= self.valid_until - RELEASE_MARGIN
+
+    def release_remainder(self, next_id: int, *, extra: Mapping[str, Any]) -> None:
+        """
+        Return the claim's unworked tail to the mailbox so the next dispatcher can
+        claim it now instead of at the deadline.
+
+        Matching the exact `schedule_for` this claim wrote is what makes the
+        release safe: a record another claim took carries that claim's timestamp,
+        and a record this drain failed and rescheduled carries its backoff — both
+        pass untouched.
+        """
+        released = WebhookPayload.objects.filter(
+            mailbox_name=self.mailbox_name,
+            id__gte=next_id,
+            schedule_for=self.valid_until,
+        ).update(schedule_for=THE_PAST)
+        if released:
+            metrics.incr(
+                "hybridcloud.deliver_webhooks.delivery",
+                amount=released,
+                tags={**self.delivery_tags, "outcome": "released"},
+            )
+        logger.info("deliver_webhook.deadline_release", extra={**extra, "released": released})
+
     def next_slice(self, start_id: int, size: int) -> list[WebhookPayload] | None:
         """
         The next `size` records this drain may deliver, or None when it must stand
         down: its head is gone, so whoever claimed the mailbox next is delivering
         these. An empty list is the ordinary end of a claim, not a stand-down.
 
-        Both drains read through here to keep that check ahead of delivery — a
-        parallel batch that delivers first duplicates every row it sends.
+        The drain reads through here to keep that check ahead of delivery — a
+        wave that delivers first duplicates every row it sends.
         """
         records = list(
             WebhookPayload.objects.filter(
@@ -435,7 +484,12 @@ def _claim_mailbox_batch(
 
 
 class DispatchOutcome(enum.StrEnum):
-    """What `_claim_and_dispatch` did for a mailbox; doubles as a metric tag."""
+    """
+    What `_claim_and_dispatch` did for a mailbox; doubles as a metric tag.
+
+    SEQUENTIAL and PARALLEL name the delivery mode the claim's drain will use
+    (`_MailboxClaim.threaded`) — one task runs both.
+    """
 
     NOT_DUE = "not_due"
     SEQUENTIAL = "sequential"
@@ -480,7 +534,7 @@ def _claim_and_dispatch(
     head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
 ) -> DispatchOutcome:
     """
-    Claim a batch for the mailbox and dispatch the drain matching its depth.
+    Claim a batch for the mailbox and dispatch its drain.
     Callers must hold the mailbox's drain lock so concurrent dispatchers cannot
     interleave around the claim.
 
@@ -500,12 +554,8 @@ def _claim_and_dispatch(
     claim = _claim_mailbox_batch(head_id, mailbox_name, dispatcher=dispatcher)
     if claim is None:
         return DispatchOutcome.NOT_DUE
-    if claim.claimed >= PARALLEL_DRAIN_THRESHOLD:
-        drain_mailbox_parallel.delay(**claim.task_args())
-        outcome = DispatchOutcome.PARALLEL
-    else:
-        drain_mailbox.delay(**claim.task_args())
-        outcome = DispatchOutcome.SEQUENTIAL
+    drain_mailbox.delay(**claim.task_args())
+    outcome = DispatchOutcome.PARALLEL if claim.threaded else DispatchOutcome.SEQUENTIAL
     _record_dispatch(
         dispatcher=dispatcher,
         drain=outcome,
@@ -877,29 +927,32 @@ def drain_mailbox(
     mailbox: str | None = None,
 ) -> None:
     """
-    Deliver webhooks from the mailbox that `payload_id` is the head of, in order.
+    Deliver webhooks from the mailbox that `payload_id` is the head of — in order,
+    or in concurrent waves when the claim qualifies (`_MailboxClaim.threaded`).
 
     The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
     each defaults so a rolling deploy can bind drains the previous version sent.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
     if claim is not None:
-        _drain_sequentially(claim)
+        _drain_mailbox(claim)
 
 
-def _drain_sequentially(claim: _MailboxClaim) -> None:
+def _drain_mailbox(claim: _MailboxClaim) -> None:
     """
-    Deliver the claimed records in order until one fails, the claim's deadline
-    passes, or all of them have been processed.
+    Deliver the claimed records until a strict provider's record fails, the claim
+    nears its deadline, or all of them have been processed. Threaded claims
+    (`_MailboxClaim.threaded`) deliver in concurrent waves sized to the work left;
+    every other claim delivers one record at a time, in order.
 
     The drain holds no lock, so it must not deliver past the records its dispatcher
     claimed: beyond them the mailbox head is due again and another dispatcher may
     already be draining it.
     """
     delivery_tags = claim.delivery_tags
-    mailbox = claim.mailbox_name
-    provider = claim.provider
     skip_on_failure = claim.skip_on_failure
+    threaded = claim.threaded
+    worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
 
     deleter = _deleter_for()
 
@@ -907,13 +960,18 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
     failed = 0
     remaining = claim.claimed
     current_id = claim.head_id
-    log_context = {"id": claim.head_id, "mailbox_name": mailbox, "provider": provider}
+    log_context = {
+        "id": claim.head_id,
+        "mailbox_name": claim.mailbox_name,
+        "provider": claim.provider,
+    }
     try:
         while True:
-            if claim.lapsed(
-                log_key="deliver_webhook.delivery_deadline",
-                extra={**log_context, "delivered": delivered},
-            ):
+            extra = {**log_context, "delivered": delivered}
+            if claim.lapsed(log_key="deliver_webhook.delivery_deadline", extra=extra):
+                break
+            if claim.nearing_deadline():
+                claim.release_remainder(current_id, extra=extra)
                 break
 
             # Slices of 100 keep query duration down and avoid reading records a
@@ -921,61 +979,70 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
             records = claim.next_slice(current_id, min(100, remaining))
             if records is None:
                 return
-            batch_count = 0
-            for record in records:
-                batch_count += 1
-                # Advance past this record regardless of outcome so that failed
-                # messages are not re-attempted in subsequent batches of this drain.
-                current_id = record.id + 1
-                try:
-                    if deliver_message(record, deleter, delivery_tags=delivery_tags):
-                        delivered += 1
-                except DeliveryFailed:
-                    failed += 1
-                    metrics.incr(
-                        "hybridcloud.deliver_webhooks.delivery",
-                        tags={
-                            **delivery_tags,
-                            "outcome": "retry",
-                        },
-                    )
-                    if not skip_on_failure:
-                        # For providers that require strict ordering, stop on the
-                        # first failure so subsequent messages are not delivered
-                        # out of order.
-                        return
-                    # For allowlisted providers: skip the failed message and
-                    # continue. It has already been rescheduled by deliver_message.
-                    continue
-
-            # No more messages to deliver
-            if batch_count < 1:
+            if not records:
                 if failed > 0:
                     logger.info(
                         "deliver_webhook.delivery_complete_with_failures",
-                        extra={**log_context, "delivered": delivered, "failed": failed},
+                        extra={**extra, "failed": failed},
                     )
                 else:
-                    logger.debug(
-                        "deliver_webhook.delivery_complete",
-                        extra={**log_context, "delivered": delivered},
-                    )
+                    logger.debug("deliver_webhook.delivery_complete", extra=extra)
                 return
 
-            remaining -= batch_count
-            if remaining <= 0:
-                # Claim exhausted. Rows past this point belong to whichever
-                # dispatcher claims them next; delivering them here would race
-                # a drain that dispatcher may have started.
-                logger.debug(
-                    "deliver_webhook.claim_exhausted",
-                    extra={**log_context, "delivered": delivered},
-                )
-                metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery",
-                    tags={**delivery_tags, "outcome": "claim_exhausted"},
-                )
-                return
+            index = 0
+            while index < len(records) and not claim.nearing_deadline():
+                if threaded:
+                    concurrency = min(worker_threads, math.ceil(remaining / MIN_RECORDS_PER_THREAD))
+                    wave = records[index : index + concurrency]
+                    # Read before delivery: an immediate delete clears pk on the
+                    # in-memory instance. Advancing past the whole wave is also what
+                    # keeps failed rows, left with a future schedule_for, from being
+                    # re-attempted here. Threading requires skip_on_failure, so a
+                    # failed request never stops the drain.
+                    next_id = wave[-1].id + 1
+                    delivered += _run_parallel_delivery_batch(
+                        wave, deleter, delivery_tags=delivery_tags
+                    )
+                    current_id = next_id
+                    index += len(wave)
+                    remaining -= len(wave)
+                else:
+                    record = records[index]
+                    # Advance past this record regardless of outcome so that failed
+                    # messages are not re-attempted later in this drain.
+                    current_id = record.id + 1
+                    index += 1
+                    remaining -= 1
+                    try:
+                        if deliver_message(record, deleter, delivery_tags=delivery_tags):
+                            delivered += 1
+                    except DeliveryFailed:
+                        failed += 1
+                        metrics.incr(
+                            "hybridcloud.deliver_webhooks.delivery",
+                            tags={**delivery_tags, "outcome": "retry"},
+                        )
+                        if not skip_on_failure:
+                            # For providers that require strict ordering, stop on the
+                            # first failure so subsequent messages are not delivered
+                            # out of order.
+                            return
+                        # For allowlisted providers: skip the failed message and
+                        # continue. It has already been rescheduled by deliver_message.
+
+                if remaining <= 0:
+                    # Claim exhausted. Rows past this point belong to whichever
+                    # dispatcher claims them next; delivering them here would race
+                    # a drain that dispatcher may have started.
+                    logger.debug(
+                        "deliver_webhook.claim_exhausted",
+                        extra={**log_context, "delivered": delivered},
+                    )
+                    metrics.incr(
+                        "hybridcloud.deliver_webhooks.delivery",
+                        tags={**delivery_tags, "outcome": "claim_exhausted"},
+                    )
+                    return
     finally:
         deleter.flush()
 
@@ -1051,6 +1118,28 @@ def _discard_if_stale(
     return True
 
 
+def _discard_if_exhausted(
+    payload: WebhookPayload, deleter: _PayloadDeleter, *, delivery_tags: Mapping[str, str]
+) -> bool:
+    """
+    Discard the payload when its delivery attempts are spent; returns whether it
+    was discarded. Checked before the request so an exhausted record never gets
+    an extra attempt.
+    """
+    if payload.attempts < MAX_ATTEMPTS:
+        return False
+    deleter.delete(payload)
+    # Unsampled: this is the count of webhooks we permanently dropped, so it
+    # wants an exact total rather than an estimated rate.
+    metrics.incr(
+        "hybridcloud.deliver_webhooks.delivery",
+        tags={**delivery_tags, "outcome": "attempts_exceed"},
+        sample_rate=1.0,
+    )
+    logger.warning("deliver_webhook.discard", extra={**payload.as_dict()})
+    return True
+
+
 def _record_delivery_time_metrics(
     payload: WebhookPayload, *, delivery_tags: Mapping[str, str]
 ) -> None:
@@ -1084,10 +1173,10 @@ def _handle_parallel_delivery_result(
     deleter: _PayloadDeleter,
     *,
     delivery_tags: Mapping[str, str],
-) -> tuple[bool, bool]:
+) -> bool:
     """
     Process one result from the parallel delivery threadpool.
-    Returns (request_failed, should_reraise).
+    Returns whether `err` is unexpected and must be re-raised.
     """
     payload_data = payload_record.as_dict()
     if isinstance(err, DeliveryDropped):
@@ -1101,36 +1190,19 @@ def _handle_parallel_delivery_result(
                 "outcome": err.outcome,
             },
         )
-        return (False, False)
+        return False
     if err:
-        if payload_record.attempts >= MAX_ATTEMPTS:
-            deleter.delete(payload_record)
-            # Unsampled: this is the count of webhooks we permanently dropped, so it
-            # wants an exact total rather than an estimated rate.
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.delivery",
-                tags={
-                    **delivery_tags,
-                    "outcome": "attempts_exceed",
-                },
-                sample_rate=1.0,
-            )
-            logger.warning(
-                "deliver_webhook.discard",
-                extra={**payload_data},
-            )
-            request_failed = False
-        else:
-            metrics.incr(
-                "hybridcloud.deliver_webhooks.delivery",
-                tags={
-                    **delivery_tags,
-                    "outcome": "retry",
-                },
-            )
-            payload_record.schedule_next_attempt()
-            request_failed = True
-        return (request_failed, not isinstance(err, DeliveryFailed))
+        # Attempts-exhausted rows are discarded before delivery, so a failure here
+        # always has a retry left; the reschedule spends it.
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={
+                **delivery_tags,
+                "outcome": "retry",
+            },
+        )
+        payload_record.schedule_next_attempt()
+        return not isinstance(err, DeliveryFailed)
     date_added = payload_record.date_added
     deleter.delete(payload_record)
     _record_delivery_time_metrics(payload_record, delivery_tags=delivery_tags)
@@ -1140,14 +1212,7 @@ def _handle_parallel_delivery_result(
     )
     if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
-    return (False, False)
-
-
-class _ParallelBatch(NamedTuple):
-    """What one parallel batch delivered, and whether any request needs a retry."""
-
-    delivered: int
-    request_failed: bool
+    return False
 
 
 def _run_parallel_delivery_batch(
@@ -1155,23 +1220,26 @@ def _run_parallel_delivery_batch(
     deleter: _PayloadDeleter,
     *,
     delivery_tags: Mapping[str, str],
-) -> "_ParallelBatch":
+) -> int:
     """
-    Deliver one batch of already-fetched records in parallel.
+    Deliver one batch of already-fetched records in parallel; returns how many
+    were delivered. Failed records are rescheduled with a backoff and skipped —
+    only skip-on-failure claims deliver in waves (`_MailboxClaim.threaded`).
 
     The caller fetches so that it can inspect the batch before any of it is
-    delivered — see the head check in `_drain_in_parallel`.
+    delivered — see the head check in `_MailboxClaim.next_slice`.
     """
-    # Stale rows are discarded in place of delivery, consuming claim budget
-    # like any delivered row rather than being swept out from under the claim.
+    # Stale and attempts-exhausted rows are discarded in place of delivery,
+    # consuming claim budget like any delivered row rather than being swept out
+    # from under the claim.
     fresh_records = [
         record
         for record in records
-        if not _discard_if_stale(record, deleter, delivery_tags=delivery_tags)
+        if not _discard_if_exhausted(record, deleter, delivery_tags=delivery_tags)
+        and not _discard_if_stale(record, deleter, delivery_tags=delivery_tags)
     ]
 
     delivered = 0
-    request_failed = False
     if fresh_records:
         with ContextPropagatingThreadPoolExecutor(max_workers=len(fresh_records)) as threadpool:
             futures = {
@@ -1179,15 +1247,14 @@ def _run_parallel_delivery_batch(
             }
             for future in as_completed(futures):
                 payload_record, err = future.result()
-                batch_request_failed, should_reraise = _handle_parallel_delivery_result(
+                should_reraise = _handle_parallel_delivery_result(
                     payload_record, err, deleter, delivery_tags=delivery_tags
                 )
-                request_failed = request_failed or batch_request_failed
                 if should_reraise and err is not None:
                     raise err
                 if err is None:
                     delivered += 1
-    return _ParallelBatch(delivered, request_failed)
+    return delivered
 
 
 @instrumented_task(
@@ -1205,76 +1272,13 @@ def drain_mailbox_parallel(
     mailbox: str | None = None,
 ) -> None:
     """
-    Deliver webhooks from the mailbox that `payload_id` is the head of, in small
-    parallel batches. Takes the same flattened claim as `drain_mailbox`.
+    Transitional alias from when sequential and parallel delivery were separate
+    tasks; `drain_mailbox` now runs both modes. Dispatch no longer enqueues this,
+    so it is deletable once no drains from the previous deploy are left in flight.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
     if claim is not None:
-        _drain_in_parallel(claim)
-
-
-def _drain_in_parallel(claim: _MailboxClaim) -> None:
-    """
-    Deliver the claimed records in small parallel batches, trading strict ordering
-    for throughput; delivery within a mailbox is otherwise sequential.
-
-    Batches run until a non-skippable failure, the claim's deadline, or the end of
-    the claim — bounded exactly as `_drain_sequentially`, and skipping past
-    retryable failures for the same allowlisted providers.
-    """
-    delivery_tags = claim.delivery_tags
-    mailbox = claim.mailbox_name
-    skip_on_failure = claim.skip_on_failure
-
-    worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
-    deleter = _deleter_for()
-    delivered = 0
-    remaining = claim.claimed
-    current_id = claim.head_id
-    log_context = {"id": claim.head_id, "mailbox_name": mailbox, "provider": claim.provider}
-    try:
-        while True:
-            extra = {**log_context, "delivered": delivered}
-            if claim.lapsed(log_key="deliver_webhook.delivery_deadline", extra=extra):
-                break
-
-            records = claim.next_slice(current_id, min(worker_threads, remaining))
-            if records is None:
-                return
-            if not records:
-                logger.info("deliver_webhook.task_complete", extra=extra)
-                break
-
-            # Read before delivery: an immediate delete clears pk on the in-memory
-            # instance. Advancing past the whole batch is also what keeps failed
-            # rows, left with a future schedule_for, from being re-attempted here.
-            next_id = records[-1].id + 1
-            attempted = len(records)
-
-            batch = _run_parallel_delivery_batch(records, deleter, delivery_tags=delivery_tags)
-            delivered += batch.delivered
-            extra = {**log_context, "delivered": delivered}
-            current_id = next_id
-
-            remaining -= attempted
-            if remaining <= 0:
-                # Claim exhausted. Rows past this point belong to whichever
-                # dispatcher claims them next; delivering them here would race
-                # a drain that dispatcher may have started.
-                logger.debug("deliver_webhook.claim_exhausted", extra=extra)
-                metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery",
-                    tags={**delivery_tags, "outcome": "claim_exhausted"},
-                )
-                return
-
-            if batch.request_failed and not skip_on_failure:
-                # For providers that require stricter mailbox behavior, stop on
-                # the first batch that had a retryable failure.
-                logger.info("deliver_webhook.delivery_request_failed", extra=extra)
-                return
-    finally:
-        deleter.flush()
+        _drain_mailbox(claim)
 
 
 def deliver_message_parallel(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
@@ -1296,19 +1300,7 @@ def deliver_message(
     False even though it was removed from the mailbox.
     """
     payload_data = payload.as_dict()
-    if payload.attempts >= MAX_ATTEMPTS:
-        deleter.delete(payload)
-
-        # Unsampled: see the parallel discard path above.
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.delivery",
-            tags={
-                **delivery_tags,
-                "outcome": "attempts_exceed",
-            },
-            sample_rate=1.0,
-        )
-        logger.warning("deliver_webhook.discard", extra={**payload_data})
+    if _discard_if_exhausted(payload, deleter, delivery_tags=delivery_tags):
         return False
 
     if _discard_if_stale(payload, deleter, delivery_tags=delivery_tags):

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import enum
 import logging
@@ -263,42 +264,57 @@ def _dispatches_from_due_head(mailbox_name: str) -> bool:
     return provider in (options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ())
 
 
-class _MailboxClaim(NamedTuple):
+class Dispatcher(enum.StrEnum):
+    """Which dispatcher enqueued a drain; a metric tag and a drain task argument."""
+
+    PUSH = "push"
+    SCHEDULER = "scheduler"
+
+
+@dataclasses.dataclass(frozen=True)
+class _MailboxClaim:
     """
-    The records one claim reserved.
+    The records one claim reserved, and the context its drain works them under.
 
     `valid_until` is stored rather than re-derived, so it names exactly when the
     records come due for other dispatchers again.
     """
 
     claimed: int
+    head_id: int
+    mailbox_name: str
+    dispatcher: str | None
     valid_until: datetime.datetime
 
-    @classmethod
-    def from_task_args(cls, claimed_count: int, valid_until: str | None) -> "_MailboxClaim":
-        """
-        The claim a drain was dispatched for, as its task args carry it.
+    @property
+    def provider(self) -> str:
+        return _provider_from_mailbox(self.mailbox_name)
 
-        Drains enqueued before dispatch sent a deadline fall back to a fresh
-        horizon, as they had before.
-        """
-        return cls(
-            claimed=claimed_count,
-            valid_until=(
-                datetime.datetime.fromisoformat(valid_until)
-                if valid_until is not None
-                else timezone.now() + BATCH_SCHEDULE_OFFSET
-            ),
-        )
+    @property
+    def dispatch_tags(self) -> dict[str, str]:
+        return _dispatch_tags(self.dispatcher)
 
-    def lapsed(
-        self,
-        *,
-        provider: str,
-        dispatch_tags: Mapping[str, str],
-        log_key: str,
-        extra: Mapping[str, Any],
-    ) -> bool:
+    @property
+    def skip_on_failure(self) -> bool:
+        """Whether this provider may skip a failed record rather than stop."""
+        allowlist = options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
+        return self.provider in allowlist
+
+    def task_args(self) -> dict[str, Any]:
+        """
+        This claim as a drain's task arguments; `_begin_drain` rebuilds it.
+
+        Scalars only: the task codec carries no datetime, hence the epoch deadline.
+        """
+        return {
+            "payload_id": self.head_id,
+            "claimed_count": self.claimed,
+            "dispatcher": self.dispatcher,
+            "valid_until": self.valid_until.timestamp(),
+            "mailbox": self.mailbox_name,
+        }
+
+    def lapsed(self, *, log_key: str, extra: Mapping[str, Any]) -> bool:
         """
         Whether this claim has lapsed, recording the stand-down when it has.
 
@@ -311,7 +327,7 @@ class _MailboxClaim(NamedTuple):
             return False
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={**dispatch_tags, "outcome": "delivery_deadline", "provider": provider},
+            tags={**self.dispatch_tags, "outcome": "delivery_deadline", "provider": self.provider},
         )
         logger.info(
             log_key,
@@ -322,13 +338,64 @@ class _MailboxClaim(NamedTuple):
         )
         return True
 
+    def record_lost_head(self, log_key: str) -> None:
+        """This drain's head row is already gone — see `_record_lost_head`."""
+        _record_lost_head(
+            self.head_id,
+            dispatch_tags=self.dispatch_tags,
+            provider=self.provider,
+            log_key=log_key,
+        )
 
-def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> _MailboxClaim:
+
+def _begin_drain(
+    payload_id: int,
+    claimed_count: int,
+    dispatcher: str | None,
+    valid_until: float | None,
+    mailbox: str | None,
+) -> _MailboxClaim | None:
+    """
+    The claim a drain runs under, or None when it must stand down first.
+
+    Resolving the mailbox before anything else lets a drain that carries none —
+    enqueued before dispatch sent one — still name its provider. Those same drains
+    carry no deadline either, and fall back to a fresh horizon as they had before.
+    """
+    mailbox_name = _resolve_mailbox(payload_id, mailbox)
+    _set_webhook_delivery_sentry_context(mailbox_name, _provider_from_mailbox(mailbox_name))
+    if mailbox_name is None:
+        _record_lost_head(
+            payload_id,
+            dispatch_tags=_dispatch_tags(dispatcher),
+            provider=UNKNOWN_PROVIDER,
+            log_key="deliver_webhook.potential_race",
+        )
+        return None
+    claim = _MailboxClaim(
+        claimed=claimed_count,
+        head_id=payload_id,
+        mailbox_name=mailbox_name,
+        dispatcher=dispatcher,
+        valid_until=(
+            datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC)
+            if valid_until is not None
+            else timezone.now() + BATCH_SCHEDULE_OFFSET
+        ),
+    )
+    if claim.lapsed(log_key="deliver_webhook.stale_claim", extra={"id": payload_id}):
+        return None
+    return claim
+
+
+def _claim_mailbox_batch(
+    head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
+) -> _MailboxClaim | None:
     """
     Claim up to MAX_MAILBOX_DRAIN records at the head of the mailbox by scheduling
     them past the drain deadline, keeping other dispatchers off the mailbox while
     the drain runs. The claim is gated on the head still being due via the
-    UPDATE's WHERE clause, so a lost race claims 0 rows.
+    UPDATE's WHERE clause, so a lost race claims nothing and returns None.
 
     In due-head mode the claim stops at the first not-due record. That stop keeps
     concurrent drains apart: an in-flight drain's records carry a future
@@ -351,7 +418,7 @@ def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> _MailboxClaim:
                 break
             prefix_ids.append(record_id)
         if not prefix_ids:
-            return _MailboxClaim(claimed=0, valid_until=valid_until)
+            return None
         claimed_ids = prefix_ids
     else:
         claimed_ids = Subquery(window.values("id")[:MAX_MAILBOX_DRAIN])
@@ -361,7 +428,15 @@ def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> _MailboxClaim:
         .filter(Exists(head_due))
         .update(schedule_for=valid_until)
     )
-    return _MailboxClaim(claimed=claimed, valid_until=valid_until)
+    if not claimed:
+        return None
+    return _MailboxClaim(
+        claimed=claimed,
+        head_id=head_id,
+        mailbox_name=mailbox_name,
+        dispatcher=dispatcher,
+        valid_until=valid_until,
+    )
 
 
 class DispatchOutcome(enum.StrEnum):
@@ -370,13 +445,6 @@ class DispatchOutcome(enum.StrEnum):
     NOT_DUE = "not_due"
     SEQUENTIAL = "sequential"
     PARALLEL = "parallel"
-
-
-class Dispatcher(enum.StrEnum):
-    """Which dispatcher enqueued a drain; a metric tag and a drain task argument."""
-
-    PUSH = "push"
-    SCHEDULER = "scheduler"
 
 
 def _dispatch_tags(dispatcher: str | None) -> dict[str, str]:
@@ -433,26 +501,14 @@ def _claim_and_dispatch(
     `dispatcher` tags this dispatch and is forwarded to the drain so its
     deliveries carry the same attribution; both callers claim identically.
     """
-    claim = _claim_mailbox_batch(head_id, mailbox_name)
-    if not claim.claimed:
+    claim = _claim_mailbox_batch(head_id, mailbox_name, dispatcher=dispatcher)
+    if claim is None:
         return DispatchOutcome.NOT_DUE
     if claim.claimed >= PARALLEL_DRAIN_THRESHOLD:
-        drain_mailbox_parallel.delay(
-            head_id,
-            claimed_count=claim.claimed,
-            dispatcher=dispatcher,
-            valid_until=claim.valid_until.isoformat(),
-            mailbox=mailbox_name,
-        )
+        drain_mailbox_parallel.delay(**claim.task_args())
         outcome = DispatchOutcome.PARALLEL
     else:
-        drain_mailbox.delay(
-            head_id,
-            claimed_count=claim.claimed,
-            dispatcher=dispatcher,
-            valid_until=claim.valid_until.isoformat(),
-            mailbox=mailbox_name,
-        )
+        drain_mailbox.delay(**claim.task_args())
         outcome = DispatchOutcome.SEQUENTIAL
     _record_dispatch(
         dispatcher=dispatcher,
@@ -821,71 +877,44 @@ def drain_mailbox(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
-    valid_until: str | None = None,
+    valid_until: float | None = None,
     mailbox: str | None = None,
 ) -> None:
     """
-    Deliver webhooks from the mailbox that `payload_id` is the head of.
+    Deliver webhooks from the mailbox that `payload_id` is the head of, in order.
 
-    Messages will be delivered in order until one fails, the claim's deadline
-    passes, or `claimed_count` records have been processed. Once messages have
-    successfully been delivered or discarded, they are deleted.
-
-    This drain holds no lock while it runs, so it must not deliver past the
-    `claimed_count` records its dispatcher claimed — beyond them the mailbox head
-    is due again and another dispatcher may have started a drain of its own.
-
-    `dispatcher` carries the enqueueing dispatcher's attribution onto every
-    delivery outcome this drain records (see `_dispatch_tags`).
-
-    `valid_until` is the claim's deadline, bounding this drain at both ends: it
-    stands down if it starts past it, and stops delivering when it reaches it.
-    Beyond it the records are due for whoever claims them next. Drains enqueued
-    before dispatch sent one fall back to a fresh horizon, as they had before.
-
-    `mailbox` names the provider without reading a row, which is what the deadline
-    check needs before it has one. Absent on those same older drains, whose
-    stand-down reports an unknown provider rather than pay for a lookup.
+    The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
+    each defaults so a rolling deploy can bind drains the previous version sent.
     """
-    dispatch_tags = _dispatch_tags(dispatcher)
-    claim = _MailboxClaim.from_task_args(claimed_count, valid_until)
-    provider = _provider_from_mailbox(mailbox)
-    _set_webhook_delivery_sentry_context(mailbox, provider)
-    if claim.lapsed(
-        provider=provider,
-        dispatch_tags=dispatch_tags,
-        log_key="deliver_webhook.stale_claim",
-        extra={"id": payload_id},
-    ):
-        return
-    mailbox = _resolve_mailbox(payload_id, mailbox)
-    if mailbox is None:
-        _record_lost_head(
-            payload_id,
-            dispatch_tags=dispatch_tags,
-            provider=provider,
-            log_key="deliver_webhook.potential_race",
-        )
-        return
-    provider = _provider_from_mailbox(mailbox)
+    claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
+    if claim is not None:
+        _drain_sequentially(claim)
 
-    skip_on_failure_providers = frozenset(
-        options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
-    )
-    skip_on_failure = provider in skip_on_failure_providers
+
+def _drain_sequentially(claim: _MailboxClaim) -> None:
+    """
+    Deliver the claimed records in order until one fails, the claim's deadline
+    passes, or all of them have been processed.
+
+    This drain holds no lock while it runs, so it must not deliver past the records
+    its dispatcher claimed — beyond them the mailbox head is due again and another
+    dispatcher may have started a drain of its own.
+    """
+    dispatch_tags = claim.dispatch_tags
+    mailbox = claim.mailbox_name
+    provider = claim.provider
+    skip_on_failure = claim.skip_on_failure
 
     deleter = _deleter_for()
 
     delivered = 0
     failed = 0
     remaining = claim.claimed
-    current_id = payload_id
-    log_context = {"id": payload_id, "mailbox_name": mailbox, "provider": provider}
+    current_id = claim.head_id
+    log_context = {"id": claim.head_id, "mailbox_name": mailbox, "provider": provider}
     try:
         while True:
             if claim.lapsed(
-                provider=provider,
-                dispatch_tags=dispatch_tags,
                 log_key="deliver_webhook.delivery_deadline",
                 extra={**log_context, "delivered": delivered},
             ):
@@ -899,15 +928,10 @@ def drain_mailbox(
 
             slice_size = min(100, remaining)
             records = list(query[:slice_size])
-            if current_id == payload_id and (not records or records[0].id != payload_id):
+            if current_id == claim.head_id and (not records or records[0].id != claim.head_id):
                 # First slice, and the head is not at its front: it has been
                 # delivered by whoever claimed it next.
-                _record_lost_head(
-                    payload_id,
-                    dispatch_tags=dispatch_tags,
-                    provider=provider,
-                    log_key="deliver_webhook.potential_race",
-                )
+                claim.record_lost_head("deliver_webhook.potential_race")
                 return
             batch_count = 0
             for record in records:
@@ -1108,7 +1132,7 @@ def _handle_parallel_delivery_result(
                 sample_rate=1.0,
             )
             logger.warning(
-                "deliver_webhook_parallel.discard",
+                "deliver_webhook.discard",
                 extra={**payload_data},
             )
             request_failed = False
@@ -1216,66 +1240,46 @@ def drain_mailbox_parallel(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
-    valid_until: str | None = None,
+    valid_until: float | None = None,
     mailbox: str | None = None,
 ) -> None:
     """
-    Deliver messages from a mailbox in small parallel batches.
-
-    Parallel delivery sacrifices strict ordering for increased throughput.
-    Because of the sequential delivery in a mailbox we can't get higher throughput
-    by scheduling batches in parallel.
-
-    Messages will be delivered in small batches until a non-skippable failure
-    occurs, the batch delay timeout is reached, or `claimed_count` records have
-    been processed. Providers in
-    `hybridcloud.webhookpayload.skip_on_failure_providers` (e.g. github) continue
-    past retryable failures in the same way as sequential `drain_mailbox`.
-
-    This drain holds no lock while it runs, so it must not deliver past the
-    `claimed_count` records its dispatcher claimed — see `drain_mailbox`.
-
-    `dispatcher`, `valid_until` and `mailbox` behave as they do on `drain_mailbox`.
+    Deliver webhooks from the mailbox that `payload_id` is the head of, in small
+    parallel batches. Takes the same flattened claim as `drain_mailbox`.
     """
-    dispatch_tags = _dispatch_tags(dispatcher)
-    claim = _MailboxClaim.from_task_args(claimed_count, valid_until)
-    provider = _provider_from_mailbox(mailbox)
-    _set_webhook_delivery_sentry_context(mailbox, provider)
-    if claim.lapsed(
-        provider=provider,
-        dispatch_tags=dispatch_tags,
-        log_key="deliver_webhook_parallel.stale_claim",
-        extra={"id": payload_id},
-    ):
-        return
-    mailbox = _resolve_mailbox(payload_id, mailbox)
-    if mailbox is None:
-        _record_lost_head(
-            payload_id,
-            dispatch_tags=dispatch_tags,
-            provider=provider,
-            log_key="deliver_webhook_parallel.potential_race",
-        )
-        return
-    provider = _provider_from_mailbox(mailbox)
+    claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
+    if claim is not None:
+        _drain_in_parallel(claim)
 
-    skip_on_failure_providers = frozenset(
-        options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
-    )
-    skip_on_failure = provider in skip_on_failure_providers
+
+def _drain_in_parallel(claim: _MailboxClaim) -> None:
+    """
+    Deliver the claimed records in small parallel batches, trading strict ordering
+    for throughput; delivery within a mailbox is otherwise sequential.
+
+    Batches run until a non-skippable failure, the claim's deadline, or the end of
+    the claim — bounded exactly as `_drain_sequentially`, and skipping past
+    retryable failures for the same allowlisted providers.
+    """
+    dispatch_tags = claim.dispatch_tags
+    mailbox = claim.mailbox_name
+    skip_on_failure = claim.skip_on_failure
 
     worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
     deleter = _deleter_for()
     delivered = 0
     remaining = claim.claimed
-    current_id = payload_id
-    extra = {"id": payload_id, "mailbox_name": mailbox, "provider": provider, "delivered": 0}
+    current_id = claim.head_id
+    extra = {
+        "id": claim.head_id,
+        "mailbox_name": mailbox,
+        "provider": claim.provider,
+        "delivered": 0,
+    }
     try:
         while True:
             if claim.lapsed(
-                provider=provider,
-                dispatch_tags=dispatch_tags,
-                log_key="deliver_webhook_parallel.delivery_deadline",
+                log_key="deliver_webhook.delivery_deadline",
                 extra={**extra, "delivered": delivered},
             ):
                 break
@@ -1288,15 +1292,10 @@ def drain_mailbox_parallel(
                 deleter,
                 dispatch_tags=dispatch_tags,
             )
-            if current_id == payload_id and batch.head_id != payload_id:
+            if current_id == claim.head_id and batch.head_id != claim.head_id:
                 # First batch, and the head is not at its front: it has been
                 # delivered by whoever claimed it next.
-                _record_lost_head(
-                    payload_id,
-                    dispatch_tags=dispatch_tags,
-                    provider=provider,
-                    log_key="deliver_webhook_parallel.potential_race",
-                )
+                claim.record_lost_head("deliver_webhook.potential_race")
                 return
             attempted, delivered_batch, request_failed, next_id = (
                 batch.attempted,
@@ -1308,7 +1307,7 @@ def drain_mailbox_parallel(
             extra["delivered"] = delivered
 
             if next_id is None:
-                logger.info("deliver_webhook_parallel.task_complete", extra=extra)
+                logger.info("deliver_webhook.task_complete", extra=extra)
                 break
 
             # Advance past this batch so failed rows (left with a future
@@ -1320,7 +1319,7 @@ def drain_mailbox_parallel(
                 # Claim exhausted. Rows past this point belong to whichever
                 # dispatcher claims them next; delivering them here would race
                 # a drain that dispatcher may have started.
-                logger.debug("deliver_webhook_parallel.claim_exhausted", extra=extra)
+                logger.debug("deliver_webhook.claim_exhausted", extra=extra)
                 metrics.incr(
                     "hybridcloud.deliver_webhooks.delivery",
                     tags={**dispatch_tags, "outcome": "claim_exhausted"},
@@ -1330,7 +1329,7 @@ def drain_mailbox_parallel(
             if request_failed and not skip_on_failure:
                 # For providers that require stricter mailbox behavior, stop on
                 # the first batch that had a retryable failure.
-                logger.info("deliver_webhook_parallel.delivery_request_failed", extra=extra)
+                logger.info("deliver_webhook.delivery_request_failed", extra=extra)
                 return
     finally:
         deleter.flush()

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1261,6 +1261,7 @@ def _run_parallel_delivery_batch(
     ]
 
     delivered = 0
+    unexpected: Exception | None = None
     if fresh_records:
         with ContextPropagatingThreadPoolExecutor(max_workers=len(fresh_records)) as threadpool:
             futures = {
@@ -1268,10 +1269,19 @@ def _run_parallel_delivery_batch(
             }
             for future in as_completed(futures):
                 payload_record, err = future.result()
-                if _handle_parallel_delivery_result(
-                    payload_record, err, deleter, delivery_tags=delivery_tags
-                ):
-                    delivered += 1
+                try:
+                    if _handle_parallel_delivery_result(
+                        payload_record, err, deleter, delivery_tags=delivery_tags
+                    ):
+                        delivered += 1
+                except Exception as handler_err:
+                    # Raising mid-wave would abandon the sibling results: rows
+                    # their threads already delivered would never be deleted,
+                    # then redelivered under a later claim.
+                    if unexpected is None:
+                        unexpected = handler_err
+    if unexpected is not None:
+        raise unexpected
     return delivered
 
 

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -70,8 +70,17 @@ worker-slot time a lone thread would spend dominates the burst cost.
 RELEASE_MARGIN = datetime.timedelta(seconds=30)
 """
 How long before its claim's deadline a drain stops delivering and releases the
-unworked tail back to the mailbox. Sized to cover a worst-case delivery wave
-plus the final delete flush, so the release lands while the claim still holds.
+unworked tail back to the mailbox. Covers a worst-case delivery wave (bounded
+by CELL_REQUEST_TIMEOUT for connect and read each) plus the final delete
+flush, so the release lands while the claim still holds.
+"""
+
+CELL_REQUEST_TIMEOUT = 12
+"""
+Connect and read timeout, each, for one delivery request to a cell. Twice this
+must stay under RELEASE_MARGIN, or a request started just ahead of the
+soft-stop carries the drain past its claim's deadline into rows another
+dispatcher may already own.
 """
 
 
@@ -295,7 +304,9 @@ class _MailboxClaim:
         strict-ordering provider would deliver out of order exactly when its
         mailbox is deep.
         """
-        return self.skip_on_failure and self.claimed > MIN_RECORDS_PER_THREAD
+        if not self.skip_on_failure or self.claimed <= MIN_RECORDS_PER_THREAD:
+            return False
+        return options.get("hybridcloud.webhookpayload.worker_threads") > 1
 
     def task_args(self) -> dict[str, Any]:
         """
@@ -347,7 +358,9 @@ class _MailboxClaim:
         Matching the exact `schedule_for` this claim wrote is what makes the
         release safe: a record another claim took carries that claim's timestamp,
         and a record this drain failed and rescheduled carries its backoff — both
-        pass untouched.
+        pass untouched. A record that entered the claim already backing off is
+        the exception: the claim rewrote its schedule (gated claims sweep the
+        whole prefix), so releasing it forfeits what remained of that backoff.
         """
         released = WebhookPayload.objects.filter(
             mailbox_name=self.mailbox_name,
@@ -413,8 +426,15 @@ def _begin_drain(
             .first()
         )
         if head is None:
-            # Head already delivered or discarded; whoever claimed the mailbox
-            # next is delivering the rest.
+            # Whoever claimed the mailbox next is delivering the rest. Every
+            # drain resolves through this read until dispatch sends the claim,
+            # so this is where a lost race shows up.
+            _record_lost_head(
+                payload_id,
+                dispatcher=dispatcher,
+                provider=_provider_from_mailbox(mailbox),
+                log_key="deliver_webhook.potential_race",
+            )
             return None
         mailbox = mailbox if mailbox is not None else head[0]
         deadline = deadline if deadline is not None else head[1]
@@ -544,7 +564,15 @@ def _claim_and_dispatch(
     claim = _claim_mailbox_batch(head_id, mailbox_name, dispatcher=dispatcher)
     if claim is None:
         return DispatchOutcome.NOT_DUE
-    drain_mailbox.delay(**claim.task_args())
+    # Only the arguments workers from the previous deploy bind: an unknown kwarg
+    # is a TypeError the taskbroker discards without retry. The drain recovers
+    # the mailbox and deadline from its head row; the full claim shape
+    # (`task_args`) starts crossing the wire one deploy later.
+    drain_mailbox.delay(
+        payload_id=claim.head_id,
+        claimed_count=claim.claimed,
+        dispatcher=claim.dispatcher,
+    )
     outcome = DispatchOutcome.PARALLEL if claim.threaded else DispatchOutcome.SEQUENTIAL
     _record_dispatch(
         dispatcher=dispatcher,
@@ -915,6 +943,7 @@ def drain_mailbox(
     dispatcher: str | None = None,
     valid_until: float | None = None,
     mailbox: str | None = None,
+    chain_depth: int = 0,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of — in order,
@@ -922,6 +951,7 @@ def drain_mailbox(
 
     The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
     each defaults so a rolling deploy can bind drains the previous version sent.
+    `chain_depth` is accepted ahead of drain chaining for the same reason.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
     if claim is not None:
@@ -1257,6 +1287,7 @@ def drain_mailbox_parallel(
     dispatcher: str | None = None,
     valid_until: float | None = None,
     mailbox: str | None = None,
+    chain_depth: int = 0,
 ) -> None:
     """
     Transitional alias from when sequential and parallel delivery were separate
@@ -1333,6 +1364,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
                 # We need to send the body as raw bytes to avoid interfering with webhook signatures
                 data=payload.request_body.encode("utf-8"),
                 json=False,
+                timeout=CELL_REQUEST_TIMEOUT,
             )
         logger.debug(
             "deliver_webhooks.success",

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -943,7 +943,7 @@ def drain_mailbox(
     dispatcher: str | None = None,
     valid_until: float | None = None,
     mailbox: str | None = None,
-    chain_depth: int = 0,
+    chain_depth: int = 1,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of — in order,
@@ -951,7 +951,8 @@ def drain_mailbox(
 
     The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
     each defaults so a rolling deploy can bind drains the previous version sent.
-    `chain_depth` is accepted ahead of drain chaining for the same reason.
+    `chain_depth` — which link of a chain this drain is, an ordinary dispatch
+    being the first — is accepted ahead of drain chaining for the same reason.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
     if claim is not None:
@@ -1287,7 +1288,7 @@ def drain_mailbox_parallel(
     dispatcher: str | None = None,
     valid_until: float | None = None,
     mailbox: str | None = None,
-    chain_depth: int = 0,
+    chain_depth: int = 1,
 ) -> None:
     """
     Transitional alias from when sequential and parallel delivery were separate

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -110,9 +110,9 @@ actions that have been made to the relevant resources.
 DELETE_BATCH_SIZE = 100
 """
 How many finished rows a batching drain accumulates before removing them.
-Sized to the sequential drain's read slice so a flush lands roughly per slice,
-and small enough that a crash strands at most this many rows until the claim
-horizon passes.
+Sized to the drain's read slice so a flush lands roughly per slice, and small
+enough that a crash strands at most this many rows until the claim horizon
+passes.
 """
 
 # Define priorities for different webhook providers
@@ -289,10 +289,11 @@ class _MailboxClaim:
     @property
     def threaded(self) -> bool:
         """
-        Whether this claim's drain delivers in concurrent waves. Only providers
-        that may skip failed records qualify: concurrent requests complete in
-        arbitrary order, so threading a strict-ordering provider would deliver
-        out of order exactly when its mailbox is deep.
+        Whether this claim's drain starts out delivering in concurrent waves; the
+        dispatch `drain` tag. Only providers that may skip failed records qualify:
+        concurrent requests complete in arbitrary order, so threading a
+        strict-ordering provider would deliver out of order exactly when its
+        mailbox is deep.
         """
         return self.skip_on_failure and self.claimed > MIN_RECORDS_PER_THREAD
 
@@ -376,18 +377,14 @@ class _MailboxClaim:
             ).order_by("id")[:size]
         )
         if start_id == self.head_id and (not records or records[0].id != self.head_id):
-            self.record_lost_head("deliver_webhook.potential_race")
+            _record_lost_head(
+                self.head_id,
+                dispatcher=self.dispatcher,
+                provider=self.provider,
+                log_key="deliver_webhook.potential_race",
+            )
             return None
         return records
-
-    def record_lost_head(self, log_key: str) -> None:
-        """This drain's head row is already gone — see `_record_lost_head`."""
-        _record_lost_head(
-            self.head_id,
-            dispatcher=self.dispatcher,
-            provider=self.provider,
-            log_key=log_key,
-        )
 
 
 def _begin_drain(
@@ -941,9 +938,9 @@ def drain_mailbox(
 def _drain_mailbox(claim: _MailboxClaim) -> None:
     """
     Deliver the claimed records until a strict provider's record fails, the claim
-    nears its deadline, or all of them have been processed. Threaded claims
-    (`_MailboxClaim.threaded`) deliver in concurrent waves sized to the work left;
-    every other claim delivers one record at a time, in order.
+    nears its deadline, or all of them have been processed. Skip-on-failure claims
+    deliver in concurrent waves sized to the work left, falling back to one record
+    at a time as the tail shrinks; strict claims always deliver in order.
 
     The drain holds no lock, so it must not deliver past the records its dispatcher
     claimed: beyond them the mailbox head is due again and another dispatcher may
@@ -951,15 +948,15 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
     """
     delivery_tags = claim.delivery_tags
     skip_on_failure = claim.skip_on_failure
-    threaded = claim.threaded
     worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
-
-    deleter = _deleter_for()
+    deleter = _PayloadDeleter(batched=options.get("hybridcloud.webhookpayload.drain_batch_deletes"))
 
     delivered = 0
     failed = 0
     remaining = claim.claimed
     current_id = claim.head_id
+    records: list[WebhookPayload] = []
+    index = 0
     log_context = {
         "id": claim.head_id,
         "mailbox_name": claim.mailbox_name,
@@ -974,75 +971,76 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                 claim.release_remainder(current_id, extra=extra)
                 break
 
-            # Slices of 100 keep query duration down and avoid reading records a
-            # failure earlier in the claim means we never get to.
-            records = claim.next_slice(current_id, min(100, remaining))
-            if records is None:
-                return
-            if not records:
-                if failed > 0:
-                    logger.info(
-                        "deliver_webhook.delivery_complete_with_failures",
-                        extra={**extra, "failed": failed},
-                    )
-                else:
-                    logger.debug("deliver_webhook.delivery_complete", extra=extra)
-                return
-
-            index = 0
-            while index < len(records) and not claim.nearing_deadline():
-                if threaded:
-                    concurrency = min(worker_threads, math.ceil(remaining / MIN_RECORDS_PER_THREAD))
-                    wave = records[index : index + concurrency]
-                    # Read before delivery: an immediate delete clears pk on the
-                    # in-memory instance. Advancing past the whole wave is also what
-                    # keeps failed rows, left with a future schedule_for, from being
-                    # re-attempted here. Threading requires skip_on_failure, so a
-                    # failed request never stops the drain.
-                    next_id = wave[-1].id + 1
-                    delivered += _run_parallel_delivery_batch(
-                        wave, deleter, delivery_tags=delivery_tags
-                    )
-                    current_id = next_id
-                    index += len(wave)
-                    remaining -= len(wave)
-                else:
-                    record = records[index]
-                    # Advance past this record regardless of outcome so that failed
-                    # messages are not re-attempted later in this drain.
-                    current_id = record.id + 1
-                    index += 1
-                    remaining -= 1
-                    try:
-                        if deliver_message(record, deleter, delivery_tags=delivery_tags):
-                            delivered += 1
-                    except DeliveryFailed:
-                        failed += 1
-                        metrics.incr(
-                            "hybridcloud.deliver_webhooks.delivery",
-                            tags={**delivery_tags, "outcome": "retry"},
+            if index >= len(records):
+                # Slices of 100 keep query duration down and avoid reading records
+                # a failure earlier in the claim means we never get to.
+                fetched = claim.next_slice(current_id, min(100, remaining))
+                if fetched is None:
+                    return
+                if not fetched:
+                    if failed > 0:
+                        logger.info(
+                            "deliver_webhook.delivery_complete_with_failures",
+                            extra={**extra, "failed": failed},
                         )
-                        if not skip_on_failure:
-                            # For providers that require strict ordering, stop on the
-                            # first failure so subsequent messages are not delivered
-                            # out of order.
-                            return
-                        # For allowlisted providers: skip the failed message and
-                        # continue. It has already been rescheduled by deliver_message.
+                    else:
+                        logger.debug("deliver_webhook.delivery_complete", extra=extra)
+                    return
+                records = fetched
+                index = 0
 
-                if remaining <= 0:
-                    # Claim exhausted. Rows past this point belong to whichever
-                    # dispatcher claims them next; delivering them here would race
-                    # a drain that dispatcher may have started.
-                    logger.debug(
-                        "deliver_webhook.claim_exhausted",
-                        extra={**log_context, "delivered": delivered},
-                    )
+            concurrency = 1
+            if skip_on_failure:
+                concurrency = min(worker_threads, math.ceil(remaining / MIN_RECORDS_PER_THREAD))
+            if concurrency > 1:
+                wave = records[index : index + concurrency]
+                # Advance past the whole wave before delivery: a delete clears pk
+                # on the in-memory instance, and failed rows — left with a future
+                # schedule_for — must not be re-attempted here. A failed request
+                # never stops the drain: threading requires skip_on_failure.
+                current_id = wave[-1].id + 1
+                index += len(wave)
+                remaining -= len(wave)
+                delivered += _run_parallel_delivery_batch(
+                    wave, deleter, delivery_tags=delivery_tags
+                )
+            else:
+                record = records[index]
+                # Advance past this record regardless of outcome so that failed
+                # messages are not re-attempted later in this drain.
+                current_id = record.id + 1
+                index += 1
+                remaining -= 1
+                try:
+                    if deliver_message(record, deleter, delivery_tags=delivery_tags):
+                        delivered += 1
+                except DeliveryFailed:
+                    failed += 1
                     metrics.incr(
                         "hybridcloud.deliver_webhooks.delivery",
-                        tags={**delivery_tags, "outcome": "claim_exhausted"},
+                        tags={**delivery_tags, "outcome": "retry"},
                     )
-                    return
+                    if not skip_on_failure:
+                        # For providers that require strict ordering, stop on the
+                        # first failure so subsequent messages are not delivered
+                        # out of order.
+                        return
+                    # For allowlisted providers: skip the failed message and
+                    # continue. It has already been rescheduled by deliver_message.
+
+            if remaining <= 0:
+                # Claim exhausted. Rows past this point belong to whichever
+                # dispatcher claims them next; delivering them here would race
+                # a drain that dispatcher may have started.
+                logger.debug(
+                    "deliver_webhook.claim_exhausted",
+                    extra={**log_context, "delivered": delivered},
+                )
+                metrics.incr(
+                    "hybridcloud.deliver_webhooks.delivery",
+                    tags={**delivery_tags, "outcome": "claim_exhausted"},
+                )
+                return
     finally:
         deleter.flush()
 
@@ -1057,6 +1055,12 @@ class _PayloadDeleter:
     traffic a drain generates on this delete-heavy table. Only the drain thread
     ever calls a deleter: parallel workers perform requests and hand their
     results back to the drain loop, so no locking is needed.
+
+    Batching is safe because every drain is bounded to a claim its dispatcher
+    owns: nothing else can touch a row between the drain finishing with it and
+    deleting it. A worker that dies before flushing reprocesses at most one batch
+    once the claim horizon passes — redelivering its delivered rows and
+    re-discarding the rest — the same window a claim-then-crash already has.
     """
 
     def __init__(self, *, batched: bool) -> None:
@@ -1079,19 +1083,6 @@ class _PayloadDeleter:
         metrics.distribution("hybridcloud.deliver_webhooks.drain.delete_batch", len(self._pending))
         WebhookPayload.objects.filter(id__in=self._pending).delete()
         self._pending.clear()
-
-
-def _deleter_for() -> _PayloadDeleter:
-    """
-    Build the deleter for a drain.
-
-    Batching is safe because every drain is bounded to a claim its dispatcher
-    owns: nothing else can touch a row between the drain finishing with it and
-    deleting it. A worker that dies before flushing reprocesses at most one batch
-    once the claim horizon passes — redelivering its delivered rows and
-    re-discarding the rest — the same window a claim-then-crash already has.
-    """
-    return _PayloadDeleter(batched=options.get("hybridcloud.webhookpayload.drain_batch_deletes"))
 
 
 def _discard_if_stale(
@@ -1167,6 +1158,22 @@ def _record_delivery_time_metrics(
     )
 
 
+def _finish_delivered(
+    payload: WebhookPayload, deleter: _PayloadDeleter, *, delivery_tags: Mapping[str, str]
+) -> None:
+    """Remove a delivered payload and record the delivery."""
+    payload_data = payload.as_dict()
+    date_added = payload.date_added
+    deleter.delete(payload)
+    _record_delivery_time_metrics(payload, delivery_tags=delivery_tags)
+    metrics.incr(
+        "hybridcloud.deliver_webhooks.delivery",
+        tags={**delivery_tags, "outcome": "ok"},
+    )
+    if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
+        logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
+
+
 def _handle_parallel_delivery_result(
     payload_record: WebhookPayload,
     err: Exception | None,
@@ -1175,10 +1182,10 @@ def _handle_parallel_delivery_result(
     delivery_tags: Mapping[str, str],
 ) -> bool:
     """
-    Process one result from the parallel delivery threadpool.
-    Returns whether `err` is unexpected and must be re-raised.
+    Process one result from the parallel delivery threadpool; returns whether the
+    payload was delivered. An unexpected `err` is re-raised, after the reschedule
+    so its record keeps a retry.
     """
-    payload_data = payload_record.as_dict()
     if isinstance(err, DeliveryDropped):
         # Permanently rejected, so it is neither a delivery nor a retryable failure:
         # drop it and let the drain continue to the next record.
@@ -1202,17 +1209,11 @@ def _handle_parallel_delivery_result(
             },
         )
         payload_record.schedule_next_attempt()
-        return not isinstance(err, DeliveryFailed)
-    date_added = payload_record.date_added
-    deleter.delete(payload_record)
-    _record_delivery_time_metrics(payload_record, delivery_tags=delivery_tags)
-    metrics.incr(
-        "hybridcloud.deliver_webhooks.delivery",
-        tags={**delivery_tags, "outcome": "ok"},
-    )
-    if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
-        logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
-    return False
+        if not isinstance(err, DeliveryFailed):
+            raise err
+        return False
+    _finish_delivered(payload_record, deleter, delivery_tags=delivery_tags)
+    return True
 
 
 def _run_parallel_delivery_batch(
@@ -1247,12 +1248,9 @@ def _run_parallel_delivery_batch(
             }
             for future in as_completed(futures):
                 payload_record, err = future.result()
-                should_reraise = _handle_parallel_delivery_result(
+                if _handle_parallel_delivery_result(
                     payload_record, err, deleter, delivery_tags=delivery_tags
-                )
-                if should_reraise and err is not None:
-                    raise err
-                if err is None:
+                ):
                     delivered += 1
     return delivered
 
@@ -1260,7 +1258,7 @@ def _run_parallel_delivery_batch(
 @instrumented_task(
     name="sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel",
     namespace=hybridcloud_control_tasks,
-    # Give more time than the threadpool delivery deadline
+    # The pre-merge task's deadline, kept for the in-flight drains this shim serves.
     processing_deadline_duration=int(BATCH_SCHEDULE_OFFSET.total_seconds() + 10),
     silo_mode=SiloMode.CONTROL,
 )
@@ -1299,7 +1297,6 @@ def deliver_message(
     discarded — attempts exhausted, too old, or permanently rejected — returns
     False even though it was removed from the mailbox.
     """
-    payload_data = payload.as_dict()
     if _discard_if_exhausted(payload, deleter, delivery_tags=delivery_tags):
         return False
 
@@ -1318,15 +1315,7 @@ def deliver_message(
             tags={**delivery_tags, "outcome": err.outcome},
         )
         return False
-    date_added = payload.date_added
-    deleter.delete(payload)
-    _record_delivery_time_metrics(payload, delivery_tags=delivery_tags)
-    if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
-        logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
-    metrics.incr(
-        "hybridcloud.deliver_webhooks.delivery",
-        tags={**delivery_tags, "outcome": "ok"},
-    )
+    _finish_delivered(payload, deleter, delivery_tags=delivery_tags)
     return True
 
 

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -412,18 +412,13 @@ def _begin_drain(
             .values_list("mailbox_name", "schedule_for")
             .first()
         )
-        if head is not None:
-            mailbox = mailbox if mailbox is not None else head[0]
-            deadline = deadline if deadline is not None else head[1]
+        if head is None:
+            # Head already delivered or discarded; whoever claimed the mailbox
+            # next is delivering the rest.
+            return None
+        mailbox = mailbox if mailbox is not None else head[0]
+        deadline = deadline if deadline is not None else head[1]
     _set_webhook_delivery_sentry_context(mailbox, _provider_from_mailbox(mailbox))
-    if mailbox is None or deadline is None:
-        _record_lost_head(
-            payload_id,
-            dispatcher=dispatcher,
-            provider=_provider_from_mailbox(mailbox),
-            log_key="deliver_webhook.potential_race",
-        )
-        return None
     claim = _MailboxClaim(
         claimed=claimed_count,
         head_id=payload_id,
@@ -484,12 +479,7 @@ def _claim_mailbox_batch(
 
 
 class DispatchOutcome(enum.StrEnum):
-    """
-    What `_claim_and_dispatch` did for a mailbox; doubles as a metric tag.
-
-    SEQUENTIAL and PARALLEL name the delivery mode the claim's drain will use
-    (`_MailboxClaim.threaded`) — one task runs both.
-    """
+    """What `_claim_and_dispatch` did for a mailbox; doubles as a metric tag."""
 
     NOT_DUE = "not_due"
     SEQUENTIAL = "sequential"

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from concurrent.futures import as_completed
-from typing import Any
+from typing import Any, NamedTuple
 
 import orjson
 import sentry_sdk
@@ -138,16 +138,47 @@ def _provider_from_mailbox(mailbox_name: str | None) -> str:
     return provider if separator and provider else UNKNOWN_PROVIDER
 
 
-def _set_webhook_delivery_sentry_context(payload: WebhookPayload) -> None:
-    """Set Sentry context at webhook delivery entrypoint for easier debugging."""
-    sentry_sdk.set_tag("mailbox_name", payload.mailbox_name)
-    sentry_sdk.set_attribute("mailbox_name", payload.mailbox_name)
-    context: dict[str, str] = {
-        "mailbox_name": payload.mailbox_name,
-        "provider": payload.provider or "unknown",
-    }
+def _resolve_mailbox(payload_id: int, mailbox: str | None) -> str | None:
+    """
+    The mailbox a drain works, reading the head row only when its task args did
+    not carry one. None means the head is already gone.
+
+    Transitional: drains enqueued before dispatch sent `mailbox` still need it to
+    scope their queries, and this read goes away once none are left in flight.
+    """
+    if mailbox is not None:
+        return mailbox
+    return (
+        WebhookPayload.objects.filter(id=payload_id).values_list("mailbox_name", flat=True).first()
+    )
+
+
+def _record_lost_head(
+    payload_id: int, *, dispatch_tags: Mapping[str, str], provider: str, log_key: str
+) -> None:
+    """
+    Record a drain whose head row is already gone, delivered by whoever claimed it
+    next. The drain stands down and lets that dispatcher, or a later one, continue.
+    """
+    metrics.incr(
+        "hybridcloud.deliver_webhooks.delivery",
+        tags={**dispatch_tags, "outcome": "race", "provider": provider},
+    )
+    logger.info(log_key, extra={"id": payload_id})
+
+
+def _set_webhook_delivery_sentry_context(mailbox_name: str | None, provider: str) -> None:
+    """
+    Set Sentry context at the delivery entrypoint for easier debugging.
+
+    Takes what the task args carry rather than a row, so it also covers a drain
+    that finds its head already gone.
+    """
+    sentry_sdk.set_tag("mailbox_name", mailbox_name)
+    sentry_sdk.set_attribute("mailbox_name", mailbox_name)
+    context: dict[str, Any] = {"mailbox_name": mailbox_name, "provider": provider}
     sentry_sdk.set_context("webhook_delivery", context)
-    sentry_sdk.set_attribute("webhook_delivery.provider", payload.provider or "unknown")
+    sentry_sdk.set_attribute("webhook_delivery.provider", provider)
 
 
 class DeliveryFailed(Exception):
@@ -232,7 +263,67 @@ def _dispatches_from_due_head(mailbox_name: str) -> bool:
     return provider in (options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ())
 
 
-def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> int:
+class _MailboxClaim(NamedTuple):
+    """
+    The records one claim reserved.
+
+    `valid_until` is stored rather than re-derived, so it names exactly when the
+    records come due for other dispatchers again.
+    """
+
+    claimed: int
+    valid_until: datetime.datetime
+
+    @classmethod
+    def from_task_args(cls, claimed_count: int, valid_until: str | None) -> "_MailboxClaim":
+        """
+        The claim a drain was dispatched for, as its task args carry it.
+
+        Drains enqueued before dispatch sent a deadline fall back to a fresh
+        horizon, as they had before.
+        """
+        return cls(
+            claimed=claimed_count,
+            valid_until=(
+                datetime.datetime.fromisoformat(valid_until)
+                if valid_until is not None
+                else timezone.now() + BATCH_SCHEDULE_OFFSET
+            ),
+        )
+
+    def lapsed(
+        self,
+        *,
+        provider: str,
+        dispatch_tags: Mapping[str, str],
+        log_key: str,
+        extra: Mapping[str, Any],
+    ) -> bool:
+        """
+        Whether this claim has lapsed, recording the stand-down when it has.
+
+        The deadline bounds a drain at both ends — it must not start past its
+        claim, and must not keep delivering past it — so both checks report one
+        outcome; `log_key` is what separates them in logs. At the deadline exactly
+        the claim is already lapsed, since the due gates are `schedule_for__lte=now`.
+        """
+        if timezone.now() < self.valid_until:
+            return False
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={**dispatch_tags, "outcome": "delivery_deadline", "provider": provider},
+        )
+        logger.info(
+            log_key,
+            extra={
+                **extra,
+                "overshoot_seconds": (timezone.now() - self.valid_until).total_seconds(),
+            },
+        )
+        return True
+
+
+def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> _MailboxClaim:
     """
     Claim up to MAX_MAILBOX_DRAIN records at the head of the mailbox by scheduling
     them past the drain deadline, keeping other dispatchers off the mailbox while
@@ -245,9 +336,9 @@ def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> int:
     backoff record keeps its backoff. As a prefix, the drain's (head, count) walk
     covers exactly the claimed records.
 
-    Returns the number of records claimed — also the depth signal that picks the
-    drain mode.
+    `claimed` doubles as the depth signal that picks the drain mode.
     """
+    valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
     window = WebhookPayload.objects.filter(id__gte=head_id, mailbox_name=mailbox_name).order_by(
         "id"
     )
@@ -260,16 +351,17 @@ def _claim_mailbox_batch(head_id: int, mailbox_name: str) -> int:
                 break
             prefix_ids.append(record_id)
         if not prefix_ids:
-            return 0
+            return _MailboxClaim(claimed=0, valid_until=valid_until)
         claimed_ids = prefix_ids
     else:
         claimed_ids = Subquery(window.values("id")[:MAX_MAILBOX_DRAIN])
     head_due = WebhookPayload.objects.filter(id=head_id, schedule_for__lte=timezone.now())
-    return (
+    claimed = (
         WebhookPayload.objects.filter(id__in=claimed_ids)
         .filter(Exists(head_due))
-        .update(schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET)
+        .update(schedule_for=valid_until)
     )
+    return _MailboxClaim(claimed=claimed, valid_until=valid_until)
 
 
 class DispatchOutcome(enum.StrEnum):
@@ -341,20 +433,32 @@ def _claim_and_dispatch(
     `dispatcher` tags this dispatch and is forwarded to the drain so its
     deliveries carry the same attribution; both callers claim identically.
     """
-    claimed = _claim_mailbox_batch(head_id, mailbox_name)
-    if not claimed:
+    claim = _claim_mailbox_batch(head_id, mailbox_name)
+    if not claim.claimed:
         return DispatchOutcome.NOT_DUE
-    if claimed >= PARALLEL_DRAIN_THRESHOLD:
-        drain_mailbox_parallel.delay(head_id, claimed_count=claimed, dispatcher=dispatcher)
+    if claim.claimed >= PARALLEL_DRAIN_THRESHOLD:
+        drain_mailbox_parallel.delay(
+            head_id,
+            claimed_count=claim.claimed,
+            dispatcher=dispatcher,
+            valid_until=claim.valid_until.isoformat(),
+            mailbox=mailbox_name,
+        )
         outcome = DispatchOutcome.PARALLEL
     else:
-        drain_mailbox.delay(head_id, claimed_count=claimed, dispatcher=dispatcher)
+        drain_mailbox.delay(
+            head_id,
+            claimed_count=claim.claimed,
+            dispatcher=dispatcher,
+            valid_until=claim.valid_until.isoformat(),
+            mailbox=mailbox_name,
+        )
         outcome = DispatchOutcome.SEQUENTIAL
     _record_dispatch(
         dispatcher=dispatcher,
         drain=outcome,
         mailbox_name=mailbox_name,
-        claimed=claimed,
+        claimed=claim.claimed,
     )
     return outcome
 
@@ -717,12 +821,14 @@ def drain_mailbox(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
+    valid_until: str | None = None,
+    mailbox: str | None = None,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of.
 
-    Messages will be delivered in order until one fails, the batch deadline is
-    reached, or `claimed_count` records have been processed. Once messages have
+    Messages will be delivered in order until one fails, the claim's deadline
+    passes, or `claimed_count` records have been processed. Once messages have
     successfully been delivered or discarded, they are deleted.
 
     This drain holds no lock while it runs, so it must not deliver past the
@@ -731,66 +837,80 @@ def drain_mailbox(
 
     `dispatcher` carries the enqueueing dispatcher's attribution onto every
     delivery outcome this drain records (see `_dispatch_tags`).
+
+    `valid_until` is the claim's deadline, bounding this drain at both ends: it
+    stands down if it starts past it, and stops delivering when it reaches it.
+    Beyond it the records are due for whoever claims them next. Drains enqueued
+    before dispatch sent one fall back to a fresh horizon, as they had before.
+
+    `mailbox` names the provider without reading a row, which is what the deadline
+    check needs before it has one. Absent on those same older drains, whose
+    stand-down reports an unknown provider rather than pay for a lookup.
     """
     dispatch_tags = _dispatch_tags(dispatcher)
-    try:
-        payload = WebhookPayload.objects.get(id=payload_id)
-    except WebhookPayload.DoesNotExist:
-        # We could have hit a race condition. Since we've lost already return
-        # and let the other process continue, or a future process.
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.delivery",
-            # The row is gone, so nothing left in hand names the provider.
-            tags={**dispatch_tags, "outcome": "race", "provider": UNKNOWN_PROVIDER},
-        )
-        logger.info("deliver_webhook.potential_race", extra={"id": payload_id})
+    claim = _MailboxClaim.from_task_args(claimed_count, valid_until)
+    provider = _provider_from_mailbox(mailbox)
+    _set_webhook_delivery_sentry_context(mailbox, provider)
+    if claim.lapsed(
+        provider=provider,
+        dispatch_tags=dispatch_tags,
+        log_key="deliver_webhook.stale_claim",
+        extra={"id": payload_id},
+    ):
         return
-
-    _set_webhook_delivery_sentry_context(payload)
+    mailbox = _resolve_mailbox(payload_id, mailbox)
+    if mailbox is None:
+        _record_lost_head(
+            payload_id,
+            dispatch_tags=dispatch_tags,
+            provider=provider,
+            log_key="deliver_webhook.potential_race",
+        )
+        return
+    provider = _provider_from_mailbox(mailbox)
 
     skip_on_failure_providers = frozenset(
         options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
     )
-    skip_on_failure = payload.provider in skip_on_failure_providers
+    skip_on_failure = provider in skip_on_failure_providers
 
     deleter = _deleter_for()
 
     delivered = 0
     failed = 0
-    remaining = claimed_count
-    current_id = payload.id
-    deadline = timezone.now() + BATCH_SCHEDULE_OFFSET
+    remaining = claim.claimed
+    current_id = payload_id
+    log_context = {"id": payload_id, "mailbox_name": mailbox, "provider": provider}
     try:
         while True:
-            # We have run until the end of our batch schedule delay. Break the loop so this worker can take another
-            # task.
-            if timezone.now() >= deadline:
-                logger.info(
-                    "deliver_webhook.delivery_deadline",
-                    extra={
-                        **payload.as_dict(),
-                        "delivered": delivered,
-                    },
-                )
-                metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery",
-                    tags={
-                        **dispatch_tags,
-                        "outcome": "delivery_deadline",
-                        "provider": _provider_tag(payload),
-                    },
-                )
+            if claim.lapsed(
+                provider=provider,
+                dispatch_tags=dispatch_tags,
+                log_key="deliver_webhook.delivery_deadline",
+                extra={**log_context, "delivered": delivered},
+            ):
                 break
 
             # Fetch records from the batch in slices of 100. This avoids reading
             # redundant data should we hit an error and should help keep query duration low.
             query = WebhookPayload.objects.filter(
-                id__gte=current_id, mailbox_name=payload.mailbox_name
+                id__gte=current_id, mailbox_name=mailbox
             ).order_by("id")
 
             slice_size = min(100, remaining)
+            records = list(query[:slice_size])
+            if current_id == payload_id and (not records or records[0].id != payload_id):
+                # First slice, and the head is not at its front: it has been
+                # delivered by whoever claimed it next.
+                _record_lost_head(
+                    payload_id,
+                    dispatch_tags=dispatch_tags,
+                    provider=provider,
+                    log_key="deliver_webhook.potential_race",
+                )
+                return
             batch_count = 0
-            for record in query[:slice_size]:
+            for record in records:
                 batch_count += 1
                 # Advance past this record regardless of outcome so that failed
                 # messages are not re-attempted in subsequent batches of this drain.
@@ -822,19 +942,12 @@ def drain_mailbox(
                 if failed > 0:
                     logger.info(
                         "deliver_webhook.delivery_complete_with_failures",
-                        extra={
-                            **payload.as_dict(),
-                            "delivered": delivered,
-                            "failed": failed,
-                        },
+                        extra={**log_context, "delivered": delivered, "failed": failed},
                     )
                 else:
                     logger.debug(
                         "deliver_webhook.delivery_complete",
-                        extra={
-                            **payload.as_dict(),
-                            "delivered": delivered,
-                        },
+                        extra={**log_context, "delivered": delivered},
                     )
                 return
 
@@ -845,10 +958,7 @@ def drain_mailbox(
                 # a drain that dispatcher may have started.
                 logger.debug(
                     "deliver_webhook.claim_exhausted",
-                    extra={
-                        **payload.as_dict(),
-                        "delivered": delivered,
-                    },
+                    extra={**log_context, "delivered": delivered},
                 )
                 metrics.incr(
                     "hybridcloud.deliver_webhooks.delivery",
@@ -1026,6 +1136,22 @@ def _handle_parallel_delivery_result(
     return (False, False)
 
 
+class _ParallelBatch(NamedTuple):
+    """
+    What one parallel batch did.
+
+    `next_start_id` is one past the highest id attempted so callers can advance
+    past failed rows (e.g. skip-on-failure providers), and `head_id` is the first
+    id the batch saw — None on both when the mailbox held nothing at `start_id`.
+    """
+
+    attempted: int
+    delivered: int
+    request_failed: bool
+    next_start_id: int | None
+    head_id: int | None
+
+
 def _run_parallel_delivery_batch(
     mailbox_name: str,
     start_id: int,
@@ -1033,14 +1159,9 @@ def _run_parallel_delivery_batch(
     deleter: _PayloadDeleter,
     *,
     dispatch_tags: Mapping[str, str],
-) -> tuple[int, int, bool, int | None]:
+) -> "_ParallelBatch":
     """
     Run one batch of up to `batch_size` parallel deliveries for the mailbox.
-
-    Returns (attempted_count, delivered_count, request_failed, next_start_id).
-    `next_start_id` is one past the highest id attempted in this batch so callers
-    can advance past failed rows when continuing (e.g. skip-on-failure providers).
-    Returns `next_start_id=None` when the mailbox has no rows at/after `start_id`.
     """
     records = list(
         WebhookPayload.objects.filter(id__gte=start_id, mailbox_name=mailbox_name).order_by("id")[
@@ -1048,11 +1169,12 @@ def _run_parallel_delivery_batch(
         ]
     )
     if not records:
-        return (0, 0, False, None)
+        return _ParallelBatch(0, 0, False, None, None)
 
     # Capture before delivery/discard — an immediate delete clears pk on the
     # in-memory instance.
     next_start_id = records[-1].id + 1
+    head_id = records[0].id
     attempted = len(records)
 
     # Stale rows are discarded in place of delivery, consuming claim budget
@@ -1080,7 +1202,7 @@ def _run_parallel_delivery_batch(
                     raise err
                 if err is None:
                     delivered += 1
-    return (attempted, delivered, request_failed, next_start_id)
+    return _ParallelBatch(attempted, delivered, request_failed, next_start_id, head_id)
 
 
 @instrumented_task(
@@ -1094,6 +1216,8 @@ def drain_mailbox_parallel(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
+    valid_until: str | None = None,
+    mailbox: str | None = None,
 ) -> None:
     """
     Deliver messages from a mailbox in small parallel batches.
@@ -1111,57 +1235,74 @@ def drain_mailbox_parallel(
     This drain holds no lock while it runs, so it must not deliver past the
     `claimed_count` records its dispatcher claimed — see `drain_mailbox`.
 
-    `dispatcher` behaves as it does on `drain_mailbox`.
+    `dispatcher`, `valid_until` and `mailbox` behave as they do on `drain_mailbox`.
     """
     dispatch_tags = _dispatch_tags(dispatcher)
-    try:
-        payload = WebhookPayload.objects.get(id=payload_id)
-    except WebhookPayload.DoesNotExist:
-        # We could have hit a race condition. Since we've lost already return
-        # and let the other process continue, or a future process.
-        metrics.incr(
-            "hybridcloud.deliver_webhooks.delivery",
-            # The row is gone, so nothing left in hand names the provider.
-            tags={**dispatch_tags, "outcome": "race", "provider": UNKNOWN_PROVIDER},
-        )
-        logger.info("deliver_webhook_parallel.potential_race", extra={"id": payload_id})
+    claim = _MailboxClaim.from_task_args(claimed_count, valid_until)
+    provider = _provider_from_mailbox(mailbox)
+    _set_webhook_delivery_sentry_context(mailbox, provider)
+    if claim.lapsed(
+        provider=provider,
+        dispatch_tags=dispatch_tags,
+        log_key="deliver_webhook_parallel.stale_claim",
+        extra={"id": payload_id},
+    ):
         return
-
-    _set_webhook_delivery_sentry_context(payload)
+    mailbox = _resolve_mailbox(payload_id, mailbox)
+    if mailbox is None:
+        _record_lost_head(
+            payload_id,
+            dispatch_tags=dispatch_tags,
+            provider=provider,
+            log_key="deliver_webhook_parallel.potential_race",
+        )
+        return
+    provider = _provider_from_mailbox(mailbox)
 
     skip_on_failure_providers = frozenset(
         options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
     )
-    skip_on_failure = payload.provider in skip_on_failure_providers
+    skip_on_failure = provider in skip_on_failure_providers
 
     worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
     deleter = _deleter_for()
-    deadline = timezone.now() + BATCH_SCHEDULE_OFFSET
     delivered = 0
-    remaining = claimed_count
-    current_id = payload.id
-    extra = {**payload.as_dict(), "delivered": delivered}
+    remaining = claim.claimed
+    current_id = payload_id
+    extra = {"id": payload_id, "mailbox_name": mailbox, "provider": provider, "delivered": 0}
     try:
         while True:
-            if timezone.now() >= deadline:
-                logger.info("deliver_webhook_parallel.delivery_deadline", extra=extra)
-                metrics.incr(
-                    "hybridcloud.deliver_webhooks.delivery",
-                    tags={
-                        **dispatch_tags,
-                        "outcome": "delivery_deadline",
-                        "provider": _provider_tag(payload),
-                    },
-                )
+            if claim.lapsed(
+                provider=provider,
+                dispatch_tags=dispatch_tags,
+                log_key="deliver_webhook_parallel.delivery_deadline",
+                extra={**extra, "delivered": delivered},
+            ):
                 break
 
             batch_size = min(worker_threads, remaining)
-            attempted, delivered_batch, request_failed, next_id = _run_parallel_delivery_batch(
-                payload.mailbox_name,
+            batch = _run_parallel_delivery_batch(
+                mailbox,
                 current_id,
                 batch_size,
                 deleter,
                 dispatch_tags=dispatch_tags,
+            )
+            if current_id == payload_id and batch.head_id != payload_id:
+                # First batch, and the head is not at its front: it has been
+                # delivered by whoever claimed it next.
+                _record_lost_head(
+                    payload_id,
+                    dispatch_tags=dispatch_tags,
+                    provider=provider,
+                    log_key="deliver_webhook_parallel.potential_race",
+                )
+                return
+            attempted, delivered_batch, request_failed, next_id = (
+                batch.attempted,
+                batch.delivered,
+                batch.request_failed,
+                batch.next_start_id,
             )
             delivered += delivered_batch
             extra["delivered"] = delivered

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1156,40 +1156,34 @@ class _ParallelBatch(NamedTuple):
     What one parallel batch did.
 
     `next_start_id` is one past the highest id attempted so callers can advance
-    past failed rows (e.g. skip-on-failure providers), and `head_id` is the first
-    id the batch saw — None on both when the mailbox held nothing at `start_id`.
+    past failed rows (e.g. skip-on-failure providers), None when the batch was
+    empty.
     """
 
     attempted: int
     delivered: int
     request_failed: bool
     next_start_id: int | None
-    head_id: int | None
 
 
 def _run_parallel_delivery_batch(
-    mailbox_name: str,
-    start_id: int,
-    batch_size: int,
+    records: Sequence[WebhookPayload],
     deleter: _PayloadDeleter,
     *,
     dispatch_tags: Mapping[str, str],
 ) -> "_ParallelBatch":
     """
-    Run one batch of up to `batch_size` parallel deliveries for the mailbox.
+    Deliver one batch of already-fetched records in parallel.
+
+    The caller fetches so that it can inspect the batch before any of it is
+    delivered — see the head check in `_drain_in_parallel`.
     """
-    records = list(
-        WebhookPayload.objects.filter(id__gte=start_id, mailbox_name=mailbox_name).order_by("id")[
-            :batch_size
-        ]
-    )
     if not records:
-        return _ParallelBatch(0, 0, False, None, None)
+        return _ParallelBatch(0, 0, False, None)
 
     # Capture before delivery/discard — an immediate delete clears pk on the
     # in-memory instance.
     next_start_id = records[-1].id + 1
-    head_id = records[0].id
     attempted = len(records)
 
     # Stale rows are discarded in place of delivery, consuming claim budget
@@ -1203,7 +1197,7 @@ def _run_parallel_delivery_batch(
     delivered = 0
     request_failed = False
     if fresh_records:
-        with ContextPropagatingThreadPoolExecutor(max_workers=batch_size) as threadpool:
+        with ContextPropagatingThreadPoolExecutor(max_workers=attempted) as threadpool:
             futures = {
                 threadpool.submit(deliver_message_parallel, record) for record in fresh_records
             }
@@ -1217,7 +1211,7 @@ def _run_parallel_delivery_batch(
                     raise err
                 if err is None:
                     delivered += 1
-    return _ParallelBatch(attempted, delivered, request_failed, next_start_id, head_id)
+    return _ParallelBatch(attempted, delivered, request_failed, next_start_id)
 
 
 @instrumented_task(
@@ -1276,18 +1270,18 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
                 break
 
             batch_size = min(worker_threads, remaining)
-            batch = _run_parallel_delivery_batch(
-                mailbox,
-                current_id,
-                batch_size,
-                deleter,
-                dispatch_tags=dispatch_tags,
+            records = list(
+                WebhookPayload.objects.filter(id__gte=current_id, mailbox_name=mailbox).order_by(
+                    "id"
+                )[:batch_size]
             )
-            if current_id == claim.head_id and batch.head_id != claim.head_id:
+            if current_id == claim.head_id and (not records or records[0].id != claim.head_id):
                 # First batch, and the head is not at its front: it has been
-                # delivered by whoever claimed it next.
+                # delivered by whoever claimed it next. Checked before delivering
+                # any of them, since they are that drain's to deliver.
                 claim.record_lost_head("deliver_webhook.potential_race")
                 return
+            batch = _run_parallel_delivery_batch(records, deleter, dispatch_tags=dispatch_tags)
             attempted, delivered_batch, request_failed, next_id = (
                 batch.attempted,
                 batch.delivered,

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -139,21 +139,6 @@ def _provider_from_mailbox(mailbox_name: str | None) -> str:
     return provider if separator and provider else UNKNOWN_PROVIDER
 
 
-def _resolve_mailbox(payload_id: int, mailbox: str | None) -> str | None:
-    """
-    The mailbox a drain works, reading the head row only when its task args did
-    not carry one. None means the head is already gone.
-
-    Transitional: drains enqueued before dispatch sent `mailbox` still need it to
-    scope their queries, and this read goes away once none are left in flight.
-    """
-    if mailbox is not None:
-        return mailbox
-    return (
-        WebhookPayload.objects.filter(id=payload_id).values_list("mailbox_name", flat=True).first()
-    )
-
-
 def _record_lost_head(
     payload_id: int, *, dispatch_tags: Mapping[str, str], provider: str, log_key: str
 ) -> None:
@@ -359,12 +344,18 @@ def _begin_drain(
     The claim a drain runs under, or None when it must stand down first.
 
     Resolving the mailbox before anything else lets a drain that carries none —
-    enqueued before dispatch sent one — still name its provider. Those same drains
-    carry no deadline either, and fall back to a fresh horizon as they had before.
+    enqueued before dispatch sent one — still name its provider, off its head row.
+    That read and the fresh-horizon fallback below both go away once no such drains
+    are left in flight.
     """
-    mailbox_name = _resolve_mailbox(payload_id, mailbox)
-    _set_webhook_delivery_sentry_context(mailbox_name, _provider_from_mailbox(mailbox_name))
-    if mailbox_name is None:
+    if mailbox is None:
+        mailbox = (
+            WebhookPayload.objects.filter(id=payload_id)
+            .values_list("mailbox_name", flat=True)
+            .first()
+        )
+    _set_webhook_delivery_sentry_context(mailbox, _provider_from_mailbox(mailbox))
+    if mailbox is None:
         _record_lost_head(
             payload_id,
             dispatch_tags=_dispatch_tags(dispatcher),
@@ -375,7 +366,7 @@ def _begin_drain(
     claim = _MailboxClaim(
         claimed=claimed_count,
         head_id=payload_id,
-        mailbox_name=mailbox_name,
+        mailbox_name=mailbox,
         dispatcher=dispatcher,
         valid_until=(
             datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC)

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -397,23 +397,30 @@ def _begin_drain(
     """
     The claim a drain runs under, or None when it must stand down first.
 
-    Resolving the mailbox before anything else lets a drain that carries none —
-    enqueued before dispatch sent one — still name its provider, off its head row.
-    That read and the fresh-horizon fallback below both go away once no such drains
-    are left in flight.
+    A drain enqueued before dispatch sent the mailbox and deadline reads both off
+    its head row: its claim already wrote its deadline as the rows' schedule_for.
+    That one-query fallback goes away once no such drains are left in flight.
     """
-    if mailbox is None:
-        mailbox = (
+    deadline = (
+        datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC)
+        if valid_until is not None
+        else None
+    )
+    if mailbox is None or deadline is None:
+        head = (
             WebhookPayload.objects.filter(id=payload_id)
-            .values_list("mailbox_name", flat=True)
+            .values_list("mailbox_name", "schedule_for")
             .first()
         )
+        if head is not None:
+            mailbox = mailbox if mailbox is not None else head[0]
+            deadline = deadline if deadline is not None else head[1]
     _set_webhook_delivery_sentry_context(mailbox, _provider_from_mailbox(mailbox))
-    if mailbox is None:
+    if mailbox is None or deadline is None:
         _record_lost_head(
             payload_id,
             dispatcher=dispatcher,
-            provider=UNKNOWN_PROVIDER,
+            provider=_provider_from_mailbox(mailbox),
             log_key="deliver_webhook.potential_race",
         )
         return None
@@ -422,11 +429,7 @@ def _begin_drain(
         head_id=payload_id,
         mailbox_name=mailbox,
         dispatcher=dispatcher,
-        valid_until=(
-            datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC)
-            if valid_until is not None
-            else timezone.now() + BATCH_SCHEDULE_OFFSET
-        ),
+        valid_until=deadline,
     )
     if claim.lapsed(log_key="deliver_webhook.stale_claim", extra={"id": payload_id}):
         return None

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -123,11 +123,6 @@ UNKNOWN_PROVIDER = "unknown"
 """The payload predates the provider column, or the mailbox name carries no provider."""
 
 
-def _provider_tag(payload: WebhookPayload) -> str:
-    """The provider column is nullable, and rows predating it still drain through here."""
-    return payload.provider or UNKNOWN_PROVIDER
-
-
 def _provider_from_mailbox(mailbox_name: str | None) -> str:
     """
     Mailboxes are named `<provider>:<identifier>`, and it is the identifier that
@@ -139,7 +134,7 @@ def _provider_from_mailbox(mailbox_name: str | None) -> str:
 
 
 def _record_lost_head(
-    payload_id: int, *, dispatch_tags: Mapping[str, str], provider: str, log_key: str
+    payload_id: int, *, dispatcher: str | None, provider: str, log_key: str
 ) -> None:
     """
     Record a drain whose head row is already gone, delivered by whoever claimed it
@@ -147,7 +142,7 @@ def _record_lost_head(
     """
     metrics.incr(
         "hybridcloud.deliver_webhooks.delivery",
-        tags={**dispatch_tags, "outcome": "race", "provider": provider},
+        tags={**_delivery_tags(dispatcher, provider), "outcome": "race"},
     )
     logger.info(log_key, extra={"id": payload_id})
 
@@ -270,8 +265,8 @@ class _MailboxClaim:
         return _provider_from_mailbox(self.mailbox_name)
 
     @property
-    def dispatch_tags(self) -> dict[str, str]:
-        return _dispatch_tags(self.dispatcher)
+    def delivery_tags(self) -> dict[str, str]:
+        return _delivery_tags(self.dispatcher, self.provider)
 
     @property
     def skip_on_failure(self) -> bool:
@@ -306,7 +301,7 @@ class _MailboxClaim:
             return False
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={**self.dispatch_tags, "outcome": "delivery_deadline", "provider": self.provider},
+            tags={**self.delivery_tags, "outcome": "delivery_deadline"},
         )
         logger.info(
             log_key,
@@ -340,7 +335,7 @@ class _MailboxClaim:
         """This drain's head row is already gone — see `_record_lost_head`."""
         _record_lost_head(
             self.head_id,
-            dispatch_tags=self.dispatch_tags,
+            dispatcher=self.dispatcher,
             provider=self.provider,
             log_key=log_key,
         )
@@ -371,7 +366,7 @@ def _begin_drain(
     if mailbox is None:
         _record_lost_head(
             payload_id,
-            dispatch_tags=_dispatch_tags(dispatcher),
+            dispatcher=dispatcher,
             provider=UNKNOWN_PROVIDER,
             log_key="deliver_webhook.potential_race",
         )
@@ -447,14 +442,15 @@ class DispatchOutcome(enum.StrEnum):
     PARALLEL = "parallel"
 
 
-def _dispatch_tags(dispatcher: str | None) -> dict[str, str]:
+def _delivery_tags(dispatcher: str | None, provider: str) -> dict[str, str]:
     """
-    Attribute a drain's deliveries to the dispatcher that enqueued it.
+    The tags every delivery outcome carries: who dispatched the drain, and whose
+    mailbox it is draining.
 
-    `unknown` covers drains enqueued before this argument deployed, and drains
-    invoked directly rather than through a dispatcher.
+    `unknown` covers a drain invoked outside a dispatcher, and a mailbox name that
+    carries no provider.
     """
-    return {"dispatcher": dispatcher or "unknown"}
+    return {"dispatcher": dispatcher or "unknown", "provider": provider}
 
 
 def _record_dispatch(
@@ -900,7 +896,7 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
     claimed: beyond them the mailbox head is due again and another dispatcher may
     already be draining it.
     """
-    dispatch_tags = claim.dispatch_tags
+    delivery_tags = claim.delivery_tags
     mailbox = claim.mailbox_name
     provider = claim.provider
     skip_on_failure = claim.skip_on_failure
@@ -932,16 +928,15 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
                 # messages are not re-attempted in subsequent batches of this drain.
                 current_id = record.id + 1
                 try:
-                    if deliver_message(record, deleter, dispatch_tags=dispatch_tags):
+                    if deliver_message(record, deleter, delivery_tags=delivery_tags):
                         delivered += 1
                 except DeliveryFailed:
                     failed += 1
                     metrics.incr(
                         "hybridcloud.deliver_webhooks.delivery",
                         tags={
-                            **dispatch_tags,
+                            **delivery_tags,
                             "outcome": "retry",
-                            "provider": _provider_tag(record),
                         },
                     )
                     if not skip_on_failure:
@@ -978,7 +973,7 @@ def _drain_sequentially(claim: _MailboxClaim) -> None:
                 )
                 metrics.incr(
                     "hybridcloud.deliver_webhooks.delivery",
-                    tags={**dispatch_tags, "outcome": "claim_exhausted"},
+                    tags={**delivery_tags, "outcome": "claim_exhausted"},
                 )
                 return
     finally:
@@ -1033,7 +1028,7 @@ def _deleter_for() -> _PayloadDeleter:
 
 
 def _discard_if_stale(
-    payload: WebhookPayload, deleter: _PayloadDeleter, *, dispatch_tags: Mapping[str, str]
+    payload: WebhookPayload, deleter: _PayloadDeleter, *, delivery_tags: Mapping[str, str]
 ) -> bool:
     """
     Discard the payload when it is older than MAX_DELIVERY_AGE; returns whether
@@ -1049,7 +1044,7 @@ def _discard_if_stale(
     # wants an exact total rather than an estimated rate.
     metrics.incr(
         "hybridcloud.deliver_webhooks.delivery",
-        tags={**dispatch_tags, "outcome": "max_age", "provider": _provider_tag(payload)},
+        tags={**delivery_tags, "outcome": "max_age"},
         sample_rate=1.0,
     )
     logger.warning("deliver_webhook.max_age_discard", extra={**payload_data})
@@ -1057,7 +1052,7 @@ def _discard_if_stale(
 
 
 def _record_delivery_time_metrics(
-    payload: WebhookPayload, *, dispatch_tags: Mapping[str, str]
+    payload: WebhookPayload, *, delivery_tags: Mapping[str, str]
 ) -> None:
     """Record delivery time metrics for a successfully delivered webhook payload.
 
@@ -1067,11 +1062,10 @@ def _record_delivery_time_metrics(
     rather than only in aggregate.
     """
     duration = timezone.now() - payload.date_added
-    provider = _provider_tag(payload)
+    provider = _provider_from_mailbox(payload.mailbox_name)
     tags = {
-        **dispatch_tags,
+        **delivery_tags,
         "region_sent_to": payload.cell_name,
-        "provider": provider,
         # The unit delivery queues by, and bounded to one value per mailbox shape.
         "event_type": event_type_from_mailbox(provider, payload.mailbox_name),
     }
@@ -1089,7 +1083,7 @@ def _handle_parallel_delivery_result(
     err: Exception | None,
     deleter: _PayloadDeleter,
     *,
-    dispatch_tags: Mapping[str, str],
+    delivery_tags: Mapping[str, str],
 ) -> tuple[bool, bool]:
     """
     Process one result from the parallel delivery threadpool.
@@ -1103,9 +1097,8 @@ def _handle_parallel_delivery_result(
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
             tags={
-                **dispatch_tags,
+                **delivery_tags,
                 "outcome": err.outcome,
-                "provider": _provider_tag(payload_record),
             },
         )
         return (False, False)
@@ -1117,9 +1110,8 @@ def _handle_parallel_delivery_result(
             metrics.incr(
                 "hybridcloud.deliver_webhooks.delivery",
                 tags={
-                    **dispatch_tags,
+                    **delivery_tags,
                     "outcome": "attempts_exceed",
-                    "provider": _provider_tag(payload_record),
                 },
                 sample_rate=1.0,
             )
@@ -1132,9 +1124,8 @@ def _handle_parallel_delivery_result(
             metrics.incr(
                 "hybridcloud.deliver_webhooks.delivery",
                 tags={
-                    **dispatch_tags,
+                    **delivery_tags,
                     "outcome": "retry",
-                    "provider": _provider_tag(payload_record),
                 },
             )
             payload_record.schedule_next_attempt()
@@ -1142,10 +1133,10 @@ def _handle_parallel_delivery_result(
         return (request_failed, not isinstance(err, DeliveryFailed))
     date_added = payload_record.date_added
     deleter.delete(payload_record)
-    _record_delivery_time_metrics(payload_record, dispatch_tags=dispatch_tags)
+    _record_delivery_time_metrics(payload_record, delivery_tags=delivery_tags)
     metrics.incr(
         "hybridcloud.deliver_webhooks.delivery",
-        tags={**dispatch_tags, "outcome": "ok", "provider": _provider_tag(payload_record)},
+        tags={**delivery_tags, "outcome": "ok"},
     )
     if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
@@ -1163,7 +1154,7 @@ def _run_parallel_delivery_batch(
     records: Sequence[WebhookPayload],
     deleter: _PayloadDeleter,
     *,
-    dispatch_tags: Mapping[str, str],
+    delivery_tags: Mapping[str, str],
 ) -> "_ParallelBatch":
     """
     Deliver one batch of already-fetched records in parallel.
@@ -1176,7 +1167,7 @@ def _run_parallel_delivery_batch(
     fresh_records = [
         record
         for record in records
-        if not _discard_if_stale(record, deleter, dispatch_tags=dispatch_tags)
+        if not _discard_if_stale(record, deleter, delivery_tags=delivery_tags)
     ]
 
     delivered = 0
@@ -1189,7 +1180,7 @@ def _run_parallel_delivery_batch(
             for future in as_completed(futures):
                 payload_record, err = future.result()
                 batch_request_failed, should_reraise = _handle_parallel_delivery_result(
-                    payload_record, err, deleter, dispatch_tags=dispatch_tags
+                    payload_record, err, deleter, delivery_tags=delivery_tags
                 )
                 request_failed = request_failed or batch_request_failed
                 if should_reraise and err is not None:
@@ -1231,7 +1222,7 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
     the claim — bounded exactly as `_drain_sequentially`, and skipping past
     retryable failures for the same allowlisted providers.
     """
-    dispatch_tags = claim.dispatch_tags
+    delivery_tags = claim.delivery_tags
     mailbox = claim.mailbox_name
     skip_on_failure = claim.skip_on_failure
 
@@ -1240,18 +1231,11 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
     delivered = 0
     remaining = claim.claimed
     current_id = claim.head_id
-    extra = {
-        "id": claim.head_id,
-        "mailbox_name": mailbox,
-        "provider": claim.provider,
-        "delivered": 0,
-    }
+    log_context = {"id": claim.head_id, "mailbox_name": mailbox, "provider": claim.provider}
     try:
         while True:
-            if claim.lapsed(
-                log_key="deliver_webhook.delivery_deadline",
-                extra={**extra, "delivered": delivered},
-            ):
+            extra = {**log_context, "delivered": delivered}
+            if claim.lapsed(log_key="deliver_webhook.delivery_deadline", extra=extra):
                 break
 
             records = claim.next_slice(current_id, min(worker_threads, remaining))
@@ -1267,9 +1251,9 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
             next_id = records[-1].id + 1
             attempted = len(records)
 
-            batch = _run_parallel_delivery_batch(records, deleter, dispatch_tags=dispatch_tags)
+            batch = _run_parallel_delivery_batch(records, deleter, delivery_tags=delivery_tags)
             delivered += batch.delivered
-            extra["delivered"] = delivered
+            extra = {**log_context, "delivered": delivered}
             current_id = next_id
 
             remaining -= attempted
@@ -1280,7 +1264,7 @@ def _drain_in_parallel(claim: _MailboxClaim) -> None:
                 logger.debug("deliver_webhook.claim_exhausted", extra=extra)
                 metrics.incr(
                     "hybridcloud.deliver_webhooks.delivery",
-                    tags={**dispatch_tags, "outcome": "claim_exhausted"},
+                    tags={**delivery_tags, "outcome": "claim_exhausted"},
                 )
                 return
 
@@ -1302,7 +1286,7 @@ def deliver_message_parallel(payload: WebhookPayload) -> tuple[WebhookPayload, E
 
 
 def deliver_message(
-    payload: WebhookPayload, deleter: _PayloadDeleter, *, dispatch_tags: Mapping[str, str]
+    payload: WebhookPayload, deleter: _PayloadDeleter, *, delivery_tags: Mapping[str, str]
 ) -> bool:
     """
     Deliver a message if it still has delivery attempts remaining and is not stale.
@@ -1319,16 +1303,15 @@ def deliver_message(
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
             tags={
-                **dispatch_tags,
+                **delivery_tags,
                 "outcome": "attempts_exceed",
-                "provider": _provider_tag(payload),
             },
             sample_rate=1.0,
         )
         logger.warning("deliver_webhook.discard", extra={**payload_data})
         return False
 
-    if _discard_if_stale(payload, deleter, dispatch_tags=dispatch_tags):
+    if _discard_if_stale(payload, deleter, delivery_tags=delivery_tags):
         return False
 
     payload.schedule_next_attempt()
@@ -1340,17 +1323,17 @@ def deliver_message(
         deleter.delete(payload)
         metrics.incr(
             "hybridcloud.deliver_webhooks.delivery",
-            tags={**dispatch_tags, "outcome": err.outcome, "provider": _provider_tag(payload)},
+            tags={**delivery_tags, "outcome": err.outcome},
         )
         return False
     date_added = payload.date_added
     deleter.delete(payload)
-    _record_delivery_time_metrics(payload, dispatch_tags=dispatch_tags)
+    _record_delivery_time_metrics(payload, delivery_tags=delivery_tags)
     if timezone.now() - date_added >= SLOW_DELIVERY_THRESHOLD:
         logger.warning("deliver_webhook.slow_delivery", extra=payload_data)
     metrics.incr(
         "hybridcloud.deliver_webhooks.delivery",
-        tags={**dispatch_tags, "outcome": "ok", "provider": _provider_tag(payload)},
+        tags={**delivery_tags, "outcome": "ok"},
     )
     return True
 
@@ -1396,7 +1379,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
             tags={
                 "reason": "host_error",
                 "destination_region": cell.name,
-                "provider": _provider_tag(payload),
+                "provider": _provider_from_mailbox(payload.mailbox_name),
             },
         )
         with sentry_sdk.isolation_scope() as scope:
@@ -1426,7 +1409,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
             tags={
                 "reason": "conflict",
                 "destination_region": cell.name,
-                "provider": _provider_tag(payload),
+                "provider": _provider_from_mailbox(payload.mailbox_name),
             },
         )
         logger.warning(
@@ -1441,7 +1424,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
             tags={
                 "reason": "timeout_reset",
                 "destination_region": cell.name,
-                "provider": _provider_tag(payload),
+                "provider": _provider_from_mailbox(payload.mailbox_name),
             },
         )
         logger.warning("deliver_webhooks.timeout_error", extra=payload.as_dict())
@@ -1472,7 +1455,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
                     tags={
                         "reason": reason,
                         "destination_region": cell.name,
-                        "provider": _provider_tag(payload),
+                        "provider": _provider_from_mailbox(payload.mailbox_name),
                     },
                 )
                 logger.warning(
@@ -1487,7 +1470,7 @@ def perform_cell_request(cell: Cell, payload: WebhookPayload) -> None:
             tags={
                 "reason": "api_error",
                 "destination_region": cell.name,
-                "provider": _provider_tag(payload),
+                "provider": _provider_from_mailbox(payload.mailbox_name),
             },
         )
         logger.warning(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2595,7 +2595,7 @@ register(
 )
 # Providers whose mailbox drains skip a failed message and keep going instead of
 # aborting. Also gates concurrent delivery: only these providers' claims deliver
-# in parallel waves, and only they dispatch from the due head. Only safe for
+# on `worker_threads` threads, and only they dispatch from the due head. Only safe for
 # providers whose cell-side handlers tolerate reordering, since a skipped or
 # concurrently delivered message can land after the ones behind it. Providers not
 # listed deliver strictly: one record at a time, in order, stopping on failure.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2594,11 +2594,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Providers whose mailbox drains skip a failed message and keep going instead of
-# aborting. Only safe for providers whose cell-side handlers tolerate reordering,
-# since a skipped message is retried after the ones behind it. Aborting is not a
-# strict-ordering guarantee to begin with: drain_mailbox_parallel delivers a whole
-# batch concurrently before it consults this list, and dispatch to it is chosen on
-# backlog depth alone (PARALLEL_DRAIN_THRESHOLD), for every provider.
+# aborting. Also gates concurrent delivery: only these providers' claims deliver
+# in parallel waves, and only they dispatch from the due head. Only safe for
+# providers whose cell-side handlers tolerate reordering, since a skipped or
+# concurrently delivered message can land after the ones behind it. Providers not
+# listed deliver strictly: one record at a time, in order, stopping on failure.
 register(
     "hybridcloud.webhookpayload.skip_on_failure_providers",
     type=Sequence,

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -171,6 +171,7 @@ class CellSiloClient(BaseApiClient):
         json: bool = True,
         raw_response: bool = False,
         prefix_hash: str | None = None,
+        timeout: int | None = None,
     ) -> Any:
         """
         Sends a request to the cell silo.
@@ -188,6 +189,7 @@ class CellSiloClient(BaseApiClient):
             json=json,
             allow_text=True,
             raw_response=raw_response,
+            timeout=timeout,
         )
 
     def build_session(self) -> SafeSession:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -19,6 +19,7 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     DRAIN_LOCK_TTL,
     MAX_MAILBOX_DRAIN,
     RELEASE_MARGIN,
+    SETTLE_ALLOWANCE,
     SLOW_DELIVERY_THRESHOLD,
     Dispatcher,
     _claim_and_dispatch,
@@ -2615,6 +2616,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
                 deliver_webhooks._PayloadDeleter(batched=False),
                 worker_threads=2,
                 delivery_tags={**UNATTRIBUTED, "provider": "github"},
+                settle_by=timezone.now() + BATCH_SCHEDULE_OFFSET,
                 spends_attempt_on_submit=False,
             )
             for record in records:
@@ -2644,6 +2646,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
                 deliver_webhooks._PayloadDeleter(batched=False),
                 worker_threads=1,
                 delivery_tags=tags,
+                settle_by=timezone.now() + BATCH_SCHEDULE_OFFSET,
                 spends_attempt_on_submit=False,
             )
             pool.submit(record)
@@ -2656,6 +2659,92 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             if call[0][0] == "hybridcloud.deliver_webhooks.drain.wind_down"
         ]
         assert [call[1]["tags"] for call in timers] == [{**tags, "reason": "deadline"}]
+
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_wind_down_abandons_a_request_it_cannot_wait_out(self, mock_metrics: MagicMock) -> None:
+        # The settle deadline bounds the wait: a request still running at it is
+        # given up on — rescheduled into its backoff, its row kept — while the
+        # sibling that answered is deleted, and the call returns without joining
+        # the stuck thread.
+        stuck, answered = create_payloads(2, "github:123", provider="github")
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            if payload.id == stuck.id:
+                release.wait()
+            return (payload, None)
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            pool = deliver_webhooks._DeliveryPool(
+                deliver_webhooks._PayloadDeleter(batched=False),
+                worker_threads=2,
+                delivery_tags={**UNATTRIBUTED, "provider": "github"},
+                settle_by=timezone.now() + timedelta(seconds=0.3),
+                spends_attempt_on_submit=False,
+            )
+            pool.submit(stuck)
+            pool.submit(answered)
+            pool.wind_down(reason="deadline")
+
+        assert pool.delivered == 1
+        assert pool.failed == 1
+        assert not WebhookPayload.objects.filter(id=answered.id).exists()
+        stuck.refresh_from_db()
+        assert stuck.attempts == 1
+        assert stuck.schedule_for > timezone.now()
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC)[-1] == {
+            **UNATTRIBUTED,
+            "provider": "github",
+            "outcome": "abandoned",
+        }
+
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 2})
+    @patch.object(deliver_webhooks, "REQUEST_BOUND", timedelta(seconds=0.3))
+    def test_unresponsive_cell_stops_the_drain_without_releasing(self) -> None:
+        # Nothing answering inside the request bound means the cell is down: the
+        # in-flight records go into their backoff and the drain stops. The tail
+        # stays under the claim rather than being released — a release would
+        # only send the next drain straight into the same cell.
+        records = create_payloads(4, "github:123", provider="github")
+        valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
+        WebhookPayload.objects.filter(id__in=[r.id for r in records]).update(
+            schedule_for=valid_until
+        )
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            release.wait()
+            return (payload, None)
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            drain_mailbox(
+                records[0].id,
+                claimed_count=4,
+                valid_until=valid_until.timestamp(),
+                mailbox="github:123",
+            )
+
+        for record in records[:2]:
+            record.refresh_from_db()
+            assert record.attempts == 1
+            assert record.schedule_for > valid_until
+        for record in records[2:]:
+            record.refresh_from_db()
+            assert record.attempts == 0
+            assert record.schedule_for == valid_until
+
+    def test_release_margin_covers_the_wait_and_the_settle(self) -> None:
+        # The soft-stop must leave room for a full request bound plus the flush
+        # and release, or a drain stopping on time still overshoots its claim.
+        assert RELEASE_MARGIN == deliver_webhooks.REQUEST_BOUND + SETTLE_ALLOWANCE
+        assert (
+            deliver_webhooks.REQUEST_BOUND.total_seconds()
+            > 2 * deliver_webhooks.CELL_REQUEST_TIMEOUT
+        )
 
 
 @control_silo_test

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -2619,11 +2619,43 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             )
             for record in records:
                 pool.submit(record)
-            lowest_cancelled = pool.wind_down()
+            lowest_cancelled = pool.wind_down(reason="deadline")
 
         assert lowest_cancelled == records[2].id
         assert pool.delivered == 2
         assert set(WebhookPayload.objects.values_list("id", flat=True)) == {records[2].id}
+
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_wind_down_records_how_long_it_waited(self, mock_metrics: MagicMock) -> None:
+        # RELEASE_MARGIN is sized to this wait, so every wind-down that had
+        # something to wait for reports its length under the reason it stopped —
+        # and one with nothing in flight reports nothing, or the no-op winds
+        # down in every drain's `finally` would bury the real ones.
+        record = create_payloads(1, "github:123", provider="github")[0]
+        tags = {**UNATTRIBUTED, "provider": "github"}
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            time.sleep(0.1)
+            return (payload, None)
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            pool = deliver_webhooks._DeliveryPool(
+                deliver_webhooks._PayloadDeleter(batched=False),
+                worker_threads=1,
+                delivery_tags=tags,
+                spends_attempt_on_submit=False,
+            )
+            pool.submit(record)
+            pool.wind_down(reason="deadline")
+            pool.wind_down(reason="exception")
+
+        timers = [
+            call
+            for call in mock_metrics.timer.call_args_list
+            if call[0][0] == "hybridcloud.deliver_webhooks.drain.wind_down"
+        ]
+        assert [call[1]["tags"] for call in timers] == [{**tags, "reason": "deadline"}]
 
 
 @control_silo_test

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from datetime import timedelta
 from typing import Any
@@ -17,7 +18,6 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     BATCH_SCHEDULE_OFFSET,
     DRAIN_LOCK_TTL,
     MAX_MAILBOX_DRAIN,
-    MIN_RECORDS_PER_THREAD,
     RELEASE_MARGIN,
     SLOW_DELIVERY_THRESHOLD,
     Dispatcher,
@@ -37,7 +37,7 @@ from sentry.types.cell import Cell, CellResolutionError
 
 cell_config = [Cell("us", 1, "http://us.testserver")]
 
-# Drains invoked directly carry no dispatcher attribution; `_dispatch_tags`
+# Drains invoked directly carry no dispatcher attribution; `_delivery_tags`
 # tags them rather than omitting the key, so the tag stays queryable.
 UNATTRIBUTED = {"dispatcher": "unknown"}
 
@@ -376,11 +376,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             schedule_for=claimed_for,
         )
 
-        outcome = _claim_and_dispatch(
+        claim = _claim_and_dispatch(
             webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
         )
 
-        assert outcome == "not_due"
+        assert claim is None
         mock_drain.delay.assert_not_called()
         webhook.refresh_from_db()
         # The existing claim must not be extended either.
@@ -397,11 +397,12 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         )
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            outcome = _claim_and_dispatch(
+            claim = _claim_and_dispatch(
                 webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
             )
 
-        assert outcome == "sequential"
+        assert claim is not None
+        assert claim.claimed == 1
         mock_drain.delay.assert_called_once_with(
             payload_id=webhook.id,
             claimed_count=1,
@@ -930,9 +931,26 @@ def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list
     return created
 
 
-def assert_drain_skips_failed_message(
-    provider: str, *, claimed_count: int = MAX_MAILBOX_DRAIN
-) -> None:
+class ConcurrencyProbe:
+    """A `deliver_message` stand-in that records how many deliveries overlapped."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._in_progress = 0
+        self.value = 0
+
+    def deliver(self, payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+        with self._lock:
+            self._in_progress += 1
+            self.value = max(self.value, self._in_progress)
+        # Long enough for every pool thread to be inside here at once.
+        time.sleep(0.2)
+        with self._lock:
+            self._in_progress -= 1
+        return (payload, None)
+
+
+def assert_drain_skips_failed_message(provider: str) -> None:
     """
     Drain a 5 message mailbox where the second delivery fails.
 
@@ -951,7 +969,7 @@ def assert_drain_skips_failed_message(
     responses.add(responses.POST, url, status=200, body="")
     records = create_payloads(5, f"{provider}:123", provider=provider)
 
-    drain_mailbox(records[0].id, claimed_count=claimed_count, valid_until=fresh_deadline())
+    drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
     assert len(responses.calls) == 5
     assert WebhookPayload.objects.count() == 1
@@ -1006,6 +1024,7 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     def test_drain_stops_at_claimed_count(self) -> None:
         # A claim-mode drain holds no lock while running: delivering past its
         # claimed records would race a drain another dispatcher may have started
@@ -1022,26 +1041,79 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    def test_drain_stops_at_claimed_count_threaded(self) -> None:
-        # The claim boundary binds waves too, not only the serial walk.
+    def test_drain_stops_at_claimed_count_concurrently(self) -> None:
+        # The claim boundary binds concurrent delivery too, not only the in-order walk.
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox(
-            records[0].id, claimed_count=MIN_RECORDS_PER_THREAD + 1, valid_until=fresh_deadline()
-        )
+        drain_mailbox(records[0].id, claimed_count=6, valid_until=fresh_deadline())
 
         assert len(responses.calls) == 6
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
         assert remaining == {records[6].id, records[7].id}
 
+    @responses.activate
     @override_cells(cell_config)
-    def test_unexpected_wave_error_does_not_abandon_sibling_deliveries(self) -> None:
-        # An unexpected error surfaces from the wave, but only after every
-        # result is processed: a sibling delivered on another thread must still
-        # be deleted, or a later claim would redeliver it.
-        records = create_payloads(MIN_RECORDS_PER_THREAD + 1, "github:123", provider="github")
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 0})
+    def test_drain_survives_zero_worker_threads(self) -> None:
+        # The option is operator-editable; a zero must degrade to one thread, not
+        # fail every drain of the provider until the claim horizon, and again.
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        records = create_payloads(3, "github:123", provider="github")
+
+        drain_mailbox(records[0].id, claimed_count=3, valid_until=fresh_deadline())
+
+        assert len(responses.calls) == 3
+        assert WebhookPayload.objects.count() == 0
+
+    @override_cells(cell_config)
+    def test_strict_provider_spends_the_attempt_before_the_request(self) -> None:
+        # A drain killed mid-request leaves no result to reschedule on. A strict
+        # provider's record would head-block its mailbox on every retry at the
+        # claim horizon, so it carries the attempt when the request goes out —
+        # and is not charged a second one when the request then fails.
+        record = create_payloads(1, "jira:123", provider="jira")[0]
+        attempts_at_request: list[int] = []
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            attempts_at_request.append(payload.attempts)
+            return (payload, deliver_webhooks.DeliveryFailed())
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            drain_mailbox(record.id, claimed_count=1, valid_until=fresh_deadline())
+
+        assert attempts_at_request == [1]
+        record.refresh_from_db()
+        assert record.attempts == 1
+        assert record.schedule_for > timezone.now()
+
+    @override_cells(cell_config)
+    def test_skip_on_failure_provider_spends_the_attempt_on_the_result(self) -> None:
+        # The high-volume providers are spared the extra write per record: their
+        # attempt is spent only when a request comes back failed.
+        record = create_payloads(1, "github:123", provider="github")[0]
+        attempts_at_request: list[int] = []
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            attempts_at_request.append(payload.attempts)
+            return (payload, deliver_webhooks.DeliveryFailed())
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            drain_mailbox(record.id, claimed_count=1, valid_until=fresh_deadline())
+
+        assert attempts_at_request == [0]
+        record.refresh_from_db()
+        assert record.attempts == 1
+        assert record.schedule_for > timezone.now()
+
+    @override_cells(cell_config)
+    def test_unexpected_delivery_error_does_not_abandon_in_flight_deliveries(self) -> None:
+        # An unexpected error surfaces from the drain, but only after every
+        # in-flight result is handled: a sibling delivered on another thread must
+        # still be deleted, or a later claim would redeliver it.
+        records = create_payloads(4, "github:123", provider="github")
 
         def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
             if payload.id == records[0].id:
@@ -1050,13 +1122,9 @@ class DrainMailboxTest(TestCase):
             time.sleep(0.2)
             return (payload, None)
 
-        with patch.object(deliver_webhooks, "deliver_message_parallel", side_effect=deliver):
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
             with pytest.raises(ValueError):
-                drain_mailbox(
-                    records[0].id,
-                    claimed_count=MIN_RECORDS_PER_THREAD + 1,
-                    valid_until=fresh_deadline(),
-                )
+                drain_mailbox(records[0].id, claimed_count=4, valid_until=fresh_deadline())
 
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
         # The delivered sibling is gone; the errored head keeps its retry.
@@ -1065,10 +1133,11 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    def test_drain_stale_discards_consume_claim_budget_in_waves(self) -> None:
-        # Stale rows are discarded inside the wave, so they consume claim budget
-        # like delivered rows. Deleting them out-of-band would leave the budget
-        # to spill onto unclaimed due rows — the overlap claimed_count prevents.
+    def test_drain_stale_discards_consume_claim_budget(self) -> None:
+        # Stale rows are discarded where they would have been delivered, so they
+        # consume claim budget like delivered rows. Deleting them out-of-band
+        # would leave the budget to spill onto unclaimed due rows — the overlap
+        # claimed_count prevents.
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=200, body="")
         stale = [
@@ -1093,8 +1162,9 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     def test_drain_discards_stale_rows_instead_of_delivering(self) -> None:
-        # MAX_DELIVERY_AGE applies to serial drains too: stale rows are
+        # MAX_DELIVERY_AGE applies to in-order drains too: stale rows are
         # discarded in the walk, not forwarded days late.
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=200, body="")
@@ -1159,10 +1229,11 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    def test_drain_skip_on_failure_serial(self) -> None:
-        # A claim at MIN_RECORDS_PER_THREAD stays serial; skipping past the
-        # failure is a distinct branch there, not a side effect of the wave.
-        assert_drain_skips_failed_message("github", claimed_count=5)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
+    def test_drain_skip_on_failure_in_order(self) -> None:
+        # One worker thread delivers in order; skipping past the failure is a
+        # distinct branch there, not a side effect of concurrent delivery.
+        assert_drain_skips_failed_message("github")
 
     @responses.activate
     @override_cells(cell_config)
@@ -1258,9 +1329,9 @@ class DrainMailboxTest(TestCase):
     @responses.activate
     @override_cells(cell_config)
     @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
-    def test_drain_batch_deletes_span_waves(self) -> None:
-        # The delete batch belongs to the drain, not to one delivery wave:
-        # accumulating per wave would cap every DELETE at the wave width.
+    def test_drain_batch_deletes_span_concurrent_deliveries(self) -> None:
+        # The delete batch belongs to the drain, not to one result: eight
+        # concurrent deliveries flush as a single DELETE.
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
@@ -1733,8 +1804,9 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_serial_conflict_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+    def test_in_order_conflict_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -1751,8 +1823,9 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_serial_unauthorized_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+    def test_in_order_unauthorized_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -1775,18 +1848,17 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         # past it even for providers that stop on the first failure.
         responses.add(
             responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
+            "http://us.testserver/extensions/jira/webhook/",
             status=401,
             body="",
         )
         responses.add(
             responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
+            "http://us.testserver/extensions/jira/webhook/",
             status=200,
             body="",
         )
-        first = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        second = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+        first, second = create_payloads(2, "jira:123", provider="jira")
 
         drain_mailbox(first.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
@@ -1865,8 +1937,9 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_serial_dropped_outcome_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
+    def test_in_order_dropped_outcome_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -1931,7 +2004,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         maybe_trigger_drain(webhook.mailbox_name)
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.push_trigger.success") == [
-            {"provider": "github", "drain": "sequential"}
+            {"provider": "github"}
         ]
 
 
@@ -1953,10 +2026,10 @@ class DispatchMetricTest(MetricCallsMixin, TestCase):
 
         assert mock_drain.delay.call_args.kwargs["dispatcher"] == Dispatcher.PUSH
         assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
-            {"dispatcher": "push", "drain": "sequential", "provider": "github"}
+            {"dispatcher": "push", "provider": "github"}
         ]
         assert self.distribution_calls(mock_metrics, DISPATCH_CLAIMED_METRIC) == [
-            (1, {"dispatcher": "push", "drain": "sequential", "provider": "github"})
+            (1, {"dispatcher": "push", "provider": "github"})
         ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
@@ -1966,7 +2039,7 @@ class DispatchMetricTest(MetricCallsMixin, TestCase):
     ) -> None:
         # Deep on purpose: `claimed` must report the batch, not one per dispatch,
         # or webhook share collapses back into dispatch share.
-        depth = MIN_RECORDS_PER_THREAD + 1
+        depth = 3
         for _ in range(depth):
             self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
@@ -1974,13 +2047,10 @@ class DispatchMetricTest(MetricCallsMixin, TestCase):
 
         assert mock_drain.delay.call_args.kwargs["dispatcher"] == Dispatcher.SCHEDULER
         assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
-            {"dispatcher": "scheduler", "drain": "parallel", "provider": "github"}
+            {"dispatcher": "scheduler", "provider": "github"}
         ]
         assert self.distribution_calls(mock_metrics, DISPATCH_CLAIMED_METRIC) == [
-            (
-                depth,
-                {"dispatcher": "scheduler", "drain": "parallel", "provider": "github"},
-            )
+            (depth, {"dispatcher": "scheduler", "provider": "github"})
         ]
 
 
@@ -2053,8 +2123,10 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_wave_delivery_time_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
-        # Attribution must survive the threadpool hop, not only the serial walk.
+    def test_concurrent_delivery_time_carries_dispatch_attribution(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # Attribution must survive the threadpool hop, not only the in-order walk.
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2065,7 +2137,7 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
 
         drain_mailbox(
             records[0].id,
-            claimed_count=MIN_RECORDS_PER_THREAD + 1,
+            claimed_count=2,
             dispatcher=Dispatcher.PUSH,
             valid_until=fresh_deadline(),
         )
@@ -2107,6 +2179,7 @@ class LostHeadTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_drain_delivers_nothing_when_its_head_is_gone(self, mock_metrics: MagicMock) -> None:
         responses.add(
@@ -2127,10 +2200,10 @@ class LostHeadTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_threaded_drain_delivers_nothing_when_its_head_is_gone(
+    def test_concurrent_drain_delivers_nothing_when_its_head_is_gone(
         self, mock_metrics: MagicMock
     ) -> None:
-        # The stand-down must come before the first wave is delivered, not after
+        # The stand-down must come before the first request is sent, not after
         # it: these rows are the overtaking drain's to deliver, and sending them
         # here duplicates every one of them.
         responses.add(
@@ -2140,12 +2213,7 @@ class LostHeadTest(MetricCallsMixin, TestCase):
         head_id = records[0].id
         records[0].delete()
 
-        drain_mailbox(
-            head_id,
-            claimed_count=MIN_RECORDS_PER_THREAD + 1,
-            mailbox="github:123",
-            valid_until=fresh_deadline(),
-        )
+        drain_mailbox(head_id, claimed_count=3, mailbox="github:123", valid_until=fresh_deadline())
 
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 2
@@ -2383,24 +2451,28 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
         ]
 
-    @responses.activate
     @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks._run_parallel_delivery_batch")
-    def test_strict_provider_never_delivers_in_waves(self, mock_batch: MagicMock) -> None:
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/jira/webhook/", status=200, body=""
-        )
-        records = create_payloads(MIN_RECORDS_PER_THREAD + 2, "jira:123", provider="jira")
+    def test_strict_provider_never_delivers_concurrently(self) -> None:
+        # Depth never buys a strict-ordering provider a second thread: the next
+        # request must not start until the previous one has completed.
+        records = create_payloads(7, "jira:123", provider="jira")
+        peak = ConcurrencyProbe()
 
-        drain_mailbox(
-            records[0].id,
-            claimed_count=len(records),
-            valid_until=(timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp(),
-            mailbox="jira:123",
-        )
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=peak.deliver):
+            drain_mailbox(records[0].id, claimed_count=len(records), valid_until=fresh_deadline())
 
-        mock_batch.assert_not_called()
-        assert len(responses.calls) == len(records)
+        assert peak.value == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @override_cells(cell_config)
+    def test_skip_on_failure_provider_delivers_concurrently(self) -> None:
+        records = create_payloads(7, "github:123", provider="github")
+        peak = ConcurrencyProbe()
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=peak.deliver):
+            drain_mailbox(records[0].id, claimed_count=len(records), valid_until=fresh_deadline())
+
+        assert peak.value > 1
         assert WebhookPayload.objects.count() == 0
 
 
@@ -2463,6 +2535,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 1})
     def test_release_covers_only_the_tail_behind_delivered_rows(self) -> None:
         responses.add(
             responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
@@ -2492,6 +2565,65 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
         for record in (records[1], records[2]):
             record.refresh_from_db()
             assert record.schedule_for <= timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.worker_threads": 2})
+    def test_release_settles_in_flight_requests_before_covering_the_tail(self) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
+        records = create_payloads(4, "github:123", provider="github")
+        WebhookPayload.objects.filter(id__in=[r.id for r in records]).update(
+            schedule_for=valid_until
+        )
+
+        # The deadline nears once the first two requests are in flight: both must
+        # settle — delivered and deleted — before the tail behind them is released.
+        with patch.object(
+            deliver_webhooks._MailboxClaim,
+            "nearing_deadline",
+            side_effect=[False, True],
+        ):
+            drain_mailbox(
+                records[0].id,
+                claimed_count=4,
+                valid_until=valid_until.timestamp(),
+                mailbox="github:123",
+            )
+
+        assert len(responses.calls) == 2
+        assert not WebhookPayload.objects.filter(id__in=[records[0].id, records[1].id]).exists()
+        for record in (records[2], records[3]):
+            record.refresh_from_db()
+            assert record.schedule_for <= timezone.now()
+
+    @override_cells(cell_config)
+    def test_wind_down_cancels_unstarted_requests_and_names_the_release_start(self) -> None:
+        # Two threads, three requests: the third waits in the executor's queue and
+        # is cancelled, so the release must start at it — not at the frontier
+        # past it, which would leave it stranded until the claim's deadline.
+        records = create_payloads(3, "github:123", provider="github")
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            time.sleep(0.2)
+            return (payload, None)
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            pool = deliver_webhooks._DeliveryPool(
+                deliver_webhooks._PayloadDeleter(batched=False),
+                worker_threads=2,
+                delivery_tags={**UNATTRIBUTED, "provider": "github"},
+                spends_attempt_on_submit=False,
+            )
+            for record in records:
+                pool.submit(record)
+            lowest_cancelled = pool.wind_down()
+
+        assert lowest_cancelled == records[2].id
+        assert pool.delivered == 2
+        assert set(WebhookPayload.objects.values_list("id", flat=True)) == {records[2].id}
 
 
 @control_silo_test
@@ -2722,57 +2854,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         mock_drain.delay.assert_not_called()
         # Lock must also be released so the scheduler can pick it up when backoff expires
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_reports_parallel_drain_for_deep_mailbox(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        records = create_payloads(MIN_RECORDS_PER_THREAD + 1, "github:123")
-
-        maybe_trigger_drain("github:123")
-
-        mock_drain.delay.assert_called_once_with(
-            payload_id=records[0].id,
-            claimed_count=MIN_RECORDS_PER_THREAD + 1,
-            dispatcher=Dispatcher.PUSH,
-        )
-        assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
-            {"dispatcher": "push", "drain": "parallel", "provider": "github"}
-        ]
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_reports_sequential_drain_for_shallow_mailbox(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        # One record short of a second delivery thread stays sequential.
-        records = create_payloads(MIN_RECORDS_PER_THREAD, "github:123")
-
-        maybe_trigger_drain("github:123")
-
-        mock_drain.delay.assert_called_once_with(
-            payload_id=records[0].id,
-            claimed_count=MIN_RECORDS_PER_THREAD,
-            dispatcher=Dispatcher.PUSH,
-        )
-        assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
-            {"dispatcher": "push", "drain": "sequential", "provider": "github"}
-        ]
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_reports_sequential_drain_for_deep_strict_mailbox(
-        self, mock_drain: MagicMock, mock_metrics: MagicMock
-    ) -> None:
-        # Depth never buys a strict-ordering provider concurrent delivery.
-        create_payloads(MIN_RECORDS_PER_THREAD + 1, "jira:123")
-
-        maybe_trigger_drain("jira:123")
-
-        assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
-            {"dispatcher": "push", "drain": "sequential", "provider": "jira"}
-        ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -12,7 +12,12 @@ from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from requests.exceptions import ConnectionError, ReadTimeout
 
-from sentry.hybridcloud.models.webhookpayload import MAX_ATTEMPTS, WebhookPayload
+from sentry.hybridcloud.models.webhookpayload import (
+    BACKOFF_INTERVAL,
+    BACKOFF_RATE,
+    MAX_ATTEMPTS,
+    WebhookPayload,
+)
 from sentry.hybridcloud.tasks import deliver_webhooks
 from sentry.hybridcloud.tasks.deliver_webhooks import (
     BATCH_SCHEDULE_OFFSET,
@@ -2616,7 +2621,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
                 deliver_webhooks._PayloadDeleter(batched=False),
                 worker_threads=2,
                 delivery_tags={**UNATTRIBUTED, "provider": "github"},
-                settle_by=timezone.now() + BATCH_SCHEDULE_OFFSET,
+                valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
                 spends_attempt_on_submit=False,
             )
             for record in records:
@@ -2630,10 +2635,10 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_wind_down_records_how_long_it_waited(self, mock_metrics: MagicMock) -> None:
-        # RELEASE_MARGIN is sized to this wait, so every wind-down that had
-        # something to wait for reports its length under the reason it stopped —
-        # and one with nothing in flight reports nothing, or the no-op winds
-        # down in every drain's `finally` would bury the real ones.
+        # REQUEST_BOUND caps this wait, so every wind-down that had something
+        # to wait for reports its length under the reason it stopped — and one
+        # with nothing in flight reports nothing, or the no-op wind-down in
+        # every drain's `finally` would bury the real ones.
         record = create_payloads(1, "github:123", provider="github")[0]
         tags = {**UNATTRIBUTED, "provider": "github"}
 
@@ -2646,34 +2651,39 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
                 deliver_webhooks._PayloadDeleter(batched=False),
                 worker_threads=1,
                 delivery_tags=tags,
-                settle_by=timezone.now() + BATCH_SCHEDULE_OFFSET,
+                valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
                 spends_attempt_on_submit=False,
             )
             pool.submit(record)
             pool.wind_down(reason="deadline")
-            pool.wind_down(reason="exception")
+            pool.wind_down(reason="cleanup")
 
-        timers = [
-            call
-            for call in mock_metrics.timer.call_args_list
-            if call[0][0] == "hybridcloud.deliver_webhooks.drain.wind_down"
-        ]
-        assert [call[1]["tags"] for call in timers] == [{**tags, "reason": "deadline"}]
+        waits = self.distribution_calls(
+            mock_metrics, "hybridcloud.deliver_webhooks.drain.wind_down_ms"
+        )
+        assert [tags_ for _, tags_ in waits] == [{**tags, "reason": "deadline"}]
+        assert waits[0][0] >= 100
 
     @override_cells(cell_config)
+    @patch.object(deliver_webhooks, "REQUEST_BOUND", timedelta(seconds=0.3))
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_wind_down_abandons_a_request_it_cannot_wait_out(self, mock_metrics: MagicMock) -> None:
-        # The settle deadline bounds the wait: a request still running at it is
+        # The request bound caps the wait: a request still running at it is
         # given up on — rescheduled into its backoff, its row kept — while the
         # sibling that answered is deleted, and the call returns without joining
         # the stuck thread.
         stuck, answered = create_payloads(2, "github:123", provider="github")
         release = threading.Event()
         self.addCleanup(release.set)
+        stuck_started = threading.Event()
+        answered_returned = threading.Event()
 
         def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
             if payload.id == stuck.id:
+                stuck_started.set()
                 release.wait()
+            else:
+                answered_returned.set()
             return (payload, None)
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
@@ -2681,11 +2691,14 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
                 deliver_webhooks._PayloadDeleter(batched=False),
                 worker_threads=2,
                 delivery_tags={**UNATTRIBUTED, "provider": "github"},
-                settle_by=timezone.now() + timedelta(seconds=0.3),
+                valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
                 spends_attempt_on_submit=False,
             )
             pool.submit(stuck)
             pool.submit(answered)
+            # Not yet started means cancellable, which is a different outcome.
+            assert stuck_started.wait(timeout=5)
+            assert answered_returned.wait(timeout=5)
             pool.wind_down(reason="deadline")
 
         assert pool.delivered == 1
@@ -2702,7 +2715,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
 
     @override_cells(cell_config)
     @override_options({"hybridcloud.webhookpayload.worker_threads": 2})
-    @patch.object(deliver_webhooks, "REQUEST_BOUND", timedelta(seconds=0.3))
+    @patch.object(deliver_webhooks, "REQUEST_BOUND", timedelta(seconds=1))
     def test_unresponsive_cell_stops_the_drain_without_releasing(self) -> None:
         # Nothing answering inside the request bound means the cell is down: the
         # in-flight records go into their backoff and the drain stops. The tail
@@ -2737,6 +2750,48 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             assert record.attempts == 0
             assert record.schedule_for == valid_until
 
+    @override_cells(cell_config)
+    def test_wind_down_handles_a_request_that_lands_during_the_settle(self) -> None:
+        # Handling the results that were in takes real time (deletes); a request
+        # that returns meanwhile has a result, and abandoning it would redeliver
+        # a webhook the cell already took.
+        early, late = create_payloads(2, "github:123", provider="github")
+        late_started = threading.Event()
+        late_may_return = threading.Event()
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            if payload.id == late.id:
+                late_started.set()
+                late_may_return.wait()
+            return (payload, None)
+
+        def delete_then_release_late(payload: WebhookPayload) -> None:
+            payload.delete()
+            late_may_return.set()
+            time.sleep(0.1)
+
+        with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
+            pool = deliver_webhooks._DeliveryPool(
+                deliver_webhooks._PayloadDeleter(batched=False),
+                worker_threads=2,
+                delivery_tags={**UNATTRIBUTED, "provider": "github"},
+                valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
+                spends_attempt_on_submit=False,
+            )
+            pool.submit(early)
+            pool.submit(late)
+            # Not yet started means cancellable, which is a different outcome.
+            assert late_started.wait(timeout=5)
+            with patch.object(
+                deliver_webhooks._PayloadDeleter, "delete", side_effect=delete_then_release_late
+            ):
+                pool.wind_down(reason="deadline", patience=0.5)
+
+        assert pool.unexpected is None, repr(pool.unexpected)
+        assert pool.delivered == 2
+        assert pool.failed == 0
+        assert WebhookPayload.objects.count() == 0
+
     def test_release_margin_covers_the_wait_and_the_settle(self) -> None:
         # The soft-stop must leave room for a full request bound plus the flush
         # and release, or a drain stopping on time still overshoots its claim.
@@ -2745,6 +2800,13 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             deliver_webhooks.REQUEST_BOUND.total_seconds()
             > 2 * deliver_webhooks.CELL_REQUEST_TIMEOUT
         )
+
+    def test_first_backoff_outlasts_the_claim(self) -> None:
+        # An abandoned record's request is still running. Its backoff must move
+        # its schedule_for off the claim's, or the release hands it straight to
+        # the next dispatcher while that request is in flight.
+        first_backoff = timedelta(minutes=BACKOFF_INTERVAL * BACKOFF_RATE)
+        assert first_backoff > BATCH_SCHEDULE_OFFSET
 
 
 @control_silo_test

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -2599,7 +2599,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         )
         deadline = timezone.now()
 
-        with patch.object(deliver_webhooks.timezone, "now", return_value=deadline):
+        with patch("sentry.hybridcloud.tasks.deliver_webhooks.timezone.now", return_value=deadline):
             drain_mailbox(
                 webhook.id,
                 claimed_count=1,

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,7 +1,7 @@
 import time
 from datetime import timedelta
 from typing import Any
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
@@ -2198,11 +2198,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         # A zero offset makes a freshly computed horizon expire immediately, so a
         # delivery here can only come from the claim's own deadline. A drain that
         # waited in the queue must run on the claim's remainder, not a new horizon.
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
+        with patch.object(deliver_webhooks, "BATCH_SCHEDULE_OFFSET", timedelta(minutes=0)):
             drain_mailbox(
                 records[0].id,
                 claimed_count=1,

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1924,9 +1924,9 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
         assert len(delivery_time_tags) == 1
         tags = delivery_time_tags[0]
         assert tags.get("region_sent_to") == "us"
-        # Rows predating the provider column still drain through here.
-        assert tags.get("provider") == "unknown"
-        assert tags.get("event_type") == "none"
+        assert tags.get("provider") == "github"
+        # An event-typed provider whose mailbox carries no event suffix.
+        assert tags.get("event_type") == "unknown"
         # A drain with no dispatcher still emits the attribution key; a tag
         # missing from some series breaks grouping rather than showing a gap.
         assert tags.get("dispatcher") == "unknown"
@@ -2224,8 +2224,9 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_provider_falls_back_to_unknown(self, mock_metrics: MagicMock) -> None:
-        # Rows predating the provider column still drain through here.
+    def test_provider_comes_from_the_mailbox_not_the_row(self, mock_metrics: MagicMock) -> None:
+        # The mailbox is what the dispatcher decided by, so it is what the outcome
+        # is tagged with — a row disagreeing with its own mailbox cannot split it.
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2234,6 +2235,22 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         webhook.update(provider=None)
+
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_provider_falls_back_to_unknown(self, mock_metrics: MagicMock) -> None:
+        # A mailbox name with no provider segment has nothing to name it with.
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        webhook = self.create_webhook_payload(mailbox_name="legacy", cell_name="us")
 
         drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
 
@@ -2253,38 +2270,6 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.push_trigger.success") == [
             {"provider": "github", "drain": "sequential"}
-        ]
-
-    @responses.activate
-    @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_retry_tagged_from_failing_record_not_mailbox_head(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # The sequential drain loops over records but holds a separate reference to
-        # the mailbox head, so `retry` must read the record that actually failed.
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            body=ReadTimeout(),
-        )
-        head = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
-        )
-        legacy = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        legacy.update(provider=None)
-
-        drain_mailbox(head.id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {**UNATTRIBUTED, "outcome": "ok", "provider": "github"},
-            {**UNATTRIBUTED, "outcome": "retry", "provider": "unknown"},
         ]
 
 
@@ -2364,7 +2349,7 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
         # to be missed when attribution is added; assert it alongside the delivery.
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {"dispatcher": "scheduler", "outcome": "ok", "provider": "github"},
-            {"dispatcher": "scheduler", "outcome": "claim_exhausted"},
+            {"dispatcher": "scheduler", "outcome": "claim_exhausted", "provider": "github"},
         ]
 
     @responses.activate

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -2455,6 +2455,57 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
 
 
 @control_silo_test
+class LostHeadTest(MetricCallsMixin, TestCase):
+    """
+    A drain whose head row is gone was overtaken: whoever claimed the mailbox next
+    has been delivering it, so anything still there belongs to that drain.
+    """
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_drain_delivers_nothing_when_its_head_is_gone(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        records = create_payloads(3, "github:123", provider="github")
+        head_id = records[0].id
+        records[0].delete()
+
+        drain_mailbox(head_id, claimed_count=3, mailbox="github:123")
+
+        assert len(responses.calls) == 0
+        assert WebhookPayload.objects.count() == 2
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {**UNATTRIBUTED, "outcome": "race", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_parallel_drain_delivers_nothing_when_its_head_is_gone(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # The stand-down must come before the batch is delivered, not after it:
+        # these rows are the overtaking drain's to deliver, and sending them here
+        # duplicates every one of them.
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        records = create_payloads(3, "github:123", provider="github")
+        head_id = records[0].id
+        records[0].delete()
+
+        drain_mailbox_parallel(head_id, claimed_count=3, mailbox="github:123")
+
+        assert len(responses.calls) == 0
+        assert WebhookPayload.objects.count() == 2
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {**UNATTRIBUTED, "outcome": "race", "provider": "github"}
+        ]
+
+
+@control_silo_test
 class StaleClaimTest(MetricCallsMixin, TestCase):
     """
     A drain that waited past its claim's deadline must stand down: its rows have

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import pytest
 import responses
@@ -124,7 +124,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id, claimed_count=2, dispatcher=Dispatcher.SCHEDULER
+            webhook_one.id,
+            claimed_count=2,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -141,7 +145,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
+            webhook_one.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -181,7 +189,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         mock_deliver.delay.assert_called_once_with(
-            due.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
+            due.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER, valid_until=ANY, mailbox=ANY
         )
         # The backing-off record keeps its retry schedule.
         backoff_schedule = backoff.schedule_for
@@ -221,7 +229,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         mock_deliver.delay.assert_called_once_with(
-            due_one.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
+            due_one.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
         backoff_schedule = backoff.schedule_for
         backoff.refresh_from_db()
@@ -244,7 +256,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         mock_deliver.delay.assert_called_once_with(
-            expired_backoff.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
+            expired_backoff.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @override_options(DUE_HEAD_OPTIONS)
@@ -300,27 +316,33 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id, claimed_count=2, dispatcher=Dispatcher.SCHEDULER
+            webhook_one.id,
+            claimed_count=2,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @responses.activate
     @override_cells(cell_config)
     def test_schedule_mailbox_with_more_than_batch_size_records(self) -> None:
         responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", body=ReadTimeout()
+            responses.POST, "http://us.testserver/extensions/jira/webhook/", body=ReadTimeout()
         )
         num_records = 55
         for _ in range(0, num_records):
             self.create_webhook_payload(
-                mailbox_name="github:123",
+                mailbox_name="jira:123",
                 cell_name="us",
+                provider="jira",
+                request_path="/extensions/jira/webhook/",
             )
         # Run the task that is spawned to provide some integration test coverage.
         with self.tasks():
             schedule_webhook_delivery()
 
-        # First attempt fails. provider=None is not in the skip-on-failure allowlist
-        # so processing stops after the first message, preserving mailbox ordering.
+        # First attempt fails. jira is not in the skip-on-failure allowlist so
+        # processing stops after the first message, preserving mailbox ordering.
         assert len(responses.calls) == 1
         assert WebhookPayload.objects.count() == num_records
         head = WebhookPayload.objects.all().order_by("id").first()
@@ -396,7 +418,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         assert outcome == "sequential"
         mock_drain.delay.assert_called_once_with(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
+            webhook.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
         # Option reads are served from the option store's cache in production,
         # so only payload-table statements count toward the round-trip budget.
@@ -572,7 +598,10 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         assert self.scheduler_skips(mock_metrics) == [{"provider": "github", "reason": "lock_held"}]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks._claim_mailbox_batch", return_value=0)
+    @patch(
+        "sentry.hybridcloud.tasks.deliver_webhooks._claim_mailbox_batch",
+        return_value=deliver_webhooks._MailboxClaim(claimed=0, valid_until=timezone.now()),
+    )
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_records_claim_lost(
         self, mock_drain: MagicMock, mock_claim: MagicMock, mock_metrics: MagicMock
@@ -1468,18 +1497,18 @@ class DrainMailboxParallelTest(TestCase):
     def test_drain_success_partial(self) -> None:
         responses.add(
             responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
+            "http://us.testserver/extensions/jira/webhook/",
             status=200,
             body="",
         )
         responses.add(
             responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
+            "http://us.testserver/extensions/jira/webhook/",
             status=500,
             body="",
         )
-        # provider=None is not in the skip-on-failure allowlist.
-        records = create_payloads(5, "github:123")
+        # jira is not in the skip-on-failure allowlist.
+        records = create_payloads(5, "jira:123", provider="jira")
         drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
         worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
@@ -2422,13 +2451,234 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
 
 
 @control_silo_test
+class StaleClaimTest(MetricCallsMixin, TestCase):
+    """
+    A drain that waited past its claim's deadline must stand down: its rows have
+    fallen due for another dispatcher, so delivering them again duplicates.
+    """
+
+    def expired(self) -> str:
+        """A claim deadline that has already passed."""
+        return (timezone.now() - timedelta(seconds=1)).isoformat()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_expired_claim_leaves_rows_alone(self, mock_metrics: MagicMock) -> None:
+        records = create_payloads(2, "github:123", provider="github")
+
+        drain_mailbox(
+            records[0].id, claimed_count=2, valid_until=self.expired(), mailbox="github:123"
+        )
+
+        assert len(responses.calls) == 0
+        # Untouched, not merely undelivered: the owning drain is mid-flight here.
+        assert WebhookPayload.objects.count() == 2
+        for record in records:
+            schedule_for = record.schedule_for
+            record.refresh_from_db()
+            assert record.attempts == 0
+            assert record.schedule_for == schedule_for
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {**UNATTRIBUTED, "outcome": "delivery_deadline", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_parallel_expired_claim_leaves_rows_alone(self, mock_metrics: MagicMock) -> None:
+        records = create_payloads(2, "github:123", provider="github")
+
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=2,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=self.expired(),
+            mailbox="github:123",
+        )
+
+        assert len(responses.calls) == 0
+        assert WebhookPayload.objects.count() == 2
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {"dispatcher": "scheduler", "outcome": "delivery_deadline", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_stops_at_the_claim_deadline_not_a_fresh_one(self) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        records = create_payloads(1, "github:123", provider="github")
+
+        # A zero offset makes a freshly computed horizon expire immediately, so a
+        # delivery here can only come from the claim's own deadline. A drain that
+        # waited in the queue must run on the claim's remainder, not a new horizon.
+        with patch.object(
+            deliver_webhooks,
+            "BATCH_SCHEDULE_OFFSET",
+            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
+        ):
+            drain_mailbox(
+                records[0].id,
+                claimed_count=1,
+                valid_until=(timezone.now() + timedelta(minutes=5)).isoformat(),
+            )
+
+        assert len(responses.calls) == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_parallel_drain_stops_at_the_claim_deadline_not_a_fresh_one(self) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        records = create_payloads(1, "github:123", provider="github")
+
+        with patch.object(
+            deliver_webhooks,
+            "BATCH_SCHEDULE_OFFSET",
+            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
+        ):
+            drain_mailbox_parallel(
+                records[0].id,
+                claimed_count=1,
+                valid_until=(timezone.now() + timedelta(minutes=5)).isoformat(),
+            )
+
+        assert len(responses.calls) == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_undated_claim_falls_back_to_a_fresh_horizon(self) -> None:
+        # Drains enqueued before dispatch sent a deadline keep the old bound, which
+        # test_drain_time_limit pins from the other side by expiring that horizon.
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox(webhook.id, claimed_count=1)
+
+        assert len(responses.calls) == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_fresh_claim_delivers(self, mock_metrics: MagicMock) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        valid_until = (timezone.now() + BATCH_SCHEDULE_OFFSET).isoformat()
+        drain_mailbox(webhook.id, claimed_count=1, valid_until=valid_until)
+
+        assert len(responses.calls) == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_claim_is_stale_at_its_deadline_exactly(self, mock_metrics: MagicMock) -> None:
+        # The due gates are schedule_for__lte=now, so at the deadline exactly the
+        # rows already belong to other dispatchers.
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+        deadline = timezone.now()
+
+        with patch.object(deliver_webhooks.timezone, "now", return_value=deadline):
+            drain_mailbox(
+                webhook.id,
+                claimed_count=1,
+                valid_until=deadline.isoformat(),
+                mailbox="github:123",
+            )
+
+        assert len(responses.calls) == 0
+        assert WebhookPayload.objects.count() == 1
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {**UNATTRIBUTED, "outcome": "delivery_deadline", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_enqueued_before_deploy_delivers(self) -> None:
+        # Drains queued before this deploys carry no deadline and must keep running.
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
+
+        assert len(responses.calls) == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @responses.activate
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_expired_claim_on_deleted_head_still_names_the_provider(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # The head may already be delivered; the stand-down still reports, and the
+        # mailbox names the provider with no row left to read.
+        drain_mailbox(
+            99,
+            claimed_count=1,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=self.expired(),
+            mailbox="github:123",
+        )
+
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_expired_claim_without_a_mailbox_reports_unknown_provider(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # Drains enqueued before dispatch sent a mailbox: attribution is the only
+        # thing lost, and only until they drain out.
+        drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired())
+
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "unknown"}
+        ]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_dispatch_passes_the_rows_own_deadline(self, mock_drain: MagicMock) -> None:
+        # The drain must be handed the schedule_for its claim wrote, not a value
+        # recomputed from an offset that may differ between dispatcher and worker.
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        schedule_webhook_delivery()
+
+        valid_until = datetime.fromisoformat(mock_drain.delay.call_args.kwargs["valid_until"])
+        webhook.refresh_from_db()
+        assert webhook.schedule_for == valid_until
+
+
+@control_silo_test
 class PushTriggerTest(MetricCallsMixin, TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_push_trigger_enqueues_drain_for_idle_mailbox(self, mock_drain: MagicMock) -> None:
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         maybe_trigger_drain(webhook.mailbox_name)
         mock_drain.delay.assert_called_once_with(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH
+            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=ANY, mailbox=ANY
         )
         # The batch is claimed before dispatch; the claim is what keeps other
         # dispatchers off the mailbox while the drain runs.
@@ -2467,7 +2717,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         maybe_trigger_drain(newer_webhook.mailbox_name)
         # Must drain from the head of the mailbox so the older payload is not skipped
         mock_drain.delay.assert_called_once_with(
-            older_webhook.id, claimed_count=2, dispatcher=Dispatcher.PUSH
+            older_webhook.id,
+            claimed_count=2,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2501,7 +2755,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         maybe_trigger_drain("github:123")
 
         mock_drain.delay.assert_called_once_with(
-            due.id, claimed_count=1, dispatcher=Dispatcher.PUSH
+            due.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=ANY, mailbox=ANY
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2569,7 +2823,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
 
         # Only mailbox B should have been scheduled
         mock_drain.delay.assert_called_once_with(
-            webhook_b.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER
+            webhook_b.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2619,7 +2877,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         webhook_two = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         maybe_trigger_drain(webhook_two.mailbox_name)
         mock_drain.delay.assert_called_once_with(
-            webhook_two.id, claimed_count=1, dispatcher=Dispatcher.PUSH
+            webhook_two.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2652,7 +2914,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # A mailbox this deep is behind; the sequential drain would work it off at
         # one in-flight request for its whole run.
         mock_drain_parallel.delay.assert_called_once_with(
-            records[0].id, claimed_count=PARALLEL_DRAIN_THRESHOLD, dispatcher=Dispatcher.PUSH
+            records[0].id,
+            claimed_count=PARALLEL_DRAIN_THRESHOLD,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
         )
         mock_drain.delay.assert_not_called()
 
@@ -2667,7 +2933,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
 
         # One record short of the threshold keeps strict ordering.
         mock_drain.delay.assert_called_once_with(
-            records[0].id, claimed_count=PARALLEL_DRAIN_THRESHOLD - 1, dispatcher=Dispatcher.PUSH
+            records[0].id,
+            claimed_count=PARALLEL_DRAIN_THRESHOLD - 1,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
         )
         mock_drain_parallel.delay.assert_not_called()
 

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -2230,6 +2230,29 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    def test_undated_claim_caps_a_backoff_rewritten_deadline(self) -> None:
+        # A failed attempt rewrote the head's schedule_for to its retry backoff,
+        # so it no longer carries the claim's deadline. A zero offset makes the
+        # cap immediate: a delivery here could only come from adopting the
+        # backoff as the deadline, which would outlive the claim.
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123",
+            cell_name="us",
+            provider="github",
+            schedule_for=timezone.now() + timedelta(minutes=30),
+        )
+
+        with patch.object(deliver_webhooks, "BATCH_SCHEDULE_OFFSET", timedelta(minutes=0)):
+            drain_mailbox(webhook.id, claimed_count=1)
+
+        assert len(responses.calls) == 0
+        assert WebhookPayload.objects.count() == 1
+
+    @responses.activate
+    @override_cells(cell_config)
     def test_undated_claim_with_lapsed_rows_stands_down(self) -> None:
         # An undated drain whose rows are already claimable belongs to whoever
         # claims them next, exactly like a dated drain past its deadline.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -11,14 +11,14 @@ from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from requests.exceptions import ConnectionError, ReadTimeout
 
-from sentry import options
 from sentry.hybridcloud.models.webhookpayload import MAX_ATTEMPTS, WebhookPayload
 from sentry.hybridcloud.tasks import deliver_webhooks
 from sentry.hybridcloud.tasks.deliver_webhooks import (
     BATCH_SCHEDULE_OFFSET,
     DRAIN_LOCK_TTL,
     MAX_MAILBOX_DRAIN,
-    PARALLEL_DRAIN_THRESHOLD,
+    MIN_RECORDS_PER_THREAD,
+    RELEASE_MARGIN,
     SLOW_DELIVERY_THRESHOLD,
     Dispatcher,
     _claim_and_dispatch,
@@ -366,8 +366,8 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         # No messages delivered
         assert WebhookPayload.objects.count() == num_records
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
-    def test_schedule_mailbox_parallel_task(self, mock_deliver: MagicMock) -> None:
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_schedule_deep_mailbox_dispatches_once(self, mock_deliver: MagicMock) -> None:
         for _ in range(0, int(MAX_MAILBOX_DRAIN / 3 + 1)):
             self.create_webhook_payload(
                 mailbox_name="github:123",
@@ -1511,13 +1511,12 @@ class DrainMailboxParallelTest(TestCase):
             status=500,
             body="",
         )
-        # jira is not in the skip-on-failure allowlist.
+        # jira is not in the skip-on-failure allowlist: delivery is one record at
+        # a time, in order, stopping at the failure.
         records = create_payloads(5, "jira:123", provider="jira")
         drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
-        worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
-        # We'll attempt one thread batch, but the second+ will fail and stop the drain.
-        assert len(responses.calls) == worker_threads
+        assert len(responses.calls) == 2
 
         # Mailbox should have 4 records left
         assert WebhookPayload.objects.count() == 4
@@ -1608,10 +1607,9 @@ class DrainMailboxParallelTest(TestCase):
         records = create_payloads(5, "jira:123", provider="jira")
         drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
-        worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
-        # jira is not in the allowlist: processing stops after the first batch
-        # that encounters a retryable failure.
-        assert len(responses.calls) == worker_threads
+        # jira is not in the allowlist: in-order delivery stops at the first
+        # retryable failure, and nothing behind it is attempted.
+        assert len(responses.calls) == 2
         assert WebhookPayload.objects.count() == 4
 
         first = WebhookPayload.objects.order_by("id").first()
@@ -1700,12 +1698,6 @@ class DrainMailboxParallelTest(TestCase):
     @responses.activate
     @override_cells(cell_config)
     def test_drain_too_many_attempts(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=500,
-            body="",
-        )
         webhook_one = self.create_webhook_payload(
             mailbox_name="github:123",
             cell_name="us",
@@ -1713,7 +1705,7 @@ class DrainMailboxParallelTest(TestCase):
         )
         drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 0
 
     @responses.activate
     @override_cells(cell_config)
@@ -1725,7 +1717,7 @@ class DrainMailboxParallelTest(TestCase):
         )
         drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 0
 
     @responses.activate
     @override_cells(cell_config)
@@ -2298,24 +2290,25 @@ class DispatchMetricTest(MetricCallsMixin, TestCase):
         ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_scheduler_dispatch_reports_batch_depth(
-        self, mock_drain_parallel: MagicMock, mock_metrics: MagicMock
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
     ) -> None:
         # Deep on purpose: `claimed` must report the batch, not one per dispatch,
         # or webhook share collapses back into dispatch share.
-        for _ in range(PARALLEL_DRAIN_THRESHOLD):
+        depth = MIN_RECORDS_PER_THREAD + 1
+        for _ in range(depth):
             self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
         schedule_webhook_delivery()
 
-        assert mock_drain_parallel.delay.call_args.kwargs["dispatcher"] == Dispatcher.SCHEDULER
+        assert mock_drain.delay.call_args.kwargs["dispatcher"] == Dispatcher.SCHEDULER
         assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
             {"dispatcher": "scheduler", "drain": "parallel", "provider": "github"}
         ]
         assert self.distribution_calls(mock_metrics, DISPATCH_CLAIMED_METRIC) == [
             (
-                PARALLEL_DRAIN_THRESHOLD,
+                depth,
                 {"dispatcher": "scheduler", "drain": "parallel", "provider": "github"},
             )
         ]
@@ -2734,6 +2727,137 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
 
 @control_silo_test
+class WaveConcurrencyTest(TestCase):
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks._run_parallel_delivery_batch")
+    def test_waves_scale_with_remaining_work(self, mock_batch: MagicMock) -> None:
+        mock_batch.side_effect = lambda records, deleter, delivery_tags: len(records)
+        records = create_payloads(12, "github:123", provider="github")
+
+        with override_options({"hybridcloud.webhookpayload.worker_threads": 3}):
+            drain_mailbox(
+                records[0].id,
+                claimed_count=12,
+                valid_until=(timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp(),
+                mailbox="github:123",
+            )
+
+        # ceil(remaining / MIN_RECORDS_PER_THREAD), capped at worker_threads,
+        # recomputed per wave so the tail tapers instead of holding full width.
+        wave_sizes = [len(call.args[0]) for call in mock_batch.call_args_list]
+        assert wave_sizes == [3, 2, 2, 1, 1, 1, 1, 1]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks._run_parallel_delivery_batch")
+    def test_strict_provider_never_delivers_in_waves(self, mock_batch: MagicMock) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/jira/webhook/", status=200, body=""
+        )
+        records = create_payloads(MIN_RECORDS_PER_THREAD + 2, "jira:123", provider="jira")
+
+        drain_mailbox(
+            records[0].id,
+            claimed_count=len(records),
+            valid_until=(timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp(),
+            mailbox="jira:123",
+        )
+
+        mock_batch.assert_not_called()
+        assert len(responses.calls) == len(records)
+        assert WebhookPayload.objects.count() == 0
+
+
+@control_silo_test
+class DeadlineReleaseTest(MetricCallsMixin, TestCase):
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_release_makes_unworked_tail_claimable_now(self, mock_metrics: MagicMock) -> None:
+        valid_until = timezone.now() + RELEASE_MARGIN / 2
+        records = create_payloads(3, "github:123", provider="github")
+        WebhookPayload.objects.filter(id__in=[r.id for r in records]).update(
+            schedule_for=valid_until
+        )
+
+        drain_mailbox(
+            records[0].id,
+            claimed_count=3,
+            valid_until=valid_until.timestamp(),
+            mailbox="github:123",
+        )
+
+        assert len(responses.calls) == 0
+        for record in records:
+            record.refresh_from_db()
+            assert record.schedule_for <= timezone.now()
+        released = [
+            call
+            for call in mock_metrics.incr.call_args_list
+            if call[0][0] == DELIVERY_METRIC and call[1]["tags"].get("outcome") == "released"
+        ]
+        assert len(released) == 1
+        assert released[0][1]["amount"] == 3
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_release_skips_rows_the_claim_no_longer_owns(self) -> None:
+        valid_until = timezone.now() + RELEASE_MARGIN / 2
+        records = create_payloads(3, "github:123", provider="github")
+        WebhookPayload.objects.filter(id__in=[r.id for r in records]).update(
+            schedule_for=valid_until
+        )
+        # A row rescheduled into a retry backoff, or taken by another claim,
+        # carries a different schedule_for and must keep it.
+        backoff = timezone.now() + timedelta(minutes=10)
+        records[1].update(schedule_for=backoff)
+
+        drain_mailbox(
+            records[0].id,
+            claimed_count=3,
+            valid_until=valid_until.timestamp(),
+            mailbox="github:123",
+        )
+
+        records[1].refresh_from_db()
+        assert records[1].schedule_for == backoff
+        for record in (records[0], records[2]):
+            record.refresh_from_db()
+            assert record.schedule_for <= timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_release_covers_only_the_tail_behind_delivered_rows(self) -> None:
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
+        records = create_payloads(3, "github:123", provider="github")
+        WebhookPayload.objects.filter(id__in=[r.id for r in records]).update(
+            schedule_for=valid_until
+        )
+
+        # Deadline nears after the first delivery: the drain must release only
+        # what it never reached.
+        with patch.object(
+            deliver_webhooks._MailboxClaim,
+            "nearing_deadline",
+            side_effect=[False, False, True, True],
+        ):
+            drain_mailbox(
+                records[0].id,
+                claimed_count=3,
+                valid_until=valid_until.timestamp(),
+                mailbox="github:123",
+            )
+
+        assert len(responses.calls) == 1
+        assert not WebhookPayload.objects.filter(id=records[0].id).exists()
+        for record in (records[1], records[2]):
+            record.refresh_from_db()
+            assert record.schedule_for <= timezone.now()
+
+
+@control_silo_test
 class PushTriggerTest(MetricCallsMixin, TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_push_trigger_enqueues_drain_for_idle_mailbox(self, mock_drain: MagicMock) -> None:
@@ -2972,44 +3096,60 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # Lock must also be released so the scheduler can pick it up when backoff expires
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_uses_parallel_drain_for_deep_mailbox(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
+    def test_push_trigger_reports_parallel_drain_for_deep_mailbox(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
     ) -> None:
-        records = create_payloads(PARALLEL_DRAIN_THRESHOLD, "github:123")
+        records = create_payloads(MIN_RECORDS_PER_THREAD + 1, "github:123")
 
         maybe_trigger_drain("github:123")
 
-        # A mailbox this deep is behind; the sequential drain would work it off at
-        # one in-flight request for its whole run.
-        mock_drain_parallel.delay.assert_called_once_with(
-            payload_id=records[0].id,
-            claimed_count=PARALLEL_DRAIN_THRESHOLD,
-            dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
-        )
-        mock_drain.delay.assert_not_called()
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_uses_sequential_drain_for_shallow_mailbox(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
-    ) -> None:
-        records = create_payloads(PARALLEL_DRAIN_THRESHOLD - 1, "github:123")
-
-        maybe_trigger_drain("github:123")
-
-        # One record short of the threshold keeps strict ordering.
         mock_drain.delay.assert_called_once_with(
             payload_id=records[0].id,
-            claimed_count=PARALLEL_DRAIN_THRESHOLD - 1,
+            claimed_count=MIN_RECORDS_PER_THREAD + 1,
             dispatcher=Dispatcher.PUSH,
             valid_until=ANY,
             mailbox=ANY,
         )
-        mock_drain_parallel.delay.assert_not_called()
+        assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
+            {"dispatcher": "push", "drain": "parallel", "provider": "github"}
+        ]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_push_trigger_reports_sequential_drain_for_shallow_mailbox(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # One record short of a second delivery thread stays sequential.
+        records = create_payloads(MIN_RECORDS_PER_THREAD, "github:123")
+
+        maybe_trigger_drain("github:123")
+
+        mock_drain.delay.assert_called_once_with(
+            payload_id=records[0].id,
+            claimed_count=MIN_RECORDS_PER_THREAD,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
+        )
+        assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
+            {"dispatcher": "push", "drain": "sequential", "provider": "github"}
+        ]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_push_trigger_reports_sequential_drain_for_deep_strict_mailbox(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # Depth never buys a strict-ordering provider concurrent delivery.
+        create_payloads(MIN_RECORDS_PER_THREAD + 1, "jira:123")
+
+        maybe_trigger_drain("jira:123")
+
+        assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
+            {"dispatcher": "push", "drain": "sequential", "provider": "jira"}
+        ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -923,6 +923,11 @@ class DueHeadDepthTest(MetricCallsMixin, TestCase):
         }
 
 
+def fresh_deadline() -> float:
+    """A live claim deadline for drains invoked directly, without a dispatcher."""
+    return (timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp()
+
+
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:
     # Keep path aligned with provider so responses mocks aren't misleading.
     request_path = f"/extensions/{provider}/webhook/" if provider else "/extensions/github/webhook/"
@@ -959,7 +964,7 @@ def assert_drain_skips_failed_message(
     responses.add(responses.POST, url, status=200, body="")
     records = create_payloads(5, f"{provider}:123", provider=provider)
 
-    drain_mailbox(records[0].id, claimed_count=claimed_count)
+    drain_mailbox(records[0].id, claimed_count=claimed_count, valid_until=fresh_deadline())
 
     assert len(responses.calls) == 5
     assert WebhookPayload.objects.count() == 1
@@ -984,7 +989,7 @@ class DrainMailboxTest(TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox(webhook_one.id, claimed_count=1)
+            drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -997,7 +1002,7 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         # github is in the skip-on-failure allowlist: failed messages are skipped
         # and processing continues. All 5 messages are attempted.
@@ -1022,7 +1027,7 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=5)
+        drain_mailbox(records[0].id, claimed_count=5, valid_until=fresh_deadline())
 
         assert len(responses.calls) == 5
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
@@ -1036,7 +1041,9 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=MIN_RECORDS_PER_THREAD + 1)
+        drain_mailbox(
+            records[0].id, claimed_count=MIN_RECORDS_PER_THREAD + 1, valid_until=fresh_deadline()
+        )
 
         assert len(responses.calls) == 6
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
@@ -1062,7 +1069,7 @@ class DrainMailboxTest(TestCase):
         fresh = create_payloads(5, "github:123", provider="github")
 
         # The claim covered the 3 stale rows plus 3 fresh ones.
-        drain_mailbox(stale[0].id, claimed_count=6)
+        drain_mailbox(stale[0].id, claimed_count=6, valid_until=fresh_deadline())
 
         # The 3 stale rows are discarded without requests and only the 3 claimed
         # fresh rows are delivered; the rest stay for the next claim.
@@ -1088,7 +1095,7 @@ class DrainMailboxTest(TestCase):
 
         head = WebhookPayload.objects.order_by("id").first()
         assert head
-        drain_mailbox(head.id, claimed_count=4)
+        drain_mailbox(head.id, claimed_count=4, valid_until=fresh_deadline())
 
         # Only the two fresh rows produce requests; everything is drained.
         assert len(responses.calls) == 2
@@ -1102,7 +1109,7 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         # jira is not in the allowlist: processing stops on the first failure
         # to preserve strict mailbox ordering.
@@ -1152,7 +1159,7 @@ class DrainMailboxTest(TestCase):
         records = create_payloads(4, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=4)
+            drain_mailbox(records[0].id, claimed_count=4, valid_until=fresh_deadline())
 
         assert len(responses.calls) == 4
         assert WebhookPayload.objects.count() == 0
@@ -1171,7 +1178,7 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
 
-        drain_mailbox(records[0].id, claimed_count=5)
+        drain_mailbox(records[0].id, claimed_count=5, valid_until=fresh_deadline())
 
         # jira requires strict ordering: the drain stops at the failure, but the
         # two messages delivered before it must still have their rows removed.
@@ -1205,7 +1212,7 @@ class DrainMailboxTest(TestCase):
         create_payloads(2, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(stale.id, claimed_count=4)
+            drain_mailbox(stale.id, claimed_count=4, valid_until=fresh_deadline())
 
         # Only the two fresh rows are delivered; the stale and attempts-exhausted
         # rows are discarded without a request.
@@ -1227,7 +1234,7 @@ class DrainMailboxTest(TestCase):
         records = create_payloads(5, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=5)
+            drain_mailbox(records[0].id, claimed_count=5, valid_until=fresh_deadline())
 
         assert WebhookPayload.objects.count() == 0
         # Two full batches during the walk plus the remainder at the end.
@@ -1245,7 +1252,7 @@ class DrainMailboxTest(TestCase):
         records = create_payloads(8, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=8)
+            drain_mailbox(records[0].id, claimed_count=8, valid_until=fresh_deadline())
 
         assert len(responses.calls) == 8
         assert WebhookPayload.objects.count() == 0
@@ -1258,7 +1265,7 @@ class DrainMailboxTest(TestCase):
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         # All 5 messages are attempted even though all fail.
         assert len(responses.calls) == 5
@@ -1279,30 +1286,10 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_time_limit(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        records = create_payloads(1, "github:123")
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        # Once start time + batch offset is in the past we stop delivery
-        assert WebhookPayload.objects.count() == 1
 
     @responses.activate
     @override_cells(cell_config)
@@ -1312,7 +1299,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1324,7 +1311,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1342,7 +1329,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox(webhook_one.id, claimed_count=1)
+            drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -1361,7 +1348,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -1381,7 +1368,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1398,7 +1385,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -1417,7 +1404,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -1436,7 +1423,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 403
         assert hook is None
@@ -1456,7 +1443,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -1473,7 +1460,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1)
+        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -1491,7 +1478,7 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1549,7 +1536,7 @@ class SlowDeliveryLoggingTest(TestCase):
         expected_date_added = webhook.date_added.isoformat()
 
         with self.assertLogs("sentry.hybridcloud.tasks.deliver_webhooks", level="WARNING") as cm:
-            drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         slow_log = next(r for r in cm.records if "deliver_webhook.slow_delivery" in r.msg)
         # extra dict from logger becomes attributes on LogRecord at runtime
@@ -1579,7 +1566,7 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1607,7 +1594,7 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1631,7 +1618,7 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="stripe",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1658,7 +1645,7 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1689,7 +1676,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -1707,7 +1694,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -1725,7 +1712,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert self.delivery_outcomes(mock_metrics) == ["ok"]
         assert len(self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC)) == 1
@@ -1742,7 +1729,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=1)
+        drain_mailbox(webhook.id, claimed_count=1, valid_until=fresh_deadline())
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -1760,7 +1747,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=1)
+        drain_mailbox(webhook.id, claimed_count=1, valid_until=fresh_deadline())
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -1787,7 +1774,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         first = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         second = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(first.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(first.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert not WebhookPayload.objects.filter(id=second.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "ok"]
@@ -1814,7 +1801,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
@@ -1834,7 +1821,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.failure") == [
             {"reason": "unauthorized", "destination_region": "us", "provider": "github"}
@@ -1856,7 +1843,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "conflict", "provider": "github"}
@@ -1876,7 +1863,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=1)
+        drain_mailbox(webhook.id, claimed_count=1, valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"}
@@ -1897,7 +1884,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         webhook.update(provider=None)
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
@@ -1913,7 +1900,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="legacy", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "unknown"}
@@ -2005,7 +1992,12 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {"dispatcher": "scheduler", "outcome": "ok", "provider": "github"}
@@ -2027,7 +2019,12 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=fresh_deadline(),
+        )
 
         assert self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC) == [
             {
@@ -2053,7 +2050,10 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
         records = create_payloads(2, "github:123", provider="github")
 
         drain_mailbox(
-            records[0].id, claimed_count=MIN_RECORDS_PER_THREAD + 1, dispatcher=Dispatcher.PUSH
+            records[0].id,
+            claimed_count=MIN_RECORDS_PER_THREAD + 1,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=fresh_deadline(),
         )
 
         expected = {
@@ -2199,9 +2199,29 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    def test_undated_claim_falls_back_to_a_fresh_horizon(self) -> None:
-        # Drains enqueued before dispatch sent a deadline keep the old bound, which
-        # test_drain_time_limit pins from the other side by expiring that horizon.
+    def test_undated_claim_reads_deadline_from_its_head_row(self) -> None:
+        # Drains enqueued before dispatch sent a deadline find it on their rows:
+        # their claim wrote it there as schedule_for.
+        responses.add(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123",
+            cell_name="us",
+            provider="github",
+            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET,
+        )
+
+        drain_mailbox(webhook.id, claimed_count=1)
+
+        assert len(responses.calls) == 1
+        assert WebhookPayload.objects.count() == 0
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_undated_claim_with_lapsed_rows_stands_down(self) -> None:
+        # An undated drain whose rows are already claimable belongs to whoever
+        # claims them next, exactly like a dated drain past its deadline.
         responses.add(
             responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
         )
@@ -2211,8 +2231,8 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
         drain_mailbox(webhook.id, claimed_count=1)
 
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
+        assert len(responses.calls) == 0
+        assert WebhookPayload.objects.count() == 1
 
     @responses.activate
     @override_cells(cell_config)
@@ -2259,12 +2279,16 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     def test_drain_enqueued_before_deploy_delivers(self) -> None:
-        # Drains queued before this deploys carry no deadline and must keep running.
+        # Drains queued before this deploys carry no deadline and must keep
+        # running on the one their claim wrote to the rows.
         responses.add(
             responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
         )
         webhook = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
+            mailbox_name="github:123",
+            cell_name="us",
+            provider="github",
+            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET,
         )
 
         drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
@@ -2683,7 +2707,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             body="",
         )
         webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
 
         # The drain emptied the mailbox; a new webhook arriving now must be able to
         # trigger a fresh drain right away.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import ANY, MagicMock, PropertyMock, patch
@@ -376,11 +375,8 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_claim_and_dispatch_skips_head_claimed_on_primary(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
-    ) -> None:
+    def test_claim_and_dispatch_skips_head_claimed_on_primary(self, mock_drain: MagicMock) -> None:
         # The scheduler discovers mailbox heads on the replica, which can lag behind
         # another dispatcher's claim on the primary. The primary re-check must stop
         # the stale head from double-dispatching a drain.
@@ -397,16 +393,12 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         assert outcome == "not_due"
         mock_drain.delay.assert_not_called()
-        mock_drain_parallel.delay.assert_not_called()
         webhook.refresh_from_db()
         # The existing claim must not be extended either.
         assert webhook.schedule_for == claimed_for
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_claim_and_dispatch_claims_in_a_single_query(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
-    ) -> None:
+    def test_claim_and_dispatch_claims_in_a_single_query(self, mock_drain: MagicMock) -> None:
         # The due-gate rides in the claim UPDATE's WHERE clause. A separate
         # primary read before the claim would double the per-mailbox dispatch
         # round trips, so lock in the single-statement shape.
@@ -946,7 +938,9 @@ def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list
     return created
 
 
-def assert_drain_skips_failed_message(drain: Callable[[int, int], None], provider: str) -> None:
+def assert_drain_skips_failed_message(
+    provider: str, *, claimed_count: int = MAX_MAILBOX_DRAIN
+) -> None:
     """
     Drain a 5 message mailbox where the second delivery fails.
 
@@ -965,7 +959,7 @@ def assert_drain_skips_failed_message(drain: Callable[[int, int], None], provide
     responses.add(responses.POST, url, status=200, body="")
     records = create_payloads(5, f"{provider}:123", provider=provider)
 
-    drain(records[0].id, MAX_MAILBOX_DRAIN)
+    drain_mailbox(records[0].id, claimed_count=claimed_count)
 
     assert len(responses.calls) == 5
     assert WebhookPayload.objects.count() == 1
@@ -990,7 +984,7 @@ class DrainMailboxTest(TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox(webhook_one.id, claimed_count=1)
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1036,8 +1030,50 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    def test_drain_stops_at_claimed_count_threaded(self) -> None:
+        # The claim boundary binds waves too, not only the serial walk.
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        records = create_payloads(8, "github:123", provider="github")
+
+        drain_mailbox(records[0].id, claimed_count=MIN_RECORDS_PER_THREAD + 1)
+
+        assert len(responses.calls) == 6
+        remaining = set(WebhookPayload.objects.values_list("id", flat=True))
+        assert remaining == {records[6].id, records[7].id}
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_stale_discards_consume_claim_budget_in_waves(self) -> None:
+        # Stale rows are discarded inside the wave, so they consume claim budget
+        # like delivered rows. Deleting them out-of-band would leave the budget
+        # to spill onto unclaimed due rows — the overlap claimed_count prevents.
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        stale = [
+            Factories.create_webhook_payload(
+                mailbox_name="github:123",
+                cell_name="us",
+                provider="github",
+                date_added=timezone.now() - timedelta(days=4),
+            )
+            for _ in range(3)
+        ]
+        fresh = create_payloads(5, "github:123", provider="github")
+
+        # The claim covered the 3 stale rows plus 3 fresh ones.
+        drain_mailbox(stale[0].id, claimed_count=6)
+
+        # The 3 stale rows are discarded without requests and only the 3 claimed
+        # fresh rows are delivered; the rest stay for the next claim.
+        assert len(responses.calls) == 3
+        remaining_ids = set(WebhookPayload.objects.values_list("id", flat=True))
+        assert remaining_ids == {fresh[3].id, fresh[4].id}
+
+    @responses.activate
+    @override_cells(cell_config)
     def test_drain_discards_stale_rows_instead_of_delivering(self) -> None:
-        # MAX_DELIVERY_AGE applies to sequential drains too: stale rows are
+        # MAX_DELIVERY_AGE applies to serial drains too: stale rows are
         # discarded in the walk, not forwarded days late.
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=200, body="")
@@ -1052,7 +1088,7 @@ class DrainMailboxTest(TestCase):
 
         head = WebhookPayload.objects.order_by("id").first()
         assert head
-        drain_mailbox(head.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(head.id, claimed_count=4)
 
         # Only the two fresh rows produce requests; everything is drained.
         assert len(responses.calls) == 2
@@ -1083,22 +1119,29 @@ class DrainMailboxTest(TestCase):
     @responses.activate
     @override_cells(cell_config)
     def test_drain_skip_on_failure_github_enterprise(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox, "github_enterprise")
+        assert_drain_skips_failed_message("github_enterprise")
 
     @responses.activate
     @override_cells(cell_config)
     def test_drain_skip_on_failure_bitbucket(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox, "bitbucket")
+        assert_drain_skips_failed_message("bitbucket")
 
     @responses.activate
     @override_cells(cell_config)
     def test_drain_skip_on_failure_bitbucket_server(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox, "bitbucket_server")
+        assert_drain_skips_failed_message("bitbucket_server")
 
     @responses.activate
     @override_cells(cell_config)
     def test_drain_skip_on_failure_gitlab(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox, "gitlab")
+        assert_drain_skips_failed_message("gitlab")
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_serial(self) -> None:
+        # A claim at MIN_RECORDS_PER_THREAD stays serial; skipping past the
+        # failure is a distinct branch there, not a side effect of the wave.
+        assert_drain_skips_failed_message("github", claimed_count=5)
 
     @responses.activate
     @override_cells(cell_config)
@@ -1193,6 +1236,24 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
+    def test_drain_batch_deletes_span_waves(self) -> None:
+        # The delete batch belongs to the drain, not to one delivery wave:
+        # accumulating per wave would cap every DELETE at the wave width.
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        records = create_payloads(8, "github:123", provider="github")
+
+        with CaptureQueriesContext(connections["control"]) as ctx:
+            drain_mailbox(records[0].id, claimed_count=8)
+
+        assert len(responses.calls) == 8
+        assert WebhookPayload.objects.count() == 0
+        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
+        assert len(delete_queries) == 1
+
+    @responses.activate
+    @override_cells(cell_config)
     def test_drain_mailbox_multiple_consecutive_failures(self) -> None:
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
@@ -1251,7 +1312,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1263,7 +1324,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1281,7 +1342,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox(webhook_one.id, claimed_count=1)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -1300,7 +1361,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -1320,7 +1381,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1337,7 +1398,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -1356,7 +1417,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -1375,7 +1436,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 403
         assert hook is None
@@ -1395,7 +1456,7 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -1412,7 +1473,7 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook_one.id, claimed_count=1)
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -1437,209 +1498,12 @@ class DrainMailboxTest(TestCase):
 
 
 @control_silo_test
-class DrainMailboxParallelTest(TestCase):
-    @responses.activate
-    def test_drain_missing_payload(self) -> None:
-        drain_mailbox_parallel(99, claimed_count=MAX_MAILBOX_DRAIN)
-        assert len(responses.calls) == 0
-
-    @responses.activate
-    def test_drain_unknown_cell(self) -> None:
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="lolnope",
-        )
-        with pytest.raises(CellResolutionError):
-            drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        assert len(responses.calls) == 0
-
+class DrainMailboxParallelShimTest(TestCase):
     @responses.activate
     @override_cells(cell_config)
-    def test_drain_stops_at_claimed_count(self) -> None:
-        # Mirrors DrainMailboxTest.test_drain_stops_at_claimed_count: a
-        # claim-mode parallel drain must not deliver past its claimed records.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(8, "github:123", provider="github")
-
-        drain_mailbox_parallel(records[0].id, claimed_count=5)
-
-        assert len(responses.calls) == 5
-        remaining = set(WebhookPayload.objects.values_list("id", flat=True))
-        assert remaining == {records[5].id, records[6].id, records[7].id}
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_stale_discards_consume_claim_budget(self) -> None:
-        # Stale rows are discarded inside the walk, so they consume claim budget
-        # like delivered rows. Deleting them out-of-band would leave the budget
-        # to spill onto unclaimed due rows — the overlap claimed_count prevents.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        stale = [
-            Factories.create_webhook_payload(
-                mailbox_name="github:123",
-                cell_name="us",
-                provider="github",
-                date_added=timezone.now() - timedelta(days=4),
-            )
-            for _ in range(3)
-        ]
-        fresh = create_payloads(5, "github:123", provider="github")
-
-        # The claim covered the 3 stale rows plus 2 fresh ones.
-        drain_mailbox_parallel(stale[0].id, claimed_count=5)
-
-        # The 3 stale rows are discarded without requests and only the 2 claimed
-        # fresh rows are delivered; the rest stay for the next claim.
-        assert len(responses.calls) == 2
-        remaining_ids = set(WebhookPayload.objects.values_list("id", flat=True))
-        assert remaining_ids == {fresh[2].id, fresh[3].id, fresh[4].id}
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_success_partial(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/jira/webhook/",
-            status=200,
-            body="",
-        )
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/jira/webhook/",
-            status=500,
-            body="",
-        )
-        # jira is not in the skip-on-failure allowlist: delivery is one record at
-        # a time, in order, stopping at the failure.
-        records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        assert len(responses.calls) == 2
-
-        # Mailbox should have 4 records left
-        assert WebhookPayload.objects.count() == 4
-
-        # Remaining record should be scheduled to run later.
-        first = WebhookPayload.objects.order_by("id").first()
-        assert first
-        assert first.attempts == 1
-        assert first.schedule_for > timezone.now()
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_skip_on_failure_for_allowlisted_provider(self) -> None:
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        responses.add(responses.POST, url, status=500, body="")
-        responses.add(responses.POST, url, status=200, body="")
-        responses.add(responses.POST, url, status=200, body="")
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        # github is in the skip-on-failure allowlist: failed messages are skipped
-        # and processing continues across parallel batches.
-        assert len(responses.calls) == 5
-
-        # Only the failed message remains in the mailbox.
-        assert WebhookPayload.objects.count() == 1
-
-        first = WebhookPayload.objects.order_by("id").first()
-        assert first
-        assert first.attempts == 1
-        assert first.schedule_for > timezone.now()
-
-    @responses.activate
-    @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
-    def test_drain_batch_deletes_span_threadpool_batches(self) -> None:
-        # The batch belongs to the drain, not to one threadpool batch: a
-        # threadpool only runs worker_threads (4) rows at a time, so accumulating
-        # per threadpool batch would cap every DELETE at that width.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(8, "github:123", provider="github")
-
-        with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox_parallel(records[0].id, claimed_count=8)
-
-        assert len(responses.calls) == 8
-        assert WebhookPayload.objects.count() == 0
-        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
-        assert len(delete_queries) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
-    def test_drain_batch_deletes_discarded_rows(self) -> None:
-        # Stale rows are discarded before the threadpool runs, so they would
-        # otherwise be the one delete path the batch never covers.
-        url = "http://us.testserver/extensions/github/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        stale = [
-            Factories.create_webhook_payload(
-                mailbox_name="github:123",
-                cell_name="us",
-                provider="github",
-                request_path="/extensions/github/webhook/",
-                date_added=timezone.now() - timedelta(days=4),
-            )
-            for _ in range(2)
-        ]
-        create_payloads(2, "github:123", provider="github")
-
-        with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox_parallel(stale[0].id, claimed_count=4)
-
-        assert len(responses.calls) == 2
-        assert WebhookPayload.objects.count() == 0
-        delete_queries = [q["sql"] for q in ctx.captured_queries if q["sql"].startswith("DELETE")]
-        assert len(delete_queries) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:
-        url = "http://us.testserver/extensions/jira/webhook/"
-        responses.add(responses.POST, url, status=200, body="")
-        responses.add(responses.POST, url, status=500, body="")
-        records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        # jira is not in the allowlist: in-order delivery stops at the first
-        # retryable failure, and nothing behind it is attempted.
-        assert len(responses.calls) == 2
-        assert WebhookPayload.objects.count() == 4
-
-        first = WebhookPayload.objects.order_by("id").first()
-        assert first
-        assert first.attempts == 1
-        assert first.schedule_for > timezone.now()
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_skip_on_failure_github_enterprise(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox_parallel, "github_enterprise")
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_skip_on_failure_bitbucket(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox_parallel, "bitbucket")
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_skip_on_failure_bitbucket_server(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox_parallel, "bitbucket_server")
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_skip_on_failure_gitlab(self) -> None:
-        assert_drain_skips_failed_message(drain_mailbox_parallel, "gitlab")
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_success(self) -> None:
+    def test_in_flight_drain_still_delivers(self) -> None:
+        # Dispatch no longer enqueues this task; drains enqueued by the deploy
+        # before the drains merged must still bind and deliver. Dies with the shim.
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -1647,211 +1511,16 @@ class DrainMailboxParallelTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
 
-        # Mailbox should be empty
-        assert not WebhookPayload.objects.filter().exists()
+        drain_mailbox_parallel(
+            payload_id=records[0].id,
+            claimed_count=3,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=(timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp(),
+            mailbox="github:123",
+        )
 
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_time_limit(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        records = create_payloads(1, "github:123")
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        # Once start time + batch offset is in the past we stop delivery
-        assert WebhookPayload.objects.count() == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_discard_old_messages(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        records = create_payloads(20, "github:123")
-
-        # Make old records
-        for record in records:
-            record.date_added = timezone.now() - timedelta(days=4)
-            record.save()
-
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        # Mailbox should be empty
-        assert not WebhookPayload.objects.filter().exists()
-        # No requests sent because records are too old
-        assert len(responses.calls) == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_too_many_attempts(self) -> None:
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-            attempts=MAX_ATTEMPTS,
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
-        assert len(responses.calls) == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_more_than_max_attempts(self) -> None:
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-            attempts=MAX_ATTEMPTS + 1,
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
-        assert len(responses.calls) == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_fatality(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            # While this specific scenario won't happen, the client libraries could fail
-            body=ValueError(),
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        with pytest.raises(ValueError):
-            drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
-        assert hook
-        assert hook.attempts == 1
-        assert hook.schedule_for >= timezone.now()
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_host_error(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            body=ConnectionError(),
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
-        assert hook
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_conflict(self) -> None:
-        # Getting a conflict back from the region silo means
-        # we should drop the hook.
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=409,
-            body="",
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_api_error_unauthorized(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=401,
-            body="",
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
-        # We don't retry 401
-        assert hook is None
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_api_error_bad_request(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=400,
-            body="",
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
-        # We don't retry 400
-        assert hook is None
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_not_found(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/plugins/github/organizations/123/webhook/",
-            status=404,
-            body="<html><title>lol nope</title></html>",
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="plugins:123",
-            cell_name="us",
-            request_path="/plugins/github/organizations/123/webhook/",
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-
-        # We don't retry if the region 404s
-        hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
-        assert hook is None
-        assert len(responses.calls) == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_drain_timeout(self) -> None:
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", body=ReadTimeout()
-        )
-        webhook_one = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
-        hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
-        assert hook
-        assert hook.schedule_for > timezone.now()
-        assert hook.attempts == 1
-
-        assert len(responses.calls) == 1
+        assert not WebhookPayload.objects.exists()
 
 
 @control_silo_test
@@ -2064,7 +1733,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_conflict_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+    def test_serial_conflict_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2073,16 +1742,16 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=1)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
-        assert self.delivery_outcomes(mock_metrics) == ["conflict"]
+        assert self.delivery_outcomes(mock_metrics) == ["conflict", "claim_exhausted"]
         assert self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC) == []
 
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_unauthorized_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
+    def test_serial_unauthorized_not_counted_as_delivered(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2091,10 +1760,10 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=1)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
-        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
+        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "claim_exhausted"]
         assert self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC) == []
 
     @responses.activate
@@ -2196,7 +1865,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_dropped_outcome_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
+    def test_serial_dropped_outcome_tagged_with_provider(self, mock_metrics: MagicMock) -> None:
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2207,10 +1876,11 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(webhook.id, claimed_count=1)
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"}
+            {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"},
+            {**UNATTRIBUTED, "outcome": "claim_exhausted", "provider": "github"},
         ]
 
     @responses.activate
@@ -2376,11 +2046,8 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_delivery_time_carries_dispatch_attribution(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # The parallel path records latency from its own callsite, so it can lose
-        # attribution independently of the sequential one.
+    def test_wave_delivery_time_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
+        # Attribution must survive the threadpool hop, not only the serial walk.
         responses.add(
             responses.POST,
             "http://us.testserver/extensions/github/webhook/",
@@ -2389,7 +2056,9 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
         )
         records = create_payloads(2, "github:123", provider="github")
 
-        drain_mailbox_parallel(records[0].id, claimed_count=2, dispatcher=Dispatcher.PUSH)
+        drain_mailbox(
+            records[0].id, claimed_count=MIN_RECORDS_PER_THREAD + 1, dispatcher=Dispatcher.PUSH
+        )
 
         expected = {
             "dispatcher": "push",
@@ -2408,15 +2077,6 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
-        ]
-
-    @responses.activate
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_drain_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
-        drain_mailbox_parallel(99, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "scheduler", "outcome": "race", "provider": "unknown"}
         ]
 
     @responses.activate
@@ -2461,12 +2121,12 @@ class LostHeadTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_drain_delivers_nothing_when_its_head_is_gone(
+    def test_threaded_drain_delivers_nothing_when_its_head_is_gone(
         self, mock_metrics: MagicMock
     ) -> None:
-        # The stand-down must come before the batch is delivered, not after it:
-        # these rows are the overtaking drain's to deliver, and sending them here
-        # duplicates every one of them.
+        # The stand-down must come before the first wave is delivered, not after
+        # it: these rows are the overtaking drain's to deliver, and sending them
+        # here duplicates every one of them.
         responses.add(
             responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
         )
@@ -2474,7 +2134,7 @@ class LostHeadTest(MetricCallsMixin, TestCase):
         head_id = records[0].id
         records[0].delete()
 
-        drain_mailbox_parallel(head_id, claimed_count=3, mailbox="github:123")
+        drain_mailbox(head_id, claimed_count=MIN_RECORDS_PER_THREAD + 1, mailbox="github:123")
 
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 2
@@ -2518,26 +2178,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_parallel_expired_claim_leaves_rows_alone(self, mock_metrics: MagicMock) -> None:
-        records = create_payloads(2, "github:123", provider="github")
-
-        drain_mailbox_parallel(
-            records[0].id,
-            claimed_count=2,
-            dispatcher=Dispatcher.SCHEDULER,
-            valid_until=self.expired(),
-            mailbox="github:123",
-        )
-
-        assert len(responses.calls) == 0
-        assert WebhookPayload.objects.count() == 2
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "scheduler", "outcome": "delivery_deadline", "provider": "github"}
-        ]
-
-    @responses.activate
-    @override_cells(cell_config)
     def test_drain_stops_at_the_claim_deadline_not_a_fresh_one(self) -> None:
         responses.add(
             responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
@@ -2553,28 +2193,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             new_callable=PropertyMock(return_value=timedelta(minutes=0)),
         ):
             drain_mailbox(
-                records[0].id,
-                claimed_count=1,
-                valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
-            )
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_parallel_drain_stops_at_the_claim_deadline_not_a_fresh_one(self) -> None:
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        records = create_payloads(1, "github:123", provider="github")
-
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox_parallel(
                 records[0].id,
                 claimed_count=1,
                 valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
@@ -2728,9 +2346,13 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
 @control_silo_test
 class WaveConcurrencyTest(TestCase):
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.deliver_message")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks._run_parallel_delivery_batch")
-    def test_waves_scale_with_remaining_work(self, mock_batch: MagicMock) -> None:
+    def test_waves_scale_with_remaining_work(
+        self, mock_batch: MagicMock, mock_deliver: MagicMock
+    ) -> None:
         mock_batch.side_effect = lambda records, deleter, delivery_tags: len(records)
+        mock_deliver.return_value = True
         records = create_payloads(12, "github:123", provider="github")
 
         with override_options({"hybridcloud.webhookpayload.worker_threads": 3}):
@@ -2742,9 +2364,10 @@ class WaveConcurrencyTest(TestCase):
             )
 
         # ceil(remaining / MIN_RECORDS_PER_THREAD), capped at worker_threads,
-        # recomputed per wave so the tail tapers instead of holding full width.
+        # recomputed per wave; the tail falls back to serial delivery.
         wave_sizes = [len(call.args[0]) for call in mock_batch.call_args_list]
-        assert wave_sizes == [3, 2, 2, 1, 1, 1, 1, 1]
+        assert wave_sizes == [3, 2, 2]
+        assert mock_deliver.call_count == 5
 
     @responses.activate
     @override_cells(cell_config)
@@ -2841,7 +2464,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
         with patch.object(
             deliver_webhooks._MailboxClaim,
             "nearing_deadline",
-            side_effect=[False, False, True, True],
+            side_effect=[False, True],
         ):
             drain_mailbox(
                 records[0].id,
@@ -3166,13 +2789,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # The push trigger's claim moved the head past the drain deadline, so the
         # scheduler must not double-dispatch a drain for this mailbox.
         assert mock_drain.delay.call_count == 1
+        # Tripwire: dispatch must never reach the transitional shim task.
         assert mock_drain_parallel.delay.call_count == 0
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_scheduler_claim_blocks_push_trigger(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
-    ) -> None:
+    def test_scheduler_claim_blocks_push_trigger(self, mock_drain: MagicMock) -> None:
         create_payloads(3, "github:123")
 
         schedule_webhook_delivery()
@@ -3183,7 +2804,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # The scheduler's claim covers the mailbox; the push trigger must not
         # dispatch a second drain.
         assert mock_drain.delay.call_count == 1
-        assert mock_drain_parallel.delay.call_count == 0
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_claim_guard_keeps_the_short_ttl(self, mock_drain: MagicMock) -> None:
@@ -3196,11 +2816,8 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # would strand the mailbox that long whenever a dispatcher dies mid-claim.
         assert mock_add.call_args.kwargs["timeout"] == DRAIN_LOCK_TTL
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_trigger_respects_held_lock(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
-    ) -> None:
+    def test_trigger_respects_held_lock(self, mock_drain: MagicMock) -> None:
         # Another dispatcher is mid-claim and holds the lock; this trigger must
         # not dispatch over it.
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
@@ -3209,7 +2826,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         maybe_trigger_drain(webhook.mailbox_name)
 
         mock_drain.delay.assert_not_called()
-        mock_drain_parallel.delay.assert_not_called()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_trigger_respects_active_claim(self, mock_drain: MagicMock) -> None:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
@@ -124,7 +124,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id,
+            payload_id=webhook_one.id,
             claimed_count=2,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -145,7 +145,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id,
+            payload_id=webhook_one.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -189,7 +189,11 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         mock_deliver.delay.assert_called_once_with(
-            due.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER, valid_until=ANY, mailbox=ANY
+            payload_id=due.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
         )
         # The backing-off record keeps its retry schedule.
         backoff_schedule = backoff.schedule_for
@@ -229,7 +233,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         mock_deliver.delay.assert_called_once_with(
-            due_one.id,
+            payload_id=due_one.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -256,7 +260,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         mock_deliver.delay.assert_called_once_with(
-            expired_backoff.id,
+            payload_id=expired_backoff.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -291,7 +295,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
 
         assert mock_deliver.delay.call_count == 2
-        call_args_list = [call[0][0] for call in mock_deliver.delay.call_args_list]
+        call_args_list = [call.kwargs["payload_id"] for call in mock_deliver.delay.call_args_list]
         assert call_args_list == [stripe_webhook.id, github_webhook.id]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -316,7 +320,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         assert mock_deliver.delay.call_count == 1
         mock_deliver.delay.assert_called_with(
-            webhook_one.id,
+            payload_id=webhook_one.id,
             claimed_count=2,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -418,7 +422,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         assert outcome == "sequential"
         mock_drain.delay.assert_called_once_with(
-            webhook.id,
+            payload_id=webhook.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -465,7 +469,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         # Verify webhooks were processed in priority order (stripe first, then github, then slack)
         assert mock_deliver.delay.call_count == 3
         # Check the order of calls
-        call_args_list = [call[0][0] for call in mock_deliver.delay.call_args_list]
+        call_args_list = [call.kwargs["payload_id"] for call in mock_deliver.delay.call_args_list]
 
         # Stripe (priority 1) should be first
         assert call_args_list[0] == stripe_webhook.id
@@ -499,7 +503,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         # Verify webhooks were processed in priority order (stripe first, then unknown)
         assert mock_deliver.delay.call_count == 2
         # Check the order of calls
-        call_args_list = [call[0][0] for call in mock_deliver.delay.call_args_list]
+        call_args_list = [call.kwargs["payload_id"] for call in mock_deliver.delay.call_args_list]
 
         # Stripe (priority 1) should be first
         assert call_args_list[0] == stripe_webhook.id
@@ -538,7 +542,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         # Verify webhooks were processed in priority order (stripe first, then null provider)
         assert mock_deliver.delay.call_count == 2
         # Check the order of calls
-        call_args_list = [call[0][0] for call in mock_deliver.delay.call_args_list]
+        call_args_list = [call.kwargs["payload_id"] for call in mock_deliver.delay.call_args_list]
 
         # Stripe (priority 1) should be first
         assert call_args_list[0] == stripe_webhook.id
@@ -564,7 +568,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         schedule_webhook_delivery()
 
-        dispatched = [call[0][0] for call in mock_drain.delay.call_args_list]
+        dispatched = [call.kwargs["payload_id"] for call in mock_drain.delay.call_args_list]
         assert dispatched == [webhooks[1].id, webhooks[2].id]
 
     @patch.object(deliver_webhooks, "BATCH_SIZE", 2)
@@ -578,7 +582,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
         schedule_webhook_delivery()
 
-        dispatched = [call[0][0] for call in mock_drain.delay.call_args_list]
+        dispatched = [call.kwargs["payload_id"] for call in mock_drain.delay.call_args_list]
         assert dispatched == [webhooks[0].id, webhooks[1].id]
         # The surplus head is untouched — still due for the next cycle.
         webhooks[2].refresh_from_db()
@@ -600,7 +604,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch(
         "sentry.hybridcloud.tasks.deliver_webhooks._claim_mailbox_batch",
-        return_value=deliver_webhooks._MailboxClaim(claimed=0, valid_until=timezone.now()),
+        return_value=None,
     )
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_records_claim_lost(
@@ -637,7 +641,7 @@ class CarryoverTestBase(MetricCallsMixin, TestCase):
         return cache.get(deliver_webhooks.CARRYOVER_CACHE_KEY)
 
     def dispatched_ids(self, mock_drain: MagicMock) -> list[int]:
-        return [call[0][0] for call in mock_drain.delay.call_args_list]
+        return [call.kwargs["payload_id"] for call in mock_drain.delay.call_args_list]
 
     def carried(self, webhooks: list[WebhookPayload]) -> list[dict[str, Any]]:
         return [{"id": w.id, "mailbox_name": w.mailbox_name} for w in webhooks]
@@ -2457,9 +2461,9 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
     fallen due for another dispatcher, so delivering them again duplicates.
     """
 
-    def expired(self) -> str:
+    def expired(self) -> float:
         """A claim deadline that has already passed."""
-        return (timezone.now() - timedelta(seconds=1)).isoformat()
+        return (timezone.now() - timedelta(seconds=1)).timestamp()
 
     @responses.activate
     @override_cells(cell_config)
@@ -2522,7 +2526,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             drain_mailbox(
                 records[0].id,
                 claimed_count=1,
-                valid_until=(timezone.now() + timedelta(minutes=5)).isoformat(),
+                valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
             )
 
         assert len(responses.calls) == 1
@@ -2544,7 +2548,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             drain_mailbox_parallel(
                 records[0].id,
                 claimed_count=1,
-                valid_until=(timezone.now() + timedelta(minutes=5)).isoformat(),
+                valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
             )
 
         assert len(responses.calls) == 1
@@ -2578,7 +2582,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        valid_until = (timezone.now() + BATCH_SCHEDULE_OFFSET).isoformat()
+        valid_until = (timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp()
         drain_mailbox(webhook.id, claimed_count=1, valid_until=valid_until)
 
         assert len(responses.calls) == 1
@@ -2599,7 +2603,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             drain_mailbox(
                 webhook.id,
                 claimed_count=1,
-                valid_until=deadline.isoformat(),
+                valid_until=deadline.timestamp(),
                 mailbox="github:123",
             )
 
@@ -2647,15 +2651,35 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_without_a_mailbox_reports_unknown_provider(
+    def test_expired_claim_without_a_mailbox_reads_it_off_the_head(
         self, mock_metrics: MagicMock
     ) -> None:
-        # Drains enqueued before dispatch sent a mailbox: attribution is the only
-        # thing lost, and only until they drain out.
+        # Drains enqueued before dispatch sent a mailbox still name their provider:
+        # the head row carries it, and the drain reads it before anything else.
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123", cell_name="us", provider="github"
+        )
+
+        drain_mailbox(
+            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired()
+        )
+
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "github"}
+        ]
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_expired_claim_with_neither_mailbox_nor_head_reports_a_race(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # Nothing left to name the provider with. Only drains enqueued before
+        # dispatch sent a mailbox can land here, and only until they drain out.
         drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "unknown"}
+            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
         ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2666,7 +2690,9 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
         schedule_webhook_delivery()
 
-        valid_until = datetime.fromisoformat(mock_drain.delay.call_args.kwargs["valid_until"])
+        valid_until = datetime.fromtimestamp(
+            mock_drain.delay.call_args.kwargs["valid_until"], tz=UTC
+        )
         webhook.refresh_from_db()
         assert webhook.schedule_for == valid_until
 
@@ -2678,7 +2704,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         maybe_trigger_drain(webhook.mailbox_name)
         mock_drain.delay.assert_called_once_with(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=ANY, mailbox=ANY
+            payload_id=webhook.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
         )
         # The batch is claimed before dispatch; the claim is what keeps other
         # dispatchers off the mailbox while the drain runs.
@@ -2717,7 +2747,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         maybe_trigger_drain(newer_webhook.mailbox_name)
         # Must drain from the head of the mailbox so the older payload is not skipped
         mock_drain.delay.assert_called_once_with(
-            older_webhook.id,
+            payload_id=older_webhook.id,
             claimed_count=2,
             dispatcher=Dispatcher.PUSH,
             valid_until=ANY,
@@ -2755,7 +2785,11 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         maybe_trigger_drain("github:123")
 
         mock_drain.delay.assert_called_once_with(
-            due.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=ANY, mailbox=ANY
+            payload_id=due.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2823,7 +2857,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
 
         # Only mailbox B should have been scheduled
         mock_drain.delay.assert_called_once_with(
-            webhook_b.id,
+            payload_id=webhook_b.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=ANY,
@@ -2877,7 +2911,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         webhook_two = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         maybe_trigger_drain(webhook_two.mailbox_name)
         mock_drain.delay.assert_called_once_with(
-            webhook_two.id,
+            payload_id=webhook_two.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
             valid_until=ANY,
@@ -2914,7 +2948,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # A mailbox this deep is behind; the sequential drain would work it off at
         # one in-flight request for its whole run.
         mock_drain_parallel.delay.assert_called_once_with(
-            records[0].id,
+            payload_id=records[0].id,
             claimed_count=PARALLEL_DRAIN_THRESHOLD,
             dispatcher=Dispatcher.PUSH,
             valid_until=ANY,
@@ -2933,7 +2967,7 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
 
         # One record short of the threshold keeps strict ordering.
         mock_drain.delay.assert_called_once_with(
-            records[0].id,
+            payload_id=records[0].id,
             claimed_count=PARALLEL_DRAIN_THRESHOLD - 1,
             dispatcher=Dispatcher.PUSH,
             valid_until=ANY,

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1745,7 +1745,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         drain_mailbox(webhook.id, claimed_count=1)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
-        assert self.delivery_outcomes(mock_metrics) == ["conflict", "claim_exhausted"]
+        assert self.delivery_outcomes(mock_metrics) == ["conflict"]
         assert self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC) == []
 
     @responses.activate
@@ -1763,7 +1763,7 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         drain_mailbox(webhook.id, claimed_count=1)
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
-        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "claim_exhausted"]
+        assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
         assert self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC) == []
 
     @responses.activate
@@ -1879,8 +1879,7 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         drain_mailbox(webhook.id, claimed_count=1)
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"},
-            {**UNATTRIBUTED, "outcome": "claim_exhausted", "provider": "github"},
+            {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"}
         ]
 
     @responses.activate
@@ -2008,11 +2007,8 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
 
         drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
 
-        # `claim_exhausted` has no provider tag, so it is the outcome most likely
-        # to be missed when attribution is added; assert it alongside the delivery.
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "scheduler", "outcome": "ok", "provider": "github"},
-            {"dispatcher": "scheduler", "outcome": "claim_exhausted", "provider": "github"},
+            {"dispatcher": "scheduler", "outcome": "ok", "provider": "github"}
         ]
 
     @responses.activate

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -2067,24 +2067,20 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
     @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_race_outcome_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
-        # A race means the row is already gone, so the outcome carries no provider
-        # and attribution is all that is left to tell the dispatchers apart.
-        drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH)
+        records = create_payloads(2, "github:123", provider="github")
+        head_id = records[0].id
+        records[0].delete()
+
+        drain_mailbox(
+            head_id,
+            claimed_count=2,
+            dispatcher=Dispatcher.PUSH,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
-        ]
-
-    @responses.activate
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_drain_enqueued_before_deploy_tags_unknown(self, mock_metrics: MagicMock) -> None:
-        # Tasks already queued when this deploys arrive without a dispatcher. The
-        # key must still be emitted: a tag absent from some series breaks grouping
-        # rather than showing a gap.
-        drain_mailbox(99, claimed_count=1)
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {**UNATTRIBUTED, "outcome": "race", "provider": "unknown"}
+            {"dispatcher": "push", "outcome": "race", "provider": "github"}
         ]
 
 
@@ -2106,7 +2102,7 @@ class LostHeadTest(MetricCallsMixin, TestCase):
         head_id = records[0].id
         records[0].delete()
 
-        drain_mailbox(head_id, claimed_count=3, mailbox="github:123")
+        drain_mailbox(head_id, claimed_count=3, mailbox="github:123", valid_until=fresh_deadline())
 
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 2
@@ -2130,7 +2126,12 @@ class LostHeadTest(MetricCallsMixin, TestCase):
         head_id = records[0].id
         records[0].delete()
 
-        drain_mailbox(head_id, claimed_count=MIN_RECORDS_PER_THREAD + 1, mailbox="github:123")
+        drain_mailbox(
+            head_id,
+            claimed_count=MIN_RECORDS_PER_THREAD + 1,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 2
@@ -2338,16 +2339,14 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_with_neither_mailbox_nor_head_reports_a_race(
+    def test_expired_claim_with_neither_mailbox_nor_head_stands_down_quietly(
         self, mock_metrics: MagicMock
     ) -> None:
-        # Nothing left to name the provider with. Only drains enqueued before
-        # dispatch sent a mailbox can land here, and only until they drain out.
+        # Only a drain enqueued before dispatch sent a mailbox can land here;
+        # there is nothing to deliver and nothing left to attribute.
         drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired())
 
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
-        ]
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == []
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_dispatch_passes_the_rows_own_deadline(self, mock_drain: MagicMock) -> None:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,6 +1,6 @@
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import Any
-from unittest.mock import ANY, MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import responses
@@ -126,8 +126,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook_one.id,
             claimed_count=2,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -147,8 +145,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook_one.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -191,8 +187,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=due.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
         # The backing-off record keeps its retry schedule.
         backoff_schedule = backoff.schedule_for
@@ -235,8 +229,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=due_one.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
         backoff_schedule = backoff.schedule_for
         backoff.refresh_from_db()
@@ -262,8 +254,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=expired_backoff.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @override_options(DUE_HEAD_OPTIONS)
@@ -322,8 +312,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook_one.id,
             claimed_count=2,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @responses.activate
@@ -417,8 +405,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
         # Option reads are served from the option store's cache in production,
         # so only payload-table statements count toward the round-trip budget.
@@ -2339,54 +2325,16 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_with_neither_mailbox_nor_head_stands_down_quietly(
+    def test_expired_claim_with_neither_mailbox_nor_head_reports_a_race(
         self, mock_metrics: MagicMock
     ) -> None:
-        # Only a drain enqueued before dispatch sent a mailbox can land here;
-        # there is nothing to deliver and nothing left to attribute.
+        # Nothing left to name the provider with; the row read is still the race
+        # site for every drain until dispatch sends the claim.
         drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired())
 
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == []
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_dispatch_passes_the_rows_own_deadline(self, mock_drain: MagicMock) -> None:
-        # The drain must be handed the schedule_for its claim wrote, not a value
-        # recomputed from an offset that may differ between dispatcher and worker.
-        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-
-        schedule_webhook_delivery()
-
-        valid_until = datetime.fromtimestamp(
-            mock_drain.delay.call_args.kwargs["valid_until"], tz=UTC
-        )
-        webhook.refresh_from_db()
-        assert webhook.schedule_for == valid_until
-
-
-@control_silo_test
-class WaveConcurrencyTest(TestCase):
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.deliver_message")
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks._run_parallel_delivery_batch")
-    def test_waves_scale_with_remaining_work(
-        self, mock_batch: MagicMock, mock_deliver: MagicMock
-    ) -> None:
-        mock_batch.side_effect = lambda records, deleter, delivery_tags: len(records)
-        mock_deliver.return_value = True
-        records = create_payloads(12, "github:123", provider="github")
-
-        with override_options({"hybridcloud.webhookpayload.worker_threads": 3}):
-            drain_mailbox(
-                records[0].id,
-                claimed_count=12,
-                valid_until=(timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp(),
-                mailbox="github:123",
-            )
-
-        # ceil(remaining / MIN_RECORDS_PER_THREAD), capped at worker_threads,
-        # recomputed per wave; the tail falls back to serial delivery.
-        wave_sizes = [len(call.args[0]) for call in mock_batch.call_args_list]
-        assert wave_sizes == [3, 2, 2]
-        assert mock_deliver.call_count == 5
+        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
+            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
+        ]
 
     @responses.activate
     @override_cells(cell_config)
@@ -2509,8 +2457,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=webhook.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
         )
         # The batch is claimed before dispatch; the claim is what keeps other
         # dispatchers off the mailbox while the drain runs.
@@ -2552,8 +2498,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=older_webhook.id,
             claimed_count=2,
             dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2590,8 +2534,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=due.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2662,8 +2604,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=webhook_b.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2716,8 +2656,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=webhook_two.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2751,8 +2689,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=records[0].id,
             claimed_count=MIN_RECORDS_PER_THREAD + 1,
             dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
         )
         assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
             {"dispatcher": "push", "drain": "parallel", "provider": "github"}
@@ -2772,8 +2708,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=records[0].id,
             claimed_count=MIN_RECORDS_PER_THREAD,
             dispatcher=Dispatcher.PUSH,
-            valid_until=ANY,
-            mailbox=ANY,
         )
         assert self.tags_for(mock_metrics, DISPATCH_METRIC) == [
             {"dispatcher": "push", "drain": "sequential", "provider": "github"}

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -1034,6 +1035,33 @@ class DrainMailboxTest(TestCase):
         assert len(responses.calls) == 6
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
         assert remaining == {records[6].id, records[7].id}
+
+    @override_cells(cell_config)
+    def test_unexpected_wave_error_does_not_abandon_sibling_deliveries(self) -> None:
+        # An unexpected error surfaces from the wave, but only after every
+        # result is processed: a sibling delivered on another thread must still
+        # be deleted, or a later claim would redeliver it.
+        records = create_payloads(MIN_RECORDS_PER_THREAD + 1, "github:123", provider="github")
+
+        def deliver(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:
+            if payload.id == records[0].id:
+                return (payload, ValueError("boom"))
+            # Complete after the error's result is already being handled.
+            time.sleep(0.2)
+            return (payload, None)
+
+        with patch.object(deliver_webhooks, "deliver_message_parallel", side_effect=deliver):
+            with pytest.raises(ValueError):
+                drain_mailbox(
+                    records[0].id,
+                    claimed_count=MIN_RECORDS_PER_THREAD + 1,
+                    valid_until=fresh_deadline(),
+                )
+
+        remaining = set(WebhookPayload.objects.values_list("id", flat=True))
+        # The delivered sibling is gone; the errored head keeps its retry.
+        assert records[1].id not in remaining
+        assert records[0].id in remaining
 
     @responses.activate
     @override_cells(cell_config)


### PR DESCRIPTION
## Problem

Two bugs in how drains relate to the claims that authorize them.

**Claims lapse while their drains sit in queue.** A dispatcher claims a mailbox's rows by pushing `schedule_for` out by `BATCH_SCHEDULE_OFFSET`, then enqueues a drain. Once `hybridcloud.control` queue wait exceeds that horizon, the rows come due again and get re-claimed while the original drain is still queued — every drain enqueued for the same rows eventually runs. Sibling drains delete rows out from under each other (`outcome:race`), cells reject deliveries they already took (`outcome:conflict`), and the waste compounds exactly when the queue is behind. The drain's stop-block had the same flaw from the other side: it computed a *fresh* horizon at start, so a drain that waited T seconds in queue delivered T seconds past the point its rows became claimable again.

**Strict-ordering providers were delivered out of order.** The drain task was chosen by claim depth alone, so any provider's deep mailbox went through the parallel drain — reordering a strict provider's webhooks precisely when its backlog was largest. This is not an edge case: in steady state, every parallel dispatch is a strict provider (github's bucketed mailboxes never cross the depth threshold), so the reordering path's entire workload was traffic it was never meant to carry.

Also fixes CW-1926

## Change

**The claim carries its deadline.** `_claim_mailbox_batch` computes it once, writes that exact value as the claimed rows' `schedule_for`, and returns it in a `_MailboxClaim`. Passing the *written* deadline rather than the claim time makes the bound exact: "my claim expired" and "my rows are claimable again" are the same instant, with no offset arithmetic in the worker to drift from the dispatcher's. The drain checks it at both ends — stands down before reading anything, stops delivering on reaching it — through one `_MailboxClaim.lapsed`.

**One drain, one delivery pool.** `drain_mailbox` and `drain_mailbox_parallel` collapse into one loop that feeds a single `ThreadPoolExecutor` per drain, one record at a time as threads free up, and handles every result on the drain thread. The pool's size is the only thing the claim decides:

- Skip-on-failure claims get `worker_threads` threads (capped at the claim's size). No waves: a slow cell request holds up its own thread, not the three beside it.
- Strict claims get one thread, at any depth: one record at a time, in order, stopping at the first retryable failure. This is the ordering fix. A strict record spends its attempt before the request goes out, as the old sequential path did, so a drain killed mid-request cannot retry it at every claim horizon until it is stale — that would head-block the mailbox for three days. Skip-on-failure records are spared the extra write; due-head dispatch passes over such a record.

**Nearing its deadline, a drain hands back what it never reached.** Within `RELEASE_MARGIN` of the deadline it stops feeding the pool, cancels what has not started, settles what has, flushes its deletes, and releases the unworked tail from the lowest cancelled id — an UPDATE matching the exact `schedule_for` its claim wrote, so rows another claim took or a failure rescheduled pass untouched. Released rows are claimable immediately; the deadline stays a failsafe instead of becoming the routine stop mechanism.

**No wait outlasts a request's bound.** A delivery request is bounded by the new `CELL_REQUEST_TIMEOUT` for connect and read back to back; `REQUEST_BOUND` is that plus slack, and `RELEASE_MARGIN` is derived from it plus a settle allowance for the flush and release. Every wait on the pool is capped by the bound, and the wind-down also by what is left before the settle deadline. A request still running past that is abandoned: its record goes into its retry backoff (`outcome:abandoned`, unsampled), its thread is left to finish on its own, and the flush and release still land in time. Nothing answering inside the bound means the cell is down: the drain stops, logs `deliver_webhook.cell_unresponsive`, and leaves its tail parked under the claim rather than releasing it, since a release would only send the next drain into the same cell.

## Behavior changes worth a look

- **Strict providers' deep-mailbox burn drops to serial speed** until they move into `hybridcloud.webhookpayload.skip_on_failure_providers`. Accepted deliberately: correctness over the accidental throughput of the bug. The list is a live option, so the escape hatch needs no deploy if a strict provider backs up in the interim.
- **A strict failure now stops delivery at the failed record.** The parallel path only stopped *between* waves, so up to a full wave delivered out of order past the failure.
- **The `drain` tag on `dispatch`, `dispatch.claimed` and `push_trigger.success` is gone.** It only restated `provider` (threaded ⇔ skip-on-failure). Widgets splitting by it need updating after deploy.
- **`outcome:released` is new; `outcome:claim_exhausted` is gone.** The latter was a per-drain marker in a per-row outcome stream, dominated by one-row push claims trivially consuming their claims; claim-cap saturation is already visible in `dispatch.claimed`.
- **A claim's records are read in one query** rather than 100-row slices: up to `MAX_MAILBOX_DRAIN` rows with bodies held for the drain's run. At 300 that is at most 3× what a slice held.
- **No path grants a delivery attempt past `MAX_ATTEMPTS` anymore**, and a `worker_threads` of 0 degrades to one thread instead of failing every skip-on-failure drain until the option changes.
- **`drain.wind_down_ms` is a new distribution**, tagged by the reason the drain stopped (`deadline`, `stuck`, `lapsed`, `error`, `cleanup`), for every wind-down that had requests to wait for. With the waits bounded it can no longer exceed `REQUEST_BOUND`; `outcome:abandoned` and `deliver_webhook.cell_unresponsive` are where a stuck cell now shows up, and a release that still lands past the deadline logs `deliver_webhook.release_overshoot`. An abandoned request's thread lives until its socket gives up — for a cell that keeps trickling bytes, until the worker process restarts — since nothing in `requests` bounds a request's wall-clock.

## Shape

- **`_MailboxClaim`** carries `head_id`, `mailbox_name`, `dispatcher`, count and deadline, and derives `provider`, `delivery_tags` and `skip_on_failure`. A frozen dataclass, not a `NamedTuple` — a tuple is precisely what the task codec flattens into a list without complaint, so this is the type that most needs to fail loudly if handed to `delay()` directly. `records()` reads the claim and does the lost-head check ahead of any delivery.
- **`_DeliveryPool`** owns the executor and the in-flight set: `submit`, `wait_one`, and `wind_down`, which returns where a release must start. Workers only perform requests, which is what lets `_PayloadDeleter` stay unlocked.
- **`_drain_mailbox`** is one loop: deadline checks, top up the pool, wait for a result, and the strict stop as its only provider-specific branch.
- **`task_args()` is the single definition of the wire shape**, read back by `_begin_drain`; `valid_until` crosses as an epoch float, since the codec carries only what msgpack has a type for.

## Rolling deploy

Dispatch still sends only the kwargs the previous deploy's workers bind — an unknown kwarg is a `TypeError` the taskbroker discards without retry — so `valid_until` and `mailbox` default to `None` and a drain missing either reads both off its head row in one query; its claim already wrote the deadline there as the rows' `schedule_for`. Drains enqueued by the previous deploy therefore get the real bound too, and one whose claim already lapsed stands down. `drain_mailbox_parallel` remains as a shim over the same loop for in-flight tasks. The full `task_args()` shape goes on the wire, and the fallbacks and shim come out, one deploy later.

## Tests

Tests pin the delivery mode they mean with `worker_threads` (1 for in-order coverage) rather than inheriting it from claim depth. New coverage: a strict claim never has two requests in flight while a skip-on-failure claim does; the release settles in-flight requests before covering the tail, and `wind_down` names a cancelled, never-started request as where the release starts; the attempt is spent before the request for strict records and on the result for the rest; an unexpected error surfaces only after every in-flight result is handled; a request the wind-down cannot wait out is abandoned into its backoff while its answered sibling is deleted, and a cell answering nothing inside the bound stops the drain with its tail left under the claim.
