### PR TITLE
feat(explore): Preserve span samples when adding columns

### DIFF
--- a/static/app/views/explore/exploreLocationQueryParamsProvider.spec.tsx
+++ b/static/app/views/explore/exploreLocationQueryParamsProvider.spec.tsx
@@ -8,6 +8,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {ExploreLocationQueryParamsProvider} from 'sentry/views/explore/exploreLocationQueryParamsProvider';
 import {
   useQueryParamsQuery,
+  useSetQueryParams,
   useSetQueryParamsQuery,
 } from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -45,11 +46,15 @@ function isDefaultFields(): boolean {
 
 function TestComponent() {
   const query = useQueryParamsQuery();
+  const setQueryParams = useSetQueryParams();
   const setQuery = useSetQueryParamsQuery();
   return (
     <div>
       <div>query: {query}</div>
       <button onClick={() => setQuery('changed')}>set changed</button>
+      <button onClick={() => setQueryParams({query: 'replaced'}, {replace: true})}>
+        set replaced
+      </button>
       <button onClick={() => setQuery(query)}>set same</button>
     </div>
   );
@@ -99,6 +104,24 @@ describe('ExploreLocationQueryParamsProvider', () => {
 
     // A single back returns to the original query, proving the same-value set
     // did not push a duplicate 'changed' entry.
+    router.navigate(-1);
+    await waitFor(() => expect(router.location.query.q).toBe('start'));
+  });
+
+  it('replaces the current history entry when requested', async () => {
+    const {router} = render(
+      <Wrapper>
+        <TestComponent />
+      </Wrapper>,
+      {initialRouterConfig: {location: {pathname: '/traces/', query: {q: 'start'}}}}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'set changed'}));
+    expect(await screen.findByText('query: changed')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'set replaced'}));
+    expect(await screen.findByText('query: replaced')).toBeInTheDocument();
+
     router.navigate(-1);
     await waitFor(() => expect(router.location.query.q).toBe('start'));
   });

--- a/static/app/views/explore/exploreLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/exploreLocationQueryParamsProvider.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import {useCallback, useMemo, useRef} from 'react';
+import type {NavigateOptions} from 'react-router-dom';
 import type {Location} from 'history';
 
 import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
@@ -54,7 +55,7 @@ export function ExploreLocationQueryParamsProvider({
   );
 
   const setWritableQueryParams = useCallback(
-    (writableQueryParams: WritableQueryParams) => {
+    (writableQueryParams: WritableQueryParams, options?: NavigateOptions) => {
       onSetWritableQueryParams?.(writableQueryParams);
 
       const target = getTargetWithReadableQueryParams(
@@ -62,7 +63,7 @@ export function ExploreLocationQueryParamsProvider({
         writableQueryParams
       );
 
-      navigateIfQueryChanged(navigate, locationRef.current, target);
+      navigateIfQueryChanged(navigate, locationRef.current, target, options);
     },
     [navigate, getTargetWithReadableQueryParams, onSetWritableQueryParams]
   );

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -234,6 +234,7 @@ function useTrackAnalytics({
     if (
       queryType !== 'samples' ||
       spansTableResult.result.isPending ||
+      spansTableResult.result.isPlaceholderData ||
       timeseriesResult.isPending ||
       isLoadingSubscriptionDetails ||
       isLoadingSeerSetup
@@ -332,6 +333,7 @@ function useTrackAnalytics({
     query_status,
     spansTableResult.result.data?.length,
     spansTableResult.result.isPending,
+    spansTableResult.result.isPlaceholderData,
     spansTableResult.result.meta?.dataScanned,
     tableErrorBox,
     chartErrorBox,

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -158,6 +158,7 @@ describe('useExploreSpansTable', () => {
     await waitFor(() =>
       expect(result.current.spansTable.result.data).toEqual(initialData)
     );
+    const initialRequestIdentityKey = result.current.spansTable.requestIdentityKey;
 
     act(() => result.current.setFields([...result.current.fields, 'span.custom']));
 
@@ -174,6 +175,7 @@ describe('useExploreSpansTable', () => {
       )
     );
     expect(result.current.spansTable.result.pageLinks).toBe(originalPageLinks);
+    expect(result.current.spansTable.requestIdentityKey).toBe(initialRequestIdentityKey);
   });
 
   it('does not reuse a visible-sample lock after the query changes', async () => {

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -229,6 +229,7 @@ describe('useExploreSpansTable', () => {
         initialRouterConfig: {
           location: {
             pathname: '/organizations/org-slug/explore/traces/',
+            query: {cursor: '0:100:0'},
           },
         },
       }
@@ -244,7 +245,7 @@ describe('useExploreSpansTable', () => {
     expect(filteredFieldsRequest).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
       expect.objectContaining({
-        query: expect.objectContaining({query: expectedQuery}),
+        query: expect.objectContaining({cursor: '', query: expectedQuery}),
       })
     );
     await waitFor(() =>
@@ -262,6 +263,110 @@ describe('useExploreSpansTable', () => {
       expect.objectContaining({
         query: expect.objectContaining({query: expectedQuery}),
       })
+    );
+  });
+
+  it('does not reuse a visible-sample lock after the query changes', async () => {
+    const initialData = [{id: 'aaaaaaaaaaaaaaaa'}];
+    const refreshedData = [{id: 'cccccccccccccccc', 'span.custom': 'fresh value'}];
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: initialData,
+        meta: {dataScanned: 'full', fields: {id: 'string'}},
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return (
+            options.query.query === 'span.op:http' &&
+            !options.query.field.includes('span.custom')
+          );
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{...initialData[0], 'span.custom': 'value'}],
+        meta: {
+          dataScanned: 'full',
+          fields: {id: 'string', 'span.custom': 'string'},
+        },
+      },
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          query: 'span.op:http id:[aaaaaaaaaaaaaaaa]',
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{id: 'bbbbbbbbbbbbbbbb', 'span.custom': 'other value'}],
+        meta: {
+          dataScanned: 'full',
+          fields: {id: 'string', 'span.custom': 'string'},
+        },
+      },
+      method: 'GET',
+      match: [MockApiClient.matchQuery({query: 'span.op:db'})],
+    });
+    const refreshedOriginalQueryRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: refreshedData,
+        meta: {
+          dataScanned: 'full',
+          fields: {id: 'string', 'span.custom': 'string'},
+        },
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return (
+            options.query.query === 'span.op:http' &&
+            options.query.field.includes('span.custom')
+          );
+        },
+      ],
+    });
+
+    const {result, rerender} = renderHookWithProviders(
+      ({query}) => useTestExploreSpansTable(query),
+      {
+        additionalWrapper: Wrapper,
+        initialProps: {query: 'span.op:http'},
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+          },
+        },
+      }
+    );
+
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual(initialData)
+    );
+    act(() => result.current.setFields([...result.current.fields, 'span.custom']));
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual([
+        {...initialData[0], 'span.custom': 'value'},
+      ])
+    );
+
+    rerender({query: 'span.op:db'});
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual([
+        {id: 'bbbbbbbbbbbbbbbb', 'span.custom': 'other value'},
+      ])
+    );
+
+    rerender({query: 'span.op:http'});
+    await waitFor(() => expect(refreshedOriginalQueryRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual(refreshedData)
     );
   });
 

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -159,12 +159,7 @@ describe('useExploreSpansTable', () => {
     const query = 'span.op:http OR span.op:db';
     const expectedQuery =
       '(span.op:http OR span.op:db) id:[aaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb]';
-    const originalPageLinks =
-      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
-      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
-    const filteredPageLinks =
-      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
-      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:100:0>; rel="next"; results="false"; cursor="0:100:0"';
+    const originalPageLinks = 'original page links';
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
@@ -188,7 +183,7 @@ describe('useExploreSpansTable', () => {
           fields: {id: 'string', 'span.custom': 'string'},
         },
       },
-      headers: {Link: filteredPageLinks},
+      headers: {Link: 'filtered page links'},
       method: 'GET',
       match: [
         function (_url: string, options: Record<string, any>) {
@@ -295,9 +290,9 @@ describe('useExploreSpansTable', () => {
       },
       method: 'GET',
       match: [
-        MockApiClient.matchQuery({
-          query: '(span.op:http) id:[aaaaaaaaaaaaaaaa]',
-        }),
+        function (_url: string, options: Record<string, any>) {
+          return options.query.query.includes('id:[aaaaaaaaaaaaaaaa]');
+        },
       ],
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -1,17 +1,33 @@
 import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
-import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useExploreSpansTable} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {
+  useQueryParamsFields,
+  useSetQueryParamsFields,
+} from 'sentry/views/explore/queryParams/context';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 
 jest.mock('sentry/components/pageFilters/usePageFilters');
 
 function Wrapper({children}: {children: ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
+}
+
+function useTestExploreSpansTable(query: string) {
+  const fields = useQueryParamsFields();
+  const setFields = useSetQueryParamsFields();
+  const spansTable = useExploreSpansTable({
+    query,
+    enabled: true,
+    limit: 10,
+  });
+
+  return {fields, setFields, spansTable};
 }
 
 describe('useExploreSpansTable', () => {
@@ -85,6 +101,166 @@ describe('useExploreSpansTable', () => {
           sampling: SAMPLING_MODE.HIGH_ACCURACY,
           query: 'test value',
         }),
+      })
+    );
+  });
+
+  it('keeps the previous samples while updated fields load', async () => {
+    const initialData = [{id: 'aaaaaaaaaaaaaaaa'}];
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: initialData,
+        meta: {
+          dataScanned: 'full',
+          fields: {id: 'string'},
+        },
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return !options.query.field.includes('span.custom');
+        },
+      ],
+    });
+    const updatedFieldsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: new Promise(() => {}),
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.field.includes('span.custom');
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(() => useTestExploreSpansTable(''), {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual(initialData)
+    );
+
+    act(() => result.current.setFields([...result.current.fields, 'span.custom']));
+
+    await waitFor(() => expect(updatedFieldsRequest).toHaveBeenCalledTimes(1));
+    expect(result.current.spansTable.result.data).toEqual(initialData);
+    expect(result.current.spansTable.result.isPlaceholderData).toBe(true);
+  });
+
+  it('filters field-only refreshes to the current sample ids', async () => {
+    const initialData = [{id: 'aaaaaaaaaaaaaaaa'}, {id: 'bbbbbbbbbbbbbbbb'}];
+    const expectedQuery = 'span.op:http id:[aaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb]';
+    const originalPageLinks =
+      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
+      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
+    const filteredPageLinks =
+      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
+      '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:100:0>; rel="next"; results="false"; cursor="0:100:0"';
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: initialData,
+        meta: {dataScanned: 'full', fields: {id: 'string'}},
+      },
+      headers: {Link: originalPageLinks},
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return !options.query.field.includes('span.custom');
+        },
+      ],
+    });
+    const filteredFieldsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: initialData.map(row => ({...row, 'span.custom': 'value'})),
+        meta: {
+          dataScanned: 'full',
+          fields: {id: 'string', 'span.custom': 'string'},
+        },
+      },
+      headers: {Link: filteredPageLinks},
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return (
+            options.query.field.includes('span.custom') &&
+            !options.query.field.includes('span.other')
+          );
+        },
+      ],
+    });
+    const secondFilteredFieldsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: initialData.map(row => ({
+          ...row,
+          'span.custom': 'value',
+          'span.other': 'other value',
+        })),
+        meta: {
+          dataScanned: 'full',
+          fields: {
+            id: 'string',
+            'span.custom': 'string',
+            'span.other': 'string',
+          },
+        },
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.field.includes('span.other');
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(
+      () => useTestExploreSpansTable('span.op:http'),
+      {
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+          },
+        },
+      }
+    );
+
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual(initialData)
+    );
+
+    act(() => result.current.setFields([...result.current.fields, 'span.custom']));
+
+    await waitFor(() => expect(filteredFieldsRequest).toHaveBeenCalledTimes(1));
+    expect(filteredFieldsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({query: expectedQuery}),
+      })
+    );
+    await waitFor(() =>
+      expect(result.current.spansTable.result.data).toEqual(
+        initialData.map(row => ({...row, 'span.custom': 'value'}))
+      )
+    );
+    expect(result.current.spansTable.result.pageLinks).toBe(originalPageLinks);
+
+    act(() => result.current.setFields([...result.current.fields, 'span.other']));
+
+    await waitFor(() => expect(secondFilteredFieldsRequest).toHaveBeenCalledTimes(1));
+    expect(secondFilteredFieldsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({query: expectedQuery}),
       })
     );
   });

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -105,55 +105,6 @@ describe('useExploreSpansTable', () => {
     );
   });
 
