### PR TITLE
feat(hybridcloud): Add a break-glass option to shed inbound webhooks

### DIFF
--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -43,7 +43,7 @@ SHED_INBOUND_KILLSWITCH = "hybridcloud.webhookpayload.shed-inbound"
 SHED_RETRY_AFTER_SECONDS = 60
 # Its own logger so the sampling stays on the shed line, rather than quietly
 # applying to every info log a future caller adds to this module.
-shed_logger = logging.getLogger(f"{__name__}.shed")
+shed_logger = logging.getLogger("sentry.integrations.webhooks.shed")
 shed_logger.addFilter(SamplingFilter(0.1))
 
 
@@ -206,20 +206,17 @@ class BaseRequestParser(ABC):
 
     def get_shed_response(self, integration_id: int | None = None) -> HttpResponse | None:
         """
-        Break glass valve for inbound floods. Drops the webhook with a 429 before the
-        WebhookPayload INSERT and the push trigger, the writes that make a flood
-        expensive. Callers reach here after their integration and cell lookups, so
-        those reads still happen. Returns None to handle the request normally.
-
-        Targets come from the hybridcloud.webhookpayload.shed-inbound killswitch, whose
-        conditions are documented in sentry.killswitches. A shed webhook is lost unless
-        the sender redelivers it.
+        Get an optional response when inbound webhooks have been shed with a killswitch.
+        Drops the webhook with a 429 before the WebhookPayload INSERT and the push
+        trigger, the writes that make a flood expensive. Use the
+        `hybridcloud.webhookpayload.shed-inbound` killswitch to control which providers
+        and integrations are dropped. Returns None to handle the request normally.
         """
         conditions = get_killswitch_value(SHED_INBOUND_KILLSWITCH)
         # A condition with no provider matches every provider. There are few enough
         # providers to name them, so drop those rather than let one option typo shed
         # all inbound traffic. Counted so an ignored condition is not a silent no-op.
