### PR TITLE
feat(autofix): Support bash tool in autofix evidence

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -563,6 +563,84 @@ describe('AutofixEvidence', () => {
     });
   });
 
+  describe('EvidenceBash', () => {
+    it('renders command label from description', () => {
+      const toolCall = makeToolCall('bash', {
+        description: 'Run tests',
+        command: 'pytest tests/ -q',
+      });
+      const props = resolveProps(toolCall);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Command: Run tests')).toBeInTheDocument();
+    });
+
+    it('renders a chip, not a link', () => {
+      const toolCall = makeToolCall('bash', {
+        description: 'Run tests',
+        command: 'pytest tests/ -q',
+      });
+      const props = resolveProps(toolCall);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      const chip = screen.queryByText('Command: Run tests');
+      expect(chip).toBeInTheDocument();
+      expect(chip!.closest('a')).toBeNull();
+    });
+
+    it('falls back to the command when description is absent', () => {
+      const toolCall = makeToolCall('bash', {command: 'pytest -q'});
+      const props = resolveProps(toolCall);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Command: pytest -q')).toBeInTheDocument();
+    });
+
+    it('renders truncated label for long descriptions', () => {
+      const toolCall = makeToolCall('bash', {
+        description: 'this is a very long description that should be truncated',
+      });
+      const props = resolveProps(toolCall);
+      render(
+        <AutofixEvidence
+          evidenceButtonProps={props!}
+          groupId="123"
+          toolCall={toolCall}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Command: this is \u2026runcated')).toBeInTheDocument();
+    });
+
+    it('returns null when neither description nor command is present', () => {
+      expect(resolveProps(makeToolCall('bash'))).toBeNull();
+    });
+
+    it('returns null when args is invalid JSON', () => {
+      expect(
+        resolveProps({id: 'tc-1', function: 'bash', args: '{invalid json'})
+      ).toBeNull();
+    });
+  });
+
   describe('EvidenceGitSearch', () => {
     const FULL_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
     const COMMIT_URL = 'https://github.com/org/repo/commit/a1b2c3d';

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -2,6 +2,7 @@ import {Fragment, type ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
 
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {IconCompass} from 'sentry/icons/iconCompass';
@@ -10,6 +11,7 @@ import {IconIssues} from 'sentry/icons/iconIssues';
 import {IconPlay} from 'sentry/icons/iconPlay';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {IconSpan} from 'sentry/icons/iconSpan';
+import {IconTerminal} from 'sentry/icons/iconTerminal';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -33,7 +35,7 @@ export function AutofixEvidence({
   toolCall,
 }: AutofixEvidenceProps) {
   const organization = useOrganization();
-  const {label, icon, tooltip, ...rest} = evidenceButtonProps;
+  const {prefix, suffix, label, icon, tooltip, ...rest} = evidenceButtonProps;
 
   const handleClick = () => {
     trackAnalytics('autofix.evidence.clicked', {
@@ -53,7 +55,10 @@ export function AutofixEvidence({
         onClick={handleClick}
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
-        {label}
+        {prefix}
+        {': '}
+        {truncateText(label)}
+        {suffix}
       </LinkButton>
     );
   }
@@ -68,31 +73,63 @@ export function AutofixEvidence({
         onClick={handleClick}
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
-        {label}
+        {prefix}
+        {': '}
+        {truncateText(label)}
+        {suffix}
       </LinkButton>
     );
   }
 
-  return null;
+  // A tool that produced no navigable resource (e.g. a bash command) renders as a
+  // plain chip rather than a link, so the reader still sees it happened.
+  return (
+    <LinkButton
+      disabled
+      icon={icon}
+      size="zero"
+      to={{}}
+      external
+      tooltipProps={tooltip ? {title: tooltip} : undefined}
+    >
+      {prefix}
+      {': '}
+      {truncateText(label)}
+      {suffix}
+    </LinkButton>
+  );
 }
 
 interface EvidenceButtonInternalProps {
   icon: ReactNode;
-  label: ReactNode;
+  label: string;
+  prefix: string;
   to: LocationDescriptor;
+  suffix?: string;
   tooltip?: ReactNode;
 }
 
 interface EvidenceButtonExternalProps {
   href: string;
   icon: ReactNode;
-  label: ReactNode;
+  label: string;
+  prefix: string;
+  suffix?: string;
+  tooltip?: ReactNode;
+}
+
+interface EvidenceButtonPlainProps {
+  icon: ReactNode;
+  label: string;
+  prefix: string;
+  suffix?: string;
   tooltip?: ReactNode;
 }
 
 export type EvidenceButtonProps =
   | EvidenceButtonInternalProps
-  | EvidenceButtonExternalProps;
+  | EvidenceButtonExternalProps
+  | EvidenceButtonPlainProps;
 
 interface GetEvidencePropsPayload {
   organization: Organization;
@@ -128,6 +165,7 @@ function getTelemetryEvidenceProps({
   return {
     to: target,
     icon: <IconCompass />,
+    prefix: t('Query'),
     label,
     tooltip: question,
   };
@@ -136,18 +174,18 @@ function getTelemetryEvidenceProps({
 function getTelemetryEvidenceLabel(dataset?: string) {
   switch (dataset) {
     case 'issues': {
-      return t('Query: Issues');
+      return t('Issues');
     }
     case 'errors':
-      return t('Query: Errors');
+      return t('Errors');
     case 'logs':
-      return t('Query: Logs');
+      return t('Logs');
     case 'metrics':
     case 'tracemetrics':
-      return t('Query: Metrics');
+      return t('Metrics');
     case 'spans':
     default:
-      return t('Query: Spans');
+      return t('Spans');
   }
 }
 
@@ -178,13 +216,14 @@ function getTraceWaterfallEvidenceProps({
     return null;
   }
 
-  const label = defined(span_id)
-    ? t('Span: %s', getShortEventId(span_id))
-    : t('Trace: %s', getShortEventId(trace_id));
+  const {prefix, label} = defined(span_id)
+    ? {prefix: t('Span'), label: getShortEventId(span_id)}
+    : {prefix: t('Trace'), label: getShortEventId(trace_id)};
 
   return {
     to: target,
     icon: <IconSpan />,
+    prefix,
     label,
   };
 }
@@ -215,7 +254,8 @@ function getIssueDetailsEvidenceProps({
   return {
     to: target,
     icon: <IconIssues />,
-    label: t('Error: %s', getShortEventId(event_id)),
+    prefix: t('Error'),
+    label: getShortEventId(event_id),
   };
 }
 
@@ -245,7 +285,8 @@ function getReplayDetailsEvidenceProps({
   return {
     to: target,
     icon: <IconPlay />,
-    label: t('Replay: %s', getShortEventId(replay_id)),
+    prefix: t('Replay'),
+    label: getShortEventId(replay_id),
   };
 }
 
@@ -275,7 +316,8 @@ function getProfileFlamegraphEvidenceProps({
   return {
     to: target,
     icon: <IconProfiling />,
-    label: t('Profile: %s', getShortEventId(profile_id)),
+    prefix: t('Profile'),
+    label: getShortEventId(profile_id),
   };
 }
 
@@ -289,36 +331,13 @@ function getCodeSearchEvidenceProps({
     if (typeof path !== 'string') {
       return null;
     }
-    const filename = extractFileName(path);
     const {code_url, start_line, end_line} = toolLink?.params ?? {};
-
-    if (!defined(filename) || !defined(code_url)) {
-      return null;
-    }
-
-    const lines =
-      start_line && end_line
-        ? start_line === end_line
-          ? `L${start_line}`
-          : `L${start_line}-L${end_line}`
-        : undefined;
-
-    return {
-      href: lines ? `${code_url}#${lines}` : code_url,
-      icon: <IconFile />,
-      label: t('File: %s%s', truncateText(filename), lines ? ` ${lines}` : ''),
-      tooltip: (
-        <Fragment>
-          {path}
-          {lines && (
-            <Fragment>
-              <br />
-              {lines}
-            </Fragment>
-          )}
-        </Fragment>
-      ),
-    };
+    return getFileEvidenceLink({
+      codeUrl: code_url,
+      filePath: path,
+      startLine: start_line,
+      endLine: end_line,
+    });
   }
 
   return null;
@@ -342,7 +361,8 @@ function getGitSearchEvidenceProps({
     return {
       href: commit_url,
       icon: <RepoProviderIcon provider={provider ?? 'integrations:github'} />,
-      label: t('Commit: %s', truncateText(getShortCommitHash(sha))),
+      prefix: t('Commit'),
+      label: getShortCommitHash(sha),
       tooltip: sha,
     };
   }
@@ -358,7 +378,8 @@ function getGitSearchEvidenceProps({
     return {
       href: commits_url,
       icon: <RepoProviderIcon provider={provider ?? 'integrations:github'} />,
-      label: t('Commits: %s', fileName ? truncateText(fileName) : repo_name),
+      prefix: t('Commit'),
+      label: fileName ? fileName : repo_name,
       tooltip: (
         <Fragment>
           {typeof file_path === 'string' ? file_path : repo_name}
@@ -382,26 +403,85 @@ function getReadFileEvidenceProps({
   if (typeof path !== 'string') {
     return null;
   }
-  const filename = extractFileName(path);
   const {code_url, start_line, end_line} = toolLink?.params ?? {};
+  return getFileEvidenceLink({
+    codeUrl: code_url,
+    filePath: path,
+    startLine: start_line,
+    endLine: end_line,
+  });
+}
 
-  if (!defined(filename) || !defined(code_url)) {
+function getBashEvidenceProps({
+  toolCall,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  // The bash tool emits no navigable resource — its tool link only carries a
+  // description — so evidence is the command itself, rendered as a plain chip
+  // with the full command in the tooltip.
+  const {description, command} = parseArgs(toolCall);
+  const descriptionText =
+    typeof description === 'string' && description ? description : undefined;
+  const commandText = typeof command === 'string' && command ? command : undefined;
+
+  const label = descriptionText ?? commandText;
+  if (!label) {
+    return null;
+  }
+
+  return {
+    icon: <IconTerminal />,
+    prefix: t('Command'),
+    label,
+    tooltip: (
+      <Stack>
+        <p>{label}</p>
+        {commandText && <p>{commandText}</p>}
+      </Stack>
+    ),
+  };
+}
+
+/**
+ * Build a "File: <name>" evidence link from a tool link's code URL.
+ *
+ * `codeUrl` is required; the displayed name is the basename of `filePath`.
+ */
+function getFileEvidenceLink({
+  codeUrl,
+  endLine,
+  filePath,
+  startLine,
+}: {
+  codeUrl: unknown;
+  endLine?: unknown;
+  filePath?: unknown;
+  startLine?: unknown;
+}): EvidenceButtonProps | null {
+  if (typeof codeUrl !== 'string' || typeof filePath !== 'string') {
+    return null;
+  }
+
+  const filename = extractFileName(filePath);
+  if (!defined(filename)) {
     return null;
   }
 
   const lines =
-    start_line && end_line
-      ? start_line === end_line
-        ? `L${start_line}`
-        : `L${start_line}-L${end_line}`
+    typeof startLine === 'number' && typeof endLine === 'number'
+      ? startLine === endLine
+        ? `L${startLine}`
+        : `L${startLine}-L${endLine}`
       : undefined;
+
   return {
-    href: lines ? `${code_url}#${lines}` : code_url,
+    href: lines ? `${codeUrl}#${lines}` : codeUrl,
     icon: <IconFile />,
-    label: t('File: %s%s', truncateText(filename), lines ? ` ${lines}` : ''),
+    prefix: t('File'),
+    label: filename,
+    suffix: ` ${lines}`,
     tooltip: (
       <Fragment>
-        {path}
+        {filePath}
         {lines && (
           <Fragment>
             <br />
@@ -426,6 +506,7 @@ export const AUTOFIX_EVIDENCE_PROPS_RESOLVER: Record<
   code_search: getCodeSearchEvidenceProps,
   git_search: getGitSearchEvidenceProps,
   read_file: getReadFileEvidenceProps,
+  bash: getBashEvidenceProps,
 };
 
 function parseArgs(toolCall: ToolCall): any {

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -479,7 +479,7 @@ function getFileEvidenceLink({
     icon: <IconFile />,
     prefix: t('File'),
     label: filename,
-    suffix: ` ${lines}`,
+    suffix: lines ? ` ${lines}` : undefined,
     tooltip: (
       <Fragment>
         {filePath}

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -1,7 +1,7 @@
 import {Fragment, type ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
-import {LinkButton} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -85,19 +85,17 @@ export function AutofixEvidence({
   // A tool that produced no navigable resource (e.g. a bash command) renders as a
   // plain chip rather than a link, so the reader still sees it happened.
   return (
-    <LinkButton
+    <Button
       disabled
       icon={icon}
       size="zero"
-      to={{}}
-      external
       tooltipProps={tooltip ? {title: tooltip} : undefined}
     >
       {prefix}
       {': '}
       {truncateText(label)}
       {suffix}
-    </LinkButton>
+    </Button>
   );
 }
 
@@ -379,7 +377,7 @@ function getGitSearchEvidenceProps({
     return {
       href: commits_url,
       icon: <RepoProviderIcon provider={provider ?? 'integrations:github'} />,
-      prefix: t('Commit'),
+      prefix: t('Commits'),
       label: fileName ? fileName : repo_name,
       tooltip: (
         <Fragment>
@@ -436,7 +434,7 @@ function getBashEvidenceProps({
     tooltip: (
       <Stack>
         <Text>{label}</Text>
-        {commandText && <Text>{commandText}</Text>}
+        {descriptionText && <Text>{commandText}</Text>}
       </Stack>
     ),
   };

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -3,6 +3,7 @@ import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {IconCompass} from 'sentry/icons/iconCompass';
@@ -434,8 +435,8 @@ function getBashEvidenceProps({
     label,
     tooltip: (
       <Stack>
-        <p>{label}</p>
-        {commandText && <p>{commandText}</p>}
+        <Text>{label}</Text>
+        {commandText && <Text>{commandText}</Text>}
       </Stack>
     ),
   };


### PR DESCRIPTION
This adds support for the bash tool that is part of the bash tools to be
rendered in autofix evidence.