### PR TITLE
ref(objectstore): Default debug file Zstd compression

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -858,14 +858,6 @@ def _clone_proguard_debug_file_for_reupload(
                     source_fileobj,
                     content_type=content_type,
                     filename=get_dif_download_filename(meta),
-                    compress=(
-                        "zstd"
-                        if features.has(
-                            "organizations:objectstore-debugfiles-compression",
-                            project.organization,
-                        )
-                        else "none"
-                    ),
                 )
 
             objectstore_metadata = {

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -13,7 +13,6 @@ from django.db import router, transaction
 from django.db.models import ProtectedError
 from objectstore_client import GetResponse, Session
 
-from sentry import features
 from sentry.constants import KNOWN_DIF_FORMATS
 from sentry.models.debugfile import (
     ProjectDebugFile,
@@ -244,13 +243,6 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
         storage_path = session.put(
             tmp,
             key=f"legacy.{debug_file.id}",
-            compress=(
-                "zstd"
-                if features.has(
-                    "organizations:objectstore-debugfiles-compression", project.organization
-                )
-                else "none"
-            ),
             content_type=content_type,
             filename=filename,
         )

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from django.db.utils import IntegrityError
 from django.utils import timezone
 
-from sentry import features, options
+from sentry import options
 from sentry.demo_mode.utils import get_demo_org, is_demo_mode_enabled
 from sentry.models.artifactbundle import (
     ArtifactBundle,
@@ -248,13 +248,6 @@ def _sync_project_debug_file(
                 try:
                     target_storage_path = get_session(UsecaseId.DEBUG_FILES, target_project).put(
                         source_fileobj,
-                        compress=(
-                            "zstd"
-                            if features.has(
-                                "organizations:objectstore-debugfiles-compression", target_org
-                            )
-                            else "none"
-                        ),
                         content_type=source_project_debug_file.get_content_type(),
                     )
                 finally:

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -529,13 +529,6 @@ def create_dif_from_file(
             with file.getfile() as source:
                 storage_path = session.put(
                     source,
-                    compress=(
-                        "zstd"
-                        if features.has(
-                            "organizations:objectstore-debugfiles-compression", project.organization
-                        )
-                        else "none"
-                    ),
                     content_type=content_type,
                     filename=get_dif_download_filename(meta),
                 )
@@ -608,13 +601,6 @@ def create_dif_from_fileobj(
             fileobj,
             content_type=content_type,
             filename=get_dif_download_filename(meta),
-            compress=(
-                "zstd"
-                if features.has(
-                    "organizations:objectstore-debugfiles-compression", project.organization
-                )
-                else "none"
-            ),
         )
 
     try:

--- a/src/sentry/objectstore/__init__.py
+++ b/src/sentry/objectstore/__init__.py
@@ -100,7 +100,7 @@ class UsecaseId(Enum):
             case UsecaseId.DEBUG_FILES:
                 return ObjectstoreClientUsecase(
                     self.value,
-                    compression="none",
+                    compression="zstd",
                     expiration_policy=TimeToIdle(timedelta(days=90)),
                 )
             case UsecaseId.PROFILE_ATTACHMENTS:

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -521,6 +521,5 @@ class DifAssembleProguardCloneBackendTransitionTest(APITestCase):
             source_fileobj,
             content_type=source_dif.get_content_type(),
             filename="11111111-1111-1111-1111-111111111111.txt",
-            compress="none",
         )
         objectstore_session.delete.assert_called_once_with("cloned-storage-path")

--- a/tests/sentry/demo_mode/test_tasks.py
+++ b/tests/sentry/demo_mode/test_tasks.py
@@ -269,12 +269,11 @@ class SyncArtifactBundlesTest(TestCase):
             data={"features": ["debug"]},
         )
 
-        with self.feature("organizations:objectstore-debugfiles-compression"):
-            _sync_project_debug_files(
-                source_org=self.source_org,
-                target_org=self.target_org,
-                cutoff_date=self.last_three_days(),
-            )
+        _sync_project_debug_files(
+            source_org=self.source_org,
+            target_org=self.target_org,
+            cutoff_date=self.last_three_days(),
+        )
 
         target_project_debug_file = ProjectDebugFile.objects.get(
             project_id=self.target_proj_foo.id,

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -272,7 +272,6 @@ class SymbolicatorLargeCompressedDifIntegrationTest(RelayStoreHelper, Transactio
             {
                 **self._FEATURES,
                 "organizations:objectstore-debugfiles-write": True,
-                "organizations:objectstore-debugfiles-compression": True,
                 "organizations:objectstore-debugfiles-read": True,
                 "organizations:objectstore-debugfiles-direct-read": True,
             }


### PR DESCRIPTION
Make Zstd the default compression for Debug Files.

Remove per-write checks of the completed compression flag. Keep the flag registration for its separate cleanup.