### PR TITLE
feat(redis): reject writes with no TTL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,12 @@ Skills under `.agents/skills/` should follow the same current-practice conventio
 
 New features should be gated behind a flag: register in `src/sentry/features/temporary.py`, check with `features.has(...)` (Python) or `organization.features.includes(...)` (frontend). For the full workflow (registration, `api_expose`, tests, rollout) → use the **`feature-flags`** skill, or see https://develop.sentry.dev/feature-flags/. Deleting a finished flag or option requires a fixed PR order across sentry and sentry-options-automator → use the **`remove-option-or-flag`** skill.
 
+## Redis TTLs
+
+**Every new Redis key sets a TTL, or is registered with Infrastructure Engineering as accepted durable data.** `CommonRedisCache.set` and `RedisKVStorage.set` raise `MissingTTL` rather than write a key with no expiry. There is no opt-out argument: the exemption is granted by Infrastructure Engineering, not at the callsite.
+
+Two things a "does this write set an expiry?" review will miss. A bare `SET`, `GETSET` or `SETEX` over an existing key clears the TTL it already had, while `SADD`, `ZADD`, `HSET`, `HINCRBY` and `INCR` leave it alone. And a TTL refreshed on every write is not a bound — shard by time window and give each shard a fixed TTL instead. Full rules: https://develop.sentry.dev/backend/application-domains/redis/.
+
 ## Customer Information
 
 **Never include customer information in pull requests, commits, or code.** This covers organization slugs, user emails, account names, internal IDs tied to specific customers, support ticket details, and any other data that identifies a Sentry customer. Use anonymized or synthetic examples (`org-slug`, `user@example.com`) in PR descriptions, commit messages, code comments, tests, and fixtures. If a real identifier is needed for debugging, keep it in internal tooling (Slack, tickets, private notes)—not in the public git history.

