### PR TITLE
docs(issues): Document the project issues `statsPeriod` default and accepted values

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -369,6 +369,19 @@ class IssueParams:
         type=OpenApiTypes.STR,
         required=False,
     )
+    PROJECT_GROUP_STATS_PERIOD = OpenApiParameter(
+        name="statsPeriod",
+        description=(
+            "The timeline on which stats for the groups should be presented. "
+            'Defaults to `"24h"`. Pass `""` to omit stats entirely. Unlike the '
+            "organization-wide issues endpoint, this does not filter the query "
+            "window and does not accept arbitrary periods."
+        ),
+        enum=["", "24h", "14d"],
+        location=OpenApiParameter.QUERY,
+        type=OpenApiTypes.STR,
+        required=False,
+    )
 
     SHORT_ID_LOOKUP = OpenApiParameter(
         name="shortIdLookup",

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -74,7 +74,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             GlobalParams.PROJECT_ID_OR_SLUG,
             GlobalParams.ENVIRONMENT,
-            GlobalParams.STATS_PERIOD,
+            IssueParams.PROJECT_GROUP_STATS_PERIOD,
             CursorQueryParam,
             VisibilityParams.PER_PAGE,
             IssueParams.PROJECT_VIEW_SORT,
@@ -106,10 +106,11 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         The ``statsPeriod`` parameter can be used to select the timeline
         stats which should be present. Possible values are: ``""`` (disable),
-        ``"24h"``, ``"14d"``
+        ``"24h"``, ``"14d"``. Defaults to ``"24h"``.
 
         :qparam string statsPeriod: an optional stat period (can be one of
-                                    ``"24h"``, ``"14d"``, and ``""``).
+                                    ``"24h"``, ``"14d"``, and ``""``),
+                                    defaults to ``"24h"``.
         :qparam bool shortIdLookup: if this is set to true then short IDs are
                                     looked up by this function as well.  This
                                     can cause the return value of the function


### PR DESCRIPTION
`ProjectGroupIndexEndpoint` documented its `statsPeriod` query param with `GlobalParams.STATS_PERIOD`, whose description belongs to the organization-wide issues endpoint.

 Adds `IssueParams.PROJECT_GROUP_STATS_PERIOD` next to its sibling `GROUP_STATS_PERIOD`, declaring the real enum, the `"24h"` default, and the difference from the org endpoint.

No behavior change.