### PR TITLE
ref(admin): Point the platform migration action at its own endpoint

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -1624,6 +1624,80 @@ describe('Customer Details', () => {
     });
   });
 
+  describe('billing platform migration', () => {
+    const migrationOrg = OrganizationFixture();
+    const mockBillingAdminUser = UserFixture({
+      permissions: new Set(['billing.admin']),
+    });
+
+    async function openMigrationAction(name: string) {
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${migrationOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: migrationOrg,
+      });
+
+      await screen.findByRole('heading', {name: 'Customers'});
+
+      await userEvent.click(
+        screen.getAllByRole('button', {
+          name: 'Customers Actions',
+        })[0]!
+      );
+
+      await userEvent.click(screen.getByText(name));
+
+      renderGlobalModal();
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+    }
+
+    it('migrates an org to the billing platform', async () => {
+      ConfigStore.set('user', mockBillingAdminUser);
+      setUpMocks(migrationOrg, {hasMigratedToBillingPlatform: false});
+
+      const migrateMock = MockApiClient.addMockResponse({
+        url: `/_admin/customers/${migrationOrg.slug}/billing-platform-migration/`,
+        method: 'POST',
+      });
+
+      await openMigrationAction('[Do Not Use] Migrate to Billing Platform');
+
+      await waitFor(() => {
+        expect(migrateMock).toHaveBeenCalledWith(
+          `/_admin/customers/${migrationOrg.slug}/billing-platform-migration/`,
+          expect.objectContaining({
+            method: 'POST',
+            data: {migrated: true},
+          })
+        );
+      });
+    });
+
+    it('unmigrates an org from the billing platform', async () => {
+      ConfigStore.set('user', mockBillingAdminUser);
+      setUpMocks(migrationOrg, {hasMigratedToBillingPlatform: true});
+
+      const unmigrateMock = MockApiClient.addMockResponse({
+        url: `/_admin/customers/${migrationOrg.slug}/billing-platform-migration/`,
+        method: 'POST',
+      });
+
+      await openMigrationAction('[Do Not Use] Unmigrate from Billing Platform');
+
+      await waitFor(() => {
+        expect(unmigrateMock).toHaveBeenCalledWith(
+          `/_admin/customers/${migrationOrg.slug}/billing-platform-migration/`,
+          expect.objectContaining({
+            method: 'POST',
+            data: {migrated: false},
+          })
+        );
+      });
+    });
+  });
+
   describe('close account', () => {
     it('closes an account', async () => {
       setUpMocks(organization);

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -191,6 +191,28 @@ export function CustomerDetails() {
     refetchBillingConfig();
   };
 
+  const onToggleBillingPlatformMigrationMutation = useMutation({
+    mutationFn: (params: Record<string, any>) =>
+      fetchMutation({
+        url: `/_admin/customers/${orgId}/billing-platform-migration/`,
+        method: 'POST',
+        data: params,
+      }),
+    onMutate: () => addLoadingMessage('Saving changes\u2026'),
+    onSuccess: (_data, variables) => {
+      addSuccessMessage(
+        variables.migrated
+          ? 'Marked this org as migrated to the billing platform.'
+          : 'Marked this org as not migrated to the billing platform.'
+      );
+      reloadData();
+    },
+    onError: (error: RequestError) => {
+      const detail = error.responseJSON?.detail;
+      addErrorMessage(typeof detail === 'string' ? detail : DEFAULT_ERROR_MESSAGE);
+    },
+  });
+
   if (isPendingSubscription || isPendingOrganization || isPendingBillingConfig) {
     return <LoadingIndicator />;
   }
@@ -460,15 +482,15 @@ export function CustomerDetails() {
           {
             key: 'toggleBillingPlatformMigration',
             name: subscription.hasMigratedToBillingPlatform
-              ? '[Do Not Use] Unmigrate to Billing Platform'
+              ? '[Do Not Use] Unmigrate from Billing Platform'
               : '[Do Not Use] Migrate to Billing Platform',
             help: subscription.hasMigratedToBillingPlatform
               ? 'Mark this org as not migrated to the billing platform.'
               : 'Mark this org as migrated to the billing platform.',
             onAction: params =>
-              onUpdateMutation.mutate({
+              onToggleBillingPlatformMigrationMutation.mutate({
                 ...params,
-                migratedToBillingPlatform: !subscription.hasMigratedToBillingPlatform,
+                migrated: !subscription.hasMigratedToBillingPlatform,
               }),
             ...actionRequiresBillingAdmin,
           },


### PR DESCRIPTION
## Context

The _admin migration action sends `migratedToBillingPlatform` to `PUT /customers/{org}/`.
That route dual writes, and the flag has no platform side to write to. getsentry now gives
the flag its own endpoint.

## Change

The action now sends `migrated` to `POST /_admin/customers/{orgId}/billing-platform-migration/`.
That endpoint returns no body, so the action refetches the customer instead of caching the
response. The unmigrate label now reads "Unmigrate **from** Billing Platform".

## Outcome

The action calls one endpoint that does one thing. Two new tests check the request body in
both directions. **Merge this second.** The sequence is getsentry/getsentry#21686 to add the
endpoint, then this PR and a pin bump, then getsentry/getsentry#21690 to remove the old path.
