### PR TITLE
ref(crons): Stop storing processing errors for throttled check-ins

### DIFF
--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -180,7 +180,30 @@ def get_errors_for_projects(projects: list[Project]) -> list[CheckinProcessingEr
     return _get_for_entities([build_project_identifier(project.id) for project in projects])
 
 
+# Error types produced by a guard that drops a check-in before any work is done. These say
+# nothing a single entry would not, and the entities producing them do so thousands of times a
+# minute, so storing each one costs far more than it is worth: two cache lookups, a json dump of
+# the whole check-in, and two redis round trips, all inside the serial per monitor environment
+# loop. Only `MAX_ERRORS_PER_SET` are ever retained anyway.
+THROTTLED_ERROR_TYPES = frozenset(
+    {
+        ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED,
+        ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED,
+    }
+)
+
+
 def handle_processing_errors(item: CheckinItem, error: ProcessingErrorsException):
+    # Still counted, just not stored. See `THROTTLED_ERROR_TYPES`.
+    if all(
+        process_error["type"] in THROTTLED_ERROR_TYPES for process_error in error.processing_errors
+    ):
+        metrics.incr(
+            "monitors.checkin.handle_processing_error",
+            tags={"source": "consumer", "stored": "false"},
+        )
+        return
+
     try:
         project = Project.objects.get_from_cache(id=item.message["project_id"])
         organization = Organization.objects.get_from_cache(id=project.organization_id)
@@ -190,6 +213,7 @@ def handle_processing_errors(item: CheckinItem, error: ProcessingErrorsException
             tags={
                 "source": "consumer",
                 "sdk_platform": item.message["sdk"],
+                "stored": "true",
             },
         )
 

--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -180,11 +180,8 @@ def get_errors_for_projects(projects: list[Project]) -> list[CheckinProcessingEr
     return _get_for_entities([build_project_identifier(project.id) for project in projects])
 
 
-# Error types produced by a guard that drops a check-in before any work is done. These say
-# nothing a single entry would not, and the entities producing them do so thousands of times a
-# minute, so storing each one costs far more than it is worth: two cache lookups, a json dump of
-# the whole check-in, and two redis round trips, all inside the serial per monitor environment
-# loop. Only `MAX_ERRORS_PER_SET` are ever retained anyway.
+# Dropped by a guard before any work is done, at a volume that makes storing each one cost more
+# than it is worth. Only `MAX_ERRORS_PER_SET` are retained anyway.
 THROTTLED_ERROR_TYPES = frozenset(
     {
         ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED,
@@ -194,7 +191,6 @@ THROTTLED_ERROR_TYPES = frozenset(
 
 
 def handle_processing_errors(item: CheckinItem, error: ProcessingErrorsException):
-    # Still counted, just not stored. See `THROTTLED_ERROR_TYPES`.
     if all(
         process_error["type"] in THROTTLED_ERROR_TYPES for process_error in error.processing_errors
     ):

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -259,3 +259,43 @@ class HandleProcessingErrorsTest(TestCase):
                 error_types=[ProcessingErrorType.CHECKIN_INVALID_GUID.value],
             ),
         )
+
+    def test_throttled_types_are_not_stored(self) -> None:
+        """
+        Guards that drop a check-in before doing any work fire thousands of times a minute for a
+        single monitor environment. Storing each one costs two cache lookups and two redis round
+        trips inside the serial processing loop, for data capped at `MAX_ERRORS_PER_SET` anyway.
+        """
+        monitor = self.create_monitor()
+        item = build_checkin_item(
+            message_overrides={"project_id": self.project.id},
+            payload_overrides={"monitor_slug": monitor.slug},
+        )
+
+        for error_type in (
+            ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED,
+            ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED,
+        ):
+            handle_processing_errors(
+                item, ProcessingErrorsException([{"type": error_type}], monitor=monitor)
+            )
+
+        assert get_errors_for_monitor(monitor) == []
+
+    def test_throttled_type_alongside_a_real_error_is_stored(self) -> None:
+        monitor = self.create_monitor()
+        handle_processing_errors(
+            build_checkin_item(
+                message_overrides={"project_id": self.project.id},
+                payload_overrides={"monitor_slug": monitor.slug},
+            ),
+            ProcessingErrorsException(
+                [
+                    {"type": ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED},
+                    {"type": ProcessingErrorType.CHECKIN_INVALID_GUID},
+                ],
+                monitor=monitor,
+            ),
+        )
+
+        assert len(get_errors_for_monitor(monitor)) == 1

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -267,13 +267,18 @@ class HandleProcessingErrorsTest(TestCase):
             payload_overrides={"monitor_slug": monitor.slug},
         )
 
-        for error_type in (
-            ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED,
-            ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED,
-        ):
-            handle_processing_errors(
-                item, ProcessingErrorsException([{"type": error_type}], monitor=monitor)
-            )
+        handle_processing_errors(
+            item,
+            ProcessingErrorsException(
+                [{"type": ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED}], monitor=monitor
+            ),
+        )
+        handle_processing_errors(
+            item,
+            ProcessingErrorsException(
+                [{"type": ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED}], monitor=monitor
+            ),
+        )
 
         assert get_errors_for_monitor(monitor) == []
 

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -261,11 +261,6 @@ class HandleProcessingErrorsTest(TestCase):
         )
 
     def test_throttled_types_are_not_stored(self) -> None:
-        """
-        Guards that drop a check-in before doing any work fire thousands of times a minute for a
-        single monitor environment. Storing each one costs two cache lookups and two redis round
-        trips inside the serial processing loop, for data capped at `MAX_ERRORS_PER_SET` anyway.
-        """
         monitor = self.create_monitor()
         item = build_checkin_item(
             message_overrides={"project_id": self.project.id},


### PR DESCRIPTION
## Problem

Rate limited and kill-switched check-ins are dropped by a guard *before any work is done* — but they still raise `ProcessingErrorsException`, so `handle_processing_errors` runs and pays:

- 2 × `get_from_cache` (Project, Organization)
- `json.dumps` of the **entire check-in**, payload included
- **two sequential redis round trips**

All of it inside the serial loop in `process_checkin_group`, which is what gates the batch commit.

The second round trip is unconditional in practice. `store_error` trims to `MAX_ERRORS_PER_SET` (10) with a `zrange` followed by individual `DELETE`s plus a `zrem`:

```python
pipeline.zrange(error_set_key, 0, -(MAX_ERRORS_PER_SET + 1))
processing_errors_to_remove = pipeline.execute()[-1]
if processing_errors_to_remove:      # always true past the first 10
    ...                              # a second pipeline
```

Any monitor environment generating these has been over the cap since its first second, so the trim fires on every drop.

## Impact

We currently see a single monitor environment sending **~2,000 rate limited check-ins/min** into one `processing_key`. That is ~66 redis round trips/sec, sequential, on one thread, to store data capped at 10 entries where every entry says the same thing.

## Change

Skip storage when *every* error in the exception is a throttled type. Still counted via `monitors.checkin.handle_processing_error`, now tagged `stored:true|false` so the volume stays visible.

Errors bundled with any other type are stored exactly as before.

## Tests

- throttled types alone are not stored
- a throttled type alongside a real error **is** stored
- existing handler test unchanged