### PR TITLE
fix(api): Reject invalid artifact bundle UUIDs

### DIFF
--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -83,7 +84,7 @@ class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
                 bundle_id=bundle_id,
                 projectartifactbundle__project_id=project.id,
             )[0]
-        except IndexError:
+        except (IndexError, ValidationError):
             return Response(
                 {
                     "error": f"The artifact bundle with {bundle_id} is not bound to this project or doesn't exist"

--- a/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_bundle_files.py
@@ -10,6 +10,22 @@ from sentry.testutils.helpers.datetime import freeze_time
 
 @freeze_time("2023-03-15 00:00:00")
 class ProjectArtifactBundleFilesEndpointTest(APITestCase):
+    def test_get_artifact_bundle_files_with_invalid_bundle_id(self) -> None:
+        project = self.create_project(name="foo")
+        url = reverse(
+            "sentry-api-0-project-artifact-bundle-files",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+                "bundle_id": "not-a-uuid",
+            },
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.get(url)
+
+        assert response.status_code == 400
+
     def test_get_artifact_bundle_files_with_multiple_files(self) -> None:
         project = self.create_project(name="foo")
 


### PR DESCRIPTION
The project artifact-bundle files endpoint now treats malformed bundle UUIDs like missing bundles and returns a 400 response. This prevents invalid path input from reaching Django's UUID field conversion and producing an internal-error traceback.

In the 30-minute production sample from August 28, 2026, 12:49–13:19 UTC, 10 malformed bundle requests generated 700 error-classified log entries because each request produced an approximately 70-line traceback. This was 3.5% of all entries in the query window.
