### PR TITLE
feat(autofix): Support read_file tool in autofix evidence

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -433,6 +433,136 @@ describe('AutofixEvidence', () => {
     });
   });
 
+  describe('EvidenceReadFile', () => {
+    const CODE_URL = 'https://github.com/org/repo/blob/main/src/foo/bar.py';
+
+    it('renders filename with code_url link', () => {
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('File: bar.py')).toBeInTheDocument();
+      expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
+        'href',
+        CODE_URL
+      );
+    });
+
+    it('renders single line anchor when start_line equals end_line', () => {
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolLink = makeToolLink('read_file', {
+        code_url: CODE_URL,
+        start_line: 10,
+        end_line: 10,
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('File: bar.py L10')).toBeInTheDocument();
+      expect(screen.getByText('File: bar.py L10').closest('a')).toHaveAttribute(
+        'href',
+        `${CODE_URL}#L10`
+      );
+    });
+
+    it('renders line range anchor when start_line and end_line differ', () => {
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolLink = makeToolLink('read_file', {
+        code_url: CODE_URL,
+        start_line: 10,
+        end_line: 20,
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('File: bar.py L10-L20')).toBeInTheDocument();
+      expect(screen.getByText('File: bar.py L10-L20').closest('a')).toHaveAttribute(
+        'href',
+        `${CODE_URL}#L10-L20`
+      );
+    });
+
+    it('renders truncated filename for long paths', () => {
+      const toolCall = makeToolCall('read_file', {
+        path: 'src/foo/thisisalongfilename.py',
+      });
+      const toolLink = makeToolLink('read_file', {
+        code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
+      });
+      const props = resolveProps(toolCall, toolLink);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
+    });
+
+    it('returns null when toolLink is missing', () => {
+      expect(
+        resolveProps(makeToolCall('read_file', {path: 'src/foo/bar.py'}))
+      ).toBeNull();
+    });
+
+    it('returns null when path is missing from args', () => {
+      expect(
+        resolveProps(
+          makeToolCall('read_file', {}),
+          makeToolLink('read_file', {code_url: CODE_URL})
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when path is not a string', () => {
+      expect(
+        resolveProps(
+          makeToolCall('read_file', {path: 123}),
+          makeToolLink('read_file', {code_url: CODE_URL})
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when code_url is missing from toolLink params', () => {
+      expect(
+        resolveProps(
+          makeToolCall('read_file', {path: 'src/foo/bar.py'}),
+          makeToolLink('read_file', {})
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when args is invalid JSON', () => {
+      expect(
+        resolveProps(
+          {id: 'tc-1', function: 'read_file', args: '{invalid json'},
+          makeToolLink('read_file', {code_url: CODE_URL})
+        )
+      ).toBeNull();
+    });
+  });
+
   describe('EvidenceGitSearch', () => {
     const FULL_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
     const COMMIT_URL = 'https://github.com/org/repo/commit/a1b2c3d';

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -374,6 +374,45 @@ function getGitSearchEvidenceProps({
   return null;
 }
 
+function getReadFileEvidenceProps({
+  toolCall,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  const {path} = parseArgs(toolCall);
+  if (typeof path !== 'string') {
+    return null;
+  }
+  const filename = extractFileName(path);
+  const {code_url, start_line, end_line} = toolLink?.params ?? {};
+
+  if (!defined(filename) || !defined(code_url)) {
+    return null;
+  }
+
+  const lines =
+    start_line && end_line
+      ? start_line === end_line
+        ? `L${start_line}`
+        : `L${start_line}-L${end_line}`
+      : undefined;
+  return {
+    href: lines ? `${code_url}#${lines}` : code_url,
+    icon: <IconFile />,
+    label: t('File: %s%s', truncateText(filename), lines ? ` ${lines}` : ''),
+    tooltip: (
+      <Fragment>
+        {path}
+        {lines && (
+          <Fragment>
+            <br />
+            {lines}
+          </Fragment>
+        )}
+      </Fragment>
+    ),
+  };
+}
+
 export const AUTOFIX_EVIDENCE_PROPS_RESOLVER: Record<
   string,
   (payload: GetEvidencePropsPayload) => EvidenceButtonProps | null
@@ -386,6 +425,7 @@ export const AUTOFIX_EVIDENCE_PROPS_RESOLVER: Record<
   get_profile_flamegraph: getProfileFlamegraphEvidenceProps,
   code_search: getCodeSearchEvidenceProps,
   git_search: getGitSearchEvidenceProps,
+  read_file: getReadFileEvidenceProps,
 };
 
 function parseArgs(toolCall: ToolCall): any {


### PR DESCRIPTION
This adds support for the read_file tool that is part of the bash tools to be rendered in autofix evidence.