-        targeted = [condition for condition in conditions if condition["provider"] is not None]
+        targeted = [condition for condition in conditions if condition.get("provider") is not None]
         if len(targeted) != len(conditions):
             metrics.incr("hybridcloud.webhookpayload.shed_condition_ignored")
 

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -27,7 +27,7 @@ from sentry.integrations.middleware.metrics import (
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration.model import RpcIntegration
-from sentry.killswitches import killswitch_matches_context
+from sentry.killswitches import get_killswitch_value, value_matches
 from sentry.ratelimits import backend as ratelimiter
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import CellSiloClient, SiloClientError
@@ -212,8 +212,17 @@ class BaseRequestParser(ABC):
         conditions are documented in sentry.killswitches. A shed webhook is lost unless
         the sender redelivers it.
         """
-        if not killswitch_matches_context(
+        conditions = get_killswitch_value(SHED_INBOUND_KILLSWITCH)
+        # A condition with no provider matches every provider. There are few enough
+        # providers to name them, so drop those rather than let one option typo shed
+        # all inbound traffic. Counted so an ignored condition is not a silent no-op.
+        targeted = [condition for condition in conditions if condition["provider"] is not None]
+        if len(targeted) != len(conditions):
+            metrics.incr("hybridcloud.webhookpayload.shed_condition_ignored")
+
+        if not value_matches(
             SHED_INBOUND_KILLSWITCH,
+            targeted,
             {"provider": self.provider, "integration_id": integration_id},
             emit_metrics=False,
         ):

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import random
 from abc import ABC
 from concurrent.futures import as_completed
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -28,6 +27,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.killswitches import get_killswitch_value, value_matches
+from sentry.logging.handlers import SamplingFilter
 from sentry.ratelimits import backend as ratelimiter
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import CellSiloClient, SiloClientError
@@ -41,7 +41,10 @@ if TYPE_CHECKING:
 
 SHED_INBOUND_KILLSWITCH = "hybridcloud.webhookpayload.shed-inbound"
 SHED_RETRY_AFTER_SECONDS = 60
-SHED_LOG_SAMPLE_RATE = 0.1
+# Its own logger so the sampling stays on the shed line, rather than quietly
+# applying to every info log a future caller adds to this module.
+shed_logger = logging.getLogger(f"{__name__}.shed")
+shed_logger.addFilter(SamplingFilter(0.1))
 
 
 def create_async_request_payload(request: HttpRequest) -> dict[str, Any]:
@@ -233,11 +236,10 @@ class BaseRequestParser(ABC):
             tags={"provider": self.provider},
             sample_rate=1.0,
         )
-        if random.random() < SHED_LOG_SAMPLE_RATE:
-            logger.info(
-                "hybridcloud.webhookpayload.shed",
-                extra={"provider": self.provider, "integration_id": integration_id},
-            )
+        shed_logger.info(
+            "hybridcloud.webhookpayload.shed",
+            extra={"provider": self.provider, "integration_id": integration_id},
+        )
 
         response = HttpResponse(status=status.HTTP_429_TOO_MANY_REQUESTS)
         response["Retry-After"] = str(SHED_RETRY_AFTER_SECONDS)

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from abc import ABC
 from concurrent.futures import as_completed
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -11,7 +12,6 @@ from django.http.response import HttpResponseBase
 from django.urls import ResolverMatch, resolve
 from rest_framework import status
 
-from sentry import options
 from sentry.api.base import ONE_DAY
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.webhookpayload import DestinationType, WebhookPayload
@@ -27,6 +27,7 @@ from sentry.integrations.middleware.metrics import (
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.killswitches import killswitch_matches_context
 from sentry.ratelimits import backend as ratelimiter
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import CellSiloClient, SiloClientError
@@ -38,7 +39,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sentry.middleware.integrations.integration_control import ResponseHandler
 
+SHED_INBOUND_KILLSWITCH = "hybridcloud.webhookpayload.shed-inbound"
 SHED_RETRY_AFTER_SECONDS = 60
+SHED_LOG_SAMPLE_RATE = 0.1
 
 
 def create_async_request_payload(request: HttpRequest) -> dict[str, Any]:
@@ -200,18 +203,19 @@ class BaseRequestParser(ABC):
 
     def get_shed_response(self, integration_id: int | None = None) -> HttpResponse | None:
         """
-        Break glass valve for inbound floods. A shed webhook costs the control primary
-        nothing: no payload rows, no push trigger. Shedding drops the webhook — the 429
-        asks the sender to back off, but whatever it does not redeliver is lost.
-        """
-        shed_targets = options.get("hybridcloud.webhookpayload.shed_inbound")
-        if not shed_targets:
-            return None
+        Break glass valve for inbound floods. Drops the webhook with a 429 before the
+        WebhookPayload INSERT and the push trigger, the writes that make a flood
+        expensive. Callers reach here after their integration and cell lookups, so
+        those reads still happen. Returns None to handle the request normally.
 
-        # Membership is the whole parse: an entry that matches neither form is inert,
-        # so a malformed target cannot shed traffic it was not meant to name.
-        if self.provider not in shed_targets and (
-            integration_id is None or f"{self.provider}:{integration_id}" not in shed_targets
+        Targets come from the hybridcloud.webhookpayload.shed-inbound killswitch, whose
+        conditions are documented in sentry.killswitches. A shed webhook is lost unless
+        the sender redelivers it.
+        """
+        if not killswitch_matches_context(
+            SHED_INBOUND_KILLSWITCH,
+            {"provider": self.provider, "integration_id": integration_id},
+            emit_metrics=False,
         ):
             return None
 
@@ -220,10 +224,11 @@ class BaseRequestParser(ABC):
             tags={"provider": self.provider},
             sample_rate=1.0,
         )
-        logger.info(
-            "hybridcloud.webhookpayload.shed",
-            extra={"provider": self.provider, "integration_id": integration_id},
-        )
+        if random.random() < SHED_LOG_SAMPLE_RATE:
+            logger.info(
+                "hybridcloud.webhookpayload.shed",
+                extra={"provider": self.provider, "integration_id": integration_id},
+            )
 
         response = HttpResponse(status=status.HTTP_429_TOO_MANY_REQUESTS)
         response["Retry-After"] = str(SHED_RETRY_AFTER_SECONDS)

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -83,6 +83,7 @@ class BaseRequestParser(ABC):
         if hasattr(self.match.func, "view_class"):
             self.view_class = self.match.func.view_class
         self.response_handler = response_handler
