### PR TITLE
fix(integrations): Check the assignment result in inbound assignee sync

### DIFF
--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -88,6 +88,12 @@ def _handle_deassign(
     return groups_deassigned
 
 
+def _assignment_succeeded(assignment: dict[str, bool], group: Group, user: RpcUser) -> bool:
+    if assignment["new_assignment"] or assignment["updated_assignment"]:
+        return True
+    return GroupAssignee.objects.filter(group=group, user_id=user.id).exists()
+
+
 def _handle_assign(
     affected_groups: Iterable[Group],
     integration: RpcIntegration | Integration,
@@ -115,12 +121,22 @@ def _handle_assign(
                 },
             )
             with action_context_scope(source=integration.provider, actor=SYSTEM_ACTOR):
-                GroupAssignee.objects.assign(
+                assignment = GroupAssignee.objects.assign(
                     group,
                     user,
                     assignment_source=AssignmentSource.from_integration(integration),
                 )
-            groups_assigned.append(group)
+
+            if _assignment_succeeded(assignment, group, user):
+                groups_assigned.append(group)
+            else:
+                logger.warning(
+                    "sync_group_assignee_inbound._handle_assign.assignment_rejected",
+                    extra={
+                        "group_id": group.id,
+                        "user_id": user.id,
+                    },
+                )
         else:
             logger.info(
                 "sync_group_assignee_inbound._handle_assign.user_not_found",

--- a/tests/sentry/integrations/utils/test_sync.py
+++ b/tests/sentry/integrations/utils/test_sync.py
@@ -746,3 +746,85 @@ class TestSyncAssigneeInboundByExternalActor(TestCase):
 
         # group4 should remain unassigned
         assert group4.get_assignee() is None
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_assign_inactive_user_is_not_reported_as_assigned(
+        self, mock_record_halt: mock.MagicMock
+    ) -> None:
+        """A deactivated user is refused by assign(), so the group is not assigned."""
+        assert self.group.get_assignee() is None
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-123",
+            integration=self.example_integration,
+        )
+        self.create_external_user(
+            user=self.test_user,
+            external_name="johndoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        with assume_test_silo_mode_of(User):
+            User.objects.filter(id=self.test_user.id).update(is_active=False)
+
+        groups_assigned = sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="johndoe",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        assert list(groups_assigned) == []
+        assert self.group.get_assignee() is None
+        mock_record_halt.assert_called_with(
+            "inbound-assignee-not-found",
+            extra={
+                "integration_id": self.example_integration.id,
+                "external_user_name": "johndoe",
+                "external_user_id": None,
+                "issue_key": external_issue.key,
+                "method": AssigneeInboundSyncMethod.EXTERNAL_ACTOR.value,
+                "assign": True,
+                "affected_group_ids": [self.group.id],
+                "match_method": "external_name",
+                "external_actor_count": 1,
+                "matched_user_ids": [self.test_user.id],
+                "user_ids": [self.test_user.id],
+                "assigned_group_ids": [],
+                "groups_assigned_count": 0,
+                "affected_groups_count": 1,
+            },
+        )
+
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_assign_when_already_assigned_to_same_user_is_reported_as_assigned(
+        self, mock_record_halt: mock.MagicMock
+    ) -> None:
+        self.assign_default_group_to_user(self.test_user)
+
+        external_issue = self.create_integration_external_issue(
+            group=self.group,
+            key="JIRA-123",
+            integration=self.example_integration,
+        )
+        self.create_external_user(
+            user=self.test_user,
+            external_name="johndoe",
+            provider=ExternalProviders.GITHUB.value,
+            integration=self.example_integration,
+        )
+
+        groups_assigned = sync_group_assignee_inbound_by_external_actor(
+            integration=self.example_integration,
+            external_user_name="johndoe",
+            external_issue_key=external_issue.key,
+            assign=True,
+        )
+
+        assert [group.id for group in groups_assigned] == [self.group.id]
+        updated_assignee = self.group.get_assignee()
+        assert updated_assignee is not None
+        assert updated_assignee.id == self.test_user.id
+        mock_record_halt.assert_not_called()


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/ISWF-2665/integration-sync-assignment-logic-does-not-check-for-assignment.

`_handle_assign` called `GroupAssignee.objects.assign()` and discarded its return value, appending the group to `groups_assigned` unconditionally. `assign()` refuses to assign a deactivated user and returns early without writing anything, so inbound assignee sync reported success for assignments that never happened.

Additionally, when a group is already assigned to that same user, we should consider that state an assignment success.