### PR TITLE
fix(issue-inbox): Enable Seer rollout in frontend

### DIFF
--- a/static/app/components/groupHeaderRow.tsx
+++ b/static/app/components/groupHeaderRow.tsx
@@ -13,6 +13,7 @@ import {IconStar} from 'sentry/icons';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getMessage} from 'sentry/utils/events';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
@@ -45,7 +46,7 @@ function usePreloadGroupOnHover({
           groupId,
           organizationSlug: organization.slug,
           environments: selection.environments,
-          expandDerivedData: organization.features.includes('issue-inbox'),
+          expandDerivedData: orgHasIssueInbox(organization),
         })
       );
     },

--- a/static/app/utils/seer/orgHasIssueInbox.spec.ts
+++ b/static/app/utils/seer/orgHasIssueInbox.spec.ts
@@ -1,0 +1,18 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
+
+describe('orgHasIssueInbox', () => {
+  it('requires a Seer entitlement for the rollout feature', () => {
+    expect(
+      orgHasIssueInbox(
+        OrganizationFixture({
+          features: ['issue-inbox-seer-rollout', 'seat-based-seer-enabled'],
+        })
+      )
+    ).toBe(true);
+    expect(
+      orgHasIssueInbox(OrganizationFixture({features: ['issue-inbox-seer-rollout']}))
+    ).toBe(false);
+  });
+});

--- a/static/app/utils/seer/orgHasIssueInbox.ts
+++ b/static/app/utils/seer/orgHasIssueInbox.ts
@@ -1,0 +1,12 @@
+import type {Organization} from 'sentry/types/organization';
+
+export function orgHasIssueInbox(organization: Organization) {
+  const hasSeerEntitlement =
+    organization.features.includes('seat-based-seer-enabled') ||
+    organization.features.includes('seer-added');
+
+  return (
+    organization.features.includes('issue-inbox') ||
+    (organization.features.includes('issue-inbox-seer-rollout') && hasSeerEntitlement)
+  );
+}

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -12,6 +12,7 @@ import {t} from 'sentry/locale';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {Group} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 
 import {NoContext} from './quickContextWrapper';
@@ -46,7 +47,7 @@ export function IssueContext(props: BaseContextProps) {
       organizationSlug: organization.slug,
       // The link to issue details doesn't seem to currently pass selected environments
       environments: [],
-      expandDerivedData: organization.features.includes('issue-inbox'),
+      expandDerivedData: orgHasIssueInbox(organization),
     })
   );
 

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -42,6 +42,7 @@ import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useDisableRouteAnalytics} from 'sentry/utils/routeAnalytics/useDisableRouteAnalytics';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocationQuery} from 'sentry/utils/url/useLocationQuery';
 import {useApi} from 'sentry/utils/useApi';
@@ -220,7 +221,7 @@ function useSyncGroupStore(groupId: string, incomingEnvs: string[]) {
             groupId: storeGroup.id,
             organizationSlug: organization.slug,
             environments: incomingEnvs,
-            expandDerivedData: organization.features.includes('issue-inbox'),
+            expandDerivedData: orgHasIssueInbox(organization),
           }).queryKey,
           prev => (prev ? {...prev, json: storeGroup as Group} : prev)
         );

--- a/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
@@ -15,6 +15,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useOpenPeriods} from 'sentry/views/detectors/hooks/useOpenPeriods';
 import {issueFirstLastReleaseQueryOptions} from 'sentry/views/issueDetails/issueFirstLastReleaseQueryOptions';
@@ -27,7 +28,7 @@ function useFetchAllEnvsGroupData(organization: Organization, group: Group) {
       organizationSlug: organization.slug,
       groupId: group.id,
       environments: [],
-      expandDerivedData: organization.features.includes('issue-inbox'),
+      expandDerivedData: orgHasIssueInbox(organization),
     }),
     gcTime: 30_000,
   });

