### PR TITLE
feat(hybridcloud): Dispatch depth-proportional drain lanes for deep mailboxes

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -127,31 +127,17 @@ def _provider_tag(payload: WebhookPayload) -> str:
     return payload.provider or UNKNOWN_PROVIDER
 
 
-def _provider_from_mailbox(mailbox_name: str | None) -> str:
+def _provider_from_mailbox(mailbox_name: str) -> str:
     """
     Mailboxes are named `<provider>:<identifier>`, and it is the identifier that
     later gains bucket and event-type suffixes, so the first segment stays the
     provider.
     """
-    provider, separator, _ = (mailbox_name or "").partition(":")
+    provider, separator, _ = mailbox_name.partition(":")
     return provider if separator and provider else UNKNOWN_PROVIDER
 
 
-def _record_lost_head(
-    payload_id: int, *, dispatch_tags: Mapping[str, str], provider: str, log_key: str
-) -> None:
-    """
-    Record a drain whose head row is already gone, delivered by whoever claimed it
-    next. The drain stands down and lets that dispatcher, or a later one, continue.
-    """
-    metrics.incr(
-        "hybridcloud.deliver_webhooks.delivery",
-        tags={**dispatch_tags, "outcome": "race", "provider": provider},
-    )
-    logger.info(log_key, extra={"id": payload_id})
-
-
-def _set_webhook_delivery_sentry_context(mailbox_name: str | None, provider: str) -> None:
+def _set_webhook_delivery_sentry_context(mailbox_name: str, provider: str) -> None:
     """Set Sentry context at the delivery entrypoint for easier debugging."""
     sentry_sdk.set_tag("mailbox_name", mailbox_name)
     sentry_sdk.set_attribute("mailbox_name", mailbox_name)
@@ -343,56 +329,33 @@ class _MailboxClaim:
         return records
 
     def record_lost_head(self, log_key: str) -> None:
-        """This drain's head row is already gone — see `_record_lost_head`."""
-        _record_lost_head(
-            self.head_id,
-            dispatch_tags=self.dispatch_tags,
-            provider=self.provider,
-            log_key=log_key,
+        """
+        This drain's head row is already gone, delivered by whoever claimed it next.
+        It stands down and lets that dispatcher, or a later one, continue.
+        """
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.delivery",
+            tags={**self.dispatch_tags, "outcome": "race", "provider": self.provider},
         )
+        logger.info(log_key, extra={"id": self.head_id})
 
 
 def _begin_drain(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None,
-    valid_until: float | None,
-    mailbox: str | None,
+    valid_until: float,
+    mailbox: str,
 ) -> _MailboxClaim | None:
-    """
-    The claim a drain runs under, or None when it must stand down first.
-
-    Resolving the mailbox before anything else lets a drain that carries none —
-    enqueued before dispatch sent one — still name its provider, off its head row.
-    That read and the fresh-horizon fallback below both go away once no such drains
-    are left in flight.
-    """
-    if mailbox is None:
-        mailbox = (
-            WebhookPayload.objects.filter(id=payload_id)
-            .values_list("mailbox_name", flat=True)
-            .first()
-        )
-    _set_webhook_delivery_sentry_context(mailbox, _provider_from_mailbox(mailbox))
-    if mailbox is None:
-        _record_lost_head(
-            payload_id,
-            dispatch_tags=_dispatch_tags(dispatcher),
-            provider=UNKNOWN_PROVIDER,
-            log_key="deliver_webhook.potential_race",
-        )
-        return None
+    """The claim a drain runs under, or None when it has already lapsed."""
     claim = _MailboxClaim(
         claimed=claimed_count,
         head_id=payload_id,
         mailbox_name=mailbox,
         dispatcher=dispatcher,
-        valid_until=(
-            datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC)
-            if valid_until is not None
-            else timezone.now() + BATCH_SCHEDULE_OFFSET
-        ),
+        valid_until=datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC),
     )
+    _set_webhook_delivery_sentry_context(mailbox, claim.provider)
     if claim.lapsed(log_key="deliver_webhook.stale_claim", extra={"id": payload_id}):
         return None
     return claim
