### PR TITLE
feat(inbox): add header docs tooltip

### DIFF
--- a/static/app/views/issueList/pages/inbox/index.spec.tsx
+++ b/static/app/views/issueList/pages/inbox/index.spec.tsx
@@ -343,7 +343,7 @@ describe('InboxPage', () => {
     expect(await screen.findByText('Diagnosed issue')).toBeInTheDocument();
     const assignedIssue = await screen.findByText('Assigned issue');
     expect(assignedIssue).toBeVisible();
-    expect(screen.getByRole('heading', {name: 'Inbox', level: 1})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: /Inbox/, level: 1})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Issues', level: 2})).toBeInTheDocument();
 
     for (const [index, query] of [

--- a/static/app/views/issueList/pages/inbox/index.tsx
+++ b/static/app/views/issueList/pages/inbox/index.tsx
@@ -363,7 +363,7 @@ function InboxContent() {
         <PageHeadingQuestionTooltip
           docsUrl="https://docs.sentry.io/product/issues/inbox/"
           title={t(
-            'A personalized view of issues relevant to you, organized by their progress toward a fix.'
+            'A personalized view of issues relevant to you, organized by how close you are to fixing them.'
           )}
         />
       </Layout.Title>

--- a/static/app/views/issueList/pages/inbox/index.tsx
+++ b/static/app/views/issueList/pages/inbox/index.tsx
@@ -28,6 +28,7 @@ import {useLinkedPullRequests} from 'sentry/components/group/externalIssuesList/
 import {getPullRequestStatusLabel} from 'sentry/components/group/externalIssuesList/pullRequestStatusBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {Placeholder} from 'sentry/components/placeholder';
 import {QueryCount} from 'sentry/components/queryCount';
 import {SuggestedAvatarStack} from 'sentry/components/suggestedAvatarStack';
@@ -357,7 +358,15 @@ function InboxContent() {
 
   return (
     <Stack flex={1} minHeight={0} contain="size" overflow="hidden">
-      <Layout.Title>{TITLE}</Layout.Title>
+      <Layout.Title>
+        {TITLE}
+        <PageHeadingQuestionTooltip
+          docsUrl="https://docs.sentry.io/product/issues/inbox/"
+          title={t(
+            'A personalized view of issues relevant to you, organized by their progress toward a fix.'
+          )}
+        />
+      </Layout.Title>
       <Grid
         flex={1}
         minHeight={0}


### PR DESCRIPTION
Adds a description tooltip with a link to the new docs page: https://docs.sentry.io/product/issues/inbox/