### PR TITLE
feat: Add cancel button when editing monitors

### DIFF
--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -2,7 +2,8 @@ import {useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import {Observer} from 'mobx-react-lite';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Separator} from '@sentry/scraps/separator';
 
 import {FormContext} from 'sentry/components/forms/formContext';
 import {FormModel} from 'sentry/components/forms/model';
@@ -14,6 +15,7 @@ import type {
   BaseDetectorUpdatePayload,
   Detector,
 } from 'sentry/types/workflowEngine/detectors';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   DeleteDetectorAction,
   DisableDetectorAction,
@@ -22,6 +24,8 @@ import {DetectorFormBreadcrumbs} from 'sentry/views/detectors/components/forms/c
 import {getSubmitButtonTitle} from 'sentry/views/detectors/components/forms/common/getSubmitButtonTitle';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
+import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
 type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
@@ -48,6 +52,7 @@ export function EditDetectorLayout<
   extraFooterButton,
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const theme = useTheme();
+  const organization = useOrganization();
   const maxWidth = theme.breakpoints.xl;
   const [formModel] = useState(() => new FormModel());
   const {onFieldChange} = useFormEagerValidation(formModel);
@@ -56,6 +61,15 @@ export function EditDetectorLayout<
     detector,
     formDataToEndpointPayload,
   });
+
+  // Without edit access, the disable and delete buttons are hidden,
+  // so we should not show the separator
+  const canEditDetector = useCanEditDetector({
+    detectorType: detector.type,
+    projectId: detector.projectId,
+  });
+
+  const shouldShowSeparator = canEditDetector || Boolean(extraFooterButton);
 
   const initialData = useMemo(() => {
     return savedDetectorToFormData(detector);
@@ -99,6 +113,14 @@ export function EditDetectorLayout<
             <DisableDetectorAction detector={detector} />
             <DeleteDetectorAction detector={detector} />
             {extraFooterButton}
+            {shouldShowSeparator && <Separator orientation="vertical" />}
+            <LinkButton
+              variant="secondary"
+              size="sm"
+              to={makeMonitorDetailsPathname(organization.slug, detector.id)}
+            >
+              {t('Cancel')}
+            </LinkButton>
             <Observer>
               {() => (
                 <Button

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -3,6 +3,7 @@ import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 import {z} from 'zod';
 
+import {LinkButton} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -23,6 +24,7 @@ import {AutomateSection} from 'sentry/views/detectors/components/forms/automateS
 import {useSubmitEditDetector} from 'sentry/views/detectors/hooks/useSubmitEditDetector';
 import {
   makeMonitorBasePathname,
+  makeMonitorDetailsPathname,
   makeMonitorTypePathname,
 } from 'sentry/views/detectors/pathnames';
 import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
@@ -181,6 +183,13 @@ export function EditExistingErrorDetectorForm({
         </EditLayout.Body>
 
         <EditLayout.Footer maxWidth={maxWidth}>
+          <LinkButton
+            variant="secondary"
+            size="sm"
+            to={makeMonitorDetailsPathname(organization.slug, detector.id)}
+          >
+            {t('Cancel')}
+          </LinkButton>
           <form.SubmitButton
             size="sm"
             disabled={!canEditWorkflowConnections}

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -189,11 +189,69 @@ describe('DetectorEdit', () => {
       // Verify the button text has changed to "Enable"
       expect(await screen.findByRole('button', {name: 'Enable'})).toBeInTheDocument();
     });
+
+    it('renders a Cancel link back to the monitor details page', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+        body: mockDetector,
+      });
+
+      render(<DetectorEdit />, {organization, initialRouterConfig});
+
+      await screen.findAllByText(mockDetector.name);
+
+      expect(await screen.findByRole('button', {name: 'Cancel'})).toHaveAttribute(
+        'href',
+        `/organizations/${organization.slug}/monitors/${mockDetector.id}/`
+      );
+      expect(screen.getByRole('separator')).toBeInTheDocument();
+    });
+
+    it('keeps Cancel available without alerts:write, hiding Disable and Delete', async () => {
+      const readOnlyOrganization = OrganizationFixture({
+        features: ['visibility-explore-view'],
+        access: ['org:read', 'project:read'],
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${readOnlyOrganization.slug}/detectors/${mockDetector.id}/`,
+        body: mockDetector,
+      });
+
+      render(<DetectorEdit />, {
+        organization: readOnlyOrganization,
+        initialRouterConfig,
+      });
+
+      await screen.findAllByText(mockDetector.name);
+
+      expect(await screen.findByRole('button', {name: 'Cancel'})).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Disable'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Delete'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+    });
   });
 
   describe('Error', () => {
     const name = 'Test Error Detector';
     const mockDetector = ErrorDetectorFixture({id: '1', name, projectId: project.id});
+
+    it('renders a Cancel link back to the monitor details page', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+        body: mockDetector,
+      });
+
+      render(<DetectorEdit />, {organization, initialRouterConfig});
+
+      await screen.findAllByText(name);
+
+      expect(await screen.findByRole('button', {name: 'Cancel'})).toHaveAttribute(
+        'href',
+        `/organizations/${organization.slug}/monitors/${mockDetector.id}/`
+      );
+      expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+    });
 
     it('allows editing the detector name/environment and saving changes', async () => {
       MockApiClient.addMockResponse({


### PR DESCRIPTION
Similar to adding it to the alert pages in #121010 

Error monitor: no seperator

<img width="267" height="126" alt="image" src="https://github.com/user-attachments/assets/e33bde14-ce33-44e0-92df-87d7c31d06e7" />


Other monitors: seperator

<img width="383" height="91" alt="image" src="https://github.com/user-attachments/assets/f8eb39f9-0c97-4101-b102-11cb591bb8f5" />


Uptime:

<img width="472" height="77" alt="image" src="https://github.com/user-attachments/assets/a7804be4-7aaf-44d6-81b1-46b6b0d91955" />


Fixes ID-1791