### PR TITLE
feat(tracemetrics): add visualize reset button

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -168,7 +168,7 @@ export function ToolbarVisualizeDropdown({
       {onDelete ? (
         <Button
           variant="transparent"
-          icon={<IconDelete />}
+          icon={<IconDelete size="sm" />}
           size="zero"
           onClick={onDelete}
           aria-label={deleteLabel ?? t('Remove Overlay')}

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -45,6 +45,7 @@ interface ToolbarVisualizeDropdownProps {
   onChangeAggregate: (option: SelectOption<SelectKey>) => void;
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   parsedFunction: ParsedFunction | null;
+  deleteLabel?: string;
   dragColumnId?: number;
   fieldDefinitionType?: GetFieldDefinitionType;
   /**
@@ -66,6 +67,7 @@ export function ToolbarVisualizeDropdown({
   onChangeAggregate,
   onChangeArgument,
   onDelete,
+  deleteLabel,
   onSearch,
   onClose,
   parsedFunction,
@@ -169,7 +171,7 @@ export function ToolbarVisualizeDropdown({
           icon={<IconDelete />}
           size="zero"
           onClick={onDelete}
-          aria-label={t('Remove Overlay')}
+          aria-label={deleteLabel ?? t('Remove Overlay')}
         />
       ) : null}
     </ToolbarRow>

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -116,7 +116,7 @@ export function VisualizeEquation({
       {onDelete && (
         <Button
           variant="transparent"
-          icon={<IconDelete />}
+          icon={<IconDelete size="sm" />}
           size="zero"
           onClick={onDelete}
           aria-label={deleteLabel ?? t('Remove Overlay')}

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -25,6 +25,7 @@ import {Visualize} from 'sentry/views/explore/queryParams/visualize';
 interface VisualizeEquationProps {
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
+  deleteLabel?: string;
   dragColumnId?: number;
   label?: ReactNode;
   onDelete?: () => void;
@@ -33,6 +34,7 @@ interface VisualizeEquationProps {
 export function VisualizeEquation({
   dragColumnId,
   onDelete,
+  deleteLabel,
   onReplace,
   visualize,
   label,
@@ -117,7 +119,7 @@ export function VisualizeEquation({
           icon={<IconDelete />}
           size="zero"
           onClick={onDelete}
-          aria-label={t('Remove Overlay')}
+          aria-label={deleteLabel ?? t('Remove Overlay')}
         />
       )}
     </ToolbarRow>

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -306,8 +306,7 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(section).getAllByLabelText('Remove Overlay')[1]!);
     expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
 
-    // only one left, so the delete button becomes a clear button since the
-    // remaining chart differs from the default
+    // only one left, so the delete button becomes a clear button
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
     await userEvent.click(within(section).getByLabelText('Clear Visualize'));
     expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -315,6 +315,16 @@ describe('ExploreToolbar', () => {
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 
+  it('does not show a clear button when the default chart is only hidden', async () => {
+    render(<ExploreToolbar />, {additionalWrapper: Wrapper});
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(within(section).queryByLabelText('Clear Visualize')).not.toBeInTheDocument();
+
+    await userEvent.click(within(section).getByText('A'));
+    expect(within(section).queryByLabelText('Clear Visualize')).not.toBeInTheDocument();
+  });
+
   it('allows changing group bys', async () => {
     let groupBys: any;
 

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -306,7 +306,13 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(section).getAllByLabelText('Remove Overlay')[1]!);
     expect(visualizes).toEqual([new VisualizeFunction('avg(span.self_time)')]);
 
-    // only one left so we hide the delete button
+    // only one left, so the delete button becomes a clear button since the
+    // remaining chart differs from the default
+    expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
+    await userEvent.click(within(section).getByLabelText('Clear Visualize'));
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
+
+    expect(within(section).queryByLabelText('Clear Visualize')).not.toBeInTheDocument();
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -111,14 +111,6 @@ export function ToolbarVisualize({
           <ToolbarVisualizeHeader />
           {editableColumns.map((column, i) => {
             const visualize = column.column;
-            const dragColumnId = editableColumns.length > 1 ? column.id : undefined;
-            const label = (
-              <VisualizeLabel
-                index={i}
-                visualize={visualize}
-                onClick={() => toggleVisibility(i)}
-              />
-            );
             const isOnlyVisualize = editableColumns.length === 1;
             const canReset = isOnlyVisualize && !isDefaultVisualize(visualize);
             const onDelete = isOnlyVisualize
@@ -126,32 +118,26 @@ export function ToolbarVisualize({
                 ? () => replaceOverlay(i, new VisualizeFunction(DEFAULT_VISUALIZATION))
                 : undefined
               : () => deleteColumnAtIndex(i);
-            const deleteLabel = canReset ? t('Clear Visualize') : undefined;
 
-            if (isVisualizeEquation(visualize)) {
-              return (
-                <VisualizeEquationInput
-                  key={column.uniqueId}
-                  dragColumnId={dragColumnId}
-                  onDelete={onDelete}
-                  deleteLabel={deleteLabel}
-                  onReplace={newVisualize => replaceOverlay(i, newVisualize)}
+            const rowProps = {
+              dragColumnId: isOnlyVisualize ? undefined : column.id,
+              onDelete,
+              deleteLabel: canReset ? t('Clear Visualize') : undefined,
+              onReplace: (newVisualize: Visualize) => replaceOverlay(i, newVisualize),
+              visualize,
+              label: (
+                <VisualizeLabel
+                  index={i}
                   visualize={visualize}
-                  label={label}
+                  onClick={() => toggleVisibility(i)}
                 />
-              );
-            }
+              ),
+            };
 
-            return (
-              <ToolbarVisualizeItem
-                key={column.uniqueId}
-                dragColumnId={dragColumnId}
-                onDelete={onDelete}
-                deleteLabel={deleteLabel}
-                onReplace={newVisualize => replaceOverlay(i, newVisualize)}
-                visualize={visualize}
-                label={label}
-              />
+            return isVisualizeEquation(visualize) ? (
+              <VisualizeEquationInput key={column.uniqueId} {...rowProps} />
+            ) : (
+              <ToolbarVisualizeItem key={column.uniqueId} {...rowProps} />
             );
           })}
           <ToolbarFooter>

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -36,6 +36,7 @@ import {useSpanItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttr
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {
   isVisualizeEquation,
+  isVisualizeFunction,
   MAX_VISUALIZES,
   Visualize,
   VisualizeEquation,
@@ -118,8 +119,14 @@ export function ToolbarVisualize({
                 onClick={() => toggleVisibility(i)}
               />
             );
-            const onDelete =
-              editableColumns.length > 1 ? () => deleteColumnAtIndex(i) : undefined;
+            const isOnlyVisualize = editableColumns.length === 1;
+            const canReset = isOnlyVisualize && !isDefaultVisualize(visualize);
+            const onDelete = isOnlyVisualize
+              ? canReset
+                ? () => replaceOverlay(i, new VisualizeFunction(DEFAULT_VISUALIZATION))
+                : undefined
+              : () => deleteColumnAtIndex(i);
+            const deleteLabel = canReset ? t('Clear Visualize') : undefined;
 
             if (isVisualizeEquation(visualize)) {
               return (
@@ -127,6 +134,7 @@ export function ToolbarVisualize({
                   key={column.uniqueId}
                   dragColumnId={dragColumnId}
                   onDelete={onDelete}
+                  deleteLabel={deleteLabel}
                   onReplace={newVisualize => replaceOverlay(i, newVisualize)}
                   visualize={visualize}
                   label={label}
@@ -139,6 +147,7 @@ export function ToolbarVisualize({
                 key={column.uniqueId}
                 dragColumnId={dragColumnId}
                 onDelete={onDelete}
+                deleteLabel={deleteLabel}
                 onReplace={newVisualize => replaceOverlay(i, newVisualize)}
                 visualize={visualize}
                 label={label}
@@ -167,6 +176,7 @@ interface VisualizeDropdownProps {
   label: ReactNode;
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
+  deleteLabel?: string;
   dragColumnId?: number;
   onDelete?: () => void;
 }
@@ -175,6 +185,7 @@ function ToolbarVisualizeItem({
   dragColumnId,
   label,
   onDelete,
+  deleteLabel,
   onReplace,
   visualize,
 }: VisualizeDropdownProps) {
@@ -317,6 +328,7 @@ function ToolbarVisualizeItem({
       onChangeAggregate={onChangeAggregate}
       onChangeArgument={onChangeArgument}
       onDelete={onDelete}
+      deleteLabel={deleteLabel}
       parsedFunction={parsedFunction}
       label={label}
       loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
@@ -345,6 +357,14 @@ function ToolbarVisualizeItem({
         ) : undefined
       }
     />
+  );
+}
+
+function isDefaultVisualize(visualize: Visualize): boolean {
+  return (
+    isVisualizeFunction(visualize) &&
+    visualize.yAxis === DEFAULT_VISUALIZATION &&
+    visualize.visible
   );
 }
 

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -347,11 +347,7 @@ function ToolbarVisualizeItem({
 }
 
 function isDefaultVisualize(visualize: Visualize): boolean {
-  return (
-    isVisualizeFunction(visualize) &&
-    visualize.yAxis === DEFAULT_VISUALIZATION &&
-    visualize.visible
-  );
+  return isVisualizeFunction(visualize) && visualize.yAxis === DEFAULT_VISUALIZATION;
 }
 
 interface VisualizeLabelProps {


### PR DESCRIPTION
This PR adds a reset button to the `visualize` row the same way `groupBy` added in EXP-802. In short, anytime a chart/equation is added or changed, the reset (trash) button will appear, allowing you to reset said chart/equation. This was the case for 2 or more chart/equations, but this PR added that behavior for the 1st equation if that is changed from its default `count` value.

Before
<img width="347" height="296" alt="Screenshot 2026-08-27 at 3 10 50 PM" src="https://github.com/user-attachments/assets/4c557da6-87bb-448c-8d12-b165970e1a72" />

After
<img width="361" height="268" alt="Screenshot 2026-08-27 at 3 11 22 PM" src="https://github.com/user-attachments/assets/4c71af7b-518b-4ead-a0de-7f34892de2be" />

Closes EXP-837