### PR TITLE
feat(seer-infra-telemetry): Verify GCP connection during integration setup (backend)

### DIFF
--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -5,8 +5,10 @@ from collections.abc import Mapping, MutableMapping
 from typing import Any, TypedDict, cast
 
 from django.http.request import HttpRequest
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from rest_framework.fields import CharField, ListField
+from rest_framework.fields import CharField, ChoiceField, ListField
+from rest_framework.serializers import Serializer
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
@@ -20,7 +22,11 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.gcp.client import delete_sentry_sa, generate_sentry_sa
-from sentry.integrations.gcp.utils import GCP_MCP_URLS, validate_gcp_project_id
+from sentry.integrations.gcp.utils import (
+    GCP_CONNECTION_STATUSES,
+    GCP_MCP_URLS,
+    validate_gcp_project_id,
+)
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
@@ -66,6 +72,9 @@ class GcpConfig(TypedDict):
     sentry_sa_email: str
     customer_sa_email: str
     projects: list[str]
+    connection_status: str
+    project_statuses: list[GcpProjectVerification]
+    last_verified_at: str
 
 
 class GcpConfigInputSerializer(CamelSnakeSerializer["GcpConfigInput"]):
@@ -76,6 +85,28 @@ class GcpConfigInputSerializer(CamelSnakeSerializer["GcpConfigInput"]):
 class GcpConfigInput(TypedDict):
     customer_sa_email: str
     projects: list[str]
+
+
+class GcpVerification(TypedDict):
+    connection_status: str
+    projects: list[GcpProjectVerification]
+
+
+class GcpProjectVerification(TypedDict):
+    gcp_project_id: str
+    connection_status: str
+    error_detail: str | None
+
+
+class GcpProjectVerificationSerializer(Serializer[GcpProjectVerification]):
+    gcp_project_id = CharField(required=True, max_length=64)
+    connection_status = ChoiceField(choices=GCP_CONNECTION_STATUSES, required=True)
+    error_detail = CharField(required=False, allow_null=True, allow_blank=True, default=None)
+
+
+class GcpVerificationInputSerializer(CamelSnakeSerializer["GcpVerification"]):
+    connection_status = ChoiceField(choices=GCP_CONNECTION_STATUSES, required=True)
+    projects = GcpProjectVerificationSerializer(many=True, required=True, allow_empty=False)
 
 
 class GcpSaGenerationApiStep:
@@ -119,7 +150,52 @@ class GcpCustomerConfigApiStep:
         pipeline: IntegrationPipeline,
         request: HttpRequest,
     ) -> PipelineStepResult:
-        pipeline.bind_state("config", dict(validated_data))
+        config = dict(validated_data)
+        config["projects"] = list(dict.fromkeys(validated_data["projects"]))
+        pipeline.bind_state("config", config)
+        return PipelineStepResult.advance()
+
+
+class GcpVerificationApiStep:
+    step_name = "gcp_verification"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        config: dict[str, Any] = pipeline.fetch_state("config") or {}
+        return {
+            "customerSaEmail": config.get("customer_sa_email", ""),
+            "projects": config.get("projects", []),
+        }
+
+    def get_serializer_cls(self) -> type:
+        return GcpVerificationInputSerializer
+
+    def handle_post(
+        self,
+        validated_data: GcpVerification,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        config: dict[str, Any] = pipeline.fetch_state("config") or {}
+        configured_projects = set(config.get("projects", []))
+        verified_projects = {p["gcp_project_id"] for p in validated_data["projects"]}
+        if configured_projects != verified_projects:
+            return PipelineStepResult.error(
+                "Verification results do not match the configured GCP projects. "
+                "Please re-run verification."
+            )
+
+        verification: GcpVerification = {
+            "connection_status": validated_data["connection_status"],
+            "projects": [
+                {
+                    "gcp_project_id": project["gcp_project_id"],
+                    "connection_status": project["connection_status"],
+                    "error_detail": project.get("error_detail") or None,
+                }
+                for project in validated_data["projects"]
+            ],
+        }
+        pipeline.bind_state("verification", verification)
         return PipelineStepResult.advance()
 
 
@@ -205,7 +281,11 @@ class GcpIntegrationProvider(IntegrationProvider):
     allow_multiple = False
 
     def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
-        return [GcpSaGenerationApiStep(), GcpCustomerConfigApiStep()]
+        return [
+            GcpSaGenerationApiStep(),
+            GcpCustomerConfigApiStep(),
+            GcpVerificationApiStep(),
+        ]
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         config = state.get("config", {})
@@ -232,6 +312,7 @@ class GcpIntegrationProvider(IntegrationProvider):
                 "sentry_sa_email": sentry_sa_email,
                 "customer_sa_email": customer_sa_email,
                 "projects": projects,
+                "verification": state.get("verification"),
             },
         }
 
