### PR TITLE
fix(slack): Stop an empty Seer mention before it runs an agent turn

### DIFF
--- a/src/sentry/integrations/messaging/metrics.py
+++ b/src/sentry/integrations/messaging/metrics.py
@@ -131,3 +131,4 @@ class SeerSlackHaltReason(StrEnum):
     IDENTITY_NOT_LINKED = "identity_not_linked"
     MISSING_EVENT_DATA = "missing_event_data"
     MISSING_MEMBERSHIP = "missing_membership"
+    EMPTY_PROMPT = "empty_prompt"

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -36,6 +36,8 @@ from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.entrypoints.slack.analytics import SlackSeerAgentConversation
+from sentry.seer.entrypoints.slack.mention import has_prompt_content
+from sentry.seer.entrypoints.slack.messaging import send_empty_prompt_message
 from sentry.seer.entrypoints.slack.tasks import (
     process_mention_for_slack,
     process_reaction_for_slack,
@@ -426,6 +428,19 @@ class SlackEventEndpoint(SlackDMEndpoint):
                 lifecycle.record_halt(SeerSlackHaltReason.MISSING_EVENT_DATA)
                 return self.respond()
 
+            authorizations = slack_request.data.get("authorizations") or []
+            bot_user_id = authorizations[0].get("user_id", "") if authorizations else ""
+
+            if not has_prompt_content(text):
+                lifecycle.record_halt(SeerSlackHaltReason.EMPTY_PROMPT)
+                send_empty_prompt_message(
+                    integration_id=slack_request.integration.id,
+                    slack_user_id=slack_request.user_id,
+                    channel_id=channel_id,
+                    thread_ts=thread_ts or ts,
+                )
+                return self.respond()
+
             try:
                 installation.set_thread_status(
                     channel_id=channel_id,
@@ -442,9 +457,6 @@ class SlackEventEndpoint(SlackDMEndpoint):
                         "thread_ts": thread_ts or ts,
                     },
                 )
