### PR TITLE
fix(inbox): add referrer to issue preview links

### DIFF
--- a/static/app/views/issueList/pages/inbox/index.spec.tsx
+++ b/static/app/views/issueList/pages/inbox/index.spec.tsx
@@ -995,6 +995,16 @@ describe('InboxPage', () => {
     expect(within(preview).getByLabelText('2,600 events')).toHaveTextContent(
       '2.6KEvents'
     );
+    expect(within(preview).getByRole('button', {name: 'Open Issue'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/${fixProposedGroup.id}/?referrer=inbox`
+    );
+    expect(
+      within(preview).getByRole('link', {name: /Fix proposed issue/})
+    ).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/${fixProposedGroup.id}/?referrer=inbox`
+    );
 
     await userEvent.click(await screen.findByRole('button', {name: 'Back to inbox'}));
     expect(router.location.query.preview).toBeUndefined();

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.spec.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.spec.tsx
@@ -206,6 +206,7 @@ describe('IssuePreview', () => {
       `/organizations/${organization.slug}/issues/${group.id}/`
     );
     expect(router.location.query).toEqual({
+      referrer: 'inbox',
       seerDrawer: 'true',
       seerDrawerAction: 'retry_code_changes',
     });

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
@@ -155,7 +155,11 @@ function IssuePreviewContent() {
   function openSeerDrawer(seerDrawerAction?: string) {
     navigate({
       pathname: issueDetailsUrl,
-      query: {seerDrawer: 'true', seerDrawerAction},
+      query: {
+        ...issueDetailsLocation.query,
+        seerDrawer: 'true',
+        seerDrawerAction,
+      },
     });
   }
 

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
@@ -75,6 +75,10 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
   const issueDetailsUrl = normalizeUrl(
     `/organizations/${organization.slug}/issues/${groupId}/`
   );
+  const issueDetailsLocation = {
+    pathname: issueDetailsUrl,
+    query: {referrer: 'inbox'},
+  };
 
   useMarkPreviewedGroupSeen(group);
 
@@ -92,7 +96,7 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
           ) : null}
           {group && (
             <LinkButton
-              to={issueDetailsUrl}
+              to={issueDetailsLocation}
               size="xs"
               analyticsEventKey="issue_inbox.open_issue_clicked"
               analyticsEventName="Issue Inbox: Open Issue Clicked"
@@ -144,6 +148,10 @@ function IssuePreviewContent() {
   const issueDetailsUrl = normalizeUrl(
     `/organizations/${organization.slug}/issues/${group.id}/`
   );
+  const issueDetailsLocation = {
+    pathname: issueDetailsUrl,
+    query: {referrer: 'inbox'},
+  };
   function openSeerDrawer(seerDrawerAction?: string) {
     navigate({
       pathname: issueDetailsUrl,
@@ -166,7 +174,7 @@ function IssuePreviewContent() {
                   delay={1000}
                 >
                   <TitleLink
-                    to={issueDetailsUrl}
+                    to={issueDetailsLocation}
                     analyticsEventKey="issue_inbox.open_issue_clicked"
                     analyticsEventName="Issue Inbox: Open Issue Clicked"
                     analyticsParams={{


### PR DESCRIPTION
This allows us to figure out what actions are being done when users navigate to issue details from the inbox UI. We already add a referrer from the issue stream.