-  it('keeps the previous samples while updated fields load', async () => {
-    const initialData = [{id: 'aaaaaaaaaaaaaaaa'}];
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: initialData,
-        meta: {
-          dataScanned: 'full',
-          fields: {id: 'string'},
-        },
-      },
-      method: 'GET',
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return !options.query.field.includes('span.custom');
-        },
-      ],
-    });
-    const updatedFieldsRequest = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: new Promise(() => {}),
-      method: 'GET',
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.query.field.includes('span.custom');
-        },
-      ],
-    });
-
-    const {result} = renderHookWithProviders(() => useTestExploreSpansTable(''), {
-      additionalWrapper: Wrapper,
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/explore/traces/',
-        },
-      },
-    });
-
-    await waitFor(() =>
-      expect(result.current.spansTable.result.data).toEqual(initialData)
-    );
-
-    act(() => result.current.setFields([...result.current.fields, 'span.custom']));
-
-    await waitFor(() => expect(updatedFieldsRequest).toHaveBeenCalledTimes(1));
-    expect(result.current.spansTable.result.data).toEqual(initialData);
-    expect(result.current.spansTable.result.isPlaceholderData).toBe(true);
-  });
-
   it('filters field-only refreshes to the current sample ids', async () => {
     const initialData = [{id: 'aaaaaaaaaaaaaaaa'}, {id: 'bbbbbbbbbbbbbbbb'}];
     const query = 'span.op:http OR span.op:db';
@@ -194,31 +145,6 @@ describe('useExploreSpansTable', () => {
         },
       ],
     });
