### PR TITLE
ref(integrations): Align Integration types with serializer payloads

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -462,6 +462,8 @@ interface CommonIntegration {
 }
 
 export interface Integration extends CommonIntegration {
+  /** OAuth scopes from provider metadata. Always sent; null when unused (e.g. GitHub). */
+  scopes: string[] | null;
   dynamicDisplayInformation?: {
     configure_integration?: {
       instructions: string[];
@@ -472,7 +474,6 @@ export interface Integration extends CommonIntegration {
   };
   // Present on OrganizationIntegration; for GitHub this is the App installation id.
   externalId?: string;
-  scopes?: string[];
 }
 
 type ConfigData = Record<string, unknown> & {
@@ -481,9 +482,10 @@ type ConfigData = Record<string, unknown> & {
 
 export interface OrganizationIntegration extends Integration {
   configData: ConfigData | null;
-  configOrganization: JsonFormAdapterFieldConfig[];
   externalId: string;
-  organizationId: string;
+  organizationId: number;
+  /** Omitted when the list endpoint is fetched with includeConfig=0. */
+  configOrganization?: JsonFormAdapterFieldConfig[];
 }
 
 // we include the configOrganization when we need it

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -170,7 +170,7 @@ function ConfigureIntegration() {
               ...cachedIntegration,
               configData: null,
               configOrganization: [],
-              organizationId: organization.id,
+              organizationId: Number(organization.id),
               externalId: cachedIntegration.externalId ?? '',
             },
             headers: {},
@@ -241,7 +241,7 @@ function ConfigureIntegration() {
   const settingsInstructions =
     integration.dynamicDisplayInformation?.configure_integration?.instructions;
   const hasSettingsTabContent =
-    integration.configOrganization.length > 0 ||
+    (integration.configOrganization?.length ?? 0) > 0 ||
     (settingsInstructions?.length ?? 0) > 0 ||
     provider.features.includes('alert-rule') ||
     provider.features.includes('serverless');
@@ -385,14 +385,14 @@ function ConfigureIntegration() {
 
     return (
       <Fragment>
-        {integration.configOrganization.length > 0 && (
+        {(integration.configOrganization?.length ?? 0) > 0 && (
           <FieldGroup
             title={
               integration.provider.aspects.configure_integration?.title ||
               t('Organization Integration Settings')
             }
           >
-            {integration.configOrganization.map(fieldConfig => (
+            {integration.configOrganization?.map(fieldConfig => (
               <BackendJsonAutoSaveForm
                 key={fieldConfig.name}
                 field={fieldConfig}

--- a/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
@@ -44,10 +44,11 @@ function makeIntegration(id: string, name: string): OrganizationIntegration {
     icon: null,
     organizationIntegrationStatus: 'active',
     status: 'active',
+    scopes: null,
     configData: null,
     configOrganization: [],
     externalId: id,
-    organizationId: '',
+    organizationId: 1,
     provider: {
       key: 'github',
       slug: 'github',

--- a/tests/js/fixtures/githubIntegration.ts
+++ b/tests/js/fixtures/githubIntegration.ts
@@ -24,6 +24,7 @@ export function GitHubIntegrationFixture(
       canDisable: false,
       slug: '',
     },
+    scopes: null,
     externalIssues: [],
     accountType: '',
     gracePeriodEnd: '',

--- a/tests/js/fixtures/gitlabIntegration.ts
+++ b/tests/js/fixtures/gitlabIntegration.ts
@@ -24,6 +24,7 @@ export function GitLabIntegrationFixture(
       canDisable: false,
       slug: '',
     },
+    scopes: null,
     externalIssues: [],
     accountType: '',
     gracePeriodEnd: '',

--- a/tests/js/fixtures/integrationListDirectory.ts
+++ b/tests/js/fixtures/integrationListDirectory.ts
@@ -52,6 +52,7 @@ export function BitbucketIntegrationConfigFixture(): Integration {
       name: 'Bitbucket',
       slug: 'bitbucket',
     },
+    scopes: null,
     status: 'active',
   };
 }
@@ -74,6 +75,7 @@ export function GitHubIntegrationConfigFixture(): Integration {
       name: 'Github',
       slug: 'github',
     },
+    scopes: null,
     status: 'active',
   };
 }

--- a/tests/js/fixtures/jiraIntegration.ts
+++ b/tests/js/fixtures/jiraIntegration.ts
@@ -24,6 +24,7 @@ export function JiraIntegrationFixture(
       canDisable: false,
       slug: '',
     },
+    scopes: null,
     accountType: '',
     gracePeriodEnd: '',
     organizationIntegrationStatus: 'active',

--- a/tests/js/fixtures/organizationIntegrations.ts
+++ b/tests/js/fixtures/organizationIntegrations.ts
@@ -9,6 +9,7 @@ export function OrganizationIntegrationsFixture(
     icon: 'https://a.slack-edge.com/80588/img/avatars-teams/ava_0012-132.png',
     domainName: 'hb-testing.slack.com',
     accountType: null,
+    scopes: null,
     status: 'active',
     provider: {
       key: 'slack',
@@ -25,7 +26,7 @@ export function OrganizationIntegrationsFixture(
     },
     externalId: 'TA99AB9CD',
     gracePeriodEnd: '',
-    organizationId: '',
+    organizationId: 1,
     organizationIntegrationStatus: 'active',
     ...params,
   };


### PR DESCRIPTION
OrganizationIntegration.organizationId is a number and configOrganization
is omitted when includeConfig=0. scopes is always present and null for
GitHub.