### PR TITLE
feat(seer): Add release card embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -256,6 +256,36 @@
     ]
   },
   {
+    "name": "release",
+    "description": "The ONLY way to reference a Sentry release. Use `version` exactly as the releases API returns it. Provide `projectId` when the release belongs to a specific project. Inline: renders a compact link. Block: renders release metadata, new issues, commit authors, the last commit, and recent deploys. Do not duplicate that data as text. Never use a markdown link for release references.",
+    "level": ["inline", "block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "projectId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["version"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Release",
+        "data": {
+          "version": "example-app@1.2.3",
+          "projectId": "1"
+        }
+      }
+    ]
+  },
+  {
     "name": "chart",
     "description": "Display numeric data as a compact Sentry-style chart. For line, area, and bar charts, prefer at least three points. Use x_axis \"time\" only with offset-bearing ISO 8601 timestamps. Category axes are supported for bar charts only. Duration values are milliseconds, percentage values are 0-100, and byte values are raw bytes.",
     "level": ["block"],

--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -268,8 +268,14 @@
           "minLength": 1
         },
         "projectId": {
-          "type": "string",
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
         }
       },
       "required": ["version"],

--- a/static/app/components/seer/markdown/__stories__/releaseEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/releaseEmbedStory.tsx
@@ -1,0 +1,44 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import type {Release} from 'sentry/types/release';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {EmbedStory, EmbedVariant} from './embedStory';
+
+export function ReleaseEmbedStory() {
+  const organization = useOrganization();
+  const {data, isError, isPending} = useQuery(
+    apiOptions.as<Release[]>()('/organizations/$organizationIdOrSlug/releases/', {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {per_page: 1},
+      staleTime: 30_000,
+    })
+  );
+  const release = data?.[0];
+
+  return (
+    <EmbedStory name="release">
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <Text variant="muted">Unable to load a release example.</Text>
+      ) : release ? (
+        <EmbedVariant
+          name="release"
+          label="Release"
+          data={{
+            version: release.version,
+            projectId:
+              release.projects.length === 1 ? String(release.projects[0]!.id) : undefined,
+          }}
+        />
+      ) : (
+        <Text variant="muted">No release is available for this organization.</Text>
+      )}
+    </EmbedStory>
+  );
+}

