### PR TITLE
perf(seer): memoize autofix overview cards to speed up group toggles

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -299,9 +299,10 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     .map(run => run.seerRunId);
   const orderedPrRunIdsKey = orderedPrRunIds.join(',');
   const scmWindowsByRunId = useMemo(() => {
+    const ids = orderedPrRunIdsKey ? orderedPrRunIdsKey.split(',') : [];
     const windows: string[][] = [];
-    for (let start = 0; start < orderedPrRunIds.length; start += SCM_WINDOW_SIZE) {
-      windows.push(orderedPrRunIds.slice(start, start + SCM_WINDOW_SIZE));
+    for (let start = 0; start < ids.length; start += SCM_WINDOW_SIZE) {
+      windows.push(ids.slice(start, start + SCM_WINDOW_SIZE));
     }
     const map = new Map<string, string[][]>();
     windows.forEach((window, index) => {
@@ -312,7 +313,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       }
     });
     return map;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orderedPrRunIdsKey]);
 
   const toggleGroup = (groupKey: StatusGroupKey, expanded: boolean) => {

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -36,6 +36,7 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Actor} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {
@@ -102,6 +103,8 @@ const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
 ];
 
 const {'90d': _90d, ...ACTIVITY_RELATIVE_PERIODS} = DEFAULT_RELATIVE_PERIODS;
+
+const EMPTY_MEMBER_LIST: User[] = [];
 
 const activityRelativeOptions = ({
   arbitraryOptions,
@@ -294,18 +297,23 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     .flatMap(section => section.runs)
     .filter(run => run.pullRequests.length > 0)
     .map(run => run.seerRunId);
-  const scmWindows: string[][] = [];
-  for (let start = 0; start < orderedPrRunIds.length; start += SCM_WINDOW_SIZE) {
-    scmWindows.push(orderedPrRunIds.slice(start, start + SCM_WINDOW_SIZE));
-  }
-  const scmWindowsByRunId = new Map<string, string[][]>();
-  scmWindows.forEach((window, index) => {
-    const nextWindow = scmWindows[index + 1];
-    const toRequest = nextWindow ? [window, nextWindow] : [window];
-    for (const id of window) {
-      scmWindowsByRunId.set(id, toRequest);
+  const orderedPrRunIdsKey = orderedPrRunIds.join(',');
+  const scmWindowsByRunId = useMemo(() => {
+    const windows: string[][] = [];
+    for (let start = 0; start < orderedPrRunIds.length; start += SCM_WINDOW_SIZE) {
+      windows.push(orderedPrRunIds.slice(start, start + SCM_WINDOW_SIZE));
     }
-  });
+    const map = new Map<string, string[][]>();
+    windows.forEach((window, index) => {
+      const nextWindow = windows[index + 1];
+      const toRequest = nextWindow ? [window, nextWindow] : [window];
+      for (const id of window) {
+        map.set(id, toRequest);
+      }
+    });
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderedPrRunIdsKey]);
 
   const toggleGroup = (groupKey: StatusGroupKey, expanded: boolean) => {
     setCollapsedGroups(previous =>
@@ -542,7 +550,9 @@ function OverviewSectionList({
                       requestScmWindow={requestScmWindow}
                       scmWindows={scmWindowsByRunId.get(run.seerRunId)}
                       projectConfig={projectConfigById.get(run.issue.project.id)}
-                      memberList={membersByProject.get(run.issue.project.slug) ?? []}
+                      memberList={
+                        membersByProject.get(run.issue.project.slug) ?? EMPTY_MEMBER_LIST
+                      }
                       assigneeReady={assigneeReady}
                     />
                   );

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef} from 'react';
+import {Fragment, memo, useEffect, useRef} from 'react';
 import {keyframes, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -525,7 +525,7 @@ function PriorityAndAssignee({
   );
 }
 
-export function OverviewCard({
+export const OverviewCard = memo(function OverviewCardComponent({
   orgSlug,
   run,
   sectionKey,
@@ -695,7 +695,7 @@ export function OverviewCard({
       }
     />
   );
-}
+});
 
 function CardFrame({
   actions,


### PR DESCRIPTION
Collapsing or expanding a status group on the Autofix Overview (`/issues/autofix/`) now re-renders only that group's header instead of every card on the page. The `collapsedGroups` state lives at the top of the view, so each toggle re-renders the whole subtree — and because collapsed groups stay mounted (the `Disclosure` only hides them) and `OverviewCard` was unmemoized, a single toggle repainted every card across every group. The cost scaled with the total number of runs on the page, not the group you touched, which made grouping feel sluggish.

`OverviewCard` is now wrapped in `React.memo`. For that to actually skip work, two props that were getting a fresh identity on every parent render are now stable:

- `scmWindowsByRunId` is built in a `useMemo` keyed on the ordered PR-run-id list, so the map and its inner window arrays keep their identity across unrelated re-renders like a group toggle.
- The empty member-list fallback is a shared module constant instead of a new `[]` literal per card.

The remaining card props (`run`, `projectConfig`, the `useCallback` handlers, and the scalar props) already had stable references across a toggle.

Behavior is unchanged; this is a render-path optimization. Note that collapsed groups' cards are still mounted (only hidden), so they still pay first-mount cost — not mounting hidden content would be a larger follow-up if very large lists still feel heavy.