-
-            authorizations = slack_request.data.get("authorizations") or []
-            bot_user_id = authorizations[0].get("user_id", "") if authorizations else ""
 
             process_mention_for_slack.apply_async(
                 kwargs={

--- a/src/sentry/seer/entrypoints/slack/mention.py
+++ b/src/sentry/seer/entrypoints/slack/mention.py
@@ -36,6 +36,17 @@ _SLACK_PERMALINK_PATH_RE = re.compile(
 # Cap how many linked messages we will fetch per prompt to bound API + token cost.
 _MAX_LINKED_MESSAGES = 5
 
+_ANY_MENTION_RE = re.compile(r"<@[^>]+>")
+
+
+def has_prompt_content(text: str) -> bool:
+    """Whether the text holds anything beyond Slack mentions and whitespace.
+
+    Takes no bot_user_id: Slack omits `authorizations` in some cases, and
+    `extract_prompt` strips nothing when the id is missing.
+    """
+    return bool(_ANY_MENTION_RE.sub("", text).strip())
+
 
 def extract_prompt(text: str, bot_user_id: str) -> str:
     """Remove the bot mention from text to get the user's clean prompt.

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -354,6 +354,9 @@ def send_halt_message(
             # This assumes the slack event is malformed, or unexpected.
             # Avoid sending irrelevant messages for what could be inconsequential.
             return
+        case SeerSlackHaltReason.EMPTY_PROMPT:
+            # Answered at the webhook by send_empty_prompt_message.
+            return
         case _:
             assert_never(halt_reason)
 
@@ -376,6 +379,34 @@ def send_halt_message(
         logger.exception("send_halt_message.error", extra=logging_ctx)
     else:
         logger.info("send_halt_message.success", extra=logging_ctx)
+
+
+@all_silo_function
+def send_empty_prompt_message(
+    *,
+    integration_id: int,
+    slack_user_id: str,
+    channel_id: str,
+    thread_ts: str | None,
+) -> None:
+    """Send an ephemeral nudge when someone mentions us without asking anything."""
+    from sentry.integrations.slack.workspace import send_threaded_ephemeral_message
+
+    message = "Looks like your message came through empty — mention me again with a question and I'll take it from there."
+    renderable = SlackRenderable(
+        blocks=[MarkdownBlock(text=message)],
+        text=message,
+    )
+    try:
+        send_threaded_ephemeral_message(
+            integration_id=integration_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            renderable=renderable,
+            slack_user_id=slack_user_id,
+        )
+    except Exception as e:
+        logger.warning("seer.slack.send_empty_prompt_message_failed", exc_info=e)
 
 
 @all_silo_function

--- a/tests/sentry/integrations/slack/webhooks/events/test_app_mention.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_app_mention.py
@@ -97,6 +97,100 @@ class AppMentionEventTest(BaseEventTest):
         mock_apply_async.assert_not_called()
         assert_halt_metric(mock_record, SeerSlackHaltReason.MISSING_EVENT_DATA)
 
+    @patch("sentry.integrations.slack.workspace.send_threaded_ephemeral_message")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
+    def test_app_mention_only_the_bot_mention_halts(self, mock_apply_async, mock_record, mock_send):
+        for text in ("<@U0BOT>", "  <@U0BOT>   "):
+            with self.subTest(text=text):
+                mock_apply_async.reset_mock()
+                mock_record.reset_mock()
+                mock_send.reset_mock()
+
+                with self.feature(SEER_EXPLORER_FEATURES):
+                    resp = self.post_webhook(
+                        event_data={**APP_MENTION_EVENT, "text": text},
+                        data=AUTHORIZATIONS_DATA,
+                    )
+
+                assert resp.status_code == 200
+                mock_apply_async.assert_not_called()
+                assert_halt_metric(mock_record, SeerSlackHaltReason.EMPTY_PROMPT)
+
+                mock_send.assert_called_once()
+                kwargs = mock_send.call_args.kwargs
+                assert kwargs["channel_id"] == APP_MENTION_EVENT["channel"]
+                assert kwargs["thread_ts"] == APP_MENTION_EVENT["ts"]
+                assert "came through empty" in kwargs["renderable"]["text"]
+
+    @patch("sentry.integrations.slack.workspace.send_threaded_ephemeral_message")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
+    def test_app_mention_only_the_bot_mention_halts_without_authorizations(
+        self, mock_apply_async, mock_record, mock_send
+    ):
+        with self.feature(SEER_EXPLORER_FEATURES):
+            resp = self.post_webhook(event_data={**APP_MENTION_EVENT, "text": "<@U0BOT>"})
+
+        assert resp.status_code == 200
+        mock_apply_async.assert_not_called()
+        assert_halt_metric(mock_record, SeerSlackHaltReason.EMPTY_PROMPT)
+        mock_send.assert_called_once()
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
+    def test_app_mention_only_mentions_halts(self, mock_apply_async, mock_record):
+        """Mentioning us alongside other users, with no question, is still empty."""
+        with self.feature(SEER_EXPLORER_FEATURES):
+            resp = self.post_webhook(
+                event_data={**APP_MENTION_EVENT, "text": "<@U0BOT> <@U1234567890|alice>"},
+                data=AUTHORIZATIONS_DATA,
+            )
+
+        assert resp.status_code == 200
+        mock_apply_async.assert_not_called()
+        assert_halt_metric(mock_record, SeerSlackHaltReason.EMPTY_PROMPT)
+
+    @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
+    def test_app_mention_other_user_mention_with_text_dispatches(self, mock_apply_async):
+        """A mention of someone else is context, not emptiness, when text follows."""
+        with self.feature(SEER_EXPLORER_FEATURES):
+            resp = self.post_webhook(
+                event_data={
+                    **APP_MENTION_EVENT,
+                    "text": "<@U0BOT> what did <@U1234567890> break?",
+                },
+                data=AUTHORIZATIONS_DATA,
+            )
+
+        assert resp.status_code == 200
+        mock_apply_async.assert_called_once()
+
+    @patch("sentry.integrations.slack.workspace.send_threaded_ephemeral_message")
+    @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
+    def test_app_mention_empty_prompt_reply_failure_is_swallowed(self, mock_apply_async, mock_send):
+        mock_send.side_effect = Exception("slack down")
+
+        with self.feature(SEER_EXPLORER_FEATURES):
+            resp = self.post_webhook(
+                event_data={**APP_MENTION_EVENT, "text": "<@U0BOT>"},
+                data=AUTHORIZATIONS_DATA,
+            )
+
+        assert resp.status_code == 200
+        mock_apply_async.assert_not_called()
+
+    @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
+    def test_app_mention_with_text_after_the_mention_dispatches(self, mock_apply_async):
+        with self.feature(SEER_EXPLORER_FEATURES):
+            resp = self.post_webhook(
+                event_data={**APP_MENTION_EVENT, "text": "<@U0BOT> why is this slow?"},
+                data=AUTHORIZATIONS_DATA,
+            )
+
+        assert resp.status_code == 200
+        mock_apply_async.assert_called_once()
+
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.seer.entrypoints.slack.tasks.process_mention_for_slack.apply_async")
     def test_app_mention_no_integration(self, mock_apply_async, mock_record):


### PR DESCRIPTION
## Problem

`_handle_seer_prompt` already rejects empty `text`, but it checks *before* the bot mention is stripped — that happens later, in `process_mention_for_slack` via `extract_prompt`. A bare `@Seer` has truthy text `"<@U0BOT>"`, so it passes the guard and reaches Seer as `query=""`.

Seer then runs a full turn on nothing — an ExplorerIndex query, four context engine stages, three Vertex embedding calls and an LLM call — only to answer *"It looks like your message came through empty!"*.

The embedding calls 400 with `The text content is empty.`:

| path | error | events / 30d |
|---|---|---|
| direct google-genai | `ClientError: Empty instances.` | [SEER-8GR](https://sentry.sentry.io/issues/SEER-8GR) — 393 (296 prod, 97 de) |
| llm-proxy `/embeddings` | `Vertex 400: "The text content is empty."` | [LLM-PROXY-S](https://sentry.sentry.io/issues/LLM-PROXY-S) |

All 393 are `explorer.category_key:slack_thread` and `explorer_main_task`. Slack is the only entrypoint affected — the Explorer chat endpoint already enforces `allow_blank=False`, and every other caller templates its prompt, so `query` is structurally non-blank there.

## Fix

Guard at the webhook, before `set_thread_status("is thinking...")` so no spinner is left running.

The check is a new `has_prompt_content` — is there anything besides mentions and whitespace — rather than reusing `extract_prompt`. `extract_prompt` needs the bot's user id, which comes from the event's `authorizations`; Slack omits that in some cases, and `test_app_mention_dispatches_task_no_authorizations` already covers it. With no id the regex degrades to `<@>` and strips nothing, so a bare mention would have slipped through as the non-empty prompt `"<@U0BOT>"`.

Another user's mention still counts as context whenever real text accompanies it; only a mention-only message is empty.

Halting silently would have been a regression — the user used to get *an* answer, however wasteful. `send_empty_prompt_message` sends a fixed ephemeral nudge, mirroring `send_not_org_member_message`: no link button, and send failures are logged rather than raised so a Slack outage can't turn the webhook into a 500. No model, no agent run, no Vertex call.

Uses a distinct `EMPTY_PROMPT` halt reason rather than `MISSING_EVENT_DATA`, which is documented as meaning the event was malformed — a bare mention is a normal user action, and conflating them would make that metric misleading.

## Test

`tests/sentry/integrations/slack/webhooks/events/` + `tests/sentry/seer/entrypoints/slack/` — 201 passed. mypy and pre-commit clean.

New coverage: bare mention halts and sends the nudge; halts with no `authorizations`; mention-only-with-other-users halts; a mention plus real text still dispatches; a failing nudge still returns 200 without dispatching.

## Notes for review

- This guard is the only empty check on the Slack path. `process_mention_for_slack` re-derives the prompt and `trigger_agent` forwards it, neither re-checks — so invoking the task directly still bypasses it.
- Not fixed here: when `authorizations` is missing, the `<@U0BOT>` token still rides along into the query as prompt noise. Storing the bot user id on the integration would close that; it's a prompt-quality issue, not correctness, now that this guard doesn't depend on the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)