### PR TITLE
ref(api): Unpublish issue view POST endpoint to fix master

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -90,7 +90,7 @@ class OrganizationGroupSearchViewGetSerializer(serializers.Serializer[None]):
 class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
-        "POST": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ISSUES
     permission_classes = (MemberPermission,)


### PR DESCRIPTION
## Summary

Master's backend suite is red on the Seer Code Mode public-API auth matrix:

```
FAILED tests/sentry/seer/endpoints/test_organization_agent_token.py::
  AgentTokenPublicGetMatrixTest::test_public_mutation_..._OrganizationGroupSearchViews_post_...
AssertionError: ('OrganizationGroupSearchViewsEndpoint', 'POST', b'')
assert 404 < 400
```

## Root cause

#122537 flipped `OrganizationGroupSearchViewsEndpoint`'s `POST` from `EXPERIMENTAL` to `PUBLIC`. The handler still returns 404 when the `organizations:issue-views` feature flag is off:

```python
if not features.has("organizations:issue-views", organization, actor=request.user):
    return Response(status=status.HTTP_404_NOT_FOUND)
```

The Seer public-mutation matrix auto-discovers every `ApiPublishStatus.PUBLIC` mutation and calls it as a normal session user without that flag, so the endpoint 404s and the matrix treats the public API as broken.

This wasn't caught on the original PR because selective testing found no static importer linking the endpoint to the matrix test, so the matrix never ran on that PR. The full suite on master caught it.

The GET listing publish (#122605) was already reverted in `cc1dbf8d51f`; this does the same for POST, which was published in a separate PR (#122537) and missed.

## Fix

Flip `POST` back to `EXPERIMENTAL`. This drops the endpoint out of `PUBLIC_MUTATION_ENDPOINTS`, so the failing matrix cases are no longer generated. The typed serializers and `@extend_schema` docs added in #122537 are kept intact — only the publish status changes.

## Verification

With the change applied, all `GroupSearchView` matrix cases are deselected (0 collected):

```
.venv/bin/pytest tests/sentry/seer/endpoints/test_organization_agent_token.py::AgentTokenPublicGetMatrixTest -k GroupSearchView
1145 deselected in 2.04s
```

Refs #122537

https://claude.ai/code/session_014sHKJHauUBAtutpo66PHJb
