### PR TITLE
perf(hybridcloud): Carry surplus discovered mailbox heads across scheduler cycles

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -80,12 +80,8 @@ cycle below its target by whatever the contention share is. Heads the cycle
 never reaches are handed to the next one (see CARRYOVER_CACHE_KEY) rather than
 rediscovered.
 
-Sized well above BATCH_SIZE because the selection is nearly free next to the
-scan that produces it: the aggregate visits every row either way, and the limit
-only bounds what is materialized. Overselecting is what makes a carried surplus
-survive contention — at 2x, a cycle skipping a fifth of what it walks carries
-less than a batch, and the next cycle then dispatches short of BATCH_SIZE with
-mailboxes still due.
+Set far above BATCH_SIZE because the limit only bounds what the scan
+materializes, and a surplus has to outlast contention to be worth carrying.
 """
 
 
@@ -535,9 +531,8 @@ CARRYOVER_CACHE_KEY = "wh:schedule:carryover"
 CARRYOVER_TTL = 60
 """
 Seconds a carried surplus stays dispatchable. Each cycle re-stores what it did
-not spend, so the TTL does not bound how long a deep backlog defers discovery —
-it is the backstop for a cycle that dies mid-list, keeping a surplus nobody is
-spending from deferring discovery indefinitely.
+not spend, so this bounds only a surplus nobody is spending — not how long a
+deep backlog defers discovery.
 """
 
 
@@ -610,8 +605,7 @@ def schedule_webhook_delivery() -> None:
     one claim attempt: `_claim_and_dispatch` gates every dispatch on the head still
     being due, so a head claimed, delivered, or backed off since discovery claims 0
     rows and is skipped. Mailboxes that arrive while a surplus is being spent are
-    dispatched by their push trigger; the ones with none wait for the surplus to
-    drain, which is the trade a deep backlog is already making.
+    dispatched by their push trigger; the ones with none wait for it to drain.
 
     Triggered frequently by task-scheduler.
     """
@@ -669,18 +663,13 @@ def schedule_webhook_delivery() -> None:
         else:
             dispatched += 1
 
-    # The next cycle takes a carryover in place of discovery, so a short surplus
-    # costs it the rest of its dispatch budget while mailboxes are still due. Half
-    # a batch is where that loss stops being worth the scan it saves; below it the
-    # surplus is dropped, and discovery finds those heads again — they are still
-    # due, and now sort ahead of the newer ones.
+    # A carryover displaces the next cycle's discovery, so a short surplus costs it
+    # the rest of its dispatch budget — below half a batch that outweighs the scan
+    # it saves, and discovery finds those heads again.
     if len(surplus) >= BATCH_SIZE // 2:
         _store_carryover(surplus)
     else:
         if surplus:
-            # Recorded because the carryover distribution only samples surpluses
-            # large enough to keep, so on its own it cannot say how often the
-            # overselect failed to survive a cycle's contention.
             metrics.incr("hybridcloud.schedule_webhook_delivery.carryover.dropped")
         if carryover:
             _clear_carryover()

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1,7 +1,7 @@
 import datetime
 import enum
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from concurrent.futures import as_completed
 from typing import Any
 
@@ -76,8 +76,9 @@ BATCH_SELECT_LIMIT = BATCH_SIZE * 2
 How many due mailbox heads a scheduler cycle selects to reach BATCH_SIZE
 dispatches. Push triggers and concurrent cycles claim heads out of the selected
 list before the loop reaches them, so selecting exactly BATCH_SIZE shrinks the
