### PR TITLE
ref(seer): Move AutofixChatProvider to the Seer Explorer page

### DIFF
--- a/static/app/components/seer/autofixChatContext.tsx
+++ b/static/app/components/seer/autofixChatContext.tsx
@@ -1,0 +1,39 @@
+import {createContext, useContext, useMemo, type ReactNode} from 'react';
+
+type AutofixChatContextValue = {
+  /**
+   * Posts `query` into the chat as a new user message. Undefined wherever no
+   * chat is mounted (Storybook) or the run is read-only, in which case callers
+   * render their entry point disabled instead of acting.
+   */
+  sendMessage?: (query: string) => void;
+};
+
+const AutofixChatContext = createContext<AutofixChatContextValue>({});
+
+/**
+ * Wraps the Seer Explorer page so anything rendered inside it — a markdown
+ * embed, a block widget, a header button — can drive the agent by posting a
+ * message into the chat rather than calling the autofix API directly. The
+ * transcript then keeps a timestamped record of the action, and the agent
+ * reacts to it exactly as it would to a typed message.
+ */
+export function AutofixChatProvider({
+  children,
+  sendMessage,
+}: {
+  children: ReactNode;
+  sendMessage?: (query: string) => void;
+}) {
+  // The page re-renders on every poll; a stable value keeps that from
+  // invalidating every consumer of this context.
+  const value = useMemo(() => ({sendMessage}), [sendMessage]);
+
+  return (
+    <AutofixChatContext.Provider value={value}>{children}</AutofixChatContext.Provider>
+  );
+}
+
+export function useAutofixChat(): AutofixChatContextValue {
+  return useContext(AutofixChatContext);
+}

--- a/static/app/components/seer/markdown/embeds/components/autofix.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useMemo, type ReactNode} from 'react';
+import {useMemo, type ReactNode} from 'react';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -26,6 +26,7 @@ import {
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {useAutofixChat} from 'sentry/components/seer/autofixChatContext';
 import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 import {IconBug} from 'sentry/icons/iconBug';
 import {IconCode} from 'sentry/icons/iconCode';
@@ -127,32 +128,6 @@ export const NEXT_STEP: Partial<Record<AutofixExplorerStep, AutofixExplorerStep>
   solution: 'code_changes',
 };
 
