### PR TITLE
ref(crons): Sample rate limited processing errors instead of dropping them

### DIFF
--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -180,20 +180,27 @@ def get_errors_for_projects(projects: list[Project]) -> list[CheckinProcessingEr
     return _get_for_entities([build_project_identifier(project.id) for project in projects])
 
 
-# Dropped by a guard before any work is done, at a volume that makes storing each one cost more
-# than it is worth. Only `MAX_ERRORS_PER_SET` are retained anyway.
-THROTTLED_ERROR_TYPES = frozenset(
-    {
-        ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED,
-        ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED,
-    }
-)
+# Fraction of each error type to store. These are dropped by a guard before any work is done and
+# arrive far faster than they are worth storing, and only `MAX_ERRORS_PER_SET` are retained anyway,
+# so a sample carries the same signal. Kill-switched organizations are abusive, nothing is kept.
+THROTTLED_SAMPLE_RATES = {
+    ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED: 0.01,
+    ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED: 0.0,
+}
+
+
+def _store_sample_rate(error: ProcessingErrorsException) -> float:
+    """
+    Anything bundled with a type we always store is always stored.
+    """
+    return max(
+        THROTTLED_SAMPLE_RATES.get(process_error["type"], 1.0)
+        for process_error in error.processing_errors
+    )
 
 
 def handle_processing_errors(item: CheckinItem, error: ProcessingErrorsException):
-    if all(
-        process_error["type"] in THROTTLED_ERROR_TYPES for process_error in error.processing_errors
-    ):
+    if random.random() >= _store_sample_rate(error):
         metrics.incr(
             "monitors.checkin.handle_processing_error",
             tags={"source": "consumer", "stored": "false"},

--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -180,9 +180,8 @@ def get_errors_for_projects(projects: list[Project]) -> list[CheckinProcessingEr
     return _get_for_entities([build_project_identifier(project.id) for project in projects])
 
 
-# Fraction of each error type to store. These are dropped by a guard before any work is done and
-# arrive far faster than they are worth storing, and only `MAX_ERRORS_PER_SET` are retained anyway,
-# so a sample carries the same signal. Kill-switched organizations are abusive, nothing is kept.
+# Fraction of each error type to store. Only `MAX_ERRORS_PER_SET` are retained, so a sample
+# carries the same signal as the full stream at a fraction of the cost.
 THROTTLED_SAMPLE_RATES = {
     ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED: 0.01,
     ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED: 0.0,
@@ -198,14 +197,13 @@ def _store_sample_rate(error: ProcessingErrorsException) -> float:
             THROTTLED_SAMPLE_RATES.get(process_error["type"], 1.0)
             for process_error in error.processing_errors
         ),
-        # Nothing to store. Not reachable from the consumer, which always raises with at least
-        # one error, but `max()` has no answer for an empty sequence.
         default=0.0,
     )
 
 
 def handle_processing_errors(item: CheckinItem, error: ProcessingErrorsException):
-    if random.random() >= _store_sample_rate(error):
+    sample_rate = _store_sample_rate(error)
+    if not sample_rate or random.random() >= sample_rate:
         metrics.incr(
             "monitors.checkin.handle_processing_error",
             tags={"source": "consumer", "stored": "false"},

--- a/src/sentry/monitors/processing_errors/manager.py
+++ b/src/sentry/monitors/processing_errors/manager.py
@@ -194,8 +194,13 @@ def _store_sample_rate(error: ProcessingErrorsException) -> float:
     Anything bundled with a type we always store is always stored.
     """
     return max(
-        THROTTLED_SAMPLE_RATES.get(process_error["type"], 1.0)
-        for process_error in error.processing_errors
+        (
+            THROTTLED_SAMPLE_RATES.get(process_error["type"], 1.0)
+            for process_error in error.processing_errors
+        ),
+        # Nothing to store. Not reachable from the consumer, which always raises with at least
+        # one error, but `max()` has no answer for an empty sequence.
+        default=0.0,
     )
 
 

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -260,21 +260,13 @@ class HandleProcessingErrorsTest(TestCase):
             ),
         )
 
-    def test_throttled_types_are_not_stored(self) -> None:
+    def test_killswitched_errors_are_never_stored(self) -> None:
         monitor = self.create_monitor()
-        item = build_checkin_item(
-            message_overrides={"project_id": self.project.id},
-            payload_overrides={"monitor_slug": monitor.slug},
-        )
-
         handle_processing_errors(
-            item,
-            ProcessingErrorsException(
-                [{"type": ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED}], monitor=monitor
+            build_checkin_item(
+                message_overrides={"project_id": self.project.id},
+                payload_overrides={"monitor_slug": monitor.slug},
             ),
-        )
-        handle_processing_errors(
-            item,
             ProcessingErrorsException(
                 [{"type": ProcessingErrorType.ORGANIZATION_KILLSWITCH_ENABLED}], monitor=monitor
             ),
@@ -282,7 +274,38 @@ class HandleProcessingErrorsTest(TestCase):
 
         assert get_errors_for_monitor(monitor) == []
 
-    def test_throttled_type_alongside_a_real_error_is_stored(self) -> None:
+    @mock.patch("sentry.monitors.processing_errors.manager.random.random", return_value=0.5)
+    def test_rate_limited_errors_are_sampled_out(self, mock_random) -> None:
+        monitor = self.create_monitor()
+        handle_processing_errors(
+            build_checkin_item(
+                message_overrides={"project_id": self.project.id},
+                payload_overrides={"monitor_slug": monitor.slug},
+            ),
+            ProcessingErrorsException(
+                [{"type": ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED}], monitor=monitor
+            ),
+        )
+
+        assert get_errors_for_monitor(monitor) == []
+
+    @mock.patch("sentry.monitors.processing_errors.manager.random.random", return_value=0.0)
+    def test_rate_limited_errors_are_sampled_in(self, mock_random) -> None:
+        monitor = self.create_monitor()
+        handle_processing_errors(
+            build_checkin_item(
+                message_overrides={"project_id": self.project.id},
+                payload_overrides={"monitor_slug": monitor.slug},
+            ),
+            ProcessingErrorsException(
+                [{"type": ProcessingErrorType.MONITOR_ENVIRONMENT_RATELIMITED}], monitor=monitor
+            ),
+        )
+
+        assert len(get_errors_for_monitor(monitor)) == 1
+
+    @mock.patch("sentry.monitors.processing_errors.manager.random.random", return_value=0.5)
+    def test_throttled_type_alongside_a_real_error_is_stored(self, mock_random) -> None:
         monitor = self.create_monitor()
         handle_processing_errors(
             build_checkin_item(

--- a/tests/sentry/monitors/processing_errors/test_manager.py
+++ b/tests/sentry/monitors/processing_errors/test_manager.py
@@ -322,3 +322,15 @@ class HandleProcessingErrorsTest(TestCase):
         )
 
         assert len(get_errors_for_monitor(monitor)) == 1
+
+    def test_no_errors_is_not_stored(self) -> None:
+        monitor = self.create_monitor()
+        handle_processing_errors(
+            build_checkin_item(
+                message_overrides={"project_id": self.project.id},
+                payload_overrides={"monitor_slug": monitor.slug},
+            ),
+            ProcessingErrorsException([], monitor=monitor),
+        )
+
+        assert get_errors_for_monitor(monitor) == []


### PR DESCRIPTION
We suspect that handling processing errors is slowing down rate limits enough to backlog consumer. Testing this theory out and just keeping 1% of rate limited processing errors