--- a/src/sentry/attachments/__init__.py
+++ b/src/sentry/attachments/__init__.py
@@ -31,7 +31,7 @@ attachment_cache: BaseAttachmentCache = import_string(settings.SENTRY_ATTACHMENT
 
 @trace
 def store_attachments_for_event(
-    project: Project, event: Any, attachments: list[CachedAttachment], timeout=None
+    project: Project, event: Any, attachments: list[CachedAttachment], timeout: int
 ):
     """
     Stores the given list of `attachments` belonging to `event` for processing.

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -131,7 +131,7 @@ class BaseAttachmentCache:
         self,
         key: str,
         attachments: list[CachedAttachment],
-        timeout=None,
+        timeout: int,
         project: Project | None = None,
     ) -> list[dict]:
         for id, attachment in enumerate(attachments):
@@ -177,12 +177,12 @@ class BaseAttachmentCache:
 
         return meta
 
-    def set_chunk(self, key: str, id: int, chunk_index: int, chunk_data: bytes, timeout=None):
+    def set_chunk(self, key: str, id: int, chunk_index: int, chunk_data: bytes, timeout: int):
         key = ATTACHMENT_DATA_CHUNK_KEY.format(key=key, id=id, chunk_index=chunk_index)
         compressed = zstandard.compress(chunk_data)
         self.inner.set(key, compressed, timeout, raw=True)
 
-    def set_unchunked_data(self, key: str, id: int, data: bytes, timeout=None, metrics_tags=None):
+    def set_unchunked_data(self, key: str, id: int, data: bytes, timeout: int, metrics_tags=None):
         key = ATTACHMENT_UNCHUNKED_DATA_KEY.format(key=key, id=id)
         compressed = zstandard.compress(data)
         metrics.distribution("attachments.blob-size.raw", len(data), tags=metrics_tags, unit="byte")

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -1,3 +1,4 @@
+from sentry.exceptions import MissingTTL
 from sentry.utils import json
 from sentry.utils.redis import get_cluster_from_options, get_cluster_routing_client, redis_clusters
 
@@ -25,13 +26,18 @@ class CommonRedisCache(BaseCache):
 
     def set(self, key, value, timeout, version=None, raw=False):
         key = self.make_key(key, version=version)
-        v = json.dumps(value) if not raw else value
+        if not timeout:
+            raise MissingTTL(key)
+
+        if raw:
+            v = value
+        else:
+            v = json.dumps(value)
+
         if len(v) > self.max_size:
             raise ValueTooLarge(f"Cache key too large: {key!r} {len(v)!r}")
-        if timeout:
-            self._client(raw=raw).setex(key, int(timeout), v)
-        else:
-            self._client(raw=raw).set(key, v)
+
+        self._client(raw=raw).setex(key, int(timeout), v)
 
         self._mark_transaction("set")
 

--- a/src/sentry/exceptions.py
+++ b/src/sentry/exceptions.py
@@ -98,3 +98,13 @@ class InvalidParams(ParseError):
     when this exception is unhandled in a view."""
 
     pass
+
+
+class MissingTTL(Exception):
+    def __init__(self, key: str) -> None:
+        super().__init__(
+            f"Refusing to write {key!r} with no expiry. Every new Redis key sets a TTL, or is "
+            "registered with Infrastructure Engineering as accepted durable data. There is no "
+            "opt-out at the callsite: "
+            "https://develop.sentry.dev/backend/application-domains/redis/"
+        )

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -6,6 +6,7 @@ from typing import TypeVar
 from redis import StrictRedis
 from sentry_redis_tools.clients import RedisCluster
 
+from sentry.exceptions import MissingTTL
 from sentry.utils.kvstore.abstract import KVStorage
 
 T = TypeVar("T", str, bytes)
@@ -24,6 +25,8 @@ class RedisKVStorage(KVStorage[str, T]):
         return self.client.get(key.encode("utf8"))
 
     def set(self, key: str, value: T, ttl: timedelta | None = None) -> None:
+        if not ttl:
+            raise MissingTTL(key)
         self.client.set(key.encode("utf8"), value, ex=ttl)
 
     def delete(self, key: str) -> None:

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -71,12 +71,12 @@ def test_basic_chunked() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
 
-    cache.set_chunk("c:foo", 123, 0, b"Hello World! ")
-    cache.set_chunk("c:foo", 123, 1, b"")
-    cache.set_chunk("c:foo", 123, 2, b"Bye.")
+    cache.set_chunk("c:foo", 123, 0, b"Hello World! ", timeout=300)
+    cache.set_chunk("c:foo", 123, 1, b"", timeout=300)
+    cache.set_chunk("c:foo", 123, 2, b"Bye.", timeout=300)
 
     att = CachedAttachment(key="c:foo", id=123, name="lol.txt", content_type="text/plain", chunks=3)
-    (meta,) = cache.set("c:foo", [att])
+    (meta,) = cache.set("c:foo", [att], timeout=300)
     att2 = CachedAttachment(cache=cache, **meta)
 
     assert att2.key == att.key == "c:foo"
@@ -91,7 +91,7 @@ def test_basic_unchunked() -> None:
     cache = BaseAttachmentCache(data)
 
     att = CachedAttachment(name="lol.txt", content_type="text/plain", data=b"Hello World! Bye.")
-    (meta,) = cache.set("c:foo", [att])
+    (meta,) = cache.set("c:foo", [att], timeout=300)
     att2 = CachedAttachment(cache=cache, **meta)
 
     assert att2.key == att.key == "c:foo"
@@ -105,15 +105,15 @@ def test_zstd_chunks() -> None:
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
 
-    cache.set_chunk("mixed_chunks", 123, 0, b"Hello World! ")
-    cache.set_chunk("mixed_chunks", 123, 1, b"Just visiting. ")
-    cache.set_chunk("mixed_chunks", 123, 2, b"Bye.")
+    cache.set_chunk("mixed_chunks", 123, 0, b"Hello World! ", timeout=300)
+    cache.set_chunk("mixed_chunks", 123, 1, b"Just visiting. ", timeout=300)
+    cache.set_chunk("mixed_chunks", 123, 2, b"Bye.", timeout=300)
 
     mixed_chunks = cache.get_from_chunks(key="mixed_chunks", id=123, chunks=3)
     assert mixed_chunks.load_data() == b"Hello World! Just visiting. Bye."
 
     att = CachedAttachment(key="not_chunked", id=456, data=b"Hello World! Bye.")
-    (meta,) = cache.set("not_chunked", [att])
+    (meta,) = cache.set("not_chunked", [att], timeout=300)
     not_chunked = CachedAttachment(cache=cache, **meta)
 
     assert not_chunked.load_data() == b"Hello World! Bye."
@@ -131,7 +131,7 @@ def test_overwriting_stored_attachment_keeps_metadata(mock_get_session: mock.Moc
         data=b'{"class": "TextView"}',
         stored_id="some-key",
     )
-    cache.set("c:foo", [att], project=project)
+    cache.set("c:foo", [att], timeout=300, project=project)
 
     kwargs = mock_get_session.return_value.put.call_args.kwargs
     assert kwargs["key"] == "some-key"
@@ -147,7 +147,7 @@ def test_basic_rate_limited() -> None:
     att = CachedAttachment(
         name="lol.txt", content_type="text/plain", data=b"Hello World! Bye.", rate_limited=True
     )
-    (meta,) = cache.set("c:foo", [att])
+    (meta,) = cache.set("c:foo", [att], timeout=300)
     att2 = CachedAttachment(cache=cache, **meta)
 
     assert att2.key == att.key == "c:foo"

--- a/tests/sentry/cache/test_redis.py
+++ b/tests/sentry/cache/test_redis.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sentry.cache.redis import RedisCache, RedisClusterCache, ValueTooLarge
+from sentry.exceptions import MissingTTL
 
 clients = pytest.mark.parametrize(
     "make_client",
@@ -25,7 +26,20 @@ def test_redis_cache_integration(make_client) -> None:
     assert result is None
 
     with pytest.raises(ValueTooLarge):
-        backend.set("foo", "x" * (RedisCache.max_size + 1), 0)
+        backend.set("foo", "x" * (RedisCache.max_size + 1), 50)
+
+
+@clients
+def test_set_without_a_timeout_is_rejected(make_client) -> None:
+    backend = make_client()
+
+    with pytest.raises(MissingTTL):
+        backend.set("foo", {"foo": "bar"}, timeout=None)
+
+    with pytest.raises(MissingTTL):
+        backend.set("foo", {"foo": "bar"}, timeout=0)
+
+    assert backend.get("foo") is None
 
 
 @clients

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2457,7 +2457,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             )
 
             cache_key = cache_key_for_event(manager.get_data())
-            attachment_cache.set(cache_key, attachments=[a1, a2])
+            attachment_cache.set(cache_key, attachments=[a1, a2], timeout=300)
 
             mock_track_outcome = mock.Mock(wraps=track_outcome)
             with (
@@ -2503,7 +2503,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         a1 = CachedAttachment(name="a1", data=b"hello", type="event.minidump")
         a2 = CachedAttachment(name="a2", data=b"world")
         cache_key = cache_key_for_event(manager.get_data())
-        attachment_cache.set(cache_key, attachments=[a1, a2])
+        attachment_cache.set(cache_key, attachments=[a1, a2], timeout=300)
 
         mock_track_outcome = mock.Mock()
         mock_track_outcome_aggregated = mock.Mock()
@@ -2534,7 +2534,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager.normalize()
 
         cache_key = cache_key_for_event(manager.get_data())
-        attachment_cache.set(cache_key, attachments=[a1, a2])
+        attachment_cache.set(cache_key, attachments=[a1, a2], timeout=300)
 
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with mock.patch(
@@ -2585,7 +2585,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         a3 = CachedAttachment(name="a3", data=b"world")
 
         cache_key = cache_key_for_event(manager.get_data())
-        attachment_cache.set(cache_key, attachments=[a1, a2, a3])
+        attachment_cache.set(cache_key, attachments=[a1, a2, a3], timeout=300)
 
         mock_track_outcome = mock.Mock()
         mock_track_outcome_aggregated = mock.Mock()
@@ -2621,7 +2621,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         a3 = CachedAttachment(name="a3", data=b"world")
 
         cache_key = cache_key_for_event(manager.get_data())
-        attachment_cache.set(cache_key, attachments=[a1, a2, a3])
+        attachment_cache.set(cache_key, attachments=[a1, a2, a3], timeout=300)
 
         mock_track_outcome = mock.Mock()
         mock_track_outcome_aggregated = mock.Mock()

--- a/tests/sentry/utils/kvstore/test_common.py
+++ b/tests/sentry/utils/kvstore/test_common.py
@@ -85,12 +85,12 @@ def test_single_key_operations(properties: Properties) -> None:
     key, value = next(properties.keys), next(properties.values)
 
     # Test setting a key with no prior value.
-    store.set(key, value)
+    store.set(key, value, ttl=timedelta(hours=1))
     assert store.get(key) == value
 
     # Test overwriting a key with a prior value.
     new_value = next(properties.values)
-    store.set(key, new_value)
+    store.set(key, new_value, ttl=timedelta(hours=1))
     assert store.get(key) == new_value
 
     # Test overwriting a key with a new TTL.
@@ -115,7 +115,7 @@ def test_multiple_key_operations(properties: Properties) -> None:
 
     items = dict(itertools.islice(properties.items, 10))
     for key, value in items.items():
-        store.set(key, value)
+        store.set(key, value, ttl=timedelta(hours=1))
 
     missing_keys = set(itertools.islice(properties.keys, 5))
 

--- a/tests/sentry/utils/kvstore/test_compat.py
+++ b/tests/sentry/utils/kvstore/test_compat.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from redis import Redis
 
 from sentry.cache.redis import CommonRedisCache
@@ -23,12 +25,12 @@ def test_redis_cache_compat() -> None:
     key = "key"
 
     value = [1, 2, 3]
-    cache_backend.set(key, value)
+    cache_backend.set(key, value, ttl=timedelta(hours=1))
     assert cache_backend.get(key) == value
     assert redis_backend.get(key) == value
 
     value = [4, 5, 6]
-    redis_backend.set("key", value)
+    redis_backend.set("key", value, ttl=timedelta(hours=1))
     assert cache_backend.get(key) == value
     assert redis_backend.get(key) == value
 

--- a/tests/sentry/utils/kvstore/test_redis.py
+++ b/tests/sentry/utils/kvstore/test_redis.py
@@ -1,0 +1,19 @@
+from datetime import timedelta
+
+import pytest
+from redis import Redis
+
+from sentry.exceptions import MissingTTL
+from sentry.utils.kvstore.redis import RedisKVStorage
+
+
+def test_set_without_a_ttl_is_rejected() -> None:
+    store = RedisKVStorage[bytes](Redis(db=6))
+
+    with pytest.raises(MissingTTL):
+        store.set("key", b"value")
+
+    with pytest.raises(MissingTTL):
+        store.set("key", b"value", ttl=timedelta(0))
+
+    assert store.get("key") is None


### PR DESCRIPTION
[INFRENG-509](https://linear.app/getsentry/issue/INFRENG-509/fail-ttl-less-writes-through-the-redis-cache-backends)'

Part of the initiative of adding TTLs to all redis keys, keys configured without a TTL raise an exception; forever keys are managed by infra eng.