### PR TITLE
fix(tasks): Extend issue merge processing deadline

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -85,6 +85,7 @@ def start_merge_groups(
     name="sentry.tasks.merge.merge_groups",
     namespace=issues_merge_tasks,
     retry=Retry(delay=60 * 5),
+    processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,
 )
 @track_group_async_operation


### PR DESCRIPTION
change deadline to 300 seconds like unmerge task, probably overkill but would make sure can handle outliers and occasional slow queries, and timeouts interrupt the merge and have no graceful recovery