+        self._shed_decisions: dict[int | None, bool] = {}
 
     # Common Helpers
 
@@ -212,6 +213,24 @@ class BaseRequestParser(ABC):
         `hybridcloud.webhookpayload.shed-inbound` killswitch to control which providers
         and integrations are dropped. Returns None to handle the request normally.
         """
+        if not self._should_shed(integration_id):
+            return None
+
+        response = HttpResponse(status=status.HTTP_429_TOO_MANY_REQUESTS)
+        response["Retry-After"] = str(SHED_RETRY_AFTER_SECONDS)
+        return response
+
+    def _should_shed(self, integration_id: int | None) -> bool:
+        """
+        Decide once per parser, which is once per request. A parser that checks the shed
+        early still reaches the base class check in get_response_from_webhookpayload, and
+        the config read and the counters below are not free to repeat.
+        """
+        if integration_id not in self._shed_decisions:
+            self._shed_decisions[integration_id] = self._evaluate_shed(integration_id)
+        return self._shed_decisions[integration_id]
+
+    def _evaluate_shed(self, integration_id: int | None) -> bool:
         conditions = get_killswitch_value(SHED_INBOUND_KILLSWITCH)
         # A condition with no provider matches every provider. There are few enough
         # providers to name them, so drop those rather than let one option typo shed
@@ -226,7 +245,7 @@ class BaseRequestParser(ABC):
             {"provider": self.provider, "integration_id": integration_id},
             emit_metrics=False,
         ):
-            return None
+            return False
 
         metrics.incr(
             "hybridcloud.webhookpayload.shed",
@@ -237,10 +256,7 @@ class BaseRequestParser(ABC):
             "hybridcloud.webhookpayload.shed",
             extra={"provider": self.provider, "integration_id": integration_id},
         )
-
-        response = HttpResponse(status=status.HTTP_429_TOO_MANY_REQUESTS)
-        response["Retry-After"] = str(SHED_RETRY_AFTER_SECONDS)
-        return response
+        return True
 
     def get_mailbox_identifier(
         self, integration: RpcIntegration | Integration, data: dict[str, Any]

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -11,6 +11,7 @@ from django.http.response import HttpResponseBase
 from django.urls import ResolverMatch, resolve
 from rest_framework import status
 
+from sentry import options
 from sentry.api.base import ONE_DAY
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.webhookpayload import DestinationType, WebhookPayload
@@ -36,6 +37,8 @@ from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sentry.middleware.integrations.integration_control import ResponseHandler
+
+SHED_RETRY_AFTER_SECONDS = 60
 
 
 def create_async_request_payload(request: HttpRequest) -> dict[str, Any]:
@@ -170,6 +173,10 @@ class BaseRequestParser(ABC):
         Used to create webhookpayloads for provided cells to handle the webhooks asynchronously.
         Responds to the webhook provider with a 202 Accepted status.
         """
+        shed_response = self.get_shed_response(integration_id=integration_id)
+        if shed_response is not None:
+            return shed_response
+
         if len(cells) < 1:
             return HttpResponse(status=status.HTTP_202_ACCEPTED)
 
@@ -190,6 +197,37 @@ class BaseRequestParser(ABC):
             maybe_trigger_drain(mailbox_name)
 
         return HttpResponse(status=status.HTTP_202_ACCEPTED)