-cycle below its target by whatever the contention share is. Contention beyond
-the surplus leaves the remainder to the next cycle.
+cycle below its target by whatever the contention share is. Heads the cycle
+never reaches are handed to the next one (see CARRYOVER_CACHE_KEY) rather than
+rediscovered.
 """
 
 
@@ -517,8 +518,67 @@ def _due_mailbox_heads() -> list[dict[str, Any]]:
     )
     return [
         {"id": head_id, "mailbox_name": mailbox_name}
-        for _, head_id, mailbox_name in heads[:BATCH_SIZE]
+        for _, head_id, mailbox_name in heads[:BATCH_SELECT_LIMIT]
     ]
+
+
+CARRYOVER_CACHE_KEY = "wh:schedule:carryover"
+"""Where a cycle leaves the due heads it discovered but had no budget to dispatch."""
+
+CARRYOVER_TTL = 60
+"""
+Seconds a carried surplus stays dispatchable. A cycle either walks the surplus to
+its end or spends a full dispatch batch of it, so a surplus of at most
+BATCH_SELECT_LIMIT drains within a couple of cycles on its own; the TTL is the
+backstop for a cycle that dies mid-list, keeping an unspent surplus from deferring
+discovery — the only thing that finds mailboxes no push trigger woke.
+"""
+
+
+def _read_carryover() -> list[dict[str, Any]]:
+    """
+    The heads a previous cycle discovered and left behind, empty when there are none.
+
+    A cache failure reads as empty so the cycle falls back to discovery, which is
+    what every cycle did before a surplus was carried at all.
+    """
+    try:
+        return cache.get(CARRYOVER_CACHE_KEY) or []
+    except Exception:
+        metrics.incr(
+            "hybridcloud.schedule_webhook_delivery.carryover.error", tags={"operation": "get"}
+        )
+        return []
+
+
+def _store_carryover(records: Sequence[Mapping[str, Any]]) -> None:
+    """
+    Hand this cycle's undispatched heads to the next one.
+
+    Stored as the head id and mailbox name a dispatch needs and nothing else: a
+    cycle's worth of heads all sit in one cache value.
+    """
+    metrics.distribution("hybridcloud.schedule_webhook_delivery.carryover", len(records))
+    try:
+        cache.set(
+            CARRYOVER_CACHE_KEY,
+            [{"id": record["id"], "mailbox_name": record["mailbox_name"]} for record in records],
+            timeout=CARRYOVER_TTL,
+        )
+    except Exception:
+        metrics.incr(
+            "hybridcloud.schedule_webhook_delivery.carryover.error", tags={"operation": "set"}
+        )
+
+
+def _clear_carryover() -> None:
+    """Drop the spent surplus so the next cycle discovers again."""
+    try:
+        cache.delete(CARRYOVER_CACHE_KEY)
+    except Exception:
+        metrics.incr(
+            "hybridcloud.schedule_webhook_delivery.carryover.error", tags={"operation": "delete"}
+        )
 
 
 @instrumented_task(
@@ -534,21 +594,45 @@ def schedule_webhook_delivery() -> None:
 
     Prioritizes webhooks based on provider importance.
 
+    Discovery aggregates the whole table, so its cost grows with the backlog while
+    it runs on a fixed short interval. A cycle that discovers more due heads than
+    it can dispatch therefore hands the surplus to the next cycle instead of
+    discarding it, and only a cycle that starts with nothing carried over pays for
+    discovery — the deeper the backlog, the more of that scan is spared.
+
+    A carried head may be stale by the time it is dispatched, which costs at most
+    one claim attempt: `_claim_and_dispatch` gates every dispatch on the head still
+    being due, so a head claimed, delivered, or backed off since discovery claims 0
+    rows and is skipped. Mailboxes that arrive while a surplus is being spent are
+    dispatched by their push trigger, and CARRYOVER_TTL bounds how long discovery
+    can be deferred for the ones that have none.
+
     Triggered frequently by task-scheduler.
     """
-    # Discovery reads the primary rather than a replica. These reads run on a
-    # short interval and can scan the whole table; on a replica they contend with
-    # WAL replay and amplify replication lag, and lag also produces spurious
-    # DoesNotExist races in the drains they enqueue (see INC-2398).
-    if options.get("hybridcloud.webhookpayload.dispatch_from_due_head"):
-        records = _due_mailbox_heads()
+    carryover = _read_carryover()
+    if carryover:
+        records = carryover
     else:
-        records = _gated_mailbox_heads()
+        # Discovery reads the primary rather than a replica. These reads run on a
+        # short interval and can scan the whole table; on a replica they contend with
+        # WAL replay and amplify replication lag, and lag also produces spurious
+        # DoesNotExist races in the drains they enqueue (see INC-2398).
+        if options.get("hybridcloud.webhookpayload.dispatch_from_due_head"):
+            records = _due_mailbox_heads()
+        else:
+            records = _gated_mailbox_heads()
+    metrics.incr(
+        "hybridcloud.schedule_webhook_delivery.cycle",
+        tags={"source": "carryover" if carryover else "discovery"},
+    )
 
     dispatched = 0
