### PR TITLE
impr(sentry apps): Add Duration, Resource ids,  Request id to the dashboard

### DIFF
--- a/src/sentry/sentry_apps/api/serializers/sentry_app_webhook_request.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_webhook_request.py
@@ -14,7 +14,7 @@ from sentry.sentry_apps.api.utils.webhook_requests import BufferedRequest
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-from sentry.utils.sentry_apps.webhooks import TIMEOUT_STATUS_CODE
+from sentry.utils.sentry_apps.webhooks import NO_RESPONSE_STATUS_CODES
 
 
 class _BufferedRequestAttrs(TypedDict):
@@ -92,7 +92,7 @@ class SentryAppWebhookRequestSerializer(Serializer[SentryAppWebhookRequestSerial
             "durationMs": obj.data.duration_ms,
         }
 
-        if response_code >= 400 or response_code == TIMEOUT_STATUS_CODE:
+        if response_code >= 400 or response_code in NO_RESPONSE_STATUS_CODES:
             # add error data to display in Sentry app dashboard
             data.update(
                 {

--- a/src/sentry/sentry_apps/api/serializers/sentry_app_webhook_request.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_webhook_request.py
@@ -39,6 +39,10 @@ class SentryAppWebhookRequestSerializerResponse(TypedDict):
     request_body: NotRequired[str | None]
     request_headers: NotRequired[Mapping[str, str] | None]
     response_body: NotRequired[str | None]
+    requestId: NotRequired[str | None]
+    subjectId: NotRequired[str | None]
+    subjectType: NotRequired[str | None]
+    durationMs: NotRequired[int | None]
 
 
 class SentryAppWebhookRequestSerializer(Serializer[SentryAppWebhookRequestSerializerResponse]):
@@ -82,6 +86,10 @@ class SentryAppWebhookRequestSerializer(Serializer[SentryAppWebhookRequestSerial
             "eventType": obj.data.event_type,
             "date": obj.data.date,
             "responseCode": response_code,
+            "requestId": obj.data.request_id,
+            "subjectId": obj.data.subject_id,
+            "subjectType": obj.data.subject_type,
+            "durationMs": obj.data.duration_ms,
         }
 
         if response_code >= 400 or response_code == TIMEOUT_STATUS_CODE:

--- a/src/sentry/sentry_apps/services/app_request/model.py
+++ b/src/sentry/sentry_apps/services/app_request/model.py
@@ -22,6 +22,10 @@ class RpcSentryAppRequest(RpcModel):
     request_body: str | None = None
     request_headers: Mapping[str, str] | None = Field(repr=False, default=None)
     response_body: str | None = None
+    request_id: str | None = None
+    subject_id: str | None = None
+    subject_type: str | None = None
+    duration_ms: int | None = None
 
 
 class SentryAppRequestFilterArgs(TypedDict, total=False):

--- a/src/sentry/sentry_apps/services/app_request/serial.py
+++ b/src/sentry/sentry_apps/services/app_request/serial.py
@@ -14,4 +14,8 @@ def serialize_rpc_sentry_app_request(request: SentryAppRequest) -> RpcSentryAppR
         request_body=request.get("request_body"),
         request_headers=request.get("request_headers"),
         response_body=request.get("response_body"),
+        request_id=request.get("request_id"),
+        subject_id=request.get("subject_id"),
+        subject_type=request.get("subject_type"),
+        duration_ms=request.get("duration_ms"),
     )

--- a/src/sentry/sentry_apps/utils/webhook_subjects.py
+++ b/src/sentry/sentry_apps/utils/webhook_subjects.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from sentry.sentry_apps.utils.webhooks import SentryAppResourceType
+from sentry.utils.safe import get_path
+
+
+@dataclass(frozen=True)
+class SubjectSpec:
+    """
+    Spec to extract subject id and type from the webhook payload.
+    """
+
+    # The resource type (e.g. Group, Event, autofix_run, etc.)
+    subject_type: str
+    # From the webhook payload, the key path to the subject's identifier
+    paths: Sequence[Sequence[str]]
+
+    def resolve(self, data: Mapping[str, Any]) -> tuple[str | None, str | None]:
+        for path in self.paths:
+            value = get_path(data, *path)
+            if value is not None:
+                return str(value), self.subject_type
+        return None, None
+
+
+# Default resource -> subject mapping. Adding a new resource here covers all of its event types.
+# Ex SubjectSpec("installation", [("installation", "uuid")]) -> data.get("installation").get("uuid")
+_SUBJECT_BY_RESOURCE: Mapping[SentryAppResourceType, SubjectSpec] = {
+    SentryAppResourceType.ERROR: SubjectSpec("event", [("error", "event_id")]),
+    SentryAppResourceType.EVENT_ALERT: SubjectSpec("event", [("event", "event_id")]),
+    SentryAppResourceType.ISSUE: SubjectSpec("group", [("issue", "id")]),
+    SentryAppResourceType.ACTIVITY_ALERT: SubjectSpec("group", [("issue", "id")]),
+    SentryAppResourceType.COMMENT: SubjectSpec("comment", [("comment_id",)]),
+    # TODO: AlertRule is a legacy model and should be migrated to Detector when we phase out the legacy payload
+    SentryAppResourceType.METRIC_ALERT: SubjectSpec(
+        "alert_rule", [("metric_alert", "alert_rule", "id")]
+    ),
+    SentryAppResourceType.INSTALLATION: SubjectSpec("installation", [("installation", "uuid")]),
+    SentryAppResourceType.SEER: SubjectSpec("autofix_run", [("run_id",), ("sentry_run_id",)]),
+    SentryAppResourceType.PREPROD_ARTIFACT: SubjectSpec("preprod_artifact", [("buildId",)]),
+}
+
+# Overrides for event types in case an event (seer.X) needs a diff. subject
+_SUBJECT_BY_EVENT_TYPE: Mapping[str, SubjectSpec] = {}
+
+
+def extract_webhook_subject(
+    resource: SentryAppResourceType, event_type: str, data: Mapping[str, Any]
+) -> tuple[str | None, str | None]:
+    """
+    Given the resource and event type, extract the subject id and type from the webhook payload(data).
+    Attempts to resolve the event type override first, then the resource default.
+    """
+    spec = _SUBJECT_BY_EVENT_TYPE.get(event_type) or _SUBJECT_BY_RESOURCE.get(resource)
+    if spec is None:
+        return None, None
+    return spec.resolve(data)

--- a/src/sentry/utils/sentry_apps/request_buffer.py
+++ b/src/sentry/utils/sentry_apps/request_buffer.py
@@ -168,7 +168,7 @@ class SentryAppWebhookRequestsBuffer:
         subject_type: str | None = None,
         duration_ms: int | None = None,
     ) -> None:
-        from sentry.utils.sentry_apps.webhooks import TIMEOUT_STATUS_CODE
+        from sentry.utils.sentry_apps.webhooks import NO_RESPONSE_STATUS_CODES
 
         if event not in EXTENDED_VALID_EVENTS:
             logger.warning("Event %s is not a valid event that can be stored.", event)
@@ -191,7 +191,7 @@ class SentryAppWebhookRequestsBuffer:
         if duration_ms is not None:
             request_data["duration_ms"] = duration_ms
         MAX_SIZE = 1024
-        if response_code >= 400 or response_code == TIMEOUT_STATUS_CODE:
+        if response_code >= 400 or response_code in NO_RESPONSE_STATUS_CODES:
             if headers:
                 request_data["request_headers"] = headers
 
@@ -217,7 +217,7 @@ class SentryAppWebhookRequestsBuffer:
         self._add_to_buffer_pipeline(request_key, request_data, pipe)
 
         # If it's an error add it to the error buffer
-        if 400 <= response_code <= 599 or response_code == TIMEOUT_STATUS_CODE:
+        if 400 <= response_code <= 599 or response_code in NO_RESPONSE_STATUS_CODES:
             error_key = self._get_redis_key(event, error=True)
             self._add_to_buffer_pipeline(error_key, request_data, pipe)
 

--- a/src/sentry/utils/sentry_apps/request_buffer.py
+++ b/src/sentry/utils/sentry_apps/request_buffer.py
@@ -41,15 +41,19 @@ EXTENDED_VALID_EVENTS = VALID_EVENTS + (
 
 class SentryAppRequest(TypedDict):
     date: str
-    response_code: int
-    webhook_url: str
-    organization_id: int
-    event_type: str
-    error_id: NotRequired[str | None]
-    project_id: NotRequired[int | None]
-    request_body: NotRequired[str | None]
-    request_headers: NotRequired[Mapping[str, str] | None]
-    response_body: NotRequired[str | None]
+    response_code: int  # HTTP response code from the received response
+    webhook_url: str  # URL of the webhook destination
+    organization_id: int  # ID of the organization that triggered the webhook
+    event_type: str  # Type of event that triggered the webhook (e.g. issue.assigned, issue.unassigned, etc.)
+    error_id: NotRequired[str | None]  # ID for the error (if applicable)
+    project_id: NotRequired[int | None]  # ID for the project (if applicable)
+    request_body: NotRequired[str | None]  # Request body from the webhook (potentially truncated)
+    request_headers: NotRequired[Mapping[str, str] | None]  # Headers sent with the webhook
+    response_body: NotRequired[str | None]  # Response body from the webhook (potentially truncated)
+    request_id: NotRequired[str | None]  # Maps to requestId header on webhook
+    subject_id: NotRequired[str | None]  # ID for the resource denoted in subjectType
+    subject_type: NotRequired[str | None]  # Resource type (e.g. Group, Event, Seer Run)
+    duration_ms: NotRequired[int | None]  # Time taken to send the request
 
 
 def _decode_body(body: str | bytes) -> str:
@@ -159,6 +163,10 @@ class SentryAppWebhookRequestsBuffer:
         project_id: int | None = None,
         response: Response | None = None,
         headers: Mapping[str, str] | None = None,
+        request_id: str | None = None,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+        duration_ms: int | None = None,
     ) -> None:
         from sentry.utils.sentry_apps.webhooks import TIMEOUT_STATUS_CODE
 
@@ -174,6 +182,14 @@ class SentryAppWebhookRequestsBuffer:
             "response_code": response_code,
             "webhook_url": url,
         }
+
+        if request_id is not None:
+            request_data["request_id"] = request_id
+        if subject_id is not None and subject_type is not None:
+            request_data["subject_id"] = subject_id
+            request_data["subject_type"] = subject_type
+        if duration_ms is not None:
+            request_data["duration_ms"] = duration_ms
         MAX_SIZE = 1024
         if response_code >= 400 or response_code == TIMEOUT_STATUS_CODE:
             if headers:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import re
 from collections.abc import Callable, Generator, Mapping
+from datetime import timedelta
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
 from urllib.parse import urlparse
@@ -57,6 +58,8 @@ if TYPE_CHECKING:
 
 
 TIMEOUT_STATUS_CODE = 0
+CONNECTION_ERROR_STATUS_CODE = -1
+NO_RESPONSE_STATUS_CODES = frozenset({TIMEOUT_STATUS_CODE, CONNECTION_ERROR_STATUS_CODE})
 
 CLAUDE_ROUTINE_URL_RE = re.compile(
     r"https://api\.anthropic\.com/v1/claude_code/routines/[^/?#]+/fire/?"
@@ -358,18 +361,7 @@ def send_and_save_webhook_request(
                 halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.HARD_TIMEOUT}"
             )
             raise
-        except (Timeout, ConnectionError) as e:
-            error_type = e.__class__.__name__.lower()
-            lifecycle.add_extras(
-                {
-                    "reason": "send_and_save_webhook_request.timeout",
-                    "error_type": error_type,
-                    "organization_id": org_id,
-                    "integration_slug": sentry_app.slug,
-                    "url": url,
-                },
-            )
-            track_response_code(error_type, slug, event)
+        except Timeout as e:
             buffer.add_request(
                 response_code=TIMEOUT_STATUS_CODE,
                 org_id=org_id,
@@ -383,6 +375,20 @@ def send_and_save_webhook_request(
             )
             lifecycle.record_halt(e)
             # Re-raise the exception because some of these tasks might retry on the exception
+            raise
+        except ConnectionError as e:
+            buffer.add_request(
+                response_code=CONNECTION_ERROR_STATUS_CODE,
+                org_id=org_id,
+                event=event,
+                url=url,
+                headers=app_platform_event.loggable_headers,
+                request_id=request_id,
+                subject_id=subject_id,
+                subject_type=subject_type,
+                duration_ms=None,
+            )
+            lifecycle.record_halt(e)
             raise
         except ChunkedEncodingError:
             lifecycle.record_halt(
@@ -407,6 +413,10 @@ def send_and_save_webhook_request(
             if (p_id := response.headers.get("Sentry-Hook-Project")) and p_id.isdigit()
             else None
         )
+        elapsed = getattr(response, "elapsed", None)
+        duration_ms = (
+            int(elapsed.total_seconds() * 1000) if isinstance(elapsed, timedelta) else None
+        )
         buffer.add_request(
             response_code=response.status_code,
             org_id=org_id,
@@ -419,7 +429,7 @@ def send_and_save_webhook_request(
             request_id=request_id,
             subject_id=subject_id,
             subject_type=subject_type,
-            duration_ms=int(response.elapsed.total_seconds() * 1000),
+            duration_ms=duration_ms,
         )
 
         debug_logging_enabled = (

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -322,7 +322,6 @@ def send_and_save_webhook_request(
 
         assert url is not None
 
-        request_id = app_platform_event.sentry_headers["Request-ID"]
         subject_id, subject_type = extract_webhook_subject(
             app_platform_event.resource, event, app_platform_event.data
         )
@@ -344,6 +343,10 @@ def send_and_save_webhook_request(
             if not _circuit_breaker_allows_request(circuit_breaker, sentry_app, lifecycle):
                 return Response()
 
+            # Read the Request-ID only after include_text_summary is set above.
+            # sentry_headers is a cached_property that signs the body on first access,
+            # so an earlier read would sign the pre-summary body.
+            request_id = app_platform_event.sentry_headers["Request-ID"]
             with circuit_breaker_tracking(circuit_breaker):
                 response = _send_webhook_request(url, app_platform_event)
 

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -39,6 +39,7 @@ from sentry.sentry_apps.metrics import (
 from sentry.sentry_apps.models.sentry_app import SentryApp, track_response_code
 from sentry.sentry_apps.services.app.service import app_service
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
+from sentry.sentry_apps.utils.webhook_subjects import extract_webhook_subject
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
 from sentry.taskworker.timeout import InnerTimeoutError, timeout_alarm
@@ -249,6 +250,16 @@ def _webhook_timeout(
             yield timeout_override
 
 
+def _get_webhook_timeout(org_id: int) -> float:
+    timeout_seconds = options.get("sentry-apps.webhook.timeout.sec")
+    overrides = options.get("sentry-apps.override.organization_ids.webhook.timeouts.sec").get(
+        str(org_id)
+    )
+    if overrides:
+        return overrides.get("webhook_timeout_override", timeout_seconds)
+    return timeout_seconds
+
+
 def _send_webhook_request(
     url: str,
     app_platform_event: AppPlatformEvent[T],
@@ -307,6 +318,12 @@ def send_and_save_webhook_request(
         )
 
         assert url is not None
+
+        request_id = app_platform_event.sentry_headers["Request-ID"]
+        subject_id, subject_type = extract_webhook_subject(
+            app_platform_event.resource, event, app_platform_event.data
+        )
+
         try:
             owner_context = organization_service.get_organization_by_id(
                 id=sentry_app.owner_id,
@@ -359,6 +376,10 @@ def send_and_save_webhook_request(
                 event=event,
                 url=url,
                 headers=app_platform_event.loggable_headers,
+                request_id=request_id,
+                subject_id=subject_id,
+                subject_type=subject_type,
+                duration_ms=int(_get_webhook_timeout(org_id) * 1000),
             )
             lifecycle.record_halt(e)
             # Re-raise the exception because some of these tasks might retry on the exception
@@ -395,6 +416,10 @@ def send_and_save_webhook_request(
             project_id=project_id,
             response=response,
             headers=app_platform_event.loggable_headers,
+            request_id=request_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+            duration_ms=int(response.elapsed.total_seconds() * 1000),
         )
 
         debug_logging_enabled = (

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_webhook_requests.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_webhook_requests.py
@@ -243,6 +243,10 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
             "sentryAppSlug": self.published_app.slug,
             "eventType": "issue.assigned",
             "responseCode": 500,
+            "requestId": None,
+            "subjectId": None,
+            "subjectType": None,
+            "durationMs": None,
             "project_id": 1,
             "date": str(now) + "+00:00",
             "error_id": "abc123",
@@ -255,6 +259,52 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert len(response.data) == 2
+
+    def test_request_id_subject_and_duration_on_success_and_error_rows(self) -> None:
+        """request_id, subject, and duration are surfaced on both success and error rows."""
+        self.login_as(user=self.user)
+        buffer = SentryAppWebhookRequestsBuffer(self.published_app)
+        now = datetime.now() - timedelta(hours=1)
+        with freeze_time(now):
+            buffer.add_request(
+                response_code=200,
+                org_id=self.org.id,
+                event="issue.assigned",
+                url=self.published_app.webhook_url,
+                request_id="req-success",
+                subject_id="123",
+                subject_type="group",
+                duration_ms=137,
+            )
+        with freeze_time(now + timedelta(seconds=1)):
+            buffer.add_request(
+                response_code=500,
+                org_id=self.org.id,
+                event="issue.assigned",
+                url=self.published_app.webhook_url,
+                request_id="req-error",
+                subject_id="456",
+                subject_type="group",
+                duration_ms=8000,
+            )
+
+        url = reverse("sentry-api-0-sentry-app-webhook-requests", args=[self.published_app.slug])
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+        # Buffer returns newest first.
+        error_row, success_row = response.data[0], response.data[1]
+        assert error_row["responseCode"] == 500
+        assert error_row["requestId"] == "req-error"
+        assert error_row["subjectId"] == "456"
+        assert error_row["subjectType"] == "group"
+        assert error_row["durationMs"] == 8000
+        assert success_row["responseCode"] == 200
+        assert success_row["requestId"] == "req-success"
+        assert success_row["subjectId"] == "123"
+        assert success_row["subjectType"] == "group"
+        assert success_row["durationMs"] == 137
 
     def test_linked_error_not_returned_if_project_does_not_exist(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_webhook_requests.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_webhook_requests.py
@@ -261,7 +261,6 @@ class SentryAppWebhookRequestsGetTest(APITestCase):
         assert len(response.data) == 2
 
     def test_request_id_subject_and_duration_on_success_and_error_rows(self) -> None:
-        """request_id, subject, and duration are surfaced on both success and error rows."""
         self.login_as(user=self.user)
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
         now = datetime.now() - timedelta(hours=1)

--- a/tests/sentry/sentry_apps/utils/test_webhook_subjects.py
+++ b/tests/sentry/sentry_apps/utils/test_webhook_subjects.py
@@ -1,0 +1,318 @@
+from unittest import mock
+
+from sentry.sentry_apps.event_types import SentryAppEventType
+from sentry.sentry_apps.utils import webhook_subjects
+from sentry.sentry_apps.utils.webhook_subjects import SubjectSpec, extract_webhook_subject
+from sentry.sentry_apps.utils.webhooks import SentryAppResourceType
+from sentry.utils import json
+
+# sentry_apps.py `_process_resource_change` -> `_webhook_event_data` (Event.as_dict()).
+ERROR_CREATED_PAYLOAD = {
+    "error": {
+        "event_id": "9b3d8a3b2a5f4b1c8e6d0a1f2c3b4a5e",
+        "project": 42,
+        "release": "backend@1.0.0",
+        "platform": "python",
+        "datetime": "2023-08-27T18:24:00.123456+00:00",
+        "tags": [["level", "error"], ["environment", "production"]],
+        "environment": "production",
+        "level": "error",
+        "culprit": "sentry.tasks.foo.run",
+        "title": "ValueError: bad value",
+        "web_url": (
+            "https://sentry.io/organizations/my-org/issues/123456/events/"
+            "9b3d8a3b2a5f4b1c8e6d0a1f2c3b4a5e/"
+        ),
+        "issue_id": "123456",
+    }
+}
+
+# sentry_apps.py `send_alert_webhook_v2` (event context + triggered rule).
+EVENT_ALERT_TRIGGERED_PAYLOAD = {
+    "event": {
+        "event_id": "abc1230000000000000000000000abcd",
+        "project": 42,
+        "release": None,
+        "platform": "python",
+        "datetime": "2023-08-27T18:24:00+00:00",
+        "tags": [["level", "error"]],
+        "title": "ValueError: bad value",
+        "issue_id": "123456",
+    },
+    "triggered_rule": "My alert rule",
+    "issue_alert": {
+        "id": 7,
+        "title": "My alert rule",
+        "sentry_app_id": 5,
+        "settings": [{"name": "channel", "value": "#alerts"}],
+    },
+}
+
+# sentry_apps.py `_webhook_issue_data` (urls prepended to a serialized Group).
+ISSUE_CREATED_PAYLOAD = {
+    "issue": {
+        "url": "https://sentry.io/api/0/organizations/my-org/issues/123456/",
+        "web_url": "https://sentry.io/organizations/my-org/issues/123456/",
+        "project_url": "https://sentry.io/organizations/my-org/projects/my-proj/",
+        "id": "123456",
+        "shortId": "MY-PROJ-1",
+        "title": "ValueError: bad value",
+        "culprit": "sentry.tasks.foo.run",
+        "level": "error",
+        "status": "unresolved",
+        "isPublic": False,
+        "platform": "python",
+        "project": {"id": "42", "name": "my-proj", "slug": "my-proj"},
+        "type": "error",
+        "metadata": {"type": "ValueError", "value": "bad value"},
+        "count": "5",
+        "userCount": 2,
+        "firstSeen": "2023-08-27T18:00:00Z",
+        "lastSeen": "2023-08-27T18:24:00Z",
+    }
+}
+
+# sentry_apps.py `build_comment_webhook` (Activity id is top-level comment_id).
+COMMENT_CREATED_PAYLOAD = {
+    "comment_id": 3405,
+    "issue_id": 123456,
+    "project_slug": "my-proj",
+    "timestamp": "2023-08-27T18:24:00.000000+00:00",
+    "comment": "hello world",
+}
+
+# notify_event_service.py `build_incident_attachment` (snake_cased Incident).
+METRIC_ALERT_CRITICAL_PAYLOAD = {
+    "metric_alert": {
+        "id": "1",
+        "identifier": "1",
+        "organization_id": "12345",
+        "projects": ["my-proj"],
+        "alert_rule": {
+            "id": "7",
+            "name": "My Metric Alert",
+            "organization_id": "12345",
+            "status": 0,
+            "aggregate": "count()",
+            "time_window": 60,
+            "threshold_type": 0,
+            "triggers": [{"id": "1", "label": "critical", "alert_threshold": 100.0}],
+            "date_created": "2023-08-27T17:00:00Z",
+            "detection_type": "static",
+        },
+        "status": 20,
+        "status_method": 3,
+        "type": 2,
+        "title": "My Metric Alert",
+        "date_started": "2023-08-27T18:24:00Z",
+        "date_closed": None,
+    },
+    "description_text": "100 events in the last 10 minutes",
+    "description_title": "Critical: My Metric Alert",
+    "web_url": "https://sentry.io/organizations/my-org/alerts/rules/details/7/",
+}
+
+# activity_registry/sentry_app.py `ActivityAlertWebhookPayload` (issue + activity + alert).
+ACTIVITY_ALERT_TRIGGERED_PAYLOAD = {
+    "issue": {
+        "url": "https://sentry.io/api/0/organizations/my-org/issues/123456/",
+        "web_url": "https://sentry.io/organizations/my-org/issues/123456/",
+        "id": "123456",
+        "shortId": "MY-PROJ-1",
+        "title": "ValueError: bad value",
+        "level": "error",
+        "status": "unresolved",
+        "project": {"id": "42", "slug": "my-proj"},
+        "metadata": {"type": "ValueError", "value": "bad value"},
+    },
+    "activity": {
+        "type": "seer_root_cause_completed",
+        "details": {"summary": "The crash is caused by a null pointer in foo()."},
+    },
+    "alert": {
+        "id": 88,
+        "title": "My Workflow",
+        "sentry_app_id": 5,
+        "web_url": "https://sentry.io/organizations/my-org/monitors/alerts/88/",
+    },
+}
+
+# installations.py `SentryAppInstallationNotifier` (serialized SentryAppInstallation).
+INSTALLATION_CREATED_PAYLOAD = {
+    "installation": {
+        "app": {"uuid": "a1b2c3d4-1111-4aaa-8bbb-222233334444", "slug": "my-app", "sentryAppId": 5},
+        "organization": {"slug": "my-org", "id": 12345},
+        "uuid": "e5f6a7b8-1234-4cde-9012-3456789abcde",
+        "status": "installed",
+        "code": "f0e1d2c3b4a5968778695a4b3c2d1e0f9a8b7c6d",
+    }
+}
+
+# autofix_agent.py `_handle_step_started_events` (run_id + sentry_run_id + group_id).
+SEER_ROOT_CAUSE_STARTED_PAYLOAD = {
+    "run_id": 90123,
+    "sentry_run_id": "d1e2f3a4-5678-4b9c-8d0e-1f2a3b4c5d6e",
+    "group_id": 123456,
+}
+
+# size_analysis.py `build_size_analysis_summary` (buildId + app/git info + sizes).
+PREPROD_SIZE_ANALYSIS_COMPLETED_PAYLOAD = {
+    "buildId": "456",
+    "organizationSlug": "my-org",
+    "projectSlug": "my-proj",
+    "platform": "IOS",
+    "state": "COMPLETED",
+    "appInfo": {
+        "appId": "com.example.app",
+        "name": "My App",
+        "version": "2.4.1",
+        "buildNumber": 42,
+        "artifactType": "XCARCHIVE",
+    },
+    "gitInfo": {
+        "headSha": "abc123",
+        "baseSha": "def456",
+        "provider": "github",
+        "headRepoName": "my-org/my-repo",
+        "headRef": "feature/x",
+        "prNumber": 123,
+    },
+    "downloadSize": 28311552,
+    "installSize": 41943040,
+    "analysisDuration": 1.5,
+}
+
+_REALISTIC_PAYLOADS = [
+    ERROR_CREATED_PAYLOAD,
+    EVENT_ALERT_TRIGGERED_PAYLOAD,
+    ISSUE_CREATED_PAYLOAD,
+    COMMENT_CREATED_PAYLOAD,
+    METRIC_ALERT_CRITICAL_PAYLOAD,
+    ACTIVITY_ALERT_TRIGGERED_PAYLOAD,
+    INSTALLATION_CREATED_PAYLOAD,
+    SEER_ROOT_CAUSE_STARTED_PAYLOAD,
+    PREPROD_SIZE_ANALYSIS_COMPLETED_PAYLOAD,
+]
+
+
+def test_extracts_subject_per_event_type() -> None:
+    assert extract_webhook_subject(
+        SentryAppResourceType.ERROR, SentryAppEventType.ERROR_CREATED, ERROR_CREATED_PAYLOAD
+    ) == ("9b3d8a3b2a5f4b1c8e6d0a1f2c3b4a5e", "event")
+    assert extract_webhook_subject(
+        SentryAppResourceType.EVENT_ALERT,
+        SentryAppEventType.EVENT_ALERT_TRIGGERED,
+        EVENT_ALERT_TRIGGERED_PAYLOAD,
+    ) == ("abc1230000000000000000000000abcd", "event")
+    assert extract_webhook_subject(
+        SentryAppResourceType.ISSUE, SentryAppEventType.ISSUE_CREATED, ISSUE_CREATED_PAYLOAD
+    ) == ("123456", "group")
+    # activity_alert payloads carry the triggering issue too.
+    assert extract_webhook_subject(
+        SentryAppResourceType.ACTIVITY_ALERT,
+        SentryAppEventType.ACTIVITY_ALERT_TRIGGERED,
+        ACTIVITY_ALERT_TRIGGERED_PAYLOAD,
+    ) == ("123456", "group")
+    assert extract_webhook_subject(
+        SentryAppResourceType.COMMENT, SentryAppEventType.COMMENT_CREATED, COMMENT_CREATED_PAYLOAD
+    ) == ("3405", "comment")
+    # Keyed on the alert rule (still the source of truth), not the transient incident id.
+    assert extract_webhook_subject(
+        SentryAppResourceType.METRIC_ALERT,
+        SentryAppEventType.METRIC_ALERT_CRITICAL,
+        METRIC_ALERT_CRITICAL_PAYLOAD,
+    ) == ("7", "alert_rule")
+    assert extract_webhook_subject(
+        SentryAppResourceType.INSTALLATION,
+        SentryAppEventType.INSTALLATION_CREATED,
+        INSTALLATION_CREATED_PAYLOAD,
+    ) == ("e5f6a7b8-1234-4cde-9012-3456789abcde", "installation")
+    assert extract_webhook_subject(
+        SentryAppResourceType.SEER,
+        SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
+        SEER_ROOT_CAUSE_STARTED_PAYLOAD,
+    ) == ("90123", "autofix_run")
+    assert extract_webhook_subject(
+        SentryAppResourceType.PREPROD_ARTIFACT,
+        SentryAppEventType.PREPROD_ARTIFACT_SIZE_ANALYSIS_COMPLETED,
+        PREPROD_SIZE_ANALYSIS_COMPLETED_PAYLOAD,
+    ) == ("456", "preprod_artifact")
+
+
+def test_realistic_payload_fixtures_stay_within_buffer_limit() -> None:
+    # Fixtures must mirror real webhook bodies but stay within the request
+    # buffer's 1024-char cap (SentryAppWebhookRequestsBuffer.MAX_SIZE).
+    for payload in _REALISTIC_PAYLOADS:
+        assert len(json.dumps(payload)) <= 1024
+
+
+def test_seer_falls_back_to_sentry_run_id() -> None:
+    # Defensive fallback: if run_id is absent, sentry_run_id is used.
+    assert extract_webhook_subject(
+        SentryAppResourceType.SEER,
+        SentryAppEventType.SEER_CODING_COMPLETED,
+        {
+            "run_id": None,
+            "sentry_run_id": "d1e2f3a4-5678-4b9c-8d0e-1f2a3b4c5d6e",
+            "group_id": 123456,
+        },
+    ) == ("d1e2f3a4-5678-4b9c-8d0e-1f2a3b4c5d6e", "autofix_run")
+
+
+def test_seer_run_id_zero_is_not_treated_as_missing() -> None:
+    assert extract_webhook_subject(
+        SentryAppResourceType.SEER,
+        SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
+        {"run_id": 0},
+    ) == ("0", "autofix_run")
+
+
+def test_returns_null_when_no_stable_id() -> None:
+    # comment with no note id (payload built with .get()).
+    assert extract_webhook_subject(
+        SentryAppResourceType.COMMENT,
+        SentryAppEventType.COMMENT_CREATED,
+        {"comment_id": None, "issue_id": 123456, "project_slug": "my-proj"},
+    ) == (None, None)
+    # external Seer RPC payload (Seer-service-defined) without a run_id.
+    assert extract_webhook_subject(
+        SentryAppResourceType.SEER,
+        SentryAppEventType.SEER_CODING_COMPLETED,
+        {"group_id": 123456},
+    ) == (None, None)
+    # caller-defined activity_alert payload lacking an issue.
+    assert extract_webhook_subject(
+        SentryAppResourceType.ACTIVITY_ALERT,
+        SentryAppEventType.ACTIVITY_ALERT_TRIGGERED,
+        {"activity": {"type": "status_resolved", "details": {}}, "alert": {"id": 88}},
+    ) == (None, None)
+
+
+def test_malformed_payload_does_not_raise() -> None:
+    assert extract_webhook_subject(
+        SentryAppResourceType.ERROR,
+        SentryAppEventType.ERROR_CREATED,
+        {"error": "nope"},
+    ) == (None, None)
+    assert extract_webhook_subject(
+        SentryAppResourceType.ISSUE,
+        SentryAppEventType.ISSUE_CREATED,
+        {},
+    ) == (None, None)
+
+
+def test_event_type_override_takes_precedence_over_resource() -> None:
+    override = {SentryAppEventType.ISSUE_ASSIGNED: SubjectSpec("custom", [("custom_id",)])}
+    with mock.patch.dict(webhook_subjects._SUBJECT_BY_EVENT_TYPE, override):
+        # issue.assigned matches the override...
+        assert extract_webhook_subject(
+            SentryAppResourceType.ISSUE,
+            SentryAppEventType.ISSUE_ASSIGNED,
+            {"custom_id": "x", "issue": {"id": "1"}},
+        ) == ("x", "custom")
+        # ...while other issue.* actions still use the resource default.
+        assert extract_webhook_subject(
+            SentryAppResourceType.ISSUE,
+            SentryAppEventType.ISSUE_CREATED,
+            {"issue": {"id": "1"}},
+        ) == ("1", "group")

--- a/tests/sentry/sentry_apps/utils/test_webhook_subjects.py
+++ b/tests/sentry/sentry_apps/utils/test_webhook_subjects.py
@@ -4,7 +4,6 @@ from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.utils import webhook_subjects
 from sentry.sentry_apps.utils.webhook_subjects import SubjectSpec, extract_webhook_subject
 from sentry.sentry_apps.utils.webhooks import SentryAppResourceType
-from sentry.utils import json
 
 # sentry_apps.py `_process_resource_change` -> `_webhook_event_data` (Event.as_dict()).
 ERROR_CREATED_PAYLOAD = {
@@ -239,13 +238,6 @@ def test_extracts_subject_per_event_type() -> None:
     ) == ("456", "preprod_artifact")
 
 
-def test_realistic_payload_fixtures_stay_within_buffer_limit() -> None:
-    # Fixtures must mirror real webhook bodies but stay within the request
-    # buffer's 1024-char cap (SentryAppWebhookRequestsBuffer.MAX_SIZE).
-    for payload in _REALISTIC_PAYLOADS:
-        assert len(json.dumps(payload)) <= 1024
-
-
 def test_seer_falls_back_to_sentry_run_id() -> None:
     # Defensive fallback: if run_id is absent, sentry_run_id is used.
     assert extract_webhook_subject(
@@ -257,14 +249,6 @@ def test_seer_falls_back_to_sentry_run_id() -> None:
             "group_id": 123456,
         },
     ) == ("d1e2f3a4-5678-4b9c-8d0e-1f2a3b4c5d6e", "autofix_run")
-
-
-def test_seer_run_id_zero_is_not_treated_as_missing() -> None:
-    assert extract_webhook_subject(
-        SentryAppResourceType.SEER,
-        SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
-        {"run_id": 0},
-    ) == ("0", "autofix_run")
 
 
 def test_returns_null_when_no_stable_id() -> None:

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import orjson
@@ -10,7 +11,11 @@ from requests.exceptions import Timeout
 from sentry.notifications.platform.service import NotificationService
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.models.sentry_app import MASKED_VALUE
-from sentry.sentry_apps.utils.webhooks import IssueActionType, SentryAppResourceType
+from sentry.sentry_apps.utils.webhooks import (
+    CommentActionType,
+    IssueActionType,
+    SentryAppResourceType,
+)
 from sentry.shared_integrations.exceptions import ApiHostError, ClientError
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
@@ -460,3 +465,105 @@ class ClaudeRoutineTextSummaryTest(TestCase):
         body = self._send(mock_safe_urlopen, "https://example.com/webhook")
 
         assert "text" not in body
+
+
+@cell_silo_test
+class WebhookRequestIdAndDurationTest(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization()
+        self.sentry_app = self.create_sentry_app(
+            name="IdApp",
+            organization=self.organization,
+            webhook_url="https://example.com/webhook",
+            published=True,
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization, slug=self.sentry_app.slug
+        )
+
+    def _issue_event(self):
+        return AppPlatformEvent(
+            resource=SentryAppResourceType.ISSUE,
+            action=IssueActionType.CREATED,
+            install=self.install,
+            data={"issue": {"id": "123"}},
+        )
+
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_success_row_stores_request_id_subject_and_duration(
+        self, MockBreaker, mock_safe_urlopen
+    ):
+        MockBreaker.return_value.should_allow_request.return_value = True
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.elapsed = timedelta(milliseconds=137)
+        mock_safe_urlopen.return_value = mock_response
+
+        event = self._issue_event()
+        send_and_save_webhook_request(self.sentry_app, event)
+
+        # request_id is persisted on a SUCCESS row and equals the Request-ID sent.
+        sent_request_id = mock_safe_urlopen.call_args.kwargs["headers"]["Request-ID"]
+        requests = SentryAppWebhookRequestsBuffer(self.sentry_app).get_requests()
+        assert len(requests) == 1
+        row = requests[0]
+        assert row["request_id"] == sent_request_id
+        assert row["request_id"] == event.sentry_headers["Request-ID"]
+        assert row["subject_id"] == "123"
+        assert row["subject_type"] == "group"
+        assert row["duration_ms"] == 137
+
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_timeout_row_stores_configured_timeout_as_duration(
+        self, MockBreaker, mock_safe_urlopen
+    ):
+        MockBreaker.return_value.should_allow_request.return_value = True
+        mock_safe_urlopen.side_effect = Timeout()
+
+        event = self._issue_event()
+        with pytest.raises(Timeout):
+            send_and_save_webhook_request(self.sentry_app, event)
+
+        requests = SentryAppWebhookRequestsBuffer(self.sentry_app).get_requests(errors_only=True)
+        assert len(requests) == 1
+        row = requests[0]
+        # CIRCUIT_BREAKER_OPTIONS sets the webhook timeout to 1.0s -> 1000ms.
+        assert row["duration_ms"] == 1000
+        assert row["request_id"] == event.sentry_headers["Request-ID"]
+        assert row["subject_id"] == "123"
+        assert row["subject_type"] == "group"
+
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_row_without_subject_stores_request_id_and_duration_only(
+        self, MockBreaker, mock_safe_urlopen
+    ):
+        MockBreaker.return_value.should_allow_request.return_value = True
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.elapsed = timedelta(milliseconds=10)
+        mock_safe_urlopen.return_value = mock_response
+
+        # A comment payload with no note id yields no stable subject.
+        event = AppPlatformEvent(
+            resource=SentryAppResourceType.COMMENT,
+            action=CommentActionType.CREATED,
+            install=self.install,
+            data={"comment_id": None},
+        )
+        send_and_save_webhook_request(self.sentry_app, event)
+
+        requests = SentryAppWebhookRequestsBuffer(self.sentry_app).get_requests()
+        assert len(requests) == 1
+        row = requests[0]
+        assert row.get("subject_id") is None
+        assert row.get("subject_type") is None
+        assert row["request_id"] == event.sentry_headers["Request-ID"]
+        assert row["duration_ms"] == 10

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -6,7 +6,7 @@ import orjson
 import pytest
 from django.conf import settings
 from requests import Response
-from requests.exceptions import Timeout
+from requests.exceptions import ConnectionError, Timeout
 
 from sentry.notifications.platform.service import NotificationService
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
@@ -25,7 +25,12 @@ from sentry.testutils.silo import cell_silo_test
 from sentry.utils import redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
-from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save_webhook_request
+from sentry.utils.sentry_apps.webhooks import (
+    CONNECTION_ERROR_STATUS_CODE,
+    TIMEOUT_STATUS_CODE,
+    WebhookTimeoutError,
+    send_and_save_webhook_request,
+)
 
 
 def _raise_status_false() -> bool:
@@ -532,8 +537,30 @@ class WebhookRequestIdAndDurationTest(TestCase):
         requests = SentryAppWebhookRequestsBuffer(self.sentry_app).get_requests(errors_only=True)
         assert len(requests) == 1
         row = requests[0]
+        assert row["response_code"] == TIMEOUT_STATUS_CODE
         # CIRCUIT_BREAKER_OPTIONS sets the webhook timeout to 1.0s -> 1000ms.
         assert row["duration_ms"] == 1000
+        assert row["request_id"] == event.sentry_headers["Request-ID"]
+        assert row["subject_id"] == "123"
+        assert row["subject_type"] == "group"
+
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_connection_error_row_stores_no_duration(self, MockBreaker, mock_safe_urlopen):
+        MockBreaker.return_value.should_allow_request.return_value = True
+        mock_safe_urlopen.side_effect = ConnectionError()
+
+        event = self._issue_event()
+        with pytest.raises(ConnectionError):
+            send_and_save_webhook_request(self.sentry_app, event)
+
+        requests = SentryAppWebhookRequestsBuffer(self.sentry_app).get_requests(errors_only=True)
+        assert len(requests) == 1
+        row = requests[0]
+        # Its own code, distinct from a timeout, and no meaningful response time.
+        assert row["response_code"] == CONNECTION_ERROR_STATUS_CODE
+        assert row.get("duration_ms") is None
         assert row["request_id"] == event.sentry_headers["Request-ID"]
         assert row["subject_id"] == "123"
         assert row["subject_type"] == "group"

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -471,6 +471,44 @@ class ClaudeRoutineTextSummaryTest(TestCase):
 
         assert "text" not in body
 
+    @with_feature("organizations:sentry-apps-claude-routine-webhooks")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    def test_routine_signature_matches_sent_body(self, mock_safe_urlopen):
+        """The signature must verify against the text-summary body we actually send.
+
+        Regression: reading the Request-ID before include_text_summary was set
+        cached sentry_headers' signature over the pre-summary body.
+        """
+        sentry_app = self.create_sentry_app(
+            name="RoutineSigApp",
+            organization=self.organization,
+            webhook_url=self.ROUTINE_URL,
+            published=True,
+        )
+        install = self.create_sentry_app_installation(
+            organization=self.organization, slug=sentry_app.slug
+        )
+        event = AppPlatformEvent(
+            resource=SentryAppResourceType.ISSUE,
+            action=IssueActionType.CREATED,
+            install=install,
+            data={"issue": {"id": "123"}},
+        )
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_safe_urlopen.return_value = mock_response
+
+        send_and_save_webhook_request(sentry_app, event)
+
+        sent_body = mock_safe_urlopen.call_args.kwargs["data"]
+        sent_headers = mock_safe_urlopen.call_args.kwargs["headers"]
+        # The text summary is part of the signed body...
+        assert "text" in orjson.loads(sent_body)
+        # ...and the signature verifies against that exact body.
+        assert sent_headers["Sentry-Hook-Signature"] == sentry_app.build_signature(sent_body)
+
 
 @cell_silo_test
 class WebhookRequestIdAndDurationTest(TestCase):


### PR DESCRIPTION
Adds 4 new fields to the request buffer
```
    request_id: NotRequired[str | None]  # Maps to requestId header on webhook
    subject_id: NotRequired[str | None]  # ID for the resource denoted in subjectType
    subject_type: NotRequired[str | None]  # Resource type (e.g. Group, Event, Seer Run)
    duration_ms: NotRequired[int | None]  # Time taken to send the request
```

For the subject/resource fields, there's a mapping we do that first checks if the specific event_type (issue.created, seer.autofix_run_started etc.) has a resource override else we have default resources(e.g Event, Group etc.) for each of the webhook resources. Currently the mapping from webhook resource -> subject is 1:1 but I think that makes sense for most cases since webhooks are generally some model being serialized.

This PR also breaks out ConnectionError to be its own handling (kinda), mainly jsut add a new fake status code so we can tell in the UI
