### PR TITLE
chore(assignment): Add type for assignment result

### DIFF
--- a/src/sentry/integrations/utils/sync.py
+++ b/src/sentry/integrations/utils/sync.py
@@ -21,7 +21,7 @@ from sentry.integrations.tasks.sync_assignee_outbound import sync_assignee_outbo
 from sentry.integrations.types import EXTERNAL_PROVIDERS_REVERSE, ExternalProviderEnum
 from sentry.issues.action_log import SYSTEM_ACTOR, action_context_scope
 from sentry.models.group import Group
-from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupassignee import GroupAssignee, GroupAssignmentState
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.services.organization.model import RpcOrganization
@@ -88,7 +88,7 @@ def _handle_deassign(
     return groups_deassigned
 
 
-def _assignment_succeeded(assignment: dict[str, bool], group: Group, user: RpcUser) -> bool:
+def _assignment_succeeded(assignment: GroupAssignmentState, group: Group, user: RpcUser) -> bool:
     if assignment["new_assignment"] or assignment["updated_assignment"]:
         return True
     return GroupAssignee.objects.filter(group=group, user_id=user.id).exists()

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypedDict
 
 from django.conf import settings
 from django.db import models, router, transaction
@@ -34,6 +34,13 @@ logger = logging.getLogger(__name__)
 class NewAssignee(NamedTuple):
     id: int
     type: str
+
+
+class GroupAssignmentState(TypedDict):
+    """The outcome of an assignment attempt."""
+
+    new_assignment: bool
+    updated_assignment: bool
 
 
 class GroupAssigneeManager(BaseManager["GroupAssignee"]):
@@ -131,7 +138,7 @@ class GroupAssigneeManager(BaseManager["GroupAssignee"]):
         extra: dict[str, str] | None = None,
         force_autoassign: bool = False,
         assignment_source: AssignmentSource | None = None,
-    ) -> dict[str, bool]:
+    ) -> GroupAssignmentState:
         from sentry.integrations.utils.sync import sync_group_assignee_outbound
         from sentry.models.activity import Activity
         from sentry.models.groupsubscription import GroupSubscription


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/122933#discussion_r3875990867.

Adding a type for the result of a group assignment operation. No change in behavior.