### PR TITLE
chore(deletions): Don't allow All-Project detectors to linger

### DIFF
--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -45,7 +45,7 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         from sentry.models.repository import Repository
         from sentry.models.team import Team
         from sentry.models.transaction_threshold import ProjectTransactionThreshold
-        from sentry.workflow_engine.models import Workflow
+        from sentry.workflow_engine.models import Detector, Workflow
 
         # Team must come first
         relations: list[BaseRelation] = [ModelRelation(Team, {"organization_id": instance.id})]
@@ -95,6 +95,14 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
                 DiscoverSavedQuery,
                 {"organization_id": instance.id},
                 task=DiscoverSavedQueryDeletionTask,
+            )
+        )
+        # The All Projects detector has project=NULL and stores org_id in config JSON.
+        # It must be deleted explicitly since it lacks a project FK cascade.
+        relations.append(
+            ModelRelation(
+                Detector,
+                {"project__isnull": True, "config__organization_id": instance.id},
             )
         )
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -246,7 +246,11 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.detector_group import DetectorGroup
 from sentry.workflow_engine.registry import data_source_type_registry
-from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from sentry.workflow_engine.types import (
+    ALL_PROJECTS_DETECTOR_NAME,
+    ActionInvocation,
+    WorkflowEventData,
+)
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from social_auth.models import UserSocialAuth
 
@@ -2650,6 +2654,17 @@ class Factories:
         return Detector.objects.create(
             name=name,
             config=config,
+            **kwargs,
+        )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_all_projects_detector(organization_id: int, **kwargs) -> Detector:
+        return Detector.objects.create(
+            name=ALL_PROJECTS_DETECTOR_NAME,
+            config={"organization_id": organization_id},
+            type=IssueStreamGroupType.slug,
+            project=None,
             **kwargs,
         )
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -833,6 +833,9 @@ class Fixtures:
 
         return Factories.create_detector(project=project, type=type, *args, **kwargs)
 
+    def create_all_projects_detector(self, organization: Organization, **kwargs):
+        return Factories.create_all_projects_detector(organization_id=organization.id, **kwargs)
+
     def create_detector_state(self, *args, **kwargs) -> DetectorState:
         return Factories.create_detector_state(*args, **kwargs)
 

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -481,3 +481,23 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
         assert not DataConditionGroup.objects.filter(id=dcg.id).exists()
         assert not DataCondition.objects.filter(id=dc.id).exists()
         assert not Workflow.objects.filter(id=workflow.id).exists()
+
+    def test_all_projects_detector_cleanup(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        all_projects_detector = self.create_all_projects_detector(organization=org)
+        project_detector = self.create_detector(project=project)
+
+        assert Detector.objects.filter(id=all_projects_detector.id).exists()
+        assert Detector.objects.filter(id=project_detector.id).exists()
+        assert all_projects_detector.project_id is None
+        assert project_detector.project_id == project.id
+
+        org.update(status=OrganizationStatus.PENDING_DELETION)
+        self.ScheduledDeletion.schedule(instance=org, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not Detector.objects.filter(id=all_projects_detector.id).exists()
+        assert not Detector.objects.filter(id=project_detector.id).exists()


### PR DESCRIPTION
Cleans them up alongside the other non-FK models.  Added a test to verify too 🙏 

Working on a follow up gs job to clean any lingering rows, but this plugs the hole.