### PR TITLE
feat(eslint): make no-redudant-default-arguments work across files

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -92,6 +92,10 @@ const config: KnipConfig = {
       // so do not report them as unused files.
       ignoreFiles: ['static/**/*.less'],
     },
+    'static/eslint/eslintPluginSentry': {
+      // RuleTester resolves these cross-file fixtures by filename.
+      ignoreFiles: ['fixtures/**/*.{ts,tsx}'],
+    },
   },
   ignoreExportsUsedInFile: isProductionMode,
   rules: {

--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -482,7 +482,7 @@ function useParenthesisItems({
     if (nextAllowedTokenKinds.includes(TokenKind.OPEN_PARENTHESIS)) {
       options.push({
         key: `${TokenKind.OPEN_PARENTHESIS}:open`,
-        label: <IconParenthesis side="left" height={26} />,
+        label: <IconParenthesis height={26} />,
         value: '(',
         textValue: '(',
         hideCheck: true,

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -135,7 +135,6 @@ function AssigneeAvatar({
       <ActorAvatar
         actor={assignedTo}
         className="avatar"
-        size={24}
         tooltip={
           <Stack gap="xs" align="start">
             <Text as="div" align="left" wrap="nowrap">

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -247,7 +247,7 @@ function Chart({
             ? tooltipFormatter(value, timeseriesResultsTypes[aggregateName])
             : tooltipFormatter(value, aggregateOutputType(aggregateName));
         }
-        return tooltipFormatter(value, 'number');
+        return tooltipFormatter(value);
       },
     },
     xAxis: timeframe

--- a/static/app/components/charts/utils.spec.tsx
+++ b/static/app/components/charts/utils.spec.tsx
@@ -36,28 +36,28 @@ describe('Chart Utils', () => {
     describe('with medium fidelity', () => {
       it('greater than 24 hours', () => {
         expect(getInterval({period: '25h'})).toBe('1h');
-        expect(getInterval({period: '25h'}, 'medium')).toBe('1h');
+        expect(getInterval({period: '25h'})).toBe('1h');
       });
 
       it('less than 30 minutes', () => {
         expect(getInterval({period: '20m'})).toBe('5m');
-        expect(getInterval({period: '20m'}, 'medium')).toBe('5m');
+        expect(getInterval({period: '20m'})).toBe('5m');
       });
       it('between 30 minutes and 24 hours', () => {
         expect(getInterval({period: '12h'})).toBe('15m');
-        expect(getInterval({period: '12h'}, 'medium')).toBe('15m');
+        expect(getInterval({period: '12h'})).toBe('15m');
       });
       it('more than 14 days', () => {
         expect(getInterval({period: '14d'})).toBe('1h');
-        expect(getInterval({period: '14d'}, 'medium')).toBe('1h');
+        expect(getInterval({period: '14d'})).toBe('1h');
       });
       it('more than 30 days', () => {
         expect(getInterval({period: '30d'})).toBe('4h');
-        expect(getInterval({period: '30d'}, 'medium')).toBe('4h');
+        expect(getInterval({period: '30d'})).toBe('4h');
       });
       it('more than 90 days', () => {
         expect(getInterval({period: '90d'})).toBe('1d');
-        expect(getInterval({period: '90d'}, 'medium')).toBe('1d');
+        expect(getInterval({period: '90d'})).toBe('1d');
       });
     });
 

--- a/static/app/components/checkInTimeline/timelineCursor.spec.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.spec.tsx
@@ -10,7 +10,6 @@ import {useTimelineCursor} from './timelineCursor';
 
 function TestComponent() {
   const {timelineCursor, cursorContainerRef} = useTimelineCursor<HTMLDivElement>({
-    enabled: true,
     labelText: p => p.toFixed(2),
   });
 

--- a/static/app/components/checkInTimeline/timelineZoom.spec.tsx
+++ b/static/app/components/checkInTimeline/timelineZoom.spec.tsx
@@ -8,7 +8,7 @@ interface TestProps {
 
 function TestComponent({onSelect}: TestProps) {
   const {isActive, timelineSelector, selectionContainerRef} =
-    useTimelineZoom<HTMLDivElement>({enabled: true, onSelect});
+    useTimelineZoom<HTMLDivElement>({onSelect});
 
   return (
     <div data-test-id="body">

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -684,7 +684,6 @@ export function CommandPalette({
             overlayIsOpen
             virtualized
             virtualizedListPadding={0}
-            size="md"
             aria-label={t('Search results')}
             selectionMode="none"
             shouldUseVirtualFocus

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -771,7 +771,7 @@ export function GlobalCommandPaletteActions() {
           )}
           {isActiveSuperuser() && (
             <CMDKAction
-              display={{label: t('Exit Superuser'), icon: <IconLock locked={false} />}}
+              display={{label: t('Exit Superuser'), icon: <IconLock />}}
               keywords={[t('superuser')]}
               onAction={() => exitSuperuser()}
             />

--- a/static/app/components/core/avatar/avatar.spec.tsx
+++ b/static/app/components/core/avatar/avatar.spec.tsx
@@ -99,7 +99,6 @@ describe('Avatar', () => {
           identifier="test-id"
           name="Test User"
           tooltip="Test Tooltip"
-          hasTooltip={false}
         />
       );
       expect(screen.getByText('TU')).toBeInTheDocument();

--- a/static/app/components/core/avatar/sentryAppAvatar.spec.tsx
+++ b/static/app/components/core/avatar/sentryAppAvatar.spec.tsx
@@ -26,7 +26,7 @@ describe('SentryAppAvatar', () => {
         ],
       });
 
-      render(<SentryAppAvatar sentryApp={sentryApp} isColor />);
+      render(<SentryAppAvatar sentryApp={sentryApp} />);
       const img = screen.getByRole('img');
       // Should include the size parameter
       expect(img).toHaveAttribute('src', 'https://example.com/color-logo.png?s=120');
@@ -117,7 +117,7 @@ describe('SentryAppAvatar', () => {
         ],
       });
 
-      render(<SentryAppAvatar sentryApp={sentryApp} isColor />);
+      render(<SentryAppAvatar sentryApp={sentryApp} />);
       expect(screen.getByTestId('default-sentry-app-avatar')).toBeInTheDocument();
       // Should not have an img element with src (the fallback is an SVG icon)
       const images = screen.queryAllByRole('img');

--- a/static/app/components/core/checkbox/checkbox.spec.tsx
+++ b/static/app/components/core/checkbox/checkbox.spec.tsx
@@ -17,7 +17,7 @@ function ControlledCheckbox() {
 
 describe('Checkbox', () => {
   it('default is unchecked', () => {
-    render(<Checkbox checked={false} onChange={jest.fn()} />);
+    render(<Checkbox onChange={jest.fn()} />);
 
     expect(screen.getByRole('checkbox')).not.toBeChecked();
   });

--- a/static/app/components/core/input/otpInput.tsx
+++ b/static/app/components/core/input/otpInput.tsx
@@ -134,7 +134,7 @@ export function OTPInput<const Format extends string>({
 }
 
 const OTPInputSlot = styled(Flex)<{$isActive: boolean}>`
-  ${p => inputStyles({theme: p.theme, size: 'md'})};
+  ${p => inputStyles({theme: p.theme})};
   display: flex;
   min-width: ${p => p.theme.form.md.height};
   padding: 0;

--- a/static/app/components/core/slider/slider.spec.tsx
+++ b/static/app/components/core/slider/slider.spec.tsx
@@ -40,7 +40,7 @@ describe('Slider', () => {
     });
 
     it('sets aria-valuetext', () => {
-      render(<Slider defaultValue={30} min={0} max={100} aria-label="Test" />);
+      render(<Slider defaultValue={30} aria-label="Test" />);
       expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '30');
     });
   });

--- a/static/app/components/core/splitPanel/splitPanel.spec.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.spec.tsx
@@ -9,7 +9,6 @@ describe('SplitPanel', () => {
   it('renders both panes and a divider', () => {
     render(
       <SplitPanel
-        orientation="horizontal"
         defaultSize={200}
         minSize={100}
         sized={<div>sized</div>}
@@ -23,9 +22,7 @@ describe('SplitPanel', () => {
   });
 
   it('renders only the sized pane (no divider) when fill is omitted', () => {
-    render(
-      <SplitPanel orientation="horizontal" defaultSize={200} sized={<div>sized</div>} />
-    );
+    render(<SplitPanel defaultSize={200} sized={<div>sized</div>} />);
 
     expect(screen.getByText('sized')).toBeInTheDocument();
     expect(screen.queryByRole('separator')).not.toBeInTheDocument();
@@ -36,7 +33,6 @@ describe('SplitPanel', () => {
     // negative flex-basis; the rendered size is floored at minSize.
     render(
       <SplitPanel
-        orientation="horizontal"
         defaultSize={200}
         initialSize={-50}
         minSize={100}
@@ -53,16 +49,11 @@ describe('SplitPanel', () => {
   it('preserves the sized pane DOM node when the fill pane is toggled', () => {
     const sized = <div>sized</div>;
     const {rerender} = render(
-      <SplitPanel
-        orientation="horizontal"
-        defaultSize={200}
-        sized={sized}
-        fill={<div>fill</div>}
-      />
+      <SplitPanel defaultSize={200} sized={sized} fill={<div>fill</div>} />
     );
     const before = screen.getByText('sized');
 
-    rerender(<SplitPanel orientation="horizontal" defaultSize={200} sized={sized} />);
+    rerender(<SplitPanel defaultSize={200} sized={sized} />);
 
     expect(screen.getByText('sized')).toBe(before);
   });
@@ -70,7 +61,6 @@ describe('SplitPanel', () => {
   it('places the sized pane after the fill pane when placement is "end"', () => {
     render(
       <SplitPanel
-        orientation="horizontal"
         placement="end"
         defaultSize={200}
         sized={<div>sized</div>}
@@ -89,7 +79,6 @@ describe('SplitPanel', () => {
   it('exposes the divider as a separator with orientation and value attributes', () => {
     render(
       <SplitPanel
-        orientation="horizontal"
         defaultSize={200}
         minSize={100}
         maxSize={600}
@@ -114,7 +103,6 @@ describe('SplitPanel', () => {
     render(
       <SplitPanel
         ref={ref}
-        orientation="horizontal"
         defaultSize={200}
         minSize={100}
         maxSize={600}
@@ -143,7 +131,6 @@ describe('SplitPanel', () => {
 
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           minSize={100}
           fillMinSize={400}
@@ -165,7 +152,6 @@ describe('SplitPanel', () => {
 
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           minSize={100}
           sized={<div>sized</div>}
@@ -185,7 +171,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           initialSize={400}
           minSize={100}
@@ -220,7 +205,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           initialSize={-50}
           minSize={100}
@@ -251,7 +235,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           initialSize={-50}
           minSize={100}
@@ -282,7 +265,6 @@ describe('SplitPanel', () => {
       const onResize = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           initialSize={-50}
           minSize={100}
@@ -302,7 +284,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           placement="end"
           defaultSize={200}
           minSize={100}
@@ -328,7 +309,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           minSize={100}
           onResizeEnd={onResizeEnd}
@@ -352,7 +332,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           defaultSize={200}
           minSize={100}
           onResizeEnd={onResizeEnd}
@@ -380,7 +359,6 @@ describe('SplitPanel', () => {
       const onResizeEnd = jest.fn();
       render(
         <SplitPanel
-          orientation="horizontal"
           placement="end"
           defaultSize={200}
           minSize={100}

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -199,7 +199,6 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
                 organization,
                 path: `/${encodeURIComponent(selectedRelease.version)}/`,
               })}${props.project ? `?project=${props.project.id}` : ''}`}
-              openInNewTab
             >
               <Flex align="center" gap="xs">
                 {t('View release')} <IconOpen size="xs" />

--- a/static/app/components/dropdownMenu/index.stories.tsx
+++ b/static/app/components/dropdownMenu/index.stories.tsx
@@ -233,7 +233,7 @@ export default Storybook.story('DropdownMenu', story => {
         </p>
         <Flex direction="row" gap="md" align="start">
           <DropdownMenu triggerLabel="Small" items={items} size="sm" />
-          <DropdownMenu triggerLabel="Medium" items={items} size="md" />
+          <DropdownMenu triggerLabel="Medium" items={items} />
         </Flex>
       </Fragment>
     );

--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -72,7 +72,6 @@ export function SeerDrawerHeader({
               <Flex align="center" gap="xs">
                 <Text size="xs">{t('Bash')}</Text>
                 <Switch
-                  size="sm"
                   checked={enableBashTools ?? false}
                   onChange={() => onEnableBashToolsChange(!enableBashTools)}
                   aria-label={t('Enable bash tools')}

--- a/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
+++ b/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
@@ -61,7 +61,6 @@ export default function ReplayInlineOnboardingPanel({
           </Container>
           <Flex gap="md">
             <Button
-              type="button"
               analyticsEventName="Clicked Replay Onboarding CTA Set Up Button in Issue Details"
               analyticsEventKey="issue_details.replay-onboarding-cta-set-up-button-clicked"
               analyticsParams={{platform}}

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -199,7 +199,7 @@ function EventDisplay({
   if (!defined(eventData) || !defined(eventIds)) {
     return (
       <EmptyStateWrapper>
-        <EmptyStateWarning withIcon>
+        <EmptyStateWarning>
           <div>{t('Unable to find a sample event')}</div>
         </EmptyStateWarning>
       </EmptyStateWrapper>

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -118,7 +118,7 @@ function LoadedHighlightsSettingsForm({project}: LoadedHighlightsSettingsFormPro
             hintText={tct(
               'Enter a valid JSON entry for mapping [Structured Context] types, to their keys. E.g. [example]',
               {
-                link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
+                link: <ExternalLink href={CONTEXT_DOCS_LINK} />,
                 example: '{"user": ["id", "email"]}',
               }
             )}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -160,13 +160,7 @@ describe('Native StackTrace', () => {
     };
 
     render(
-      <NativeContent
-        data={newData}
-        platform="cocoa"
-        event={event}
-        includeSystemFrames
-        newestFirst={false}
-      />
+      <NativeContent data={newData} platform="cocoa" event={event} newestFirst={false} />
     );
 
     const frames = screen.getAllByTestId('stack-trace-frame');
@@ -202,15 +196,7 @@ describe('Native StackTrace', () => {
       ],
     };
 
-    render(
-      <NativeContent
-        data={newData}
-        platform="cocoa"
-        event={event}
-        includeSystemFrames
-        newestFirst
-      />
-    );
+    render(<NativeContent data={newData} platform="cocoa" event={event} newestFirst />);
 
     expect(screen.getByRole('button', {name: 'Collapse Context'})).toBeInTheDocument();
     const collapsed = screen.getAllByRole('button', {name: 'Expand Context'});

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -72,7 +72,6 @@ describe('RawStacktraceContent', () => {
           },
           platform: 'java',
           exception,
-          isMinified: false,
         })
       ).toBe('com.example.app.CustomException: Original error message');
     });
@@ -164,7 +163,6 @@ describe('RawStacktraceContent', () => {
           },
           platform: 'java',
           exception,
-          isMinified: false,
         })
       ).toBe('IllegalStateException: Oops!');
     });
@@ -233,8 +231,6 @@ describe('RawStacktraceContent', () => {
           data,
           platform: 'javascript',
           exception,
-          rawTrace: true,
-          newestFirst: true,
         })
       ).toBe(
         `Error: an error occurred
@@ -252,7 +248,6 @@ describe('RawStacktraceContent', () => {
           platform: 'javascript',
           exception,
           rawTrace: false,
-          newestFirst: true,
         })
       ).toBe(
         `Error: an error occurred
@@ -269,7 +264,6 @@ describe('RawStacktraceContent', () => {
           data,
           platform: 'javascript',
           exception,
-          rawTrace: true,
           newestFirst: false,
         })
       ).toBe(
@@ -347,8 +341,6 @@ Error: an error occurred`
           data,
           platform: 'python',
           exception,
-          rawTrace: true,
-          newestFirst: true,
         })
       ).toBe(
         `Traceback (most recent call last):
@@ -367,7 +359,6 @@ Error: an error occurred`
           platform: 'python',
           exception,
           rawTrace: false,
-          newestFirst: true,
         })
       ).toBe(
         `Traceback (most recent call first):
@@ -385,7 +376,6 @@ Error: an error occurred
           data,
           platform: 'python',
           exception,
-          rawTrace: true,
           newestFirst: false,
         })
       ).toBe(

--- a/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
+++ b/static/app/components/events/interfaces/performance/traceLinkedIssues.tsx
@@ -41,7 +41,6 @@ export function TraceLinkedIssues({
       queryParams={queryParams}
       source={source}
       canSelectGroups={false}
-      withChart
       withColumns={['event', 'firstSeen', 'lastSeen']}
       withPagination={false}
       numPlaceholderRows={3}

--- a/static/app/components/events/interfaces/request/index.tsx
+++ b/static/app/components/events/interfaces/request/index.tsx
@@ -290,7 +290,7 @@ function TruncatedPathLink(props: TruncatedPathLinkProps) {
   return (
     <Flex as="span" gap="sm" align="baseline" padding="0 0 md 0">
       <Text bold>{props.method || 'GET'}</Text>
-      <ExternalLink openInNewTab href={props.fullUrl} title={props.fullUrl}>
+      <ExternalLink href={props.fullUrl} title={props.fullUrl}>
         <Flex gap="xs" align="baseline">
           {flexProps => (
             <Text {...flexProps} variant="primary">

--- a/static/app/components/events/suspectCommitFeedback.tsx
+++ b/static/app/components/events/suspectCommitFeedback.tsx
@@ -49,7 +49,7 @@ export function SuspectCommitFeedback({
       <Flex gap="2xs">
         <Button
           size="zero"
-          icon={<IconThumb direction="up" size="xs" />}
+          icon={<IconThumb size="xs" />}
           onClick={() => handleFeedback(true)}
           aria-label={t('Yes, this suspect commit is correct')}
         />

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -254,9 +254,6 @@ export function TraceEventDataSection({
                 data: stacktraceData,
                 platform: stacktraceData?.frames?.[0]?.platform ?? platform,
                 exception,
-                hasSimilarityEmbeddingsFeature: false,
-                includeLocation: true,
-                rawTrace: true,
                 isMinified: useMinified,
               });
             })
@@ -268,9 +265,6 @@ export function TraceEventDataSection({
         return displayRawContent({
           data: entry.data,
           platform: entry.data.frames?.[0]?.platform ?? platform,
-          hasSimilarityEmbeddingsFeature: false,
-          includeLocation: true,
-          rawTrace: true,
           isMinified: useMinified,
         });
       }
@@ -289,9 +283,6 @@ export function TraceEventDataSection({
               displayRawContent({
                 data: stacktraceData,
                 platform: stacktraceData.frames?.[0]?.platform ?? platform,
-                hasSimilarityEmbeddingsFeature: false,
-                includeLocation: true,
-                rawTrace: true,
                 isMinified: useMinified,
               })
             );

--- a/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
+++ b/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
@@ -18,7 +18,6 @@ export function ReplayInlineCTAPanel() {
       button={
         <Grid flow="column" align="center" gap="md">
           <Button
-            type="button"
             variant="primary"
             analyticsEventName="Clicked Replay Onboarding CTA Button in User Feedback"
             analyticsEventKey="feedback.replay-onboarding-cta-button-clicked"

--- a/static/app/components/feedback/list/useMailboxCounts.tsx
+++ b/static/app/components/feedback/list/useMailboxCounts.tsx
@@ -58,7 +58,6 @@ export function useMailboxCounts({
     () =>
       coaleseIssueStatsPeriodQuery({
         listHeadTime,
-        prefetch: false,
         queryView,
       }),
     [listHeadTime, queryView]

--- a/static/app/components/logoSentry.stories.tsx
+++ b/static/app/components/logoSentry.stories.tsx
@@ -8,7 +8,7 @@ export default Storybook.story('LogoSentry', story => {
     </Storybook.SizingWindow>
   ));
 
-  story('Wordmark', () => <LogoSentry showWordmark />);
+  story('Wordmark', () => <LogoSentry />);
 
   story('No wordmark', () => <LogoSentry showWordmark={false} />);
 });

--- a/static/app/components/mentionInput/mentionInput.tsx
+++ b/static/app/components/mentionInput/mentionInput.tsx
@@ -201,7 +201,6 @@ export function MentionInput<TSuggestion>({
     position: 'bottom-start',
     offset: 4,
     shouldApplyMinWidth: false,
-    shouldCloseOnBlur: false,
     isKeyboardDismissDisabled: true,
     onClose: () => setActiveMention(null),
     shouldCloseOnInteractOutside: element => !inputRef.current?.contains(element),

--- a/static/app/components/onboarding/scm/scmFeatureCard.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureCard.tsx
@@ -101,7 +101,6 @@ export function ScmFeatureCard({
                   role="presentation"
                   tabIndex={-1}
                   readOnly
-                  size="sm"
                 />
               </Tooltip>
             </Flex>

--- a/static/app/components/onboarding/scm/scmIntegrationSelect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationSelect.tsx
@@ -43,7 +43,6 @@ export function ScmIntegrationSelect({
 
   return (
     <CompactSelect
-      size="md"
       value={selectedIntegration.id}
       options={options}
       onChange={option => {

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow.spec.tsx
@@ -398,7 +398,6 @@ describe('ScmMessagingProviderRow', () => {
           onActiveRowChange={jest.fn()}
           onInstallComplete={onInstallComplete}
           onMessagingSetupChange={jest.fn()}
-          isRefetchingIntegrations={false}
         />
       );
 
@@ -441,7 +440,6 @@ describe('ScmMessagingProviderRow', () => {
           onActiveRowChange={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          isRefetchingIntegrations={false}
         />,
         {organization}
       );
@@ -473,7 +471,6 @@ describe('ScmMessagingProviderRow', () => {
           onActiveRowChange={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          isRefetchingIntegrations={false}
         />
       );
 
@@ -496,7 +493,6 @@ describe('ScmMessagingProviderRow', () => {
           onActiveRowChange={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          isRefetchingIntegrations={false}
         />,
         {organization}
       );
@@ -528,7 +524,6 @@ describe('ScmMessagingProviderRow', () => {
           onActiveRowChange={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
-          isRefetchingIntegrations={false}
         />
       );
 

--- a/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.spec.tsx
@@ -18,7 +18,6 @@ function useTestOptions(
       label: 'Option One',
       leadingItems: ({isSelected}: {isSelected: boolean}) => (
         <Checkbox
-          size="sm"
           checked={isSelected}
           onChange={() => toggleOptionRef.current?.('one')}
           aria-label="Select Option One"
@@ -31,7 +30,6 @@ function useTestOptions(
       label: 'Option Two',
       leadingItems: ({isSelected}: {isSelected: boolean}) => (
         <Checkbox
-          size="sm"
           checked={isSelected}
           onChange={() => toggleOptionRef.current?.('two')}
           aria-label="Select Option Two"
@@ -44,7 +42,6 @@ function useTestOptions(
       label: 'Option Three',
       leadingItems: ({isSelected}: {isSelected: boolean}) => (
         <Checkbox
-          size="sm"
           checked={isSelected}
           onChange={() => toggleOptionRef.current?.('three')}
           aria-label="Select Option Three"

--- a/static/app/components/percentChange.spec.tsx
+++ b/static/app/components/percentChange.spec.tsx
@@ -22,7 +22,7 @@ describe('PercentChange', () => {
   });
 
   it('respects preferred positive polarity', () => {
-    render(<PercentChange value={0.0552} preferredPolarity="+" />);
+    render(<PercentChange value={0.0552} />);
 
     expect(screen.getByText('+5.52%')).toHaveAttribute('data-rating', 'good');
   });

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -182,7 +182,6 @@ const FlamegraphDrawer = memo(function FlamegraphDrawerImpl(
         <ProfilingDetailsListItem>
           <FrameDrawerLabel>
             <Checkbox
-              size="sm"
               checked={recursion === 'collapsed'}
               onChange={handleRecursionChange}
             />

--- a/static/app/components/projectList.spec.tsx
+++ b/static/app/components/projectList.spec.tsx
@@ -15,9 +15,7 @@ describe('ProjectList', () => {
   });
 
   it('renders all projects when there is no overflow', async () => {
-    render(
-      <ProjectList projectSlugs={['project1', 'project2']} maxVisibleProjects={2} />
-    );
+    render(<ProjectList projectSlugs={['project1', 'project2']} />);
 
     // Project avatars render decorative platform icons (alt=""), so they are
     // queried by test id rather than the img role.
@@ -25,12 +23,7 @@ describe('ProjectList', () => {
   });
 
   it('renders the collapsed projects when there is overflow', async () => {
-    render(
-      <ProjectList
-        projectSlugs={['project1', 'project2', 'project3']}
-        maxVisibleProjects={2}
-      />
-    );
+    render(<ProjectList projectSlugs={['project1', 'project2', 'project3']} />);
 
     // Should show project 1 and the collapsed badge
     expect(await screen.findAllByTestId(/^platform-icon-/)).toHaveLength(1);

--- a/static/app/components/replays/breadcrumbs/gridlines.tsx
+++ b/static/app/components/replays/breadcrumbs/gridlines.tsx
@@ -40,7 +40,7 @@ type Props = {
 };
 
 export function MajorGridlines({durationMs, width}: Props) {
-  const {cols, remaining} = countColumns(durationMs, width, 50);
+  const {cols, remaining} = countColumns(durationMs, width);
 
   return <Gridlines cols={cols} lineStyle="solid" remaining={remaining} />;
 }

--- a/static/app/components/replays/diff/replayTextDiff.tsx
+++ b/static/app/components/replays/diff/replayTextDiff.tsx
@@ -61,7 +61,7 @@ export function ReplayTextDiff() {
         </After>
       </ContentSliderDiff.Header>
       <Flex flexGrow={1} height="0" overflow="auto">
-        <SplitDiff base={leftBody} target={rightBody} type="lines" />
+        <SplitDiff base={leftBody} target={rightBody} />
       </Flex>
     </Stack>
   );

--- a/static/app/components/replays/player/replayCurrentTime.stories.tsx
+++ b/static/app/components/replays/player/replayCurrentTime.stories.tsx
@@ -15,7 +15,7 @@ export default Storybook.story('ReplayCurrentTime', story => {
           <ReplayPlayPauseButton />
           <ReplayCurrentTime />
           <NegativeSpaceContainer style={{height: 300}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>
@@ -38,7 +38,7 @@ export default Storybook.story('ReplayCurrentTime', story => {
           <JumpToOffsetButtonBar intervals={['0m', '1m', '12m']} />
 
           <NegativeSpaceContainer style={{height: 300}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>

--- a/static/app/components/replays/player/replayPlayPauseButton.stories.tsx
+++ b/static/app/components/replays/player/replayPlayPauseButton.stories.tsx
@@ -19,7 +19,7 @@ export default Storybook.story('ReplayPlayer', story => {
           </p>
 
           <NegativeSpaceContainer style={{height: 400}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>
@@ -45,13 +45,13 @@ export default Storybook.story('ReplayPlayer', story => {
           </p>
 
           <NegativeSpaceContainer style={{height: 200}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>
           <hr />
           <NegativeSpaceContainer style={{height: 200}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>

--- a/static/app/components/replays/player/replayPlayer.stories.tsx
+++ b/static/app/components/replays/player/replayPlayer.stories.tsx
@@ -23,7 +23,7 @@ export default Storybook.story('ReplayPlayer', story => {
           <DebugReplayPlayerState />
           <DebugReplayPrefsState />
           <NegativeSpaceContainer style={{height: 500}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>

--- a/static/app/components/replays/player/replayPlayerMeasurer.stories.tsx
+++ b/static/app/components/replays/player/replayPlayerMeasurer.stories.tsx
@@ -28,7 +28,7 @@ export default Storybook.story('ReplayPlayerMeasurer', story => {
           </p>
 
           <NegativeSpaceContainer style={{height: 500}}>
-            <ReplayPlayerMeasurer measure="both">
+            <ReplayPlayerMeasurer>
               {style => <ReplayPlayer style={style} />}
             </ReplayPlayerMeasurer>
           </NegativeSpaceContainer>

--- a/static/app/components/scrollCarousel.stories.tsx
+++ b/static/app/components/scrollCarousel.stories.tsx
@@ -13,7 +13,7 @@ export default Storybook.story('ScrollCarousel', story => {
         and show arrows to scroll left and right. Native scrollbars are hidden.
       </p>
       <div style={{width: '375px', display: 'block'}}>
-        <ScrollCarousel aria-label="example" gap="md">
+        <ScrollCarousel aria-label="example">
           {['one', 'two', 'three', 'four', 'five', 'six'].map(item => (
             <ExampleItem key={item}>{item}</ExampleItem>
           ))}
@@ -29,7 +29,7 @@ export default Storybook.story('ScrollCarousel', story => {
         <Storybook.JSXProperty name="orientation" value="vertical" />.
       </p>
       <div style={{width: '240px', height: '160px', display: 'block'}}>
-        <ScrollCarousel aria-label="vertical-example" orientation="vertical" gap="md">
+        <ScrollCarousel aria-label="vertical-example" orientation="vertical">
           {['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta'].map(item => (
             <ExampleItem key={item}>{item}</ExampleItem>
           ))}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -579,7 +579,6 @@ function ItemCheckbox({disabled, value}: {disabled: boolean; value: string}) {
     >
       <CheckWrap role="presentation">
         <Checkbox
-          size="sm"
           checked={selected}
           disabled={disabled}
           onChange={() => {

--- a/static/app/components/slider/index.spec.tsx
+++ b/static/app/components/slider/index.spec.tsx
@@ -4,7 +4,7 @@ import {Slider} from 'sentry/components/slider';
 
 describe('Slider', () => {
   it('renders', () => {
-    render(<Slider label="Test" min={0} max={10} step={1} defaultValue={5} />);
+    render(<Slider label="Test" max={10} defaultValue={5} />);
 
     expect(screen.getByRole('group', {name: 'Test'})).toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveTextContent('5'); // <output /> element
@@ -17,7 +17,7 @@ describe('Slider', () => {
   });
 
   it('renders without label/output', () => {
-    render(<Slider aria-label="Test" min={0} max={10} step={1} defaultValue={5} />);
+    render(<Slider aria-label="Test" max={10} defaultValue={5} />);
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
@@ -54,7 +54,6 @@ describe('Slider', () => {
     render(
       <Slider
         label="Test"
-        min={0}
         max={10}
         step={5}
         defaultValue={5}
@@ -76,13 +75,7 @@ describe('Slider', () => {
   it('supports advanced keyboard navigation', async () => {
     const onChangeEndMock = jest.fn();
     render(
-      <Slider
-        label="Test"
-        min={5}
-        max={100}
-        defaultValue={5}
-        onChangeEnd={onChangeEndMock}
-      />
+      <Slider label="Test" min={5} defaultValue={5} onChangeEnd={onChangeEndMock} />
     );
 
     // To focus on the slider, we should call the focus() method. The slider input element

--- a/static/app/components/structuredEventData/index.spec.tsx
+++ b/static/app/components/structuredEventData/index.spec.tsx
@@ -77,7 +77,7 @@ describe('StructuredEventData', () => {
 
   describe('null', () => {
     it('should render null values correctly', () => {
-      render(<StructuredEventData data={null} />);
+      render(<StructuredEventData />);
       expect(
         within(screen.getByTestId('value-null')).getByText('null')
       ).toBeInTheDocument();
@@ -104,7 +104,7 @@ describe('StructuredEventData', () => {
           rem: [['project:0', 'x']],
         },
       };
-      render(<StructuredEventData data={null} meta={meta} withAnnotatedText />);
+      render(<StructuredEventData meta={meta} withAnnotatedText />);
       expect(screen.getByText(/redacted/)).toBeInTheDocument();
       expect(screen.queryByText('null')).not.toBeInTheDocument();
     });
@@ -112,7 +112,6 @@ describe('StructuredEventData', () => {
     it('preserves renderNull when meta has no annotations', () => {
       render(
         <StructuredEventData
-          data={null}
           config={{renderNull: () => 'None'}}
           meta={{}}
           withAnnotatedText
@@ -246,7 +245,7 @@ describe('StructuredEventData', () => {
     });
 
     it('auto-expands N levels when forceDefaultExpand=undefined maxDefaultDepth=N', () => {
-      render(<StructuredEventData data={data} maxDefaultDepth={2} />);
+      render(<StructuredEventData data={data} />);
 
       // String value, visible
       expect(screen.getByText('foo')).toBeInTheDocument();

--- a/static/app/components/structuredEventData/index.stories.tsx
+++ b/static/app/components/structuredEventData/index.stories.tsx
@@ -17,7 +17,7 @@ export default Storybook.story('StructuredEventData', story => {
         </p>
         <StructuredEventData data="foo" />
         <StructuredEventData data={100} />
-        <StructuredEventData data={null} />
+        <StructuredEventData />
         <StructuredEventData data={false} />
         <StructuredEventData data={{foo: 'bar', arr: [1, 2, 3, 4, 5, 6]}} />
         <StructuredEventData data={['one', 2, null]} />

--- a/static/app/components/tables/gridEditable/index.stories.tsx
+++ b/static/app/components/tables/gridEditable/index.stories.tsx
@@ -139,7 +139,6 @@ export default Storybook.story('GridEditable', story => {
   story('Column Resize', () => {
     const queryBasedColumnResize = useQueryBasedColumnResize({
       columns: columnsWithWidth,
-      paramName: 'width',
     });
 
     return (

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -112,7 +112,7 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
           </div>
           <div>
             <h6 style={{textAlign: 'right'}}>{t('Date Created')}</h6>
-            <DateTime date={release.dateCreated} seconds={false} />
+            <DateTime date={release.dateCreated} />
           </div>
         </Flex>
         {parsedVersion?.package && (

--- a/static/app/components/workflowEngine/form/environmentSelector.tsx
+++ b/static/app/components/workflowEngine/form/environmentSelector.tsx
@@ -46,7 +46,6 @@ export function EnvironmentSelector() {
 
   return (
     <CompactSelect
-      size="md"
       options={options}
       search
       disabled={!projectsLoaded}

--- a/static/app/gettingStartedDocs/playstation/onboarding.tsx
+++ b/static/app/gettingStartedDocs/playstation/onboarding.tsx
@@ -70,7 +70,6 @@ const onboardingRetail: OnboardingConfig = {
               projectSettingsLink: (
                 <ExternalLink
                   href={`/settings/${params.organization.slug}/projects/${params.project.slug}/playstation/?tab=retail`}
-                  openInNewTab
                 />
               ),
             }

--- a/static/app/icons/pluginIcon.spec.tsx
+++ b/static/app/icons/pluginIcon.spec.tsx
@@ -9,6 +9,6 @@ jest.mock('images/logos/logo-github.svg', () => 'github', {});
 
 describe('PluginIcon', () => {
   it('renders', () => {
-    render(<PluginIcon pluginId="github" size={20} />);
+    render(<PluginIcon pluginId="github" />);
   });
 });

--- a/static/app/utils/api/useAggregatedQueryKeys.stories.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.stories.tsx
@@ -39,7 +39,6 @@ export default Storybook.story('useAggregatedQueryKeys', story => {
         const defaults = Object.fromEntries(aggregates.map(id => [id, 0]));
         return {...defaults, ...prevState, ...response.json};
       }, []),
-      bufferLimit: 50,
     });
 
     useEffect(() => {

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -58,7 +58,7 @@ export function tooltipFormatterUsingAggregateOutputType(
     case 'number':
       return value.toLocaleString();
     case 'percentage':
-      return formatPercentage(value, 2);
+      return formatPercentage(value);
     case 'duration': {
       const durationUnitString = unit ?? undefined;
       const durationMultiplier = isADurationUnit(durationUnitString)

--- a/static/app/utils/middleEllipsis.spec.tsx
+++ b/static/app/utils/middleEllipsis.spec.tsx
@@ -2,19 +2,17 @@ import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 
 describe('middleEllipsis', () => {
   it('returns slug if it is already short enough', () => {
-    expect(middleEllipsis('javascript', 20, ' ')).toBe('javascript');
+    expect(middleEllipsis('javascript', 20)).toBe('javascript');
   });
 
   it('trims long but unhyphenated slug', () => {
-    expect(middleEllipsis('javascriptfrontendproject', 20, ' ')).toBe(
-      'javascriptfrontendp…'
-    );
+    expect(middleEllipsis('javascriptfrontendproject', 20)).toBe('javascriptfrontendp…');
   });
 
   it('trims slug from the middle, preserves whole words', () => {
-    expect(middleEllipsis('symbol collector console', 20, ' ')).toBe('symbol…console');
-    expect(middleEllipsis('symbol collector mobile', 20, ' ')).toBe('symbol…mobile');
-    expect(middleEllipsis('visual snapshot cloud run', 20, ' ')).toBe('visual…cloud run');
+    expect(middleEllipsis('symbol collector console', 20)).toBe('symbol…console');
+    expect(middleEllipsis('symbol collector mobile', 20)).toBe('symbol…mobile');
+    expect(middleEllipsis('visual snapshot cloud run', 20)).toBe('visual…cloud run');
     expect(middleEllipsis('visual snapshot.cloud-run', 20, / |\./)).toBe(
       'visual…cloud-run'
     );
@@ -28,9 +26,7 @@ describe('middleEllipsis', () => {
   });
 
   it('trims slug from the middle, cuts whole words', () => {
-    expect(middleEllipsis('sourcemapsio javascript', 20, ' ')).toBe(
-      'sourcemaps…javascript'
-    );
+    expect(middleEllipsis('sourcemapsio javascript', 20)).toBe('sourcemaps…javascript');
     expect(middleEllipsis('armcknight ios.ephemeraldemo', 20, /\.| /)).toBe(
       'armcknig…phemeraldemo'
     );

--- a/static/app/utils/number/formatNumberWithDynamicDecimalPoints.spec.tsx
+++ b/static/app/utils/number/formatNumberWithDynamicDecimalPoints.spec.tsx
@@ -14,11 +14,11 @@ describe('formatNumberWithDynamicDecimals', () => {
   });
 
   it('rounds up to the maximum fraction digits passed', () => {
-    expect(formatNumberWithDynamicDecimalPoints(1, 2)).toBe('1');
+    expect(formatNumberWithDynamicDecimalPoints(1)).toBe('1');
     // eslint-disable-next-line unicorn/no-zero-fractions
-    expect(formatNumberWithDynamicDecimalPoints(1.0, 2)).toBe('1');
+    expect(formatNumberWithDynamicDecimalPoints(1.0)).toBe('1');
     expect(formatNumberWithDynamicDecimalPoints(1.2345, 1)).toBe('1.2');
-    expect(formatNumberWithDynamicDecimalPoints(1.2345, 2)).toBe('1.23');
+    expect(formatNumberWithDynamicDecimalPoints(1.2345)).toBe('1.23');
     expect(formatNumberWithDynamicDecimalPoints(1.2345, 3)).toBe('1.235');
     expect(formatNumberWithDynamicDecimalPoints(1.2345, 4)).toBe('1.2345');
     expect(formatNumberWithDynamicDecimalPoints(1.2345, 5)).toBe('1.2345');

--- a/static/app/utils/number/formatPercentage.spec.tsx
+++ b/static/app/utils/number/formatPercentage.spec.tsx
@@ -5,9 +5,9 @@ describe('formatPercentage()', () => {
     expect(formatPercentage(0, 0)).toBe('0%');
     // eslint-disable-next-line unicorn/no-zero-fractions
     expect(formatPercentage(0.0, 0)).toBe('0%');
-    expect(formatPercentage(0, 2)).toBe('0%');
+    expect(formatPercentage(0)).toBe('0%');
     // eslint-disable-next-line unicorn/no-zero-fractions
-    expect(formatPercentage(0.0, 2)).toBe('0%');
+    expect(formatPercentage(0.0)).toBe('0%');
     expect(formatPercentage(0.10513434, 1)).toBe('10.5%');
     expect(formatPercentage(0.10513494, 3)).toBe('10.513%');
     expect(formatPercentage(0.10513494, 4)).toBe('10.5135%');

--- a/static/app/utils/replays/getReplayEvent.spec.tsx
+++ b/static/app/utils/replays/getReplayEvent.spec.tsx
@@ -89,7 +89,6 @@ describe('getNextReplayFrame', () => {
     const result = getNextReplayFrame({
       frames,
       targetOffsetMs: exactTime,
-      allowExact: false,
     });
 
     expect(result).toEqual(frames[2]);
@@ -159,7 +158,6 @@ describe('getPrevReplayFrame', () => {
     const result = getPrevReplayFrame({
       frames,
       targetOffsetMs: exactTime,
-      allowExact: false,
     });
 
     expect(result).toEqual(frames[0]);

--- a/static/app/utils/string/trimSlug.spec.tsx
+++ b/static/app/utils/string/trimSlug.spec.tsx
@@ -2,21 +2,21 @@ import {trimSlug} from 'sentry/utils/string/trimSlug';
 
 describe('trimSlug', () => {
   it('returns slug if it is already short enough', () => {
-    expect(trimSlug('javascript', 20)).toBe('javascript');
+    expect(trimSlug('javascript')).toBe('javascript');
   });
 
   it('trims long but unhyphenated slug', () => {
-    expect(trimSlug('javascriptfrontendproject', 20)).toBe('javascriptfrontendp…');
+    expect(trimSlug('javascriptfrontendproject')).toBe('javascriptfrontendp…');
   });
 
   it('trims slug from the middle, preserves whole words', () => {
-    expect(trimSlug('symbol-collector-console', 20)).toBe('symbol…console');
-    expect(trimSlug('symbol-collector-mobile', 20)).toBe('symbol…mobile');
-    expect(trimSlug('visual-snapshot-cloud-run', 20)).toBe('visual…cloud-run');
+    expect(trimSlug('symbol-collector-console')).toBe('symbol…console');
+    expect(trimSlug('symbol-collector-mobile')).toBe('symbol…mobile');
+    expect(trimSlug('visual-snapshot-cloud-run')).toBe('visual…cloud-run');
   });
 
   it('trims slug from the middle, cuts whole words', () => {
-    expect(trimSlug('sourcemapsio-javascript', 20)).toBe('sourcemaps…javascript');
-    expect(trimSlug('armcknight-ios-ephemeraldemo', 20)).toBe('armcknig…phemeraldemo');
+    expect(trimSlug('sourcemapsio-javascript')).toBe('sourcemaps…javascript');
+    expect(trimSlug('armcknight-ios-ephemeraldemo')).toBe('armcknig…phemeraldemo');
   });
 });

--- a/static/app/utils/url/useQueryParamState.spec.tsx
+++ b/static/app/utils/url/useQueryParamState.spec.tsx
@@ -166,7 +166,7 @@ describe('useQueryParamState', () => {
     );
 
     const {result, rerender} = renderHook(
-      () => useQueryParamState({fieldName: 'testField', syncStateWithUrl: false}),
+      () => useQueryParamState({fieldName: 'testField'}),
       {
         wrapper: UrlParamBatchProvider,
       }

--- a/static/app/utils/usePrismTokens.stories.tsx
+++ b/static/app/utils/usePrismTokens.stories.tsx
@@ -73,12 +73,7 @@ export default Storybook.story('usePrismTokens', story => {
           <tr>
             <th>Output</th>
             <td>
-              <StructuredEventData
-                data={lines}
-                forceDefaultExpand
-                maxDefaultDepth={2}
-                config={config}
-              />
+              <StructuredEventData data={lines} forceDefaultExpand config={config} />
             </td>
           </tr>
         </table>

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -84,9 +84,7 @@ function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormMod
           inline={false}
         />
         <Flex justify="end" gap="md">
-          <Button type="button" onClick={closeDrawer}>
-            {t('Cancel')}
-          </Button>
+          <Button onClick={closeDrawer}>{t('Cancel')}</Button>
           <Observer>
             {() => (
               <Button variant="primary" type="submit" busy={model.isSaving}>

--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
@@ -171,7 +171,6 @@ export function DashboardBreadcrumbTitle({
       onAction: () => {
         openConfirmModal({
           message: t('Are you sure you want to duplicate this dashboard?'),
-          priority: 'primary',
           onConfirm: () => duplicateDashboard(dashboard, 'details'),
         });
       },

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -128,7 +128,6 @@ export function AddFilter({
         setSelectedFilterKey(null);
         setIsSelectingFilterKey(true);
       }}
-      size="md"
       menuWidth="300px"
       menuTitle={
         <MenuTitleWrapper>

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -168,7 +168,6 @@ function DashboardTable({
                 e.stopPropagation();
                 openConfirmModal({
                   message: t('Are you sure you want to duplicate this dashboard?'),
-                  priority: 'primary',
                   onConfirm: () => handleDuplicateDashboard(dataRow, 'table'),
                 });
               }}

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -239,7 +239,6 @@ function ManageDashboards() {
         marginBottom="xl"
       >
         <SearchBar
-          defaultQuery=""
           query={getQuery()}
           placeholder={t('Search Dashboards')}
           onSearch={query => handleSearch(query)}

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -87,7 +87,7 @@ export function WidgetBuilderNameAndDescription({
           {t('+ Add Description')}
         </Button>
       )}
-      {!isTextWidget && isDescSelected && <WidgetBuilderDescriptionField rows={4} />}
+      {!isTextWidget && isDescSelected && <WidgetBuilderDescriptionField />}
     </Fragment>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -24,7 +24,7 @@ import {canUseMetricsHeatMap} from 'sentry/views/explore/metrics/metricsFlags';
 export const DISPLAY_TYPE_ICONS: Partial<Record<DisplayType, React.ReactNode>> = {
   [DisplayType.AREA]: <IconGraph key="area" type="area" />,
   [DisplayType.BAR]: <IconGraph key="bar" type="bar" />,
-  [DisplayType.LINE]: <IconGraph key="line" type="line" />,
+  [DisplayType.LINE]: <IconGraph key="line" />,
   [DisplayType.TABLE]: <IconTable key="table" />,
   [DisplayType.BIG_NUMBER]: <IconNumber key="number" />,
   [DisplayType.DETAILS]: <IconSettings key="details" />,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
@@ -74,7 +74,7 @@ export function MetricQueryRows({
     }
   }, [equationSnapshot, metricQueries, selectedLabel]);
   const referenceMap = useMetricReferences(metricQueries);
-  const addAggregate = useAddMetricQuery({type: 'aggregate'});
+  const addAggregate = useAddMetricQuery({});
 
   const aggregateSource = getTraceMetricAggregateSource(
     state.displayType,

--- a/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/differenceToPreviousPeriodValue.tsx
@@ -77,7 +77,7 @@ const Deemphasize = styled('span')`
 
 function getDifferenceDirectionMarker(difference: number) {
   if (difference > 0) {
-    return <IconArrow direction="up" size="xs" />;
+    return <IconArrow size="xs" />;
   }
 
   if (difference < 0) {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTooltipValue.tsx
@@ -52,7 +52,7 @@ export function formatTooltipValue(
         maximumFractionDigits: NUMBER_MAX_FRACTION_DIGITS,
       });
     case 'percentage':
-      return formatPercentage(value, 2);
+      return formatPercentage(value);
     case 'duration': {
       const durationUnit = isADurationUnit(unit) ? unit : DurationUnit.MILLISECOND;
       const durationInSeconds = convertDuration(value, durationUnit, DurationUnit.SECOND);

--- a/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
+++ b/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
@@ -45,10 +45,7 @@ export function MigratedAlertWarning({detector}: {detector: MetricDetector}) {
           {
             editLink: <Link to={editLink} disabled={!canEdit} />,
             samplingLink: (
-              <ExternalLink
-                href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
-                openInNewTab
-              />
+              <ExternalLink href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer" />
             ),
           }
         )}

--- a/static/app/views/detectors/components/detectorListTable/detectorAssigneeCell.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorAssigneeCell.tsx
@@ -14,7 +14,7 @@ function AssigneeContent({assignee}: {assignee: Actor | null}) {
     return '—';
   }
 
-  return <ActorAvatar actor={assignee} size={24} />;
+  return <ActorAvatar actor={assignee} />;
 }
 
 export function DetectorAssigneeCell({assignee, className}: DetectorAssigneeCellProps) {

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -545,10 +545,7 @@ function DetectSection({step}: {step?: number}) {
                   'Your thresholds may need to be adjusted to take into account [samplingLink:sampling].',
                   {
                     samplingLink: (
-                      <ExternalLink
-                        href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
-                        openInNewTab
-                      />
+                      <ExternalLink href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer" />
                     ),
                   }
                 ),
@@ -682,10 +679,7 @@ function MigratedAlertWarningListener() {
             'The thresholds on this chart may look off. This is because, once saved, alerts will now take into account [samplingLink:sampling rate]. Before clicking save, take the time to update your [thresholdsLink:thresholds]. Cancel to continue running this alert in compatibility mode.',
             {
               samplingLink: (
-                <ExternalLink
-                  href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
-                  openInNewTab
-                />
+                <ExternalLink href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer" />
               ),
               thresholdsLink: (
                 <Link

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -110,7 +110,7 @@ function MetricsEquationVisualizeContent({
   const initialAggregate = useFormField<string>(aggregateFieldName);
   const metricQueries = useMultiMetricsQueryParams();
   const referenceMap = useMetricReferences(metricQueries);
-  const addAggregate = useAddMetricQuery({type: 'aggregate'});
+  const addAggregate = useAddMetricQuery({});
   const addEquation = useAddMetricQuery({type: 'equation'});
 
   // Track the selected row by its stable label (A, B, …)

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -123,7 +123,6 @@ export function IssueContext(props: BaseContextProps) {
               data-test-id="assigned-avatar"
               actor={issue.assignedTo}
               hasTooltip={false}
-              size={24}
             />
           ) : (
             <StyledIconWrapper>

--- a/static/app/views/explore/components/attributeBreakdowns/styles.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/styles.tsx
@@ -260,7 +260,6 @@ function Chart({
     <BaseChart
       ref={chartRef}
       autoHeightResize
-      isGroupedByDate={false}
       tooltip={tooltip}
       grid={{
         left: 2,

--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -67,7 +67,6 @@ function MeasuredSplitPanel({
 
   return (
     <SplitPanel
-      orientation="horizontal"
       defaultSize={defaultLeft}
       initialSize={storedSize}
       minSize={LEFT_PANEL_MIN}

--- a/static/app/views/explore/conversations/hooks/useConversationSelection.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationSelection.spec.tsx
@@ -34,7 +34,6 @@ describe('useConversationSelection', () => {
         selectedSpanId: null,
         onSelectSpan,
         isLoading: false,
-        autoSelectDefaultNode: true,
       })
     );
 

--- a/static/app/views/explore/errors/charts/index.tsx
+++ b/static/app/views/explore/errors/charts/index.tsx
@@ -58,7 +58,7 @@ function Chart() {
             <OverlayTrigger.Button
               {...triggerProps}
               aria-label={t('Chart type')}
-              icon={<IconGraph type="line" />}
+              icon={<IconGraph />}
               variant="transparent"
               showChevron={false}
               size="xs"

--- a/static/app/views/explore/logs/tables/logsEmptyResults.tsx
+++ b/static/app/views/explore/logs/tables/logsEmptyResults.tsx
@@ -38,7 +38,7 @@ export function LogsEmptyResults({
 
     return (
       <DataTable.Status>
-        <EmptyStateWarning withIcon variant="accent">
+        <EmptyStateWarning variant="accent">
           <EmptyStateText size="xl">{t('No logs found yet')}</EmptyStateText>
           <EmptyStateText size="md">
             {displayTotalPayloadBytes
@@ -80,7 +80,7 @@ export function LogsEmptyResults({
 
   return (
     <DataTable.Status>
-      <EmptyStateWarning withIcon variant="accent">
+      <EmptyStateWarning variant="accent">
         <EmptyStateText size="xl">{t('No logs found')}</EmptyStateText>
         <EmptyStateText size="md">
           {tct(

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -951,7 +951,7 @@ function BackToTopButton({
       }}
       aria-label="Back to top"
     >
-      <IconArrow direction="up" size="md" />
+      <IconArrow size="md" />
     </Button>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -422,9 +422,7 @@ export function MetricSelector({
     position: 'bottom-start',
     offset: 6,
     isOpen: comboBoxState.isOpen,
-    isDismissable: true,
     isKeyboardDismissDisabled: true,
-    shouldApplyMinWidth: true,
     disableTrigger: isFetching && !traceMetric.name,
     onOpenChange: open => {
       if (open === comboBoxState.isOpen) {

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -119,9 +119,7 @@ function MetricsTabBodySection({
   const metricQueries = useMultiMetricsQueryParams();
   const [interval] = useChartInterval();
   const pageFilters = usePageFilters();
-  const {isFetching: areToolbarsLoading, isMetricOptionsEmpty} = useMetricOptions({
-    enabled: true,
-  });
+  const {isFetching: areToolbarsLoading, isMetricOptionsEmpty} = useMetricOptions({});
 
   useLLMContext({
     contextHint:

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -333,7 +333,6 @@ export function ReleaseIssues({
           description={t(
             'Along with reviewing how your release is trending over time compared to previous releases, you can view new and regressed issues here.'
           )}
-          position="top-start"
         >
           {tourProps => (
             <Container {...tourProps} width={{zero: '100%', md: 'max-content'}}>

--- a/static/app/views/explore/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/explore/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -48,7 +48,7 @@ export function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
         <KeyValueTable>
           <KeyValueTableRow
             keyName={t('Created')}
-            value={<DateTime date={dateCreated} seconds={false} />}
+            value={<DateTime date={dateCreated} />}
           />
           <KeyValueTableRow
             keyName={
@@ -74,7 +74,7 @@ export function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
             }
             value={
               dateReleased ? (
-                <DateTime date={dateReleased} seconds={false} />
+                <DateTime date={dateReleased} />
               ) : (
                 <ButtonContainer>
                   <Tooltip

--- a/static/app/views/explore/releases/drawer/newIssues.tsx
+++ b/static/app/views/explore/releases/drawer/newIssues.tsx
@@ -47,7 +47,6 @@ export function NewIssues({release, projectId}: Props) {
       canSelectGroups={false}
       withChart={false}
       renderEmptyMessage={renderEmptyMessage}
-      withPagination
       source="release-drawer"
       numPlaceholderRows={3}
     />

--- a/static/app/views/explore/releases/list/index.tsx
+++ b/static/app/views/explore/releases/list/index.tsx
@@ -611,7 +611,6 @@ function ReleasesListInnerPage() {
                       description={t(
                         'View the latest releases for your project. Select a release to review new and regressed issues, and business critical metrics like crash rate, and user adoption. '
                       )}
-                      position="top-start"
                     >
                       {props => (
                         <div {...props}>

--- a/static/app/views/explore/replays/detail/ai/ai.tsx
+++ b/static/app/views/explore/replays/detail/ai/ai.tsx
@@ -118,7 +118,6 @@ export function Ai() {
             </Text>
             <Button
               variant="secondary"
-              type="button"
               size="xs"
               onClick={() => {
                 startSummaryRequest();

--- a/static/app/views/explore/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/explore/replays/detail/errorList/errorTableCell.tsx
@@ -176,7 +176,6 @@ export function ErrorTableCell({
       <Cell {...columnProps} numeric>
         <ButtonWrapper>
           <TimestampButton
-            precision="sec"
             onClick={event => {
               event.stopPropagation();
               onClickTimestamp(frame);

--- a/static/app/views/explore/replays/detail/network/details/sections.tsx
+++ b/static/app/views/explore/replays/detail/network/details/sections.tsx
@@ -223,7 +223,6 @@ export function RequestPayloadSection({item}: SectionProps) {
           <StructuredEventData
             data={body}
             forceDefaultExpand
-            maxDefaultDepth={2}
             showCopyButton
             config={config}
           />
@@ -262,7 +261,6 @@ export function ResponsePayloadSection({item}: SectionProps) {
           <StructuredEventData
             data={body}
             forceDefaultExpand
-            maxDefaultDepth={2}
             showCopyButton
             config={config}
           />

--- a/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
@@ -202,7 +202,6 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
         >
           <Button
             data-test-id="setup-replays-btn"
-            type="button"
             onClick={() => activateSidebar()}
             variant="primary"
             disabled={disabled}

--- a/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
+++ b/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
@@ -90,7 +90,6 @@ function AccordionWidget({
       ) : (
         <Stack flex="1 1 auto" justify="start">
           <Accordion
-            collapsible
             collapsedChevronDirection="right"
             expandedIndex={selectedListIndex}
             expandedChevronDirection="down"

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -111,7 +111,7 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
             )}
             {showEmptyState && (
               <StyledPanelItem span={6} overflow>
-                <EmptyStateWarning withIcon>
+                <EmptyStateWarning>
                   <EmptyStateText size="xl">{t('No trace results found')}</EmptyStateText>
                   <EmptyStateText size="md">
                     {tct('Try adjusting your filters or refer to [docSearchProps].', {

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.spec.tsx
@@ -14,8 +14,6 @@ describe('PerformanceScoreRingWithTooltips', () => {
     };
     render(
       <PerformanceScoreRingWithTooltips
-        width={220}
-        height={200}
         projectScore={projectScore}
         ringBackgroundColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
         ringSegmentColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
@@ -40,8 +38,6 @@ describe('PerformanceScoreRingWithTooltips', () => {
     };
     render(
       <PerformanceScoreRingWithTooltips
-        width={220}
-        height={200}
         projectScore={projectScore}
         ringBackgroundColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}
         ringSegmentColors={['#444674', '#895289', '#d6567f', '#f38150', '#f2b712']}

--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -41,10 +41,7 @@ export const VITAL_DESCRIPTIONS: Partial<
       'First Contentful Paint (FCP) measures the amount of time the first content takes to render in the viewport. Like FP, this could also show up in any form from the document object model (DOM), such as images, SVGs, or text blocks.'
     ),
     link: (
-      <ExternalLink
-        openInNewTab
-        href="https://blog.sentry.io/how-to-make-your-web-page-faster-before-it-even-loads/"
-      >
+      <ExternalLink href="https://blog.sentry.io/how-to-make-your-web-page-faster-before-it-even-loads/">
         How do I fix my FCP?
       </ExternalLink>
     ),
@@ -57,10 +54,7 @@ export const VITAL_DESCRIPTIONS: Partial<
       'Cumulative Layout Shift (CLS) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. Imagine navigating to an article and trying to click a link before the page finishes loading. Before your cursor even gets there, the link may have shifted down due to an image rendering. Rather than using duration for this Web Vital, the CLS score represents the degree of disruptive and visually unstable shifts.'
     ),
     link: (
-      <ExternalLink
-        openInNewTab
-        href="https://blog.sentry.io/from-lcp-to-cls-improve-your-core-web-vitals-with-image-loading-best/"
-      >
+      <ExternalLink href="https://blog.sentry.io/from-lcp-to-cls-improve-your-core-web-vitals-with-image-loading-best/">
         How do I fix my CLS score?
       </ExternalLink>
     ),
@@ -73,10 +67,7 @@ export const VITAL_DESCRIPTIONS: Partial<
       'Largest Contentful Paint (LCP) measures the render time for the largest content to appear in the viewport. This may be in any form from the document object model (DOM), such as images, SVGs, or text blocks. It’s the largest pixel area in the viewport, thus most visually defining. LCP helps developers understand how long it takes to see the main content on the page.'
     ),
     link: (
-      <ExternalLink
-        openInNewTab
-        href="https://blog.sentry.io/from-lcp-to-cls-improve-your-core-web-vitals-with-image-loading-best/"
-      >
+      <ExternalLink href="https://blog.sentry.io/from-lcp-to-cls-improve-your-core-web-vitals-with-image-loading-best/">
         How do I fix my LCP score?
       </ExternalLink>
     ),
@@ -89,10 +80,7 @@ export const VITAL_DESCRIPTIONS: Partial<
       'Time to First Byte (TTFB) is a foundational metric for measuring connection setup time and web server responsiveness in both the lab and the field. It helps identify when a web server is too slow to respond to requests. In the case of navigation requests—that is, requests for an HTML document—it precedes every other meaningful loading performance metric.'
     ),
     link: (
-      <ExternalLink
-        openInNewTab
-        href="https://blog.sentry.io/how-i-fixed-my-brutal-ttfb/"
-      >
+      <ExternalLink href="https://blog.sentry.io/how-i-fixed-my-brutal-ttfb/">
         How do I fix my TTFB score?
       </ExternalLink>
     ),
@@ -105,7 +93,7 @@ export const VITAL_DESCRIPTIONS: Partial<
       "Interaction to Next Paint (INP) is a metric that assesses a page's overall responsiveness to user interactions by observing the latency of all click, tap, and keyboard interactions that occur throughout the lifespan of a user's visit to a page. The final INP value is the longest interaction observed, ignoring outliers."
     ),
     link: (
-      <ExternalLink openInNewTab href="https://blog.sentry.io/what-is-inp/">
+      <ExternalLink href="https://blog.sentry.io/what-is-inp/">
         How do I fix my INP score?
       </ExternalLink>
     ),

--- a/static/app/views/insights/common/components/tableCells/percentChangeCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/percentChangeCell.tsx
@@ -8,7 +8,7 @@ type PercentChangeCellProps = {
 export function PercentChangeCell({deltaValue}: PercentChangeCellProps) {
   return (
     <NumberContainer>
-      <PercentChange value={deltaValue} colorize />
+      <PercentChange value={deltaValue} />
     </NumberContainer>
   );
 }

--- a/static/app/views/insights/common/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/timeSpentCell.tsx
@@ -35,7 +35,7 @@ function getTimeSpentExplanation(percentage: number, op?: string) {
     'The application spent [percentage] of its total time on this [span]. Read more about Time Spent in our [documentation:documentation].',
     {
       percentage: formattedPercentage,
-      span: formatSpanOperation(op, 'short'),
+      span: formatSpanOperation(op),
       documentation: <ExternalLink href={`${MODULE_DOC_LINK}#what-is-time-spent`} />,
     }
   );

--- a/static/app/views/insights/crons/components/detailsSidebar.tsx
+++ b/static/app/views/insights/crons/components/detailsSidebar.tsx
@@ -123,13 +123,7 @@ export function DetailsSidebar({monitorEnv, monitor, showUnknownLegend}: Props) 
         />
         <KeyValueTableRow
           keyName={t('Owner')}
-          value={
-            monitor.owner ? (
-              <ActorAvatar size={24} actor={monitor.owner} />
-            ) : (
-              t('Unassigned')
-            )
-          }
+          value={monitor.owner ? <ActorAvatar actor={monitor.owner} /> : t('Unassigned')}
         />
         <KeyValueTableRow
           keyName={t('Date created')}

--- a/static/app/views/insights/mobile/screenload/components/platformSelector.tsx
+++ b/static/app/views/insights/mobile/screenload/components/platformSelector.tsx
@@ -26,7 +26,6 @@ export function PlatformSelector() {
   return (
     <Flex>
       <SegmentedControl
-        size="md"
         value={platform}
         aria-label={t('Filter platform')}
         onChange={val => {

--- a/static/app/views/investigations/index.tsx
+++ b/static/app/views/investigations/index.tsx
@@ -270,7 +270,6 @@ function InvestigationsPage() {
                   marginBottom="xl"
                 >
                   <SearchBar
-                    defaultQuery=""
                     query={query ?? ''}
                     placeholder={t('Search Investigations')}
                     onSearch={handleSearch}

--- a/static/app/views/issueDetails/eventSearch.tsx
+++ b/static/app/views/issueDetails/eventSearch.tsx
@@ -65,10 +65,7 @@ export function EventSearch({
 }: EventSearchProps) {
   const api = useApi();
   const organization = useOrganization();
-  const groupTagsQuery = useGroupTags(
-    {groupId: group.id, environment: environments},
-    {enabled: true}
-  );
+  const groupTagsQuery = useGroupTags({groupId: group.id, environment: environments}, {});
 
   const filterKeys = useMemo<TagCollection>(() => {
     const acc: TagCollection = {};

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -115,7 +115,7 @@ export function GroupPriorityCommandPaletteAction({
       }}
     >
       <CMDKAction
-        display={{label: t('High'), icon: <IconCellSignal bars={3} />}}
+        display={{label: t('High'), icon: <IconCellSignal />}}
         onAction={() => onChangePriority(PriorityLevel.HIGH)}
       />
       <CMDKAction

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -335,7 +335,6 @@ function ContributingIssues({
           <GroupList
             queryParams={queryParams}
             canSelectGroups={false}
-            withChart
             withPagination={false}
             source="metric-issue-contributing-issues"
             numPlaceholderRows={3}

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -92,7 +92,6 @@ export function IssueListSortOptions({
   return (
     <CompactSelect
       className={className}
-      size="md"
       onChange={opt => onSelect(opt.value)}
       options={sortKeys.map(key => ({
         value: key,

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -187,7 +187,7 @@ function PriorityActions({
       keywords={['priority', 'urgency', 'critical', 'high', 'medium', 'low']}
     >
       <CMDKAction
-        display={{label: t('High'), icon: <IconCellSignal bars={3} />}}
+        display={{label: t('High'), icon: <IconCellSignal />}}
         onAction={() =>
           onConfirmUpdate(t('set issue priority to high'), {
             priority: PriorityLevel.HIGH,

--- a/static/app/views/issueList/pages/inbox/index.tsx
+++ b/static/app/views/issueList/pages/inbox/index.tsx
@@ -771,7 +771,6 @@ function InboxIssueCard({
                 <ActorAvatar
                   actor={group.assignedTo}
                   size={18}
-                  hasTooltip
                   tooltip={t('Assigned to: %s', getActorLabel(group.assignedTo))}
                   title={group.assignedTo.name}
                 />

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -268,7 +268,7 @@ function SupergroupIssueList({
           </LoadingHeader>
           <PanelBody>
             {visibleIds.map(id => (
-              <LoadingStreamGroup key={id} withChart withColumns={DRAWER_COLUMNS} />
+              <LoadingStreamGroup key={id} withColumns={DRAWER_COLUMNS} />
             ))}
           </PanelBody>
         </PanelContainer>
@@ -310,8 +310,6 @@ function SupergroupIssueList({
                   )}
                   <StreamGroup
                     group={group}
-                    canSelect
-                    withChart
                     withColumns={DRAWER_COLUMNS}
                     memberList={members}
                     statsPeriod={DEFAULT_STREAM_GROUP_STATS_PERIOD}

--- a/static/app/views/issueList/supergroups/supergroupFeedback.tsx
+++ b/static/app/views/issueList/supergroups/supergroupFeedback.tsx
@@ -40,7 +40,7 @@ export function SupergroupFeedback({supergroupId}: SupergroupFeedbackProps) {
           <Flex gap="sm">
             <Button
               size="zero"
-              icon={<IconThumb direction="up" size="xs" />}
+              icon={<IconThumb size="xs" />}
               onClick={() => handleFeedback(true)}
               aria-label={t('Yes, this grouping is accurate')}
             />

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -483,7 +483,6 @@ export function UsageStatsProjects({
       {!isSingleProject && (
         <Container>
           <SearchBar
-            defaultQuery=""
             query={tableQuery}
             placeholder={t('Filter your projects')}
             aria-label={t('Filter projects')}

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -372,7 +372,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           let currentSeriesNames = [field];
           let includePreviousParam = true;
           let yAxis = provided.yAxis;
-          let interval = getInterval(pageFilterDatetime, 'medium');
+          let interval = getInterval(pageFilterDatetime);
           let partialDataParam = true;
 
           if (

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -199,7 +199,7 @@ export function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps)
           const currentSeriesNames = [field];
           const includePreviousParam = false;
           const yAxis = provided.yAxis;
-          const interval = getInterval(pageFilterDatetime, 'medium');
+          const interval = getInterval(pageFilterDatetime);
           const partialDataParam = true;
 
           eventView.additionalConditions.setFilterValues('transaction', [

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -89,7 +89,6 @@ export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
                   width={280}
                   height={240}
                   size={160}
-                  barWidth={16}
                   ringBackgroundColors={ringBackgroundColors}
                   ringSegmentColors={ringSegmentColors}
                   radiusPadding={10}

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -68,14 +68,11 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
           currentSeriesNames={[field!]}
           previousSeriesNames={[getPreviousSeriesName(field!)]}
           query={provided.eventView.getQueryWithAdditionalConditions()}
-          interval={getInterval(
-            {
-              start: provided.start,
-              end: provided.end,
-              period: provided.period,
-            },
-            'medium'
-          )}
+          interval={getInterval({
+            start: provided.start,
+            end: provided.end,
+            period: provided.period,
+          })}
           hideError
           onError={setPageDanger}
           queryExtras={queryExtras}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/profiling/profilePreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/profiling/profilePreview.tsx
@@ -172,7 +172,6 @@ export function ProfilePreview({
         <FoldSection
           title={t('Profile')}
           sectionKey="no_instrumentation_profile"
-          initialCollapse={false}
           actions={
             <LinkButton size="xs" onClick={handleGoToProfile} to={target}>
               {t('Open in Profiling')}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
@@ -103,14 +103,14 @@ describe('AIContentRenderer', () => {
 
   it('renders collapsible XML tags with tag name label', () => {
     const text = '<thinking>\nsome thought\n</thinking>';
-    render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+    render(<AIContentRenderer text={text} inline />);
 
     expect(screen.getByText('<thinking>')).toBeInTheDocument();
   });
 
   it('renders nested collapsible XML with hierarchy', () => {
     const text = '<outer>\n<inner>nested content</inner>\n</outer>';
-    render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+    render(<AIContentRenderer text={text} inline />);
 
     expect(screen.getByText('<outer>')).toBeInTheDocument();
     expect(screen.getByText('<inner>')).toBeInTheDocument();
@@ -134,7 +134,7 @@ describe('AIContentRenderer', () => {
 
   it('collapses generic XML tags by default', () => {
     const text = '<thinking>\nhidden thought\n</thinking>';
-    render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+    render(<AIContentRenderer text={text} inline />);
 
     expect(screen.getByText('<thinking>').closest('details')).not.toHaveAttribute('open');
   });
@@ -143,7 +143,7 @@ describe('AIContentRenderer', () => {
     'expands the %s tag by default',
     tagName => {
       const text = `<${tagName}>\nhello there\n</${tagName}>`;
-      render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+      render(<AIContentRenderer text={text} inline />);
 
       expect(screen.getByText(`<${tagName}>`).closest('details')).toHaveAttribute('open');
     }

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -349,7 +349,7 @@ export function redirectToPerformanceHomepage(
   // If there is no transaction name, redirect to the Performance landing page
   navigate(
     normalizeUrl({
-      pathname: getPerformanceBaseUrl(organization.slug, 'backend'),
+      pathname: getPerformanceBaseUrl(organization.slug),
       query: {
         ...location.query,
       },

--- a/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
+++ b/static/app/views/preprod/buildComparison/header/buildCompareHeaderContent.tsx
@@ -57,9 +57,7 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
   const labels = getLabels(buildDetails.app_info?.platform ?? undefined);
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(organization.slug, String(buildDetails.project_id), {
-        tab: 'mobile-builds',
-      }),
+      to: makeReleasesUrl(organization.slug, String(buildDetails.project_id), {}),
       label: t('Releases'),
     },
   ];
@@ -68,7 +66,6 @@ export function BuildCompareHeaderContent(props: BuildCompareHeaderContentProps)
     breadcrumbs.push({
       to: makeReleasesUrl(organization.slug, String(buildDetails.project_id), {
         query: buildDetails.app_info.version,
-        tab: 'mobile-builds',
       }),
       label: buildDetails.app_info.version,
     });

--- a/static/app/views/preprod/buildComparison/main/buildComparisonMetricCards.tsx
+++ b/static/app/views/preprod/buildComparison/main/buildComparisonMetricCards.tsx
@@ -133,7 +133,6 @@ export function BuildComparisonMetricCards(props: BuildComparisonMetricCardsProp
                           value={metric.percentageChange}
                           minimumValue={0.001}
                           preferredPolarity="-"
-                          colorize
                         />
                         {')'}
                       </Text>

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -370,7 +370,6 @@ export function SizeCompareMainContent() {
                   <Text wrap="nowrap">{t('Hide changes < 500B')}</Text>
                   <Switch
                     checked={hideSmallChanges}
-                    size="sm"
                     title={t('Hide < 500B')}
                     onChange={() => setHideSmallChanges(!hideSmallChanges)}
                     aria-label={

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -94,7 +94,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
 
   const breadcrumbs: Crumb[] = [
     {
-      to: makeReleasesUrl(organization.slug, projectSlug, {tab: 'mobile-builds'}),
+      to: makeReleasesUrl(organization.slug, projectSlug, {}),
       label: 'Releases',
     },
   ];
@@ -106,7 +106,6 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     breadcrumbs.push({
       to: makeReleasesUrl(organization.slug, projectSlug, {
         query: version,
-        tab: 'mobile-builds',
       }),
       label: version,
     });

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -282,7 +282,6 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                                 value={card.delta.percentageChange}
                                 minimumValue={0.001}
                                 preferredPolarity="-"
-                                colorize
                               />
                               {')'}
                             </Text>

--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -34,11 +34,7 @@ function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) 
         </Container>
       </Grid>
       <Container padding="xl">
-        <InstallDetailsContent
-          artifactId={artifactId}
-          size="sm"
-          projectSlug={projectSlug}
-        />
+        <InstallDetailsContent artifactId={artifactId} projectSlug={projectSlug} />
       </Container>
     </Stack>
   );

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -76,7 +76,7 @@ function FullscreenModalContent({
   const [localHighlightInsights, setLocalHighlightInsights] = useState(
     initialHighlightInsights
   );
-  const filteredRoot = filterTreemapElement(unfilteredRoot, localSearch, '');
+  const filteredRoot = filterTreemapElement(unfilteredRoot, localSearch);
 
   const handleSearchChange = (value: string) => {
     setLocalSearch(value);

--- a/static/app/views/preprod/install/buildInstallHeader.tsx
+++ b/static/app/views/preprod/install/buildInstallHeader.tsx
@@ -55,7 +55,6 @@ export function BuildInstallHeader(props: BuildInstallHeaderProps) {
     to: makeReleasesUrl(organization.slug, projectId, {
       display: PreprodBuildsDisplay.DISTRIBUTION,
       query: 'installable:true',
-      tab: 'mobile-builds',
     }),
     label: t('Releases'),
   };

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -292,8 +292,6 @@ function OnionView({
         </Text>
         <Flex width="200px">
           <Slider
-            min={0}
-            max={100}
             value={opacity}
             onChange={onOpacityChange}
             formatOptions={{style: 'unit', unit: 'percent'}}

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -273,8 +273,6 @@ export const OnionCardBody = memo(function OnionCardBodyImpl({
         </Text>
         <Flex width="200px">
           <Slider
-            min={0}
-            max={100}
             value={opacity}
             onChange={setOpacity}
             formatOptions={{style: 'unit', unit: 'percent'}}

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -584,7 +584,7 @@ function SingleViewLayout({
                 <Button
                   ref={navButtonRefs.prev}
                   size="sm"
-                  icon={<IconArrow direction="up" />}
+                  icon={<IconArrow />}
                   aria-label={t('Previous snapshot')}
                   disabled={!canNavigatePrev}
                   onClick={() => onNavigateSingleView('prev')}

--- a/static/app/views/preprod/utils/labelUtils.tsx
+++ b/static/app/views/preprod/utils/labelUtils.tsx
@@ -160,7 +160,7 @@ export function getTrend(diff: number): {
   if (diff > 0) {
     return {
       variant: 'danger',
-      icon: <IconArrow direction="up" size="xs" />,
+      icon: <IconArrow size="xs" />,
     };
   }
 

--- a/static/app/views/preprod/utils/treemapFiltering.spec.tsx
+++ b/static/app/views/preprod/utils/treemapFiltering.spec.tsx
@@ -275,7 +275,7 @@ describe('filterTreemapElement', () => {
       ]),
     ]);
 
-    const result = filterTreemapElement(element, 'HackerNews', '');
+    const result = filterTreemapElement(element, 'HackerNews');
 
     expect(result?.children).toHaveLength(1);
     expect(result?.children[0]?.name).toBe('Applications');

--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -301,7 +301,7 @@ class Chart extends Component<ChartProps, ChartState> {
           }
 
           if (this.isCrashFree) {
-            return displayCrashFreePercent(value, 0, 3);
+            return displayCrashFreePercent(value, 0);
           }
 
           if (this.isAnr) {

--- a/static/app/views/projectDetail/projectLatestReleases.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.tsx
@@ -140,10 +140,7 @@ function ReleasesBody({
     <ReleasesTable>
       {releases.map(release => (
         <Fragment key={release.version}>
-          <DateTime
-            date={release.lastDeploy?.dateFinished || release.dateCreated}
-            seconds={false}
-          />
+          <DateTime date={release.lastDeploy?.dateFinished || release.dateCreated} />
           <TextOverflow>
             <StyledVersion
               version={release.version}

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -520,7 +520,6 @@ export function CreateProject() {
             organization={organization}
             source="project-creation"
             variant="legacy"
-            showOther
             noAutoFilter
           />
           <StyledListItem>{t('Set your alert frequency')}</StyledListItem>

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -256,7 +256,6 @@ function Dashboard() {
             />
             <Container flexGrow={1}>
               <SearchBar
-                defaultQuery=""
                 placeholder={t('Search for projects by name')}
                 onChange={setProjectQuery}
                 query={projectQuery}

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -85,7 +85,7 @@ export function ProjectCard({
     defined(currentCrashFreeRate) && defined(crashFreeTrend) ? (
       <div>
         {crashFreeTrend >= 0 ? (
-          <IconArrow direction="up" size="xs" />
+          <IconArrow size="xs" />
         ) : (
           <IconArrow direction="down" size="xs" />
         )}

--- a/static/app/views/seerExplorer/components/seerExplorerDebugMenu.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerDebugMenu.tsx
@@ -40,7 +40,7 @@ export function SeerExplorerDebugMenu({
           {
             key: 'context-engine',
             label: t('Context Engine'),
-            leadingItems: <Checkbox size="sm" checked={overrideCtxEngEnable} readOnly />,
+            leadingItems: <Checkbox checked={overrideCtxEngEnable} readOnly />,
             onAction: onOverrideCtxEngEnableToggle,
             closeOnSelect: false,
           },
@@ -51,7 +51,7 @@ export function SeerExplorerDebugMenu({
           {
             key: 'show-thinking',
             label: t('Show thinking'),
-            leadingItems: <Checkbox size="sm" checked={showThinking} readOnly />,
+            leadingItems: <Checkbox checked={showThinking} readOnly />,
             onAction: onShowThinkingToggle,
             closeOnSelect: false,
           },

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -172,7 +172,7 @@ function OverviewAction({
         >
           {getProcessingLabel(sectionKey)}
         </Button>
-        <OpenSeerButton run={run} section={sectionKey} size="sm" variant="secondary" />
+        <OpenSeerButton run={run} section={sectionKey} size="sm" />
       </ActionButtonBar>
     );
   }
@@ -207,12 +207,7 @@ function OverviewAction({
                     {label}
                   </LinkButton>
                 </Tooltip>
-                <OpenSeerButton
-                  run={run}
-                  section={sectionKey}
-                  size="sm"
-                  variant="secondary"
-                />
+                <OpenSeerButton run={run} section={sectionKey} size="sm" />
               </ActionButtonBar>
             );
           })}

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -187,7 +187,6 @@ function AccountClose() {
                   {organization.slug}
                 </Text>
                 <Switch
-                  size="sm"
                   id={`delete-organization-${organization.slug}`}
                   checked={orgsToRemove.has(organization.slug)}
                   value={organization.slug}

--- a/static/app/views/settings/account/accountSecurity/components/smsEnrollForm.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/smsEnrollForm.tsx
@@ -148,7 +148,7 @@ export function SmsEnrollForm({
 
         <Flex justify="end" align="center" gap="md">
           {isCodeSent && (
-            <Button type="button" onClick={resetEnrollment} disabled={isSubmitting}>
+            <Button onClick={resetEnrollment} disabled={isSubmitting}>
               {t('Start Over')}
             </Button>
           )}

--- a/static/app/views/settings/account/accountSecurity/components/u2fEnrollForm.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/u2fEnrollForm.tsx
@@ -161,7 +161,6 @@ export function U2fEnrollForm({
               <Flex align="center" justify="end" gap="sm">
                 <Stack gap="sm" align="end">
                   <Button
-                    type="button"
                     onClick={() => triggerEnroll(field.handleChange)}
                     disabled={
                       !isWebAuthnSupported || Boolean(field.state.value.challenge)

--- a/static/app/views/settings/components/dataScrubbing/modals/dataScrubFormModal.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/dataScrubFormModal.tsx
@@ -417,7 +417,7 @@ export function DataScrubFormModal({
                               onClick={() => setDisplayEventId(false)}
                             >
                               {t('Hide event ID field')}
-                              <IconChevron direction="up" size="xs" />
+                              <IconChevron size="xs" />
                             </Toggle>
                           ) : (
                             <Toggle
@@ -500,7 +500,7 @@ export function DataScrubFormModal({
                     {displayEventId ? (
                       <Toggle variant="link" onClick={() => setDisplayEventId(false)}>
                         {t('Hide event ID field')}
-                        <IconChevron direction="up" size="xs" />
+                        <IconChevron size="xs" />
                       </Toggle>
                     ) : (
                       <Toggle variant="link" onClick={() => setDisplayEventId(true)}>

--- a/static/app/views/settings/dynamicSampling/projectsTable.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.spec.tsx
@@ -8,7 +8,7 @@ import type {ProjectionSamplePeriod} from 'sentry/views/settings/dynamicSampling
 
 import {ProjectsTable} from './projectsTable';
 
-mockElementSize({width: 500, height: 400});
+mockElementSize({height: 400});
 
 describe('ProjectsTable', () => {
   const organization = OrganizationFixture({

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -527,7 +527,6 @@ function ClaudeRoutineTemplateForm() {
       </form.FieldGroup>
 
       <PermissionsObserver
-        appPublished={false}
         scopes={CLAUDE_ROUTINE_SCOPES}
         events={CLAUDE_ROUTINE_EVENTS}
         newApp
@@ -707,7 +706,6 @@ function InternalSentryAppCreationForm() {
       </form.FieldGroup>
 
       <PermissionsObserver
-        appPublished={false}
         scopes={[]}
         events={[]}
         newApp
@@ -771,7 +769,6 @@ function PublicSentryAppCreationForm() {
       </form.FieldGroup>
 
       <PermissionsObserver
-        appPublished={false}
         scopes={[]}
         events={[]}
         newApp

--- a/static/app/views/settings/organizationIntegrations/integrationItem.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationItem.tsx
@@ -19,7 +19,7 @@ export function IntegrationItem({integration, requiresUpgrade}: Props) {
   return (
     <Flex align="center">
       <div>
-        <IntegrationIcon size={32} integration={integration} />
+        <IntegrationIcon integration={integration} />
       </div>
       <Stack align={undefined} justify="center" paddingLeft="md" minWidth={0}>
         <Flex align="center" gap="xs">

--- a/static/app/views/settings/organizationRelay/list/activityList.tsx
+++ b/static/app/views/settings/organizationRelay/list/activityList.tsx
@@ -27,10 +27,10 @@ export function ActivityList({activities}: Props) {
               <Version>{version}</Version>
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
-              <DateTime date={firstSeen} seconds={false} />
+              <DateTime date={firstSeen} />
             </SimpleTable.RowCell>
             <SimpleTable.RowCell>
-              <DateTime date={lastSeen} seconds={false} />
+              <DateTime date={lastSeen} />
             </SimpleTable.RowCell>
           </SimpleTable.Row>
         );

--- a/static/app/views/settings/organizationRepositories/components/noIntegrationsEmptyState.tsx
+++ b/static/app/views/settings/organizationRepositories/components/noIntegrationsEmptyState.tsx
@@ -27,7 +27,7 @@ export function NoIntegrationsEmptyState({providers, onAddIntegration}: Props) {
       {providers.map(provider => (
         <PanelItem key={provider.key} center>
           <Flex align="center" gap="md" flex="1">
-            {getIntegrationIcon(provider.key, 'md')}
+            {getIntegrationIcon(provider.key)}
             <Heading as="h4">{provider.name}</Heading>
             {isSeerSupported({id: provider.key, name: provider.name}) && (
               <Tooltip title={t('Compatible with Seer.')}>

--- a/static/app/views/settings/project/projectFilters/groupTombstones.tsx
+++ b/static/app/views/settings/project/projectFilters/groupTombstones.tsx
@@ -97,7 +97,6 @@ function GroupTombstoneRow({data, disabled, onUndiscard}: GroupTombstoneRowProps
           disabled={disabled}
         >
           <Button
-            type="button"
             aria-label={t('Undiscard')}
             tooltipProps={{
               title: disabled

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -153,7 +153,6 @@ export default function ProjectOwnership() {
         </Access>
       )}
       <Button
-        type="button"
         size="md"
         icon={<IconEdit />}
         variant="primary"

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -162,7 +162,7 @@ export function OwnerInput({
         <ActionBar>
           <div>{parseError(error)}</div>
           <Grid flow="column" align="center" gap="md">
-            <Button type="button" size="sm" onClick={onCancel}>
+            <Button size="sm" onClick={onCancel}>
               {t('Cancel')}
             </Button>
             <Button

--- a/static/eslint/eslintPluginSentry/fixtures/componentConsumer.tsx
+++ b/static/eslint/eslintPluginSentry/fixtures/componentConsumer.tsx
@@ -1,0 +1,3 @@
+// RuleTester replaces this file's contents with each test case's code. It only
+// needs to exist on disk so the fixture tsconfig pulls it into the program.
+export const consumer = true;

--- a/static/eslint/eslintPluginSentry/fixtures/consumer.ts
+++ b/static/eslint/eslintPluginSentry/fixtures/consumer.ts
@@ -1,0 +1,3 @@
+// RuleTester replaces this file's contents with each test case's code. It only
+// needs to exist on disk so the fixture tsconfig pulls it into the program.
+export const consumer = true;

--- a/static/eslint/eslintPluginSentry/fixtures/importedDefault.ts
+++ b/static/eslint/eslintPluginSentry/fixtures/importedDefault.ts
@@ -1,0 +1,11 @@
+export function a(value = 0) {
+  return value;
+}
+
+export function withOptions({value = 5}: {value?: number}) {
+  return value;
+}
+
+export function Component({value = 5}: {value?: number}) {
+  return value;
+}

--- a/static/eslint/eslintPluginSentry/fixtures/tsconfig.json
+++ b/static/eslint/eslintPluginSentry/fixtures/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "jsx": "preserve",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "include": ["."]
+}

--- a/static/eslint/eslintPluginSentry/noRedundantDefaultArgument.spec.ts
+++ b/static/eslint/eslintPluginSentry/noRedundantDefaultArgument.spec.ts
@@ -1,4 +1,5 @@
 import {RuleTester} from '@typescript-eslint/rule-tester';
+import {TSESLint} from '@typescript-eslint/utils';
 
 import {noRedundantDefaultArgument} from './noRedundantDefaultArgument';
 
@@ -260,6 +261,106 @@ ruleTester.run('no-redundant-default-argument', noRedundantDefaultArgument, {
       name: 'TypeScript const assertion',
       code: 'const foo = (value = 5 as const) => {}; foo(5 as const);',
       output: 'const foo = (value = 5 as const) => {}; foo();',
+      errors: [{messageId: 'redundantDefaultValue'}],
+    },
+  ],
+});
+
+const crossFileRuleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      project: './tsconfig.json',
+      tsconfigRootDir: `${__dirname}/fixtures`,
+    },
+  },
+});
+
+crossFileRuleTester.run('no-redundant-default-argument', noRedundantDefaultArgument, {
+  valid: [
+    {
+      name: 'imported function argument differs from default',
+      code: `
+import {a} from './importedDefault';
+a(1);
+`,
+      filename: 'consumer.ts',
+    },
+    {
+      name: 'imported component prop differs from default',
+      code: `
+import {Component} from './importedDefault';
+<Component value={6} />;
+`,
+      filename: 'componentConsumer.tsx',
+    },
+  ],
+  invalid: [
+    {
+      name: 'imported function with numeric default',
+      code: `
+import {a} from './importedDefault';
+a(0);
+`,
+      filename: 'consumer.ts',
+      output: `
+import {a} from './importedDefault';
+a();
+`,
+      errors: [
+        {
+          messageId: 'redundantDefaultValue',
+          data: {kind: 'argument', name: 'value', value: '0'},
+        },
+      ],
+    },
+    {
+      name: 'imported function with destructured default',
+      code: `
+import {withOptions} from './importedDefault';
+withOptions({value: 5});
+`,
+      filename: 'consumer.ts',
+      output: `
+import {withOptions} from './importedDefault';
+withOptions({});
+`,
+      errors: [
+        {
+          messageId: 'redundantDefaultValue',
+          data: {kind: 'property', name: 'value', value: '5'},
+        },
+      ],
+    },
+    {
+      name: 'imported component with destructured default',
+      code: `
+import {Component} from './importedDefault';
+<Component value={5} />;
+`,
+      filename: 'componentConsumer.tsx',
+      output: `
+import {Component} from './importedDefault';
+<Component />;
+`,
+      errors: [
+        {
+          messageId: 'redundantDefaultValue',
+          data: {kind: 'prop', name: 'value', value: '5'},
+        },
+      ],
+    },
+  ],
+});
+
+const nonTypeScriptRuleTester = new TSESLint.RuleTester();
+
+nonTypeScriptRuleTester.run('no-redundant-default-argument', noRedundantDefaultArgument, {
+  valid: [],
+  invalid: [
+    {
+      name: 'parser without TypeScript parser services',
+      code: 'function foo(value = 5) {} foo(5);',
+      output: 'function foo(value = 5) {} foo();',
       errors: [{messageId: 'redundantDefaultValue'}],
     },
   ],

--- a/static/eslint/eslintPluginSentry/noRedundantDefaultArgument.ts
+++ b/static/eslint/eslintPluginSentry/noRedundantDefaultArgument.ts
@@ -1,5 +1,7 @@
 import {AST_NODE_TYPES, ESLintUtils, type TSESTree} from '@typescript-eslint/utils';
+import {getParserServices} from '@typescript-eslint/utils/eslint-utils';
 import type {RuleFix, RuleFixer, Scope} from '@typescript-eslint/utils/ts-eslint';
+import ts from 'typescript';
 
 const NOT_HARDCODED = Symbol('not hardcoded');
 
@@ -140,6 +142,165 @@ function hasDefaults(defaults: FunctionDefaults): boolean {
   return defaults.positional.size > 0 || defaults.objectProperties.size > 0;
 }
 
+function unwrapTypeScriptExpression(node: ts.Expression): ts.Expression {
+  if (
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    return unwrapTypeScriptExpression(node.expression);
+  }
+  return node;
+}
+
+function getTypeScriptHardcodedValue(
+  expression: ts.Expression
+): HardcodedValue | typeof NOT_HARDCODED {
+  const node = unwrapTypeScriptExpression(expression);
+
+  if (ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return Number(node.text);
+  }
+  if (ts.isBigIntLiteral(node)) {
+    return BigInt(node.getText().replaceAll('_', '').slice(0, -1));
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) {
+    return false;
+  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) {
+    return null;
+  }
+  if (ts.isPrefixUnaryExpression(node)) {
+    const operand = getTypeScriptHardcodedValue(node.operand);
+    if (typeof operand === 'number') {
+      if (node.operator === ts.SyntaxKind.MinusToken) {
+        return -operand;
+      }
+      if (node.operator === ts.SyntaxKind.PlusToken) {
+        return operand;
+      }
+    }
+    if (typeof operand === 'bigint' && node.operator === ts.SyntaxKind.MinusToken) {
+      return -operand;
+    }
+  }
+  return NOT_HARDCODED;
+}
+
+function getTypeScriptPropertyName(
+  node: ts.BindingName | ts.PropertyName
+): string | undefined {
+  if (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return String(Number(node.text));
+  }
+  return undefined;
+}
+
+function getTypeScriptObjectDefaults(pattern: ts.ObjectBindingPattern) {
+  const defaults = new Map<string, DefaultValue>();
+
+  for (const element of pattern.elements) {
+    if (element.dotDotDotToken || !element.initializer) {
+      continue;
+    }
+
+    const name = getTypeScriptPropertyName(element.propertyName ?? element.name);
+    const value = getTypeScriptHardcodedValue(element.initializer);
+    if (name !== undefined && value !== NOT_HARDCODED) {
+      defaults.set(name, {name, value});
+    }
+  }
+
+  return defaults;
+}
+
+function getTypeScriptFunctionDefaults(
+  node: ts.SignatureDeclarationBase
+): FunctionDefaults {
+  const defaults: FunctionDefaults = {
+    objectProperties: new Map(),
+    positional: new Map(),
+  };
+  let runtimeIndex = 0;
+
+  for (const parameter of node.parameters) {
+    if (ts.isIdentifier(parameter.name) && parameter.name.text === 'this') {
+      continue;
+    }
+
+    if (parameter.initializer && ts.isIdentifier(parameter.name)) {
+      const value = getTypeScriptHardcodedValue(parameter.initializer);
+      if (value !== NOT_HARDCODED) {
+        defaults.positional.set(runtimeIndex, {
+          name: parameter.name.text,
+          value,
+        });
+      }
+    } else if (ts.isObjectBindingPattern(parameter.name)) {
+      const properties = getTypeScriptObjectDefaults(parameter.name);
+      if (properties.size > 0) {
+        defaults.objectProperties.set(runtimeIndex, properties);
+      }
+    }
+
+    runtimeIndex++;
+  }
+
+  return defaults;
+}
+
+function getFunctionLikeDeclaration(
+  declaration: ts.Declaration
+): ts.SignatureDeclarationBase | undefined {
+  if (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isFunctionExpression(declaration) ||
+    ts.isArrowFunction(declaration)
+  ) {
+    return declaration;
+  }
+  if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) {
+    return undefined;
+  }
+
+  const initializer = unwrapTypeScriptExpression(declaration.initializer);
+  return ts.isFunctionExpression(initializer) || ts.isArrowFunction(initializer)
+    ? initializer
+    : undefined;
+}
+
+function getTypeScriptSymbolDefaults(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol
+): FunctionDefaults | undefined {
+  const resolvedSymbol =
+    symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+
+  for (const declaration of resolvedSymbol.getDeclarations() ?? []) {
+    const functionDeclaration = getFunctionLikeDeclaration(declaration);
+    if (!functionDeclaration) {
+      continue;
+    }
+
+    const defaults = getTypeScriptFunctionDefaults(functionDeclaration);
+    if (hasDefaults(defaults)) {
+      return defaults;
+    }
+  }
+  return undefined;
+}
+
 function formatHardcodedValue(value: HardcodedValue): string {
   if (typeof value === 'string') {
     return JSON.stringify(value);
@@ -168,8 +329,20 @@ export const noRedundantDefaultArgument = ESLintUtils.RuleCreator.withoutDocs({
     },
   },
   create(context) {
+    const parserServices =
+      context.sourceCode.parserServices?.esTreeNodeToTSNodeMap &&
+      context.sourceCode.parserServices.tsNodeToESTreeNodeMap
+        ? getParserServices(context, true)
+        : undefined;
     const defaultsByVariable = new Map<Scope.Variable, FunctionDefaults>();
-    const calls: Array<{node: TSESTree.CallExpression; variable: Scope.Variable}> = [];
+    const typeAwareDefaultsByVariable = new Map<
+      Scope.Variable,
+      FunctionDefaults | null
+    >();
+    const calls: Array<{
+      node: TSESTree.CallExpression;
+      variable: Scope.Variable;
+    }> = [];
     const elements: Array<{
       node: TSESTree.JSXOpeningElement;
       variable: Scope.Variable;
@@ -185,6 +358,37 @@ export const noRedundantDefaultArgument = ESLintUtils.RuleCreator.withoutDocs({
         scope = scope.upper;
       }
       return;
+    }
+
+    function getTypeAwareDefaults(
+      identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
+      variable: Scope.Variable
+    ) {
+      if (typeAwareDefaultsByVariable.has(variable)) {
+        return typeAwareDefaultsByVariable.get(variable);
+      }
+
+      const program = parserServices?.program;
+      if (!program) {
+        typeAwareDefaultsByVariable.set(variable, null);
+        return;
+      }
+
+      const checker = program.getTypeChecker();
+      const typeScriptNode = parserServices.esTreeNodeToTSNodeMap.get(identifier);
+      const symbol = checker.getSymbolAtLocation(typeScriptNode);
+      const defaults = symbol ? getTypeScriptSymbolDefaults(checker, symbol) : undefined;
+      typeAwareDefaultsByVariable.set(variable, defaults ?? null);
+      return defaults;
+    }
+
+    function getDefaults(
+      identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
+      variable: Scope.Variable
+    ) {
+      return (
+        defaultsByVariable.get(variable) ?? getTypeAwareDefaults(identifier, variable)
+      );
     }
 
     function registerFunction(
@@ -558,7 +762,10 @@ export const noRedundantDefaultArgument = ESLintUtils.RuleCreator.withoutDocs({
           if (!isStable(variable)) {
             continue;
           }
-          const defaults = defaultsByVariable.get(variable);
+          if (node.callee.type !== AST_NODE_TYPES.Identifier) {
+            continue;
+          }
+          const defaults = getDefaults(node.callee, variable);
           if (defaults) {
             checkCall(node, defaults);
           }
@@ -567,7 +774,10 @@ export const noRedundantDefaultArgument = ESLintUtils.RuleCreator.withoutDocs({
           if (!isStable(variable)) {
             continue;
           }
-          const defaults = defaultsByVariable.get(variable);
+          if (node.name.type !== AST_NODE_TYPES.JSXIdentifier) {
+            continue;
+          }
+          const defaults = getDefaults(node.name, variable);
           if (defaults) {
             checkElement(node, defaults);
           }

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -91,7 +91,6 @@ function SoftCapTypeDetail({
               {`${getPlanCategoryName({
                 plan,
                 category: categoryHistory.category,
-                capitalize: true,
                 hadCustomDynamicSampling: shouldUseDsNames,
               })}: `}
               {softCapName}

--- a/static/gsAdmin/components/eventUsers.tsx
+++ b/static/gsAdmin/components/eventUsers.tsx
@@ -46,7 +46,6 @@ export function EventUsers({orgId, projectId, onRemoveEmail}: Props) {
             </Fragment>
           }
           onConfirm={() => onRemoveEmail(row.hash)}
-          showAuditFields
         >
           <Button size="xs" variant="danger">
             Delete Email

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -189,7 +189,6 @@ export function ProductSelect({
                               {getSingularCategoryName({
                                 plan: activePlan,
                                 category: category as DataCategory,
-                                hadCustomDynamicSampling: false,
                               })}
                               {' - '}
                               {eventPrice &&

--- a/static/gsApp/views/legalAndCompliance/gdprPanel.tsx
+++ b/static/gsApp/views/legalAndCompliance/gdprPanel.tsx
@@ -133,9 +133,7 @@ function GDPREditModal({
         </Stack>
         <Footer>
           <Grid flow="column" align="center" gap="md">
-            <Button type="button" onClick={closeModal}>
-              {t('Cancel')}
-            </Button>
+            <Button onClick={closeModal}>{t('Cancel')}</Button>
             <form.SubmitButton>{t('Save Changes')}</form.SubmitButton>
           </Grid>
         </Footer>

--- a/static/gsApp/views/spendLimits/editModal.tsx
+++ b/static/gsApp/views/spendLimits/editModal.tsx
@@ -148,8 +148,7 @@ class SpendLimitsEditModal extends Component<Props, State> {
         trackOnDemandBudgetAnalytics(
           organization,
           this.state.currentOnDemandBudget,
-          newOnDemandBudget,
-          'ondemand_budget_modal'
+          newOnDemandBudget
         );
 
         if (this.getTotalBudget() > 0) {

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -108,7 +108,6 @@ function getPaygPpe({
   const bucket = getBucket({
     buckets: activePlan.planCategories[category],
     events: reserved === RESERVED_BUDGET_QUOTA ? reserved : reserved + 1, // +1 to get the next bucket, if any
-    shouldMinimize: false,
   });
   return bucket.onDemandPrice ?? 0;
 }
@@ -208,7 +207,6 @@ export function SharedSpendLimitPriceTable({
         const pluralName = getPlanCategoryName({
           plan: activePlan,
           category,
-          capitalize: true,
         });
         const singularName =
           categoryInfo?.shortenedUnitName ??


### PR DESCRIPTION
The initial rule worked without type information, which means it couldn’t track across files. That made it somewhat usable, but the biggest offenders are usually cross-file imports.

The rule is now updated and found 150+ more usages where we pass the defaultValue unnecessarily to a function or component.