@@ -963,15 +926,15 @@ def schedule_webhook_delivery() -> None:
 def drain_mailbox(
     payload_id: int,
     claimed_count: int,
+    valid_until: float,
+    mailbox: str,
     dispatcher: str | None = None,
-    valid_until: float | None = None,
-    mailbox: str | None = None,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of, in order.
 
-    The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
-    each defaults so a rolling deploy can bind drains the previous version sent.
+    The arguments are one claim flattened for the wire — see
+    `_MailboxClaim.task_args`.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
     if claim is not None:
@@ -1312,9 +1275,9 @@ def _run_parallel_delivery_batch(
 def drain_mailbox_parallel(
     payload_id: int,
     claimed_count: int,
+    valid_until: float,
+    mailbox: str,
     dispatcher: str | None = None,
-    valid_until: float | None = None,
-    mailbox: str | None = None,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of, in small

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -254,6 +254,12 @@ class _MailboxClaim:
     """
     The records one claim reserved, and the context its drain works them under.
 
+    `head_id` is the first record claimed, not where the scan started: a lane scans
+    from the previous lane's boundary, which is rarely a record's own id.
+
+    `next_start_id` is one past the last record claimed, or None when no lane may
+    follow — as on every strict-ordering claim.
+
     `valid_until` is stored rather than re-derived, so it names exactly when the
     records come due for other dispatchers again.
     """
@@ -263,6 +269,7 @@ class _MailboxClaim:
     mailbox_name: str
     dispatcher: str | None
     valid_until: datetime.datetime
+    next_start_id: int | None = None
 
     @property
     def provider(self) -> str:
@@ -395,20 +402,26 @@ def _claim_mailbox_batch(
     head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
 ) -> _MailboxClaim | None:
     """
-    Claim up to MAX_MAILBOX_DRAIN records at the head of the mailbox by scheduling
-    them past the drain deadline. The UPDATE gates on the head still being due, so
-    a lost race claims nothing and returns None.
+    Claim up to MAX_MAILBOX_DRAIN records from `head_id` forward by scheduling them
+    past the drain deadline. The UPDATE gates on the claim's own head still being
+    due, so a lost race claims nothing and returns None.
 
     In due-head mode the claim stops at the first not-due record, which is what
     keeps concurrent drains apart: an in-flight drain's records carry a future
     schedule_for, so a claim starting behind it ends before its range, and a
     backoff record keeps its backoff.
+
+    `head_id` is the mailbox's due head for a cycle's first claim on it, and the
+    previous lane's boundary after that (see `_dispatch_extra_lanes`). Because that
+    boundary need not be a record, the due gate re-checks the first record the
+    claim actually covers rather than `head_id` itself.
     """
     valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
     window = WebhookPayload.objects.filter(id__gte=head_id, mailbox_name=mailbox_name).order_by(
         "id"
     )
     claimed_ids: list[int] | Subquery
+    next_start_id: int | None
     if _dispatches_from_due_head(mailbox_name):
         now = timezone.now()
         prefix_ids: list[int] = []
@@ -419,9 +432,15 @@ def _claim_mailbox_batch(
         if not prefix_ids:
             return None
         claimed_ids = prefix_ids
+        claim_head_id = prefix_ids[0]
+        next_start_id = prefix_ids[-1] + 1
     else:
         claimed_ids = Subquery(window.values("id")[:MAX_MAILBOX_DRAIN])
-    head_due = WebhookPayload.objects.filter(id=head_id, schedule_for__lte=timezone.now())
+        claim_head_id = head_id
+        # A strict-ordering mailbox runs one drain at a time by design: the records
+        # behind this claim must not move until it has been delivered in order.
+        next_start_id = None
+    head_due = WebhookPayload.objects.filter(id=claim_head_id, schedule_for__lte=timezone.now())
     claimed = (
         WebhookPayload.objects.filter(id__in=claimed_ids)
         .filter(Exists(head_due))
@@ -431,7 +450,8 @@ def _claim_mailbox_batch(
         return None
     return _MailboxClaim(
         claimed=claimed,
-        head_id=head_id,
+        head_id=claim_head_id,
+        next_start_id=next_start_id,
         mailbox_name=mailbox_name,
         dispatcher=dispatcher,
         valid_until=valid_until,
@@ -479,18 +499,31 @@ def _record_dispatch(
     metrics.distribution("hybridcloud.deliver_webhooks.dispatch.claimed", claimed, tags=tags)
 
 
+class _DispatchResult(NamedTuple):
+    """
+    What `_claim_and_dispatch` did: the drain's mode, where a following lane may
+    claim from (None when none may), and how many records it claimed.
+
+    `claimed` is the mailbox's depth signal — see `_has_more_to_claim`.
+    """
+
+    outcome: DispatchOutcome
+    next_start_id: int | None
+    claimed: int
+
+
 def _claim_and_dispatch(
     head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
-) -> DispatchOutcome:
+) -> _DispatchResult:
     """
     Claim a batch for the mailbox and dispatch the drain matching its depth.
     Callers must hold the mailbox's drain lock so concurrent dispatchers cannot
     interleave around the claim.
 
-    Returns the dispatched drain's mode, or NOT_DUE when the head has already
-    been claimed, delivered, or moved into a retry backoff. Dispatchers discover
-    mailbox heads outside the drain lock, so the due-gate inside the claim is
-    what stops two of them from double-dispatching the same head.
+    The outcome is NOT_DUE when the head has already been claimed, delivered, or
+    moved into a retry backoff. Dispatchers discover mailbox heads outside the
+    drain lock, so the due-gate inside the claim is what stops two of them from
+    double-dispatching the same head.
 
     The drain is bounded to the claimed records (`claimed_count`). Without the
     bound a fast drain walks past its claim into unclaimed rows, at which point
@@ -502,7 +535,7 @@ def _claim_and_dispatch(
     """
     claim = _claim_mailbox_batch(head_id, mailbox_name, dispatcher=dispatcher)
     if claim is None:
-        return DispatchOutcome.NOT_DUE
+        return _DispatchResult(outcome=DispatchOutcome.NOT_DUE, next_start_id=None, claimed=0)
     if claim.claimed >= PARALLEL_DRAIN_THRESHOLD:
         drain_mailbox_parallel.delay(**claim.task_args())
         outcome = DispatchOutcome.PARALLEL
@@ -515,7 +548,9 @@ def _claim_and_dispatch(
         mailbox_name=mailbox_name,
         claimed=claim.claimed,
     )
-    return outcome
+    return _DispatchResult(
+        outcome=outcome, next_start_id=claim.next_start_id, claimed=claim.claimed
+    )
 
 
 def maybe_trigger_drain(mailbox_name: str) -> None:
@@ -558,7 +593,8 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
             # backoff — the scheduler covers it when schedule_for comes due.
             metrics.incr("hybridcloud.deliver_webhooks.push_trigger.backoff", tags=trigger_tags)
             return
-        outcome = _claim_and_dispatch(head[0], mailbox_name, dispatcher=Dispatcher.PUSH)
+        # A push trigger claims for one drain; depth behind it is the scheduler's.
+        outcome = _claim_and_dispatch(head[0], mailbox_name, dispatcher=Dispatcher.PUSH).outcome
         if outcome is DispatchOutcome.NOT_DUE:
             # The head moved between our read and the claim; whoever moved it has
             # the mailbox covered.
@@ -742,6 +778,79 @@ def _clear_carryover() -> None:
         )
 
 
+def _has_more_to_claim(result: _DispatchResult, mailbox_name: str) -> bool:
+    """
+    Whether this mailbox has more due work to hand another lane.
+
+    A claim stops at MAX_MAILBOX_DRAIN or at the first not-due record, so one that
+    filled its cap left more behind and a short one drained what was due. That also
+    self-throttles: an in-flight lane's records are not due, so the claim behind
+    them comes back short.
+
+    Lanes past the first are due-head mode only — strict providers tolerate neither
+    the reordering nor the concurrent claims.
+    """
+    return result.claimed >= MAX_MAILBOX_DRAIN and _dispatches_from_due_head(mailbox_name)
+
+
+@dataclasses.dataclass
+class _LaneChain:
+    """
+    A mailbox still handing out lanes: where the next claims from, and how many the
+    cycle's cap leaves it. `remaining` is only that cap — a short claim is what
+    actually ends a chain.
+    """
+
+    mailbox_name: str
+    start_id: int
+    remaining: int
+
+
+def _dispatch_extra_lanes(chains: Sequence[_LaneChain], *, budget: int) -> None:
+    """
+    Dispatch the lanes past each mailbox's first, breadth-first.
+
+    Every mailbox gets a first lane from `schedule_webhook_delivery` before any
+    gets a second; each round here hands out one more per mailbox in priority
+    order, out of whatever `budget` that pass left. A short claim ends that
+    mailbox's chain, showing up as extra_lanes under the cap rather than a skip.
+    """
+    extra_lanes = {_provider_from_mailbox(chain.mailbox_name): 0 for chain in chains}
+    dispatched = 0
+    active = list(chains)
+    while active and dispatched < budget:
+        next_round: list[_LaneChain] = []
+        for chain in active:
+            if dispatched >= budget:
+                break
+            guard = _acquire_drain_guard(chain.mailbox_name)
+            if guard is False:
+                # Another dispatcher is mid-claim here; leave the depth to it.
+                continue
+            try:
+                result = _claim_and_dispatch(
+                    chain.start_id, chain.mailbox_name, dispatcher=Dispatcher.SCHEDULER
+                )
+            finally:
+                if guard:
+                    _release_drain_lock(chain.mailbox_name)
+            if result.outcome is DispatchOutcome.NOT_DUE or result.next_start_id is None:
+                continue
+            dispatched += 1
+            extra_lanes[_provider_from_mailbox(chain.mailbox_name)] += 1
+            chain.start_id = result.next_start_id
+            chain.remaining -= 1
+            if chain.remaining and _has_more_to_claim(result, chain.mailbox_name):
+                next_round.append(chain)
+        active = next_round
+    for provider, lanes in extra_lanes.items():
+        metrics.distribution(
+            "hybridcloud.schedule_webhook_delivery.extra_lanes",
+            lanes,
+            tags={"provider": provider},
+        )
+
+
 @instrumented_task(
     name="sentry.hybridcloud.tasks.deliver_webhooks.schedule_webhook_delivery",
     namespace=hybridcloud_control_tasks,
@@ -750,22 +859,18 @@ def _clear_carryover() -> None:
 )
 def schedule_webhook_delivery() -> None:
     """
-    Find mailboxes that contain undelivered webhooks that were scheduled
-    to be delivered now or in the past.
+    Find mailboxes holding undelivered webhooks due now or earlier, and dispatch a
+    drain for each in provider-priority order.
 
-    Prioritizes webhooks based on provider importance.
+    Discovery aggregates the whole table on a fixed short interval, so a cycle that
+    finds more due heads than it can dispatch hands the surplus to the next one
+    rather than rediscovering it. A carried head costs at most one wasted claim —
+    `_claim_and_dispatch` gates on it still being due — and mailboxes arriving
+    meanwhile are covered by their push trigger.
 
-    Discovery aggregates the whole table, so its cost grows with the backlog while
-    it runs on a fixed short interval. A cycle that discovers more due heads than
-    it can dispatch therefore hands the surplus to the next cycle instead of
-    discarding it, and only a cycle that starts with nothing carried over pays for
-    discovery — the deeper the backlog, the more of that scan is spared.
-
-    A carried head may be stale by the time it is dispatched, which costs at most
-    one claim attempt: `_claim_and_dispatch` gates every dispatch on the head still
-    being due, so a head claimed, delivered, or backed off since discovery claims 0
-    rows and is skipped. Mailboxes that arrive while a surplus is being spent are
-    dispatched by their push trigger; the ones with none wait for it to drain.
+    Dispatches in two passes: one claim per due mailbox, then the extra lanes deep
+    mailboxes earned (see `_has_more_to_claim`). Every mailbox is served before any
+    is served twice.
 
     Triggered frequently by task-scheduler.
     """
@@ -788,6 +893,9 @@ def schedule_webhook_delivery() -> None:
 
     dispatched = 0
     surplus: list[dict[str, Any]] = []
+    lane_chains: list[_LaneChain] = []
+    # Read once so every mailbox in the cycle is sized against the same cap.
+    max_lanes = options.get("hybridcloud.webhookpayload.max_drain_lanes")
     for index, record in enumerate(records):
         if dispatched >= BATCH_SIZE:
             # Dispatch target reached; the heads this cycle never reached go to the
@@ -807,21 +915,32 @@ def schedule_webhook_delivery() -> None:
         # A None guard is a cache outage. Claims still keep dispatchers apart across
         # cycles, so proceed — just unserialized against push triggers.
         try:
-            outcome = _claim_and_dispatch(
+            result = _claim_and_dispatch(
                 record["id"], mailbox_name, dispatcher=Dispatcher.SCHEDULER
             )
         finally:
             if guard:
                 _release_drain_lock(mailbox_name)
-        if outcome is DispatchOutcome.NOT_DUE:
+        if result.outcome is DispatchOutcome.NOT_DUE:
             # Claimed out of the list between discovery and here, usually by a
             # push trigger.
             metrics.incr(
                 "hybridcloud.deliver_webhooks.scheduler.skipped",
                 tags={**skip_tags, "reason": "claim_lost"},
             )
-        else:
-            dispatched += 1
+            continue
+        dispatched += 1
+        next_start_id = result.next_start_id
+        if max_lanes > 1 and next_start_id is not None and _has_more_to_claim(result, mailbox_name):
+            lane_chains.append(
+                _LaneChain(
+                    mailbox_name=mailbox_name,
+                    start_id=next_start_id,
+                    remaining=max_lanes - 1,
+                )
+            )
+
+    _dispatch_extra_lanes(lane_chains, budget=BATCH_SIZE - dispatched)
 
     # A carryover displaces the next cycle's discovery, so a short surplus costs it
     # the rest of its dispatch budget — below half a batch that outweighs the scan

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2626,6 +2626,15 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# How many concurrent claims — lanes — a scheduler cycle may dispatch for one
+# mailbox, letting a deep mailbox burn down proportionally instead of one claim's
+# worth per cycle. Only skip-on-failure providers in due-head mode take more than
+# one. 1 is the pre-existing behavior: one dispatch per due mailbox per cycle.
+register(
+    "hybridcloud.webhookpayload.max_drain_lanes",
+    default=1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Drops GitHub check webhooks that reference no pull request based in their own
 # repo (see ActionFilter.own_repo_pr_actions). The predicate reads payload shape
 # rather than a header, so it keeps a switch: setting this false stops the drop

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import ANY, MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 import responses
@@ -1032,6 +1032,11 @@ class DrainLaneTest(MetricCallsMixin, TestCase):
             assert record.schedule_for <= timezone.now()
 
 
+def fresh_deadline() -> float:
+    """A claim deadline far enough out that a drain runs to completion."""
+    return (timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp()
+
+
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:
     # Keep path aligned with provider so responses mocks aren't misleading.
     request_path = f"/extensions/{provider}/webhook/" if provider else "/extensions/github/webhook/"
@@ -1047,7 +1052,7 @@ def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list
     return created
 
 
-def assert_drain_skips_failed_message(drain: Callable[[int, int], None], provider: str) -> None:
+def assert_drain_skips_failed_message(drain: Callable[..., None], provider: str) -> None:
     """
     Drain a 5 message mailbox where the second delivery fails.
 
@@ -1066,7 +1071,12 @@ def assert_drain_skips_failed_message(drain: Callable[[int, int], None], provide
     responses.add(responses.POST, url, status=200, body="")
     records = create_payloads(5, f"{provider}:123", provider=provider)
 
-    drain(records[0].id, MAX_MAILBOX_DRAIN)
+    drain(
+        records[0].id,
+        MAX_MAILBOX_DRAIN,
+        mailbox=f"{provider}:123",
+        valid_until=fresh_deadline(),
+    )
 
     assert len(responses.calls) == 5
     assert WebhookPayload.objects.count() == 1
@@ -1081,7 +1091,9 @@ def assert_drain_skips_failed_message(drain: Callable[[int, int], None], provide
 class DrainMailboxTest(TestCase):
     @responses.activate
     def test_drain_missing_payload(self) -> None:
-        drain_mailbox(99, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            99, claimed_count=MAX_MAILBOX_DRAIN, mailbox="github:123", valid_until=fresh_deadline()
+        )
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1091,7 +1103,12 @@ class DrainMailboxTest(TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox(
+                webhook_one.id,
+                claimed_count=MAX_MAILBOX_DRAIN,
+                mailbox="github:123",
+                valid_until=fresh_deadline(),
+            )
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1104,7 +1121,12 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # github is in the skip-on-failure allowlist: failed messages are skipped
         # and processing continues. All 5 messages are attempted.
@@ -1129,7 +1151,9 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=5)
+        drain_mailbox(
+            records[0].id, claimed_count=5, mailbox="github:123", valid_until=fresh_deadline()
+        )
 
         assert len(responses.calls) == 5
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
@@ -1153,7 +1177,12 @@ class DrainMailboxTest(TestCase):
 
         head = WebhookPayload.objects.order_by("id").first()
         assert head
-        drain_mailbox(head.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            head.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # Only the two fresh rows produce requests; everything is drained.
         assert len(responses.calls) == 2
@@ -1167,7 +1196,12 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="jira:123",
+            valid_until=fresh_deadline(),
+        )
 
         # jira is not in the allowlist: processing stops on the first failure
         # to preserve strict mailbox ordering.
@@ -1210,7 +1244,9 @@ class DrainMailboxTest(TestCase):
         records = create_payloads(4, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=4)
+            drain_mailbox(
+                records[0].id, claimed_count=4, mailbox="github:123", valid_until=fresh_deadline()
+            )
 
         assert len(responses.calls) == 4
         assert WebhookPayload.objects.count() == 0
@@ -1229,7 +1265,9 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
 
-        drain_mailbox(records[0].id, claimed_count=5)
+        drain_mailbox(
+            records[0].id, claimed_count=5, mailbox="jira:123", valid_until=fresh_deadline()
+        )
 
         # jira requires strict ordering: the drain stops at the failure, but the
         # two messages delivered before it must still have their rows removed.
@@ -1263,7 +1301,9 @@ class DrainMailboxTest(TestCase):
         create_payloads(2, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(stale.id, claimed_count=4)
+            drain_mailbox(
+                stale.id, claimed_count=4, mailbox="github:123", valid_until=fresh_deadline()
+            )
 
         # Only the two fresh rows are delivered; the stale and attempts-exhausted
         # rows are discarded without a request.
@@ -1285,7 +1325,9 @@ class DrainMailboxTest(TestCase):
         records = create_payloads(5, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=5)
+            drain_mailbox(
+                records[0].id, claimed_count=5, mailbox="github:123", valid_until=fresh_deadline()
+            )
 
         assert WebhookPayload.objects.count() == 0
         # Two full batches during the walk plus the remainder at the end.
@@ -1298,7 +1340,12 @@ class DrainMailboxTest(TestCase):
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # All 5 messages are attempted even though all fail.
         assert len(responses.calls) == 5
@@ -1319,7 +1366,12 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1334,14 +1386,14 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(1, "github:123")
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=timezone.now().timestamp(),
+        )
 
-        # Once start time + batch offset is in the past we stop delivery
+        # At its deadline the records already belong to whoever claims next.
         assert WebhookPayload.objects.count() == 1
 
     @responses.activate
@@ -1352,7 +1404,12 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1364,7 +1421,12 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1382,7 +1444,12 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox(
+                webhook_one.id,
+                claimed_count=MAX_MAILBOX_DRAIN,
+                mailbox="github:123",
+                valid_until=fresh_deadline(),
+            )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -1401,7 +1468,12 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -1421,7 +1493,12 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1438,7 +1515,12 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -1457,7 +1539,12 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -1476,7 +1563,12 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 403
         assert hook is None
@@ -1496,7 +1588,12 @@ class DrainMailboxTest(TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="plugins:123",
+            valid_until=fresh_deadline(),
+        )
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -1513,7 +1610,12 @@ class DrainMailboxTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -1531,7 +1633,12 @@ class DrainMailboxTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1541,7 +1648,9 @@ class DrainMailboxTest(TestCase):
 class DrainMailboxParallelTest(TestCase):
     @responses.activate
     def test_drain_missing_payload(self) -> None:
-        drain_mailbox_parallel(99, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            99, claimed_count=MAX_MAILBOX_DRAIN, mailbox="github:123", valid_until=fresh_deadline()
+        )
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1551,7 +1660,12 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox_parallel(
+                webhook_one.id,
+                claimed_count=MAX_MAILBOX_DRAIN,
+                mailbox="github:123",
+                valid_until=fresh_deadline(),
+            )
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1563,7 +1677,9 @@ class DrainMailboxParallelTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox_parallel(records[0].id, claimed_count=5)
+        drain_mailbox_parallel(
+            records[0].id, claimed_count=5, mailbox="github:123", valid_until=fresh_deadline()
+        )
 
         assert len(responses.calls) == 5
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
@@ -1589,7 +1705,9 @@ class DrainMailboxParallelTest(TestCase):
         fresh = create_payloads(5, "github:123", provider="github")
 
         # The claim covered the 3 stale rows plus 2 fresh ones.
-        drain_mailbox_parallel(stale[0].id, claimed_count=5)
+        drain_mailbox_parallel(
+            stale[0].id, claimed_count=5, mailbox="github:123", valid_until=fresh_deadline()
+        )
 
         # The 3 stale rows are discarded without requests and only the 2 claimed
         # fresh rows are delivered; the rest stay for the next claim.
@@ -1614,7 +1732,12 @@ class DrainMailboxParallelTest(TestCase):
         )
         # jira is not in the skip-on-failure allowlist.
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="jira:123",
+            valid_until=fresh_deadline(),
+        )
 
         worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
         # We'll attempt one thread batch, but the second+ will fail and stop the drain.
@@ -1639,7 +1762,12 @@ class DrainMailboxParallelTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # github is in the skip-on-failure allowlist: failed messages are skipped
         # and processing continues across parallel batches.
@@ -1665,7 +1793,9 @@ class DrainMailboxParallelTest(TestCase):
         records = create_payloads(8, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox_parallel(records[0].id, claimed_count=8)
+            drain_mailbox_parallel(
+                records[0].id, claimed_count=8, mailbox="github:123", valid_until=fresh_deadline()
+            )
 
         assert len(responses.calls) == 8
         assert WebhookPayload.objects.count() == 0
@@ -1693,7 +1823,9 @@ class DrainMailboxParallelTest(TestCase):
         create_payloads(2, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox_parallel(stale[0].id, claimed_count=4)
+            drain_mailbox_parallel(
+                stale[0].id, claimed_count=4, mailbox="github:123", valid_until=fresh_deadline()
+            )
 
         assert len(responses.calls) == 2
         assert WebhookPayload.objects.count() == 0
@@ -1707,7 +1839,12 @@ class DrainMailboxParallelTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="jira:123",
+            valid_until=fresh_deadline(),
+        )
 
         worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
         # jira is not in the allowlist: processing stops after the first batch
@@ -1750,7 +1887,12 @@ class DrainMailboxParallelTest(TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1765,14 +1907,14 @@ class DrainMailboxParallelTest(TestCase):
             body="",
         )
         records = create_payloads(1, "github:123")
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=timezone.now().timestamp(),
+        )
 
-        # Once start time + batch offset is in the past we stop delivery
+        # At its deadline the records already belong to whoever claims next.
         assert WebhookPayload.objects.count() == 1
 
     @responses.activate
@@ -1791,7 +1933,12 @@ class DrainMailboxParallelTest(TestCase):
             record.date_added = timezone.now() - timedelta(days=4)
             record.save()
 
-        drain_mailbox_parallel(records[0].id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1812,7 +1959,12 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1824,7 +1976,12 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1842,7 +1999,12 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox_parallel(
+                webhook_one.id,
+                claimed_count=MAX_MAILBOX_DRAIN,
+                mailbox="github:123",
+                valid_until=fresh_deadline(),
+            )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -1861,7 +2023,12 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -1881,7 +2048,12 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1898,7 +2070,12 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -1917,7 +2094,12 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -1937,7 +2119,12 @@ class DrainMailboxParallelTest(TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="plugins:123",
+            valid_until=fresh_deadline(),
+        )
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -1954,7 +2141,12 @@ class DrainMailboxParallelTest(TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox_parallel(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -1989,7 +2181,12 @@ class SlowDeliveryLoggingTest(TestCase):
         expected_date_added = webhook.date_added.isoformat()
 
         with self.assertLogs("sentry.hybridcloud.tasks.deliver_webhooks", level="WARNING") as cm:
-            drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+            drain_mailbox(
+                webhook.id,
+                claimed_count=MAX_MAILBOX_DRAIN,
+                mailbox="github:123",
+                valid_until=fresh_deadline(),
+            )
 
         slow_log = next(r for r in cm.records if "deliver_webhook.slow_delivery" in r.msg)
         # extra dict from logger becomes attributes on LogRecord at runtime
@@ -2019,7 +2216,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -2047,7 +2249,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123:0:pull_request",
+            valid_until=fresh_deadline(),
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -2071,7 +2278,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="stripe",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="stripe:123",
+            valid_until=fresh_deadline(),
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -2098,7 +2310,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -2129,7 +2346,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -2147,7 +2369,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -2165,7 +2392,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.delivery_outcomes(mock_metrics) == ["ok"]
         assert len(self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC)) == 1
@@ -2182,7 +2414,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -2200,7 +2437,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -2227,7 +2469,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         first = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         second = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(first.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            first.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert not WebhookPayload.objects.filter(id=second.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "ok"]
@@ -2254,7 +2501,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
@@ -2274,7 +2526,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.failure") == [
             {"reason": "unauthorized", "destination_region": "us", "provider": "github"}
@@ -2296,7 +2553,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "conflict", "provider": "github"}
@@ -2316,7 +2578,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox_parallel(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox_parallel(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"}
@@ -2336,7 +2603,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         webhook.update(provider=None)
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "unknown"}
@@ -2381,7 +2653,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         legacy = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         legacy.update(provider=None)
 
-        drain_mailbox(head.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            head.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"},
@@ -2459,7 +2736,13 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # `claim_exhausted` has no provider tag, so it is the outcome most likely
         # to be missed when attribution is added; assert it alongside the delivery.
@@ -2484,7 +2767,13 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
+        drain_mailbox(
+            webhook.id,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC) == [
             {
@@ -2512,7 +2801,13 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
         )
         records = create_payloads(2, "github:123", provider="github")
 
-        drain_mailbox_parallel(records[0].id, claimed_count=2, dispatcher=Dispatcher.PUSH)
+        drain_mailbox_parallel(
+            records[0].id,
+            claimed_count=2,
+            dispatcher=Dispatcher.PUSH,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         expected = {
             "dispatcher": "push",
@@ -2527,31 +2822,42 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
     def test_race_outcome_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
         # A race means the row is already gone, so the outcome carries no provider
         # and attribution is all that is left to tell the dispatchers apart.
-        drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH)
+        drain_mailbox(
+            99,
+            claimed_count=1,
+            dispatcher=Dispatcher.PUSH,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
+            {"dispatcher": "push", "outcome": "race", "provider": "github"}
         ]
 
     @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_parallel_drain_carries_dispatch_attribution(self, mock_metrics: MagicMock) -> None:
-        drain_mailbox_parallel(99, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
+        drain_mailbox_parallel(
+            99,
+            claimed_count=1,
+            dispatcher=Dispatcher.SCHEDULER,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "scheduler", "outcome": "race", "provider": "unknown"}
+            {"dispatcher": "scheduler", "outcome": "race", "provider": "github"}
         ]
 
     @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_drain_enqueued_before_deploy_tags_unknown(self, mock_metrics: MagicMock) -> None:
-        # Tasks already queued when this deploys arrive without a dispatcher. The
-        # key must still be emitted: a tag absent from some series breaks grouping
-        # rather than showing a gap.
-        drain_mailbox(99, claimed_count=1)
+    def test_drain_without_a_dispatcher_tags_unknown(self, mock_metrics: MagicMock) -> None:
+        # A drain invoked outside a dispatcher still emits the key: a tag absent
+        # from some series breaks grouping rather than showing a gap.
+        drain_mailbox(99, claimed_count=1, mailbox="github:123", valid_until=fresh_deadline())
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {**UNATTRIBUTED, "outcome": "race", "provider": "unknown"}
+            {**UNATTRIBUTED, "outcome": "race", "provider": "github"}
         ]
 
 
@@ -2573,7 +2879,7 @@ class LostHeadTest(MetricCallsMixin, TestCase):
         head_id = records[0].id
         records[0].delete()
 
-        drain_mailbox(head_id, claimed_count=3, mailbox="github:123")
+        drain_mailbox(head_id, claimed_count=3, mailbox="github:123", valid_until=fresh_deadline())
 
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 2
@@ -2597,7 +2903,9 @@ class LostHeadTest(MetricCallsMixin, TestCase):
         head_id = records[0].id
         records[0].delete()
 
-        drain_mailbox_parallel(head_id, claimed_count=3, mailbox="github:123")
+        drain_mailbox_parallel(
+            head_id, claimed_count=3, mailbox="github:123", valid_until=fresh_deadline()
+        )
 
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 2
@@ -2661,70 +2969,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    def test_drain_stops_at_the_claim_deadline_not_a_fresh_one(self) -> None:
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        records = create_payloads(1, "github:123", provider="github")
-
-        # A zero offset makes a freshly computed horizon expire immediately, so a
-        # delivery here can only come from the claim's own deadline. A drain that
-        # waited in the queue must run on the claim's remainder, not a new horizon.
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox(
-                records[0].id,
-                claimed_count=1,
-                valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
-            )
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_parallel_drain_stops_at_the_claim_deadline_not_a_fresh_one(self) -> None:
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        records = create_payloads(1, "github:123", provider="github")
-
-        with patch.object(
-            deliver_webhooks,
-            "BATCH_SCHEDULE_OFFSET",
-            new_callable=PropertyMock(return_value=timedelta(minutes=0)),
-        ):
-            drain_mailbox_parallel(
-                records[0].id,
-                claimed_count=1,
-                valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
-            )
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_undated_claim_falls_back_to_a_fresh_horizon(self) -> None:
-        # Drains enqueued before dispatch sent a deadline keep the old bound, which
-        # test_drain_time_limit pins from the other side by expiring that horizon.
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
-        )
-
-        drain_mailbox(webhook.id, claimed_count=1)
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
-    @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_fresh_claim_delivers(self, mock_metrics: MagicMock) -> None:
         responses.add(
@@ -2735,7 +2979,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         )
 
         valid_until = (timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp()
-        drain_mailbox(webhook.id, claimed_count=1, valid_until=valid_until)
+        drain_mailbox(webhook.id, claimed_count=1, valid_until=valid_until, mailbox="github:123")
 
         assert len(responses.calls) == 1
         assert WebhookPayload.objects.count() == 0
@@ -2766,22 +3010,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         ]
 
     @responses.activate
-    @override_cells(cell_config)
-    def test_drain_enqueued_before_deploy_delivers(self) -> None:
-        # Drains queued before this deploys carry no deadline and must keep running.
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
-        )
-
-        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_expired_claim_on_deleted_head_still_names_the_provider(
         self, mock_metrics: MagicMock
@@ -2798,40 +3026,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "github"}
-        ]
-
-    @responses.activate
-    @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_without_a_mailbox_reads_it_off_the_head(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # Drains enqueued before dispatch sent a mailbox still name their provider:
-        # the head row carries it, and the drain reads it before anything else.
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
-        )
-
-        drain_mailbox(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired()
-        )
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "github"}
-        ]
-
-    @responses.activate
-    @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_with_neither_mailbox_nor_head_reports_a_race(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # Nothing left to name the provider with. Only drains enqueued before
-        # dispatch sent a mailbox can land here, and only until they drain out.
-        drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired())
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
         ]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -3056,7 +3250,12 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             body="",
         )
         webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            mailbox="github:123",
+            valid_until=fresh_deadline(),
+        )
 
         # The drain emptied the mailbox; a new webhook arriving now must be able to
         # trigger a fresh drain right away.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -50,6 +50,7 @@ CYCLE_METRIC = "hybridcloud.schedule_webhook_delivery.cycle"
 CARRYOVER_METRIC = "hybridcloud.schedule_webhook_delivery.carryover"
 CARRYOVER_ERROR_METRIC = "hybridcloud.schedule_webhook_delivery.carryover.error"
 CARRYOVER_DROPPED_METRIC = "hybridcloud.schedule_webhook_delivery.carryover.dropped"
+EXTRA_LANES_METRIC = "hybridcloud.schedule_webhook_delivery.extra_lanes"
 
 
 class MetricCallsMixin:
@@ -388,11 +389,13 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             schedule_for=claimed_for,
         )
 
-        outcome = _claim_and_dispatch(
+        result = _claim_and_dispatch(
             webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
         )
 
-        assert outcome == "not_due"
+        assert result.outcome == "not_due"
+        assert result.next_start_id is None
+        assert result.claimed == 0
         mock_drain.delay.assert_not_called()
         mock_drain_parallel.delay.assert_not_called()
         webhook.refresh_from_db()
@@ -413,11 +416,13 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         )
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            outcome = _claim_and_dispatch(
+            result = _claim_and_dispatch(
                 webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
             )
 
-        assert outcome == "sequential"
+        assert result.outcome == "sequential"
+        # Strict ordering: the mailbox admits no second lane behind this claim.
+        assert result.next_start_id is None
         mock_drain.delay.assert_called_once_with(
             payload_id=webhook.id,
             claimed_count=1,
@@ -846,6 +851,185 @@ class ScheduleCarryoverFloorTest(CarryoverTestBase):
 
         assert self.carryover() is None
         assert self.tags_for(mock_metrics, CARRYOVER_DROPPED_METRIC) == [{}]
+
+
+def lane_options(max_lanes: int) -> dict[str, Any]:
+    """Due-head mode with a lane ceiling; lanes are only taken in that mode."""
+    return {**DUE_HEAD_OPTIONS, "hybridcloud.webhookpayload.max_drain_lanes": max_lanes}
+
+
+@control_silo_test
+class DrainLaneTest(MetricCallsMixin, TestCase):
+    """
+    A cycle claims in proportion to a mailbox's depth, so a mailbox holding a burst
+    is not capped at one claim while the fleet has capacity. `MAX_MAILBOX_DRAIN` is
+    patched small: what matters is depth in claims, not the production size.
+    """
+
+    def dispatched_claims(self, mock_drain: MagicMock) -> list[tuple[int, int]]:
+        """`(head id, claimed count)` of each drain dispatched, in dispatch order."""
+        return [
+            (call.kwargs["payload_id"], call.kwargs["claimed_count"])
+            for call in mock_drain.delay.call_args_list
+        ]
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @override_options(lane_options(4))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_deep_mailbox_dispatches_disjoint_lanes(self, mock_drain: MagicMock) -> None:
+        records = create_payloads(5, "github:123", provider="github")
+
+        schedule_webhook_delivery()
+
+        # ceil(5 / 2) lanes, each claiming where the one before it stopped.
+        assert self.dispatched_claims(mock_drain) == [
+            (records[0].id, 2),
+            (records[2].id, 2),
+            (records[4].id, 1),
+        ]
+        # Every record is claimed exactly once: the claims tile the mailbox.
+        for record in records:
+            record.refresh_from_db()
+            assert record.schedule_for > timezone.now()
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @override_options(lane_options(4))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_strict_provider_stays_single_lane(self, mock_drain: MagicMock) -> None:
+        # Jira is not skip-on-failure, so depth buys it nothing.
+        records = create_payloads(5, "jira:123", provider="jira")
+
+        schedule_webhook_delivery()
+
+        assert self.dispatched_claims(mock_drain) == [(records[0].id, 2)]
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @override_options(DUE_HEAD_OPTIONS)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_option_default_dispatches_one_lane(self, mock_drain: MagicMock) -> None:
+        assert options.get("hybridcloud.webhookpayload.max_drain_lanes") == 1
+        records = create_payloads(5, "github:123", provider="github")
+
+        schedule_webhook_delivery()
+
+        assert self.dispatched_claims(mock_drain) == [(records[0].id, 2)]
+        # The depth past the single claim waits for the next cycle, as it does today.
+        for record in records[2:]:
+            record.refresh_from_db()
+            assert record.schedule_for <= timezone.now()
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @override_options(lane_options(4))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_lanes_tile_only_the_due_records(self, mock_drain: MagicMock) -> None:
+        due = create_payloads(5, "github:123", provider="github")
+        in_flight = create_payloads(4, "github:123", provider="github")
+        held_until = timezone.now() + BATCH_SCHEDULE_OFFSET
+        WebhookPayload.objects.filter(id__in=[record.id for record in in_flight]).update(
+            schedule_for=held_until
+        )
+
+        schedule_webhook_delivery()
+
+        # Lanes tile the five due records: the claim reaching the in-flight range
+        # comes back short, which ends the chain.
+        assert self.dispatched_claims(mock_drain) == [
+            (due[0].id, 2),
+            (due[2].id, 2),
+            (due[4].id, 1),
+        ]
+        for record in in_flight:
+            record.refresh_from_db()
+            assert record.schedule_for == held_until
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @override_options(lane_options(4))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_carried_head_earns_the_same_lanes(self, mock_drain: MagicMock) -> None:
+        records = create_payloads(5, "github:123", provider="github")
+        # A carried head arrives without anything discovery measured.
+        cache.set(
+            deliver_webhooks.CARRYOVER_CACHE_KEY,
+            [{"id": records[0].id, "mailbox_name": "github:123"}],
+            timeout=deliver_webhooks.CARRYOVER_TTL,
+        )
+
+        schedule_webhook_delivery()
+
+        # Depth comes off the claims, so it earns what a fresh head would.
+        assert self.dispatched_claims(mock_drain) == [
+            (records[0].id, 2),
+            (records[2].id, 2),
+            (records[4].id, 1),
+        ]
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @override_options(lane_options(2))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_lane_one_reaches_every_mailbox_first(self, mock_drain: MagicMock) -> None:
+        first = create_payloads(4, "github:123", provider="github")
+        second = create_payloads(4, "github:456", provider="github")
+
+        schedule_webhook_delivery()
+
+        # Breadth-first: no second lane until both have had a first, so one deep
+        # mailbox cannot spend the cycle ahead of the others.
+        assert self.dispatched_claims(mock_drain) == [
+            (first[0].id, 2),
+            (second[0].id, 2),
+            (first[2].id, 2),
+            (second[2].id, 2),
+        ]
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 2)
+    @patch.object(deliver_webhooks, "BATCH_SIZE", 2)
+    @override_options(lane_options(4))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_dispatch_budget_stops_extra_lanes(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        first = create_payloads(4, "github:123", provider="github")
+        second = create_payloads(4, "github:456", provider="github")
+
+        schedule_webhook_delivery()
+
+        # Both earn a second lane; the budget is spent on their firsts.
+        assert self.dispatched_claims(mock_drain) == [(first[0].id, 2), (second[0].id, 2)]
+        assert self.distribution_calls(mock_metrics, EXTRA_LANES_METRIC) == [
+            (0, {"provider": "github"})
+        ]
+
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 1)
+    @override_options(lane_options(8))
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_lane_chain_stops_at_a_claim_that_reserves_nothing(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        records = create_payloads(6, "github:123", provider="github")
+        backoff = records[3]
+        backoff_schedule = timezone.now() + timedelta(minutes=1)
+        WebhookPayload.objects.filter(id=backoff.id).update(schedule_for=backoff_schedule)
+
+        schedule_webhook_delivery()
+
+        # The backing-off record bounds the chain: the lane reaching it claims
+        # nothing and the mailbox stops there.
+        assert self.dispatched_claims(mock_drain) == [
+            (records[0].id, 1),
+            (records[1].id, 1),
+            (records[2].id, 1),
+        ]
+        assert self.distribution_calls(mock_metrics, EXTRA_LANES_METRIC) == [
+            (2, {"provider": "github"})
+        ]
+        backoff.refresh_from_db()
+        assert backoff.schedule_for == backoff_schedule
+        # Records behind the backoff wait rather than be claimed out of order.
+        for record in records[4:]:
+            record.refresh_from_db()
+            assert record.schedule_for <= timezone.now()
 
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:


### PR DESCRIPTION
Stacked on #122893.

## Problem

A scheduler cycle dispatches at most one claim (up to `MAX_MAILBOX_DRAIN` records) per mailbox, so a mailbox's burn rate is flat regardless of depth: one holding orders of magnitude more than another drains at the same fixed rate while the rest of the fleet has idle capacity. Deepening the claim instead is not an option — claim size bounds how long one drain holds a worker.

## Change

Beyond the first dispatch every due head already gets, a deep mailbox now gets further disjoint claims — lanes — up to the new `hybridcloud.webhookpayload.max_drain_lanes` option.

Depth is read off the claim itself. `_claim_mailbox_batch` scans a due-prefix capped at `MAX_MAILBOX_DRAIN` and stops at the first not-due record, which makes the claim's own size the signal:

- **filled its cap** → it saw nothing but due records and left more behind → chain another lane
- **came back short** → the due prefix is exhausted → the chain ends

Three properties make this safe:

- **Claims are disjoint.** Each lane claims from where the previous one stopped, and an in-flight claim's future `schedule_for` bounds the next lane.
- **Reordering is already accepted.** Lanes apply only to skip-on-failure providers in due-head mode; strict providers stay at one lane.
- **It self-throttles.** An in-flight lane's records are not due, so the claim behind them comes back short and the chain ends. A mailbox whose drains sit in the queue or keep failing stops being handed lanes, with no arithmetic to keep in sync.

Extra lanes dispatch breadth-first — every mailbox gets its first claim before any gets a second — within the cycle's existing `BATCH_SIZE` budget. With the default of 1, behavior is byte-for-byte today's.

Reading depth from the claim rather than from discovery counts also means a head that reached the cycle through the carryover cache earns the same lanes as a freshly discovered one, which matters because a cycle only spends carryover when the backlog is wide.

## Also here: the transitional fallbacks come out

#122893 gave `drain_mailbox` / `drain_mailbox_parallel` a `valid_until` and a `mailbox` argument, each defaulting to `None` so that drains enqueued by the deploy before it would still bind. Both are now required, which is what lets `_begin_drain` reduce to building the claim and asking whether it has lapsed — no head-row read, no recomputed horizon, and no nullable mailbox name anywhere downstream.

Two consequences worth naming. A lapsed drain that lost its head now reports its real provider on `outcome:race` rather than `unknown`, since the mailbox travels with the claim. And six tests covered only the fallbacks, so they go; the two time-limit tests now state "already past its deadline" with a deadline instead of patching `BATCH_SCHEDULE_OFFSET` out from under a freshly computed one.

## ⚠️ Rollout dependency

**This PR must not reach production in the same deploy as #122893.**

Making those arguments required means a drain enqueued by the deploy *before* #122893 cannot bind — it carries neither argument, and the task raises `TypeError`. #122893 must be deployed and given time for its pre-existing drains to clear before this one lands.

The failure is noisy rather than lossy if that ordering slips: the task errors, its rows keep the `schedule_for` their claim wrote, and the next dispatcher re-claims them once that passes. Delivery is delayed, not dropped. The window matters more than usual here, though, precisely because #122893 exists — the drains that sit longest in the queue are the ones this stack is about.

## Observability and rollout

Lane dispatches land in the existing `dispatch` / `dispatch.claimed` metrics; the new `…schedule_webhook_delivery.extra_lanes` distribution records per-cycle extra dispatches by provider.

Ramp the option 1 → 2 → 4 → 8 in the automator, watching per-provider `due_rows` burn slope, the `outcome:race` / `outcome:conflict` share (the disjointness test), `outcome:delivery_deadline`, and `hybridcloud.control` queue latency. Setting it back to 1 reverts without a deploy.

## Follow-up

Consider adding `jira` to `hybridcloud.webhookpayload.skip_on_failure_providers` once #121157 lands and soaks, so lanes cover jira mailboxes too: under the strict head gate, a head in retry backoff parks its entire mailbox for the backoff duration.
