### PR TITLE
feat(seer): Add force bash mode toggles for Ask Seer and Autofix

### DIFF
--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -28,6 +28,7 @@ import {getGithubPermissionsUpdateUrl} from 'sentry/utils/integrationUtil';
 import {useAutoScroll} from 'sentry/utils/useAutoScroll';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useDismissAlert} from 'sentry/utils/useDismissAlert';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 import {useSeerExplorerDrawer} from 'sentry/views/seerExplorer/components/drawer/useSeerExplorerDrawer';
@@ -46,7 +47,10 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
       organization.features.includes('autofix-pr-iteration') ||
       organization.features.includes('autofix-pr-iteration-manual'),
   });
-  const [enableBashTools, setEnableBashTools] = useState(false);
+  const [enableBashTools, setEnableBashTools] = useLocalStorageState(
+    'autofix-force-bash-mode',
+    false
+  );
 
   const autofix = useMemo(
     () => ({
@@ -54,7 +58,11 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
       startStep: (
         step: AutofixExplorerStep,
         options?: Parameters<ReturnType<typeof useExplorerAutofix>['startStep']>[1]
-      ) => aiAutofix.startStep(step, {...options, enableBashTools}),
+      ) =>
+        aiAutofix.startStep(step, {
+          ...options,
+          enableBashTools: enableBashTools || undefined,
+        }),
     }),
     [aiAutofix, enableBashTools]
   );

