### PR TITLE
ref(pr-metrics): Unsample the quantized counters and route defects to Sentry

### DIFF
--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -299,7 +299,7 @@ def _apply_entry(
             "pr_metrics.activity_doc.events_capped",
             extra={"event_type": event_type, "events_dropped": doc["events_dropped"]},
         )
-        metrics.incr("pr_metrics.activity_doc.events_capped")
+        metrics.incr("pr_metrics.activity_doc.events_capped", sample_rate=1.0)
         return
 
     doc["events"].append(
@@ -363,7 +363,7 @@ def _fold_sync_chain(
             "pr_metrics.activity_doc.sync_chain_capped",
             extra={"after_sha": after},
         )
-        metrics.incr("pr_metrics.activity_doc.sync_chain_capped")
+        metrics.incr("pr_metrics.activity_doc.sync_chain_capped", sample_rate=1.0)
 
     chain.append(
         [
@@ -449,7 +449,7 @@ def _apply_check_run(
                     "check_name": name,
                 },
             )
-            metrics.incr("pr_metrics.activity_doc.check_runs_capped")
+            metrics.incr("pr_metrics.activity_doc.check_runs_capped", sample_rate=1.0)
             return
         runs[name] = {
             "conclusion": conclusion,
@@ -519,6 +519,9 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
             "pr_metrics.activity_doc.check_head_groups_capped",
             extra={"head_sha": head_sha, "app_slug": app_slug, "evicted_key": evicted_key},
         )
+        # Ambient rate for both head- and document-wide group caps: they bite on every
+        # CI-heavy PR rather than exceptionally, so what matters is the trend, which
+        # sampling resolves. The forward-path caps below are the rare ones.
         metrics.incr("pr_metrics.activity_doc.check_head_groups_capped")
     elif len(checks) >= MAX_CHECK_GROUPS:
         evicted_key = min(checks, key=lambda existing: _forward_priority(checks[existing]))
@@ -1073,7 +1076,7 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
                     "dropped": len(head_groups) - MAX_FORWARDED_GROUPS_PER_HEAD,
                 },
             )
-            metrics.incr("pr_metrics.activity_doc.forward_head_groups_capped")
+            metrics.incr("pr_metrics.activity_doc.forward_head_groups_capped", sample_rate=1.0)
             head_groups = sorted(head_groups, key=_forward_priority)[
                 -MAX_FORWARDED_GROUPS_PER_HEAD:
             ]
@@ -1085,7 +1088,7 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
             "pr_metrics.activity_doc.forward_groups_capped",
             extra={"check_groups": len(groups), "dropped": dropped},
         )
-        metrics.incr("pr_metrics.activity_doc.forward_groups_capped")
+        metrics.incr("pr_metrics.activity_doc.forward_groups_capped", sample_rate=1.0)
         groups = sorted(groups, key=_forward_priority)[-MAX_FORWARDED_CHECK_GROUPS:]
 
     for group in groups:

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -519,9 +519,8 @@ def _get_or_create_group(doc: ActivityDoc, payload: Mapping[str, Any]) -> CheckG
             "pr_metrics.activity_doc.check_head_groups_capped",
             extra={"head_sha": head_sha, "app_slug": app_slug, "evicted_key": evicted_key},
         )
