### PR TITLE
fix(ai-monitoring): Raise conversation title max_tokens to 192

### DIFF
--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -280,7 +280,7 @@ def _generate_title_with_legacy_seer(
         system_prompt=TITLE_SYSTEM_PROMPT,
         prompt=f"First user message:\n\n{clamp_user_message(first_user_message)}",
         temperature=0.2,
-        max_tokens=64,
+        max_tokens=192,
         response_schema=TITLE_RESPONSE_SCHEMA,
         reasoning="off",  # force thinking_budget=0 on Gemini 2.x flash-lite
         # Never attach this call to a conversation: its own gen_ai spans would be


### PR DESCRIPTION
`_generate_title_with_legacy_seer` asks Seer for structured output with `max_tokens=64` and `reasoning="off"` (so `thinking_budget=0` and no padding) — a hard 64-token ceiling on visible output. On noisy input the model over-generates, the JSON never closes, and the response is unparseable. All three retries re-send an identical request at `temperature=0.2`, so they truncate identically, and `llm_total_models: 1` means there is no fallback model behind it.

`seer.llm.structured_invalid` over the last 24h, grouped by `finish_reason`:

| finish_reason | count |
|---|---|
| `max_tokens` | 1,819 |
| `stop` | 7 |
| `unknown` | 1 |

Truncation is ~99.6% of direct structured failures. 192 leaves ~180 tokens for the title after the JSON envelope, against a happy path of ~25.

Notes:
- Paired with getsentry/seer#7944, which fixes the identical 64 in seer's `conversation_title` one-shot handler. The `ai-monitoring.conversation-title-generation.oneshot-rollout-rate` option defaults to 0.0, so all real traffic is currently on this legacy path — but the one-shot path inherited the same bug and needs both.
- User-visible impact of the failure is cosmetic: `generate_conversation_title` falls back to `fallback_title_from_message`, so a conversation shows a truncated first message instead of a real title. The cost is ~3,700 wasted flash-lite calls/day and ~29k Sentry error events (SEER-945), which is the largest issue in the seer project.
- This does not close SEER-945 on its own. The raise in seer's `llm_proxy.py:120` still turns any remaining parse failure into a 500, and other structured callers have their own budgets.