### PR TITLE
ref(issue detection): Update conditions for segment-based occurrence creation

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -196,7 +196,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enables setting the fetch all custom measurements request time range to match the user selected time range instead of 90 days
     manager.add("organizations:performance-discover-get-custom-measurements-reduced-range", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Detect performance issues in the new standalone spans pipeline instead of on transactions
-    manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
+    manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable all registered prebuilt dashboards to be synced to the database
     manager.add("organizations:dashboards-sync-all-registered-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer Suggestions for Web Vitals Module

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -316,8 +316,8 @@ def _detect_performance_problems(
         return
 
     try:
-        # Run the legacy detectors and, if the `_performance_issues_spans` flag is set on the
-        # segment span, produce occurrences from the results
+        # Run the legacy detectors and, possibly produce occurrences from the results (depending on
+        # conditions explained in `_run_legacy_detectors`)
         detection_settings = get_detection_settings(project)
         legacy_detected_problems = _run_legacy_detectors(
             segment_span, spans, project, enabled_legacy_detector_types, detection_settings
@@ -344,8 +344,8 @@ def _run_legacy_detectors(
 ) -> list[PerformanceProblem]:
     """
     Run legacy issue detectors corresponding to the given detector types on segment data by first
-    creating a fake transaction event. If the `_performance_issues_spans` flag is set, also create
-    occurrences from the results.
+    creating a fake transaction event. If the right conditions hold (see below), create issue
+    occurrences from any detected problems.
     """
     # Create a fake transaction event out of the segment data, to match what the legacy detectors
     # are expecting

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
-from sentry import options
+from sentry import features, options
 from sentry.ai_monitoring.tasks import spawn_conversation_title_generation
 from sentry.constants import DataCategory
 from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_release
@@ -376,40 +376,81 @@ def _run_legacy_detectors(
         standalone=True,
     )
 
-    # This flag is set in Relay, and here enables producing occurrences from the legacy detector
-    # results. For segments derived from transactions, it additionally suppresses the running of
-    # legacy detectors in `save_transaction_events`, thus preventing duplicate occurrences from
-    # being created.
-    if segment_span.get("_performance_issues_spans"):
-        # Prepare a slimmer event payload for the occurrence consumer. This event will be persisted
-        # by the consumer. Once issue detectors can run on standalone spans, we should directly
-        # build a minimal occurrence event payload here, instead.
-        event_data["spans"] = []
-        event_data["timestamp"] = event_data["datetime"]
+    # If we didn't find anything, it's not worth going through all the "can we save occurrences"
+    # checks below, because there's nothing to save
+    if not detected_problems:
+        return []
 
-        for problem in detected_problems:
-            occurrence = IssueOccurrence(
-                id=uuid.uuid4().hex,
-                resource_id=None,
-                project_id=project.id,
-                event_id=event_data["event_id"],
-                fingerprint=[problem.fingerprint],
-                type=problem.type,
-                issue_title=problem.title,
-                subtitle=problem.desc,
-                culprit=event_data["transaction"],
-                evidence_data=problem.evidence_data or {},
-                evidence_display=problem.evidence_display,
-                detection_time=to_datetime(segment_span["end_timestamp"]),
-                level="info",
-            )
+    # Whether or not we create issue occurrences from the problems we've found depends on two
+    # factors:
+    #
+    #  - The `organizations:performance-issues-spans` feature flag, which must be on for occurrences
+    #    to be created.
+    #
+    #  - Whether or not the occurrence might already have been created via
+    #    `save_transaction_events`. If it might have, we don't create the occurrence, because we
+    #    don't want duplicates. (The reason we say "might have" rather than "did" is because there
+    #    are delays built into both the propagation of feature flags to Relay's cache and the
+    #    buffering of segment data, and together those mean that when the relevant feature flags are
+    #    flipped in either direction, checks in Relay and checks in `save_transaction_events` and
+    #    checks here won't give the same answers until all the data sources are reconciled.)
+    #
+    #    In order for it to be possible for a transaction version of this segment's data to have
+    #    already created an occurrence we need the following:
+    #      a) there has to be a transaction,
+    #      b) that transaction has to reach `save_transaction_events`
+    #      c) when it does, `save_transaction_events` has to not skip occurrence creation
+    #    which corresponds to the following conditions:
+    #      a) the segment span has an event id (only exists if copied from a transaction event)
+    #      b) the discard transactions flag is off for the project
+    #      c) the `_performance_issues_spans` flag (set by relay on transaction and segment) is falsy
+    #    And then if those hold, we don't create an occurrence here, because we don't want to have
+    #    duplicate occurrence records.
+    #
+    # To allow us to short circuit and save calls to `features.has`, we check both of the data-based
+    # conditions (event id and `_performance_issues_spans` flag) before checking either of the
+    # feature-flag-based conditions.
 
-            produce_occurrence_to_kafka(
-                payload_type=PayloadType.OCCURRENCE,
-                occurrence=occurrence,
-                event_data=event_data,
-                is_buffered_spans=True,
-            )
+    transaction_occurrence_creation_possible = (
+        segment_span.get("event_id") is not None
+        and not segment_span.get("_performance_issues_spans")
+        and not features.has("projects:discard-transaction", project)
+    )
+
+    if transaction_occurrence_creation_possible or not features.has(
+        "organizations:performance-issues-spans", project.organization
+    ):
+        return detected_problems
+
+    # Prepare a slimmer event payload for the occurrence consumer. This event will be persisted
+    # by the consumer. Once issue detectors can run on standalone spans, we should directly
+    # build a minimal occurrence event payload here, instead.
+    event_data["spans"] = []
+    event_data["timestamp"] = event_data["datetime"]
+
+    for problem in detected_problems:
+        occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            resource_id=None,
+            project_id=project.id,
+            event_id=event_data["event_id"],
+            fingerprint=[problem.fingerprint],
+            type=problem.type,
+            issue_title=problem.title,
+            subtitle=problem.desc,
+            culprit=event_data["transaction"],
+            evidence_data=problem.evidence_data or {},
+            evidence_display=problem.evidence_display,
+            detection_time=to_datetime(segment_span["end_timestamp"]),
+            level="info",
+        )
+
+        produce_occurrence_to_kafka(
+            payload_type=PayloadType.OCCURRENCE,
+            occurrence=occurrence,
+            event_data=event_data,
+            is_buffered_spans=True,
+        )
 
     return detected_problems
 

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -19,6 +19,7 @@ from sentry.issue_detection.performance_detection import (
 )
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.environment import Environment
+from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
@@ -36,6 +37,66 @@ from sentry.testutils.issue_detection.experiments import exclude_experimental_de
 from tests.sentry.spans.consumers.process import build_mock_span
 
 DETECTORS_ENABLED_OPTION = "spans.process-segments.detect-performance-problems.detectors-enabled"
+
+
+def generate_n_plus_one_spans(
+    project: Project,
+    *,
+    has_performance_issues_spans_relay_flag: bool = False,
+    event_id: str | None = None,
+):
+    """
+    Build a set of spans containing an N+1 problem.
+
+    `has_performance_issues_spans_relay_flag` controls Relay's `_performance_issues_spans` marker.
+    Relay omits the marker entirely rather than serializing it as `False`, so it's only set here
+    if the parameter is True.
+    """
+    segment_span_kwargs: dict[str, Any] = {}
+    if has_performance_issues_spans_relay_flag:
+        segment_span_kwargs["_performance_issues_spans"] = True
+    if event_id is not None:
+        segment_span_kwargs["event_id"] = event_id
+
+    segment_span = build_mock_span(
+        project_id=project.id,
+        is_segment=True,
+        **segment_span_kwargs,
+    )
+    child_span = build_mock_span(
+        project_id=project.id,
+        description="OrganizationNPlusOne.get",
+        parent_span_id=segment_span["span_id"],
+        span_id="940ce942561548b5",
+        start_timestamp_ms=1707953018867,
+        start_timestamp=1707953018.867,
+    )
+    cause_span = build_mock_span(
+        project_id=project.id,
+        span_op="db",
+        description='SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project"',
+        parent_span_id="940ce942561548b5",
+        span_id="a974da4671bc3857",
+        start_timestamp_ms=1707953018867,
+        start_timestamp=1707953018.867,
+    )
+    repeating_span_description = 'SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug", "sentry_organization"."status", "sentry_organization"."date_added", "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s LIMIT 21'
+
+    def repeating_span():
+        return build_mock_span(
+            project_id=project.id,
+            span_op="db",
+            description=repeating_span_description,
+            parent_span_id="940ce942561548b5",
+            span_id=uuid.uuid4().hex[:16],
+            start_timestamp_ms=1707953018869,
+            start_timestamp=1707953018.869,
+        )
+
+    repeating_spans = [repeating_span() for _ in range(7)]
+    spans = [segment_span, child_span, cause_span] + repeating_spans
+
+    return spans
 
 
 @exclude_experimental_detectors
@@ -71,47 +132,6 @@ class TestSpansTask(TestCase):
         )
 
         return [child_span, segment_span]
-
-    def generate_n_plus_one_spans(self):
-        segment_span = build_mock_span(
-            project_id=self.project.id,
-            is_segment=True,
-            _performance_issues_spans=True,
-        )
-        child_span = build_mock_span(
-            project_id=self.project.id,
-            description="OrganizationNPlusOne.get",
-            parent_span_id=segment_span["span_id"],
-            span_id="940ce942561548b5",
-            start_timestamp_ms=1707953018867,
-            start_timestamp=1707953018.867,
-        )
-        cause_span = build_mock_span(
-            project_id=self.project.id,
-            span_op="db",
-            description='SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project"',
-            parent_span_id="940ce942561548b5",
-            span_id="a974da4671bc3857",
-            start_timestamp_ms=1707953018867,
-            start_timestamp=1707953018.867,
-        )
-        repeating_span_description = 'SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug", "sentry_organization"."status", "sentry_organization"."date_added", "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s LIMIT 21'
-
-        def repeating_span():
-            return build_mock_span(
-                project_id=self.project.id,
-                span_op="db",
-                description=repeating_span_description,
-                parent_span_id="940ce942561548b5",
-                span_id=uuid.uuid4().hex[:16],
-                start_timestamp_ms=1707953018869,
-                start_timestamp=1707953018.869,
-            )
-
-        repeating_spans = [repeating_span() for _ in range(7)]
-        spans = [segment_span, child_span, cause_span] + repeating_spans
-
-        return spans
 
     def test_enrich_spans(self) -> None:
         spans = self.generate_basic_spans()
@@ -223,7 +243,7 @@ class TestSpansTask(TestCase):
     @override_options({DETECTORS_ENABLED_OPTION: ["*"]})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:
-        spans = self.generate_n_plus_one_spans()
+        spans = generate_n_plus_one_spans(self.project)
         with mock.patch("sentry.issues.ingest.should_create_group", return_value=True):
             process_segment(spans)
 
@@ -331,7 +351,7 @@ class TestSpansTask(TestCase):
         An empty option value is the killswitch for all segment-based issue detection, so nothing
         downstream of it should run -- not even the settings fetch.
         """
-        spans = self.generate_n_plus_one_spans()
+        spans = generate_n_plus_one_spans(self.project)
 
         with (
             override_options({DETECTORS_ENABLED_OPTION: []}),
@@ -348,7 +368,7 @@ class TestSpansTask(TestCase):
             legacy_detectors_mock.assert_not_called()
 
     def test_blanket_detector_enablement(self) -> None:
-        spans = self.generate_n_plus_one_spans()
+        spans = generate_n_plus_one_spans(self.project)
 
         with (
             override_options({DETECTORS_ENABLED_OPTION: ["*"]}),
@@ -362,7 +382,7 @@ class TestSpansTask(TestCase):
             assert legacy_detectors_spy.call_args.kwargs["detector_classes"] == DETECTOR_CLASSES
 
     def test_selective_detector_enablement(self) -> None:
-        spans = self.generate_n_plus_one_spans()
+        spans = generate_n_plus_one_spans(self.project)
 
         with (
             override_options({DETECTORS_ENABLED_OPTION: ["n_plus_one_db"]}),
@@ -383,7 +403,7 @@ class TestSpansTask(TestCase):
         it lets the valid entries keep working, but it needs to be noisy about it, because
         otherwise a typo is indistinguishable from having deliberately switched that detector off.
         """
-        spans = self.generate_n_plus_one_spans()
+        spans = generate_n_plus_one_spans(self.project)
 
         with (
             override_options({DETECTORS_ENABLED_OPTION: ["n_plus_one_db", "dogs_are_great"]}),

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -32,11 +32,15 @@ from sentry.spans.consumers.process_segments.message import (
 from sentry.spans.consumers.process_segments.shim import build_shim_event_data
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.issue_detection.experiments import exclude_experimental_detectors
+from sentry.testutils.pytest.fixtures import django_db_all
 from tests.sentry.spans.consumers.process import build_mock_span
 
 DETECTORS_ENABLED_OPTION = "spans.process-segments.detect-performance-problems.detectors-enabled"
+PERFORMANCE_ISSUES_SPANS_ORG_FEATURE_FLAG = "organizations:performance-issues-spans"
+DISCARD_TRANSACTIONS_PROJECT_FEATURE_FLAG = "projects:discard-transaction"
 
 
 def generate_n_plus_one_spans(
@@ -241,9 +245,15 @@ class TestSpansTask(TestCase):
         assert not Release.objects.filter(organization_id=self.organization.id).exists()
 
     @override_options({DETECTORS_ENABLED_OPTION: ["*"]})
+    @with_feature(PERFORMANCE_ISSUES_SPANS_ORG_FEATURE_FLAG)
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:
-        spans = generate_n_plus_one_spans(self.project)
+        spans = generate_n_plus_one_spans(
+            self.project,
+            # Force segment to create an occurrence so we can examine it
+            has_performance_issues_spans_relay_flag=True,
+        )
+
         with mock.patch("sentry.issues.ingest.should_create_group", return_value=True):
             process_segment(spans)
 
@@ -834,3 +844,69 @@ class TestProcessSegmentCaching(TestCase):
 
         mock_create.assert_not_called()
         mock_bump.assert_not_called()
+
+
+@django_db_all
+@pytest.mark.parametrize(
+    [
+        "incoming_data_is_transaction",
+        "discard_transactions_feature_flag",
+        "performance_issues_spans_relay_flag",
+        "performance_issues_spans_feature_flag",
+        "create_occurrence_calls_expected",
+    ],
+    [
+        # Data received as standalone spans, feature flag on -> segment creates occurrence
+        (False, True, True, True, 1),
+        (False, True, False, True, 1),
+        (False, False, True, True, 1),
+        (False, False, False, True, 1),
+        # Transaction discarded, feature flag on -> segment creates occurrence
+        (True, True, True, True, 1),
+        (True, True, False, True, 1),
+        # Transaction kept, relay flag set, feature flag on -> segment creates occurrence
+        (True, False, True, True, 1),
+        # Transaction kept, relay flag not set -> no segment-based occurrence
+        (True, False, False, True, 0),
+        # Feature flag off -> no segment-based occurrence regardless of other values
+        (True, True, True, False, 0),
+        (True, True, False, False, 0),
+        (True, False, True, False, 0),
+        (True, False, False, False, 0),
+        (False, True, True, False, 0),
+        (False, True, False, False, 0),
+        (False, False, True, False, 0),
+        (False, False, False, False, 0),
+    ],
+)
+def test_issue_detector_occurrence_creation(
+    incoming_data_is_transaction: bool,
+    discard_transactions_feature_flag: bool,
+    performance_issues_spans_relay_flag: bool,
+    performance_issues_spans_feature_flag: bool,
+    create_occurrence_calls_expected: int,
+    default_project: Project,
+) -> None:
+    # Segments only have an event id if it's copied over from a transaction
+    event_id = uuid.uuid4().hex if incoming_data_is_transaction else None
+
+    spans = generate_n_plus_one_spans(
+        default_project,
+        has_performance_issues_spans_relay_flag=performance_issues_spans_relay_flag,
+        event_id=event_id,
+    )
+
+    with (
+        with_feature(
+            {
+                PERFORMANCE_ISSUES_SPANS_ORG_FEATURE_FLAG: performance_issues_spans_feature_flag,
+                DISCARD_TRANSACTIONS_PROJECT_FEATURE_FLAG: discard_transactions_feature_flag,
+            }
+        ),
+        override_options({DETECTORS_ENABLED_OPTION: ["*"]}),
+        mock.patch(
+            "sentry.spans.consumers.process_segments.message.produce_occurrence_to_kafka"
+        ) as mock_produce_occurrence,
+    ):
+        process_segment(spans)
+        assert mock_produce_occurrence.call_count == create_occurrence_calls_expected


### PR DESCRIPTION
This changes the way we decide whether or not to create issue occurrences from the performance problems we detect using the fake-transaction-event shim in the segment processing pipeline. 

Until now, it's been solely based on the presence of a `_performance_issues_spans` flag added to the segment span by Relay, which is in turn based on Relay's cached value of the `organizations:performance-issues-spans` feature flag. The problem is, Relay only sets this flag on segments which it's created as copies of incoming transaction events; segments which are created by the span buffer out of standalone spans don't get the flag.

At the same time, it's not enough to just add a direct feature flag check (of that same feature flag) for span buffer segments, because as we're rolling this out, and feature flag values are getting flipped, Relay's cached values and flagpole's values will be out of sync. 

The `projects:discard-transaction` flag also comes into play here: Even if the `_performance_issues_spans` flag set by Relay implies that it should be `save_transaction_events` which does occurrence creation, that obviously can't happen if the transaction is discarded before it gets there, in which case we want the segment processor to know it needs to take up the slack.

All of this together means that currently, only projects which are both sending transactions and not having them discarded are able to collect performance issues. This PR therefore adjusts the conditions under which the segment processor creates occurrences so that a) segment-first and discarded-transaction projects can again get performance issues, and b) we can continue to gate that using the organization feature flag. 

To account for the time before feature flag values get synced after they're changed, if there's even the possibility of a transaction event already having created the occurrence, the segment processor will choose not to, because briefly not recording occurrences is better than recording two copies of the same occurrence.

Finally, in order to make the `organizations:performance-issues-spans`  feature flag controllable from options-automator, it switches it from an internal feature flag to a flagpole one.

Note: The test changes look bigger than they are - parameterized tests are incompatible with our way of doing class-based ones, so I had to move an existing test class helper method out to module scope and make it a function instead, and then update all the existing calls.