-    const secondFilteredFieldsRequest = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: initialData.map(row => ({
-          ...row,
-          'span.custom': 'value',
-          'span.other': 'other value',
-        })),
-        meta: {
-          dataScanned: 'full',
-          fields: {
-            id: 'string',
-            'span.custom': 'string',
-            'span.other': 'string',
-          },
-        },
-      },
-      method: 'GET',
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.query.field.includes('span.other');
-        },
-      ],
-    });
-
     const {result} = renderHookWithProviders(() => useTestExploreSpansTable(query), {
       additionalWrapper: Wrapper,
       initialRouterConfig: {
@@ -248,16 +174,6 @@ describe('useExploreSpansTable', () => {
       )
     );
     expect(result.current.spansTable.result.pageLinks).toBe(originalPageLinks);
-
-    act(() => result.current.setFields([...result.current.fields, 'span.other']));
-
-    await waitFor(() => expect(secondFilteredFieldsRequest).toHaveBeenCalledTimes(1));
-    expect(secondFilteredFieldsRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      expect.objectContaining({
-        query: expect.objectContaining({query: expectedQuery}),
-      })
-    );
   });
 
   it('does not reuse a visible-sample lock after the query changes', async () => {

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -156,7 +156,9 @@ describe('useExploreSpansTable', () => {
 
   it('filters field-only refreshes to the current sample ids', async () => {
     const initialData = [{id: 'aaaaaaaaaaaaaaaa'}, {id: 'bbbbbbbbbbbbbbbb'}];
-    const expectedQuery = 'span.op:http id:[aaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb]';
+    const query = 'span.op:http OR span.op:db';
+    const expectedQuery =
+      '(span.op:http OR span.op:db) id:[aaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb]';
     const originalPageLinks =
       '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
       '<http://localhost/api/0/organizations/org-slug/events/?cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
@@ -222,18 +224,15 @@ describe('useExploreSpansTable', () => {
       ],
     });
 
-    const {result} = renderHookWithProviders(
-      () => useTestExploreSpansTable('span.op:http'),
-      {
-        additionalWrapper: Wrapper,
-        initialRouterConfig: {
-          location: {
-            pathname: '/organizations/org-slug/explore/traces/',
-            query: {cursor: '0:100:0'},
-          },
+    const {result} = renderHookWithProviders(() => useTestExploreSpansTable(query), {
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {cursor: '0:100:0'},
         },
-      }
-    );
+      },
+    });
 
     await waitFor(() =>
       expect(result.current.spansTable.result.data).toEqual(initialData)
@@ -297,7 +296,7 @@ describe('useExploreSpansTable', () => {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          query: 'span.op:http id:[aaaaaaaaaaaaaaaa]',
+          query: '(span.op:http) id:[aaaaaaaaaaaaaaaa]',
         }),
       ],
     });

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -191,7 +191,7 @@ export function useExploreSpansTable({
     // Keep the links from the original response so pagination can leave the lock.
     return {
       ...spansTableResult,
-      requestIdentityKey: identityKey,
+      requestIdentityKey: visibleSamples.identityKey,
       result: {
         ...spansTableResult.result,
         pageLinks: visibleSamples.pageLinks,

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -1,14 +1,15 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {NewQuery} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
-import {EventView} from 'sentry/utils/discover/eventView';
+import {EventView, type EventData} from 'sentry/utils/discover/eventView';
 import {
   useProgressiveQuery,
   type RPCQueryExtras,
 } from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
+  useQueryParamsCursor,
   useQueryParamsExtrapolate,
   useQueryParamsFields,
   useQueryParamsSortBys,
@@ -25,7 +26,24 @@ interface UseExploreSpansTableOptions {
 
 export interface SpansTableResult {
   eventView: EventView;
-  result: ReturnType<typeof useSpansQuery<any[]>>;
+  result: ReturnType<typeof useSpansQuery<EventData[]>>;
+}
+
+interface ResolvedSpanSamples {
+  data: EventData[];
+  fieldsKey: string;
+  identityKey: string;
+  pageLinks: string | undefined;
+  spanIds: string[];
+}
+
+interface SpanSamplesRequestState {
+  lastResolved: ResolvedSpanSamples | null;
+  lockedSamples: {
+    identityKey: string;
+    pageLinks: string | undefined;
+    spanIds: string[];
+  } | null;
 }
 
 export function useExploreSpansTable({
@@ -34,10 +52,59 @@ export function useExploreSpansTable({
   query,
   queryExtras,
 }: UseExploreSpansTableOptions) {
+  const {selection} = usePageFilters();
   const extrapolate = useQueryParamsExtrapolate();
+  const cursor = useQueryParamsCursor();
+  const dataset = useSpansDataset();
+  const fields = useQueryParamsFields();
+  const sortBys = useQueryParamsSortBys();
+
+  const fieldsKey = JSON.stringify(fields);
+  const identityKey = useMemo(
+    () =>
+      JSON.stringify([
+        cursor,
+        dataset,
+        limit,
+        query,
+        queryExtras,
+        selection.datetime,
+        selection.environments,
+        selection.projects,
+        sortBys,
+      ]),
+    [cursor, dataset, limit, query, queryExtras, selection, sortBys]
+  );
+  const [requestState, setRequestState] = useState<SpanSamplesRequestState>({
+    lastResolved: null,
+    lockedSamples: null,
+  });
+
+  const visibleSamples = useMemo(() => {
+    if (requestState.lockedSamples?.identityKey === identityKey) {
+      return requestState.lockedSamples;
+    }
+
+    if (
+      requestState.lastResolved?.identityKey === identityKey &&
+      requestState.lastResolved.fieldsKey !== fieldsKey &&
+      requestState.lastResolved.spanIds.length > 0
+    ) {
+      return {
+        identityKey,
+        pageLinks: requestState.lastResolved.pageLinks,
+        spanIds: requestState.lastResolved.spanIds,
+      };
+    }
+
+    return;
+  }, [fieldsKey, identityKey, requestState]);
+  const constrainedQuery = visibleSamples
+    ? [query, `id:[${visibleSamples.spanIds.join(',')}]`].filter(Boolean).join(' ')
+    : query;
 
   const canTriggerHighAccuracy = useCallback(
-    (results: ReturnType<typeof useSpansQuery<any[]>>) => {
+    (results: ReturnType<typeof useSpansQuery<EventData[]>>) => {
       const canGoToHigherAccuracyTier = results.meta?.dataScanned === 'partial';
       const hasData = defined(results.data) && results.data.length > 0;
       return !hasData && canGoToHigherAccuracyTier;
@@ -45,14 +112,72 @@ export function useExploreSpansTable({
     []
   );
 
-  return useProgressiveQuery<typeof useExploreSpansTableImp>({
+  const spansTableResult = useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
-    queryHookArgs: {enabled, limit, query, queryExtras},
+    queryHookArgs: {enabled, limit, query: constrainedQuery, queryExtras},
     queryOptions: {
       canTriggerHighAccuracy,
       disableExtrapolation: !extrapolate,
     },
   });
+
+  const resolvedSamples = useMemo<ResolvedSpanSamples | null>(() => {
+    const {result} = spansTableResult;
+    if (!enabled || !result.isSuccess || result.isPlaceholderData || !result.data) {
+      return null;
+    }
+
+    const spanIds = Array.from(
+      new Set(
+        result.data
+          .map(row => row.id)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      )
+    );
+
+    return {
+      data: result.data,
+      fieldsKey,
+      identityKey,
+      pageLinks: result.pageLinks,
+      spanIds,
+    };
+  }, [enabled, fieldsKey, identityKey, spansTableResult]);
+
+  const shouldUpdateLastResolved =
+    resolvedSamples !== null &&
+    (requestState.lastResolved?.data !== resolvedSamples.data ||
+      requestState.lastResolved.fieldsKey !== resolvedSamples.fieldsKey ||
+      requestState.lastResolved.identityKey !== resolvedSamples.identityKey);
+  const shouldLockVisibleSamples =
+    visibleSamples !== undefined && requestState.lockedSamples !== visibleSamples;
+
+  if (shouldUpdateLastResolved || shouldLockVisibleSamples) {
+    setRequestState({
+      lastResolved: shouldUpdateLastResolved
+        ? resolvedSamples
+        : requestState.lastResolved,
+      lockedSamples: shouldLockVisibleSamples
+        ? visibleSamples
+        : requestState.lockedSamples,
+    });
+  }
+
+  return useMemo(() => {
+    if (!visibleSamples) {
+      return spansTableResult;
+    }
+
+    // The constrained response only describes pagination within the visible IDs.
+    // Keep the links from the original response so pagination can leave the lock.
+    return {
+      ...spansTableResult,
+      result: {
+        ...spansTableResult.result,
+        pageLinks: visibleSamples.pageLinks,
+      },
+    };
+  }, [spansTableResult, visibleSamples]);
 }
 
 function useExploreSpansTableImp({
@@ -93,12 +218,13 @@ function useExploreSpansTableImp({
     };
 
     return EventView.fromNewQueryWithPageFilters(discoverQuery, selection);
-  }, [dataset, sortBys, query, selection, visibleFields]);
+  }, [dataset, query, selection, sortBys, visibleFields]);
 
-  const result = useSpansQuery({
+  const result = useSpansQuery<EventData[]>({
     enabled,
     eventView,
     initialData: [],
+    keepPreviousData: true,
     limit,
     referrer: 'api.explore.spans-samples-table',
     allowAggregateConditions: false,

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -31,6 +31,7 @@ interface UseExploreSpansTableImpOptions extends UseExploreSpansTableOptions {
 export interface SpansTableResult {
   eventView: EventView;
   result: ReturnType<typeof useSpansQuery<EventData[]>>;
+  requestIdentityKey?: string;
 }
 
 interface ResolvedSpanSamples {
@@ -182,19 +183,20 @@ export function useExploreSpansTable({
 
   return useMemo(() => {
     if (!visibleSamples) {
-      return spansTableResult;
+      return {...spansTableResult, requestIdentityKey: identityKey};
     }
 
     // The constrained response only describes pagination within the visible IDs.
     // Keep the links from the original response so pagination can leave the lock.
     return {
       ...spansTableResult,
+      requestIdentityKey: identityKey,
       result: {
         ...spansTableResult.result,
         pageLinks: visibleSamples.pageLinks,
       },
     };
-  }, [spansTableResult, visibleSamples]);
+  }, [identityKey, spansTableResult, visibleSamples]);
 }
 
 function useExploreSpansTableImp({

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -104,7 +104,9 @@ export function useExploreSpansTable({
     return;
   }, [fieldsKey, identityKey, requestState]);
   const constrainedQuery = visibleSamples
-    ? [query, `id:[${visibleSamples.spanIds.join(',')}]`].filter(Boolean).join(' ')
+    ? [query ? `(${query})` : '', `id:[${visibleSamples.spanIds.join(',')}]`]
+        .filter(Boolean)
+        .join(' ')
     : query;
 
   const canTriggerHighAccuracy = useCallback(

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -24,6 +24,10 @@ interface UseExploreSpansTableOptions {
   queryExtras?: RPCQueryExtras;
 }
 
+interface UseExploreSpansTableImpOptions extends UseExploreSpansTableOptions {
+  cursor?: string;
+}
+
 export interface SpansTableResult {
   eventView: EventView;
   result: ReturnType<typeof useSpansQuery<EventData[]>>;
@@ -114,7 +118,13 @@ export function useExploreSpansTable({
 
   const spansTableResult = useProgressiveQuery<typeof useExploreSpansTableImp>({
     queryHookImplementation: useExploreSpansTableImp,
-    queryHookArgs: {enabled, limit, query: constrainedQuery, queryExtras},
+    queryHookArgs: {
+      cursor: visibleSamples ? '' : undefined,
+      enabled,
+      limit,
+      query: constrainedQuery,
+      queryExtras,
+    },
     queryOptions: {
       canTriggerHighAccuracy,
       disableExtrapolation: !extrapolate,
@@ -151,15 +161,20 @@ export function useExploreSpansTable({
       requestState.lastResolved.identityKey !== resolvedSamples.identityKey);
   const shouldLockVisibleSamples =
     visibleSamples !== undefined && requestState.lockedSamples !== visibleSamples;
+  const shouldClearLockedSamples =
+    requestState.lockedSamples !== null &&
+    requestState.lockedSamples.identityKey !== identityKey;
 
-  if (shouldUpdateLastResolved || shouldLockVisibleSamples) {
+  if (shouldUpdateLastResolved || shouldLockVisibleSamples || shouldClearLockedSamples) {
     setRequestState({
       lastResolved: shouldUpdateLastResolved
         ? resolvedSamples
         : requestState.lastResolved,
       lockedSamples: shouldLockVisibleSamples
         ? visibleSamples
-        : requestState.lockedSamples,
+        : shouldClearLockedSamples
+          ? null
+          : requestState.lockedSamples,
     });
   }
 
@@ -181,11 +196,12 @@ export function useExploreSpansTable({
 }
 
 function useExploreSpansTableImp({
+  cursor,
   enabled,
   limit,
   query,
   queryExtras,
-}: UseExploreSpansTableOptions): SpansTableResult {
+}: UseExploreSpansTableImpOptions): SpansTableResult {
   const {selection} = usePageFilters();
 
   const dataset = useSpansDataset();
@@ -221,6 +237,7 @@ function useExploreSpansTableImp({
   }, [dataset, query, selection, sortBys, visibleFields]);
 
   const result = useSpansQuery<EventData[]>({
+    cursor,
     enabled,
     eventView,
     initialData: [],

--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -70,6 +70,7 @@ export function useExploreSpansTable({
       JSON.stringify([
         cursor,
         dataset,
+        extrapolate,
         limit,
         query,
         queryExtras,
@@ -78,7 +79,7 @@ export function useExploreSpansTable({
         selection.projects,
         sortBys,
       ]),
-    [cursor, dataset, limit, query, queryExtras, selection, sortBys]
+    [cursor, dataset, extrapolate, limit, query, queryExtras, selection, sortBys]
   );
   const [requestState, setRequestState] = useState<SpanSamplesRequestState>({
     lastResolved: null,

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import type {NavigateOptions} from 'react-router-dom';
 import {parseAsString, useQueryStates} from 'nuqs';
 
 import {defined} from 'sentry/utils/defined';
@@ -36,7 +37,7 @@ interface QueryParamsContextValue {
   managedFields: Set<string>;
   queryParams: ReadableQueryParams;
   setManagedFields: (managedFields: Set<string>) => void;
-  setQueryParams: (queryParams: WritableQueryParams) => void;
+  setQueryParams: (queryParams: WritableQueryParams, options?: NavigateOptions) => void;
 }
 
 const QueryParamsContext = createContext<QueryParamsContextValue | undefined>(undefined);
@@ -55,7 +56,7 @@ interface QueryParamsContextProps {
   children: ReactNode;
   isUsingDefaultFields: boolean;
   queryParams: ReadableQueryParams;
-  setQueryParams: (queryParams: WritableQueryParams) => void;
+  setQueryParams: (queryParams: WritableQueryParams, options?: NavigateOptions) => void;
   shouldManageFields: boolean;
 }
 
@@ -106,7 +107,7 @@ export function useSetQueryParams() {
   } = useQueryParamsContext();
 
   return useCallback(
-    (writableQueryParams: WritableQueryParams) => {
+    (writableQueryParams: WritableQueryParams, options?: NavigateOptions) => {
       const {updatedFields, updatedManagedFields} = deriveUpdatedManagedFields(
         managedFields,
         readableQueryParams,
@@ -130,7 +131,11 @@ export function useSetQueryParams() {
         writableQueryParams.breakdownCursor = null;
       }
 
-      setQueryParams(writableQueryParams);
+      if (options) {
+        setQueryParams(writableQueryParams, options);
+      } else {
+        setQueryParams(writableQueryParams);
+      }
     },
     [managedFields, setManagedFields, readableQueryParams, setQueryParams]
   );
@@ -235,8 +240,8 @@ export function useSetQueryParamsFields() {
   const setQueryParams = useSetQueryParams();
 
   return useCallback(
-    (fields: string[]) => {
-      setQueryParams({fields});
+    (fields: string[], options?: NavigateOptions) => {
+      setQueryParams({fields}, options);
     },
     [setQueryParams]
   );

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -151,16 +151,56 @@ describe('SpansTabContent', () => {
   });
 
   it('should fire analytics once per change', async () => {
-    render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
-      organization,
-      additionalWrapper: Wrapper,
-    });
+    const {router} = render(
+      <SpansTabContent datePageFilterProps={datePageFilterProps} />,
+      {
+        organization,
+        additionalWrapper: Wrapper,
+      }
+    );
 
     await screen.findByText(/No spans found/);
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
     expect(trackAnalytics).toHaveBeenCalledWith(
       'trace.explorer.metadata',
       expect.objectContaining({result_mode: 'span samples'})
+    );
+
+    const tableResponse = Promise.withResolvers<void>();
+    const tableRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({query: 'span.op:http'}),
+        (_url, options) => options.query?.field?.includes('id'),
+      ],
+      asyncDelay: tableResponse.promise,
+      body: {
+        data: [{id: 'aaaaaaaaaaaaaaaa', timestamp: '2024-01-01T00:00:00+00:00'}],
+        meta: {dataScanned: 'full', fields: {id: 'string'}},
+      },
+    });
+
+    jest.mocked(trackAnalytics).mockClear();
+    router.navigate(
+      `/organizations/${organization.slug}/explore/traces/?query=span.op%3Ahttp`
+    );
+    await waitFor(() => expect(tableRequest).toHaveBeenCalledTimes(1));
+    const getMetadataCalls = () =>
+      jest
+        .mocked(trackAnalytics)
+        .mock.calls.filter(([eventKey]) => eventKey === 'trace.explorer.metadata');
+    expect(getMetadataCalls()).toHaveLength(0);
+
+    tableResponse.resolve();
+    await waitFor(() => expect(getMetadataCalls()).toHaveLength(1));
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'trace.explorer.metadata',
+      expect.objectContaining({
+        dataScanned: 'full',
+        result_length: 1,
+        result_mode: 'span samples',
+      })
     );
 
     jest.mocked(trackAnalytics).mockClear();

--- a/static/app/views/explore/spans/tracesExportModalButton.tsx
+++ b/static/app/views/explore/spans/tracesExportModalButton.tsx
@@ -106,7 +106,10 @@ export function TracesExportModalButton({
       disabled={!isExportSupported}
       isDataEmpty={isExportSupported && data.length === 0}
       isDataError={isExportSupported && targetTableResult.result.error !== null}
-      isDataLoading={isExportSupported && targetTableResult.result.isPending}
+      isDataLoading={
+        isExportSupported &&
+        (targetTableResult.result.isPending || targetTableResult.result.isPlaceholderData)
+      }
     />
   );
 }

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -13,6 +13,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import * as indicators from 'sentry/actionCreators/indicator';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {ResponseMeta} from 'sentry/types/api';
@@ -301,15 +302,25 @@ describe('SpansTable', () => {
     });
   });
 
-  it('retains expanded details while a new column loads or fails', async () => {
+  it('retains expanded details while a new column loads and rolls it back on failure', async () => {
+    const addErrorMessage = jest.spyOn(indicators, 'addErrorMessage');
     mockSpanDetails(firstRow, [
       {name: 'span.custom', type: 'str', value: 'custom value'},
     ]);
 
-    const {rerenderTable} = renderTable({tableRows: [firstRow]});
+    const {rerenderTable, router} = renderTable({tableRows: [firstRow]});
     await openAttributeActions('span.custom');
     expect(await screen.findByText('custom value')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Add this as table column'));
+
+    router.navigate(
+      `/organizations/${organization.slug}/explore/traces/?field=id&field=span.name&field=span.duration&field=transaction&field=timestamp&field=span.custom`
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('columnheader', {name: 'span.description'})
+      ).not.toBeInTheDocument();
+    });
 
     const pendingResult = makeQueryResult([firstRow]);
     Object.assign(pendingResult, {
@@ -332,9 +343,17 @@ describe('SpansTable', () => {
     });
     rerenderTable(failedResult);
 
+    const table = screen.getByTestId('spans-table');
+    await waitFor(() => {
+      expect(
+        within(table).queryByRole('columnheader', {name: 'span.custom'})
+      ).not.toBeInTheDocument();
+    });
+    expect(addErrorMessage).toHaveBeenCalledWith('Failed to add column');
+    expect(
+      within(table).getByRole('columnheader', {name: 'span.description'})
+    ).toBeInTheDocument();
     expect(screen.getByText('custom value')).toBeInTheDocument();
-    expect(screen.getByText('Failed to update span samples')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
   });
 
   it('resets expanded details when the result identity changes', async () => {

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -331,7 +331,7 @@ describe('SpansTable', () => {
       ).not.toBeInTheDocument();
     });
 
-    const pendingResult = makeQueryResult([firstRow]);
+    const pendingResult = makeQueryResult([]);
     Object.assign(pendingResult, {
       isFetching: true,
       isPlaceholderData: true,

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -155,10 +155,12 @@ describe('SpansTable', () => {
 
   function renderTable({
     features = ['explore-span-item-details'],
+    requestIdentityKey,
     tableResult,
     tableRows = rows,
   }: {
     features?: string[];
+    requestIdentityKey?: string;
     tableResult?: SpansTableResult['result'];
     tableRows?: Array<Record<string, unknown>>;
   } = {}) {
@@ -166,7 +168,7 @@ describe('SpansTable', () => {
       <SpansTable
         booleanTags={{}}
         numberTags={{}}
-        spansTableResult={{eventView, result}}
+        spansTableResult={{eventView, requestIdentityKey, result}}
         stringTags={{}}
         validatedFieldTypes={{'span.custom': FieldValueType.STRING}}
       />
@@ -308,7 +310,14 @@ describe('SpansTable', () => {
       {name: 'span.custom', type: 'str', value: 'custom value'},
     ]);
 
-    const {rerenderTable, router} = renderTable({tableRows: [firstRow]});
+    const {rerenderTable, router} = renderTable({
+      requestIdentityKey: 'page-two',
+      tableRows: [firstRow],
+    });
+    router.navigate(
+      `/organizations/${organization.slug}/explore/traces/?cursor=0%3A100%3A0`
+    );
+    await waitFor(() => expect(router.location.query.cursor).toBe('0:100:0'));
     await openAttributeActions('span.custom');
     expect(await screen.findByText('custom value')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Add this as table column'));

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -214,6 +214,21 @@ describe('SpansTable', () => {
     });
   }
 
+  it('shows a loading state before the initial rows resolve', () => {
+    const pendingResult = makeQueryResult([]);
+    Object.assign(pendingResult, {
+      isFetching: true,
+      isPending: true,
+      isSuccess: false,
+      status: 'pending',
+    });
+
+    renderTable({tableResult: pendingResult});
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(screen.queryByText('No spans found')).not.toBeInTheDocument();
+  });
+
   it('does not render or fetch span details when the feature is disabled', () => {
     const detailsMock = mockSpanDetails(firstRow, []);
 

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -154,16 +154,24 @@ describe('SpansTable', () => {
 
   function renderTable({
     features = ['explore-span-item-details'],
+    tableResult,
     tableRows = rows,
-  }: {features?: string[]; tableRows?: Array<Record<string, unknown>>} = {}) {
-    return render(
+  }: {
+    features?: string[];
+    tableResult?: SpansTableResult['result'];
+    tableRows?: Array<Record<string, unknown>>;
+  } = {}) {
+    const renderSpansTable = (result: SpansTableResult['result']) => (
       <SpansTable
         booleanTags={{}}
         numberTags={{}}
-        spansTableResult={{eventView, result: makeQueryResult(tableRows)}}
+        spansTableResult={{eventView, result}}
         stringTags={{}}
-        validatedFieldTypes={{}}
-      />,
+        validatedFieldTypes={{'span.custom': FieldValueType.STRING}}
+      />
+    );
+    const renderResult = render(
+      renderSpansTable(tableResult ?? makeQueryResult(tableRows)),
       {
         organization: {...organization, features},
         additionalWrapper: Wrapper,
@@ -174,6 +182,12 @@ describe('SpansTable', () => {
         },
       }
     );
+
+    return {
+      ...renderResult,
+      rerenderTable: (result: SpansTableResult['result']) =>
+        renderResult.rerender(renderSpansTable(result)),
+    };
   }
 
   function mockSpanDetails(
@@ -283,7 +297,77 @@ describe('SpansTable', () => {
         expect.arrayContaining(['span.custom'])
       );
     });
+    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
+    expect(screen.getByText('custom value')).toBeInTheDocument();
+  });
+
+  it('retains expanded details while a new column loads or fails', async () => {
+    mockSpanDetails(firstRow, [
+      {name: 'span.custom', type: 'str', value: 'custom value'},
+    ]);
+
+    const {rerenderTable} = renderTable({tableRows: [firstRow]});
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+    expect(await screen.findByText('custom value')).toBeInTheDocument();
+
+    const attributeRow = screen
+      .getByTestId('tree-key-span.custom')
+      .closest<HTMLElement>('[data-test-id="attribute-tree-row"]');
+    expect(attributeRow).not.toBeNull();
+    await userEvent.hover(attributeRow!);
+    await userEvent.click(
+      within(attributeRow!).getByRole('button', {
+        name: 'Attribute Actions Menu',
+      }),
+      {pointerEventsCheck: 0}
+    );
+    await userEvent.click(screen.getByText('Add this as table column'));
+
+    const pendingResult = makeQueryResult([firstRow]);
+    Object.assign(pendingResult, {
+      isFetching: true,
+      isPlaceholderData: true,
+    });
+    rerenderTable(pendingResult);
+
+    expect(screen.getByTestId('spans-table')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
+    expect(screen.getByText('custom value')).toBeInTheDocument();
+    expect(screen.getByTestId('column-loading-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
+
+    const failedResult = makeQueryResult(undefined);
+    Object.assign(failedResult, {
+      error: new QueryError('Failed to update span samples'),
+      isError: true,
+      isFetching: false,
+      isPlaceholderData: false,
+      isSuccess: false,
+      status: 'error',
+    });
+    rerenderTable(failedResult);
+
+    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
+    expect(screen.getByText('custom value')).toBeInTheDocument();
+    expect(screen.getByText('Failed to update span samples')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+  });
+
+  it('resets expanded details when the result identity changes', async () => {
+    mockSpanDetails(firstRow, [
+      {name: 'span.custom', type: 'str', value: 'custom value'},
+    ]);
+
+    const {router} = renderTable({tableRows: [firstRow]});
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+    expect(await screen.findByText('custom value')).toBeInTheDocument();
+
+    router.navigate(
+      `/organizations/${organization.slug}/explore/traces/?query=span.op%3Ahttp`
+    );
+
     expect(screen.getByRole('button', {name: 'Show span details'})).toBeInTheDocument();
+    expect(screen.queryByText('custom value')).not.toBeInTheDocument();
   });
 
   it('retries a failed span details request without collapsing the row', async () => {
@@ -338,7 +422,7 @@ describe('SpansTable', () => {
 });
 
 function makeQueryResult(
-  data: Array<Record<string, unknown>>
+  data: Array<Record<string, unknown>> | undefined
 ): SpansTableResult['result'] {
   const queryClient = makeTestQueryClient();
   const queryKey = ['spans-table-test'];

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -217,6 +217,21 @@ describe('SpansTable', () => {
     });
   }
 
+  async function openAttributeActions(attribute: string) {
+    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+    const attributeRow = (
+      await screen.findByTestId(`tree-key-${attribute}`)
+    ).closest<HTMLElement>('[data-test-id="attribute-tree-row"]');
+    expect(attributeRow).not.toBeNull();
+    await userEvent.hover(attributeRow!);
+    await userEvent.click(
+      within(attributeRow!).getByRole('button', {
+        name: 'Attribute Actions Menu',
+      }),
+      {pointerEventsCheck: 0}
+    );
+  }
+
   function QueriedSpansTable({caseInsensitive}: {caseInsensitive?: true}) {
     const spansTableResult = useExploreSpansTable({
       enabled: true,
@@ -285,7 +300,7 @@ describe('SpansTable', () => {
     rerender(<QueriedSpansTable caseInsensitive />);
     await waitFor(() => expect(updatedQueryRequest).toHaveBeenCalledTimes(1));
 
-    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(screen.queryByText('span one')).not.toBeInTheDocument();
     expect(screen.queryByText('custom value')).not.toBeInTheDocument();
   });
 
@@ -346,20 +361,7 @@ describe('SpansTable', () => {
     ]);
 
     const {router} = renderTable({tableRows: [firstRow]});
-    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
-
-    const attributeKey = await screen.findByTestId('tree-key-span.custom');
-    const attributeRow = attributeKey.closest<HTMLElement>(
-      '[data-test-id="attribute-tree-row"]'
-    );
-    expect(attributeRow).not.toBeNull();
-    await userEvent.hover(attributeRow!);
-    await userEvent.click(
-      within(attributeRow!).getByRole('button', {
-        name: 'Attribute Actions Menu',
-      }),
-      {pointerEventsCheck: 0}
-    );
+    await openAttributeActions('span.custom');
 
     expect(await screen.findByText('Add to filter')).toBeInTheDocument();
     expect(screen.getByText('Exclude this value')).toBeInTheDocument();
@@ -372,8 +374,6 @@ describe('SpansTable', () => {
         expect.arrayContaining(['span.custom'])
       );
     });
-    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
-    expect(screen.getByText('custom value')).toBeInTheDocument();
   });
 
   it('retains expanded details while a new column loads or fails', async () => {
@@ -382,20 +382,8 @@ describe('SpansTable', () => {
     ]);
 
     const {rerenderTable} = renderTable({tableRows: [firstRow]});
-    await userEvent.click(screen.getByRole('button', {name: 'Show span details'}));
+    await openAttributeActions('span.custom');
     expect(await screen.findByText('custom value')).toBeInTheDocument();
-
-    const attributeRow = screen
-      .getByTestId('tree-key-span.custom')
-      .closest<HTMLElement>('[data-test-id="attribute-tree-row"]');
-    expect(attributeRow).not.toBeNull();
-    await userEvent.hover(attributeRow!);
-    await userEvent.click(
-      within(attributeRow!).getByRole('button', {
-        name: 'Attribute Actions Menu',
-      }),
-      {pointerEventsCheck: 0}
-    );
     await userEvent.click(screen.getByText('Add this as table column'));
 
     const pendingResult = makeQueryResult([firstRow]);
@@ -405,7 +393,6 @@ describe('SpansTable', () => {
     });
     rerenderTable(pendingResult);
 
-    expect(screen.getByTestId('spans-table')).toHaveAttribute('aria-busy', 'true');
     expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
     expect(screen.getByText('custom value')).toBeInTheDocument();
     expect(screen.getByTestId('column-loading-indicator')).toBeInTheDocument();

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -21,7 +21,10 @@ import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {FieldValueType} from 'sentry/utils/fields';
-import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import {
+  type SpansTableResult,
+  useExploreSpansTable,
+} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {
@@ -214,6 +217,25 @@ describe('SpansTable', () => {
     });
   }
 
+  function QueriedSpansTable({caseInsensitive}: {caseInsensitive?: true}) {
+    const spansTableResult = useExploreSpansTable({
+      enabled: true,
+      limit: 10,
+      query: '',
+      queryExtras: {caseInsensitive},
+    });
+
+    return (
+      <SpansTable
+        booleanTags={{}}
+        numberTags={{}}
+        spansTableResult={spansTableResult}
+        stringTags={{}}
+        validatedFieldTypes={{}}
+      />
+    );
+  }
+
   it('shows a loading state before the initial rows resolve', () => {
     const pendingResult = makeQueryResult([]);
     Object.assign(pendingResult, {
@@ -227,6 +249,44 @@ describe('SpansTable', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(screen.queryByText('No spans found')).not.toBeInTheDocument();
+  });
+
+  it('does not retain rows when query extras change', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [firstRow],
+        meta: {dataScanned: 'full', fields: {id: 'string'}},
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.caseInsensitive === undefined;
+        },
+      ],
+    });
+    const updatedQueryRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: new Promise(() => {}),
+      method: 'GET',
+      match: [MockApiClient.matchQuery({caseInsensitive: '1'})],
+    });
+    mockSpanDetails(firstRow, [
+      {name: 'span.custom', type: 'str', value: 'custom value'},
+    ]);
+
+    const {rerender} = render(<QueriedSpansTable />, {
+      organization,
+      additionalWrapper: Wrapper,
+    });
+    await userEvent.click(await screen.findByRole('button', {name: 'Show span details'}));
+    expect(await screen.findByText('custom value')).toBeInTheDocument();
+
+    rerender(<QueriedSpansTable caseInsensitive />);
+    await waitFor(() => expect(updatedQueryRequest).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(screen.queryByText('custom value')).not.toBeInTheDocument();
   });
 
   it('does not render or fetch span details when the feature is disabled', () => {

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -21,10 +21,7 @@ import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import {EventView} from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {FieldValueType} from 'sentry/utils/fields';
-import {
-  type SpansTableResult,
-  useExploreSpansTable,
-} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {
@@ -232,78 +229,6 @@ describe('SpansTable', () => {
     );
   }
 
-  function QueriedSpansTable({caseInsensitive}: {caseInsensitive?: true}) {
-    const spansTableResult = useExploreSpansTable({
-      enabled: true,
-      limit: 10,
-      query: '',
-      queryExtras: {caseInsensitive},
-    });
-
-    return (
-      <SpansTable
-        booleanTags={{}}
-        numberTags={{}}
-        spansTableResult={spansTableResult}
-        stringTags={{}}
-        validatedFieldTypes={{}}
-      />
-    );
-  }
-
-  it('shows a loading state before the initial rows resolve', () => {
-    const pendingResult = makeQueryResult([]);
-    Object.assign(pendingResult, {
-      isFetching: true,
-      isPending: true,
-      isSuccess: false,
-      status: 'pending',
-    });
-
-    renderTable({tableResult: pendingResult});
-
-    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    expect(screen.queryByText('No spans found')).not.toBeInTheDocument();
-  });
-
-  it('does not retain rows when query extras change', async () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: [firstRow],
-        meta: {dataScanned: 'full', fields: {id: 'string'}},
-      },
-      method: 'GET',
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.query.caseInsensitive === undefined;
-        },
-      ],
-    });
-    const updatedQueryRequest = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: new Promise(() => {}),
-      method: 'GET',
-      match: [MockApiClient.matchQuery({caseInsensitive: '1'})],
-    });
-    mockSpanDetails(firstRow, [
-      {name: 'span.custom', type: 'str', value: 'custom value'},
-    ]);
-
-    const {rerender} = render(<QueriedSpansTable />, {
-      organization,
-      additionalWrapper: Wrapper,
-    });
-    await userEvent.click(await screen.findByRole('button', {name: 'Show span details'}));
-    expect(await screen.findByText('custom value')).toBeInTheDocument();
-
-    rerender(<QueriedSpansTable caseInsensitive />);
-    await waitFor(() => expect(updatedQueryRequest).toHaveBeenCalledTimes(1));
-
-    expect(screen.queryByText('span one')).not.toBeInTheDocument();
-    expect(screen.queryByText('custom value')).not.toBeInTheDocument();
-  });
-
   it('does not render or fetch span details when the feature is disabled', () => {
     const detailsMock = mockSpanDetails(firstRow, []);
 
@@ -393,9 +318,7 @@ describe('SpansTable', () => {
     });
     rerenderTable(pendingResult);
 
-    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
     expect(screen.getByText('custom value')).toBeInTheDocument();
-    expect(screen.getByTestId('column-loading-indicator')).toBeInTheDocument();
     expect(screen.getByTestId('loading-placeholder')).toBeInTheDocument();
 
     const failedResult = makeQueryResult(undefined);
@@ -409,7 +332,6 @@ describe('SpansTable', () => {
     });
     rerenderTable(failedResult);
 
-    expect(screen.getByRole('button', {name: 'Hide span details'})).toBeInTheDocument();
     expect(screen.getByText('custom value')).toBeInTheDocument();
     expect(screen.getByText('Failed to update span samples')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -6,6 +6,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -28,6 +29,7 @@ import {
   useQueryParamsFields,
   useQueryParamsQuery,
   useQueryParamsSortBys,
+  useSetQueryParamsFields,
   useSetQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
 
@@ -46,6 +48,7 @@ interface SpansTableProps {
 
 interface ResolvedSpanTable {
   data: EventData[];
+  dataUpdatedAt: number;
   fields: readonly string[];
   identityKey: string;
   meta: MetaType;
@@ -63,6 +66,7 @@ export function SpansTable({
   const query = useQueryParamsQuery();
   const cursor = useQueryParamsCursor();
   const sortBys = useQueryParamsSortBys();
+  const setFields = useSetQueryParamsFields();
   const setSortBys = useSetQueryParamsSortBys();
   const organization = useOrganization();
   const canExpandSpanDetails = organization.features.includes(
@@ -93,24 +97,30 @@ export function SpansTable({
       ]),
     [cursor, eventView, query, requestIdentityKey, sortBys]
   );
-  const resolvedTable = useMemo<ResolvedSpanTable | null>(() => {
+  const resolvedTable = useMemo<Omit<ResolvedSpanTable, 'fields'> | null>(() => {
     if (result.isSuccess && !result.isPlaceholderData && result.data) {
       return {
         data: result.data,
-        fields: eventView.fields.map(field => field.field),
+        dataUpdatedAt: result.dataUpdatedAt,
         identityKey: tableIdentityKey,
         meta: result.meta ?? {},
         pageLinks: result.pageLinks,
       };
     }
     return null;
-  }, [eventView.fields, result, tableIdentityKey]);
+  }, [result, tableIdentityKey]);
   const [lastResolvedTable, setLastResolvedTable] = useState<ResolvedSpanTable | null>(
-    resolvedTable
+    resolvedTable ? {...resolvedTable, fields} : null
   );
+  const rolledBackResultRef = useRef<SpansTableResult['result'] | null>(null);
 
-  if (resolvedTable && resolvedTable !== lastResolvedTable) {
-    setLastResolvedTable(resolvedTable);
+  if (
+    resolvedTable &&
+    (resolvedTable.data !== lastResolvedTable?.data ||
+      resolvedTable.dataUpdatedAt !== lastResolvedTable?.dataUpdatedAt ||
+      resolvedTable.identityKey !== lastResolvedTable?.identityKey)
+  ) {
+    setLastResolvedTable({...resolvedTable, fields});
   }
 
   const canRetainLastResolvedTable = lastResolvedTable?.identityKey === tableIdentityKey;
@@ -128,13 +138,32 @@ export function SpansTable({
     (result.isPlaceholderData || result.isError) && canRetainLastResolvedTable
       ? lastResolvedTable.pageLinks
       : result.pageLinks;
+  const addedFields = useMemo(
+    () =>
+      canRetainLastResolvedTable
+        ? fields.filter(field => !lastResolvedTable.fields.includes(field))
+        : [],
+    [canRetainLastResolvedTable, fields, lastResolvedTable]
+  );
   const isRetainedError =
     result.isError && canRetainLastResolvedTable && Boolean(displayedData?.length);
-  const pendingFields = new Set(
-    canRetainLastResolvedTable && (result.isFetching || result.isError)
-      ? fields.filter(field => !lastResolvedTable.fields.includes(field))
-      : []
-  );
+  const isFieldAdditionError = result.isError && addedFields.length > 0;
+  const pendingFields = new Set(result.isFetching ? addedFields : []);
+
+  useEffect(() => {
+    if (
+      !result.isError ||
+      !lastResolvedTable ||
+      addedFields.length === 0 ||
+      rolledBackResultRef.current === result
+    ) {
+      return;
+    }
+
+    rolledBackResultRef.current = result;
+    setFields([...lastResolvedTable.fields], {replace: true});
+    addErrorMessage(t('Failed to add column'));
+  }, [addedFields, lastResolvedTable, result, setFields]);
 
   const meta = useMemo(
     () =>
@@ -248,7 +277,7 @@ export function SpansTable({
           )}
         </DataTable.Body>
       </DataTable>
-      {isRetainedError ? (
+      {isRetainedError && !isFieldAdditionError ? (
         <LoadingError
           message={t('Failed to update span samples')}
           onRetry={() => void result.refetch()}

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -83,8 +83,7 @@ export function SpansTable({
   const tableIdentityKey = useMemo(
     () =>
       JSON.stringify([
-        requestIdentityKey,
-        cursor,
+        requestIdentityKey ?? cursor,
         eventView.dataset,
         eventView.end,
         eventView.environment,

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -111,7 +111,7 @@ export function SpansTable({
   const [lastResolvedTable, setLastResolvedTable] = useState<ResolvedSpanTable | null>(
     resolvedTable ? {...resolvedTable, fields} : null
   );
-  const rolledBackResultRef = useRef<SpansTableResult['result'] | null>(null);
+  const rolledBackErrorRef = useRef<SpansTableResult['result']['error']>(null);
 
   if (
     resolvedTable &&
@@ -154,15 +154,15 @@ export function SpansTable({
       !result.isError ||
       !lastResolvedTable ||
       addedFields.length === 0 ||
-      rolledBackResultRef.current === result
+      rolledBackErrorRef.current === result.error
     ) {
       return;
     }
 
-    rolledBackResultRef.current = result;
+    rolledBackErrorRef.current = result.error;
     setFields([...lastResolvedTable.fields], {replace: true});
     addErrorMessage(t('Failed to add column'));
-  }, [addedFields, lastResolvedTable, result, setFields]);
+  }, [addedFields, lastResolvedTable, result.error, result.isError, setFields]);
 
   const meta = useMemo(
     () =>

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -125,7 +125,7 @@ export function SpansTable({
   const canRetainLastResolvedTable = lastResolvedTable?.identityKey === tableIdentityKey;
   const isLoadingDifferentTable = result.isPlaceholderData && !canRetainLastResolvedTable;
   const displayedData =
-    !result.isPending && !isLoadingDifferentTable && result.data
+    !result.isPending && !result.isPlaceholderData && result.data
       ? result.data
       : canRetainLastResolvedTable
         ? lastResolvedTable.data

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -74,11 +74,12 @@ export function SpansTable({
     [fields]
   );
 
-  const {result, eventView} = spansTableResult;
+  const {eventView, requestIdentityKey, result} = spansTableResult;
 
   const tableIdentityKey = useMemo(
     () =>
       JSON.stringify([
+        requestIdentityKey,
         cursor,
         eventView.dataset,
         eventView.end,
@@ -90,7 +91,7 @@ export function SpansTable({
         eventView.statsPeriod,
         eventView.utc,
       ]),
-    [cursor, eventView, query, sortBys]
+    [cursor, eventView, query, requestIdentityKey, sortBys]
   );
   const resolvedTable = useMemo<ResolvedSpanTable | null>(() => {
     if (result.isSuccess && !result.isPlaceholderData && result.data) {

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -2,10 +2,14 @@ import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
+import {Text} from '@sentry/scraps/text';
 
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
+import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Placeholder} from 'sentry/components/placeholder';
 import {DataTable} from 'sentry/components/tables/dataTable';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
@@ -40,6 +44,14 @@ interface SpansTableProps {
   validatedFieldTypes: Partial<Record<string, FieldValueType>>;
 }
 
+interface ResolvedSpanTable {
+  data: EventData[];
+  fields: readonly string[];
+  identityKey: string;
+  meta: MetaType;
+  pageLinks: string | undefined;
+}
+
 export function SpansTable({
   booleanTags,
   numberTags,
@@ -64,31 +76,86 @@ export function SpansTable({
 
   const {result, eventView} = spansTableResult;
 
+  const tableIdentityKey = useMemo(
+    () =>
+      JSON.stringify([
+        cursor,
+        eventView.dataset,
+        eventView.end,
+        eventView.environment,
+        eventView.project,
+        query,
+        sortBys,
+        eventView.start,
+        eventView.statsPeriod,
+        eventView.utc,
+      ]),
+    [cursor, eventView, query, sortBys]
+  );
+  const resolvedTable = useMemo<ResolvedSpanTable | null>(() => {
+    if (result.isSuccess && !result.isPlaceholderData && result.data) {
+      return {
+        data: result.data,
+        fields: eventView.fields.map(field => field.field),
+        identityKey: tableIdentityKey,
+        meta: result.meta ?? {},
+        pageLinks: result.pageLinks,
+      };
+    }
+    return null;
+  }, [eventView.fields, result, tableIdentityKey]);
+  const [lastResolvedTable, setLastResolvedTable] = useState<ResolvedSpanTable | null>(
+    resolvedTable
+  );
+
+  if (resolvedTable && resolvedTable !== lastResolvedTable) {
+    setLastResolvedTable(resolvedTable);
+  }
+
+  const canRetainLastResolvedTable = lastResolvedTable?.identityKey === tableIdentityKey;
+  const isLoadingDifferentTable = result.isPlaceholderData && !canRetainLastResolvedTable;
+  const displayedData =
+    !isLoadingDifferentTable && result.data
+      ? result.data
+      : canRetainLastResolvedTable
+        ? lastResolvedTable.data
+        : undefined;
+  const displayedMeta =
+    (isLoadingDifferentTable ? undefined : result.meta) ??
+    (canRetainLastResolvedTable ? lastResolvedTable.meta : undefined);
+  const displayedPageLinks =
+    (result.isPlaceholderData || result.isError) && canRetainLastResolvedTable
+      ? lastResolvedTable.pageLinks
+      : result.pageLinks;
+  const isRetainedError =
+    result.isError && canRetainLastResolvedTable && Boolean(displayedData?.length);
+  const pendingFields = new Set(
+    canRetainLastResolvedTable && (result.isFetching || result.isError)
+      ? fields.filter(field => !lastResolvedTable.fields.includes(field))
+      : []
+  );
+
   const meta = useMemo(
     () =>
       addValidatedFieldTypesToMeta({
-        meta: result.meta ?? {},
+        meta: displayedMeta ?? {},
         validatedFieldTypes,
       }),
-    [result.meta, validatedFieldTypes]
+    [displayedMeta, validatedFieldTypes]
   );
   const columnsFromEventView = useMemo(
     () => eventView.getColumns(meta),
     [eventView, meta]
   );
-  const expansionResetKey = useMemo(
-    () => JSON.stringify([query, cursor, fields, sortBys]),
-    [cursor, fields, query, sortBys]
-  );
-
   const paginationAnalyticsEvent = usePaginationAnalytics(
     'samples',
-    result.data?.length ?? 0
+    displayedData?.length ?? 0
   );
 
   return (
     <Fragment>
       <DataTable
+        aria-busy={result.isFetching}
         data-test-id="spans-table"
         fields={visibleFields}
         minimumColumnWidth={50}
@@ -101,7 +168,7 @@ export function SpansTable({
             )}
             {visibleFields.map((field, i) => {
               // Hide column names before alignment is determined
-              if (result.isPending) {
+              if (result.isPending || isLoadingDifferentTable) {
                 return (
                   <DataTable.HeadCell
                     key={i}
@@ -133,29 +200,41 @@ export function SpansTable({
                   onSort={updateSort}
                   sort={direction}
                 >
-                  {label}
+                  <Flex align="center" gap="xs">
+                    <Text as="span" size="sm" variant="inherit">
+                      {label}
+                    </Text>
+                    {pendingFields.has(field) ? (
+                      <LoadingIndicator
+                        data-test-id="column-loading-indicator"
+                        size={12}
+                        style={{margin: 0}}
+                      />
+                    ) : null}
+                  </Flex>
                 </DataTable.HeadCell>
               );
             })}
           </DataTable.Row>
         </DataTable.Head>
         <DataTable.Body>
-          {result.isPending ? (
+          {(result.isPending || isLoadingDifferentTable) && !displayedData ? (
             <DataTable.Status>
               <LoadingIndicator />
             </DataTable.Status>
-          ) : result.isError ? (
+          ) : result.isError && !isRetainedError ? (
             <DataTable.Status>
               <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
             </DataTable.Status>
-          ) : result.isFetched && result.data?.length ? (
-            result.data?.map((row, i) => (
+          ) : displayedData?.length ? (
+            displayedData.map((row, i) => (
               <SpanSampleRow
-                key={`${expansionResetKey}:${getSpanKey(row, i)}`}
+                key={`${tableIdentityKey}:${getSpanKey(row, i)}`}
                 canExpandSpanDetails={canExpandSpanDetails}
                 columns={columnsFromEventView}
                 data={row}
                 fields={visibleFields}
+                pendingFields={pendingFields}
                 meta={meta}
               />
             ))
@@ -168,8 +247,14 @@ export function SpansTable({
           )}
         </DataTable.Body>
       </DataTable>
+      {isRetainedError ? (
+        <LoadingError
+          message={t('Failed to update span samples')}
+          onRetry={() => void result.refetch()}
+        />
+      ) : null}
       <Pagination
-        pageLinks={result.pageLinks}
+        pageLinks={displayedPageLinks}
         paginationAnalyticsEvent={paginationAnalyticsEvent}
       />
     </Fragment>
@@ -181,6 +266,7 @@ function SpanSampleRow({
   columns,
   data,
   fields,
+  pendingFields,
   meta,
 }: {
   canExpandSpanDetails: boolean;
@@ -188,6 +274,7 @@ function SpanSampleRow({
   data: EventData;
   fields: readonly string[];
   meta: MetaType;
+  pendingFields: ReadonlySet<string>;
 }) {
   const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -215,12 +302,16 @@ function SpanSampleRow({
         ) : null}
         {fields.map((field, index) => (
           <DataTable.Cell key={field}>
-            <FieldRenderer
-              column={columns[index]}
-              data={data}
-              unit={meta.units?.[field]}
-              meta={meta}
-            />
+            {pendingFields.has(field) ? (
+              <Placeholder height="14px" width="60%" />
+            ) : (
+              <FieldRenderer
+                column={columns[index]}
+                data={data}
+                unit={meta.units?.[field]}
+                meta={meta}
+              />
+            )}
           </DataTable.Cell>
         ))}
       </DataTable.Row>

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -115,7 +115,7 @@ export function SpansTable({
   const canRetainLastResolvedTable = lastResolvedTable?.identityKey === tableIdentityKey;
   const isLoadingDifferentTable = result.isPlaceholderData && !canRetainLastResolvedTable;
   const displayedData =
-    !isLoadingDifferentTable && result.data
+    !result.isPending && !isLoadingDifferentTable && result.data
       ? result.data
       : canRetainLastResolvedTable
         ? lastResolvedTable.data

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -37,6 +37,7 @@ type SpansQueryProps<T = any[]> = {
   enabled?: boolean;
   eventView?: EventView;
   initialData?: T;
+  keepPreviousData?: boolean;
   limit?: number;
   queryExtras?: RPCQueryExtras;
   referrer?: string;
@@ -76,6 +77,7 @@ export function useSpansQueryWithoutPageFilters<T = any[]>({
 function useSpansQueryBase<T>({
   eventView,
   initialData,
+  keepPreviousData,
   limit,
   enabled,
   referrer,
@@ -105,6 +107,7 @@ function useSpansQueryBase<T>({
   const response = queryFunction<T>({
     eventView: newEventView,
     initialData,
+    keepPreviousData,
     limit,
     enabled,
     referrer,


### PR DESCRIPTION
## Summary

- retain span sample rows, scroll position, and expanded details while added columns load
- constrain column-only refreshes to the span IDs currently in view so newer spans cannot displace them
- preserve pagination metadata from the unconstrained response so Next and Previous continue navigating the full result set
- show per-column loading placeholders and retain the table with a retry action on refresh failure

Closes EXP-1162

**Before:**

https://github.com/user-attachments/assets/634a76af-c023-4d5c-843a-d192b133aa5b

**After:**

https://github.com/user-attachments/assets/e287643d-02a5-42ac-8bf7-1288054b9932