### PR TITLE
fix(scraps): Stop calling the tracking hook from inside Button

### DIFF
--- a/static/app/components/core/button/button.spec.tsx
+++ b/static/app/components/core/button/button.spec.tsx
@@ -12,9 +12,7 @@ const theme = ThemeFixture();
 function renderWithTracking(ui: React.ReactElement) {
   const tracking = jest.fn();
   function TrackingWrapper({children}: {children: React.ReactNode}) {
-    return (
-      <TrackingContextProvider value={() => tracking}>{children}</TrackingContextProvider>
-    );
+    return <TrackingContextProvider value={tracking}>{children}</TrackingContextProvider>;
   }
 
   return {tracking, ...render(ui, {additionalWrapper: TrackingWrapper})};

--- a/static/app/components/core/link/link.spec.tsx
+++ b/static/app/components/core/link/link.spec.tsx
@@ -6,9 +6,7 @@ import {TrackingContextProvider} from '@sentry/scraps/trackingContext';
 function renderWithTracking(ui: React.ReactElement) {
   const tracking = jest.fn();
   function TrackingWrapper({children}: {children: React.ReactNode}) {
-    return (
-      <TrackingContextProvider value={() => tracking}>{children}</TrackingContextProvider>
-    );
+    return <TrackingContextProvider value={tracking}>{children}</TrackingContextProvider>;
   }
 
   return {tracking, ...render(ui, {additionalWrapper: TrackingWrapper})};

--- a/static/app/components/core/trackingContext.tsx
+++ b/static/app/components/core/trackingContext.tsx
@@ -29,9 +29,7 @@ export type TrackingProps = AnalyticsProps &
     clickType: ClickTrackingType;
   };
 
-const TrackingContext = createContext<() => (props: TrackingProps) => void>(
-  () => () => {}
-);
+const TrackingContext = createContext<(props: TrackingProps) => void>(() => {});
 
 export const TrackingContextProvider = TrackingContext.Provider;
 
@@ -39,7 +37,7 @@ export const useClickTracking = (
   props: ButtonProps | LinkButtonProps | LinkProps,
   clickType: ClickTrackingType
 ) => {
-  const clickTracking = useContext(TrackingContext)();
+  const clickTracking = useContext(TrackingContext);
   const accessibleLabel =
     props['aria-label'] ??
     (typeof props.children === 'string' ? props.children : undefined);

--- a/static/app/scrapsProviders/index.tsx
+++ b/static/app/scrapsProviders/index.tsx
@@ -5,7 +5,6 @@ import {t, tct} from 'sentry/locale';
 import {SentryDateTimeProvider} from './datetime';
 import {SentryFormErrorProvider} from './formError';
 import {SentryLinkBehaviorProvider} from './link';
-import {SentryTrackingProvider} from './tracking';
 
 const sentryTranslation = {t, tct};
 
@@ -14,9 +13,7 @@ export function ScrapsProviders({children}: {children: React.ReactNode}) {
     <SentryFormErrorProvider>
       <TranslationContextProvider value={sentryTranslation}>
         <SentryDateTimeProvider>
-          <SentryTrackingProvider>
-            <SentryLinkBehaviorProvider>{children}</SentryLinkBehaviorProvider>
-          </SentryTrackingProvider>
+          <SentryLinkBehaviorProvider>{children}</SentryLinkBehaviorProvider>
         </SentryDateTimeProvider>
       </TranslationContextProvider>
     </SentryFormErrorProvider>

--- a/static/app/scrapsProviders/tracking.tsx
+++ b/static/app/scrapsProviders/tracking.tsx
@@ -25,10 +25,13 @@ function useDefaultButtonTracking() {
 }
 
 export function SentryTrackingProvider({children}: {children: React.ReactNode}) {
+  // Called here, not in `useClickTracking`, so a Button's hook count doesn't
+  // depend on which implementation is registered.
+  const useButtonTracking =
+    getOverride('react-hook:use-button-tracking') ?? useDefaultButtonTracking;
+
   return (
-    <TrackingContextProvider
-      value={getOverride('react-hook:use-button-tracking') ?? useDefaultButtonTracking}
-    >
+    <TrackingContextProvider value={useButtonTracking()}>
       {children}
     </TrackingContextProvider>
   );

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -183,11 +183,12 @@ function useStoriesFavicon() {
   }, []);
 }
 
-const storiesTracking: React.ComponentProps<typeof TrackingContextProvider>['value'] =
-  () => props => {
-    // eslint-disable-next-line no-console
-    console.log('analyticsEvent', props);
-  };
+const storiesTracking: React.ComponentProps<
+  typeof TrackingContextProvider
+>['value'] = props => {
+  // eslint-disable-next-line no-console
+  console.log('analyticsEvent', props);
+};
 
 function StoriesLayout(props: PropsWithChildren) {
   useStoriesFavicon();

--- a/static/app/views/app/appProviders.tsx
+++ b/static/app/views/app/appProviders.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {SentryTrackingProvider} from 'sentry/scrapsProviders/tracking';
 import {DemoToursProvider} from 'sentry/utils/demoMode/demoTours';
 import {GlobalFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {AsyncSDKIntegrationContextProvider} from 'sentry/views/app/asyncSDKIntegrationProvider';
@@ -32,6 +33,9 @@ export function AppProviders({preloadData, children}: AppProvidersProps) {
       LastKnownRouteContextProvider,
       RouteAnalyticsContextProvider,
       OrganizationProvider,
+      // Reads the organization to build the button/link click tracker, so must
+      // render inside OrganizationProvider.
+      SentryTrackingProvider,
       AsyncSDKIntegrationContextProvider,
       GlobalFeedbackForm,
       DemoToursProvider,


### PR DESCRIPTION
Fixes `Rendered fewer hooks than expected. This may be caused by an accidental early return statement.`
in `pnpm dev-ui`.

`TrackingContext` held a **hook**, and `useClickTracking` invoked it inline during render:

```ts
const clickTracking = useContext(TrackingContext)();
```

The two implementations that can land in that context call different numbers of hooks:

| implementation | hooks |
| --- | --- |
| `useDefaultButtonTracking` (`scrapsProviders/tracking.tsx`) | 0 |
| `useButtonTracking` (`gsApp/overrides/useButtonTracking.tsx`) | 2 — `useOrganization`, `useMatches` |

So the hook count of `Button` and `Link` in the app depends on which implementation
`getOverride('react-hook:use-button-tracking')` returns.
If that value ever changes, React sees a different number of hooks than the previous render and throws.