### PR TITLE
fix(ai): Avoid deprecated message attribute access

### DIFF
--- a/src/sentry/ai_monitoring/conversation_titles.py
+++ b/src/sentry/ai_monitoring/conversation_titles.py
@@ -27,13 +27,14 @@ MAX_USER_MESSAGE_CHARS = 8 * 1024
 TITLE_MAX_LENGTH = 256
 TITLE_MAX_WORDS = 12
 UNTITLED = "Untitled conversation"
+LEGACY_GEN_AI_REQUEST_MESSAGES = "gen_ai.request.messages"
 # Matches AIConversationMetadata.conversation_id max_length.
 CONVERSATION_ID_MAX_LENGTH = 2048
 CONVERSATION_ID_TRUNCATE_TO = 2040
 # Priority matches organization_ai_conversations list helpers.
 _MESSAGE_ATTRS = (
     ATTRIBUTE_NAMES.GEN_AI_INPUT_MESSAGES,
-    ATTRIBUTE_NAMES.GEN_AI_REQUEST_MESSAGES,
+    LEGACY_GEN_AI_REQUEST_MESSAGES,
 )
 
 

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -8,6 +8,7 @@ from django.db.models.query import QuerySet
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.ai_monitoring.conversation_titles import (
+    LEGACY_GEN_AI_REQUEST_MESSAGES,
     MAX_USER_MESSAGE_CHARS,
     clamp_conversation_id_for_storage,
     clamp_user_message,
@@ -55,7 +56,7 @@ def make_gen_ai_span(
         attributes[ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID] = _attr(conversation_id)
     if not omit_messages:
         key = (
-            ATTRIBUTE_NAMES.GEN_AI_REQUEST_MESSAGES
+            LEGACY_GEN_AI_REQUEST_MESSAGES
             if use_request_messages
             else ATTRIBUTE_NAMES.GEN_AI_INPUT_MESSAGES
         )
@@ -124,7 +125,7 @@ class TitleHelpersTest(TestCase):
                 ]
             ),
         )
-        span["attributes"][ATTRIBUTE_NAMES.GEN_AI_REQUEST_MESSAGES] = _attr(
+        span["attributes"][LEGACY_GEN_AI_REQUEST_MESSAGES] = _attr(
             json.dumps([{"role": "user", "content": "from request"}])
         )
         assert first_user_message_from_span(span) == "from input"


### PR DESCRIPTION
AI conversation title extraction now uses the legacy request-message attribute key without accessing its deprecated convention constant. Legacy spans remain supported, while importing the module no longer emits a deprecation warning in every web process.

In the 30-minute production sample from August 28, 2026, 12:49–13:19 UTC, this import-time warning occurred 1,950 times and generated 3,900 error-classified log entries including warning context lines. This was 19.3% of all entries in the query window.
