### PR TITLE
feat(markdown): Report silent markdown render fallbacks to Sentry

### DIFF
--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -1,5 +1,6 @@
 import {Fragment, type ReactNode} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
 import {CodeBlock, InlineCode} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -208,11 +209,46 @@ export const DefaultTableCell = styled('td')<{align?: Align}>`
   text-align: ${p => p.align ?? 'left'};
 `;
 
-export function DefaultTag(_props: {
+/**
+ * Markdown re-lexes and re-renders on every streamed chunk, so an unhandled tag
+ * would otherwise report once per chunk. Report each tag only once per page
+ * load.
+ */
+const reportedUnhandledTags = new Set<string>();
+
+/**
+ * Fallback for `<tag>` tokens that no `components.Tag` renderer handled. The
+ * tag's content is dropped from the rendered output, so report it rather than
+ * failing silently.
+ */
+export function DefaultTag({
+  attrs,
+  level,
+  name,
+}: {
   attrs: Record<string, string>;
   data: unknown;
   level: 'block' | 'inline';
   name: string;
 }) {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(`[Markdown] no renderer for tag: ${name}`, attrs);
+    return null;
+  }
+
+  if (!reportedUnhandledTags.has(name)) {
+    reportedUnhandledTags.add(name);
+
+    Sentry.withScope(scope => {
+      scope.setLevel('warning');
+      scope.setTag('markdown.tag', name);
+      scope.setTag('markdown.tag_level', level);
+      scope.setExtra('attrs', attrs);
+      scope.setFingerprint(['markdown-unhandled-tag', name]);
+      Sentry.captureException(new Error(`[Markdown] no renderer for tag: ${name}`));
+    });
+  }
+
   return null;
 }

--- a/static/app/components/core/markdown/defaultComponents.tsx
+++ b/static/app/components/core/markdown/defaultComponents.tsx
@@ -216,6 +216,32 @@ export const DefaultTableCell = styled('td')<{align?: Align}>`
  */
 const reportedUnhandledTags = new Set<string>();
 
+function reportUnhandledTag(
+  name: string,
+  level: 'block' | 'inline',
+  attrs: Record<string, string>
+) {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(`[Markdown] no renderer for tag: ${name}`, attrs);
+    return;
+  }
+
+  if (reportedUnhandledTags.has(name)) {
+    return;
+  }
+  reportedUnhandledTags.add(name);
+
+  Sentry.withScope(scope => {
+    scope.setLevel('warning');
+    scope.setTag('markdown.tag', name);
+    scope.setTag('markdown.tag_level', level);
+    scope.setExtra('attrs', attrs);
+    scope.setFingerprint(['markdown-unhandled-tag', name]);
+    Sentry.captureException(new Error(`[Markdown] no renderer for tag: ${name}`));
+  });
+}
+
 /**
  * Fallback for `<tag>` tokens that no `components.Tag` renderer handled. The
  * tag's content is dropped from the rendered output, so report it rather than
@@ -231,24 +257,6 @@ export function DefaultTag({
   level: 'block' | 'inline';
   name: string;
 }) {
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.warn(`[Markdown] no renderer for tag: ${name}`, attrs);
-    return null;
-  }
-
-  if (!reportedUnhandledTags.has(name)) {
-    reportedUnhandledTags.add(name);
-
-    Sentry.withScope(scope => {
-      scope.setLevel('warning');
-      scope.setTag('markdown.tag', name);
-      scope.setTag('markdown.tag_level', level);
-      scope.setExtra('attrs', attrs);
-      scope.setFingerprint(['markdown-unhandled-tag', name]);
-      Sentry.captureException(new Error(`[Markdown] no renderer for tag: ${name}`));
-    });
-  }
-
+  reportUnhandledTag(name, level, attrs);
   return null;
 }

--- a/static/app/components/seer/markdown/embeds/utils.tsx
+++ b/static/app/components/seer/markdown/embeds/utils.tsx
@@ -1,4 +1,5 @@
 import type {ReactNode} from 'react';
+import * as Sentry from '@sentry/react';
 import type {z} from 'zod';
 
 import {NODE_ENV} from 'sentry/constants/env';
@@ -9,6 +10,35 @@ import {ALL_SEER_EMBED_SCHEMAS, type SeerEmbedName} from './schemas';
 export type EmbedOutput<N extends SeerEmbedName> = z.output<
   (typeof ALL_SEER_EMBED_SCHEMAS)[N]['schema']
 >;
+
+/**
+ * Seer markdown re-lexes and re-renders on every streamed chunk, so an embed
+ * with invalid props would otherwise report once per chunk. Report each
+ * distinct failure only once per page load.
+ */
+const reportedInvalidEmbeds = new Set<string>();
+
+function reportInvalidEmbed(name: string, issues: readonly z.core.$ZodIssue[]) {
+  if (NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(`[SeerEmbed] ${name}: invalid props`, issues);
+    return;
+  }
+
+  const key = `${name}:${issues.map(issue => `${issue.code}@${issue.path.join('.')}`).join('|')}`;
+  if (reportedInvalidEmbeds.has(key)) {
+    return;
+  }
+  reportedInvalidEmbeds.add(key);
+
+  Sentry.withScope(scope => {
+    scope.setLevel('warning');
+    scope.setTag('seer_embed.name', name);
+    scope.setExtra('issues', issues);
+    scope.setFingerprint(['seer-embed-invalid-props', name]);
+    Sentry.captureException(new Error(`[SeerEmbed] ${name}: invalid props`));
+  });
+}
 
 interface DefineSeerEmbedOptions<N extends SeerEmbedName> {
   name: N;
@@ -24,10 +54,7 @@ export function defineSeerEmbed<N extends SeerEmbedName>({
   function Embed({data, level}: SeerEmbedProps) {
     const parsed = schema.safeParse(data);
     if (!parsed.success) {
-      if (NODE_ENV === 'development') {
-        // eslint-disable-next-line no-console
-        console.warn(`[SeerEmbed] ${name}: invalid props`, parsed.error.issues);
-      }
+      reportInvalidEmbed(name, parsed.error.issues);
       return null;
     }
     return render(parsed.data as EmbedOutput<N>, level);


### PR DESCRIPTION
Two markdown render fallbacks dropped content and returned `null` with no signal outside a development-only `console.warn`, so a broken Seer embed or an unregistered tag was invisible in production. Both now capture a warning-level Sentry event.

`DefaultTag` is what renders a `<tag>` token that no `components.Tag` renderer handled — it discarded the token entirely. It now reports the tag name, the tag level, and the tag attributes. `defineSeerEmbed` hit the same silence when an embed's props failed its Zod schema; it now reports the embed name and the Zod issues, which is the signal for a backend/frontend schema drift.

The part worth a look is the deduplication. `Markdown` calls `MarkedLexer.lex(raw)` on every `raw` change, so during a streamed Seer response a single malformed embed re-renders once per chunk. Reporting unconditionally would emit hundreds of events for one bad response. Each distinct failure is therefore reported once per page load, keyed by tag name (or by embed name plus the failing issue paths). Development keeps the `console.warn` and sends nothing, matching the existing pattern in `static/app/components/core/slot/slot.tsx`.


https://claude.ai/code/session_016A9XzQjqMy9qy22rUytLiq