-        # Ambient rate for both head- and document-wide group caps: they bite on every
-        # CI-heavy PR rather than exceptionally, so what matters is the trend, which
-        # sampling resolves. The forward-path caps below are the rare ones.
+        # Ambient rate: both group caps bite on every CI-heavy PR, so the trend is what
+        # matters and sampling resolves it. The forward-path caps below are the rare ones.
         metrics.incr("pr_metrics.activity_doc.check_head_groups_capped")
     elif len(checks) >= MAX_CHECK_GROUPS:
         evicted_key = min(checks, key=lambda existing: _forward_priority(checks[existing]))

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -148,7 +148,7 @@ def select_verdict(
     rather than emit zeroed counters (merge) or guess abandoned (close).
     """
     if not is_activity_tracking_enabled(organization):
-        metrics.incr("pr_metrics.select_verdict.activity_disabled")
+        metrics.incr("pr_metrics.select_verdict.activity_disabled", sample_rate=1.0)
         return VerdictDeferral.INDETERMINATE
 
     metrics_row = PullRequestMetrics.objects.filter(pull_request=pull_request).first()
@@ -161,7 +161,7 @@ def select_verdict(
                 "pull_request_id": pull_request.id,
             },
         )
-        metrics.incr("pr_metrics.select_verdict.metrics_row_missing")
+        metrics.incr("pr_metrics.select_verdict.metrics_row_missing", sample_rate=1.0)
         return VerdictDeferral.INDETERMINATE
 
     has_commits_after_open = _has_commits_after_open(pull_request)
@@ -654,7 +654,7 @@ def _canonical_sibling(siblings: list[PullRequest]) -> PullRequest:
                 "organization_ids": sorted({pr.organization_id for pr in siblings}),
             },
         )
-        metrics.incr("pr_metrics.emit.dedup_no_run_org_row")
+        metrics.incr("pr_metrics.emit.dedup_no_run_org_row", sample_rate=1.0)
     return canonical
 
 
@@ -952,9 +952,9 @@ def _log_reducer_parity(pull_request: PullRequest) -> None:
                 "reduced": reduced,
             },
         )
-        metrics.incr("pr_metrics.reducer_parity.mismatch")
+        metrics.incr("pr_metrics.reducer_parity.mismatch", sample_rate=1.0)
     else:
-        metrics.incr("pr_metrics.reducer_parity.match")
+        metrics.incr("pr_metrics.reducer_parity.match", sample_rate=1.0)
 
 
 def _activity_derived_metrics(pull_request: PullRequest) -> dict[str, Any]:
@@ -1075,6 +1075,12 @@ def emit_pr_metrics_row(
     # and rides along on the emitted row, so the two can't diverge.
     attributions = active_attributions(pull_request)
     if not attributions:
+        # Deliberately left at the ambient sample rate while every other `reason` on
+        # this metric is unsampled: `untracked` is the webhook firehose — most PRs
+        # Sentry sees are never attributed — so sampling already resolves its rate,
+        # and the rare reasons are what needed an exact count. Both `untracked` call
+        # sites must keep the same rate: a tag value split across two rates still
+        # totals correctly, but stops being exact, which is the point of the others.
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return False
 
@@ -1082,7 +1088,9 @@ def emit_pr_metrics_row(
     # and each otherwise emitting — dedupe to a single canonical row so counts
     # aren't inflated by sibling-org duplicates.
     if not is_canonical_github_pr_row(pull_request):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "duplicate_github_pr"})
+        metrics.incr(
+            "pr_metrics.emit.skipped", tags={"reason": "duplicate_github_pr"}, sample_rate=1.0
+        )
         return False
 
     # Derive the activity-sourced counters at the terminal event — before the
@@ -1109,7 +1117,7 @@ def emit_pr_metrics_row(
         diagnosis_labels=diagnosis_labels,
     )
     analytics.record(row)
-    metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action})
+    metrics.incr("pr_metrics.emit.recorded", tags={"close_action": close_action}, sample_rate=1.0)
     logger.info(
         "pr_metrics.emit.recorded",
         extra={

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -153,11 +153,9 @@ def select_verdict(
 
     metrics_row = PullRequestMetrics.objects.filter(pull_request=pull_request).first()
     if metrics_row is None:
-        # error, not warning: handle_metrics persists this row before emission under
-        # the same gate, so its absence means that write failed and the PR will now
-        # never emit. Silent data loss wants an issue someone owns, not a counter —
-        # only ERROR reaches Sentry as one (the SDK sets event_level=None and the
-        # root `internal` handler is level ERROR).
+        # error, not warning: handle_metrics writes this row before emission, so its
+        # absence means that write failed and the PR will never emit. Only ERROR
+        # reaches Sentry as an issue, and silent data loss wants an owner.
         logger.error(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
@@ -946,9 +944,8 @@ def _log_reducer_parity(pull_request: PullRequest) -> None:
         activity_doc.human_participant_count(doc),
     )
     if legacy != reduced:
-        # error, not warning: the two reducers disagreeing is a correctness bug to be
-        # told about once, not a rate to trend, so it goes to Sentry rather than to a
-        # counter that is expected to read zero forever.
+        # error, not warning: the reducers disagreeing is a correctness bug to be told
+        # about once, not a rate to trend.
         logger.error(
             "pr_metrics.reducer_parity.mismatch",
             extra={
@@ -960,9 +957,8 @@ def _log_reducer_parity(pull_request: PullRequest) -> None:
             },
         )
     else:
-        # Only the match half is a counter, despite the name pairing: it tracks how
-        # much traffic still takes the legacy path, which is a rate that should drain
-        # to zero. Its mismatch counterpart is handled above.
+        # Only the match half is a counter: it tracks how much traffic still takes the
+        # legacy path, a rate that should drain to zero. Mismatch is the error above.
         metrics.incr("pr_metrics.reducer_parity.match", sample_rate=1.0)
 
 
@@ -1084,12 +1080,10 @@ def emit_pr_metrics_row(
     # and rides along on the emitted row, so the two can't diverge.
     attributions = active_attributions(pull_request)
     if not attributions:
-        # Deliberately left at the ambient sample rate while every other `reason` on
-        # this metric is unsampled: `untracked` is the webhook firehose — most PRs
-        # Sentry sees are never attributed — so sampling already resolves its rate,
-        # and the rare reasons are what needed an exact count. Both `untracked` call
-        # sites must keep the same rate: a tag value split across two rates still
-        # totals correctly, but stops being exact, which is the point of the others.
+        # Ambient rate while this metric's rarer reasons are unsampled: `untracked` is
+        # the webhook firehose, so sampling already resolves it. Keep both `untracked`
+        # sites on the same rate — one tag value split across two rates still totals
+        # correctly, but stops being exact.
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return False
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -153,7 +153,12 @@ def select_verdict(
 
     metrics_row = PullRequestMetrics.objects.filter(pull_request=pull_request).first()
     if metrics_row is None:
-        logger.warning(
+        # error, not warning: handle_metrics persists this row before emission under
+        # the same gate, so its absence means that write failed and the PR will now
+        # never emit. Silent data loss wants an issue someone owns, not a counter —
+        # only ERROR reaches Sentry as one (the SDK sets event_level=None and the
+        # root `internal` handler is level ERROR).
+        logger.error(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
                 "organization_id": pull_request.organization_id,
@@ -161,7 +166,6 @@ def select_verdict(
                 "pull_request_id": pull_request.id,
             },
         )
-        metrics.incr("pr_metrics.select_verdict.metrics_row_missing", sample_rate=1.0)
         return VerdictDeferral.INDETERMINATE
 
     has_commits_after_open = _has_commits_after_open(pull_request)
@@ -942,7 +946,10 @@ def _log_reducer_parity(pull_request: PullRequest) -> None:
         activity_doc.human_participant_count(doc),
     )
     if legacy != reduced:
-        logger.warning(
+        # error, not warning: the two reducers disagreeing is a correctness bug to be
+        # told about once, not a rate to trend, so it goes to Sentry rather than to a
+        # counter that is expected to read zero forever.
+        logger.error(
             "pr_metrics.reducer_parity.mismatch",
             extra={
                 "organization_id": pull_request.organization_id,
@@ -952,8 +959,10 @@ def _log_reducer_parity(pull_request: PullRequest) -> None:
                 "reduced": reduced,
             },
         )
-        metrics.incr("pr_metrics.reducer_parity.mismatch", sample_rate=1.0)
     else:
+        # Only the match half is a counter, despite the name pairing: it tracks how
+        # much traffic still takes the legacy path, which is a rate that should drain
+        # to zero. Its mismatch counterpart is handled above.
         metrics.incr("pr_metrics.reducer_parity.match", sample_rate=1.0)
 
 

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -597,6 +597,14 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
         metrics.incr(
             "pr_metrics.judge.reaper.skipped", tags={"reason": "org_gone"}, sample_rate=1.0
         )
+        logger.info(
+            "pr_metrics.judge.reaper.org_gone",
+            extra={
+                "organization_id": pull_request.organization_id,
+                "repository_id": pull_request.repository_id,
+                "pull_request_id": pull_request.id,
+            },
+        )
         return
 
     if not features.has("organizations:pr-metrics", organization):
@@ -607,6 +615,14 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
                 "pr_metrics.judge.reaper.released",
                 tags={"reason": "feature_disabled"},
                 sample_rate=1.0,
+            )
+            logger.info(
+                "pr_metrics.judge.reaper.feature_disabled",
+                extra={
+                    "organization_id": pull_request.organization_id,
+                    "repository_id": pull_request.repository_id,
+                    "pull_request_id": pull_request.id,
+                },
             )
         return
 

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -141,7 +141,7 @@ def _pr_activity_timeline(pull_request: PullRequest) -> tuple[list[PrActivityEve
                 "dropped": dropped,
             },
         )
-        metrics.incr("pr_metrics.judge.check_rows_capped")
+        metrics.incr("pr_metrics.judge.check_rows_capped", sample_rate=1.0)
         kept_check_ids = {row.id for row in check_rows[-_MAX_FORWARDED_CHECK_ROWS:]}
         rows = [
             row
@@ -245,9 +245,11 @@ def forward_pr_to_seer_judge(pull_request: PullRequest, repository: Repository) 
         logger.warning(
             "pr_metrics.judge.forward_rejected", extra={**log_extra, "status": response.status}
         )
-        metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "client_error"})
+        metrics.incr(
+            "pr_metrics.judge.forward_failed", tags={"reason": "client_error"}, sample_rate=1.0
+        )
         return
-    metrics.incr("pr_metrics.judge.forwarded")
+    metrics.incr("pr_metrics.judge.forwarded", sample_rate=1.0)
     logger.info("pr_metrics.judge.forwarded", extra=log_extra)
 
 
@@ -298,7 +300,7 @@ def _parse_conversation_analysis(
         return analysis
     except (ValidationError, TypeError, ValueError):
         logger.warning("pr_metrics.update.invalid_conversation_analysis", extra=dict(log_extra))
-        metrics.incr("pr_metrics.update.invalid_conversation_analysis")
+        metrics.incr("pr_metrics.update.invalid_conversation_analysis", sample_rate=1.0)
         return None
 
 
@@ -321,7 +323,7 @@ def _clean_diagnosis_labels(raw: Any, log_extra: Mapping[str, Any]) -> list[str]
     ):
         return list(raw)
     logger.warning("pr_metrics.update.invalid_diagnosis_labels", extra=dict(log_extra))
-    metrics.incr("pr_metrics.update.invalid_diagnosis_labels")
+    metrics.incr("pr_metrics.update.invalid_diagnosis_labels", sample_rate=1.0)
     return None
 
 
@@ -375,14 +377,18 @@ def update_pr_metrics(
     # internal forward sentinel) is malformed input — reject rather than write it.
     if verdict is None or verdict not in RESULT_VERDICTS:
         logger.warning("pr_metrics.update.invalid_verdict", extra={**log_extra, "verdict": verdict})
-        metrics.incr("pr_metrics.update.skipped", tags={"reason": "invalid_verdict"})
+        metrics.incr(
+            "pr_metrics.update.skipped", tags={"reason": "invalid_verdict"}, sample_rate=1.0
+        )
         return UpdatePrMetricsErrorResponse(error="invalid_verdict")
 
     try:
         parsed_attributions = _parse_attributions(attributions or ())
     except (KeyError, TypeError, ValueError):
         logger.warning("pr_metrics.update.invalid_attribution", extra=log_extra)
-        metrics.incr("pr_metrics.update.skipped", tags={"reason": "invalid_attribution"})
+        metrics.incr(
+            "pr_metrics.update.skipped", tags={"reason": "invalid_attribution"}, sample_rate=1.0
+        )
         return UpdatePrMetricsErrorResponse(error="invalid_attribution")
 
     parsed_conversation_analysis = _parse_conversation_analysis(conversation_analysis, log_extra)
@@ -398,7 +404,7 @@ def update_pr_metrics(
         )
     except PullRequest.DoesNotExist:
         logger.warning("pr_metrics.update.pull_request_not_found", extra=log_extra)
-        metrics.incr("pr_metrics.update.skipped", tags={"reason": "pr_not_found"})
+        metrics.incr("pr_metrics.update.skipped", tags={"reason": "pr_not_found"}, sample_rate=1.0)
         return UpdatePrMetricsErrorResponse(error="pull_request_not_found")
 
     # Emit needs a terminal PR (closed_at + head_commit_sha). Validate it before
@@ -406,7 +412,7 @@ def update_pr_metrics(
     # verdict and then failing in emit — i.e. no committed-but-errored state.
     if pull_request.closed_at is None or pull_request.head_commit_sha is None:
         logger.warning("pr_metrics.update.not_terminal", extra=log_extra)
-        metrics.incr("pr_metrics.update.skipped", tags={"reason": "not_terminal"})
+        metrics.incr("pr_metrics.update.skipped", tags={"reason": "not_terminal"}, sample_rate=1.0)
         return UpdatePrMetricsErrorResponse(error="pull_request_not_terminal")
 
     # Only the verdict is written here; the webhook keeps the activity counters
@@ -428,7 +434,9 @@ def update_pr_metrics(
             logger.info(
                 "pr_metrics.update.already_settled", extra={**log_extra, "verdict": verdict}
             )
-            metrics.incr("pr_metrics.update.skipped", tags={"reason": "already_settled"})
+            metrics.incr(
+                "pr_metrics.update.skipped", tags={"reason": "already_settled"}, sample_rate=1.0
+            )
             return UpdatePrMetricsSuccessResponse()
         for signal_type, source, signal_details in parsed_attributions:
             record_attribution_signal(
@@ -444,7 +452,7 @@ def update_pr_metrics(
         diagnosis_labels=clean_diagnosis_labels,
     )
 
-    metrics.incr("pr_metrics.update.recorded", tags={"verdict": verdict})
+    metrics.incr("pr_metrics.update.recorded", tags={"verdict": verdict}, sample_rate=1.0)
     logger.info("pr_metrics.update.recorded", extra={**log_extra, "verdict": verdict})
     return UpdatePrMetricsSuccessResponse()
 
@@ -516,9 +524,11 @@ def _release_reopened_judge_claim(pull_request: PullRequest) -> None:
     re-close can re-claim and re-forward rather than finding the row stuck.
     """
     if not _release_judge_sentinel(pull_request):
-        metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
+        metrics.incr(
+            "pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"}, sample_rate=1.0
+        )
         return