--- a/static/app/components/seer/markdown/__stories__/releaseEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/releaseEmbedStory.tsx
@@ -33,7 +33,7 @@ export function ReleaseEmbedStory() {
           data={{
             version: release.version,
             projectId:
-              release.projects.length === 1 ? String(release.projects[0]!.id) : undefined,
+              release.projects.length === 1 ? release.projects.at(0)?.id : undefined,
           }}
         />
       ) : (

--- a/static/app/components/seer/markdown/embeds/components/release.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/release.spec.tsx
@@ -1,0 +1,98 @@
+import {CommitFixture} from 'sentry-fixture/commit';
+import {CommitAuthorFixture} from 'sentry-fixture/commitAuthor';
+import {DeployFixture} from 'sentry-fixture/deploy';
+import {ReleaseFixture} from 'sentry-fixture/release';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+
+const version = 'frontend@65318d61d370';
+const projectId = '4383603';
+
+function renderReleaseEmbed(level: 'block' | 'inline' = 'block') {
+  const tag = `{% release %}${JSON.stringify({version, projectId})}{% /release %}`;
+  return render(<SeerMarkdown raw={level === 'inline' ? `See ${tag}` : tag} />);
+}
+
+describe('release embed', () => {
+  it('renders a horizontal release summary', async () => {
+    const author = CommitAuthorFixture({name: 'Example Author'});
+    const commit = CommitFixture({
+      author,
+      dateCreated: '2020-04-08T12:00:00Z',
+      message: 'feat(metrics): Add formula support',
+    });
+    const defaultRelease = ReleaseFixture();
+    const release = ReleaseFixture({
+      authors: [author],
+      commitCount: 1,
+      dateCreated: '2020-04-08T12:18:00Z',
+      lastCommit: commit,
+      newGroups: 2,
+      shortVersion: version,
+      version,
+      versionInfo: {...defaultRelease.versionInfo!, package: 'frontend'},
+    });
+    const releaseRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent(version)}/`,
+      body: release,
+    });
+    const deployRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent(version)}/deploys/`,
+      body: [
+        DeployFixture({id: '1', environment: 'production', dateFinished: '2020-04-08'}),
+        DeployFixture({id: '2', environment: 'staging', dateFinished: '2020-04-07'}),
+        DeployFixture({id: '3', environment: 'development', dateFinished: '2020-04-06'}),
+        DeployFixture({id: '4', environment: 'old', dateFinished: '2020-04-05'}),
+      ],
+    });
+
+    renderReleaseEmbed();
+
+    expect(await screen.findByText('New Issues')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Date Created')).toBeInTheDocument();
+    expect(screen.getByText(/Apr 8, 2020/)).toBeInTheDocument();
+    expect(screen.getByText('frontend')).toBeInTheDocument();
+    expect(screen.getByText('1 commit by 1 author')).toBeInTheDocument();
+    expect(screen.getByText('feat(metrics): Add formula support')).toBeInTheDocument();
+    expect(screen.getByText('Example Author')).toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+    expect(screen.getByText('staging')).toBeInTheDocument();
+    expect(screen.getByText('development')).toBeInTheDocument();
+    expect(screen.queryByText('old')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: /Release:/})).toHaveAttribute(
+      'href',
+      `/organizations/org-slug/explore/releases/${encodeURIComponent(version)}/?project=${projectId}`
+    );
+    expect(
+      screen.getByRole('button', {name: 'Copy release version to clipboard'})
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(releaseRequest).toHaveBeenCalled();
+      expect(deployRequest).toHaveBeenCalledWith(
+        `/organizations/org-slug/releases/${encodeURIComponent(version)}/deploys/`,
+        expect.objectContaining({query: {project: projectId}})
+      );
+    });
+  });
+
+  it('renders an inline link without fetching release data', () => {
+    const releaseRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent(version)}/`,
+      body: ReleaseFixture({version}),
+    });
+    const deployRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent(version)}/deploys/`,
+      body: [],
+    });
+
+    renderReleaseEmbed('inline');
+
+    expect(screen.getByRole('link', {name: /Release:/})).toBeInTheDocument();
+    expect(releaseRequest).not.toHaveBeenCalled();
+    expect(deployRequest).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/seer/markdown/embeds/components/release.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/release.spec.tsx
@@ -8,7 +8,7 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 
 const version = 'frontend@65318d61d370';
