### PR TITLE
feat(inbox): track issue preview views

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -58,6 +58,12 @@ interface SetPriorityParams extends CommonGroupAnalyticsData {
   to_priority: PriorityLevel;
 }
 
+interface IssueInboxItemParams extends CommonGroupAnalyticsData {
+  assignment_filter: 'me' | 'my_teams' | 'all';
+  last_progressed_at: string | null;
+  progress: ProgressState | undefined;
+}
+
 export type IssueEventParameters = {
   'actionable_items.expand_clicked': ActionableItemDebugParam;
   'breadcrumbs.drawer.action': {control: string; value?: string};
@@ -197,12 +203,8 @@ export type IssueEventParameters = {
   'issue_inbox.assignment_filter_changed': {
     assignment_filter: 'me' | 'my_teams' | 'all';
   };
-  'issue_inbox.item_clicked': {
-    assignment_filter: 'me' | 'my_teams' | 'all';
-    group_id: string;
-    last_progressed_at: string | null;
-    progress: ProgressState | undefined;
-  };
+  'issue_inbox.issue_viewed': IssueInboxItemParams;
+  'issue_inbox.item_clicked': IssueInboxItemParams;
   'issue_search.empty': {
     query: string;
     search_source: string;
@@ -369,6 +371,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_search.failed': 'Issue Search: Failed',
   'issue_search.empty': 'Issue Search: Empty',
   'issue_inbox.assignment_filter_changed': 'Issue Inbox: Assignment Filter Changed',
+  'issue_inbox.issue_viewed': 'Issue Inbox: Issue Viewed',
   'issue_inbox.item_clicked': 'Issue Inbox: Item Clicked',
   'issues_stream.archived': 'Issues Stream: Archived',
   'issues_stream.updated_priority': 'Issues Stream: Updated Priority',

--- a/static/app/views/issueList/pages/inbox/index.tsx
+++ b/static/app/views/issueList/pages/inbox/index.tsx
@@ -9,7 +9,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import orderBy from 'lodash/orderBy';
-import {parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
+import {parseAsString, useQueryState} from 'nuqs';
 
 import {ActorAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Badge} from '@sentry/scraps/badge';
@@ -40,7 +40,7 @@ import type {PullRequestStatus} from 'sentry/types/integrations';
 import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import {getMessage, getTitle} from 'sentry/utils/events';
+import {getAnalyticsDataForGroup, getMessage, getTitle} from 'sentry/utils/events';
 import {useMembers} from 'sentry/utils/members/useMembers';
 import {parseActorString} from 'sentry/utils/parseActorString';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -56,6 +56,10 @@ import {IssueListContainer} from 'sentry/views/issueList';
 import {IssuePreview} from 'sentry/views/issueList/pages/inbox/issuePreview/issuePreview';
 import {INBOX_AUTOFIX_CATEGORY_FILTER} from 'sentry/views/issueList/pages/inbox/utils';
 import {InboxEmptyState} from 'sentry/views/issueList/pages/inboxEmptyState';
+import {
+  type AssignmentFilter,
+  useAssignmentFilter,
+} from 'sentry/views/issueList/pages/useAssignmentFilter';
 import {useInboxPreviewPrefetch} from 'sentry/views/issueList/pages/useInboxPreviewPrefetch';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
@@ -64,14 +68,10 @@ import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationCon
 const TITLE = t('Inbox');
 const ISSUE_LIMIT = 10;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
-const ASSIGNMENT_QUERY_PARAM = 'assignment';
-const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;
 const INBOX_SPLIT_SIZE_STORAGE_KEY = 'inbox-split-size';
 const INBOX_DEFAULT_SIZE = 480;
 const INBOX_MIN_SIZE = 320;
 const INBOX_MAX_SIZE = 640;
-type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
-
 interface AssignmentCounts {
   all: number;
   me: number;
@@ -311,12 +311,7 @@ function InboxContent() {
   const resizableContainerRef = useRef<HTMLDivElement>(null);
   const organization = useOrganization();
   const hasSeer = orgHasSeerAccess(organization);
-  const [assignmentFilter, setAssignmentFilter] = useQueryState(
-    ASSIGNMENT_QUERY_PARAM,
-    parseAsStringLiteral(ASSIGNMENT_FILTERS)
-      .withDefault('me')
-      .withOptions({history: 'replace'})
-  );
+  const [assignmentFilter, setAssignmentFilter] = useAssignmentFilter();
   const [selectedIssueId, setSelectedIssueId] = useQueryState(
     SELECTED_ISSUE_QUERY_PARAM,
     parseAsString.withOptions({history: 'replace'})
@@ -709,8 +704,8 @@ function InboxIssueCard({
         onClick={() =>
           trackAnalytics('issue_inbox.item_clicked', {
             organization,
+            ...getAnalyticsDataForGroup(group),
             assignment_filter: assignmentFilter,
-            group_id: group.id,
             progress: group.derivedData?.progress,
             last_progressed_at: group.derivedData?.lastProgressedAt ?? null,
           })

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -20,7 +20,8 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import {getMessage, getTitle} from 'sentry/utils/events';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getAnalyticsDataForGroup, getMessage, getTitle} from 'sentry/utils/events';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -51,6 +52,7 @@ import {
   useIssuePreviewSeer,
 } from 'sentry/views/issueList/pages/inbox/issuePreview/issuePreviewSeer';
 import {IssueSeenTimes} from 'sentry/views/issueList/pages/issueSeenTimes';
+import {useAssignmentFilter} from 'sentry/views/issueList/pages/useAssignmentFilter';
 
 interface IssuePreviewProps {
   groupId: string;
@@ -67,6 +69,27 @@ function useMarkPreviewedGroupSeen(group: Group | undefined) {
   }, [groupId, markGroupSeen]);
 }
 
+function useTrackPreviewedGroup(group: Group | undefined) {
+  const organization = useOrganization();
+  const lastTrackedGroupId = useRef<string | null>(null);
+  const [assignmentFilter] = useAssignmentFilter();
+
+  useEffect(() => {
+    if (!group || lastTrackedGroupId.current === group.id) {
+      return;
+    }
+
+    lastTrackedGroupId.current = group.id;
+    trackAnalytics('issue_inbox.issue_viewed', {
+      organization,
+      ...getAnalyticsDataForGroup(group),
+      assignment_filter: assignmentFilter,
+      progress: group.derivedData?.progress,
+      last_progressed_at: group.derivedData?.lastProgressedAt ?? null,
+    });
+  }, [assignmentFilter, group, organization]);
+}
+
 export function IssuePreview({groupId}: IssuePreviewProps) {
   const {data: group, isPending, isError} = useGroup({groupId});
   const organization = useOrganization();
@@ -77,6 +100,7 @@ export function IssuePreview({groupId}: IssuePreviewProps) {
   );
 
   useMarkPreviewedGroupSeen(group);
+  useTrackPreviewedGroup(group);
 
   return (
     <AnalyticsArea name="issue_inbox" overrideParent>

--- a/static/app/views/issueList/pages/useAssignmentFilter.tsx
+++ b/static/app/views/issueList/pages/useAssignmentFilter.tsx
@@ -1,0 +1,15 @@
+import {parseAsStringLiteral, useQueryState} from 'nuqs';
+
+const ASSIGNMENT_QUERY_PARAM = 'assignment';
+const ASSIGNMENT_FILTERS = ['me', 'my_teams', 'all'] as const;
+
+export type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
+
+export function useAssignmentFilter() {
+  return useQueryState(
+    ASSIGNMENT_QUERY_PARAM,
+    parseAsStringLiteral(ASSIGNMENT_FILTERS)
+      .withDefault('me')
+      .withOptions({history: 'replace'})
+  );
+}


### PR DESCRIPTION
We were tracking issue clicks in the issue inbox, but because only the query params change this did not trigger a new page view event. For proper tracking of issue views, this adds an event when the issue has loaded, which includes more group information than before.