--- a/static/app/views/issueDetails/useGroup.tsx
+++ b/static/app/views/issueDetails/useGroup.tsx
@@ -2,6 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import type {Group} from 'sentry/types/group';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
@@ -58,7 +59,7 @@ export function useGroup({groupId, options}: UseGroupOptions) {
       organizationSlug: organization.slug,
       groupId,
       environments,
-      expandDerivedData: organization.features.includes('issue-inbox'),
+      expandDerivedData: orgHasIssueInbox(organization),
     }),
     gcTime: 30_000,
     retry: false,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -44,6 +44,7 @@ import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useDisableRouteAnalytics} from 'sentry/utils/routeAnalytics/useDisableRouteAnalytics';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -221,7 +222,7 @@ function IssueListOverviewInner({
   const hasRecommendedSortDefault = organization.features.includes(
     'issue-stream-recommended-sort-default'
   );
-  const hasIssueInbox = organization.features.includes('issue-inbox');
+  const hasIssueInbox = orgHasIssueInbox(organization);
   // The stored sort is the user's preferred sort for the unsaved feed.
   // Saved views persist their own sort, so they neither read nor write it.
   const defaultSort = urlParams.viewId

--- a/static/app/views/issueList/pages/inbox/index.tsx
+++ b/static/app/views/issueList/pages/inbox/index.tsx
@@ -44,6 +44,7 @@ import {getMessage, getTitle} from 'sentry/utils/events';
 import {useMembers} from 'sentry/utils/members/useMembers';
 import {parseActorString} from 'sentry/utils/parseActorString';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {orgHasSeerAccess} from 'sentry/utils/seer/orgHasSeerAccess';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMedia} from 'sentry/utils/useMedia';
@@ -148,7 +149,7 @@ const SECTIONS: [InboxSectionConfig, ...InboxSectionConfig[]] = [
 
 export default function InboxPage() {
   const organization = useOrganization();
-  const hasIssueInbox = organization.features.includes('issue-inbox');
+  const hasIssueInbox = orgHasIssueInbox(organization);
 
   if (!hasIssueInbox || !orgHasSeerAccess(organization)) {
     return <NotFound />;

--- a/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
+++ b/static/app/views/issueList/pages/useInboxPreviewPrefetch.tsx
@@ -7,6 +7,7 @@ import {explorerAutofixApiOptions} from 'sentry/components/events/autofix/useExp
 import {linkedPullRequestsApiOptions} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
 import type {Group} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
@@ -32,7 +33,7 @@ export function useInboxPreviewPrefetch(group: Group) {
         groupApiOptions({
           ...issueParams,
           environments,
-          expandDerivedData: organization.features.includes('issue-inbox'),
+          expandDerivedData: orgHasIssueInbox(organization),
         })
       );
       void queryClient.prefetchQuery({

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -28,6 +28,7 @@ import {
 import {useAssignedSearchValues} from 'sentry/utils/membersAndTeams/useAssignedSearchValues';
 import {useMemberUsernames} from 'sentry/utils/membersAndTeams/useMemberUsernames';
 import {escapeIssueTagKey} from 'sentry/utils/queryString';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {useFetchOrganizationFeatureFlags} from 'sentry/views/issueList/utils/useFetchOrganizationFeatureFlags';
 
@@ -429,7 +430,7 @@ function builtInIssuesFields({
     ...semverFields,
   };
 
-  if (!organization.features.includes('issue-inbox')) {
+  if (!orgHasIssueInbox(organization)) {
     delete allFields[FieldKey.ISSUE_PROGRESS];
   }
 

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import {FeatureBadge} from '@sentry/scraps/badge';
 
 import {t} from 'sentry/locale';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {orgHasSeerAccess} from 'sentry/utils/seer/orgHasSeerAccess';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useInboxIssueCount} from 'sentry/views/issueList/pages/inbox/useInboxIssueCount';
@@ -34,7 +35,7 @@ const InboxCountBadge = registerLLMContext('navigation', InboxCountBadgeImpl);
 function IssuesSecondaryNavigationImpl() {
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/issues`;
-  const hasIssueInbox = organization.features.includes('issue-inbox');
+  const hasIssueInbox = orgHasIssueInbox(organization);
   const hasInbox = hasIssueInbox && orgHasSeerAccess(organization);
   const hasSeerNightShift = organization.features.includes('seer-night-shift-ui');
   const hasAutofixSection = hasSeerNightShift || !hasIssueInbox;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -14,6 +14,7 @@ import {t} from 'sentry/locale';
 import type {Level} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {RequestError} from 'sentry/utils/requestError/requestError';
+import {orgHasIssueInbox} from 'sentry/utils/seer/orgHasIssueInbox';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {getTraceIssueSeverityClassName} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
@@ -60,7 +61,7 @@ function Issue(props: IssueProps) {
       groupId: String(props.issue.issue_id),
       organizationSlug: props.organization.slug,
       environments: [],
-      expandDerivedData: props.organization.features.includes('issue-inbox'),
+      expandDerivedData: orgHasIssueInbox(props.organization),
     }),
     staleTime: 10 * 60 * 1000,
   });


### PR DESCRIPTION
Since there are complications in the feature flags right now, this is a temporary measure that would let us do the inbox rollout  without having to fix the `batch_has` feature flag problem for now