+
+    def get_shed_response(self, integration_id: int | None = None) -> HttpResponse | None:
+        """
+        Break glass valve for inbound floods. A shed webhook costs the control primary
+        nothing: no payload rows, no push trigger. Shedding drops the webhook — the 429
+        asks the sender to back off, but whatever it does not redeliver is lost.
+        """
+        shed_targets = options.get("hybridcloud.webhookpayload.shed_inbound")
+        if not shed_targets:
+            return None
+
+        # Membership is the whole parse: an entry that matches neither form is inert,
+        # so a malformed target cannot shed traffic it was not meant to name.
+        if self.provider not in shed_targets and (
+            integration_id is None or f"{self.provider}:{integration_id}" not in shed_targets
+        ):
+            return None
+
+        metrics.incr(
+            "hybridcloud.webhookpayload.shed",
+            tags={"provider": self.provider},
+            sample_rate=1.0,
+        )
+        logger.info(
+            "hybridcloud.webhookpayload.shed",
+            extra={"provider": self.provider, "integration_id": integration_id},
+        )
+
+        response = HttpResponse(status=status.HTTP_429_TOO_MANY_REQUESTS)
+        response["Retry-After"] = str(SHED_RETRY_AFTER_SECONDS)
+        return response
 
     def get_mailbox_identifier(
         self, integration: RpcIntegration | Integration, data: dict[str, Any]

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -250,6 +250,24 @@ ALL_KILLSWITCH_OPTIONS = {
             "project_id": "A project ID to halt merge for.",
         },
     ),