-const projectId = '4383603';
+const projectId = 4383603;
 
 function renderReleaseEmbed(level: 'block' | 'inline' = 'block') {
   const tag = `{% release %}${JSON.stringify({version, projectId})}{% /release %}`;
@@ -29,7 +29,7 @@ describe('release embed', () => {
       commitCount: 1,
       dateCreated: '2020-04-08T12:18:00Z',
       lastCommit: commit,
-      newGroups: 2,
+      newGroups: 9,
       shortVersion: version,
       version,
       versionInfo: {...defaultRelease.versionInfo!, package: 'frontend'},
@@ -51,7 +51,7 @@ describe('release embed', () => {
     renderReleaseEmbed();
 
     expect(await screen.findByText('New Issues')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getByText('Date Created')).toBeInTheDocument();
     expect(screen.getByText(/Apr 8, 2020/)).toBeInTheDocument();
     expect(screen.getByText('frontend')).toBeInTheDocument();
@@ -77,6 +77,28 @@ describe('release embed', () => {
         expect.objectContaining({query: {project: projectId}})
       );
     });
+  });
+
+  it('renders a commit count when no commit authors are available', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent(version)}/`,
+      body: ReleaseFixture({
+        authors: [],
+        commitCount: 2,
+        lastCommit: undefined,
+        shortVersion: version,
+        version,
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/releases/${encodeURIComponent(version)}/deploys/`,
+      body: [],
+    });
+
+    renderReleaseEmbed();
+
+    expect(await screen.findByText('2 commits')).toBeInTheDocument();
+    expect(screen.queryByText('2 commits by 0 authors')).not.toBeInTheDocument();
   });
 
   it('renders an inline link without fetching release data', () => {

--- a/static/app/components/seer/markdown/embeds/components/release.tsx
+++ b/static/app/components/seer/markdown/embeds/components/release.tsx
@@ -1,0 +1,11 @@
+import {ReleaseBlock} from 'sentry/components/seer/markdown/embeds/components/releaseBlock';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
+
+import {ReleaseLink} from './releaseLink';
+
+export const Release = defineSeerEmbed({
+  name: 'release',
+  render(props, level) {
+    return level === 'block' ? <ReleaseBlock {...props} /> : <ReleaseLink {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
@@ -42,6 +42,12 @@ function releaseEmbedApiOptions({
 }
 
 function getCommitSummary(commitCount: number, authorCount: number) {
+  if (authorCount === 0) {
+    return commitCount === 1
+      ? t('1 commit')
+      : tct('[commitCount] commits', {commitCount});
+  }
+
   if (commitCount === 1) {
     return authorCount === 1
       ? t('1 commit by 1 author')
@@ -65,7 +71,7 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
     deploysApiOptions({
       orgSlug: organization.slug,
       releaseVersion: version,
-      query: projectId ? {project: projectId} : undefined,
+      query: projectId === undefined ? undefined : {project: projectId},
     })
   );
   const release = releaseQuery.data;
@@ -90,6 +96,11 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
   );
   const packageName =
     release?.versionInfo?.package ?? parseVersion(release?.version ?? version)?.package;
+  const newGroups =
+    release && projectId !== undefined
+      ? (release.projects.find(project => String(project.id) === String(projectId))
+          ?.newGroups ?? 0)
+      : (release?.newGroups ?? 0);
   const lastCommitTitle = release?.lastCommit?.message?.split(/\r?\n/, 1)[0];
   const sectionCount =
     4 + Number((release?.commitCount ?? 0) > 0) + Number(Boolean(release?.lastCommit));
@@ -135,7 +146,7 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
                 {t('New Issues')}
               </Text>
               <Text size="xl" tabular>
-                {release.newGroups}
+                {newGroups}
               </Text>
             </Stack>
 

--- a/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
@@ -1,0 +1,234 @@
+import {useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import {AvatarList, UserAvatar} from '@sentry/scraps/avatar';
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {CommitLink} from 'sentry/components/commitLink';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {DateTime} from 'sentry/components/dateTime';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {TimeSince} from 'sentry/components/timeSince';
+import {t, tct} from 'sentry/locale';
+import type {Actor} from 'sentry/types/core';
+import type {ReleaseWithHealth} from 'sentry/types/release';
+import type {User} from 'sentry/types/user';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {deploysApiOptions} from 'sentry/utils/deploysApiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {parseVersion} from 'sentry/utils/versions/parseVersion';
+
+import {ReleaseLink} from './releaseLink';
+
+type ReleaseData = EmbedOutput<'release'>;
+
+function releaseEmbedApiOptions({
+  organizationSlug,
+  version,
+}: {
+  organizationSlug: string;
+  version: string;
+}) {
+  return apiOptions.as<ReleaseWithHealth>()(
+    '/organizations/$organizationIdOrSlug/releases/$version/',
+    {
+      path: {organizationIdOrSlug: organizationSlug, version},
+      staleTime: 30_000,
+    }
+  );
+}
+
+function getCommitSummary(commitCount: number, authorCount: number) {
+  if (commitCount === 1) {
+    return authorCount === 1
+      ? t('1 commit by 1 author')
+      : tct('1 commit by [authorCount] authors', {authorCount});
+  }
+
+  return authorCount === 1
+    ? tct('[commitCount] commits by 1 author', {commitCount})
+    : tct('[commitCount] commits by [authorCount] authors', {
+        authorCount,
+        commitCount,
+      });
+}
+
+export function ReleaseBlock({version, projectId}: ReleaseData) {
+  const organization = useOrganization();
+  const releaseQuery = useQuery(
+    releaseEmbedApiOptions({organizationSlug: organization.slug, version})
+  );
+  const deploysQuery = useQuery(
+    deploysApiOptions({
+      orgSlug: organization.slug,
+      releaseVersion: version,
+      query: projectId ? {project: projectId} : undefined,
+    })
+  );
+  const release = releaseQuery.data;
+  const authors = useMemo(
+    () =>
+      release?.authors.map<Actor | User>((author, index) => ({
+        ...author,
+        type: 'user',
+        id: 'id' in author ? author.id : `${author.email}-${index}`,
+      })) ?? [],
+    [release?.authors]
+  );
+  const recentDeploys = useMemo(
+    () =>
+      deploysQuery.data
+        ?.toSorted(
+          (a, b) =>
+            new Date(b.dateFinished).getTime() - new Date(a.dateFinished).getTime()
+        )
+        .slice(0, 3) ?? [],
+    [deploysQuery.data]
+  );
+  const packageName =
+    release?.versionInfo?.package ?? parseVersion(release?.version ?? version)?.package;
+  const lastCommitTitle = release?.lastCommit?.message?.split(/\r?\n/, 1)[0];
+
+  return (
+    <Container
+      background="primary"
+      border="primary"
+      containerType="inline-size"
+      data-test-id="seer-release-embed"
+      padding="lg"
+      radius="md"
+      width="100%"
+    >
+      <Stack gap="lg">
+        <Flex align="center" gap="sm" justify="between">
+          <ReleaseLink version={version} projectId={projectId} />
+          <CopyToClipboardButton
+            aria-label={t('Copy release version to clipboard')}
+            size="zero"
+            text={version}
+            variant="transparent"
+          />
+        </Flex>
+
+        {releaseQuery.isPending ? (
+          <Flex justify="center" padding="md">
+            <LoadingIndicator mini />
+          </Flex>
+        ) : releaseQuery.isError || !release ? (
+          <Text variant="muted">{t('Unable to load release details')}</Text>
+        ) : (
+          <Grid
+            columns={{
+              zero: 'minmax(0, 1fr)',
+              sm: 'repeat(2, minmax(0, 1fr))',
+              xl: 'repeat(4, minmax(0, 1fr))',
+            }}
+            gap="xl"
+          >
+            <Stack gap="xs">
+              <Text bold size="xs" uppercase variant="muted">
+                {t('New Issues')}
+              </Text>
+              <Text size="xl" tabular>
+                {release.newGroups}
+              </Text>
+            </Stack>
+
+            <Stack gap="xs">
+              <Text bold size="xs" uppercase variant="muted">
+                {t('Date Created')}
+              </Text>
+              <Text>
+                <DateTime date={release.dateCreated} seconds={false} />
+              </Text>
+            </Stack>
+
+            <Stack gap="xs">
+              <Text bold size="xs" uppercase variant="muted">
+                {t('Package')}
+              </Text>
+              <Text ellipsis>{packageName ?? '—'}</Text>
+            </Stack>
+
+            {release.commitCount > 0 ? (
+              <Stack gap="sm">
+                <Text bold size="xs" uppercase variant="muted">
+                  {getCommitSummary(release.commitCount, release.authors.length)}
+                </Text>
+                <Flex>
+                  <AvatarList
+                    avatarSize={24}
+                    maxVisibleAvatars={5}
+                    typeAvatars="authors"
+                    users={authors}
+                  />
+                </Flex>
+              </Stack>
+            ) : null}
+
+            {release.lastCommit ? (
+              <Stack column={{zero: 'auto', sm: 'span 2'}} gap="xs" minWidth="0">
+                <Text bold size="xs" uppercase variant="muted">
+                  {t('Last Commit')}
+                </Text>
+                <Text ellipsis>
+                  <CommitLink
+                    commitId={release.lastCommit.id}
+                    commitTitle={lastCommitTitle}
+                    inline
+                    repository={release.lastCommit.repository}
+                    showIcon={false}
+                  />
+                </Text>
+                <Flex align="center" gap="xs" minWidth="0">
+                  {release.lastCommit.author ? (
+                    <UserAvatar size={16} user={release.lastCommit.author} />
+                  ) : null}
+                  <Text bold ellipsis size="sm">
+                    {release.lastCommit.author?.name ?? t('Unknown author')}
+                  </Text>
+                  <Text size="sm" variant="muted">
+                    <TimeSince date={release.lastCommit.dateCreated} />
+                  </Text>
+                </Flex>
+              </Stack>
+            ) : null}
+
+            <Stack column={{zero: 'auto', sm: 'span 2'}} gap="xs" minWidth="0">
+              <Text bold size="xs" uppercase variant="muted">
+                {t('Deploys')}
+              </Text>
+              {deploysQuery.isPending ? (
+                <Flex justify="start">
+                  <LoadingIndicator mini />
+                </Flex>
+              ) : deploysQuery.isError ? (
+                <Text size="sm" variant="muted">
+                  {t('Unable to load deploys')}
+                </Text>
+              ) : recentDeploys.length > 0 ? (
+                <Flex align="center" gap="md" wrap="wrap">
+                  {recentDeploys.map(deploy => (
+                    <Flex key={deploy.id} align="center" gap="xs">
+                      <Tag variant="info">{deploy.environment}</Tag>
+                      <Text size="sm" variant="muted">
+                        <TimeSince date={deploy.dateFinished} />
+                      </Text>
+                    </Flex>
+                  ))}
+                </Flex>
+              ) : (
+                <Text size="sm" variant="muted">
+                  {t('No deploys')}
+                </Text>
+              )}
+            </Stack>
+          </Grid>
+        )}
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
@@ -91,6 +91,8 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
   const packageName =
     release?.versionInfo?.package ?? parseVersion(release?.version ?? version)?.package;
   const lastCommitTitle = release?.lastCommit?.message?.split(/\r?\n/, 1)[0];
+  const sectionCount =
+    4 + Number((release?.commitCount ?? 0) > 0) + Number(Boolean(release?.lastCommit));
 
   return (
     <Container
@@ -124,7 +126,7 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
             columns={{
               zero: 'minmax(0, 1fr)',
               sm: 'repeat(2, minmax(0, 1fr))',
-              xl: 'repeat(4, minmax(0, 1fr))',
+              lg: `repeat(${sectionCount}, minmax(0, 1fr))`,
             }}
             gap="xl"
           >
@@ -165,7 +167,11 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
             ) : null}
 
             {release.lastCommit ? (
-              <Stack column={{zero: 'auto', sm: 'span 2'}} gap="xs" minWidth="0">
+              <Stack
+                column={{zero: 'auto', sm: 'span 2', lg: 'auto'}}
+                gap="xs"
+                minWidth="0"
+              >
                 <Text bold size="xs" uppercase variant="muted">
                   {t('Last Commit')}
                 </Text>
@@ -192,7 +198,11 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
               </Stack>
             ) : null}
 
-            <Stack column={{zero: 'auto', sm: 'span 2'}} gap="xs" minWidth="0">
+            <Stack
+              column={{zero: 'auto', sm: 'span 2', lg: 'auto'}}
+              gap="xs"
+              minWidth="0"
+            >
               <Text bold size="xs" uppercase variant="muted">
                 {t('Deploys')}
               </Text>

--- a/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/releaseBlock.tsx
@@ -142,7 +142,7 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
                 {t('Date Created')}
               </Text>
               <Text>
-                <DateTime date={release.dateCreated} seconds={false} />
+                <DateTime date={release.dateCreated} />
               </Text>
             </Stack>
 
@@ -159,12 +159,7 @@ export function ReleaseBlock({version, projectId}: ReleaseData) {
                   {getCommitSummary(release.commitCount, release.authors.length)}
                 </Text>
                 <Flex>
-                  <AvatarList
-                    avatarSize={24}
-                    maxVisibleAvatars={5}
-                    typeAvatars="authors"
-                    users={authors}
-                  />
+                  <AvatarList avatarSize={24} typeAvatars="authors" users={authors} />
                 </Flex>
               </Stack>
             ) : null}

--- a/static/app/components/seer/markdown/embeds/components/releaseLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/releaseLink.tsx
@@ -1,0 +1,31 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconReleases} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
+import {makeReleasesPathname} from 'sentry/views/explore/releases/utils/pathnames';
+
+export function ReleaseLink({version, projectId}: EmbedOutput<'release'>) {
+  const organization = useOrganization();
+  const href = queryString.stringifyUrl(
+    {
+      url: makeReleasesPathname({
+        organization,
+        path: `/${encodeURIComponent(version)}/`,
+      }),
+      query: {project: projectId},
+    },
+    {skipNull: true}
+  );
+
+  return (
+    <ResourceLink
+      icon={IconReleases}
+      href={href}
+      title={t('Release: %s', formatVersion(version))}
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -12,6 +12,7 @@ import {LogsQuery} from './components/logsQuery';
 import {MetricsQuery} from './components/metricsQuery';
 import {Monitor} from './components/monitor';
 import {Profile} from './components/profile';
+import {Release} from './components/release';
 import {Replay} from './components/replay';
 import {ReplaysQuery} from './components/replaysQuery';
 import {SavedIssueView} from './components/savedIssueView';
@@ -39,6 +40,7 @@ const embeds = [
   MetricsQuery,
   Monitor,
   Profile,
+  Release,
   Replay,
   ReplaysQuery,
   SavedIssueView,

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -234,6 +234,27 @@ export const SEER_EMBED_SCHEMAS = {
       },
     ],
   },
+  release: {
+    description:
+      'The ONLY way to reference a Sentry release. ' +
+      'Use `version` exactly as the releases API returns it. ' +
+      'Provide `projectId` when the release belongs to a specific project. ' +
+      'Inline: renders a compact link. ' +
+      'Block: renders release metadata, new issues, commit authors, the last commit, ' +
+      'and recent deploys. Do not duplicate that data as text. ' +
+      'Never use a markdown link for release references.',
+    level: ['inline', 'block'],
+    schema: z.object({
+      version: z.string().min(1),
+      projectId: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Release',
+        data: {version: 'example-app@1.2.3', projectId: '1'},
+      },
+    ],
+  },
   chart: {
     description:
       'Display numeric data as a compact Sentry-style chart. For line, area, and bar charts, ' +

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -246,7 +246,7 @@ export const SEER_EMBED_SCHEMAS = {
     level: ['inline', 'block'],
     schema: z.object({
       version: z.string().min(1),
-      projectId: z.string().min(1).optional(),
+      projectId: idString.optional(),
     }),
     examples: [
       {

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -11,6 +11,7 @@ import * as Storybook from 'sentry/stories';
 import {BasicDemo, LinkifyDemo, StreamingEmbedExamples} from './__stories__/components';
 import {DashboardEmbedStory} from './__stories__/dashboardEmbedStory';
 import {EmbedStory} from './__stories__/embedStory';
+import {ReleaseEmbedStory} from './__stories__/releaseEmbedStory';
 import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
@@ -70,6 +71,10 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 ### replay
 
 <ReplayEmbedStory />
+
+### release
+
+<ReleaseEmbedStory />
 
 ### chart
 


### PR DESCRIPTION
Adds a `release` Seer embed with a compact inline link and a responsive block card modeled on the existing release hovercard. The block surfaces new issues, creation time, package, commit authors, the last commit, and the three most recent deploys without a fixed height.

Storybook selects the organization's latest release so both levels render against live data. The optional project ID is preserved in release links and deploy lookups, and the generated widget schema teaches Seer when to use the embed.

<img width="827" height="240" alt="image" src="https://github.com/user-attachments/assets/0f89b326-0500-4f8c-acae-163146512c48" />


Refs [CW-1954](https://linear.app/getsentry/issue/CW-1954/add-release-card-embed)


