### PR TITLE
ref(debug-files): remove the dead artifact bundle in-use renewal path

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1204,10 +1204,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         # Run once a day at 04:00 UTC, off-peak.
         "schedule": crontab("0", "4", "*", "*", "*"),
     },
-    "refresh-artifact-bundles-in-use": {
-        "task": "attachments:sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
-        "schedule": crontab("*/1", "*", "*", "*", "*"),
-    },
     "on-demand-metrics-schedule-on-demand-check": {
         "task": "performance:sentry.tasks.on_demand_metrics.schedule_on_demand_check",
         "schedule": crontab("*/5", "*", "*", "*", "*"),

--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from datetime import datetime, timedelta
 
 import sentry_sdk
@@ -44,10 +43,6 @@ INDEXING_CACHE_TIMEOUT = 600
 def get_redis_cluster_for_artifact_bundles() -> RedisCluster:
     cluster_key = settings.SENTRY_ARTIFACT_BUNDLES_INDEXING_REDIS_CLUSTER
     return redis.redis_clusters.get(cluster_key)
-
-
-def get_refresh_key() -> str:
-    return "artifact_bundles_in_use"
 
 
 def _generate_artifact_bundle_indexing_state_cache_key(
@@ -182,55 +177,6 @@ def index_urls_in_bundle(
 
 
 # ===== Renewal of Artifact Bundles =====
-
-
-@trace
-def maybe_renew_artifact_bundles_from_processing(project_id: int, used_download_ids: list[str]):
-    # Note: This random rollout is reversed because it is an early return
-    if random.random() >= options.get("symbolicator.sourcemaps-bundle-index-refresh-sample-rate"):
-        return
-
-    artifact_bundle_ids = []
-    for download_id in used_download_ids:
-        # the `download_id` is in a `artifact_bundle/$ID` format
-        split = download_id.split("/")
-        if len(split) < 2:
-            continue
-        ty, ty_id, *_rest = split
-        if ty != "artifact_bundle":
-            continue
-        artifact_bundle_ids.append(ty_id)
-
-    redis_client = get_redis_cluster_for_artifact_bundles()
-
-    redis_client.sadd(get_refresh_key(), *artifact_bundle_ids)
-
-
-@trace
-def refresh_artifact_bundles_in_use():
-    LOOP_TIMES = 100
-    IDS_PER_LOOP = 50
-
-    redis_client = get_redis_cluster_for_artifact_bundles()
-
-    now = timezone.now()
-    threshold_date = now - timedelta(
-        days=options.get("system.debug-files-renewal-age-threshold-days")
-    )
-
-    for _ in range(LOOP_TIMES):
-        artifact_bundle_ids = redis_client.spop(get_refresh_key(), IDS_PER_LOOP)
-        used_artifact_bundles = {
-            id: date_added
-            for id, date_added in ArtifactBundle.objects.filter(
-                id__in=artifact_bundle_ids, date_added__lte=threshold_date
-            ).values_list("id", "date_added")
-        }
-
-        maybe_renew_artifact_bundles(used_artifact_bundles)
-
-        if len(artifact_bundle_ids) < IDS_PER_LOOP:
-            break
 
 
 def maybe_renew_artifact_bundles(used_artifact_bundles: dict[int, datetime]):

--- a/src/sentry/debug_files/tasks.py
+++ b/src/sentry/debug_files/tasks.py
@@ -3,16 +3,6 @@ from sentry.taskworker.namespaces import attachments_tasks
 
 
 @instrumented_task(
-    name="sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
-    namespace=attachments_tasks,
-)
-def refresh_artifact_bundles_in_use() -> None:
-    from .artifact_bundles import refresh_artifact_bundles_in_use as do_refresh
-
-    do_refresh()
-
-
-@instrumented_task(
     name="sentry.debug_files.tasks.backfill_artifact_bundle_db_indexing",
     namespace=attachments_tasks,
 )

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -2,7 +2,6 @@ import logging
 import re
 from typing import Any
 
-from sentry.debug_files.artifact_bundles import maybe_renew_artifact_bundles_from_processing
 from sentry.lang.javascript.utils import JAVASCRIPT_PLATFORMS
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import FrameOrder, Symbolicator
@@ -264,10 +263,6 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     if not _handle_response_status(data, response):
         return data
-
-    used_artifact_bundles = response.get("used_artifact_bundles", [])
-    if used_artifact_bundles:
-        maybe_renew_artifact_bundles_from_processing(symbolicator.project.id, used_artifact_bundles)
 
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -971,7 +971,10 @@ register(
 )
 
 
-# Refresh Bundle Indexes reported as used by symbolicator
+# Gated the processing-side artifact bundle renewal, which was removed because
+# symbolicator stopped reporting used bundles in getsentry/symbolicator#1397.
+# Nothing reads this option now.
+# TODO(INFRENG-460): unregister once the sentry-options-automator entries are gone.
 register(
     "symbolicator.sourcemaps-bundle-index-refresh-sample-rate",
     default=0.0,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -971,10 +971,7 @@ register(
 )
 
 
-# Gated the processing-side artifact bundle renewal, which was removed because
-# symbolicator stopped reporting used bundles in getsentry/symbolicator#1397.
-# Nothing reads this option now.
-# TODO(INFRENG-460): unregister once the sentry-options-automator entries are gone.
+# TODO(INFRENG-460): unregister once the sentry-options-automator entries are gone
 register(
     "symbolicator.sourcemaps-bundle-index-refresh-sample-rate",
     default=0.0,


### PR DESCRIPTION
The processing-side artifact bundle renewal path has been unreachable [since March 2024](https://github.com/getsentry/symbolicator/pull/1397). That PR deleted the only place that inserted into the used_artifact_bundles set, so we can delete the renewal path.

(I had originally planned to add expiries to these keys in https://github.com/getsentry/sentry/pull/122680, but realized after some investigation that this is a dead code path) 

The chain _was_: 
1. symbolicator reports which bundles it used
2. Sentry writes those ids into the Redis set `artifact_bundles_in_use`
3. a task every minute drains the set and pushes each bundle's `date_added` forward so the cleanup job does not delete a bundle a customer still needs

With the PR getting shipped in 2024, step 1 stopped happening.

Evidence, because don't take my word for it:
- Context: the drain is itself a measurement of set size. It pops in batches of 50 and breaks as soon as a batch comes back short, so the number of `spop` calls in one run is a direct read of how full the set was when the run started, aka one call means under 50 members, or no key at all.
- With that in mind, check out [this metric](https://app.datadoghq.com/metric/explorer?fromUser=false&graph_layout=stacked&session_id=d8235364-7146-44fb-8f01-15ad5654bfe0&start=1772224109921&end=1787858909921&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMyxdoD6qqIEcAAUUBCCgiGmOlhkAJTxIDwAulQxuvquoFAYCBh+GvjaAMZKyCDqCLolllQiGOrKGXEGIC3KGniqyEbhGgB0JTiqqhgiUEMYaGgawH0QGn7yeNryOFrIAoIYTggUWiLVWH5GMJIiyHgaFAtL2jhocMhjGgg6FMOj41DIGuvyHjJNIgIz-KRaPweMaEFQQdRaTJ1EBvLBPGQgeTTRDvZRQHAwPwlZwaCAlNpoURwPxyRSdR7QClUvz0JjKET2MZoZL8RbyTAnWnlECUkRKVI8Pgo-niADCUmEMBQIicaB4QA) -> what you'll see is ~1 call/min for the last 3 months. meaning the set has been ~empty that entire time.

Notes:
- Renewals are still happening, never fear. `_maybe_renew_and_return_bundles` renews inline from the lookup endpoint symbolicator calls while resolving files. [That runs at about 12,000 to 15,000 a day in us](https://app.datadoghq.com/metric/explorer?fromUser=true&graph_layout=stacked&session_id=d8235364-7146-44fb-8f01-15ad5654bfe0&start=1779910398646&end=1787859198646&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMy0zqxkQHgBdKl9dfVdQKAwEDAB9DXxtAGMlZBB1BF1kyyoRDHUfM21-AxAwmnSNPFVkLREsrAA6DG0JQQxkhDiAIzwRKDQ4OKMRODAMNCawHWHR8bgoYHrGkbgYSRFkPA0eFo045PwGgAoASibtHDQ0PHkT6tUKAAIADgA2ABYABm+zwJCICMGnkUi0cQ8qhiyjUmh0elyIA0ciGMhA8kmiAQaRAUBwMEOzg0EGSZTQomGckUykS5KgZIpcXoTGUInsULQgX4EBBmCwcSpOPJYwBPD4SPk5IQAGEpMIYCgRE40DwgA)

There are going to be some followups in separate PRs:
1. `symbolicator.sourcemaps-bundle-index-refresh-sample-rate` stays registered here with a TODO to remove it. Can't unregister while options automator is still setting it, so we'll remove it from options automator first.
2. Symbolicator still declares `used_artifact_bundles` in its response interface and carries it through `lookup.rs` with nothing writing to it. We'll want to clean that up.

Refs INFRENG-460