-    metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "reopened"})
+    metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "reopened"}, sample_rate=1.0)
     logger.info(
         "pr_metrics.judge.reaper.released",
         extra={
@@ -543,9 +553,13 @@ def _release_indeterminate_judge_claim(pull_request: PullRequest) -> None:
     ``INDETERMINATE`` path, which also never emits.
     """
     if not _release_judge_sentinel(pull_request):
-        metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
+        metrics.incr(
+            "pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"}, sample_rate=1.0
+        )
         return
-    metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "indeterminate"})
+    metrics.incr(
+        "pr_metrics.judge.reaper.released", tags={"reason": "indeterminate"}, sample_rate=1.0
+    )
     logger.warning(
         "pr_metrics.judge.reaper.indeterminate",
         extra={
@@ -580,14 +594,20 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
     try:
         organization = Organization.objects.get(id=pull_request.organization_id)
     except Organization.DoesNotExist:
-        metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "org_gone"})
+        metrics.incr(
+            "pr_metrics.judge.reaper.skipped", tags={"reason": "org_gone"}, sample_rate=1.0
+        )
         return
 
     if not features.has("organizations:pr-metrics", organization):
         # Org lost pr-metrics mid-forward: release the claim so the row can't sit
         # at the sentinel forever, but settle nothing for a pipeline that no longer runs.
         if _release_judge_sentinel(pull_request):
-            metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "feature_disabled"})
+            metrics.incr(
+                "pr_metrics.judge.reaper.released",
+                tags={"reason": "feature_disabled"},
+                sample_rate=1.0,
+            )
         return
 
     outcome = select_verdict(pull_request, organization)
@@ -611,9 +631,15 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
             pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
         ).update(verdict=verdict)
         if not settled:
-            metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
+            metrics.incr(
+                "pr_metrics.judge.reaper.skipped",
+                tags={"reason": "already_settled"},
+                sample_rate=1.0,
+            )
             return
 
     emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
-    metrics.incr("pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict})
+    metrics.incr(
+        "pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict}, sample_rate=1.0
+    )
     logger.info("pr_metrics.judge.reaper.fallback_emitted", extra=log_extra)

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -109,14 +109,18 @@ def forward_pr_to_seer_task(
         )
     except PullRequest.DoesNotExist:
         logger.warning("pr_metrics.judge.pull_request_not_found", extra=log_extra)
-        metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "pr_not_found"})
+        metrics.incr(
+            "pr_metrics.judge.forward_failed", tags={"reason": "pr_not_found"}, sample_rate=1.0
+        )
         return
 
     try:
         repository = Repository.objects.get(id=repository_id, organization_id=organization_id)
     except Repository.DoesNotExist:
         logger.warning("pr_metrics.judge.repository_not_found", extra=log_extra)
-        metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "repo_not_found"})
+        metrics.incr(
+            "pr_metrics.judge.forward_failed", tags={"reason": "repo_not_found"}, sample_rate=1.0
+        )
         return
 
     forward_pr_to_seer_judge(pull_request, repository)
@@ -156,7 +160,7 @@ def emit_pr_metrics_cooldown_task(
         )
     except PullRequest.DoesNotExist:
         logger.warning("pr_metrics.cooldown.pull_request_not_found", extra=log_extra)
-        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "pr_gone"})
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "pr_gone"}, sample_rate=1.0)
         return
 
     PullRequestMetrics.objects.filter(
@@ -167,7 +171,7 @@ def emit_pr_metrics_cooldown_task(
         organization = Organization.objects.get(id=organization_id)
     except Organization.DoesNotExist:
         logger.warning("pr_metrics.cooldown.organization_not_found", extra=log_extra)
-        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "org_gone"})
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "org_gone"}, sample_rate=1.0)
         return
 
     # Imported here to avoid a circular import: webhooks imports this module.
@@ -194,9 +198,9 @@ def cleanup_pr_activity_task(*, pull_request_id: int) -> None:
     """
     logger.info("pr_metrics.cleanup_activity", extra={"pull_request_id": pull_request_id})
     deleted, _ = PullRequestActivity.objects.filter(pull_request_id=pull_request_id).delete()
-    metrics.incr("pr_metrics.cleanup_activity.deleted", amount=deleted)
+    metrics.incr("pr_metrics.cleanup_activity.deleted", amount=deleted, sample_rate=1.0)
     doc_deleted, _ = PullRequestActivityLog.objects.filter(pull_request_id=pull_request_id).delete()
-    metrics.incr("pr_metrics.cleanup_activity.doc_deleted", amount=doc_deleted)
+    metrics.incr("pr_metrics.cleanup_activity.doc_deleted", amount=doc_deleted, sample_rate=1.0)
 
 
 def _unswept(
@@ -533,7 +537,7 @@ def detect_stale_pull_requests_task() -> None:
 
     cutoff = dj_timezone.now() - STALENESS_WINDOW
     pr_ids = find_stale_pull_requests(cutoff=cutoff)
-    metrics.incr("pr_metrics.stale.candidates", amount=len(pr_ids))
+    metrics.incr("pr_metrics.stale.candidates", amount=len(pr_ids), sample_rate=1.0)
     logger.info("pr_metrics.stale.candidates", extra={"count": len(pr_ids)})
 
     emitted = 0
@@ -582,7 +586,9 @@ def detect_stale_pull_requests_task() -> None:
             PullRequestMetrics.objects.get_or_create(pull_request=pr)
 
             if not _claim_terminal_event(pr, PullRequestVerdict.ABANDONED):
-                metrics.incr("pr_metrics.stale.skipped", tags={"reason": "already_claimed"})
+                metrics.incr(
+                    "pr_metrics.stale.skipped", tags={"reason": "already_claimed"}, sample_rate=1.0
+                )
                 continue
 
             diagnosis_labels = []
@@ -602,7 +608,7 @@ def detect_stale_pull_requests_task() -> None:
                     emitted += 1
             except Exception:
                 logger.exception("pr_metrics.stale.emit_failed", extra={"pull_request_id": pr.id})
-                metrics.incr("pr_metrics.stale.emit_failed")
+                metrics.incr("pr_metrics.stale.emit_failed", sample_rate=1.0)
 
-    metrics.incr("pr_metrics.stale.emitted", amount=emitted)
+    metrics.incr("pr_metrics.stale.emitted", amount=emitted, sample_rate=1.0)
     logger.info("pr_metrics.stale.emitted", extra={"count": emitted})

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -608,7 +608,6 @@ def detect_stale_pull_requests_task() -> None:
                     emitted += 1
             except Exception:
                 logger.exception("pr_metrics.stale.emit_failed", extra={"pull_request_id": pr.id})
-                metrics.incr("pr_metrics.stale.emit_failed", sample_rate=1.0)
 
     metrics.incr("pr_metrics.stale.emitted", amount=emitted, sample_rate=1.0)
     logger.info("pr_metrics.stale.emitted", extra={"count": emitted})

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -364,7 +364,6 @@ def _forward_to_judge(
         PullRequestMetrics.objects.filter(
             pull_request=pr, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
         ).update(verdict=None)
-        metrics.incr("pr_metrics.judge.enqueue_failed", sample_rate=1.0)
         logger.exception(
             "pr_metrics.judge.enqueue_failed",
             extra={
@@ -472,7 +471,6 @@ def handle_emission(
         PullRequestMetrics.objects.filter(
             pull_request=pr, verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
         ).update(verdict=None)
-        metrics.incr("pr_metrics.cooldown.enqueue_failed", sample_rate=1.0)
         logger.exception("pr_metrics.cooldown.enqueue_failed", extra=log_extra)
         return
 
@@ -582,11 +580,10 @@ def handle_metrics(
         return
 
     if is_stale_github_pull_request_payload(pr, pull_request):
-        # Ambient rate: this fires per reordered delivery across the whole webhook
-        # stream, and the unsampled provider-tagged
-        # `scm.webhook.pull_request.stale_snapshot` already counts the same condition
-        # exactly. Read this one as a rate.
-        metrics.incr("pr_metrics.metrics.stale_snapshot")
+        # Counted by the unsampled, provider-tagged
+        # `scm.webhook.pull_request.stale_snapshot` in lifecycle_mapping, which sees the
+        # same condition across every provider; this path keeps only the log, for the
+        # delivery id.
         logger.info(
             "pr_metrics.metrics.stale_snapshot",
             extra={

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -294,6 +294,7 @@ def _forward_to_judge(
             metrics.incr(
                 "pr_metrics.emit.skipped",
                 tags={"reason": "no_eligible_attribution_indeterminate"},
+                sample_rate=1.0,
             )
             logger.warning(
                 "pr_metrics.emit.needs_judge",
@@ -307,7 +308,7 @@ def _forward_to_judge(
             return
 
         verdict = select_fallback_verdict(pr)
-        metrics.incr("pr_metrics.emit.fallback_verdict", tags={"verdict": verdict})
+        metrics.incr("pr_metrics.emit.fallback_verdict", tags={"verdict": verdict}, sample_rate=1.0)
         logger.info(
             "pr_metrics.emit.fallback_verdict",
             extra={
@@ -321,7 +322,7 @@ def _forward_to_judge(
         return
 
     if not has_seer_access(organization):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_seer_access"})
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_seer_access"}, sample_rate=1.0)
         logger.info(
             "pr_metrics.emit.needs_judge",
             extra={
@@ -334,7 +335,7 @@ def _forward_to_judge(
         return
 
     if not features.has("organizations:pr-metrics", organization):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "needs_judge"})
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "needs_judge"}, sample_rate=1.0)
         logger.info(
             "pr_metrics.emit.needs_judge",
             extra={
@@ -347,7 +348,7 @@ def _forward_to_judge(
         return
 
     if not _claim_for_judge(pr):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"})
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"}, sample_rate=1.0)
         return
 
     try:
@@ -363,7 +364,7 @@ def _forward_to_judge(
         PullRequestMetrics.objects.filter(
             pull_request=pr, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
         ).update(verdict=None)
-        metrics.incr("pr_metrics.judge.enqueue_failed")
+        metrics.incr("pr_metrics.judge.enqueue_failed", sample_rate=1.0)
         logger.exception(
             "pr_metrics.judge.enqueue_failed",
             extra={
@@ -373,7 +374,7 @@ def _forward_to_judge(
             },
         )
         return
-    metrics.incr("pr_metrics.judge.enqueued")
+    metrics.incr("pr_metrics.judge.enqueued", sample_rate=1.0)
 
 
 def _claim_cooldown(pr: PullRequest) -> bool:
@@ -435,11 +436,19 @@ def handle_emission(
         return
 
     if not is_pr_tracked(pr):
+        # Deliberately left at the ambient sample rate while every other `reason` on
+        # this metric is unsampled: `untracked` is the webhook firehose — most PRs
+        # Sentry sees are never attributed — so sampling already resolves its rate,
+        # and the rare reasons are what needed an exact count. Both `untracked` call
+        # sites must keep the same rate: a tag value split across two rates still
+        # totals correctly, but stops being exact, which is the point of the others.
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return
 
     if not _claim_cooldown(pr):
-        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "already_claimed"})
+        metrics.incr(
+            "pr_metrics.cooldown.skipped", tags={"reason": "already_claimed"}, sample_rate=1.0
+        )
         return
 
     log_extra = {
@@ -463,11 +472,11 @@ def handle_emission(
         PullRequestMetrics.objects.filter(
             pull_request=pr, verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
         ).update(verdict=None)
-        metrics.incr("pr_metrics.cooldown.enqueue_failed")
+        metrics.incr("pr_metrics.cooldown.enqueue_failed", sample_rate=1.0)
         logger.exception("pr_metrics.cooldown.enqueue_failed", extra=log_extra)
         return
 
-    metrics.incr("pr_metrics.cooldown.scheduled")
+    metrics.incr("pr_metrics.cooldown.scheduled", sample_rate=1.0)
 
 
 def run_deferred_emission(pull_request: PullRequest, organization: Organization) -> None:
@@ -497,7 +506,7 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
     if pull_request.closed_at is None or pull_request.head_commit_sha is None:
         # Reopened (or no longer terminal) while waiting. Release the sentinel so a
         # later re-close can re-claim and reschedule.
-        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "reopened"})
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "reopened"}, sample_rate=1.0)
         logger.info("pr_metrics.cooldown.reopened", extra=log_extra)
         return
 
@@ -520,7 +529,7 @@ def _claim_and_emit(
     claim. ``emitted_metric`` lets each caller keep its own success counter.
     """
     if not _claim_terminal_event(pull_request, verdict):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"})
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"}, sample_rate=1.0)
         return
 
     diagnosis_labels = calculate_deterministic_diagnosis_labels(pull_request, verdict)
@@ -530,7 +539,7 @@ def _claim_and_emit(
     # claim still stands and the row is forgone — an acceptable loss for telemetry,
     # not worth a rollback that would reopen the redelivery race.
     emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
-    metrics.incr(emitted_metric)
+    metrics.incr(emitted_metric, sample_rate=1.0)
 
 
 def handle_metrics(
@@ -573,6 +582,10 @@ def handle_metrics(
         return
 
     if is_stale_github_pull_request_payload(pr, pull_request):
+        # Ambient rate: this fires per reordered delivery across the whole webhook
+        # stream, and the unsampled provider-tagged
+        # `scm.webhook.pull_request.stale_snapshot` already counts the same condition
+        # exactly. Read this one as a rate.
         metrics.incr("pr_metrics.metrics.stale_snapshot")
         logger.info(
             "pr_metrics.metrics.stale_snapshot",
@@ -1018,7 +1031,7 @@ def _prs_from_check_payload(
         if number is None or str(number) in seen:
             continue
         if not is_own_repo_pull_request(pull_request_base_repo_id(ref), repo.external_id):
-            metrics.incr("pr_metrics.check.foreign_pull_request")
+            metrics.incr("pr_metrics.check.foreign_pull_request", sample_rate=1.0)
             continue
         seen.add(str(number))
         # Check payloads carry no PR timestamp, only a number. A missing row is the
@@ -1108,7 +1121,7 @@ def _resolve_or_stub_pull_request(
         reason = None
 
     if reason is not None:
-        metrics.incr("pr_metrics.pull_request.unresolved", tags={"reason": reason})
+        metrics.incr("pr_metrics.pull_request.unresolved", tags={"reason": reason}, sample_rate=1.0)
         logger.info("pr_metrics.pull_request.unresolved", extra={**log_extra, "reason": reason})
         return None
 
@@ -1119,7 +1132,7 @@ def _resolve_or_stub_pull_request(
         defaults={"opened_at": opened_at, "title": title},
     )
     if created:
-        metrics.incr("pr_metrics.pull_request.stub_created")
+        metrics.incr("pr_metrics.pull_request.stub_created", sample_rate=1.0)
         logger.info("pr_metrics.pull_request.stub_created", extra=log_extra)
     return pull_request
 
@@ -1236,6 +1249,7 @@ def _record_delegated_candidate(provider: str, outcome: str) -> None:
     metrics.incr(
         "pr_metrics.delegated_agent.candidate",
         tags={"provider": provider, "outcome": outcome},
+        sample_rate=1.0,
     )
 
 
@@ -1425,6 +1439,7 @@ def _link_matched_delegated_agent_pr(
                 "outcome": outcome,
                 "match_path": match.match_path,
             },
+            sample_rate=1.0,
         )
 
     try:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -435,12 +435,10 @@ def handle_emission(
         return
 
     if not is_pr_tracked(pr):
-        # Deliberately left at the ambient sample rate while every other `reason` on
-        # this metric is unsampled: `untracked` is the webhook firehose — most PRs
-        # Sentry sees are never attributed — so sampling already resolves its rate,
-        # and the rare reasons are what needed an exact count. Both `untracked` call
-        # sites must keep the same rate: a tag value split across two rates still
-        # totals correctly, but stops being exact, which is the point of the others.
+        # Ambient rate while this metric's rarer reasons are unsampled: `untracked` is
+        # the webhook firehose, so sampling already resolves it. Keep both `untracked`
+        # sites on the same rate — one tag value split across two rates still totals
+        # correctly, but stops being exact.
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return
 
@@ -580,9 +578,8 @@ def handle_metrics(
         return
 
     if is_stale_github_pull_request_payload(pr, pull_request):
-        # Counted by the unsampled, provider-tagged
-        # `scm.webhook.pull_request.stale_snapshot` in lifecycle_mapping, which sees the
-        # same condition across every provider; this path keeps only the log, for the
+        # Counted by lifecycle_mapping's unsampled, provider-tagged
+        # `scm.webhook.pull_request.stale_snapshot`; this path keeps the log for its
         # delivery id.
         logger.info(
             "pr_metrics.metrics.stale_snapshot",

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -317,7 +317,7 @@ def test_events_cap_drops_and_counts_dropped() -> None:
     assert doc["events_dropped"] == 3
     # Counts increment before the cap, so the total is exact even past the cap.
     assert doc["counts"] == {PullRequestActivityType.SYNCHRONIZED: MAX_EVENTS + 3}
-    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.events_capped")
+    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.events_capped", sample_rate=1.0)
     assert mock_logger.warning.call_count == 3
 
 
@@ -440,7 +440,7 @@ def test_sync_chain_evicts_oldest_past_cap() -> None:
     assert ["sha0000", None] not in chain  # oldest synchronize link evicted
     # newest link retained
     assert chain[-1] == ["sha-new", "sha-prev", None, None, "d-new"]
-    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.sync_chain_capped")
+    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.sync_chain_capped", sample_rate=1.0)
     assert mock_logger.warning.call_count == 1
 
 
@@ -943,7 +943,7 @@ def test_check_runs_per_group_cap_drops_new_failing_runs() -> None:
         for i in range(MAX_RUNS_PER_GROUP + 2):
             _run(doc, check_name=f"check-{i}", conclusion="failure")
     assert len(_group(doc)["runs"]) == MAX_RUNS_PER_GROUP
-    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.check_runs_capped")
+    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.check_runs_capped", sample_rate=1.0)
     assert mock_logger.warning.call_count == 2
 
 
@@ -1317,7 +1317,9 @@ def test_timeline_forward_trims_per_head_keeping_failures() -> None:
         "pr_metrics.activity_doc.forward_head_groups_capped",
         extra={"head_sha": "sha1", "dropped": 2},
     )
-    mock_metrics.incr.assert_any_call("pr_metrics.activity_doc.forward_head_groups_capped")
+    mock_metrics.incr.assert_any_call(
+        "pr_metrics.activity_doc.forward_head_groups_capped", sample_rate=1.0
+    )
 
 
 def test_timeline_forward_keeps_every_head_represented() -> None:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -312,7 +312,7 @@ class PrMetricsEmissionTest(TestCase):
                 select_verdict(self.pull_request, self.organization)
                 == VerdictDeferral.INDETERMINATE
             )
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.error.assert_called_once_with(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
                 "organization_id": self.organization.id,
@@ -322,8 +322,8 @@ class PrMetricsEmissionTest(TestCase):
         )
 
     def test_select_verdict_closed_without_metrics_row_is_indeterminate(self) -> None:
-        # A missing row is an error state (handle_metrics failed): warn, and defer
-        # as indeterminate rather than guess "abandoned".
+        # A missing row is an error state (handle_metrics failed): raise it as a
+        # Sentry issue, and defer as indeterminate rather than guess "abandoned".
         self.pull_request.merged_at = None
         PullRequestMetrics.objects.filter(pull_request=self.pull_request).delete()
         with patch("sentry.pr_metrics.emit.logger") as mock_logger:
@@ -331,7 +331,7 @@ class PrMetricsEmissionTest(TestCase):
                 select_verdict(self.pull_request, self.organization)
                 == VerdictDeferral.INDETERMINATE
             )
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.error.assert_called_once_with(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
                 "organization_id": self.organization.id,

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -359,7 +359,9 @@ class PrMetricsEmissionTest(TestCase):
                     select_verdict(self.pull_request, self.organization)
                     == VerdictDeferral.INDETERMINATE
                 )
-        mock_metrics.incr.assert_called_once_with("pr_metrics.select_verdict.activity_disabled")
+        mock_metrics.incr.assert_called_once_with(
+            "pr_metrics.select_verdict.activity_disabled", sample_rate=1.0
+        )
 
     def test_ci_failing_at_close_no_check_activity_is_false(self) -> None:
         assert _ci_failing_at_close(self.pull_request, doc=None) is False

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -171,7 +171,9 @@ class UpdatePrMetricsTest(TestCase):
         assert row.conversation_sentiment is None
         assert row.conversation_comments_total is None
         assert row.conversation_metadata is None
-        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_conversation_analysis")
+        mock_metrics.incr.assert_any_call(
+            "pr_metrics.update.invalid_conversation_analysis", sample_rate=1.0
+        )
 
     @patch("sentry.pr_metrics.judge.metrics")
     @patch("sentry.analytics.record")
@@ -192,7 +194,9 @@ class UpdatePrMetricsTest(TestCase):
         row = _last_row(mock_record)
         assert row.conversation_sentiment is None
         assert row.conversation_metadata is None
-        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_conversation_analysis")
+        mock_metrics.incr.assert_any_call(
+            "pr_metrics.update.invalid_conversation_analysis", sample_rate=1.0
+        )
 
     @patch("sentry.pr_metrics.judge.metrics")
     @patch("sentry.analytics.record")
@@ -207,7 +211,9 @@ class UpdatePrMetricsTest(TestCase):
         assert result.dict() == {"success": True}
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
         assert _last_row(mock_record).diagnosis_labels is None
-        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_diagnosis_labels")
+        mock_metrics.incr.assert_any_call(
+            "pr_metrics.update.invalid_diagnosis_labels", sample_rate=1.0
+        )
 
     @patch("sentry.pr_metrics.judge.metrics")
     @patch("sentry.analytics.record")
@@ -218,7 +224,9 @@ class UpdatePrMetricsTest(TestCase):
 
         assert result.dict() == {"success": True}
         assert _last_row(mock_record).diagnosis_labels is None
-        mock_metrics.incr.assert_any_call("pr_metrics.update.invalid_diagnosis_labels")
+        mock_metrics.incr.assert_any_call(
+            "pr_metrics.update.invalid_diagnosis_labels", sample_rate=1.0
+        )
 
     @patch("sentry.analytics.record")
     def test_judge_enrichment_absent_is_back_compat(self, mock_record: Any) -> None:
@@ -728,7 +736,7 @@ class ForwardPrToSeerJudgeTest(TestCase):
         assert timestamps == sorted(timestamps)
         # Hitting the cap is observable: it emits a metric and a warning so a
         # persistently high rate can argue for raising the cap.
-        mock_metrics.incr.assert_any_call("pr_metrics.judge.check_rows_capped")
+        mock_metrics.incr.assert_any_call("pr_metrics.judge.check_rows_capped", sample_rate=1.0)
         mock_logger.warning.assert_any_call(
             "pr_metrics.judge.check_rows_capped",
             extra={
@@ -764,5 +772,5 @@ class ForwardPrToSeerJudgeTest(TestCase):
         mock_request.return_value = self._response(404)
         forward_pr_to_seer_judge(self.pull_request, self.repo)
         mock_metrics.incr.assert_any_call(
-            "pr_metrics.judge.forward_failed", tags={"reason": "client_error"}
+            "pr_metrics.judge.forward_failed", tags={"reason": "client_error"}, sample_rate=1.0
         )

--- a/tests/sentry/pr_metrics/test_metrics_sample_rates.py
+++ b/tests/sentry/pr_metrics/test_metrics_sample_rates.py
@@ -31,7 +31,6 @@ DELIBERATELY_SAMPLED = {
     ("emit.py", "pr_metrics.emit.skipped", "untracked"),
     ("webhooks.py", "pr_metrics.emit.skipped", "untracked"),
     ("webhooks.py", "pr_metrics.check.activity_recorded", None),
-    ("webhooks.py", "pr_metrics.metrics.stale_snapshot", None),
 }
 
 _EMITTERS = ("incr", "gauge", "timing", "distribution", "set")

--- a/tests/sentry/pr_metrics/test_metrics_sample_rates.py
+++ b/tests/sentry/pr_metrics/test_metrics_sample_rates.py
@@ -1,22 +1,17 @@
 """Guards which pr_metrics counters are emitted at the ambient sample rate.
 
-Most of the module's counters sit on paths that fire a handful of times a day. At
-the ambient rate (``SENTRY_METRICS_SAMPLE_RATE``, 10% in production) such a
-counter resolves to roughly one surviving packet per reporting bucket, so its
-chart quantizes to the extrapolation factor and "never fired" is
-indistinguishable from "fired a few times". Those call sites pass
-``sample_rate=1.0``.
+Most of the module's counters fire a handful of times a day. Sampled, such a
+counter resolves to about one surviving packet per reporting bucket, so its chart
+quantizes and "never fired" is indistinguishable from "fired a few times". Those
+call sites pass ``sample_rate=1.0``.
 
-A handful carry enough volume that sampling already yields a precise rate, and
-unsampling them would only multiply packets. They stay ambient, and are listed
-here so that staying ambient is a decision rather than an oversight — a new
-counter is unsampled unless it is deliberately added below.
+A few carry enough volume that sampling already resolves their rate. They are
+listed below so that staying ambient is a decision rather than an oversight — a
+new counter is unsampled unless deliberately added here.
 
-The ``emit.skipped`` entries are the subtle case: ``sample_rate`` is per packet,
-so one metric name can carry both rates and still total correctly. What must not
-drift is a single *tag value* being split across rates — it would stay correct in
-aggregate but stop being exact. Both ``untracked`` sites are therefore pinned
-here together.
+``sample_rate`` is per packet, so one metric name can carry both rates and still
+total correctly. What must not drift is a single *tag value* split across rates:
+still correct in aggregate, but no longer exact. Hence both ``untracked`` entries.
 """
 
 import ast

--- a/tests/sentry/pr_metrics/test_metrics_sample_rates.py
+++ b/tests/sentry/pr_metrics/test_metrics_sample_rates.py
@@ -1,0 +1,94 @@
+"""Guards which pr_metrics counters are emitted at the ambient sample rate.
+
+Most of the module's counters sit on paths that fire a handful of times a day. At
+the ambient rate (``SENTRY_METRICS_SAMPLE_RATE``, 10% in production) such a
+counter resolves to roughly one surviving packet per reporting bucket, so its
+chart quantizes to the extrapolation factor and "never fired" is
+indistinguishable from "fired a few times". Those call sites pass
+``sample_rate=1.0``.
+
+A handful carry enough volume that sampling already yields a precise rate, and
+unsampling them would only multiply packets. They stay ambient, and are listed
+here so that staying ambient is a decision rather than an oversight — a new
+counter is unsampled unless it is deliberately added below.
+
+The ``emit.skipped`` entries are the subtle case: ``sample_rate`` is per packet,
+so one metric name can carry both rates and still total correctly. What must not
+drift is a single *tag value* being split across rates — it would stay correct in
+aggregate but stop being exact. Both ``untracked`` sites are therefore pinned
+here together.
+"""
+
+import ast
+import pathlib
+
+PR_METRICS = pathlib.Path(__file__).parents[3] / "src" / "sentry" / "pr_metrics"
+
+# (module, metric name, `reason` tag if the call hardcodes one)
+DELIBERATELY_SAMPLED = {
+    ("activity_doc.py", "pr_metrics.activity_doc.check_head_groups_capped", None),
+    ("activity_doc.py", "pr_metrics.activity_doc.check_groups_capped", None),
+    ("emit.py", "pr_metrics.emit.skipped", "untracked"),
+    ("webhooks.py", "pr_metrics.emit.skipped", "untracked"),
+    ("webhooks.py", "pr_metrics.check.activity_recorded", None),
+    ("webhooks.py", "pr_metrics.metrics.stale_snapshot", None),
+}
+
+_EMITTERS = ("incr", "gauge", "timing", "distribution", "set")
+
+
+def _reason_tag(call: ast.Call) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg != "tags" or not isinstance(keyword.value, ast.Dict):
+            continue
+        for key, value in zip(keyword.value.keys, keyword.value.values):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "reason"
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                return value.value
+    return None
+
+
+def _metric_calls() -> list[tuple[str, ast.Call]]:
+    calls = []
+    for path in sorted(PR_METRICS.glob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "metrics":
+                continue
+            if node.func.attr in _EMITTERS:
+                calls.append((path.name, node))
+    return calls
+
+
+def _sample_rate(call: ast.Call) -> str | None:
+    return next(
+        (ast.unparse(kw.value) for kw in call.keywords if kw.arg == "sample_rate"),
+        None,
+    )
+
+
+def test_only_listed_call_sites_are_sampled() -> None:
+    sampled = set()
+    for module, call in _metric_calls():
+        if _sample_rate(call) is not None:
+            continue
+        name = call.args[0].value if isinstance(call.args[0], ast.Constant) else None
+        sampled.add((module, name, _reason_tag(call)))
+
+    assert sampled == DELIBERATELY_SAMPLED
+
+
+def test_no_partial_sample_rates() -> None:
+    # A rate between the ambient one and 1.0 buys neither an exact count nor a
+    # cheaper packet stream, and makes two counters on one path incomparable.
+    rates = {
+        (module, ast.unparse(call.args[0]), rate)
+        for module, call in _metric_calls()
+        if (rate := _sample_rate(call)) is not None
+    }
+    assert {rate for _, _, rate in rates} == {"1.0"}

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -459,4 +459,4 @@ class ActivityDocumentReadersTest(TestCase):
             payload={"sender_login": "commenter", "sender_type": "User"},
         )
         _activity_derived_metrics(self.pr)
-        mock_metrics.incr.assert_any_call("pr_metrics.reducer_parity.match")
+        mock_metrics.incr.assert_any_call("pr_metrics.reducer_parity.match", sample_rate=1.0)


### PR DESCRIPTION
**Unsampling.** Most counters here fire a handful of times a day, which sampled is roughly one surviving packet per reporting bucket — the chart quantizes and "never fired" is indistinguishable from "fired a few times". 59 sites now pass `sample_rate=1.0`, following the `activity_sweep` family in #121616. The `amount=`-carrying ones were wrong rather than coarse, since a surviving emission is multiplied by the inverse rate: `detect_stale_pull_requests` emits once per daily run, so most runs reported nothing and survivors overstated by 10x — the value recurring in Datadog is `_STALE_SCAN_LIMIT` scaled, not a candidate count.

Four sites stay ambient where sampling already resolves the rate: `check.activity_recorded`, both `emit.skipped{untracked}` sites, and the two `activity_doc.*_groups_capped` caps. `sample_rate` is per packet, so `emit.skipped` keeps `untracked` sampled while its rare reasons go exact. What must not drift is one *tag value* split across rates — correct in aggregate, no longer exact — so `test_metrics_sample_rates.py` pins the sampled set.

**Defect signals.** Six counters duplicated something better. Three sat beside a `logger.exception` that already carries the traceback. Two guarded invariants at `warning`, which never becomes an issue (the SDK sets `event_level=None`; only the root `internal` handler, at ERROR, raises one), so a missing `PullRequestMetrics` row and a reducer-parity mismatch are `logger.error` now. One duplicated `scm.webhook.pull_request.stale_snapshot`, which is unsampled and provider-tagged. `reducer_parity.match` stays — it measures legacy-path drain, which is a rate — and `update.skipped`/`update.invalid_*` stay counters because they sit on the Seer RPC boundary where issues would be spammable. Two reaper branches that counted without logging now log.

[Dashboard](https://app.datadoghq.com/dashboard/p5z-993-rwj/pr-metrics-pipeline) updated to match; expect a step change at the deploy boundary rather than a traffic change. Surfaced but out of scope: `activity_sweep.capped{store:pullrequestactivity}` fires on every hourly run, with that store ~52 days behind and growing.
