### PR TITLE
feat(scim): Extend privilege sync to support all UserPermissions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1534,6 +1534,10 @@ SENTRY_SCIM_STAFF_TEAM_SLUG: str | None = None
 SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG: str | None = None
 SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG: str | None = None
 
+# Mapping of UserPermission strings to SCIM team slugs.
+# Adding/removing members from these teams grants/revokes the corresponding UserPermission.
+SENTRY_SCIM_PERMISSION_TEAM_SLUGS: dict[str, str] = {}
+
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT: int | None = None
 # DSN for the frontend to use explicitly, which takes priority

--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -49,6 +49,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.roles import organization_roles
 from sentry.signals import member_invited
+from sentry.tasks.scim.privilege_sync import SUPERUSER_WRITE_PERMISSION
 from sentry.users.services.user.service import user_service
 from sentry.utils import json, metrics
 from sentry.utils.cursors import SCIMCursor
@@ -214,21 +215,27 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
             )
 
         # In SaaS mode with the default organization, revoke superuser/staff privileges
-        # in addition to removing the membership.
+        # and any SCIM-managed permissions in addition to removing the membership.
         if (
             settings.SENTRY_MODE == SentryMode.SAAS
             and organization.id == settings.SUPERUSER_ORG_ID
             and user_id is not None
         ):
             user = user_service.get_user(user_id=user_id)