-    for record in records:
+    surplus: list[dict[str, Any]] = []
+    for index, record in enumerate(records):
         if dispatched >= BATCH_SIZE:
-            # Dispatch target reached; surplus heads stay due for the next cycle.
+            # Dispatch target reached; the heads this cycle never reached go to the
+            # next one, which dispatches them without rediscovering them.
+            surplus = records[index:]
             break
         mailbox_name = record["mailbox_name"]
         skip_tags = {"provider": _provider_from_mailbox(mailbox_name)}
@@ -578,6 +662,11 @@ def schedule_webhook_delivery() -> None:
             )
         else:
             dispatched += 1
+
+    if surplus:
+        _store_carryover(surplus)
+    elif carryover:
+        _clear_carryover()
 
 
 @instrumented_task(

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -71,7 +71,7 @@ but not at the timeout threshold
 BATCH_SIZE = 1000
 """The number of mailboxes a scheduler cycle aims to dispatch drains for."""
 
-BATCH_SELECT_LIMIT = BATCH_SIZE * 2
+BATCH_SELECT_LIMIT = BATCH_SIZE * 10
 """
 How many due mailbox heads a scheduler cycle selects to reach BATCH_SIZE
 dispatches. Push triggers and concurrent cycles claim heads out of the selected
@@ -79,6 +79,13 @@ list before the loop reaches them, so selecting exactly BATCH_SIZE shrinks the
 cycle below its target by whatever the contention share is. Heads the cycle
 never reaches are handed to the next one (see CARRYOVER_CACHE_KEY) rather than
 rediscovered.
+
+Sized well above BATCH_SIZE because the selection is nearly free next to the
+scan that produces it: the aggregate visits every row either way, and the limit
+only bounds what is materialized. Overselecting is what makes a carried surplus
+survive contention — at 2x, a cycle skipping a fifth of what it walks carries
+less than a batch, and the next cycle then dispatches short of BATCH_SIZE with
+mailboxes still due.
 """
 
 
@@ -527,11 +534,10 @@ CARRYOVER_CACHE_KEY = "wh:schedule:carryover"
 
 CARRYOVER_TTL = 60
 """
-Seconds a carried surplus stays dispatchable. A cycle either walks the surplus to
-its end or spends a full dispatch batch of it, so a surplus of at most
-BATCH_SELECT_LIMIT drains within a couple of cycles on its own; the TTL is the
-backstop for a cycle that dies mid-list, keeping an unspent surplus from deferring
-discovery — the only thing that finds mailboxes no push trigger woke.
+Seconds a carried surplus stays dispatchable. Each cycle re-stores what it did
+not spend, so the TTL does not bound how long a deep backlog defers discovery —
+it is the backstop for a cycle that dies mid-list, keeping a surplus nobody is
+spending from deferring discovery indefinitely.
 """
 
 
@@ -604,8 +610,8 @@ def schedule_webhook_delivery() -> None:
     one claim attempt: `_claim_and_dispatch` gates every dispatch on the head still
     being due, so a head claimed, delivered, or backed off since discovery claims 0
     rows and is skipped. Mailboxes that arrive while a surplus is being spent are
-    dispatched by their push trigger, and CARRYOVER_TTL bounds how long discovery
-    can be deferred for the ones that have none.
+    dispatched by their push trigger; the ones with none wait for the surplus to
+    drain, which is the trade a deep backlog is already making.
 
     Triggered frequently by task-scheduler.
     """
@@ -663,10 +669,21 @@ def schedule_webhook_delivery() -> None:
         else:
             dispatched += 1
 
-    if surplus:
+    # The next cycle takes a carryover in place of discovery, so a short surplus
+    # costs it the rest of its dispatch budget while mailboxes are still due. Half
+    # a batch is where that loss stops being worth the scan it saves; below it the
+    # surplus is dropped, and discovery finds those heads again — they are still
+    # due, and now sort ahead of the newer ones.
+    if len(surplus) >= BATCH_SIZE // 2:
         _store_carryover(surplus)
-    elif carryover:
-        _clear_carryover()
+    else:
+        if surplus:
+            # Recorded because the carryover distribution only samples surpluses
+            # large enough to keep, so on its own it cannot say how often the
+            # overselect failed to survive a cycle's contention.
+            metrics.incr("hybridcloud.schedule_webhook_delivery.carryover.dropped")
+        if carryover:
+            _clear_carryover()
 
 
 @instrumented_task(

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -45,6 +45,9 @@ DISPATCH_METRIC = "hybridcloud.deliver_webhooks.dispatch"
 DISPATCH_CLAIMED_METRIC = "hybridcloud.deliver_webhooks.dispatch.claimed"
 PUSH_TRIGGER_ERROR_METRIC = "hybridcloud.deliver_webhooks.push_trigger.error"
 SCHEDULER_SKIPPED_METRIC = "hybridcloud.deliver_webhooks.scheduler.skipped"
+CYCLE_METRIC = "hybridcloud.schedule_webhook_delivery.cycle"
+CARRYOVER_METRIC = "hybridcloud.schedule_webhook_delivery.carryover"
+CARRYOVER_ERROR_METRIC = "hybridcloud.schedule_webhook_delivery.carryover.error"
 
 
 class MetricCallsMixin:
@@ -579,6 +582,180 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         assert self.scheduler_skips(mock_metrics) == [
             {"provider": "github", "reason": "claim_lost"}
         ]
+
+
+@control_silo_test
+@patch.object(deliver_webhooks, "BATCH_SIZE", 2)
+@patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 4)
+class ScheduleCarryoverTest(MetricCallsMixin, TestCase):
+    """
+    Cycles dispatch two mailboxes apiece here, so a third mailbox is the surplus a
+    cycle discovers but has no budget to dispatch.
+    """
+
+    def create_mailboxes(self, count: int) -> list[WebhookPayload]:
+        return [
+            self.create_webhook_payload(mailbox_name=f"github:{index}", cell_name="us")
+            for index in range(count)
+        ]
+
+    def failing_cache(self, method: str) -> MagicMock:
+        """A cache whose `method` raises; every other call reaches the real one."""
+        double = MagicMock(wraps=cache)
+        getattr(double, method).side_effect = Exception("cache unavailable")
+        return double
+
+    def carryover(self) -> list[dict[str, Any]] | None:
+        return cache.get(deliver_webhooks.CARRYOVER_CACHE_KEY)
+
+    def dispatched_ids(self, mock_drain: MagicMock) -> list[int]:
+        return [call[0][0] for call in mock_drain.delay.call_args_list]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_surplus_heads_are_stored(self, mock_drain: MagicMock, mock_metrics: MagicMock) -> None:
+        webhooks = self.create_mailboxes(3)
+        double = MagicMock(wraps=cache)
+
+        with patch.object(deliver_webhooks, "cache", double):
+            schedule_webhook_delivery()
+
+        assert self.dispatched_ids(mock_drain) == [webhooks[0].id, webhooks[1].id]
+        double.set.assert_called_once_with(
+            deliver_webhooks.CARRYOVER_CACHE_KEY,
+            [{"id": webhooks[2].id, "mailbox_name": webhooks[2].mailbox_name}],
+            timeout=deliver_webhooks.CARRYOVER_TTL,
+        )
+        assert self.distribution_calls(mock_metrics, CARRYOVER_METRIC) == [(1, {})]
+
+    @override_options(DUE_HEAD_OPTIONS)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_due_head_discovery_carries_its_surplus_too(self, mock_drain: MagicMock) -> None:
+        webhooks = self.create_mailboxes(3)
+
+        schedule_webhook_delivery()
+
+        assert self.dispatched_ids(mock_drain) == [webhooks[0].id, webhooks[1].id]
+        assert self.carryover() == [
+            {"id": webhooks[2].id, "mailbox_name": webhooks[2].mailbox_name}
+        ]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_carried_heads_dispatch_without_discovery(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhooks = self.create_mailboxes(3)
+        schedule_webhook_delivery()
+        mock_drain.delay.reset_mock()
+
+        with (
+            patch.object(deliver_webhooks, "_gated_mailbox_heads") as mock_gated,
+            patch.object(deliver_webhooks, "_due_mailbox_heads") as mock_due,
+        ):
+            schedule_webhook_delivery()
+
+        mock_gated.assert_not_called()
+        mock_due.assert_not_called()
+        assert self.dispatched_ids(mock_drain) == [webhooks[2].id]
+        assert self.tags_for(mock_metrics, CYCLE_METRIC) == [
+            {"source": "discovery"},
+            {"source": "carryover"},
+        ]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_discovery_resumes_once_the_surplus_is_spent(self, mock_drain: MagicMock) -> None:
+        self.create_mailboxes(3)
+        schedule_webhook_delivery()
+        schedule_webhook_delivery()
+        assert self.carryover() is None
+
+        with patch.object(deliver_webhooks, "_gated_mailbox_heads", return_value=[]) as mock_gated:
+            schedule_webhook_delivery()
+
+        mock_gated.assert_called_once()
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_stale_carried_head_claims_nothing(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhooks = self.create_mailboxes(3)
+        schedule_webhook_delivery()
+        mock_drain.delay.reset_mock()
+        # Another dispatcher claimed the carried head between the two cycles. The
+        # claim's due-gate is what makes carrying a head safe, so the cycle must
+        # spend one claim attempt on it and move on.
+        WebhookPayload.objects.filter(id=webhooks[2].id).update(
+            schedule_for=timezone.now() + timedelta(hours=1)
+        )
+
+        schedule_webhook_delivery()
+
+        mock_drain.delay.assert_not_called()
+        assert self.tags_for(mock_metrics, SCHEDULER_SKIPPED_METRIC) == [
+            {"provider": "github", "reason": "claim_lost"}
+        ]
+        assert self.carryover() is None
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_cache_read_failure_falls_back_to_discovery(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        self.create_mailboxes(3)
+        schedule_webhook_delivery()
+
+        with patch.object(deliver_webhooks, "cache", self.failing_cache("get")):
+            schedule_webhook_delivery()
+
+        assert self.tags_for(mock_metrics, CYCLE_METRIC) == [
+            {"source": "discovery"},
+            {"source": "discovery"},
+        ]
+        assert self.tags_for(mock_metrics, CARRYOVER_ERROR_METRIC) == [{"operation": "get"}]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_cache_write_failure_leaves_the_cycle_intact(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhooks = self.create_mailboxes(3)
+
+        with patch.object(deliver_webhooks, "cache", self.failing_cache("set")):
+            schedule_webhook_delivery()
+
+        assert self.dispatched_ids(mock_drain) == [webhooks[0].id, webhooks[1].id]
+        assert self.tags_for(mock_metrics, CARRYOVER_ERROR_METRIC) == [{"operation": "set"}]
+        assert self.carryover() is None
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_cache_delete_failure_leaves_the_cycle_intact(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhooks = self.create_mailboxes(3)
+        schedule_webhook_delivery()
+        mock_drain.delay.reset_mock()
+
+        with patch.object(deliver_webhooks, "cache", self.failing_cache("delete")):
+            schedule_webhook_delivery()
+
+        assert self.dispatched_ids(mock_drain) == [webhooks[2].id]
+        assert self.tags_for(mock_metrics, CARRYOVER_ERROR_METRIC) == [{"operation": "delete"}]
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_cycle_within_budget_carries_nothing(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        self.create_mailboxes(2)
+
+        schedule_webhook_delivery()
+
+        assert self.carryover() is None
+        assert self.distribution_calls(mock_metrics, CARRYOVER_METRIC) == []
+        assert self.tags_for(mock_metrics, CYCLE_METRIC) == [{"source": "discovery"}]
 
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -585,7 +585,7 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         ]
 
 
-class CarryoverMixin(MetricCallsMixin):
+class CarryoverTestBase(MetricCallsMixin, TestCase):
     """Mailbox setup and cache reads shared by the carryover suites."""
 
     def create_mailboxes(self, count: int) -> list[WebhookPayload]:
@@ -613,7 +613,7 @@ class CarryoverMixin(MetricCallsMixin):
 @control_silo_test
 @patch.object(deliver_webhooks, "BATCH_SIZE", 2)
 @patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 4)
-class ScheduleCarryoverTest(CarryoverMixin, TestCase):
+class ScheduleCarryoverTest(CarryoverTestBase):
     """
     Cycles dispatch two mailboxes apiece here, so a third mailbox is the surplus a
     cycle discovers but has no budget to dispatch. A one-head surplus sits exactly
@@ -770,7 +770,7 @@ class ScheduleCarryoverTest(CarryoverMixin, TestCase):
 @control_silo_test
 @patch.object(deliver_webhooks, "BATCH_SIZE", 4)
 @patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 12)