@@ -246,10 +327,34 @@ class GcpIntegrationProvider(IntegrationProvider):
             organization_id=organization.id,
             integration_id=integration.id,
         )
+        verification: GcpVerification | None = extra.get("verification")
+        if verification is None:
+            logger.error(
+                "gcp.post_install_missing_verification",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                },
+            )
+            verification = {
+                "connection_status": "error",
+                "projects": [
+                    {
+                        "gcp_project_id": project_id,
+                        "connection_status": "error",
+                        "error_detail": "Verification failed to run during setup.",
+                    }
+                    for project_id in extra["projects"]
+                ],
+            }
+
         gcp_config: GcpConfig = {
             "sentry_sa_email": extra["sentry_sa_email"],
             "customer_sa_email": extra["customer_sa_email"],
             "projects": extra["projects"],
+            "connection_status": verification["connection_status"],
+            "project_statuses": verification["projects"],
+            "last_verified_at": timezone.now().isoformat(),
         }
         org_integration.update(config=gcp_config)
 

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -7,7 +7,7 @@ from typing import Any, TypedDict, cast
 from django.http.request import HttpRequest
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from rest_framework.fields import CharField, ChoiceField, ListField
+from rest_framework.fields import CharField, ListField
 from rest_framework.serializers import Serializer
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
@@ -22,11 +22,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.gcp.client import delete_sentry_sa, generate_sentry_sa
-from sentry.integrations.gcp.utils import (
-    GCP_CONNECTION_STATUSES,
-    GCP_MCP_URLS,
-    validate_gcp_project_id,
-)
+from sentry.integrations.gcp.utils import GCP_MCP_URLS, validate_gcp_project_id
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
@@ -74,7 +70,7 @@ class GcpConfig(TypedDict):
     projects: list[str]
     connection_status: str
     project_statuses: list[GcpProjectVerification]
-    last_verified_at: str
+    last_verified_at: str | None
 
 
 class GcpConfigInputSerializer(CamelSnakeSerializer["GcpConfigInput"]):
@@ -100,12 +96,12 @@ class GcpProjectVerification(TypedDict):
 
 class GcpProjectVerificationSerializer(Serializer[GcpProjectVerification]):
     gcp_project_id = CharField(required=True, max_length=64)
-    connection_status = ChoiceField(choices=GCP_CONNECTION_STATUSES, required=True)
+    connection_status = CharField(required=True)
     error_detail = CharField(required=False, allow_null=True, allow_blank=True, default=None)
 
 
 class GcpVerificationInputSerializer(CamelSnakeSerializer["GcpVerification"]):
-    connection_status = ChoiceField(choices=GCP_CONNECTION_STATUSES, required=True)
+    connection_status = CharField(required=True)
     projects = GcpProjectVerificationSerializer(many=True, required=True, allow_empty=False)
 
 
@@ -328,6 +324,7 @@ class GcpIntegrationProvider(IntegrationProvider):
             integration_id=integration.id,
         )
         verification: GcpVerification | None = extra.get("verification")
+        last_verified_at = timezone.now().isoformat() if verification is not None else None
         if verification is None:
             logger.error(
                 "gcp.post_install_missing_verification",
@@ -354,7 +351,7 @@ class GcpIntegrationProvider(IntegrationProvider):
             "projects": extra["projects"],
             "connection_status": verification["connection_status"],
             "project_statuses": verification["projects"],
-            "last_verified_at": timezone.now().isoformat(),
+            "last_verified_at": last_verified_at,
         }
         org_integration.update(config=gcp_config)
 

--- a/src/sentry/integrations/gcp/utils.py
+++ b/src/sentry/integrations/gcp/utils.py
@@ -12,6 +12,16 @@ GCP_MCP_URLS: tuple[str, ...] = (
     "https://cloudtrace.googleapis.com/mcp",
 )
 
+# Connection statuses returned by Seer's GCP verification endpoint. Mirrors
+# ConnectionStatus in seer/automation/agent/mcp/gcp_verification.py.
+GCP_CONNECTION_STATUSES: tuple[str, ...] = (
+    "connected",
+    "permission_denied",
+    "api_disabled",
+    "project_not_found",
+    "error",
+)
+
 
 def validate_gcp_project_id(project_id: str) -> None:
     if not GCP_PROJECT_ID_RE.match(project_id):

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -297,15 +297,17 @@ class GcpIntegrationTest(TestCase):
         assert "do not match the configured GCP projects" in result.data["detail"]
         assert "verification" not in state
 