-            if user and (user.is_superuser or user.is_staff):
-                user_service.update_user(
-                    user_id=user.id,
-                    attrs={
-                        "is_superuser": False,
-                        "is_staff": False,
-                    },
+            if user:
+                if user.is_superuser or user.is_staff:
+                    user_service.update_user(
+                        user_id=user.id,
+                        attrs={
+                            "is_superuser": False,
+                            "is_staff": False,
+                        },
+                    )
+                user_service.remove_permission(
+                    user_id=user.id, permission=SUPERUSER_WRITE_PERMISSION
                 )
+                for permission in settings.SENTRY_SCIM_PERMISSION_TEAM_SLUGS:
+                    user_service.remove_permission(user_id=user.id, permission=permission)
 
     def _should_delete_member(self, operation):
         if operation.get("op").lower() == MemberPatchOps.REPLACE:

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -378,15 +378,18 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         return Response(body)
 
     def _should_manage_privileges(self, team: Team) -> bool:
+        if settings.SENTRY_MODE != SentryMode.SAAS:
+            return False
+        if team.organization.id != settings.SUPERUSER_ORG_ID:
+            return False
         return (
-            settings.SENTRY_MODE == SentryMode.SAAS
-            and team.organization.id == settings.SUPERUSER_ORG_ID
-            and team.slug
+            team.slug
             in (
                 settings.SENTRY_SCIM_STAFF_TEAM_SLUG,
                 settings.SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG,
                 settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG,
             )
+            or team.slug in settings.SENTRY_SCIM_PERMISSION_TEAM_SLUGS.values()
         )
 
     def _add_members_operation(

--- a/src/sentry/tasks/scim/privilege_sync.py
+++ b/src/sentry/tasks/scim/privilege_sync.py
@@ -27,28 +27,55 @@ def _resolve_privilege_attrs(team_slug: str, *, grant: bool) -> dict[str, bool]:
     return {}
 
 
+def _slug_to_permission() -> dict[str, str]:
+    """Build a reverse map from team slug to permission string."""
+    return {slug: perm for perm, slug in settings.SENTRY_SCIM_PERMISSION_TEAM_SLUGS.items()}
+
+
+def _resolve_managed_permission(team_slug: str) -> str | None:
+    """Return the UserPermission string managed by this team slug, if any."""
+    if team_slug == settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG:
+        return SUPERUSER_WRITE_PERMISSION
+    return _slug_to_permission().get(team_slug)
+
+
+def _is_privileged_slug(team_slug: str) -> bool:
+    return (
+        team_slug
+        in (
+            settings.SENTRY_SCIM_STAFF_TEAM_SLUG,
+            settings.SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG,
+            settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG,
+        )
+        or team_slug in settings.SENTRY_SCIM_PERMISSION_TEAM_SLUGS.values()
+    )
+
+
 def update_privilege(
     user_id: int,
     attrs: dict[str, bool],
     *,
     grant: bool,
-    manage_write_permission: bool,
+    managed_permission: str | None,
 ) -> None:
     """
-    Update a single user's privilege flags and optionally manage the superuser.write permission.
+    Update a single user's privilege flags and optionally manage a UserPermission.
 
-    For grants with write permission: adds permission first, rolls back on failure.
-    For revokes with write permission: removes permission first (fail-secure).
+    For grants with a permission: adds permission first, rolls back on failure.
+    For revokes with a permission: removes permission first (fail-secure).
     """
     permission_added = False
 
-    if manage_write_permission:
+    if managed_permission:
         if grant:
             permission_added = user_service.add_permission(
-                user_id=user_id, permission=SUPERUSER_WRITE_PERMISSION
+                user_id=user_id, permission=managed_permission
             )
         else:
-            user_service.remove_permission(user_id=user_id, permission=SUPERUSER_WRITE_PERMISSION)
+            user_service.remove_permission(user_id=user_id, permission=managed_permission)
+
+    if not attrs:
+        return
 
     try:
         user_service.update_user(user_id=user_id, attrs=attrs)
@@ -58,11 +85,11 @@ def update_privilege(
             extra={"user_id": user_id},
         )
         if permission_added:
-            user_service.remove_permission(user_id=user_id, permission=SUPERUSER_WRITE_PERMISSION)
+            user_service.remove_permission(user_id=user_id, permission=managed_permission)
         return
     except Exception:
         if permission_added:
-            user_service.remove_permission(user_id=user_id, permission=SUPERUSER_WRITE_PERMISSION)
+            user_service.remove_permission(user_id=user_id, permission=managed_permission)
         raise
 
 
@@ -82,21 +109,17 @@ def sync_scim_team_privileges(
     if settings.SENTRY_MODE != SentryMode.SAAS or organization_id != settings.SUPERUSER_ORG_ID:
         return
 
-    if team_slug not in (
-        settings.SENTRY_SCIM_STAFF_TEAM_SLUG,
-        settings.SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG,
-        settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG,
-    ):
+    if not _is_privileged_slug(team_slug):
         return
 
-    manage_write_permission = team_slug == settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG
+    managed_permission = _resolve_managed_permission(team_slug)
 
     # Revoke
     revoke_attrs = _resolve_privilege_attrs(team_slug, grant=False)
     for user_id in user_ids_to_revoke:
         try:
             update_privilege(
-                user_id, revoke_attrs, grant=False, manage_write_permission=manage_write_permission
+                user_id, revoke_attrs, grant=False, managed_permission=managed_permission
             )
             logger.info(
                 "scim.privilege.revoked",
@@ -118,7 +141,7 @@ def sync_scim_team_privileges(
     for user_id in user_ids_to_grant:
         try:
             update_privilege(
-                user_id, grant_attrs, grant=True, manage_write_permission=manage_write_permission
+                user_id, grant_attrs, grant=True, managed_permission=managed_permission
             )
             logger.info(
                 "scim.privilege.granted",

--- a/src/sentry/tasks/scim/privilege_sync.py
+++ b/src/sentry/tasks/scim/privilege_sync.py
@@ -11,6 +11,7 @@ from sentry.taskworker.namespaces import auth_tasks
 from sentry.users.services.user.service import user_service
 
 logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("sentry.audit.user")
 
 SUPERUSER_WRITE_PERMISSION = "superuser.write"
 
@@ -51,6 +52,17 @@ def _is_privileged_slug(team_slug: str) -> bool:
     )
 
 
+def _audit_permission_change(user_id: int, permission: str | None, *, grant: bool) -> None:
+    audit_logger.info(
+        "user.add-permission" if grant else "user.delete-permission",
+        extra={
+            "actor": "scim",
+            "user_id": user_id,
+            "permission_name": permission,
+        },
+    )
+
+
 def update_privilege(
     user_id: int,
     attrs: dict[str, bool],
@@ -72,9 +84,13 @@ def update_privilege(
                 user_id=user_id, permission=managed_permission
             )
         else:
-            user_service.remove_permission(user_id=user_id, permission=managed_permission)
+            removed = user_service.remove_permission(user_id=user_id, permission=managed_permission)
+            if removed:
+                _audit_permission_change(user_id, managed_permission, grant=False)
 
     if not attrs:
+        if permission_added:
+            _audit_permission_change(user_id, managed_permission, grant=True)
         return
 
     try:
@@ -91,6 +107,9 @@ def update_privilege(
         if permission_added:
             user_service.remove_permission(user_id=user_id, permission=managed_permission)
         raise
+
+    if permission_added:
+        _audit_permission_change(user_id, managed_permission, grant=True)
 
 
 @instrumented_task(

--- a/tests/sentry/tasks/scim/test_privilege_sync.py
+++ b/tests/sentry/tasks/scim/test_privilege_sync.py
@@ -13,6 +13,7 @@ from sentry.tasks.scim.privilege_sync import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 from sentry.users.models.user import User
+from sentry.users.models.userpermission import UserPermission
 from sentry.users.services.user.service import user_service
 
 
@@ -26,9 +27,7 @@ class UpdatePrivilegeGrantTest(TestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not User.objects.get(id=self.user.id).is_staff
 
-        update_privilege(
-            self.user.id, {"is_staff": True}, grant=True, manage_write_permission=False
-        )
+        update_privilege(self.user.id, {"is_staff": True}, grant=True, managed_permission=None)
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.get(id=self.user.id).is_staff
@@ -37,23 +36,19 @@ class UpdatePrivilegeGrantTest(TestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not User.objects.get(id=self.user.id).is_superuser
 
-        update_privilege(
-            self.user.id, {"is_superuser": True}, grant=True, manage_write_permission=False
-        )
+        update_privilege(self.user.id, {"is_superuser": True}, grant=True, managed_permission=None)
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.get(id=self.user.id).is_superuser
 
     def test_grant_superuser_write_sets_superuser_and_permission(self) -> None:
-        from sentry.users.models.userpermission import UserPermission
-
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not UserPermission.objects.filter(
                 user_id=self.user.id, permission="superuser.write"
             ).exists()
 
         update_privilege(
-            self.user.id, {"is_superuser": True}, grant=True, manage_write_permission=True
+            self.user.id, {"is_superuser": True}, grant=True, managed_permission="superuser.write"
         )
 
         user = user_service.get_user(user_id=self.user.id)
@@ -66,8 +61,6 @@ class UpdatePrivilegeGrantTest(TestCase):
             ).exists()
 
     def test_grant_superuser_write_rolls_back_permission_on_failure(self) -> None:
-        from sentry.users.models.userpermission import UserPermission
-
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not UserPermission.objects.filter(
                 user_id=self.user.id, permission="superuser.write"
@@ -81,7 +74,7 @@ class UpdatePrivilegeGrantTest(TestCase):
                     self.user.id,
                     {"is_superuser": True},
                     grant=True,
-                    manage_write_permission=True,
+                    managed_permission="superuser.write",
                 )
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -90,8 +83,6 @@ class UpdatePrivilegeGrantTest(TestCase):
             ).exists()
 
     def test_grant_superuser_write_integrity_error_removes_permission_without_raising(self) -> None:
-        from sentry.users.models.userpermission import UserPermission
-
         with patch("sentry.tasks.scim.privilege_sync.user_service.update_user") as mock_update:
             mock_update.side_effect = IntegrityError("user deleted")
 
@@ -99,7 +90,7 @@ class UpdatePrivilegeGrantTest(TestCase):
                 self.user.id,
                 {"is_superuser": True},
                 grant=True,
-                manage_write_permission=True,
+                managed_permission="superuser.write",
             )
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -117,9 +108,7 @@ class UpdatePrivilegeRevokeTest(TestCase):
     def test_revoke_staff(self) -> None:
         user_service.update_user(user_id=self.user.id, attrs={"is_staff": True})
 
-        update_privilege(
-            self.user.id, {"is_staff": False}, grant=False, manage_write_permission=False
-        )
+        update_privilege(self.user.id, {"is_staff": False}, grant=False, managed_permission=None)
 
         user = user_service.get_user(user_id=self.user.id)
         assert user is not None
@@ -129,7 +118,7 @@ class UpdatePrivilegeRevokeTest(TestCase):
         user_service.update_user(user_id=self.user.id, attrs={"is_superuser": True})
 
         update_privilege(
-            self.user.id, {"is_superuser": False}, grant=False, manage_write_permission=False
+            self.user.id, {"is_superuser": False}, grant=False, managed_permission=None
         )
 
         user = user_service.get_user(user_id=self.user.id)
@@ -137,14 +126,12 @@ class UpdatePrivilegeRevokeTest(TestCase):
         assert not user.is_superuser
 
     def test_revoke_superuser_write_removes_permission_and_superuser(self) -> None:
-        from sentry.users.models.userpermission import UserPermission
-
         user_service.update_user(user_id=self.user.id, attrs={"is_superuser": True})
         with assume_test_silo_mode(SiloMode.CONTROL):
             UserPermission.objects.create(user_id=self.user.id, permission="superuser.write")
 
         update_privilege(
-            self.user.id, {"is_superuser": False}, grant=False, manage_write_permission=True
+            self.user.id, {"is_superuser": False}, grant=False, managed_permission="superuser.write"
         )
 
         user = user_service.get_user(user_id=self.user.id)
@@ -157,8 +144,6 @@ class UpdatePrivilegeRevokeTest(TestCase):
             ).exists()
 
     def test_revoke_superuser_write_failure_keeps_permission_removed(self) -> None:
-        from sentry.users.models.userpermission import UserPermission
-
         user_service.update_user(
             user_id=self.user.id, attrs={"is_staff": True, "is_superuser": True}
         )
@@ -173,7 +158,7 @@ class UpdatePrivilegeRevokeTest(TestCase):
                     self.user.id,
                     {"is_superuser": False},
                     grant=False,
-                    manage_write_permission=True,
+                    managed_permission="superuser.write",
                 )
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -182,14 +167,14 @@ class UpdatePrivilegeRevokeTest(TestCase):
             ).exists()
 
 
-PRIVILEGE_SETTINGS = {
-    "SENTRY_SCIM_STAFF_TEAM_SLUG": "snty-staff",
-    "SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG": "snty-superuser-read",
-    "SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG": "snty-superuser-write",
-}
-
-
 @cell_silo_test
+@override_settings(
+    SENTRY_MODE=SentryMode.SAAS,
+    SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+    SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+    SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+    SENTRY_SCIM_PERMISSION_TEAM_SLUGS={"broadcasts.admin": "snty-broadcasts-admin"},
+)
 class SyncScimTeamPrivilegesTaskTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -197,12 +182,9 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
         self.user_two = self.create_user(email="user2@example.com")
         self.organization = self.create_organization(name="Test Org")
 
+    @override_settings(SENTRY_MODE=SentryMode.SELF_HOSTED)
     def test_non_saas_mode_is_noop(self) -> None:
-        with override_settings(
-            SENTRY_MODE=SentryMode.SELF_HOSTED,
-            SUPERUSER_ORG_ID=self.organization.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
             sync_scim_team_privileges(
                 team_slug="snty-staff",
                 organization_id=self.organization.id,
@@ -210,17 +192,13 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                 user_ids_to_revoke=[],
             )
 
-            user = user_service.get_user(user_id=self.user_one.id)
-            assert user is not None
-            assert not user.is_staff
+        user = user_service.get_user(user_id=self.user_one.id)
+        assert user is not None
+        assert not user.is_staff
 
     def test_wrong_org_is_noop(self) -> None:
         other_org = self.create_organization(name="Other Org")
-        with override_settings(
-            SENTRY_MODE=SentryMode.SAAS,
-            SUPERUSER_ORG_ID=other_org.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=other_org.id):
             sync_scim_team_privileges(
                 team_slug="snty-staff",
                 organization_id=self.organization.id,
@@ -228,18 +206,14 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                 user_ids_to_revoke=[],
             )
 
-            user = user_service.get_user(user_id=self.user_one.id)
-            assert user is not None
-            assert not user.is_staff
+        user = user_service.get_user(user_id=self.user_one.id)
+        assert user is not None
+        assert not user.is_staff
 
     def test_batch_grant_and_revoke(self) -> None:
         user_service.update_user(user_id=self.user_two.id, attrs={"is_staff": True})
 
-        with override_settings(
-            SENTRY_MODE=SentryMode.SAAS,
-            SUPERUSER_ORG_ID=self.organization.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
             sync_scim_team_privileges(
                 team_slug="snty-staff",
                 organization_id=self.organization.id,
@@ -247,20 +221,16 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                 user_ids_to_revoke=[self.user_two.id],
             )
 
-            user_one = user_service.get_user(user_id=self.user_one.id)
-            assert user_one is not None
-            assert user_one.is_staff
+        user_one = user_service.get_user(user_id=self.user_one.id)
+        assert user_one is not None
+        assert user_one.is_staff
 
-            user_two = user_service.get_user(user_id=self.user_two.id)
-            assert user_two is not None
-            assert not user_two.is_staff
+        user_two = user_service.get_user(user_id=self.user_two.id)
+        assert user_two is not None
+        assert not user_two.is_staff
 
     def test_grant_failure_raises(self) -> None:
-        with override_settings(
-            SENTRY_MODE=SentryMode.SAAS,
-            SUPERUSER_ORG_ID=self.organization.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
             with patch("sentry.tasks.scim.privilege_sync.update_privilege") as mock_update:
                 mock_update.side_effect = Exception("grant failure")
 
@@ -273,11 +243,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                     )
 
     def test_revoke_failure_raises(self) -> None:
-        with override_settings(
-            SENTRY_MODE=SentryMode.SAAS,
-            SUPERUSER_ORG_ID=self.organization.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
             with patch("sentry.tasks.scim.privilege_sync.update_privilege") as mock_update:
                 mock_update.side_effect = Exception("revoke failure")
 
@@ -290,11 +256,7 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                     )
 
     def test_unknown_team_slug_is_noop(self) -> None:
-        with override_settings(
-            SENTRY_MODE=SentryMode.SAAS,
-            SUPERUSER_ORG_ID=self.organization.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
             sync_scim_team_privileges(
                 team_slug="some-random-team",
                 organization_id=self.organization.id,
@@ -302,17 +264,13 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                 user_ids_to_revoke=[],
             )
 
-            user = user_service.get_user(user_id=self.user_one.id)
-            assert user is not None
-            assert not user.is_staff
-            assert not user.is_superuser
+        user = user_service.get_user(user_id=self.user_one.id)
+        assert user is not None
+        assert not user.is_staff
+        assert not user.is_superuser
 
     def test_empty_lists_is_noop(self) -> None:
-        with override_settings(
-            SENTRY_MODE=SentryMode.SAAS,
-            SUPERUSER_ORG_ID=self.organization.id,
-            **PRIVILEGE_SETTINGS,
-        ):
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
             sync_scim_team_privileges(
                 team_slug="snty-staff",
                 organization_id=self.organization.id,
@@ -320,6 +278,82 @@ class SyncScimTeamPrivilegesTaskTest(TestCase):
                 user_ids_to_revoke=[],
             )
 
-            user_one = user_service.get_user(user_id=self.user_one.id)
-            assert user_one is not None
-            assert not user_one.is_staff
+        user_one = user_service.get_user(user_id=self.user_one.id)
+        assert user_one is not None
+        assert not user_one.is_staff
+
+    def test_superuser_write_grant_sets_superuser_and_permission(self) -> None:
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
+            sync_scim_team_privileges(
+                team_slug="snty-superuser-write",
+                organization_id=self.organization.id,
+                user_ids_to_grant=[self.user_one.id],
+                user_ids_to_revoke=[],
+            )
+
+        user = user_service.get_user(user_id=self.user_one.id)
+        assert user is not None
+        assert user.is_superuser
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert UserPermission.objects.filter(
+                user_id=self.user_one.id, permission="superuser.write"
+            ).exists()
+
+    def test_superuser_write_revoke_removes_superuser_and_permission(self) -> None:
+        user_service.update_user(user_id=self.user_one.id, attrs={"is_superuser": True})
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            UserPermission.objects.create(user_id=self.user_one.id, permission="superuser.write")
+
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
+            sync_scim_team_privileges(
+                team_slug="snty-superuser-write",
+                organization_id=self.organization.id,
+                user_ids_to_grant=[],
+                user_ids_to_revoke=[self.user_one.id],
+            )
+
+        user = user_service.get_user(user_id=self.user_one.id)
+        assert user is not None
+        assert not user.is_superuser
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not UserPermission.objects.filter(
+                user_id=self.user_one.id, permission="superuser.write"
+            ).exists()
+
+    def test_permission_team_grant_adds_permission_only(self) -> None:
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
+            sync_scim_team_privileges(
+                team_slug="snty-broadcasts-admin",
+                organization_id=self.organization.id,
+                user_ids_to_grant=[self.user_one.id],
+                user_ids_to_revoke=[],
+            )
+
+        user = user_service.get_user(user_id=self.user_one.id)
+        assert user is not None
+        assert not user.is_staff
+        assert not user.is_superuser
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert UserPermission.objects.filter(
+                user_id=self.user_one.id, permission="broadcasts.admin"
+            ).exists()
+
+    def test_permission_team_revoke_removes_permission_only(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            UserPermission.objects.create(user_id=self.user_one.id, permission="broadcasts.admin")
+
+        with override_settings(SUPERUSER_ORG_ID=self.organization.id):
+            sync_scim_team_privileges(
+                team_slug="snty-broadcasts-admin",
+                organization_id=self.organization.id,
+                user_ids_to_grant=[],
+                user_ids_to_revoke=[self.user_one.id],
+            )
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not UserPermission.objects.filter(
+                user_id=self.user_one.id, permission="broadcasts.admin"
+            ).exists()


### PR DESCRIPTION
Add a dict-based setting (SENTRY_SCIM_PERMISSION_TEAM_SLUGS) that maps arbitrary UserPermission strings to SCIM team slugs. Adding or removing members from these teams now grants or revokes the corresponding permission, following the same pattern as the existing staff/superuser privilege sync.

The task worker generalizes the superuser.write-specific boolean into a generic managed_permission parameter that works for any permission string. Permission-only teams skip the user model flag update entirely.

Also fixes a pre-existing gap where deleting a SCIM member did not revoke the superuser.write permission row.
