### PR TITLE
feat(seer-infra-telemetry): Add GCP connection verification step to install wizard

### DIFF
--- a/static/app/components/pipeline/integrationGcp/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.spec.tsx
@@ -6,9 +6,11 @@ import {gcpIntegrationPipeline} from '.';
 
 const GcpSaGenerationStep = gcpIntegrationPipeline.steps[0].component;
 const GcpCustomerConfigStep = gcpIntegrationPipeline.steps[1].component;
+const GcpVerificationStep = gcpIntegrationPipeline.steps[2].component;
 
-const makeSaGenerationStepProps = createMakeStepProps({totalSteps: 2});
-const makeCustomerConfigStepProps = createMakeStepProps({totalSteps: 2});
+const makeSaGenerationStepProps = createMakeStepProps({totalSteps: 3});
+const makeCustomerConfigStepProps = createMakeStepProps({totalSteps: 3});
+const makeVerificationStepProps = createMakeStepProps({totalSteps: 3});
 
 describe('GcpSaGenerationStep', () => {
   const sentrySaEmail = 'sentry-org-123@sentry-connectors.iam.gserviceaccount.com';
@@ -137,10 +139,317 @@ describe('GcpCustomerConfigStep', () => {
   });
 });
 
+describe('GcpVerificationStep', () => {
+  const VERIFY_URL =
+    '/organizations/org-slug/monitoring-providers/gcp/verify-connection/';
+
+  const stepData = {
+    customerSaEmail: 'gcp-sentry@my-project.iam.gserviceaccount.com',
+    projects: ['my-project-prod'],
+  };
+
+  const connectedResponse = {
+    connectionStatus: 'connected',
+    projects: [
+      {
+        gcpProjectId: 'my-project-prod',
+        connectionStatus: 'connected',
+        services: [
+          {service: 'logging', status: 'connected'},
+          {service: 'monitoring', status: 'connected'},
+          {service: 'cloudtrace', status: 'connected'},
+        ],
+      },
+    ],
+  };
+
+  const deniedResponse = {
+    connectionStatus: 'permission_denied',
+    projects: [
+      {
+        gcpProjectId: 'my-project-prod',
+        connectionStatus: 'permission_denied',
+        services: [
+          {service: 'logging', status: 'connected'},
+          {
+            service: 'cloudtrace',
+            status: 'permission_denied',
+            errorDetail: 'IAM roles not granted',
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows the check running before it has a result, with no way to skip it', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: connectedResponse,
+      asyncDelay: 20,
+    });
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData})} />);
+
+    // The mutation starts idle, so this covers the gap before the effect fires.
+    expect(screen.getByText('Testing your GCP connection...')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
+    );
+  });
+
+  it('cannot be advanced twice while the first advance is in flight', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: connectedResponse,
+    });
+
+    render(
+      <GcpVerificationStep
+        {...makeVerificationStepProps({stepData, isAdvancing: true})}
+      />
+    );
+
+    // Wait for the result, so the check being in flight isn't what disables it.
+    expect(await screen.findByText('my-project-prod')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
+  });
+
+  it('advances with the result when every project is connected', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: connectedResponse,
+    });
+    const advance = jest.fn();
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Continue'}));
+
+    expect(advance).toHaveBeenCalledWith({
+      connectionStatus: 'connected',
+      projects: [
+        {
+          gcpProjectId: 'my-project-prod',
+          connectionStatus: 'connected',
+          errorDetail: null,
+        },
+      ],
+    });
+  });
+
+  it('verifies the connection on mount and shows a connected project', async () => {
+    const verify = MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: connectedResponse,
+    });
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData})} />);
+
+    expect(await screen.findByText('my-project-prod')).toBeInTheDocument();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+
+    expect(verify).toHaveBeenCalledWith(
+      VERIFY_URL,
+      expect.objectContaining({
+        method: 'POST',
+        data: {
+          customerSaEmail: stepData.customerSaEmail,
+          gcpProjectIds: stepData.projects,
+        },
+      })
+    );
+  });
+
+  it('shows per-service remediation detail when a project fails', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: deniedResponse,
+    });
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData})} />);
+
+    expect(await screen.findByText('Permission denied')).toBeInTheDocument();
+    expect(screen.getByText('Cloud Trace: IAM roles not granted')).toBeInTheDocument();
+    // Services that passed are not listed.
+    expect(screen.queryByText(/^Cloud Logging:/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue Anyway'})).toBeEnabled();
+  });
+
+  it('advances with the verification result', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: deniedResponse,
+    });
+    const advance = jest.fn();
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Continue Anyway'}));
+
+    // Seer reports the actionable message per service, not per project.
+    expect(advance).toHaveBeenCalledWith({
+      connectionStatus: 'permission_denied',
+      projects: [
+        {
+          gcpProjectId: 'my-project-prod',
+          connectionStatus: 'permission_denied',
+          errorDetail: 'Cloud Trace: IAM roles not granted',
+        },
+      ],
+    });
+  });
+
+  it('rolls several failing services into one detail', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: {
+        connectionStatus: 'error',
+        projects: [
+          {
+            gcpProjectId: 'my-project-prod',
+            connectionStatus: 'error',
+            services: [
+              {service: 'logging', status: 'connected'},
+              {
+                service: 'monitoring',
+                status: 'api_disabled',
+                errorDetail: 'Cloud Monitoring API is disabled',
+              },
+              {service: 'cloudtrace', status: 'project_not_found'},
+            ],
+          },
+        ],
+      },
+    });
+    const advance = jest.fn();
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Continue Anyway'}));
+
+    expect(advance).toHaveBeenCalledWith({
+      connectionStatus: 'error',
+      projects: [
+        {
+          gcpProjectId: 'my-project-prod',
+          connectionStatus: 'error',
+          errorDetail:
+            'Cloud Monitoring: Cloud Monitoring API is disabled; Cloud Trace: Project not found',
+        },
+      ],
+    });
+  });
+
+  it('keeps the project-level detail when the impersonation chain fails', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: {
+        connectionStatus: 'permission_denied',
+        errorDetail: 'SA impersonation chain failed',
+        projects: [
+          {
+            gcpProjectId: 'my-project-prod',
+            connectionStatus: 'permission_denied',
+            errorDetail: 'SA impersonation chain failed',
+            services: [
+              {
+                service: 'logging',
+                status: 'permission_denied',
+                errorDetail: 'SA impersonation chain failed',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const advance = jest.fn();
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Continue Anyway'}));
+
+    expect(advance).toHaveBeenCalledWith({
+      connectionStatus: 'permission_denied',
+      projects: [
+        {
+          gcpProjectId: 'my-project-prod',
+          connectionStatus: 'permission_denied',
+          errorDetail: 'SA impersonation chain failed',
+        },
+      ],
+    });
+  });
+
+  it('re-tests the connection on demand', async () => {
+    const verify = MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: deniedResponse,
+    });
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData})} />);
+
+    await screen.findByText('Permission denied');
+    expect(verify).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+
+    await waitFor(() => expect(verify).toHaveBeenCalledTimes(2));
+  });
+
+  it('lets the customer finish setup when the check cannot be completed', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      statusCode: 502,
+    });
+    const advance = jest.fn();
+
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
+
+    expect(
+      await screen.findByText(
+        'We could not complete the connection test. You can finish setup and re-test from the integration settings page.'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Continue Anyway'}));
+
+    expect(advance).toHaveBeenCalledWith({
+      connectionStatus: 'error',
+      projects: [
+        {
+          gcpProjectId: 'my-project-prod',
+          connectionStatus: 'error',
+          errorDetail: 'Verification could not be completed.',
+        },
+      ],
+    });
+  });
+});
+
 describe('gcpIntegrationPipeline', () => {
-  it('has two steps in the correct order', () => {
-    expect(gcpIntegrationPipeline.steps).toHaveLength(2);
+  it('has three steps in the correct order', () => {
+    expect(gcpIntegrationPipeline.steps).toHaveLength(3);
     expect(gcpIntegrationPipeline.steps[0].stepId).toBe('gcp_sa_generation');
     expect(gcpIntegrationPipeline.steps[1].stepId).toBe('gcp_customer_config');
+    expect(gcpIntegrationPipeline.steps[2].stepId).toBe('gcp_verification');
   });
 });

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -28,10 +28,10 @@ import type {
 } from 'sentry/utils/seer/gcpConnection';
 import {
   describeService,
-  GCP_STATUS_VARIANTS,
   getFailedServices,
   getProjectErrorDetail,
   getStatusLabel,
+  getStatusVariant,
 } from 'sentry/utils/seer/gcpConnection';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -218,7 +218,7 @@ function GcpProjectStatus({project}: {project: GcpProjectResult}) {
     <Stack gap="xs">
       <Flex gap="sm" align="center">
         <StatusIndicator
-          variant={GCP_STATUS_VARIANTS[project.connectionStatus]}
+          variant={getStatusVariant(project.connectionStatus)}
           animationIterationCount={1}
         />
         <Text bold>{project.gcpProjectId}</Text>

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -1,20 +1,39 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
+import {useMutation} from '@tanstack/react-query';
 import {z} from 'zod';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Text} from '@sentry/scraps/text';
 
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {
   PipelineDefinition,
   PipelineStepProps,
 } from 'sentry/components/pipeline/types';
 import {pipelineComplete} from 'sentry/components/pipeline/types';
 import {TextCopyInput} from 'sentry/components/textCopyInput';
-import {IconAdd, IconDelete} from 'sentry/icons';
+import {IconAdd, IconDelete, IconRefresh} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import type {
+  GcpProjectResult,
+  GcpVerificationInput,
+  GcpVerifyConnectionResponse,
+} from 'sentry/utils/seer/gcpConnection';
+import {
+  describeService,
+  GCP_STATUS_VARIANTS,
+  getFailedServices,
+  getProjectErrorDetail,
+  getStatusLabel,
+} from 'sentry/utils/seer/gcpConnection';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 const GCP_PROJECT_ID_RE = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
 const MAX_PROJECTS = 20;
@@ -187,6 +206,159 @@ function GcpCustomerConfigStep({
   );
 }
 
+interface GcpVerificationStepData {
+  customerSaEmail: string;
+  projects: string[];
+}
+
+function GcpProjectStatus({project}: {project: GcpProjectResult}) {
+  const failedServices = getFailedServices(project);
+
+  return (
+    <Stack gap="xs">
+      <Flex gap="sm" align="center">
+        <StatusIndicator
+          variant={GCP_STATUS_VARIANTS[project.connectionStatus]}
+          animationIterationCount={1}
+        />
+        <Text bold>{project.gcpProjectId}</Text>
+        <Text variant="muted" size="sm">
+          {getStatusLabel(project.connectionStatus)}
+        </Text>
+      </Flex>
+      {failedServices.map(service => (
+        <Text key={service.service} variant="muted" size="sm">
+          {describeService(service)}
+        </Text>
+      ))}
+    </Stack>
+  );
+}
+
+function GcpVerificationStep({
+  advance,
+  isAdvancing,
+  isInitializing,
+  stepData,
+}: PipelineStepProps<GcpVerificationStepData, GcpVerificationInput>) {
+  const organization = useOrganization();
+  const customerSaEmail = stepData?.customerSaEmail ?? '';
+  const projects = stepData?.projects;
+
+  const {
+    mutate: verify,
+    data: result,
+    isPending,
+    isError,
+  } = useMutation<GcpVerifyConnectionResponse>({
+    mutationFn: () =>
+      fetchMutation({
+        url: getApiUrl(
+          '/organizations/$organizationIdOrSlug/monitoring-providers/gcp/verify-connection/',
+          {path: {organizationIdOrSlug: organization.slug}}
+        ),
+        method: 'POST',
+        data: {customerSaEmail, gcpProjectIds: projects},
+      }),
+  });
+
+  const canVerify = Boolean(customerSaEmail && projects?.length);
+
+  const hasVerifiedRef = useRef(false);
+  useEffect(() => {
+    if (hasVerifiedRef.current || !canVerify) {
+      return;
+    }
+    hasVerifiedRef.current = true;
+    verify();
+  }, [verify, canVerify]);
+
+  const isChecking = isPending || (canVerify && !result && !isError);
+  const isConnected = result?.connectionStatus === 'connected';
+  const continueLabel = isChecking || isConnected ? t('Continue') : t('Continue Anyway');
+
+  function handleContinue() {
+    if (result) {
+      advance({
+        connectionStatus: result.connectionStatus,
+        projects: result.projects.map(project => ({
+          gcpProjectId: project.gcpProjectId,
+          connectionStatus: project.connectionStatus,
+          errorDetail: getProjectErrorDetail(project),
+        })),
+      });
+      return;
+    }
+
+    // The check never completed, so record it as an error against every
+    // configured project. The customer can re-test from the settings page.
+    advance({
+      connectionStatus: 'error',
+      projects: (projects ?? []).map(gcpProjectId => ({
+        gcpProjectId,
+        connectionStatus: 'error' as const,
+        errorDetail: 'Verification could not be completed.',
+      })),
+    });
+  }
+
+  return (
+    <Stack gap="lg">
+      <Text>
+        {t(
+          'Sentry is testing that it can read Cloud Logging, Cloud Monitoring, and Cloud Trace data from each of your GCP projects.'
+        )}
+      </Text>
+
+      <Stack gap="md" role="status" aria-live="polite">
+        {isChecking ? (
+          <Flex gap="sm" align="center">
+            <LoadingIndicator mini />
+            <Text variant="muted">{t('Testing your GCP connection...')}</Text>
+          </Flex>
+        ) : isError ? (
+          <Alert variant="warning">
+            {t(
+              'We could not complete the connection test. You can finish setup and re-test from the integration settings page.'
+            )}
+          </Alert>
+        ) : result ? (
+          <Fragment>
+            <Alert variant={isConnected ? 'success' : 'warning'}>
+              {isConnected
+                ? t('Sentry can read telemetry from all of your connected GCP projects.')
+                : t(
+                    'Sentry could not read telemetry from every project. IAM changes can take a couple of minutes to take effect, so re-testing may help. You can also finish setup and re-test from the integration settings page.'
+                  )}
+            </Alert>
+            {result.projects.map(project => (
+              <GcpProjectStatus key={project.gcpProjectId} project={project} />
+            ))}
+          </Fragment>
+        ) : null}
+      </Stack>
+
+      <Flex gap="md">
+        <Button
+          variant="primary"
+          onClick={handleContinue}
+          busy={isAdvancing}
+          disabled={isInitializing || isChecking || isAdvancing}
+        >
+          {continueLabel}
+        </Button>
+        <Button
+          icon={<IconRefresh size="xs" />}
+          onClick={() => verify()}
+          disabled={isInitializing || isChecking || isAdvancing || !canVerify}
+        >
+          {t('Re-test')}
+        </Button>
+      </Flex>
+    </Stack>
+  );
+}
+
 export const gcpIntegrationPipeline = {
   type: 'integration',
   provider: 'gcp',
@@ -203,6 +375,11 @@ export const gcpIntegrationPipeline = {
       stepId: 'gcp_customer_config',
       shortDescription: t('Configuring GCP connection'),
       component: GcpCustomerConfigStep,
+    },
+    {
+      stepId: 'gcp_verification',
+      shortDescription: t('Verifying GCP connection'),
+      component: GcpVerificationStep,
     },
   ],
 } as const satisfies PipelineDefinition;

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -8,7 +8,7 @@ import {unreachable} from 'sentry/utils/unreachable';
  * src/sentry/integrations/gcp/utils.py, which in turn mirrors ConnectionStatus
  * in seer/automation/agent/mcp/gcp_verification.py.
  */
-export const GCP_STATUS_VARIANTS = {
+const GCP_STATUS_VARIANTS = {
   connected: 'success',
   permission_denied: 'danger',
   api_disabled: 'warning',
@@ -16,25 +16,31 @@ export const GCP_STATUS_VARIANTS = {
   error: 'danger',
 } as const satisfies Record<string, 'success' | 'warning' | 'danger'>;
 
-export type GcpConnectionStatus = keyof typeof GCP_STATUS_VARIANTS;
+type GcpConnectionStatus = keyof typeof GCP_STATUS_VARIANTS;
+
+type GcpStatusVariant = (typeof GCP_STATUS_VARIANTS)[GcpConnectionStatus];
+
+function isKnownStatus(status: string): status is GcpConnectionStatus {
+  return status in GCP_STATUS_VARIANTS;
+}
 
 /** One MCP server's result, as returned by Seer's verification endpoint. */
 export interface GcpServiceResult {
   service: string;
-  status: GcpConnectionStatus;
+  status: string;
   errorDetail?: string | null;
 }
 
 /** One project's result, aggregated across its services. */
 export interface GcpProjectResult {
-  connectionStatus: GcpConnectionStatus;
+  connectionStatus: string;
   gcpProjectId: string;
   services: GcpServiceResult[];
   errorDetail?: string | null;
 }
 
 export interface GcpVerifyConnectionResponse {
-  connectionStatus: GcpConnectionStatus;
+  connectionStatus: string;
   projects: GcpProjectResult[];
   errorDetail?: string | null;
 }
@@ -53,7 +59,14 @@ export interface GcpVerificationInput extends Pick<
   projects: GcpProjectVerification[];
 }
 
-export function getStatusLabel(status: GcpConnectionStatus): string {
+export function getStatusVariant(status: string): GcpStatusVariant {
+  return isKnownStatus(status) ? GCP_STATUS_VARIANTS[status] : 'danger';
+}
+
+export function getStatusLabel(status: string): string {
+  if (!isKnownStatus(status)) {
+    return t('Error');
+  }
   switch (status) {
     case 'connected':
       return t('Connected');

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -39,7 +39,7 @@ export interface GcpVerifyConnectionResponse {
   errorDetail?: string | null;
 }
 
-export interface GcpProjectVerification extends Pick<
+interface GcpProjectVerification extends Pick<
   GcpProjectResult,
   'gcpProjectId' | 'connectionStatus'
 > {
@@ -70,7 +70,7 @@ export function getStatusLabel(status: GcpConnectionStatus): string {
   }
 }
 
-export function getServiceLabel(service: string): string {
+function getServiceLabel(service: string): string {
   switch (service) {
     case 'logging':
       return t('Cloud Logging');

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -1,0 +1,105 @@
+import {t} from 'sentry/locale';
+import {unreachable} from 'sentry/utils/unreachable';
+
+/**
+ * Status of a GCP connection, per project and per service.
+ *
+ * Keep in sync with GCP_CONNECTION_STATUSES in
+ * src/sentry/integrations/gcp/utils.py, which in turn mirrors ConnectionStatus
+ * in seer/automation/agent/mcp/gcp_verification.py.
+ */
+export const GCP_STATUS_VARIANTS = {
+  connected: 'success',
+  permission_denied: 'danger',
+  api_disabled: 'warning',
+  project_not_found: 'danger',
+  error: 'danger',
+} as const satisfies Record<string, 'success' | 'warning' | 'danger'>;
+
+export type GcpConnectionStatus = keyof typeof GCP_STATUS_VARIANTS;
+
+/** One MCP server's result, as returned by Seer's verification endpoint. */
+export interface GcpServiceResult {
+  service: string;
+  status: GcpConnectionStatus;
+  errorDetail?: string | null;
+}
+
+/** One project's result, aggregated across its services. */
+export interface GcpProjectResult {
+  connectionStatus: GcpConnectionStatus;
+  gcpProjectId: string;
+  services: GcpServiceResult[];
+  errorDetail?: string | null;
+}
+
+export interface GcpVerifyConnectionResponse {
+  connectionStatus: GcpConnectionStatus;
+  projects: GcpProjectResult[];
+  errorDetail?: string | null;
+}
+
+export interface GcpProjectVerification extends Pick<
+  GcpProjectResult,
+  'gcpProjectId' | 'connectionStatus'
+> {
+  errorDetail: string | null;
+}
+
+export interface GcpVerificationInput extends Pick<
+  GcpVerifyConnectionResponse,
+  'connectionStatus'
+> {
+  projects: GcpProjectVerification[];
+}
+
+export function getStatusLabel(status: GcpConnectionStatus): string {
+  switch (status) {
+    case 'connected':
+      return t('Connected');
+    case 'permission_denied':
+      return t('Permission denied');
+    case 'api_disabled':
+      return t('API disabled');
+    case 'project_not_found':
+      return t('Project not found');
+    case 'error':
+      return t('Error');
+    default:
+      return unreachable(status);
+  }
+}
+
+export function getServiceLabel(service: string): string {
+  switch (service) {
+    case 'logging':
+      return t('Cloud Logging');
+    case 'monitoring':
+      return t('Cloud Monitoring');
+    case 'cloudtrace':
+      return t('Cloud Trace');
+    default:
+      return service;
+  }
+}
+
+export function getFailedServices(project: GcpProjectResult): GcpServiceResult[] {
+  return project.services.filter(service => service.status !== 'connected');
+}
+
+export function describeService(service: GcpServiceResult): string {
+  return `${getServiceLabel(service.service)}: ${
+    service.errorDetail ?? getStatusLabel(service.status)
+  }`;
+}
+
+export function getProjectErrorDetail(project: GcpProjectResult): string | null {
+  if (project.errorDetail) {
+    return project.errorDetail;
+  }
+  const failed = getFailedServices(project);
+  if (failed.length === 0) {
+    return null;
+  }
+  return failed.map(describeService).join('; ');
+}


### PR DESCRIPTION
PR 2 for https://linear.app/getsentry/issue/CW-1965/hook-gcp-connection-verification-into-the-integration-creation-flow.

Adds the verification step UI to the GCP install wizard: it tests the SA impersonation chain against each configured project and reports the result back to the pipeline, which records it on the integration.

The check runs against `monitoring-providers/gcp/verify-connection/`. Results show per project, with per-service detail for anything that failed, plus a Re-test button since IAM grants take time to propagate.

A failed check doesn't block the install - the org can finish setup and re-test from the integration settings page.