-    def test_verification_serializer_rejects_unknown_status(self) -> None:
+    def test_verification_serializer_accepts_unknown_status(self) -> None:
         serializer = GcpVerificationInputSerializer(
             data={
-                "connectionStatus": "not_a_real_status",
-                "projects": [{"gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}],
+                "connectionStatus": "quota_exceeded",
+                "projects": [
+                    {"gcpProjectId": "my-gcp-project", "connectionStatus": "quota_exceeded"}
+                ],
             }
         )
-        assert not serializer.is_valid()
-        assert "connectionStatus" in serializer.errors
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["connection_status"] == "quota_exceeded"
 
     def test_verification_serializer_requires_at_least_one_project(self) -> None:
         serializer = GcpVerificationInputSerializer(
@@ -507,6 +509,7 @@ class GcpIntegrationTest(TestCase):
             integration_id=integration.id,
         )
         assert org_integration.config["connection_status"] == "error"
+        assert org_integration.config["last_verified_at"] is None
         assert org_integration.config["project_statuses"] == [
             {
                 "gcp_project_id": "my-gcp-project",

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock, patch
 
 import pytest
@@ -12,6 +12,7 @@ from sentry.integrations.gcp.integration import (
     GcpIntegration,
     GcpIntegrationProvider,
     GcpSaGenerationApiStep,
+    GcpVerification,
     GcpVerificationApiStep,
     GcpVerificationInputSerializer,
 )
@@ -162,7 +163,9 @@ class GcpIntegrationTest(TestCase):
     # -- Setup wizard: step contract --
 
     def test_pipeline_steps_match_frontend_step_ids(self) -> None:
-        steps = self.provider.get_pipeline_api_steps()
+        steps = [
+            step() if callable(step) else step for step in self.provider.get_pipeline_api_steps()
+        ]
         assert [step.step_name for step in steps] == [
             "gcp_sa_generation",
             "gcp_customer_config",
@@ -190,7 +193,7 @@ class GcpIntegrationTest(TestCase):
 
     # -- Setup wizard: verification step --
 
-    def _validated_verification(self, **overrides: object) -> dict[str, Any]:
+    def _validated_verification(self, **overrides: object) -> GcpVerification:
         data: dict[str, Any] = {
             "connectionStatus": "connected",
             "projects": [{"gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}],
@@ -198,7 +201,7 @@ class GcpIntegrationTest(TestCase):
         data.update(overrides)
         serializer = GcpVerificationInputSerializer(data=data)
         assert serializer.is_valid(), serializer.errors
-        return serializer.validated_data
+        return cast(GcpVerification, serializer.validated_data)
 
     def test_verification_step_exposes_values_to_verify(self) -> None:
         step = GcpVerificationApiStep()

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
 
 from sentry.integrations.gcp.client import _CONNECTORS_PROJECT, _GCP_IAM_BASE
 from sentry.integrations.gcp.integration import (
+    GcpCustomerConfigApiStep,
     GcpIntegration,
     GcpIntegrationProvider,
     GcpSaGenerationApiStep,
+    GcpVerificationApiStep,
+    GcpVerificationInputSerializer,
 )
 from sentry.integrations.gcp.utils import validate_gcp_project_id
 from sentry.integrations.models.gcp_service_account import GcpServiceAccount
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.types import PipelineStepAction, PipelineStepResult
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError, IntegrationError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -155,6 +159,183 @@ class GcpIntegrationTest(TestCase):
 
         assert not GcpServiceAccount.objects.filter(organization_id=self.organization.id).exists()
 
+    # -- Setup wizard: step contract --
+
+    def test_pipeline_steps_match_frontend_step_ids(self) -> None:
+        steps = self.provider.get_pipeline_api_steps()
+        assert [step.step_name for step in steps] == [
+            "gcp_sa_generation",
+            "gcp_customer_config",
+            "gcp_verification",
+        ]
+
+    def test_config_step_drops_duplicate_projects(self) -> None:
+        step = GcpCustomerConfigApiStep()
+        state: dict[str, object] = {"sentry_sa_email": _SA_EMAIL}
+        pipeline = self._make_pipeline(state=state)
+
+        result = step.handle_post(
+            {
+                "customer_sa_email": _CUSTOMER_SA,
+                "projects": ["project-prod", "project-staging", "project-prod"],
+            },
+            pipeline,
+            Mock(),
+        )
+
+        assert result == PipelineStepResult.advance()
+        config = state["config"]
+        assert isinstance(config, dict)
+        assert config["projects"] == ["project-prod", "project-staging"]
+
+    # -- Setup wizard: verification step --
+
+    def _validated_verification(self, **overrides: object) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "connectionStatus": "connected",
+            "projects": [{"gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}],
+        }
+        data.update(overrides)
+        serializer = GcpVerificationInputSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+        return serializer.validated_data
+
+    def test_verification_step_exposes_values_to_verify(self) -> None:
+        step = GcpVerificationApiStep()
+        pipeline = self._make_pipeline(
+            state={
+                "sentry_sa_email": _SA_EMAIL,
+                "config": {
+                    "customer_sa_email": _CUSTOMER_SA,
+                    "projects": ["my-gcp-project"],
+                },
+            }
+        )
+
+        assert step.get_step_data(pipeline, Mock()) == {
+            "customerSaEmail": _CUSTOMER_SA,
+            "projects": ["my-gcp-project"],
+        }
+
+    def test_verification_step_records_result(self) -> None:
+        step = GcpVerificationApiStep()
+        state: dict[str, object] = {
+            "config": {"customer_sa_email": _CUSTOMER_SA, "projects": ["my-gcp-project"]}
+        }
+        pipeline = self._make_pipeline(state=state)
+
+        result = step.handle_post(self._validated_verification(), pipeline, Mock())
+
+        assert result == PipelineStepResult.advance()
+        assert state["verification"] == {
+            "connection_status": "connected",
+            "projects": [
+                {
+                    "gcp_project_id": "my-gcp-project",
+                    "connection_status": "connected",
+                    "error_detail": None,
+                }
+            ],
+        }
+
+    def test_verification_step_advances_when_connection_fails(self) -> None:
+        step = GcpVerificationApiStep()
+        state: dict[str, object] = {
+            "config": {"customer_sa_email": _CUSTOMER_SA, "projects": ["my-gcp-project"]}
+        }
+        pipeline = self._make_pipeline(state=state)
+
+        result = step.handle_post(
+            self._validated_verification(
+                connectionStatus="permission_denied",
+                projects=[
+                    {
+                        "gcpProjectId": "my-gcp-project",
+                        "connectionStatus": "permission_denied",
+                        "errorDetail": "IAM roles not granted",
+                    }
+                ],
+            ),
+            pipeline,
+            Mock(),
+        )
+
+        assert result == PipelineStepResult.advance()
+        assert state["verification"] == {
+            "connection_status": "permission_denied",
+            "projects": [
+                {
+                    "gcp_project_id": "my-gcp-project",
+                    "connection_status": "permission_denied",
+                    "error_detail": "IAM roles not granted",
+                }
+            ],
+        }
+
+    def test_verification_step_rejects_results_for_other_projects(self) -> None:
+        step = GcpVerificationApiStep()
+        state: dict[str, object] = {
+            "config": {
+                "customer_sa_email": _CUSTOMER_SA,
+                "projects": ["project-prod", "project-staging"],
+            }
+        }
+        pipeline = self._make_pipeline(state=state)
+
+        result = step.handle_post(
+            self._validated_verification(
+                projects=[{"gcpProjectId": "project-prod", "connectionStatus": "connected"}]
+            ),
+            pipeline,
+            Mock(),
+        )
+
+        assert result.action == PipelineStepAction.ERROR
+        assert "do not match the configured GCP projects" in result.data["detail"]
+        assert "verification" not in state
+
+    def test_verification_serializer_rejects_unknown_status(self) -> None:
+        serializer = GcpVerificationInputSerializer(
+            data={
+                "connectionStatus": "not_a_real_status",
+                "projects": [{"gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}],
+            }
+        )
+        assert not serializer.is_valid()
+        assert "connectionStatus" in serializer.errors
+
+    def test_verification_serializer_requires_at_least_one_project(self) -> None:
+        serializer = GcpVerificationInputSerializer(
+            data={"connectionStatus": "connected", "projects": []}
+        )
+        assert not serializer.is_valid()
+        assert "projects" in serializer.errors
+
+    def test_verification_step_normalizes_blank_error_detail(self) -> None:
+        step = GcpVerificationApiStep()
+        state: dict[str, object] = {
+            "config": {"customer_sa_email": _CUSTOMER_SA, "projects": ["my-gcp-project"]}
+        }
+        pipeline = self._make_pipeline(state=state)
+
+        step.handle_post(
+            self._validated_verification(
+                projects=[
+                    {
+                        "gcpProjectId": "my-gcp-project",
+                        "connectionStatus": "connected",
+                        "errorDetail": "",
+                    }
+                ],
+            ),
+            pipeline,
+            Mock(),
+        )
+
+        verification = state["verification"]
+        assert isinstance(verification, dict)
+        assert verification["projects"][0]["error_detail"] is None
+
     # -- Build + install --
 
     def test_build_integration_returns_correct_data(self) -> None:
@@ -182,6 +363,23 @@ class GcpIntegrationTest(TestCase):
             self._state(projects=["project-prod", "project-staging"])
         )
         assert result["post_install_data"]["projects"] == ["project-prod", "project-staging"]
+
+    def test_build_integration_passes_verification_through(self) -> None:
+        state = self._state()
+        verification = {
+            "connection_status": "connected",
+            "projects": [
+                {
+                    "gcp_project_id": "my-gcp-project",
+                    "connection_status": "connected",
+                    "error_detail": None,
+                }
+            ],
+        }
+        state["verification"] = verification
+
+        result = self.provider.build_integration(state)
+        assert result["post_install_data"]["verification"] == verification
 
     def test_build_integration_requires_config(self) -> None:
         with pytest.raises(IntegrationConfigurationError):
@@ -220,15 +418,99 @@ class GcpIntegrationTest(TestCase):
                 "sentry_sa_email": _SA_EMAIL,
                 "customer_sa_email": _CUSTOMER_SA,
                 "projects": ["my-gcp-project"],
+                "verification": {
+                    "connection_status": "connected",
+                    "projects": [
+                        {
+                            "gcp_project_id": "my-gcp-project",
+                            "connection_status": "connected",
+                            "error_detail": None,
+                        }
+                    ],
+                },
             },
         )
 
         org_integration.refresh_from_db()
-        assert org_integration.config == {
-            "sentry_sa_email": _SA_EMAIL,
-            "customer_sa_email": _CUSTOMER_SA,
-            "projects": ["my-gcp-project"],
-        }
+        assert org_integration.config["sentry_sa_email"] == _SA_EMAIL
+        assert org_integration.config["customer_sa_email"] == _CUSTOMER_SA
+        assert org_integration.config["projects"] == ["my-gcp-project"]
+
+    def test_post_install_stores_verification_status(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="gcp",
+            external_id=str(self.organization.id),
+            name="Google Cloud Platform",
+            metadata={},
+        )
+
+        self.provider.post_install(
+            integration,
+            self.organization,
+            extra={
+                "sentry_sa_email": _SA_EMAIL,
+                "customer_sa_email": _CUSTOMER_SA,
+                "projects": ["my-gcp-project"],
+                "verification": {
+                    "connection_status": "permission_denied",
+                    "projects": [
+                        {
+                            "gcp_project_id": "my-gcp-project",
+                            "connection_status": "permission_denied",
+                            "error_detail": "IAM roles not granted",
+                        }
+                    ],
+                },
+            },
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+        )
+        assert org_integration.config["connection_status"] == "permission_denied"
+        assert org_integration.config["project_statuses"] == [
+            {
+                "gcp_project_id": "my-gcp-project",
+                "connection_status": "permission_denied",
+                "error_detail": "IAM roles not granted",
+            }
+        ]
+        assert org_integration.config["last_verified_at"]
+
+    def test_post_install_records_error_when_verification_missing(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="gcp",
+            external_id=str(self.organization.id),
+            name="Google Cloud Platform",
+            metadata={},
+        )
+
+        self.provider.post_install(
+            integration,
+            self.organization,
+            extra={
+                "sentry_sa_email": _SA_EMAIL,
+                "customer_sa_email": _CUSTOMER_SA,
+                "projects": ["my-gcp-project"],
+                "verification": None,
+            },
+        )
+
+        org_integration = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+        )
+        assert org_integration.config["connection_status"] == "error"
+        assert org_integration.config["project_statuses"] == [
+            {
+                "gcp_project_id": "my-gcp-project",
+                "connection_status": "error",
+                "error_detail": "Verification failed to run during setup.",
+            }
+        ]
 
     # -- Installed integration: config access --
 


### PR DESCRIPTION
PR 1 for https://linear.app/getsentry/issue/CW-1965/hook-gcp-connection-verification-into-the-integration-creation-flow.

Adds `GcpVerificationApiStep` as a third setup step in the GCP integration pipeline. A failed check doesn't block installation - the connection status is simply recorded on the integration, and we can figure out the UX for how to display/remedy this later.

`OrganizationIntegration.config` gains `connection_status`, `project_statuses`, and `last_verified_at`.