+    "hybridcloud.webhookpayload.shed-inbound": KillswitchInfo(
+        description="""
+        Drop inbound integration webhooks before a WebhookPayload row is written.
+
+        Break glass for an inbound flood: matching senders get a 429 with a
+        Retry-After instead of having their webhook queued, so the flood stops
+        costing the control primary payload INSERTs and push triggers.
+
+        Leaving `integration_id` unset sheds a whole provider; leaving both fields
+        unset is a wildcard that sheds *every* inbound webhook.
+
+        Shed webhooks are gone unless the sender redelivers them.
+        """,
+        fields={
+            "provider": "An integration provider slug, e.g. github or jira.",
+            "integration_id": "An integration ID, to shed a single integration.",
+        },
+    ),
 }
 
 

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -258,8 +258,9 @@ ALL_KILLSWITCH_OPTIONS = {
         Retry-After instead of having their webhook queued, so the flood stops
         costing the control primary payload INSERTs and push triggers.
 
-        Leaving `integration_id` unset sheds a whole provider; leaving both fields
-        unset is a wildcard that sheds *every* inbound webhook.
+        Every condition must name a `provider`; leaving `integration_id` unset sheds
+        that whole provider. A condition without a `provider` would match every one
+        of them, so it is ignored rather than honoured.
 
         Shed webhooks are gone unless the sender redelivers them.
         """,

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -214,9 +214,8 @@ class GithubRequestParser(BaseRequestParser):
             )
             return HttpResponse(status=202)
 
-        # Shed ahead of the forwarded_event counter and the mailbox lookup, so a shed
-        # webhook is neither counted as forwarded nor charged for routing work it will
-        # not use. The base class check still covers every other provider.
+        # Ahead of the forwarded_event counter and the mailbox lookup, so a shed webhook
+        # is neither counted as forwarded nor charged for routing it will not use.
         shed_response = self.get_shed_response(integration_id=integration.id)
         if shed_response is not None:
             return shed_response

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -214,6 +214,13 @@ class GithubRequestParser(BaseRequestParser):
             )
             return HttpResponse(status=202)
 
+        # Shed ahead of the forwarded_event counter and the mailbox lookup, so a shed
+        # webhook is neither counted as forwarded nor charged for routing work it will
+        # not use. The base class check still covers every other provider.
+        shed_response = self.get_shed_response(integration_id=integration.id)
+        if shed_response is not None:
+            return shed_response
+
         metrics.incr(
             "github.webhook.forwarded_event",
             tags=_forwarded_event_tags(github_event, event, action, action_filter),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2625,14 +2625,11 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Operator break glass for inbound floods: listed targets are DROPPED before any
-# WebhookPayload row is written, so a flood stops costing control primary writes
-# without a deploy. This is data loss by design — senders get a 429 and whatever
-# they do not redeliver is gone. An entry is either a provider name ("jira"),
-# which sheds everything for that provider, or "provider:integration_id"
-# ("jira:12345"), which sheds a single integration.
+# Break glass for inbound webhook floods. Matching webhooks are dropped with a
+# 429 before any WebhookPayload row is written, and whatever the sender does not
+# redeliver is lost. Conditions are documented in sentry.killswitches.
 register(
-    "hybridcloud.webhookpayload.shed_inbound",
+    "hybridcloud.webhookpayload.shed-inbound",
     type=Sequence,
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2625,6 +2625,18 @@ register(
     default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Operator break glass for inbound floods: listed targets are DROPPED before any
+# WebhookPayload row is written, so a flood stops costing control primary writes
+# without a deploy. This is data loss by design — senders get a 429 and whatever
+# they do not redeliver is gone. An entry is either a provider name ("jira"),
+# which sheds everything for that provider, or "provider:integration_id"
+# ("jira:12345"), which sheds a single integration.
+register(
+    "hybridcloud.webhookpayload.shed_inbound",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Break glass controls
 register(
     "hybrid_cloud.rpc.disabled-service-methods",

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -20,7 +20,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.types.cell import Cell
 
-SHED_INBOUND_OPTION = "hybridcloud.webhookpayload.shed_inbound"
+SHED_INBOUND_OPTION = "hybridcloud.webhookpayload.shed-inbound"
 
 
 def error_regions(region: Cell, invalid_region_names: Iterable[str]) -> HttpResponse:
@@ -158,7 +158,14 @@ class BaseRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    @override_options({SHED_INBOUND_OPTION: ["other_provider", "test_provider:98765"]})
+    @override_options(
+        {
+            SHED_INBOUND_OPTION: [
+                {"provider": "other_provider", "integration_id": None},
+                {"provider": "test_provider", "integration_id": "98765"},
+            ]
+        }
+    )
     def test_shed_inbound_ignores_unmatched_targets(self, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -173,7 +180,7 @@ class BaseRequestParserTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
-    @override_options({SHED_INBOUND_OPTION: ["test_provider"]})
+    @override_options({SHED_INBOUND_OPTION: [{"provider": "test_provider"}]})
     def test_shed_inbound_by_provider(self, mock_incr: MagicMock, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -185,7 +192,7 @@ class BaseRequestParserTest(TestCase):
         assert response["Retry-After"] == "60"
         assert not WebhookPayload.objects.exists()
         assert not mock_trigger.called
-        mock_incr.assert_called_once_with(
+        mock_incr.assert_any_call(
             "hybridcloud.webhookpayload.shed",
             tags={"provider": "test_provider"},
             sample_rate=1.0,
@@ -193,7 +200,7 @@ class BaseRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    @override_options({SHED_INBOUND_OPTION: ["test_provider"]})
+    @override_options({SHED_INBOUND_OPTION: [{"provider": "test_provider"}]})
     def test_shed_inbound_by_provider_without_integration_id(self, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -205,7 +212,9 @@ class BaseRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    @override_options({SHED_INBOUND_OPTION: ["test_provider:12345"]})
+    @override_options(
+        {SHED_INBOUND_OPTION: [{"provider": "test_provider", "integration_id": "12345"}]}
+    )
     def test_shed_inbound_by_integration(self, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -227,10 +236,8 @@ class BaseRequestParserTest(TestCase):
         assert mock_trigger.call_count == 2
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options(
-        {SHED_INBOUND_OPTION: ["", ":12345", "test_provider:", "test_provider:not_an_id"]}
-    )
-    def test_shed_inbound_ignores_malformed_targets(self) -> None:
+    @override_options({SHED_INBOUND_OPTION: [{"unknown_field": "test_provider"}]})
+    def test_shed_inbound_ignores_unknown_condition_fields(self) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
         response = parser.get_response_from_webhookpayload(
@@ -239,6 +246,20 @@ class BaseRequestParserTest(TestCase):
 
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert WebhookPayload.objects.count() == 2
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    @override_options({SHED_INBOUND_OPTION: [{}]})
+    def test_shed_inbound_wildcard_sheds_every_provider(self, mock_trigger: MagicMock) -> None:
+        parser = ExampleRequestParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(
+            cells=self.region_config, integration_id=12345
+        )
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert not WebhookPayload.objects.exists()
+        assert not mock_trigger.called
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_get_organizations_from_integration_success(self) -> None:

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -248,18 +248,20 @@ class BaseRequestParserTest(TestCase):
         assert WebhookPayload.objects.count() == 2
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    @override_options({SHED_INBOUND_OPTION: [{}]})
-    def test_shed_inbound_wildcard_sheds_every_provider(self, mock_trigger: MagicMock) -> None:
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
+    @override_options({SHED_INBOUND_OPTION: [{}, {"integration_id": "12345"}]})
+    def test_shed_inbound_ignores_conditions_without_a_provider(self, mock_incr: MagicMock) -> None:
+        """A provider-less condition is an every-provider wildcard, which is more reach
+        than this valve should have. It is dropped, and counted so it is not silent."""
         parser = ExampleRequestParser(self.request, self.response_handler)
 
         response = parser.get_response_from_webhookpayload(
             cells=self.region_config, integration_id=12345
         )
 
-        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
-        assert not WebhookPayload.objects.exists()
-        assert not mock_trigger.called
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert WebhookPayload.objects.count() == 2
+        mock_incr.assert_any_call("hybridcloud.webhookpayload.shed_condition_ignored")
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_get_organizations_from_integration_success(self) -> None:

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -17,7 +17,10 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.silo.base import SiloLimit, SiloMode
 from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.types.cell import Cell
+
+SHED_INBOUND_OPTION = "hybridcloud.webhookpayload.shed_inbound"
 
 
 def error_regions(region: Cell, invalid_region_names: Iterable[str]) -> HttpResponse:
@@ -152,6 +155,90 @@ class BaseRequestParserTest(TestCase):
             "slack:us:0",
             "slack:eu:0",
         }
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    @override_options({SHED_INBOUND_OPTION: ["other_provider", "test_provider:98765"]})
+    def test_shed_inbound_ignores_unmatched_targets(self, mock_trigger: MagicMock) -> None:
+        parser = ExampleRequestParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(
+            cells=self.region_config, integration_id=12345
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert WebhookPayload.objects.count() == 2
+        assert mock_trigger.call_count == 2
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
+    @override_options({SHED_INBOUND_OPTION: ["test_provider"]})
+    def test_shed_inbound_by_provider(self, mock_incr: MagicMock, mock_trigger: MagicMock) -> None:
+        parser = ExampleRequestParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(
+            cells=self.region_config, integration_id=12345
+        )
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert response["Retry-After"] == "60"
+        assert not WebhookPayload.objects.exists()
+        assert not mock_trigger.called
+        mock_incr.assert_called_once_with(
+            "hybridcloud.webhookpayload.shed",
+            tags={"provider": "test_provider"},
+            sample_rate=1.0,
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    @override_options({SHED_INBOUND_OPTION: ["test_provider"]})
+    def test_shed_inbound_by_provider_without_integration_id(self, mock_trigger: MagicMock) -> None:
+        parser = ExampleRequestParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(cells=self.region_config)
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert not WebhookPayload.objects.exists()
+        assert not mock_trigger.called
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
+    @override_options({SHED_INBOUND_OPTION: ["test_provider:12345"]})
+    def test_shed_inbound_by_integration(self, mock_trigger: MagicMock) -> None:
+        parser = ExampleRequestParser(self.request, self.response_handler)
+
+        shed_response = parser.get_response_from_webhookpayload(
+            cells=self.region_config, integration_id=12345
+        )
+
+        assert shed_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert not WebhookPayload.objects.exists()
+        assert not mock_trigger.called
+
+        # A sibling integration on the same provider is untouched.
+        passed_response = parser.get_response_from_webhookpayload(
+            cells=self.region_config, integration_id=54321
+        )
+
+        assert passed_response.status_code == status.HTTP_202_ACCEPTED
+        assert WebhookPayload.objects.count() == 2
+        assert mock_trigger.call_count == 2
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_options(
+        {SHED_INBOUND_OPTION: ["", ":12345", "test_provider:", "test_provider:not_an_id"]}
+    )
+    def test_shed_inbound_ignores_malformed_targets(self) -> None:
+        parser = ExampleRequestParser(self.request, self.response_handler)
+
+        response = parser.get_response_from_webhookpayload(
+            cells=self.region_config, integration_id=12345
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert WebhookPayload.objects.count() == 2
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_get_organizations_from_integration_success(self) -> None:

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -10,7 +10,10 @@ from rest_framework import status
 from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.webhookpayload import DestinationType, WebhookPayload
 from sentry.hybridcloud.outbox.category import WebhookProviderIdentifier
-from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
+from sentry.integrations.middleware.hybrid_cloud.parser import (
+    SHED_INBOUND_KILLSWITCH,
+    BaseRequestParser,
+)
 from sentry.integrations.middleware.metrics import MiddlewareHaltReason
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -19,8 +22,6 @@ from sentry.testutils.asserts import assert_failure_metric, assert_halt_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.types.cell import Cell
-
-SHED_INBOUND_OPTION = "hybridcloud.webhookpayload.shed-inbound"
 
 
 def error_regions(region: Cell, invalid_region_names: Iterable[str]) -> HttpResponse:
@@ -160,7 +161,7 @@ class BaseRequestParserTest(TestCase):
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
     @override_options(
         {
-            SHED_INBOUND_OPTION: [
+            SHED_INBOUND_KILLSWITCH: [
                 {"provider": "other_provider", "integration_id": None},
                 {"provider": "test_provider", "integration_id": "98765"},
             ]
@@ -180,7 +181,7 @@ class BaseRequestParserTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
-    @override_options({SHED_INBOUND_OPTION: [{"provider": "test_provider"}]})
+    @override_options({SHED_INBOUND_KILLSWITCH: [{"provider": "test_provider"}]})
     def test_shed_inbound_by_provider(self, mock_incr: MagicMock, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -200,7 +201,7 @@ class BaseRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
-    @override_options({SHED_INBOUND_OPTION: [{"provider": "test_provider"}]})
+    @override_options({SHED_INBOUND_KILLSWITCH: [{"provider": "test_provider"}]})
     def test_shed_inbound_by_provider_without_integration_id(self, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -213,7 +214,7 @@ class BaseRequestParserTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.maybe_trigger_drain")
     @override_options(
-        {SHED_INBOUND_OPTION: [{"provider": "test_provider", "integration_id": "12345"}]}
+        {SHED_INBOUND_KILLSWITCH: [{"provider": "test_provider", "integration_id": "12345"}]}
     )
     def test_shed_inbound_by_integration(self, mock_trigger: MagicMock) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
@@ -236,7 +237,7 @@ class BaseRequestParserTest(TestCase):
         assert mock_trigger.call_count == 2
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({SHED_INBOUND_OPTION: [{"unknown_field": "test_provider"}]})
+    @override_options({SHED_INBOUND_KILLSWITCH: [{"unknown_field": "test_provider"}]})
     def test_shed_inbound_ignores_unknown_condition_fields(self) -> None:
         parser = ExampleRequestParser(self.request, self.response_handler)
 
@@ -249,7 +250,7 @@ class BaseRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
-    @override_options({SHED_INBOUND_OPTION: [{}, {"integration_id": "12345"}]})
+    @override_options({SHED_INBOUND_KILLSWITCH: [{}, {"integration_id": "12345"}]})
     def test_shed_inbound_ignores_conditions_without_a_provider(self, mock_incr: MagicMock) -> None:
         """A provider-less condition is an every-provider wildcard, which is more reach
         than this valve should have. It is dropped, and counted so it is not silent."""

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -784,6 +784,35 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)
     @responses.activate
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics")
+    @override_options({SHED_INBOUND_KILLSWITCH: [{"integration_id": "12345"}]})
+    def test_shed_condition_ignored_counted_once_per_webhook(self, mock_metrics: Mock) -> None:
+        """GitHub checks the shed twice per request: once ahead of its own counters and
+        again inside get_response_from_webhookpayload. An ignored condition is a property
+        of the config, so it must be counted per webhook, not per check."""
+        self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 123}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        ignored_calls = [
+            call
+            for call in mock_metrics.incr.call_args_list
+            if call.args and call.args[0] == "hybridcloud.webhookpayload.shed_condition_ignored"
+        ]
+        assert len(ignored_calls) == 1
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
     @patch("sentry.middleware.integrations.parsers.github.metrics")
     def test_forwarded_event_metric_omits_action_when_unfiltered(self, mock_metrics: Mock) -> None:
         """Event types with no action allowlist are not tagged by action, which would

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.hybridcloud.models.webhookpayload import DestinationType, WebhookPayload
 from sentry.integrations.github.webhook_types import GithubWebhookType
+from sentry.integrations.middleware.hybrid_cloud.parser import SHED_INBOUND_KILLSWITCH
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.middleware.integrations.parsers.github import GithubRequestParser
@@ -27,7 +28,6 @@ cell = Cell("us", 1, "https://us.testserver")
 cell_config = (cell,)
 
 DROP_NO_OWN_REPO_PR_OPTION = "hybridcloud.webhookpayload.github_drop_checks_without_own_repo_pr"
-SHED_INBOUND_OPTION = "hybridcloud.webhookpayload.shed-inbound"
 
 
 @control_silo_test
@@ -757,7 +757,7 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
     @override_cells(cell_config)
     @responses.activate
     @patch("sentry.middleware.integrations.parsers.github.metrics")
-    @override_options({SHED_INBOUND_OPTION: [{"provider": "github"}]})
+    @override_options({SHED_INBOUND_KILLSWITCH: [{"provider": "github"}]})
     def test_shed_inbound_is_not_counted_as_forwarded(self, mock_metrics: Mock) -> None:
         self.get_integration()
         request = self.factory.post(

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -27,6 +27,7 @@ cell = Cell("us", 1, "https://us.testserver")
 cell_config = (cell,)
 
 DROP_NO_OWN_REPO_PR_OPTION = "hybridcloud.webhookpayload.github_drop_checks_without_own_repo_pr"
+SHED_INBOUND_OPTION = "hybridcloud.webhookpayload.shed-inbound"
 
 
 @control_silo_test
@@ -751,6 +752,34 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
             mailbox_name=f"github:{integration.id}:23:check_suite",
             cell_names=[cell.name],
         )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @patch("sentry.middleware.integrations.parsers.github.metrics")
+    @override_options({SHED_INBOUND_OPTION: [{"provider": "github"}]})
+    def test_shed_inbound_is_not_counted_as_forwarded(self, mock_metrics: Mock) -> None:
+        self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 123}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert response["Retry-After"] == "60"
+        assert_no_webhook_payloads()
+        forwarded_calls = [
+            call
+            for call in mock_metrics.incr.call_args_list
+            if call.args and call.args[0] == "github.webhook.forwarded_event"
+        ]
+        assert forwarded_calls == []
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_cells(cell_config)


