### PR TITLE
feat(admin): require retention periods to be 30 day intervals

### DIFF
--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
@@ -81,12 +81,12 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    expectSelectValue('Spans Standard', '90 days');
-    expectSelectValue('Spans Downsampled', '30 days');
+    expectSelectValue('Spans Standard', '90 days (current)');
+    expectSelectValue('Spans Downsampled', '30 days (current)');
     // values that are not multiples of 30 are preserved as-is
-    expectSelectValue('Logs Standard', '45 (current)');
-    expectSelectValue('Logs Downsampled', '15 (current)');
-    expectSelectValue('Org Retention', '1234567 (current)');
+    expectSelectValue('Logs Standard', '45 days (current)');
+    expectSelectValue('Logs Downsampled', '15 days (current)');
+    expectSelectValue('Org Retention', '1234567 days (current)');
 
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Update Settings'})).toBeInTheDocument();
@@ -124,7 +124,7 @@ describe('UpdateRetentionSettingsModal', () => {
     expect(options).toEqual([
       '30 days',
       '60 days',
-      '90 days',
+      '90 days (current)',
       '120 days',
       '150 days',
       '180 days',
@@ -167,8 +167,23 @@ describe('UpdateRetentionSettingsModal', () => {
       .getAllByRole('menuitemradio')
       .map(option => option.textContent);
 
-    expect(options[0]).toBe('30 days');
-    expect(options).not.toContain('0 (same as standard)');
+    // Downsampled fields get exactly the same choices as standard ones; there
+    // is no longer a zero option, and 30 is the smallest selectable retention.
+    expect(options).toEqual([
+      '30 days (current)',
+      '60 days',
+      '90 days',
+      '120 days',
+      '150 days',
+      '180 days',
+      '210 days',
+      '240 days',
+      '270 days',
+      '300 days',
+      '330 days',
+      '360 days',
+      '390 days',
+    ]);
   });
 
   it('keeps an existing zero downsampled value as an option', async () => {
@@ -194,7 +209,76 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    expectSelectValue('Spans Downsampled', '0 (current)');
+    expectSelectValue('Spans Downsampled', '0 days (current)');
+  });
+
+  it('keeps a legacy value selectable after selecting away from it', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        logBytes: MetricHistoryFixture({
+          retention: {
+            standard: 45,
+            downsampled: null,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: null, downsampled: null},
+    });
+
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/retention-settings/`,
+      method: 'POST',
+      body: {},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    expectSelectValue('Logs Standard', '45 days (current)');
+
+    // Move off the legacy value.
+    await selectRetention('Logs Standard', '90 days');
+    expectSelectValue('Logs Standard', '90 days');
+
+    // The legacy value must still be offered, otherwise an admin who changes
+    // their mind can no longer restore what the subscription started with.
+    await selectEvent.openMenu(getSelect('Logs Standard'));
+
+    const options = screen
+      .getAllByRole('menuitemradio')
+      .map(option => option.textContent);
+
+    expect(options[0]).toBe('45 days (current)');
+
+    // Selecting it back round-trips the original value to the API.
+    await selectRetention('Logs Standard', '45 days (current)');
+    expectSelectValue('Logs Standard', '45 days (current)');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(
+        `/_admin/customers/${organization.slug}/retention-settings/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: expect.objectContaining({
+            retentions: expect.objectContaining({
+              logBytes: {
+                standard: 45,
+                downsampled: null,
+              },
+            }),
+          }),
+        })
+      );
+    });
   });
 
   it('prefills the form with existing AM2 retention values', async () => {
@@ -225,10 +309,10 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    expectSelectValue('Transactions Standard', '90 days');
-    expectSelectValue('Transactions Downsampled', '30 days');
-    expectSelectValue('Logs Standard', '60 days');
-    expectSelectValue('Logs Downsampled', '30 days');
+    expectSelectValue('Transactions Standard', '90 days (current)');
+    expectSelectValue('Transactions Downsampled', '30 days (current)');
+    expectSelectValue('Logs Standard', '60 days (current)');
+    expectSelectValue('Logs Downsampled', '30 days (current)');
 
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Update Settings'})).toBeInTheDocument();
@@ -264,9 +348,9 @@ describe('UpdateRetentionSettingsModal', () => {
     await loadModal();
 
     expectSelectValue('Org Retention', null);
-    expectSelectValue('Spans Standard', '90 days');
+    expectSelectValue('Spans Standard', '90 days (current)');
     expectSelectValue('Spans Downsampled', null);
-    expectSelectValue('Logs Standard', '30 days');
+    expectSelectValue('Logs Standard', '30 days (current)');
     expectSelectValue('Logs Downsampled', null);
   });
 
@@ -309,7 +393,7 @@ describe('UpdateRetentionSettingsModal', () => {
     await selectRetention('Spans Standard', '120 days');
     await selectRetention('Spans Downsampled', '60 days');
     await selectRetention('Logs Standard', '60 days');
-    await selectRetention('Logs Downsampled', '30 days');
+    await selectRetention('Logs Downsampled', '30 days (current)');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -379,7 +463,7 @@ describe('UpdateRetentionSettingsModal', () => {
     await selectRetention('Transactions Standard', '120 days');
     await selectRetention('Transactions Downsampled', '60 days');
     await selectRetention('Logs Standard', '60 days');
-    await selectRetention('Logs Downsampled', '30 days');
+    await selectRetention('Logs Downsampled', '30 days (current)');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -725,7 +809,7 @@ describe('UpdateRetentionSettingsModal', () => {
     await loadModal();
 
     await selectRetention('Logs Standard', '60 days');
-    await selectRetention('Logs Downsampled', '30 days');
+    await selectRetention('Logs Downsampled', '30 days (current)');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
@@ -138,7 +138,7 @@ describe('UpdateRetentionSettingsModal', () => {
     ]);
   });
 
-  it('offers zero for downsampled fields', async () => {
+  it('does not offer zero for downsampled fields', async () => {
     const subscription = SubscriptionFixture({
       organization,
       categories: {
@@ -163,9 +163,38 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await selectEvent.openMenu(getSelect('Spans Downsampled'));
 
-    expect(screen.getAllByRole('menuitemradio')[0]).toHaveTextContent(
-      '0 (same as standard)'
-    );
+    const options = screen
+      .getAllByRole('menuitemradio')
+      .map(option => option.textContent);
+
+    expect(options[0]).toBe('30 days');
+    expect(options).not.toContain('0 (same as standard)');
+  });
+
+  it('keeps an existing zero downsampled value as an option', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: 90,
+            downsampled: 0,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: null, downsampled: null},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    expectSelectValue('Spans Downsampled', '0 (current)');
   });
 
   it('prefills the form with existing AM2 retention values', async () => {
@@ -442,76 +471,6 @@ describe('UpdateRetentionSettingsModal', () => {
               logBytes: {
                 standard: 30,
                 downsampled: null,
-              },
-            },
-          },
-        })
-      );
-    });
-
-    expect(onSuccess).toHaveBeenCalled();
-  });
-
-  it('calls api with zero for downsampled values when set to 0', async () => {
-    const subscription = SubscriptionFixture({
-      organization,
-      categories: {
-        spans: MetricHistoryFixture({
-          retention: {
-            standard: 90,
-            downsampled: 30,
-          },
-        }),
-        logBytes: MetricHistoryFixture({
-          retention: {
-            standard: 30,
-            downsampled: 30,
-          },
-        }),
-      },
-      planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: null, downsampled: null},
-    });
-
-    const updateMock = MockApiClient.addMockResponse({
-      url: `/_admin/customers/${organization.slug}/retention-settings/`,
-      method: 'POST',
-      body: {},
-    });
-
-    openUpdateRetentionSettingsModal({
-      subscription,
-      organization,
-      onSuccess,
-    });
-
-    await loadModal();
-
-    await selectRetention('Spans Standard', '90 days');
-    await selectRetention('Spans Downsampled', '0 (same as standard)');
-    await selectRetention('Logs Standard', '30 days');
-    await selectRetention('Logs Downsampled', '0 (same as standard)');
-
-    await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
-
-    await waitFor(() => {
-      expect(updateMock).toHaveBeenCalledWith(
-        `/_admin/customers/${organization.slug}/retention-settings/`,
-        expect.objectContaining({
-          method: 'POST',
-          data: {
-            orgRetention: {
-              standard: null,
-              downsampled: null,
-            },
-            retentions: {
-              spans: {
-                standard: 90,
-                downsampled: 0,
-              },
-              logBytes: {
-                standard: 30,
-                downsampled: 0,
               },
             },
           },

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
@@ -481,6 +481,148 @@ describe('UpdateRetentionSettingsModal', () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
+  it('sends null for fields left at the plan default', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: null,
+            downsampled: null,
+          },
+        }),
+        logBytes: MetricHistoryFixture({
+          retention: {
+            standard: null,
+            downsampled: null,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: null, downsampled: null},
+    });
+
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/retention-settings/`,
+      method: 'POST',
+      body: {},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    // Nothing is configured, so every field sits at the plan default.
+    expectSelectValue('Org Retention', null);
+    expectSelectValue('Spans Standard', null);
+    expectSelectValue('Spans Downsampled', null);
+    expectSelectValue('Logs Standard', null);
+    expectSelectValue('Logs Downsampled', null);
+
+    // Submit without touching a single field.
+    await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(
+        `/_admin/customers/${organization.slug}/retention-settings/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: {
+            orgRetention: {
+              standard: null,
+              downsampled: null,
+            },
+            retentions: {
+              spans: {
+                standard: null,
+                downsampled: null,
+              },
+              logBytes: {
+                standard: null,
+                downsampled: null,
+              },
+            },
+          },
+        })
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('keeps other fields null when only one field is set', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: null,
+            downsampled: null,
+          },
+        }),
+        logBytes: MetricHistoryFixture({
+          retention: {
+            standard: null,
+            downsampled: null,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: null, downsampled: null},
+    });
+
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/_admin/customers/${organization.slug}/retention-settings/`,
+      method: 'POST',
+      body: {},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    await selectRetention('Spans Standard', '90 days');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
+
+    // Selecting one value must not backfill the rest with plan values; the
+    // untouched fields stay null so the API keeps applying its own defaults.
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(
+        `/_admin/customers/${organization.slug}/retention-settings/`,
+        expect.objectContaining({
+          method: 'POST',
+          data: {
+            orgRetention: {
+              standard: null,
+              downsampled: null,
+            },
+            retentions: {
+              spans: {
+                standard: 90,
+                downsampled: null,
+              },
+              logBytes: {
+                standard: null,
+                downsampled: null,
+              },
+            },
+          },
+        })
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
   it('updates only spans retention', async () => {
     const subscription = SubscriptionFixture({
       organization,

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
@@ -8,7 +8,9 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
 
 import {openUpdateRetentionSettingsModal} from 'admin/components/customers/updateRetentionSettingsModal';
 
@@ -16,8 +18,28 @@ describe('UpdateRetentionSettingsModal', () => {
   const onSuccess = jest.fn();
   const organization = OrganizationFixture();
 
-  function getSpinbutton(name: string) {
-    return screen.getByRole('spinbutton', {name});
+  function getSelect(name: string) {
+    return screen.getByRole('textbox', {name});
+  }
+
+  function getSelectContainer(name: string) {
+    // scope assertions to a single select, since several share option labels
+    return getSelect(name).closest<HTMLElement>('[class$="-container"]')!;
+  }
+
+  function expectSelectValue(name: string, value: string | null) {
+    const container = getSelectContainer(name);
+    expect(within(container).getByText(value ?? 'Plan default')).toBeInTheDocument();
+  }
+
+  async function selectRetention(name: string, option: string) {
+    await selectEvent.select(getSelect(name), option);
+  }
+
+  async function clearRetention(name: string) {
+    await userEvent.click(
+      within(getSelectContainer(name)).getByLabelText('Clear choices')
+    );
   }
 
   async function loadModal() {
@@ -59,14 +81,91 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    expect(getSpinbutton('Spans Standard')).toHaveValue(90);
-    expect(getSpinbutton('Spans Downsampled')).toHaveValue(30);
-    expect(getSpinbutton('Logs Standard')).toHaveValue(45);
-    expect(getSpinbutton('Logs Downsampled')).toHaveValue(15);
-    expect(getSpinbutton('Org Retention')).toHaveValue(1234567);
+    expectSelectValue('Spans Standard', '90 days');
+    expectSelectValue('Spans Downsampled', '30 days');
+    // values that are not multiples of 30 are preserved as-is
+    expectSelectValue('Logs Standard', '45 (current)');
+    expectSelectValue('Logs Downsampled', '15 (current)');
+    expectSelectValue('Org Retention', '1234567 (current)');
 
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Update Settings'})).toBeInTheDocument();
+  });
+
+  it('only offers multiples of 30 up to 390', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: 90,
+            downsampled: 30,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: null, downsampled: null},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    await selectEvent.openMenu(getSelect('Spans Standard'));
+
+    const options = screen
+      .getAllByRole('menuitemradio')
+      .map(option => option.textContent);
+
+    expect(options).toEqual([
+      '30 days',
+      '60 days',
+      '90 days',
+      '120 days',
+      '150 days',
+      '180 days',
+      '210 days',
+      '240 days',
+      '270 days',
+      '300 days',
+      '330 days',
+      '360 days',
+      '390 days',
+    ]);
+  });
+
+  it('offers zero for downsampled fields', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      categories: {
+        spans: MetricHistoryFixture({
+          retention: {
+            standard: 90,
+            downsampled: 30,
+          },
+        }),
+      },
+      planDetails: PlanDetailsLookupFixture('am3_f'),
+      orgRetention: {standard: null, downsampled: null},
+    });
+
+    openUpdateRetentionSettingsModal({
+      subscription,
+      organization,
+      onSuccess,
+    });
+
+    await loadModal();
+
+    await selectEvent.openMenu(getSelect('Spans Downsampled'));
+
+    expect(screen.getAllByRole('menuitemradio')[0]).toHaveTextContent(
+      '0 (same as standard)'
+    );
   });
 
   it('prefills the form with existing AM2 retention values', async () => {
@@ -81,8 +180,8 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
         logBytes: MetricHistoryFixture({
           retention: {
-            standard: 45,
-            downsampled: 15,
+            standard: 60,
+            downsampled: 30,
           },
         }),
       },
@@ -97,10 +196,10 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    expect(getSpinbutton('Transactions Standard')).toHaveValue(90);
-    expect(getSpinbutton('Transactions Downsampled')).toHaveValue(30);
-    expect(getSpinbutton('Logs Standard')).toHaveValue(45);
-    expect(getSpinbutton('Logs Downsampled')).toHaveValue(15);
+    expectSelectValue('Transactions Standard', '90 days');
+    expectSelectValue('Transactions Downsampled', '30 days');
+    expectSelectValue('Logs Standard', '60 days');
+    expectSelectValue('Logs Downsampled', '30 days');
 
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Update Settings'})).toBeInTheDocument();
@@ -135,11 +234,11 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    expect(getSpinbutton('Org Retention')).toHaveValue(null);
-    expect(getSpinbutton('Spans Standard')).toHaveValue(90);
-    expect(getSpinbutton('Spans Downsampled')).toHaveValue(null);
-    expect(getSpinbutton('Logs Standard')).toHaveValue(30);
-    expect(getSpinbutton('Logs Downsampled')).toHaveValue(null);
+    expectSelectValue('Org Retention', null);
+    expectSelectValue('Spans Standard', '90 days');
+    expectSelectValue('Spans Downsampled', null);
+    expectSelectValue('Logs Standard', '30 days');
+    expectSelectValue('Logs Downsampled', null);
   });
 
   it('calls api with correct data when updating all fields', async () => {
@@ -155,12 +254,12 @@ describe('UpdateRetentionSettingsModal', () => {
         logBytes: MetricHistoryFixture({
           retention: {
             standard: 30,
-            downsampled: 7,
+            downsampled: 30,
           },
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: 123, downsampled: null},
+      orgRetention: {standard: 120, downsampled: null},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -177,20 +276,11 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    await userEvent.clear(getSpinbutton('Org Retention'));
-    await userEvent.type(getSpinbutton('Org Retention'), '456');
-
-    await userEvent.clear(getSpinbutton('Spans Standard'));
-    await userEvent.type(getSpinbutton('Spans Standard'), '120');
-
-    await userEvent.clear(getSpinbutton('Spans Downsampled'));
-    await userEvent.type(getSpinbutton('Spans Downsampled'), '60');
-
-    await userEvent.clear(getSpinbutton('Logs Standard'));
-    await userEvent.type(getSpinbutton('Logs Standard'), '60');
-
-    await userEvent.clear(getSpinbutton('Logs Downsampled'));
-    await userEvent.type(getSpinbutton('Logs Downsampled'), '14');
+    await selectRetention('Org Retention', '390 days');
+    await selectRetention('Spans Standard', '120 days');
+    await selectRetention('Spans Downsampled', '60 days');
+    await selectRetention('Logs Standard', '60 days');
+    await selectRetention('Logs Downsampled', '30 days');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -201,7 +291,7 @@ describe('UpdateRetentionSettingsModal', () => {
           method: 'POST',
           data: {
             orgRetention: {
-              standard: 456,
+              standard: 390,
               downsampled: null,
             },
             retentions: {
@@ -211,7 +301,7 @@ describe('UpdateRetentionSettingsModal', () => {
               },
               logBytes: {
                 standard: 60,
-                downsampled: 14,
+                downsampled: 30,
               },
             },
           },
@@ -235,7 +325,7 @@ describe('UpdateRetentionSettingsModal', () => {
         logBytes: MetricHistoryFixture({
           retention: {
             standard: 30,
-            downsampled: 7,
+            downsampled: 30,
           },
         }),
       },
@@ -257,19 +347,10 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    await userEvent.clear(getSpinbutton('Org Retention'));
-
-    await userEvent.clear(getSpinbutton('Transactions Standard'));
-    await userEvent.type(getSpinbutton('Transactions Standard'), '120');
-
-    await userEvent.clear(getSpinbutton('Transactions Downsampled'));
-    await userEvent.type(getSpinbutton('Transactions Downsampled'), '60');
-
-    await userEvent.clear(getSpinbutton('Logs Standard'));
-    await userEvent.type(getSpinbutton('Logs Standard'), '60');
-
-    await userEvent.clear(getSpinbutton('Logs Downsampled'));
-    await userEvent.type(getSpinbutton('Logs Downsampled'), '14');
+    await selectRetention('Transactions Standard', '120 days');
+    await selectRetention('Transactions Downsampled', '60 days');
+    await selectRetention('Logs Standard', '60 days');
+    await selectRetention('Logs Downsampled', '30 days');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -290,7 +371,7 @@ describe('UpdateRetentionSettingsModal', () => {
               },
               logBytes: {
                 standard: 60,
-                downsampled: 14,
+                downsampled: 30,
               },
             },
           },
@@ -301,7 +382,7 @@ describe('UpdateRetentionSettingsModal', () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
-  it('calls api with null downsampled values when fields are empty', async () => {
+  it('calls api with null values when fields are cleared', async () => {
     const subscription = SubscriptionFixture({
       organization,
       categories: {
@@ -314,12 +395,12 @@ describe('UpdateRetentionSettingsModal', () => {
         logBytes: MetricHistoryFixture({
           retention: {
             standard: 30,
-            downsampled: 7,
+            downsampled: 30,
           },
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: 123, downsampled: null},
+      orgRetention: {standard: 120, downsampled: null},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -336,16 +417,10 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    await userEvent.clear(getSpinbutton('Org Retention'));
-
-    await userEvent.clear(getSpinbutton('Spans Standard'));
-
-    await userEvent.clear(getSpinbutton('Spans Downsampled'));
-
-    await userEvent.clear(getSpinbutton('Logs Standard'));
-    await userEvent.type(getSpinbutton('Logs Standard'), '30');
-
-    await userEvent.clear(getSpinbutton('Logs Downsampled'));
+    await clearRetention('Org Retention');
+    await clearRetention('Spans Standard');
+    await clearRetention('Spans Downsampled');
+    await clearRetention('Logs Downsampled');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -390,7 +465,7 @@ describe('UpdateRetentionSettingsModal', () => {
         logBytes: MetricHistoryFixture({
           retention: {
             standard: 30,
-            downsampled: 7,
+            downsampled: 30,
           },
         }),
       },
@@ -412,19 +487,10 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    await userEvent.clear(getSpinbutton('Org Retention'));
-
-    await userEvent.clear(getSpinbutton('Spans Standard'));
-    await userEvent.type(getSpinbutton('Spans Standard'), '90');
-
-    await userEvent.clear(getSpinbutton('Spans Downsampled'));
-    await userEvent.type(getSpinbutton('Spans Downsampled'), '0');
-
-    await userEvent.clear(getSpinbutton('Logs Standard'));
-    await userEvent.type(getSpinbutton('Logs Standard'), '30');
-
-    await userEvent.clear(getSpinbutton('Logs Downsampled'));
-    await userEvent.type(getSpinbutton('Logs Downsampled'), '0');
+    await selectRetention('Spans Standard', '90 days');
+    await selectRetention('Spans Downsampled', '0 (same as standard)');
+    await selectRetention('Logs Standard', '30 days');
+    await selectRetention('Logs Downsampled', '0 (same as standard)');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -469,7 +535,7 @@ describe('UpdateRetentionSettingsModal', () => {
         logBytes: MetricHistoryFixture({
           retention: {
             standard: 30,
-            downsampled: 7,
+            downsampled: 30,
           },
         }),
       },
@@ -491,13 +557,8 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    await userEvent.clear(getSpinbutton('Org Retention'));
-
-    await userEvent.clear(getSpinbutton('Spans Standard'));
-    await userEvent.type(getSpinbutton('Spans Standard'), '180');
-
-    await userEvent.clear(getSpinbutton('Spans Downsampled'));
-    await userEvent.type(getSpinbutton('Spans Downsampled'), '90');
+    await selectRetention('Spans Standard', '180 days');
+    await selectRetention('Spans Downsampled', '90 days');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 
@@ -518,7 +579,7 @@ describe('UpdateRetentionSettingsModal', () => {
               },
               logBytes: {
                 standard: 30,
-                downsampled: 7,
+                downsampled: 30,
               },
             },
           },
@@ -540,7 +601,7 @@ describe('UpdateRetentionSettingsModal', () => {
         logBytes: MetricHistoryFixture({
           retention: {
             standard: 30,
-            downsampled: 7,
+            downsampled: 30,
           },
         }),
       },
@@ -562,13 +623,8 @@ describe('UpdateRetentionSettingsModal', () => {
 
     await loadModal();
 
-    await userEvent.clear(getSpinbutton('Org Retention'));
-
-    await userEvent.clear(getSpinbutton('Logs Standard'));
-    await userEvent.type(getSpinbutton('Logs Standard'), '60');
-
-    await userEvent.clear(getSpinbutton('Logs Downsampled'));
-    await userEvent.type(getSpinbutton('Logs Downsampled'), '30');
+    await selectRetention('Logs Standard', '60 days');
+    await selectRetention('Logs Downsampled', '30 days');
 
     await userEvent.click(screen.getByRole('button', {name: 'Update Settings'}));
 

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -3,7 +3,7 @@ import {Fragment, useState} from 'react';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
-import {NumberField} from 'sentry/components/forms/fields/numberField';
+import {SelectField} from 'sentry/components/forms/fields/selectField';
 import {Form} from 'sentry/components/forms/form';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -19,8 +19,69 @@ type Props = {
 
 type ModalProps = Props & ModalRenderProps;
 
-function getNumberOrNull(n: number | null | string): number | null {
-  return n === null || n === '' ? null : Number(n);
+const RETENTION_STEP_DAYS = 30;
+const MAX_RETENTION_DAYS = 390;
+
+const RETENTION_DAY_CHOICES = Array.from(
+  {length: MAX_RETENTION_DAYS / RETENTION_STEP_DAYS},
+  (_, i) => (i + 1) * RETENTION_STEP_DAYS
+);
+
+type RetentionOption = {label: string; value: number};
+
+/**
+ * Retention must be picked from multiples of 30, up to 390. Existing values
+ * that predate this restriction are kept as an option so they aren't silently
+ * dropped when the form is submitted.
+ */
+function getRetentionOptions(
+  currentValue: number | null,
+  {allowZero}: {allowZero: boolean}
+): RetentionOption[] {
+  const options: RetentionOption[] = RETENTION_DAY_CHOICES.map(days => ({
+    value: days,
+    label: `${days} days`,
+  }));
+
+  if (allowZero) {
+    options.unshift({value: 0, label: '0 (same as standard)'});
+  }
+
+  if (currentValue !== null && !options.some(option => option.value === currentValue)) {
+    options.unshift({value: currentValue, label: `${currentValue} (current)`});
+  }
+
+  return options;
+}
+
+type RetentionFieldProps = {
+  label: string;
+  name: string;
+  onChange: (value: number | null) => void;
+  value: number | null;
+  allowZero?: boolean;
+};
+
+function RetentionField({
+  name,
+  label,
+  value,
+  onChange,
+  allowZero = false,
+}: RetentionFieldProps) {
+  const [options] = useState(() => getRetentionOptions(value, {allowZero}));
+
+  return (
+    <SelectField
+      name={name}
+      label={label}
+      defaultValue={value}
+      options={options}
+      onChange={(newValue: number | null | undefined) => onChange(newValue ?? null)}
+      placeholder="Plan default"
+      allowClear
+    />
+  );
 }
 
 function UpdateRetentionSettingsModal({
@@ -33,28 +94,28 @@ function UpdateRetentionSettingsModal({
 }: ModalProps) {
   const api = useApi();
 
-  const [orgStandard, setOrgStandard] = useState<number | null | string>(
+  const [orgStandard, setOrgStandard] = useState<number | null>(
     subscription.orgRetention?.standard ?? null
   );
 
-  const [logBytesStandard, setLogBytesStandard] = useState<number | null | string>(
+  const [logBytesStandard, setLogBytesStandard] = useState<number | null>(
     subscription.categories.logBytes?.retention?.standard ?? null
   );
-  const [logBytesDownsampled, setLogBytesDownsampled] = useState<number | null | string>(
+  const [logBytesDownsampled, setLogBytesDownsampled] = useState<number | null>(
     subscription.categories.logBytes?.retention?.downsampled ?? null
   );
 
-  const [transactionsStandard, setTransactionsStandard] = useState<
-    number | null | string
-  >(subscription.categories.transactions?.retention?.standard ?? null);
-  const [transactionsDownsampled, setTransactionsDownsampled] = useState<
-    number | null | string
-  >(subscription.categories.transactions?.retention?.downsampled ?? null);
+  const [transactionsStandard, setTransactionsStandard] = useState<number | null>(
+    subscription.categories.transactions?.retention?.standard ?? null
+  );
+  const [transactionsDownsampled, setTransactionsDownsampled] = useState<number | null>(
+    subscription.categories.transactions?.retention?.downsampled ?? null
+  );
 
-  const [spansStandard, setSpansStandard] = useState<number | null | string>(
+  const [spansStandard, setSpansStandard] = useState<number | null>(
     subscription.categories.spans?.retention?.standard ?? null
   );
-  const [spansDownsampled, setSpansDownsampled] = useState<number | null | string>(
+  const [spansDownsampled, setSpansDownsampled] = useState<number | null>(
     subscription.categories.spans?.retention?.downsampled ?? null
   );
 
@@ -65,27 +126,27 @@ function UpdateRetentionSettingsModal({
 
     if (subscription.planDetails.categories.includes(DataCategory.LOG_BYTE)) {
       retentions.logBytes = {
-        standard: getNumberOrNull(logBytesStandard),
-        downsampled: getNumberOrNull(logBytesDownsampled),
+        standard: logBytesStandard,
+        downsampled: logBytesDownsampled,
       };
     }
 
     if (subscription.planDetails.categories.includes(DataCategory.TRANSACTIONS)) {
       retentions.transactions = {
-        standard: getNumberOrNull(transactionsStandard),
-        downsampled: getNumberOrNull(transactionsDownsampled),
+        standard: transactionsStandard,
+        downsampled: transactionsDownsampled,
       };
     }
 
     if (subscription.planDetails.categories.includes(DataCategory.SPANS)) {
       retentions.spans = {
-        standard: getNumberOrNull(spansStandard),
-        downsampled: getNumberOrNull(spansDownsampled),
+        standard: spansStandard,
+        downsampled: spansDownsampled,
       };
     }
 
     const orgRetention = {
-      standard: getNumberOrNull(orgStandard),
+      standard: orgStandard,
       downsampled: null,
     };
 
@@ -111,8 +172,9 @@ function UpdateRetentionSettingsModal({
       <Body>
         <div>
           <p>
-            Update the retention settings for each data category. Null values will default
-            to the plan's retention value for the category.
+            Update the retention settings for each data category. Retention must be a
+            multiple of 30 days, up to 390. Clearing a field defaults to the plan's
+            retention value for the category.
           </p>
           <p>
             A value of zero for downsampled means that the downsampled retention defaults
@@ -121,59 +183,62 @@ function UpdateRetentionSettingsModal({
         </div>
         <br />
         <Form onSubmit={onSubmit} submitLabel="Update Settings" onCancel={closeModal}>
-          <NumberField
+          <RetentionField
             name="orgStandard"
             label="Org Retention"
-            defaultValue={orgStandard}
+            value={orgStandard}
             onChange={setOrgStandard}
           />
           {subscription.planDetails.categories.includes(DataCategory.LOG_BYTE) && (
             <Fragment>
-              <NumberField
+              <RetentionField
                 name="logBytesStandard"
                 label="Logs Standard"
-                defaultValue={logBytesStandard}
+                value={logBytesStandard}
                 onChange={setLogBytesStandard}
               />
-              <NumberField
+              <RetentionField
                 name="logBytesDownsampled"
                 label="Logs Downsampled"
-                defaultValue={logBytesDownsampled}
+                value={logBytesDownsampled}
                 onChange={setLogBytesDownsampled}
+                allowZero
               />
             </Fragment>
           )}
 
           {subscription.planDetails.categories.includes(DataCategory.TRANSACTIONS) && (
             <Fragment>
-              <NumberField
+              <RetentionField
                 name="transactionsStandard"
                 label="Transactions Standard"
-                defaultValue={transactionsStandard}
+                value={transactionsStandard}
                 onChange={setTransactionsStandard}
               />
-              <NumberField
+              <RetentionField
                 name="transactionsDownsampled"
                 label="Transactions Downsampled"
-                defaultValue={transactionsDownsampled}
+                value={transactionsDownsampled}
                 onChange={setTransactionsDownsampled}
+                allowZero
               />
             </Fragment>
           )}
 
           {subscription.planDetails.categories.includes(DataCategory.SPANS) && (
             <Fragment>
-              <NumberField
+              <RetentionField
                 name="spansStandard"
                 label="Spans Standard"
-                defaultValue={spansStandard}
+                value={spansStandard}
                 onChange={setSpansStandard}
               />
-              <NumberField
+              <RetentionField
                 name="spansDownsampled"
                 label="Spans Downsampled"
-                defaultValue={spansDownsampled}
+                value={spansDownsampled}
                 onChange={setSpansDownsampled}
+                allowZero
               />
             </Fragment>
           )}

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -30,22 +30,15 @@ const RETENTION_DAY_CHOICES = Array.from(
 type RetentionOption = {label: string; value: number};
 
 /**
- * Retention must be picked from multiples of 30, up to 390. Existing values
+ * Retention must be picked from multiples of 30. Existing values
  * that predate this restriction are kept as an option so they aren't silently
  * dropped when the form is submitted.
  */
-function getRetentionOptions(
-  currentValue: number | null,
-  {allowZero}: {allowZero: boolean}
-): RetentionOption[] {
+function getRetentionOptions(currentValue: number | null): RetentionOption[] {
   const options: RetentionOption[] = RETENTION_DAY_CHOICES.map(days => ({
     value: days,
     label: `${days} days`,
   }));
-
-  if (allowZero) {
-    options.unshift({value: 0, label: '0 (same as standard)'});
-  }
 
   if (currentValue !== null && !options.some(option => option.value === currentValue)) {
     options.unshift({value: currentValue, label: `${currentValue} (current)`});
@@ -59,17 +52,10 @@ type RetentionFieldProps = {
   name: string;
   onChange: (value: number | null) => void;
   value: number | null;
-  allowZero?: boolean;
 };
 
-function RetentionField({
-  name,
-  label,
-  value,
-  onChange,
-  allowZero = false,
-}: RetentionFieldProps) {
-  const [options] = useState(() => getRetentionOptions(value, {allowZero}));
+function RetentionField({name, label, value, onChange}: RetentionFieldProps) {
+  const [options] = useState(() => getRetentionOptions(value));
 
   return (
     <SelectField
@@ -173,12 +159,8 @@ function UpdateRetentionSettingsModal({
         <div>
           <p>
             Update the retention settings for each data category. Retention must be a
-            multiple of 30 days, up to 390. Clearing a field defaults to the plan's
-            retention value for the category.
-          </p>
-          <p>
-            A value of zero for downsampled means that the downsampled retention defaults
-            to the standard retention.
+            multiple of 30 days. Clearing a field defaults to the plan's retention value
+            for the category.
           </p>
         </div>
         <br />
@@ -202,7 +184,6 @@ function UpdateRetentionSettingsModal({
                 label="Logs Downsampled"
                 value={logBytesDownsampled}
                 onChange={setLogBytesDownsampled}
-                allowZero
               />
             </Fragment>
           )}
@@ -220,7 +201,6 @@ function UpdateRetentionSettingsModal({
                 label="Transactions Downsampled"
                 value={transactionsDownsampled}
                 onChange={setTransactionsDownsampled}
-                allowZero
               />
             </Fragment>
           )}
@@ -238,7 +218,6 @@ function UpdateRetentionSettingsModal({
                 label="Spans Downsampled"
                 value={spansDownsampled}
                 onChange={setSpansDownsampled}
-                allowZero
               />
             </Fragment>
           )}

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -37,11 +37,11 @@ type RetentionOption = {label: string; value: number};
 function getRetentionOptions(currentValue: number | null): RetentionOption[] {
   const options: RetentionOption[] = RETENTION_DAY_CHOICES.map(days => ({
     value: days,
-    label: `${days} days`,
+    label: days === currentValue ? `${days} days (current)` : `${days} days`,
   }));
 
   if (currentValue !== null && !options.some(option => option.value === currentValue)) {
-    options.unshift({value: currentValue, label: `${currentValue} (current)`});
+    options.unshift({value: currentValue, label: `${currentValue} days (current)`});
   }
 
   return options;


### PR DESCRIPTION
@phacops requested that retention only be set in 30 day increments, this makes it hard to do otherwise:

<img width="629" height="624" alt="Screenshot 2026-08-28 at 9 31 07 AM" src="https://github.com/user-attachments/assets/f0603d33-1a98-4938-9a6a-96a62012c150" />

## Testing in Upstream API

Verified that null values are properly handled in upstream API:

  Traced and confirmed:

  - Serializer (admin_retention_settings.py:22-23) — allow_null=True, so None reaches the handlers as a real value.
  - Legacy write — subscription.retention_days and BillingMetricHistory.retention_days/retention_days_downsampled are
    all null=True, and SubscriptionUpdates only filters UnsetVal, so None is persisted as NULL. Migration
    0408_bmh_remove_retention_default_zero removed the old 0 default that used to cause exactly this hazard.
  - Legacy read (getsentry/quotas.py) — NULL skips the org branch, and normalized_override_days() collapses None (and
    0) to "no override" → plan_item(category).retention.
  - Platform shadow — _positive_or_none() maps None/0 to None, which removes the override rather than storing a zero;
    the read side then falls back to the package defaults.

  I ran a live test posting nulls over pre-existing overrides (org 11, error 7/9) on AM3_TEAM: stored values became
  NULL, and get_event_retention(org, ERROR) returned 90 — the plan default.