-class ScheduleCarryoverFloorTest(CarryoverMixin, TestCase):
+class ScheduleCarryoverFloorTest(CarryoverTestBase):
     """A surplus under `BATCH_SIZE // 2` is dropped rather than carried."""
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -617,8 +617,7 @@ class ScheduleCarryoverTest(CarryoverMixin, TestCase):
     """
     Cycles dispatch two mailboxes apiece here, so a third mailbox is the surplus a
     cycle discovers but has no budget to dispatch. A one-head surplus sits exactly
-    on the `BATCH_SIZE // 2` floor at this batch size, so it is kept --
-    `ScheduleCarryoverFloorTest` runs a wider batch to put a surplus under it.
+    on the `BATCH_SIZE // 2` floor here, so it is kept.
     """
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
@@ -772,19 +771,13 @@ class ScheduleCarryoverTest(CarryoverMixin, TestCase):
 @patch.object(deliver_webhooks, "BATCH_SIZE", 4)
 @patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 12)
 class ScheduleCarryoverFloorTest(CarryoverMixin, TestCase):
-    """
-    A surplus under `BATCH_SIZE // 2` is dropped rather than carried. The next cycle
-    takes a carryover in place of discovery, so a short one would cost it the rest
-    of its budget with mailboxes still due.
-    """
+    """A surplus under `BATCH_SIZE // 2` is dropped rather than carried."""
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_surplus_below_the_floor_is_dropped(
         self, mock_drain: MagicMock, mock_metrics: MagicMock
     ) -> None:
-        # One head past the dispatch budget: carrying it would leave the next cycle
-        # dispatching a single mailbox out of a budget of four.
         self.create_mailboxes(5)
 
         schedule_webhook_delivery()
@@ -814,8 +807,7 @@ class ScheduleCarryoverFloorTest(CarryoverMixin, TestCase):
         schedule_webhook_delivery()
         assert self.carryover() == self.carried(webhooks[4:])
 
-        # Spending the surplus strands one head. It must not linger in the cache: a
-        # stale carryover would displace the next cycle's discovery.
+        # A stale carryover would displace the next cycle's discovery.
         schedule_webhook_delivery()
 
         assert self.carryover() is None

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -48,6 +48,7 @@ SCHEDULER_SKIPPED_METRIC = "hybridcloud.deliver_webhooks.scheduler.skipped"
 CYCLE_METRIC = "hybridcloud.schedule_webhook_delivery.cycle"
 CARRYOVER_METRIC = "hybridcloud.schedule_webhook_delivery.carryover"
 CARRYOVER_ERROR_METRIC = "hybridcloud.schedule_webhook_delivery.carryover.error"
+CARRYOVER_DROPPED_METRIC = "hybridcloud.schedule_webhook_delivery.carryover.dropped"
 
 
 class MetricCallsMixin:
