### PR TITLE
fix(seer): Propagate Explorer failure reasons

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -264,7 +264,7 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
     updated_at: str
-    failure_reason: Literal["timeout", "stalled"] | None = None
+    failure_reason: str | None = None
     owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)

--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -264,6 +264,7 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
     updated_at: str
+    failure_reason: Literal["timeout", "stalled"] | None = None
     owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -66,14 +66,14 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             blocks=[],
             status="error",
             updated_at="2024-01-01T00:00:00Z",
-            failure_reason="timeout",
+            failure_reason="provider_unavailable",
         )
         mock_client_class.return_value = mock_client
 
         response = self.client.get(f"{self.url}123/")
 
         assert response.status_code == 200
-        assert response.data["session"]["failure_reason"] == "timeout"
+        assert response.data["session"]["failure_reason"] == "provider_unavailable"
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_get_excludes_private_fields(self, mock_client_class: MagicMock) -> None:

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -59,6 +59,23 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client.get_run.assert_called_once_with(run_id=123)
 
     @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
+    def test_get_includes_failure_reason(self, mock_client_class: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.get_run.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="error",
+            updated_at="2024-01-01T00:00:00Z",
+            failure_reason="timeout",
+        )
+        mock_client_class.return_value = mock_client
+
+        response = self.client.get(f"{self.url}123/")
+
+        assert response.status_code == 200
+        assert response.data["session"]["failure_reason"] == "timeout"
+
+    @patch("sentry.seer.endpoints.organization_seer_agent_chat.SeerAgentClient")
     def test_get_excludes_private_fields(self, mock_client_class: MagicMock) -> None:
         mock_state = SeerRunState(
             run_id=123,


### PR DESCRIPTION
Preserve `timeout` and `stalled` failure reasons when Sentry parses Seer run state, allowing the Explorer chat API to expose the terminal cause to the frontend.

Seer begins emitting these reasons in [getsentry/seer#7911](https://github.com/getsentry/seer/pull/7911), but Sentry's Pydantic boundary previously discarded the unknown field. The field remains optional for compatibility with older Seer responses. This unblocks the timeout recovery UI in #122934.