--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -68,7 +68,7 @@ export function SeerDrawerHeader({
             variant="transparent"
           />
           {isSentryEmployee && onEnableBashToolsChange && (
-            <Tooltip title={t('Enable bash mode for the autofix analysis')} skipWrapper>
+            <Tooltip title={t('Force bash mode on for the autofix analysis')} skipWrapper>
               <Flex align="center" gap="xs">
                 <Text size="xs">{t('Bash')}</Text>
                 <Switch

--- a/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
@@ -872,6 +872,8 @@ describe('SeerExplorerContent', () => {
             onCopyLinkClick={undefined}
             overrideCtxEngEnable
             onOverrideCtxEngEnableToggle={() => {}}
+            overrideBashModeEnabled={false}
+            onOverrideBashModeToggle={() => {}}
             showThinking={false}
             onShowThinkingToggle={() => {}}
             isPipSupported={false}

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -204,6 +204,7 @@ export function SeerExplorerContent({
     hasSentInterrupt,
     overrideCtxEngEnable,
     setOverrideCtxEngEnable,
+    overrideBashModeEnabled,
     setOverrideBashModeEnabled,
     setOverrideCodeModeEnable,
   } = useSeerExplorer();
@@ -558,6 +559,8 @@ export function SeerExplorerContent({
       onCopyLinkClick={runId === null ? undefined : handleCopyLink}
       overrideCtxEngEnable={overrideCtxEngEnable}
       onOverrideCtxEngEnableToggle={() => setOverrideCtxEngEnable(v => !v)}
+      overrideBashModeEnabled={overrideBashModeEnabled}
+      onOverrideBashModeToggle={() => setOverrideBashModeEnabled(v => !v)}
       showThinking={showThinking}
       onShowThinkingToggle={() => setShowThinking(v => !v)}
       isPipSupported={isPipSupported}

--- a/static/app/views/seerExplorer/components/seerExplorerDebugMenu.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerDebugMenu.tsx
@@ -7,22 +7,26 @@ import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface SeerExplorerDebugMenuProps {
+  onOverrideBashModeToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
   onShowThinkingToggle: () => void;
+  overrideBashModeEnabled: boolean;
   overrideCtxEngEnable: boolean;
   showThinking: boolean;
 }
 
 /**
  * Consolidated "Debug" dropdown holding the feature-flagged developer toggles
- * (Context Engine override, Show thinking). The flag checks live here so the
- * parent doesn't thread them through — if no flags are enabled the whole menu
- * renders nothing. The toggle state stays lifted (it's consumed elsewhere), so
- * we only receive the current values and their toggle handlers.
+ * (Context Engine override, Force bash mode, Show thinking). The flag checks
+ * live here so the parent doesn't thread them through — if no flags are enabled
+ * the whole menu renders nothing. The toggle state stays lifted (it's consumed
+ * elsewhere), so we only receive the current values and their toggle handlers.
  */
 export function SeerExplorerDebugMenu({
   overrideCtxEngEnable,
   onOverrideCtxEngEnableToggle,
+  overrideBashModeEnabled,
+  onOverrideBashModeToggle,
   showThinking,
   onShowThinkingToggle,
 }: SeerExplorerDebugMenuProps) {
@@ -33,6 +37,9 @@ export function SeerExplorerDebugMenu({
   const showThinkingToggle = !!organization?.features.includes(
     'seer-explorer-thinking-blocks'
   );
+  const showBashModeToggle = !!organization?.features.includes(
+    'seer-explorer-allow-bash-mode'
+  );
 
   const items: MenuItemProps[] = [
     ...(showContextEngineToggle
@@ -42,6 +49,17 @@ export function SeerExplorerDebugMenu({
             label: t('Context Engine'),
             leadingItems: <Checkbox checked={overrideCtxEngEnable} readOnly />,
             onAction: onOverrideCtxEngEnableToggle,
+            closeOnSelect: false,
+          },
+        ]
+      : []),
+    ...(showBashModeToggle
+      ? [
+          {
+            key: 'force-bash-mode',
+            label: t('Force bash mode on'),
+            leadingItems: <Checkbox checked={overrideBashModeEnabled} readOnly />,
+            onAction: onOverrideBashModeToggle,
             closeOnSelect: false,
           },
         ]

--- a/static/app/views/seerExplorer/components/seerExplorerHeader.spec.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerHeader.spec.tsx
@@ -23,6 +23,8 @@ function defaultProps(overrides = {}) {
     onCopyLinkClick: jest.fn(),
     overrideCtxEngEnable: false,
     onOverrideCtxEngEnableToggle: jest.fn(),
+    overrideBashModeEnabled: false,
+    onOverrideBashModeToggle: jest.fn(),
     showThinking: false,
     onShowThinkingToggle: jest.fn(),
     isPipSupported: false,
@@ -76,6 +78,26 @@ describe('SeerExplorerHeader', () => {
       expect(
         screen.queryByRole('menuitemradio', {name: /Context Engine/})
       ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitemradio', {name: /Force bash mode on/})
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the force bash mode toggle behind its own flag', async () => {
+      const onOverrideBashModeToggle = jest.fn();
+      await renderHeader(
+        {overrideBashModeEnabled: true, onOverrideBashModeToggle},
+        orgWith('seer-explorer-allow-bash-mode')
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Debug'}));
+
+      expect(screen.getByRole('checkbox')).toBeChecked();
+
+      await userEvent.click(
+        screen.getByRole('menuitemradio', {name: /Force bash mode on/})
+      );
+      expect(onOverrideBashModeToggle).toHaveBeenCalled();
     });
 
     it('reflects the toggle state and fires the handler', async () => {

--- a/static/app/views/seerExplorer/components/seerExplorerHeader.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerHeader.tsx
@@ -37,9 +37,11 @@ interface SeerExplorerHeaderProps {
   onCopyLinkClick: (() => void) | undefined;
   onCopySessionClick: (() => void) | undefined;
   onNewChatClick: () => void;
+  onOverrideBashModeToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
   onShowThinkingToggle: () => void;
   onTogglePictureInPicture: () => void;
+  overrideBashModeEnabled: boolean;
   overrideCtxEngEnable: boolean;
   showThinking: boolean;
   disableNewChatButton?: boolean;
@@ -54,6 +56,8 @@ export function SeerExplorerHeader({
   onCopyLinkClick,
   overrideCtxEngEnable,
   onOverrideCtxEngEnableToggle,
+  overrideBashModeEnabled,
+  onOverrideBashModeToggle,
   showThinking,
   onShowThinkingToggle,
   isPipSupported,
@@ -130,6 +134,8 @@ export function SeerExplorerHeader({
         <SeerExplorerDebugMenu
           overrideCtxEngEnable={overrideCtxEngEnable}
           onOverrideCtxEngEnableToggle={onOverrideCtxEngEnableToggle}
+          overrideBashModeEnabled={overrideBashModeEnabled}
+          onOverrideBashModeToggle={onOverrideBashModeToggle}
           showThinking={showThinking}
           onShowThinkingToggle={onShowThinkingToggle}
         />


### PR DESCRIPTION
Update the debug 'bash mode' toggle.
- Add the toggle on the Ask Seer pane.
- On the Autofix pane persist the toggle setting to local storage (Ask Seer already does this) 
- On both panes make the toggle 'Force enable'  (e.g. it selects between null/true on the tristate rather than false/true).