### PR TITLE
fix(dynamic-sampling): invalidate project config when recalibration factor changes

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -49,30 +49,42 @@ def write_caches(config: BaseDynamicSamplingConfiguration) -> None:
     compute it.
     """
     org_id = config.organization.id
-    write_recalibration_factor(org_id, config.results.recalibration_factor)
+    wrote_recalibration_factor = write_recalibration_factor(
+        org_id, config.results.previous_recalibration_factor, config.results.recalibration_factor
+    )
     wrote_project_rates = set_project_sample_rates(org_id, config.results.rebalanced_projects)
     wrote_transaction_rates = set_transaction_sample_rates(
         org_id, config.results.rebalanced_transactions
     )
-    if wrote_project_rates or wrote_transaction_rates:
-        if not is_org_in_serving_rollout(org_id):
-            return
-
-        schedule_invalidate_project_config(
-            organization_id=org_id, trigger="dynamic_sampling_per_org"
-        )
-
-
-def write_recalibration_factor(org_id: int, factor: float | None) -> None:
-    if factor is None:
+    if not (wrote_recalibration_factor or wrote_project_rates or wrote_transaction_rates):
         return
+
+    if not is_org_in_serving_rollout(org_id):
+        return
+
+    schedule_invalidate_project_config(organization_id=org_id, trigger="dynamic_sampling_per_org")
+
+
+def write_recalibration_factor(org_id: int, previous_factor: float, factor: float | None) -> bool:
+    """Store the recalibration factor this pass computed.
+
+    A factor outside the rebalance bounds clears the stored one, so that a stale factor
+    cannot keep being applied.
+
+    Returns whether the factor the organization is served with moved, which is what makes
+    its rules worth republishing.
+    """
+    if factor is None:
+        return False
 
     if MIN_REBALANCE_FACTOR <= factor <= MAX_REBALANCE_FACTOR:
         set_adjusted_factor(org_id, factor)
+        served_factor = factor
     else:
-        # A factor outside the rebalance bounds clears the cached one, so that a stale
-        # factor cannot keep being applied.
         delete_adjusted_factor(org_id)
+        served_factor = 1.0
+
+    return not are_equal_with_epsilon(previous_factor, served_factor)
 
 
 def generate_recalibrate_orgs_cache_key(org_id: int) -> str:

--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -55,7 +55,7 @@ def write_caches(config: BaseDynamicSamplingConfiguration) -> None:
     """
     org_id = config.organization.id
     wrote_recalibration_factor = write_recalibration_factor(
-        org_id, config.results.previous_recalibration_factor, config.results.recalibration_factor
+        org_id, config.results.recalibration_factor
     )
     wrote_project_rates = set_project_sample_rates(org_id, config.results.rebalanced_projects)
     wrote_transaction_rates = set_transaction_sample_rates(
@@ -70,14 +70,15 @@ def write_caches(config: BaseDynamicSamplingConfiguration) -> None:
     schedule_invalidate_project_config(organization_id=org_id, trigger="dynamic_sampling_per_org")
 
 
-def write_recalibration_factor(org_id: int, previous_factor: float, factor: float | None) -> bool:
+def write_recalibration_factor(org_id: int, factor: float | None) -> bool:
     """Store the recalibration factor this pass computed.
 
     A factor outside the rebalance bounds clears the stored one, so that a stale factor
     cannot keep being applied.
 
-    Returns whether the factor the organization is served with moved, which is what makes
-    its rules worth republishing.
+    Returns whether the stored factor was written or cleared, which is what makes the
+    organization's rules worth republishing. The stored factor expires quickly, so a
+    rewrite of the same value still counts.
     """
     if factor is None:
         return False
@@ -89,12 +90,9 @@ def write_recalibration_factor(org_id: int, previous_factor: float, factor: floa
 
     if MIN_REBALANCE_FACTOR <= factor <= MAX_REBALANCE_FACTOR:
         set_adjusted_factor(org_id, factor)
-        served_factor = factor
     else:
         delete_adjusted_factor(org_id)
-        served_factor = 1.0
-
-    return not are_equal_with_epsilon(previous_factor, served_factor)
+    return True
 
 
 def generate_recalibrate_orgs_cache_key(org_id: int) -> str:

--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -47,12 +47,6 @@ CachedTransactionSampleRates = dict[int, tuple[dict[str, float], float] | None]
 
 
 def write_caches(config: BaseDynamicSamplingConfiguration) -> None:
-    """Persist what one pass of the per-org pipeline computed.
-
-    Runs once at the end of the pass, so that every cache the new pipeline owns is written
-    from one place out of ``config.results``, rather than by the stage that happens to
-    compute it.
-    """
     org_id = config.organization.id
     wrote_recalibration_factor = write_recalibration_factor(
         org_id, config.results.recalibration_factor
@@ -71,15 +65,6 @@ def write_caches(config: BaseDynamicSamplingConfiguration) -> None:
 
 
 def write_recalibration_factor(org_id: int, factor: float | None) -> bool:
-    """Store the recalibration factor this pass computed.
-
-    A factor outside the rebalance bounds clears the stored one, so that a stale factor
-    cannot keep being applied.
-
-    Returns whether the stored factor was written or cleared, which is what makes the
-    organization's rules worth republishing. The stored factor expires quickly, so a
-    rewrite of the same value still counts.
-    """
     if factor is None:
         return False
 

--- a/tests/sentry/dynamic_sampling/per_org/test_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_cache.py
@@ -145,9 +145,7 @@ class InvalidateProjectConfigsTest(TestCase):
             override_options(self.SERVING_ON),
             patch_configuration({SET_FACTOR: DEFAULT, DELETE_FACTOR: DEFAULT}),
         ):
-            invalidate = self._write(
-                DynamicSamplingResults(previous_recalibration_factor=1.0, recalibration_factor=1.5)
-            )
+            invalidate = self._write(DynamicSamplingResults(recalibration_factor=1.5))
 
         invalidate.assert_called_once()
 
@@ -157,24 +155,10 @@ class InvalidateProjectConfigsTest(TestCase):
             patch_configuration({SET_FACTOR: DEFAULT, DELETE_FACTOR: DEFAULT}),
         ):
             invalidate = self._write(
-                DynamicSamplingResults(
-                    previous_recalibration_factor=1.5,
-                    recalibration_factor=MAX_REBALANCE_FACTOR * 2,
-                )
+                DynamicSamplingResults(recalibration_factor=MAX_REBALANCE_FACTOR * 2)
             )
 
         invalidate.assert_called_once()
-
-    def test_an_unchanged_recalibration_factor_does_not_republish(self) -> None:
-        with (
-            override_options(self.SERVING_ON),
-            patch_configuration({SET_FACTOR: DEFAULT, DELETE_FACTOR: DEFAULT}),
-        ):
-            invalidate = self._write(
-                DynamicSamplingResults(previous_recalibration_factor=1.5, recalibration_factor=1.5)
-            )
-
-        invalidate.assert_not_called()
 
     def test_a_pass_that_wrote_nothing_does_not_republish(self) -> None:
         with override_options(self.SERVING_ON):

--- a/tests/sentry/dynamic_sampling/per_org/test_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_cache.py
@@ -134,6 +134,42 @@ class InvalidateProjectConfigsTest(TestCase):
 
         invalidate.assert_not_called()
 
+    def test_a_moved_recalibration_factor_is_republished(self) -> None:
+        with (
+            override_options(self.SERVING_ON),
+            patch_configuration({SET_FACTOR: DEFAULT, DELETE_FACTOR: DEFAULT}),
+        ):
+            invalidate = self._write(
+                DynamicSamplingResults(previous_recalibration_factor=1.0, recalibration_factor=1.5)
+            )
+
+        invalidate.assert_called_once()
+
+    def test_a_cleared_recalibration_factor_is_republished(self) -> None:
+        with (
+            override_options(self.SERVING_ON),
+            patch_configuration({SET_FACTOR: DEFAULT, DELETE_FACTOR: DEFAULT}),
+        ):
+            invalidate = self._write(
+                DynamicSamplingResults(
+                    previous_recalibration_factor=1.5,
+                    recalibration_factor=MAX_REBALANCE_FACTOR * 2,
+                )
+            )
+
+        invalidate.assert_called_once()
+
+    def test_an_unchanged_recalibration_factor_does_not_republish(self) -> None:
+        with (
+            override_options(self.SERVING_ON),
+            patch_configuration({SET_FACTOR: DEFAULT, DELETE_FACTOR: DEFAULT}),
+        ):
+            invalidate = self._write(
+                DynamicSamplingResults(previous_recalibration_factor=1.5, recalibration_factor=1.5)
+            )
+
+        invalidate.assert_not_called()
+
     def test_a_pass_that_wrote_nothing_does_not_republish(self) -> None:
         with override_options(self.SERVING_ON):
             invalidate = self._write(DynamicSamplingResults())


### PR DESCRIPTION
- `write_caches` only scheduled a project config invalidation after project or transaction rates were written. A pass that only moved or cleared the recalibration factor left Relay with the old factor until another cache changed.
- `write_recalibration_factor` now reports whether the served factor moved, compared against the factor read at the start of the pass. That result joins the invalidation condition.
- A cleared factor counts as `1.0`. Clearing a stored factor republishes. A repeat of the same factor does not.
- Tests cover a moved factor, a cleared factor, and an unchanged factor.