@@ -584,14 +585,8 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         ]
 
 
-@control_silo_test
-@patch.object(deliver_webhooks, "BATCH_SIZE", 2)
-@patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 4)
-class ScheduleCarryoverTest(MetricCallsMixin, TestCase):
-    """
-    Cycles dispatch two mailboxes apiece here, so a third mailbox is the surplus a
-    cycle discovers but has no budget to dispatch.
-    """
+class CarryoverMixin(MetricCallsMixin):
+    """Mailbox setup and cache reads shared by the carryover suites."""
 
     def create_mailboxes(self, count: int) -> list[WebhookPayload]:
         return [
@@ -610,6 +605,21 @@ class ScheduleCarryoverTest(MetricCallsMixin, TestCase):
 
     def dispatched_ids(self, mock_drain: MagicMock) -> list[int]:
         return [call[0][0] for call in mock_drain.delay.call_args_list]
+
+    def carried(self, webhooks: list[WebhookPayload]) -> list[dict[str, Any]]:
+        return [{"id": w.id, "mailbox_name": w.mailbox_name} for w in webhooks]
+
+
+@control_silo_test
+@patch.object(deliver_webhooks, "BATCH_SIZE", 2)
+@patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 4)
+class ScheduleCarryoverTest(CarryoverMixin, TestCase):
+    """
+    Cycles dispatch two mailboxes apiece here, so a third mailbox is the surplus a
+    cycle discovers but has no budget to dispatch. A one-head surplus sits exactly
+    on the `BATCH_SIZE // 2` floor at this batch size, so it is kept --
+    `ScheduleCarryoverFloorTest` runs a wider batch to put a surplus under it.
+    """
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -756,6 +766,60 @@ class ScheduleCarryoverTest(MetricCallsMixin, TestCase):
         assert self.carryover() is None
         assert self.distribution_calls(mock_metrics, CARRYOVER_METRIC) == []
         assert self.tags_for(mock_metrics, CYCLE_METRIC) == [{"source": "discovery"}]
