### PR TITLE
fix(bitbucket): Skip deleted refs in webhooks

### DIFF
--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -99,11 +99,12 @@ class PushEventWebhook(BitbucketServerWebhook):
             [project_name, repo_name] = repo.name.split("/")
 
             for change in event["changes"]:
+                to_hash = change.get("toHash")
+                if to_hash == "0" * 40:
+                    continue
                 from_hash = None if change.get("fromHash") == "0" * 40 else change.get("fromHash")
                 try:
-                    commits = client.get_commits(
-                        project_name, repo_name, from_hash, change.get("toHash")
-                    )
+                    commits = client.get_commits(project_name, repo_name, from_hash, to_hash)
                 except ApiHostError as e:
                     lifecycle.record_halt(halt_reason=e)
                     raise BadRequest(detail="Unable to reach host")

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -141,6 +141,29 @@ class RefsChangedWebhookTest(WebhookTestBase):
         assert_success_metric(mock_record)
 
     @patch("sentry.integrations.bitbucket_server.client.BitbucketServerClient.get_commits")
+    def test_deleted_ref_skips_commit_lookup(self, mock_get_commits: MagicMock) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.add_organization(self.organization, default_auth_id=self.identity.id)
+
+        self.create_repository()
+        self.get_success_response(
+            self.organization.id,
+            self.integration.id,
+            raw_data={
+                "changes": [{"fromHash": "1" * 40, "toHash": "0" * 40}],
+                "repository": {
+                    "id": self.external_id,
+                    "project": {"key": "my-project"},
+                    "slug": "marcos",
+                },
+            },
+            extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
+            status_code=204,
+        )
+
+        mock_get_commits.assert_not_called()
+
+    @patch("sentry.integrations.bitbucket_server.client.BitbucketServerClient.get_commits")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_webhook_error_metric(
         self, mock_record: MagicMock, mock_get_commits: MagicMock


### PR DESCRIPTION
Bitbucket Server push webhooks now skip commit discovery for deleted refs, whose destination hash is the all-zero sentinel. Branch deletion events still update repository metadata but no longer request a nonexistent commit and produce an integration error.

In the 30-minute production sample from August 28, 2026, 12:49–13:19 UTC, six deleted-ref webhook failures generated 240 error-classified log entries, or roughly 40 traceback lines per webhook. This was 1.2% of all entries in the query window.
