### PR TITLE
chore(ai-conversations): Sample endpoint traces at 100%

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import functools
 import logging
+import re
 import sys
 import typing
 from collections.abc import Generator, Mapping, Sequence, Sized
@@ -103,6 +104,10 @@ SAMPLED_ROUTES = {
     "/api/0/auth/validate/": 0.0,
 }
 
+AI_CONVERSATION_ROUTE = re.compile(
+    r"/api/0/organizations/[^/]+/(?:ai-conversations|agents/conversations)(?:/[^/]+)?/"
+)
+
 if settings.ADDITIONAL_SAMPLED_TASKS:
     SAMPLED_TASKS.update(settings.ADDITIONAL_SAMPLED_TASKS)
 
@@ -195,8 +200,11 @@ def get_project_key():
 
 def traces_sampler(sampling_context):
     wsgi_path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
-    if wsgi_path and wsgi_path in SAMPLED_ROUTES:
-        return SAMPLED_ROUTES[wsgi_path]
+    if wsgi_path:
+        if wsgi_path in SAMPLED_ROUTES:
+            return SAMPLED_ROUTES[wsgi_path]
+        if AI_CONVERSATION_ROUTE.fullmatch(wsgi_path):
+            return 1.0
 
     # Apply sample_rate from custom_sampling_context
     custom_sample_rate = sampling_context.get("sample_rate")

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from unittest.mock import MagicMock, patch
 
+import pytest
 import sentry_sdk.scope
 from django.conf import settings
 from django.db import OperationalError
@@ -35,6 +36,27 @@ def patch_isolation_scope():
         mock_get_isolation_scope.return_value = scope
 
         yield scope
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/0/organizations/org-slug/ai-conversations/",
+        "/api/0/organizations/org-slug/ai-conversations/conversation-id/",
+        "/api/0/organizations/another-org/agents/conversations/",
+        "/api/0/organizations/another-org/agents/conversations/conversation-id/",
+    ],
+)
+def test_ai_conversation_routes_are_fully_sampled(path: str) -> None:
+    assert (
+        sdk.traces_sampler(
+            {
+                "wsgi_environ": {"PATH_INFO": path},
+                "parent_sampled": False,
+            }
+        )
+        == 1.0
+    )
 
 
 class SDKUtilsTest(TestCase):


### PR DESCRIPTION
AI Conversation list and detail requests now sample backend traces at 100% for every organization across both legacy `/ai-conversations/` and current `/agents/conversations/` routes. This restores full endpoint visibility while both route forms remain active.

This is only a temporary boost to make sure we have very good visibility into what's happening on this endpoint