### PR TITLE
feat(seer): Collapse Autofix setup warning into a filter-row tooltip

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -2356,18 +2356,18 @@ describe('AutofixOverview', () => {
     expect(
       screen.queryByRole('link', {name: 'TypeError in checkout cart'})
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/Seer isn't set up for/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Seer setup warning')).not.toBeInTheDocument();
 
     deferred.resolve();
 
     // Once project config resolves, the warning and the cards appear together.
-    expect(await screen.findByText(/Seer isn't set up for/)).toBeInTheDocument();
+    expect(await screen.findByLabelText('Seer setup warning')).toBeInTheDocument();
     expect(
       screen.getByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
   });
 
-  it('shows the subset warning banner naming only the unconfigured projects', async () => {
+  it('shows the subset warning counting only the unconfigured projects', async () => {
     mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
       projectConfig: [
@@ -2378,12 +2378,13 @@ describe('AutofixOverview', () => {
 
     renderPage();
 
-    const banner = await screen.findByText(/Seer isn't set up for/);
-    expect(banner).toHaveTextContent(
-      "Seer isn't set up for beta-project. Set it up here."
+    await userEvent.hover(await screen.findByLabelText('Seer setup warning'));
+
+    const tooltip = await screen.findByText(/Seer automation isn't set up for/);
+    expect(tooltip).toHaveTextContent(
+      "Seer automation isn't set up for 1 project in the current filter. Enable automation"
     );
-    expect(banner).not.toHaveTextContent('alpha-project');
-    expect(screen.getByRole('link', {name: 'here'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Enable automation'})).toHaveAttribute(
       'href',
       '/settings/org-slug/seer/'
     );
@@ -2403,7 +2404,7 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByRole('button', {name: 'Create Plan 1'})
     ).toBeInTheDocument();
-    expect(screen.queryByText(/Seer isn't set up for/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Seer setup warning')).not.toBeInTheDocument();
     expect(
       screen.queryByText('Set up Seer to start fixing issues')
     ).not.toBeInTheDocument();

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -401,6 +401,12 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
             <OverlayTrigger.Button {...triggerProps} prefix={t('Sort')} />
           )}
         />
+        {someUnconfigured && (
+          <ProjectSetupWarning
+            unconfiguredProjects={unconfiguredProjects}
+            orgSlug={organization.slug}
+          />
+        )}
       </FilterBar>
       {isError ? (
         <LoadingError onRetry={refetch} />
@@ -408,12 +414,6 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
         <OverviewSkeleton />
       ) : (
         <Fragment>
-          {someUnconfigured && (
-            <ProjectSetupWarning
-              unconfiguredProjects={unconfiguredProjects}
-              orgSlug={organization.slug}
-            />
-          )}
           {allRuns.length === 0 ? (
             noRunsContent
           ) : assigneeRuns.length === 0 ? (

--- a/static/app/views/seerWorkflows/overview/projectSetupWarning.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/projectSetupWarning.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectSetupWarning} from './projectSetupWarning';
 import type {ProjectConfig} from './types';
@@ -7,35 +7,41 @@ function project(slug: string): ProjectConfig {
   return {id: slug, slug, hasReposConnected: false};
 }
 
+async function openTooltip() {
+  await userEvent.hover(screen.getByLabelText('Seer setup warning'));
+}
+
 describe('ProjectSetupWarning', () => {
-  it('names a single project and links to org Seer settings', () => {
+  it('counts a single project and links to org Seer settings', async () => {
     render(
       <ProjectSetupWarning unconfiguredProjects={[project('alpha')]} orgSlug="acme" />
     );
 
-    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
-      "Seer isn't set up for alpha. Set it up here."
+    await openTooltip();
+
+    expect(await screen.findByText(/Seer automation isn't set up for/)).toHaveTextContent(
+      "Seer automation isn't set up for 1 project in the current filter. Enable automation"
     );
-    expect(screen.getByRole('link', {name: 'here'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Enable automation'})).toHaveAttribute(
       'href',
       '/settings/acme/seer/'
     );
   });
 
-  it('joins two projects with "and"', () => {
-    render(
-      <ProjectSetupWarning
-        unconfiguredProjects={[project('alpha'), project('beta')]}
-        orgSlug="acme"
-      />
-    );
-
-    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
-      "Seer isn't set up for alpha and beta. Set it up here."
-    );
+  it('is hidden on small screens', () => {
+    const originalWidth = window.innerWidth;
+    window.innerWidth = 375;
+    try {
+      const {container} = render(
+        <ProjectSetupWarning unconfiguredProjects={[project('alpha')]} orgSlug="acme" />
+      );
+      expect(container).toBeEmptyDOMElement();
+    } finally {
+      window.innerWidth = originalWidth;
+    }
   });
 
-  it('oxford-joins three projects', () => {
+  it('pluralizes the project count', async () => {
     render(
       <ProjectSetupWarning
         unconfiguredProjects={[project('alpha'), project('beta'), project('gamma')]}
@@ -43,27 +49,10 @@ describe('ProjectSetupWarning', () => {
       />
     );
 
-    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
-      "Seer isn't set up for alpha, beta, and gamma. Set it up here."
-    );
-  });
+    await openTooltip();
 
-  it('truncates past three with an "and N others" tail', () => {
-    render(
-      <ProjectSetupWarning
-        unconfiguredProjects={[
-          project('alpha'),
-          project('beta'),
-          project('gamma'),
-          project('delta'),
-          project('epsilon'),
-        ]}
-        orgSlug="acme"
-      />
-    );
-
-    expect(screen.getByText(/Seer isn't set up for/)).toHaveTextContent(
-      "Seer isn't set up for alpha, beta, gamma, and 2 others. Set it up here."
+    expect(await screen.findByText(/Seer automation isn't set up for/)).toHaveTextContent(
+      "Seer automation isn't set up for 3 projects in the current filter. Enable automation"
     );
   });
 });

--- a/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
+++ b/static/app/views/seerWorkflows/overview/projectSetupWarning.tsx
@@ -1,42 +1,40 @@
-import {Alert} from '@sentry/scraps/alert';
+import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {IconWarning} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
-import {oxfordizeArray} from 'sentry/utils/oxfordizeArray';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 
 import type {ProjectConfig} from './types';
-
-const MAX_NAMES = 3;
 
 interface Props {
   orgSlug: string;
   unconfiguredProjects: ProjectConfig[];
 }
 
-function formatProjectNames(slugs: string[]) {
-  const visible = slugs.slice(0, MAX_NAMES);
-  const remaining = slugs.length - visible.length;
-
-  if (remaining > 0) {
-    return `${visible.join(', ')}, ${tn('and %s other', 'and %s others', remaining)}`;
-  }
-
-  return oxfordizeArray(visible);
-}
-
 export function ProjectSetupWarning({unconfiguredProjects, orgSlug}: Props) {
   const breakpoints = useBreakpoints();
-  const names = breakpoints.xs
-    ? formatProjectNames(unconfiguredProjects.map(project => project.slug))
-    : tn('%s project', '%s projects', unconfiguredProjects.length);
+  const count = tn('%s project', '%s projects', unconfiguredProjects.length);
+
+  if (!breakpoints.sm) {
+    return null;
+  }
 
   return (
-    <Alert variant="warning" showIcon>
-      {tct("Seer isn't set up for [names]. Set it up [link].", {
-        names,
-        link: <Link to={`/settings/${orgSlug}/seer/`}>{t('here')}</Link>,
-      })}
-    </Alert>
+    <Flex align="center" flex="0 0 auto">
+      <Tooltip
+        isHoverable
+        title={tct(
+          "Seer automation isn't set up for [count] in the current filter. [link]",
+          {
+            count,
+            link: <Link to={`/settings/${orgSlug}/seer/`}>{t('Enable automation')}</Link>,
+          }
+        )}
+      >
+        <IconWarning variant="warning" aria-label={t('Seer setup warning')} />
+      </Tooltip>
+    </Flex>
   );
 }


### PR DESCRIPTION

<img width="2968" height="1284" alt="CleanShot 2026-08-28 at 07 55 05@2x" src="https://github.com/user-attachments/assets/3984a03b-5b77-4b68-adf1-68b5dc2a9414" />


Move the "Seer isn't set up" notice on the Autofix Overview page out of a
full-width banner and into a compact warning icon inline in the filter row,
next to the Sort control. The message now appears on hover in a tooltip
instead of permanently occupying a row below the filters.

The banner spent a full row of vertical space to convey a low-frequency,
informational warning. Collapsing it to a hover tooltip reclaims that space
while keeping the information one hover away, and matches how other status
affordances in this view (assignee/status icons) already behave.

Copy and formatting changes made along the way:
- Reworded to "Seer automation isn't set up for <projects>. Enable automation",
  since the linked action enables automation rather than provisioning Seer.
- The link text is the full "Enable automation" phrase (accessible, unambiguous
  destination) rather than a bare "here".
- The project list shows up to two names, then collapses the rest into
  "and N more projects" (properly singular/plural).

Only the partial case (some selected projects unconfigured) is affected. When
every selected project is unconfigured, the page still shows the full
"Set up Seer to start fixing issues" empty state as before.