### PR DESCRIPTION
Every accepted inbound integration webhook synchronously INSERTs a `WebhookPayload` row and runs an inline push trigger against the control primary. That means an inbound flood buys the primary the most writes at exactly the moment the primary is the bottleneck, and there is no valve short of a deploy.

This adds `hybridcloud.webhookpayload.shed-inbound` as a killswitch (see `sentry.killswitches`, default `[]`) with `provider` and `integration_id` fields, so a condition is `{"provider": "github"}` for a whole provider or `{"provider": "github", "integration_id": "12345"}` for a single integration. It is checked once in the shared parser path before any payload is created, so multi-cell fan-out sheds before the loop rather than per cell. GitHub checks it a few lines earlier, ahead of the `forwarded_event` counter and `get_mailbox_identifier`, so a shed webhook is neither miscounted as forwarded nor charged for routing work it will not use.

Matching requests get a 429 with `Retry-After: 60`, an unsampled `hybridcloud.webhookpayload.shed` counter tagged by provider, and a 10%-sampled log line — unsampled, the log pipeline would absorb exactly the volume the shed takes off the primary. This is data loss by design — the 429 asks the sender to back off, and whatever it does not redeliver is gone — so the default is empty and unmatched conditions are inert. Every condition must name a provider: killswitch conditions treat an unset field as a wildcard, so a provider-less condition would shed all inbound traffic off a single typo. Those are dropped and counted on `hybridcloud.webhookpayload.shed_condition_ignored`, so a condition that will never fire is visible rather than silent.

Tests cover the empty default, provider-wide shed, per-integration shed with a sibling integration passing through, unknown condition fields being inert, provider-less conditions being dropped and counted, and GitHub not counting a shed webhook as forwarded.
