### PR TITLE
fix(snuba): Register generated query referrers

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -25,6 +25,7 @@ class Referrer(StrEnum):
         "api.auth-token.events.metrics-enhanced.primary"
     )
     API_AUTH_TOKEN_EVENTS = "api.auth-token.events"
+    API_AUTH_TOKEN_EVENTS_FIND_TOPN = "api.auth-token.events.find-topn"
 
     # ** Dashboards **
 
@@ -439,6 +440,7 @@ class Referrer(StrEnum):
     API_METRICS_TOTALS = "api.metrics.totals"
     API_METRICS_TOTALS_INITIAL_QUERY = "api.metrics.totals.initial_query"
     API_METRICS_TOTALS_SECOND_QUERY = "api.metrics.totals.second_query"
+    API_METRICS_SERIES = "api.metrics.series"
     API_METRICS_SERIES_SECOND_QUERY = "api.metrics.series.second_query"
 
     API_ORGANIZATION_TRACE_ITEM_DETAILS = "api.organization-trace-item-details"

--- a/tests/snuba/test_referrer.py
+++ b/tests/snuba/test_referrer.py
@@ -46,6 +46,12 @@ class ReferrerTest(TestCase):
         assert warn_log.call_count == 2
 
     @patch("sentry.snuba.referrer.logger.warning")
+    def test_referrer_validate_registered_dynamic_queries(self, warn_log: MagicMock) -> None:
+        assert validate_referrer("api.auth-token.events.find-topn")
+        assert validate_referrer("api.metrics.series")
+        assert warn_log.call_count == 0
+
+    @patch("sentry.snuba.referrer.logger.warning")
     def test_referrer_validate_tsdb_models(self, warn_log: MagicMock) -> None:
         assert warn_log.call_count == 0
         for model in TSDBModel:


### PR DESCRIPTION
Register the existing `api.auth-token.events.find-topn` and `api.metrics.series` query referrers so legitimate Snuba requests no longer trigger the unknown-referrer warning. The validator remains unchanged and will continue reporting genuinely unregistered values.

In the 30-minute production sample from August 28, 2026, 12:49–13:19 UTC, these two known query paths generated 37,548 warnings: 7,743 for authenticated Top-N event queries and 29,805 for metrics series queries.

After the change is fully deployed and old web pods have drained, the expected volume for these two exact warning signatures is zero in a comparable 30-minute window, eliminating all 37,548 sampled warnings. Some residual warnings may appear during the rollout while pods running the previous release are still serving requests.