-/**
- * Lets the AutofixRef embed post a message into the enclosing Seer Explorer
- * chat instead of calling the autofix API directly, so the chat transcript
- * keeps a timestamped record of the retry/continue/draft-PR action. Provided
- * by `AssistantBlock`, where the embed actually renders; `sendMessage` is
- * undefined wherever that provider isn't mounted (e.g. Storybook), in which
- * case the buttons render disabled.
- */
-const AutofixChatContext = createContext<{
-  sendMessage?: (query: string) => void;
-}>({});
-
-export function AutofixChatProvider({
-  children,
-  sendMessage,
-}: {
-  children: ReactNode;
-  sendMessage?: (query: string) => void;
-}) {
-  return (
-    <AutofixChatContext.Provider value={{sendMessage}}>
-      {children}
-    </AutofixChatContext.Provider>
-  );
-}
-
 interface AutofixRefContentProps extends Pick<Group, 'id' | 'shortId'> {
   runId: string | number;
   step: AutofixExplorerStep;
@@ -161,7 +136,7 @@ interface AutofixRefContentProps extends Pick<Group, 'id' | 'shortId'> {
 function AutofixRefContent({id, shortId, step}: AutofixRefContentProps) {
   const autofix = useExplorerAutofix({id, shortId});
   const {runState, isLoading, isPolling} = autofix;
-  const {sendMessage} = useContext(AutofixChatContext);
+  const {sendMessage} = useAutofixChat();
 
   const sections = useMemo(() => getOrderedAutofixSections(runState), [runState]);
   const section = useMemo(() => findStepSection(sections, step), [sections, step]);

--- a/static/app/views/seerExplorer/components/chat/assistant.tsx
+++ b/static/app/views/seerExplorer/components/chat/assistant.tsx
@@ -4,7 +4,6 @@ import {css} from '@emotion/react';
 import {AssistantActions, AssistantMessage, MessageRow} from '@sentry/scraps/chat';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
-import {AutofixChatProvider} from 'sentry/components/seer/markdown/embeds/components/autofix';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
@@ -21,7 +20,6 @@ export function AssistantBlock({
   runId,
   interactionPending,
   readOnly,
-  sendMessage,
 }: AssistantBlockProps) {
   const organization = useOrganization();
   const content = block.message.content ?? '';
@@ -41,24 +39,22 @@ export function AssistantBlock({
   }
 
   return (
-    <AutofixChatProvider sendMessage={sendMessage}>
-      <Fragment>
-        {hasValidContent(content) && (
-          <MessageRow from="assistant">
-            <AssistantMessage>
-              <SeerMarkdown raw={content} />
-            </AssistantMessage>
-          </MessageRow>
-        )}
-        <BlockActionBar
-          block={block}
-          blockIndex={blockIndex}
-          runId={runId}
-          interactionPending={interactionPending}
-          readOnly={readOnly}
-        />
-      </Fragment>
-    </AutofixChatProvider>
+    <Fragment>
+      {hasValidContent(content) && (
+        <MessageRow from="assistant">
+          <AssistantMessage>
+            <SeerMarkdown raw={content} />
+          </AssistantMessage>
+        </MessageRow>
+      )}
+      <BlockActionBar
+        block={block}
+        blockIndex={blockIndex}
+        runId={runId}
+        interactionPending={interactionPending}
+        readOnly={readOnly}
+      />
+    </Fragment>
   );
 }
 

--- a/static/app/views/seerExplorer/components/chat/index.tsx
+++ b/static/app/views/seerExplorer/components/chat/index.tsx
@@ -25,7 +25,6 @@ interface BlockProps {
   ref?: React.Ref<HTMLDivElement>;
   respondToUserInput?: (inputId: string, responseData?: Record<string, unknown>) => void;
   runId?: SeerExplorerRunId;
-  sendMessage?: (query: string) => void;
   showThinking?: boolean;
 }
 
@@ -72,7 +71,6 @@ function BlockVariant(props: Omit<BlockProps, 'onClick' | 'ref'>) {
           runId={props.runId}
           interactionPending={props.interactionPending}
           readOnly={props.readOnly}
-          sendMessage={props.sendMessage}
         />
       );
     default: {

--- a/static/app/views/seerExplorer/components/chat/shared.tsx
+++ b/static/app/views/seerExplorer/components/chat/shared.tsx
@@ -20,7 +20,6 @@ export interface AssistantBlockProps extends BlockVariantProps {
   interactionPending?: boolean;
   readOnly?: boolean;
   runId?: SeerExplorerRunId;
-  sendMessage?: (query: string) => void;
 }
 
 export interface ToolUseBlockProps extends BlockVariantProps {

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -7,6 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {usePictureInPicture} from '@sentry/scraps/pictureInPicture';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {AutofixChatProvider} from 'sentry/components/seer/autofixChatContext';
 import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -534,141 +535,142 @@ export function SeerExplorerContent({
   );
 
   return (
-    <Stack
-      ref={rootRef}
-      data-seer-explorer-root=""
-      width="100%"
-      height="100%"
-      position="relative"
-      background="primary"
-      overflow="hidden"
-      containerType="inline-size"
-    >
-      {renderHeader ? (
-        renderHeader({children: headerContent, isPoppedOut, onClose: handleClose})
-      ) : (
-        <SidebarHeaderShell onClose={handleClose}>{headerContent}</SidebarHeaderShell>
-      )}
-      {menu}
-      {needsSlackUpgrade && (
-        <UpdateSlackAlert num_configurations={activeSlackIntegrations.length} />
-      )}
-      <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
-        {isEmptyState ? (
-          <EmptyState
-            isLoading={isPolling}
-            isError={isError}
-            errorStatusCode={errorStatusCode}
-            runId={runId}
-            displaySlackAgentReminder={hasSlackIntegration && !needsSlackUpgrade}
-            onSuggestionClick={readOnly ? undefined : sendMessage}
-          />
+    <AutofixChatProvider sendMessage={readOnly ? undefined : sendMessage}>
+      <Stack
+        ref={rootRef}
+        data-seer-explorer-root=""
+        width="100%"
+        height="100%"
+        position="relative"
+        background="primary"
+        overflow="hidden"
+        containerType="inline-size"
+      >
+        {renderHeader ? (
+          renderHeader({children: headerContent, isPoppedOut, onClose: handleClose})
         ) : (
-          <Fragment>
-            {blocks.map((block: Block, index: number) => {
-              // For slide-in animation that runs on mount. Avoid running this twice on user blocks when blocks are hydrated.
-              const key = block.message.role === 'user' ? `user-${index}` : block.id;
+          <SidebarHeaderShell onClose={handleClose}>{headerContent}</SidebarHeaderShell>
+        )}
+        {menu}
+        {needsSlackUpgrade && (
+          <UpdateSlackAlert num_configurations={activeSlackIntegrations.length} />
+        )}
+        <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
+          {isEmptyState ? (
+            <EmptyState
+              isLoading={isPolling}
+              isError={isError}
+              errorStatusCode={errorStatusCode}
+              runId={runId}
+              displaySlackAgentReminder={hasSlackIntegration && !needsSlackUpgrade}
+              onSuggestionClick={readOnly ? undefined : sendMessage}
+            />
+          ) : (
+            <Fragment>
+              {blocks.map((block: Block, index: number) => {
+                // For slide-in animation that runs on mount. Avoid running this twice on user blocks when blocks are hydrated.
+                const key = block.message.role === 'user' ? `user-${index}` : block.id;
 
-              return (
-                <BlockComponent
-                  key={key}
-                  ref={el => {
-                    blockRefs.current[index] = el;
-                  }}
-                  block={block}
-                  blockIndex={index}
-                  blocks={blocks}
-                  runId={runId ?? undefined}
-                  getPageReferrer={getPageReferrer}
-                  interactionPending={
-                    isFileApprovalPending ||
-                    isAgentWriteApprovalPending ||
-                    isQuestionPending ||
-                    showReauth
-                  }
-                  pendingInput={pendingInput}
-                  readOnly={readOnly}
-                  respondToUserInput={respondToUserInput}
-                  sendMessage={readOnly ? undefined : sendMessage}
-                  showThinking={showThinking}
-                />
-              );
-            })}
-            {!readOnly &&
-              isFileApprovalPending &&
-              fileApprovalIndex < fileApprovalTotalPatches && (
-                <FileChangeApprovalBlock
-                  currentIndex={fileApprovalIndex}
-                  pendingInput={pendingInput}
+                return (
+                  <BlockComponent
+                    key={key}
+                    ref={el => {
+                      blockRefs.current[index] = el;
+                    }}
+                    block={block}
+                    blockIndex={index}
+                    blocks={blocks}
+                    runId={runId ?? undefined}
+                    getPageReferrer={getPageReferrer}
+                    interactionPending={
+                      isFileApprovalPending ||
+                      isAgentWriteApprovalPending ||
+                      isQuestionPending ||
+                      showReauth
+                    }
+                    pendingInput={pendingInput}
+                    readOnly={readOnly}
+                    respondToUserInput={respondToUserInput}
+                    showThinking={showThinking}
+                  />
+                );
+              })}
+              {!readOnly &&
+                isFileApprovalPending &&
+                fileApprovalIndex < fileApprovalTotalPatches && (
+                  <FileChangeApprovalBlock
+                    currentIndex={fileApprovalIndex}
+                    pendingInput={pendingInput}
+                  />
+                )}
+              {!readOnly && isQuestionPending && currentQuestion && (
+                <AskUserQuestionBlock
+                  currentQuestion={currentQuestion}
+                  customText={customText}
+                  isOtherSelected={isOtherSelected}
+                  onCustomTextChange={handleQuestionCustomTextChange}
+                  onSelectOption={handleQuestionSelectOption}
+                  questionIndex={questionIndex}
+                  selectedOption={selectedOption}
                 />
               )}
-            {!readOnly && isQuestionPending && currentQuestion && (
-              <AskUserQuestionBlock
-                currentQuestion={currentQuestion}
-                customText={customText}
-                isOtherSelected={isOtherSelected}
-                onCustomTextChange={handleQuestionCustomTextChange}
-                onSelectOption={handleQuestionSelectOption}
-                questionIndex={questionIndex}
-                selectedOption={selectedOption}
-              />
-            )}
-            {!readOnly && showReauth && reauthData && (
-              <ReauthMonitoringProviderBlock
-                data={reauthData}
-                onComplete={handleReauthComplete}
-                returnUrl={
-                  runId === null
-                    ? undefined
-                    : getRelativeExplorerUrl(runId, {resume: true})
+              {!readOnly && showReauth && reauthData && (
+                <ReauthMonitoringProviderBlock
+                  data={reauthData}
+                  onComplete={handleReauthComplete}
+                  returnUrl={
+                    runId === null
+                      ? undefined
+                      : getRelativeExplorerUrl(runId, {resume: true})
+                  }
+                />
+              )}
+            </Fragment>
+          )}
+        </BlocksContainer>
+        <InputSection
+          blocks={blocks}
+          enabled={!readOnly}
+          inputValue={inputValue}
+          canSendMessage={canSendMessage}
+          interruptState={interruptState}
+          isTimedOut={isTimedOut}
+          onCreatePR={createPR}
+          onInputChange={handleInputChange}
+          onInputClick={handleInputClick}
+          onInterrupt={interruptRun}
+          onKeyDown={handleInputKeyDown}
+          onSend={handleSend}
+          onPRWidgetClick={openPRWidget}
+          prWidgetButtonRef={prWidgetButtonRef}
+          repoPRStates={repoPRStates}
+          textAreaRef={textareaRef}
+          fileApprovalActions={
+            isFileApprovalPending && fileApprovalIndex < fileApprovalTotalPatches
+              ? {
+                  currentIndex: fileApprovalIndex,
+                  totalPatches: fileApprovalTotalPatches,
+                  onApprove: handleFileApprovalApprove,
+                  onReject: handleFileApprovalReject,
                 }
-              />
-            )}
-          </Fragment>
-        )}
-      </BlocksContainer>
-      <InputSection
-        blocks={blocks}
-        enabled={!readOnly}
-        inputValue={inputValue}
-        canSendMessage={canSendMessage}
-        interruptState={interruptState}
-        isTimedOut={isTimedOut}
-        onCreatePR={createPR}
-        onInputChange={handleInputChange}
-        onInputClick={handleInputClick}
-        onInterrupt={interruptRun}
-        onKeyDown={handleInputKeyDown}
-        onSend={handleSend}
-        onPRWidgetClick={openPRWidget}
-        prWidgetButtonRef={prWidgetButtonRef}
-        repoPRStates={repoPRStates}
-        textAreaRef={textareaRef}
-        fileApprovalActions={
-          isFileApprovalPending && fileApprovalIndex < fileApprovalTotalPatches
-            ? {
-                currentIndex: fileApprovalIndex,
-                totalPatches: fileApprovalTotalPatches,
-                onApprove: handleFileApprovalApprove,
-                onReject: handleFileApprovalReject,
-              }
-            : undefined
-        }
-        questionActions={
-          isQuestionPending && currentQuestion
-            ? {
-                currentIndex: questionIndex,
-                totalQuestions,
-                canSubmit: canSubmitQuestion,
-                onNext: handleQuestionNext,
-                onBack: handleQuestionBack,
-                onMoveUp: handleQuestionMoveUp,
-                onMoveDown: handleQuestionMoveDown,
-              }
-            : undefined
-        }
-      />
-    </Stack>
+              : undefined
+          }
+          questionActions={
+            isQuestionPending && currentQuestion
+              ? {
+                  currentIndex: questionIndex,
+                  totalQuestions,
+                  canSubmit: canSubmitQuestion,
+                  onNext: handleQuestionNext,
+                  onBack: handleQuestionBack,
+                  onMoveUp: handleQuestionMoveUp,
+                  onMoveDown: handleQuestionMoveDown,
+                }
+              : undefined
+          }
+        />
+      </Stack>
+    </AutofixChatProvider>
   );
 }
 


### PR DESCRIPTION
Stacked on #122099, which adds the `autofixRef` embed and the chat provider this moves. Review that one first; the base here is `worktree-autofix-ref-embed`, not `master`, because `AutofixChatProvider` does not exist on `master` yet.

The provider that lets an embed post a message into the Seer Explorer chat was defined inside the embed's own module and mounted by `AssistantBlock` — one instance per assistant block, fed by a `sendMessage` prop threaded down through `BlockComponent` and `BlockVariant`. That put a hard limit on who could use it: only an embed that happened to render inside an assistant block could drive the agent.

This pulls the context, provider, and a `useAutofixChat` hook out into `sentry/components/seer/autofixChatContext`, and mounts the provider once around the whole `SeerExplorerContent` tree. Anything on the page — an embed, a block widget, the header, the input section — can now call `useAutofixChat().sendMessage` to put a message into the chat instead of calling the autofix API directly, so the transcript keeps a timestamped record of the action and the agent reacts to it exactly as it would to something typed. The prop threading goes away with it.

Two behavioral edges are preserved rather than reworked. `sendMessage` is still `undefined` on read-only runs, so entry points keep rendering disabled there. And dropping the explicit insert index is safe: `useSeerExplorer`'s `sendMessage` already defaults it to `blocks.length`, which appends — the same result as the old call site, without closing over a possibly stale count.

Worth knowing about scope: this covers the Explorer page, which means the drawer, the sidebar panel, and the picture-in-picture window, since all three render `SeerExplorerContent`. It is not app-wide. Components mounted outside that tree still cannot reach `sendMessage`, because it only exists where `useSeerExplorer()` is called. Making it genuinely global would mean lifting that session hook into `SeerExplorerContextProvider`, which is a larger change and not attempted here.

Most of the diff in `seerExplorerContent.tsx` is the re-indent from the added wrapper — `?w=1` reduces it to the real change.

Refs #122099
