### PR TITLE
fix(onboarding): Keep SCM provider pills on a single wrapping row

### DIFF
--- a/static/app/components/onboarding/scm/scmProviderPills.tsx
+++ b/static/app/components/onboarding/scm/scmProviderPills.tsx
@@ -1,4 +1,4 @@
-import {Flex, Grid, useResponsivePropValue} from '@sentry/scraps/layout';
+import {Flex, useResponsivePropValue} from '@sentry/scraps/layout';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
@@ -27,11 +27,11 @@ interface ScmProviderPillsProps {
 
 export function ScmProviderPills(props: ScmProviderPillsProps) {
   return (
-    // Declares its own query container: the pills always render on one row and
-    // compact against this wrapper's width when it is tight. The wrapper is
-    // capped well below the page-level container scale, so page-relative keys
-    // would never fire here. The row is a separate component because it reads
-    // this container in JS, and an element can't query itself.
+    // Declares its own query container: the pills compact and wrap against
+    // this wrapper's width when it is tight. The wrapper is capped well below
+    // the page-level container scale, so page-relative keys would never fire
+    // here. The row is a separate component because it reads this container in
+    // JS, and an element can't query itself.
     <Flex justify="start" containerType="inline-size">
       <ScmProviderPillRow {...props} />
     </Flex>
@@ -48,29 +48,15 @@ function ScmProviderPillRow({
   const {primaryProviders, moreProviders} = partitionScmProviders(providers);
   const view = INSTALL_VIEW[analyticsFlow];
 
-  // When the row is tight the pills compact instead of stacking: the xs button
-  // size with matching icons, natural-width tracks, and a tighter gap, all
-  // flipping at the same container threshold.
-  const buttonSize = useResponsivePropValue<'xs' | 'md'>({zero: 'xs', sm: 'md'});
-  const iconSize = buttonSize === 'md' ? 'sm' : 'xs';
-
-  const columnTracks = (providerTrack: string) =>
-    [
-      primaryProviders.length && `repeat(${primaryProviders.length}, ${providerTrack})`,
-      moreProviders.length && 'min-content',
-    ]
-      .filter(Boolean)
-      .join(' ');
+  // When the row is tight the pills compact: the xs button size with matching
+  // icons and a tighter gap. Pills that still do not fit wrap to the next line
+  // instead of overflowing the container.
+  const isCompact = useResponsivePropValue({zero: true, sm: false});
+  const buttonSize = isCompact ? 'xs' : 'md';
+  const iconSize = isCompact ? 'xs' : 'sm';
 
   return (
-    <Grid
-      columns={{
-        zero: columnTracks('auto'),
-        sm: columnTracks('1fr'),
-      }}
-      justify="center"
-      gap={{zero: 'sm', sm: 'md'}}
-    >
+    <Flex wrap="wrap" gap={{zero: 'sm', sm: 'md'}}>
       {primaryProviders.map(provider => (
         <IntegrationContext
           key={provider.key}
@@ -122,6 +108,6 @@ function ScmProviderPillRow({
           }))}
         />
       )}
-    </Grid>
+    </Flex>
   );
 }

--- a/static/app/components/onboarding/scm/scmProviderPills.tsx
+++ b/static/app/components/onboarding/scm/scmProviderPills.tsx
@@ -1,4 +1,4 @@
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, useResponsivePropValue} from '@sentry/scraps/layout';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
@@ -25,7 +25,20 @@ interface ScmProviderPillsProps {
   providers: IntegrationProvider[];
 }
 
-export function ScmProviderPills({
+export function ScmProviderPills(props: ScmProviderPillsProps) {
+  return (
+    // Declares its own query container: the pills always render on one row and
+    // compact against this wrapper's width when it is tight. The wrapper is
+    // capped well below the page-level container scale, so page-relative keys
+    // would never fire here. The row is a separate component because it reads
+    // this container in JS, and an element can't query itself.
+    <Flex justify="start" containerType="inline-size">
+      <ScmProviderPillRow {...props} />
+    </Flex>
+  );
+}
+
+function ScmProviderPillRow({
   analyticsFlow,
   providers,
   onInstall,
@@ -34,76 +47,81 @@ export function ScmProviderPills({
   const {startFlow} = useAddIntegration();
   const {primaryProviders, moreProviders} = partitionScmProviders(providers);
   const view = INSTALL_VIEW[analyticsFlow];
-  const gridItemCount = primaryProviders.length + (moreProviders.length > 0 ? 1 : 0);
 
-  const columnsXs = `repeat(${Math.min(gridItemCount, 2)}, 1fr)`;
-  const columnsMd = [
-    primaryProviders.length && `repeat(${primaryProviders.length}, 1fr)`,
-    moreProviders.length && 'min-content',
-  ]
-    .filter(Boolean)
-    .join(' ');
+  // When the row is tight the pills compact instead of stacking: the xs button
+  // size with matching icons, natural-width tracks, and a tighter gap, all
+  // flipping at the same container threshold.
+  const buttonSize = useResponsivePropValue<'xs' | 'md'>({zero: 'xs', sm: 'md'});
+  const iconSize = buttonSize === 'md' ? 'sm' : 'xs';
+
+  const columnTracks = (providerTrack: string) =>
+    [
+      primaryProviders.length && `repeat(${primaryProviders.length}, ${providerTrack})`,
+      moreProviders.length && 'min-content',
+    ]
+      .filter(Boolean)
+      .join(' ');
 
   return (
-    <Flex justify="start">
-      <Grid
-        columns={{
-          zero: columnsXs,
-          '3xl': columnsMd,
-        }}
-        justify="center"
-        gap="md"
-      >
-        {primaryProviders.map(provider => (
-          <IntegrationContext
-            key={provider.key}
-            value={{
-              provider,
-              type: 'first_party',
-              installStatus: 'Not Installed',
-              analyticsParams: {
-                view,
-                variant: 'scm',
-                already_installed: false,
-              },
-              suppressSuccessMessage: true,
+    <Grid
+      columns={{
+        zero: columnTracks('auto'),
+        sm: columnTracks('1fr'),
+      }}
+      justify="center"
+      gap={{zero: 'sm', sm: 'md'}}
+    >
+      {primaryProviders.map(provider => (
+        <IntegrationContext
+          key={provider.key}
+          value={{
+            provider,
+            type: 'first_party',
+            installStatus: 'Not Installed',
+            analyticsParams: {
+              view,
+              variant: 'scm',
+              already_installed: false,
+            },
+            suppressSuccessMessage: true,
+          }}
+        >
+          <IntegrationButton
+            userHasAccess
+            onAddIntegration={onInstall}
+            onExternalClick={() => {}}
+            buttonProps={{
+              size: buttonSize,
+              icon: getIntegrationIcon(provider.key, iconSize),
+              buttonText: provider.name,
             }}
-          >
-            <IntegrationButton
-              userHasAccess
-              onAddIntegration={onInstall}
-              onExternalClick={() => {}}
-              buttonProps={{
-                icon: getIntegrationIcon(provider.key, 'sm'),
-                buttonText: provider.name,
-              }}
-            />
-          </IntegrationContext>
-        ))}
-        {moreProviders.length > 0 && (
-          <DropdownMenu
-            triggerLabel={t('More')}
-            position="bottom-end"
-            items={moreProviders.map(provider => ({
-              key: provider.key,
-              label: provider.name,
-              leadingItems: getIntegrationIcon(provider.key, 'sm'),
-              onAction: () =>
-                startFlow({
-                  provider,
-                  organization,
-                  onInstall,
-                  analyticsParams: {
-                    view,
-                    variant: 'scm',
-                    already_installed: false,
-                  },
-                  suppressSuccessMessage: true,
-                }),
-            }))}
           />
-        )}
-      </Grid>
-    </Flex>
+        </IntegrationContext>
+      ))}
+      {moreProviders.length > 0 && (
+        <DropdownMenu
+          triggerLabel={t('More')}
+          position="bottom-end"
+          size={buttonSize}
+          items={moreProviders.map(provider => ({
+            key: provider.key,
+            label: provider.name,
+            leadingItems: getIntegrationIcon(provider.key, iconSize),
+            onAction: () =>
+              startFlow({
+                provider,
+                organization,
+                onInstall,
+                analyticsParams: {
+                  view,
+                  variant: 'scm',
+                  already_installed: false,
+                },
+                suppressSuccessMessage: true,
+              }),
+          }))}
+        />
+      )}
+    </Grid>
   );
 }


### PR DESCRIPTION
With the SCM steps' query containers restored in the base PR, the provider pills would regain their old behavior: stacking into a 2x2 grid below a 1024px page container, which showed the mobile layout at tablet widths. That breakpoint was too conservative even before the container query migration, engaging the single row only at a 992px viewport when the row fits in about 500px.

The pills now render as a single wrapping flex row and declare their own query container, so they behave the same in onboarding and project creation. Below 512px of available room they compact instead of stacking: the xs button size with matching icons and a tighter gap, resolved against the wrapper with `useResponsivePropValue`. Pills that still do not fit at any size wrap to the next line instead of overflowing the container.

Replacing the previous grid with a flex row also means pills take their natural width everywhere; the old grid stretched every pill to the width of the widest one.

|before|after|
|-|-|
|<img width="400" height="859" alt="Screenshot 2026-08-27 at 1 29 28 PM" src="https://github.com/user-attachments/assets/78092712-1d5a-49f7-8716-92e82c7e0be8" />|<img width="402" height="864" alt="Screenshot 2026-08-27 at 1 29 06 PM" src="https://github.com/user-attachments/assets/60ac3883-2043-4126-8b87-691e269752ef" />|
