### PR TITLE
feat(seer): Add user-initiated Seer activities to issue details tool output

### DIFF
--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -1360,8 +1360,7 @@ def _get_recommended_event(
     return fallback_event or get_latest_event()
 
 
-# Activity types to include in issue details for Seer Agent (manual actions only)
-_SEER_EXPLORER_ACTIVITY_TYPES = [
+_SEER_EXPLORER_ACTOR_OPTIONAL_ACTIVITY_TYPES = [
     ActivityType.NOTE.value,
     ActivityType.SET_RESOLVED.value,
     ActivityType.SET_RESOLVED_IN_RELEASE.value,
@@ -1369,6 +1368,11 @@ _SEER_EXPLORER_ACTIVITY_TYPES = [
     ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
     ActivityType.SET_UNRESOLVED.value,
     ActivityType.ASSIGNED.value,
+]
+
+_SEER_EXPLORER_ACTOR_REQUIRED_ACTIVITY_TYPES = [
+    ActivityType.TRIGGER_AUTOFIX.value,
+    ActivityType.SEER_ITERATION_STARTED.value,
 ]
 
 
@@ -1540,10 +1544,15 @@ def get_issue_details(
         timeseries, timeseries_stats_period, timeseries_interval = None, None, None
 
     try:
-        activities = Activity.objects.filter(
-            group=group,
-            type__in=_SEER_EXPLORER_ACTIVITY_TYPES,
-        ).order_by("-datetime")[:50]
+        activity_filter = models.Q(
+            type__in=_SEER_EXPLORER_ACTOR_OPTIONAL_ACTIVITY_TYPES
+        ) | models.Q(
+            type__in=_SEER_EXPLORER_ACTOR_REQUIRED_ACTIVITY_TYPES,
+            user_id__isnull=False,
+        )
+        activities = (
+            Activity.objects.filter(group=group).filter(activity_filter).order_by("-datetime")[:50]
+        )
         serialized_activities = serialize(
             list(activities), user=None, serializer=ActivitySerializer(resolve_mentions=True)
         )

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -1462,6 +1462,40 @@ class TestGetIssueDetails(APITransactionTestCase, SnubaTestCase, SearchIssueTest
         assert len(result["user_activity"]) == 1
         assert result["user_activity"][0]["type"] == "note"
 
+    @patch("sentry.seer.agent.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.agent.tools.get_all_tags_overview")
+    def test_user_attributed_seer_actions_are_included(self, mock_tags, mock_ts):
+        mock_ts.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_tags.return_value = {"tags_overview": []}
+
+        event = self._make_error_event()
+        group = event.group
+        assert isinstance(group, Group)
+
+        for activity_type, user_id in (
+            (ActivityType.TRIGGER_AUTOFIX, self.user.id),
+            (ActivityType.SEER_ITERATION_STARTED, self.user.id),
+            (ActivityType.TRIGGER_AUTOFIX, None),
+        ):
+            Activity.objects.create(
+                group=group,
+                project=self.project,
+                type=activity_type.value,
+                user_id=user_id,
+            )
+
+        result = get_issue_details(
+            organization_id=self.organization.id,
+            issue_id=str(group.id),
+        )
+
+        assert result is not None
+        assert {activity["type"] for activity in result["user_activity"]} == {
+            "trigger_autofix",
+            "seer_iteration_started",
+        }
+        assert all(activity["user"] is not None for activity in result["user_activity"])
+
     # --- assignee ---
 
     @patch("sentry.seer.agent.tools._get_issue_event_timeseries")


### PR DESCRIPTION
In addition to `_SEER_EXPLORER_ACTIVITY_TYPES` (renamed `...ACTOR_OPTIONAL...`), include `_SEER_EXPLORER_ACTOR_REQUIRED_ACTIVITY_TYPES` which are Seer activities that we care about, IF a user performed them. This goes into the `user_activity` section of the `get_issue_details` tool.

This will affect a tool used by many Seer products across the company, so I want to be careful here. But if we include other activities performed by users, these seem valid too.

We've also had some concerns about "punishing" a user who clicks "start RCA" by assigning the issue to them, but in terms of getting issues looked at, they are probably a viable last resort. (And, of course, auto-assignment only happens if it's enabled by the customer.)