+
+
+@control_silo_test
+@patch.object(deliver_webhooks, "BATCH_SIZE", 4)
+@patch.object(deliver_webhooks, "BATCH_SELECT_LIMIT", 12)
+class ScheduleCarryoverFloorTest(CarryoverMixin, TestCase):
+    """
+    A surplus under `BATCH_SIZE // 2` is dropped rather than carried. The next cycle
+    takes a carryover in place of discovery, so a short one would cost it the rest
+    of its budget with mailboxes still due.
+    """
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_surplus_below_the_floor_is_dropped(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        # One head past the dispatch budget: carrying it would leave the next cycle
+        # dispatching a single mailbox out of a budget of four.
+        self.create_mailboxes(5)
+
+        schedule_webhook_delivery()
+
+        assert self.carryover() is None
+        assert self.tags_for(mock_metrics, CARRYOVER_DROPPED_METRIC) == [{}]
+        assert self.distribution_calls(mock_metrics, CARRYOVER_METRIC) == []
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_surplus_at_the_floor_is_carried(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhooks = self.create_mailboxes(6)
+
+        schedule_webhook_delivery()
+
+        assert self.carryover() == self.carried(webhooks[4:])
+        assert self.tags_for(mock_metrics, CARRYOVER_DROPPED_METRIC) == []
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_carryover_spent_below_the_floor_is_cleared(
+        self, mock_drain: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        webhooks = self.create_mailboxes(9)
+        schedule_webhook_delivery()
+        assert self.carryover() == self.carried(webhooks[4:])
+
+        # Spending the surplus strands one head. It must not linger in the cache: a
+        # stale carryover would displace the next cycle's discovery.
+        schedule_webhook_delivery()
+
+        assert self.carryover() is None
+        assert self.tags_for(mock_metrics, CARRYOVER_DROPPED_METRIC) == [{}]
 
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:


### PR DESCRIPTION
The webhook scheduler starts each cycle with a discovery query that aggregates the entire `WebhookPayload` table on the primary (deliberately — replica lag races the drains it enqueues). The scan's cost grows with the table, and it routinely finds more due mailbox heads than one cycle's `BATCH_SIZE` budget can dispatch; the surplus was discarded and rediscovered 10s later.

A cycle now stores its undispatched heads in the cache, and a cycle that finds a surplus dispatches from it instead of running discovery. Due-head discovery selects up to `BATCH_SELECT_LIMIT` like the gated path, so both produce a surplus. Carrying is safe because `_claim_and_dispatch` gates every claim on the head still being due: a head claimed, delivered, or backed off since discovery claims zero rows and is skipped, so a stale carried head costs one claim attempt and cannot duplicate a delivery.

Two limits size it. The select limit is 10x `BATCH_SIZE` — a cycle stops at `BATCH_SIZE` dispatches, so every head it skips along the way comes out of the surplus, and the limit only bounds what the scan materializes, so overselecting is close to free. And a surplus below half a batch is dropped rather than carried: a carryover displaces the next cycle's discovery, so a short one would cost that cycle the rest of its budget with mailboxes still due. Both are sized against control's memcached, the one pool with no `max-item-size` override and so on the 1 MiB default — a 9k-head surplus pickles to 0.52 MiB with every mailbox name at the longest currently in the table.

Cache errors fall back to discovery (`hybridcloud.schedule_webhook_delivery.carryover.error`). Cycles are tagged `discovery`/`carryover` on `...cycle`, the stored surplus size is a distribution, and a surplus dropped under the floor increments `...carryover.dropped`.
