### PR TITLE
feat(seer): Add spans query embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -887,7 +887,7 @@
   },
   {
     "name": "spansQuery",
-    "description": "Preview an Explore > Traces (spans) query. Use mode \"samples\" for individual spans; inline renders a link and block renders the first five matching rows. Use mode \"aggregate\" for grouped results; supply `groupBy` and `yAxes`, and the block renders the first five grouped rows. `query` uses span search syntax, e.g. \"span.op:http.client\".",
+    "description": "Preview an Explore > Traces (spans) query. Use mode \"samples\" for individual spans and mode \"aggregate\" for grouped results, supplying `groupBy` and `yAxes`. `query` uses span search syntax, e.g. \"span.op:http.client\". Inline renders a link; block renders the first five matching rows beneath a timeseries chart of the same query. A query with `groupBy` charts the top five groups as one series each, matching the rows below it; every other query charts a single total for the period. Provide `yAxes` to pick which aggregate is charted — samples mode, and any query naming none, charts \"count(span.duration)\". When aggregate mode supplies no `groupBy` there is only one row to show, so the chart replaces the table.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -989,6 +989,16 @@
           "sort": "-p95_span_duration",
           "statsPeriod": "7d",
           "title": "p95 by span op"
+        }
+      },
+      {
+        "label": "Total spans",
+        "data": {
+          "query": "span.op:http.client",
+          "mode": "aggregate",
+          "yAxes": ["count(span.duration)"],
+          "statsPeriod": "24h",
+          "title": "Total spans"
         }
       }
     ]

--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -887,7 +887,7 @@
   },
   {
     "name": "spansQuery",
-    "description": "Link to an Explore > Traces (spans) query. Use mode \"samples\" to show individual spans and \"aggregate\" to group and chart them. In aggregate mode supply `groupBy` and `yAxes`. `query` uses span search syntax, e.g. \"span.op:http.client\".",
+    "description": "Preview an Explore > Traces (spans) query. Use mode \"samples\" for individual spans; inline renders a link and block renders the first five matching rows. Use mode \"aggregate\" for grouped results; supply `groupBy` and `yAxes`, and the block renders the first five grouped rows. `query` uses span search syntax, e.g. \"span.op:http.client\".",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -973,8 +973,10 @@
         "data": {
           "query": "span.op:http.client",
           "mode": "samples",
+          "fields": ["span.description", "span.op", "span.duration", "timestamp"],
           "sort": "-span.duration",
-          "statsPeriod": "24h"
+          "statsPeriod": "24h",
+          "title": "Slow HTTP spans"
         }
       },
       {
@@ -984,7 +986,9 @@
           "mode": "aggregate",
           "groupBy": ["span.op"],
           "yAxes": ["p95(span.duration)"],
-          "statsPeriod": "7d"
+          "sort": "-p95_span_duration",
+          "statsPeriod": "7d",
+          "title": "p95 by span op"
         }
       }
     ]

--- a/static/app/components/seer/markdown/embeds/components/chart.tsx
+++ b/static/app/components/seer/markdown/embeds/components/chart.tsx
@@ -146,28 +146,16 @@ export function ChartContent({
         </Stack>
       ) : null}
       {/*
-        A multi-series chart renders a legend, and the legend lays its items out
-        at their natural width — each `flex-shrink: 0` and up to 180px — only
-        collapsing them into a "+N more" dropdown once it has measured the room
-        it actually has. That natural width becomes this box's min-content
-        width, which no ancestor can shrink below, so the surrounding embed ends
-        up wider than its container. `overflow` alone can't hold it back: a
-        non-visible overflow only zeroes the automatic minimum size of a *flex
-        item*, while a block's min-content width goes on depending on its
-        children regardless.
-
-        Inline-axis size containment is what detaches the two — this box's width
-        is computed as if it had no contents, so it takes its width from the
-        embed and the legend measures against that instead of dictating it,
-        which is also what lets the "+N more" collapse do its job. `overflow`
-        then clips a canvas that is briefly stale between a resize and ECharts'
-        own ResizeObserver catching up.
+        Inline-size containment: without it a wide legend sets this box's
+        min-content width, which no ancestor can shrink below, and the chart
+        overflows its container. Containment computes the width as if the box
+        were empty, so the legend measures against the container instead of
+        dictating it.
       */}
       <Container
         containerType="inline-size"
         data-test-id="seer-chart-content"
         height="220px"
-        overflow="hidden"
         width="100%"
       >
         {visualizationComponent}

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
@@ -2,6 +2,10 @@ import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 
+jest.mock('sentry/components/charts/baseChart', () => ({
+  BaseChart: jest.fn(() => null),
+}));
+
 function renderEmbed({
   data,
   level = 'block',
@@ -46,6 +50,7 @@ describe('spans query embed', () => {
       'href',
       expect.stringContaining('/explore/traces/')
     );
+    expect(screen.getAllByLabelText('span.op:http.server').length).toBeGreaterThan(0);
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith(
@@ -92,6 +97,10 @@ describe('spans query embed', () => {
     expect(await screen.findByText('http.server')).toBeInTheDocument();
     expect(screen.getByText('1,234')).toBeInTheDocument();
     expect(screen.getByText('Aggregate')).toBeInTheDocument();
+    // A group-by column is present, so the table still renders instead of a
+    // chart.
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.queryByTestId('seer-chart-content')).not.toBeInTheDocument();
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith(
@@ -103,6 +112,52 @@ describe('spans query embed', () => {
             per_page: 5,
             sort: '-p95_span_duration',
             statsPeriod: '7d',
+          }),
+        })
+      );
+    });
+  });
+
+  it('renders a chart instead of a table when aggregate mode has no groupBy', async () => {
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
+    });
+    const statsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [1_700_000_000, [{count: 5}]],
+          [1_700_003_600, [{count: 8}]],
+        ],
+      },
+    });
+
+    renderEmbed({
+      data: {
+        query: 'span.op:http.server',
+        mode: 'aggregate',
+        yAxes: ['count(span.duration)'],
+        statsPeriod: '1h',
+        title: 'Span count',
+      },
+    });
+
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('span.op:http.server').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    // The table's own fetch is skipped entirely in chart mode.
+    expect(eventsRequest).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(statsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'spans',
+            query: 'span.op:http.server',
+            statsPeriod: '1h',
+            yAxis: ['count(span.duration)'],
           }),
         })
       );

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
@@ -6,6 +6,11 @@ jest.mock('sentry/components/charts/baseChart', () => ({
   BaseChart: jest.fn(() => null),
 }));
 
+const SERIES = [
+  [1_700_000_000, [{count: 5}]],
+  [1_700_003_600, [{count: 8}]],
+];
+
 function renderEmbed({
   data,
   level = 'block',
@@ -18,7 +23,7 @@ function renderEmbed({
 }
 
 describe('spans query embed', () => {
-  it('previews five span samples', async () => {
+  it('previews five span samples under a count timeseries', async () => {
     const request = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
@@ -29,6 +34,10 @@ describe('spans query embed', () => {
           'span.op': 'http.server',
         })),
       },
+    });
+    const statsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {data: SERIES},
     });
 
     renderEmbed({
@@ -52,6 +61,10 @@ describe('spans query embed', () => {
     );
     expect(screen.getAllByLabelText('span.op:http.server').length).toBeGreaterThan(0);
 
+    // The chart accompanies the sample rows rather than replacing them.
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith(
         '/organizations/org-slug/events/',
@@ -67,6 +80,28 @@ describe('spans query embed', () => {
         })
       );
     });
+
+    // A samples query names no aggregate, so it charts Explore's own default
+    // visualization as a single total for the period.
+    await waitFor(() => {
+      expect(statsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'spans',
+            query: 'span.op:http.server',
+            statsPeriod: '24h',
+            yAxis: ['count(span.duration)'],
+          }),
+        })
+      );
+    });
+
+    // Without group-by columns there is nothing to break the total into, so the
+    // grouping params must stay off the request.
+    const [, options] = statsRequest.mock.calls.at(-1)!;
+    expect(options.query).not.toHaveProperty('field');
+    expect(options.query).not.toHaveProperty('topEvents');
   });
 
   it('previews aggregate spans using API field aliases', async () => {
@@ -79,6 +114,13 @@ describe('spans query embed', () => {
             p95_span_duration: 1234,
           },
         ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        'http.server': {data: SERIES, order: 0},
+        'db.query': {data: SERIES, order: 1},
       },
     });
 
@@ -97,10 +139,10 @@ describe('spans query embed', () => {
     expect(await screen.findByText('http.server')).toBeInTheDocument();
     expect(screen.getByText('1,234')).toBeInTheDocument();
     expect(screen.getByText('Aggregate')).toBeInTheDocument();
-    // A group-by column is present, so the table still renders instead of a
-    // chart.
+    // A group-by column is present, so the table is still worth rendering —
+    // now beneath the chart.
     expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.queryByTestId('seer-chart-content')).not.toBeInTheDocument();
+    expect(screen.getByTestId('seer-chart-content')).toBeInTheDocument();
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith(
@@ -118,6 +160,96 @@ describe('spans query embed', () => {
     });
   });
 
+  it('charts a grouped query as one series per top group', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'span.op': 'http.server', p95_span_duration: 1234}]},
+    });
+    const statsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        'http.server': {data: SERIES, order: 0},
+        'db.query': {data: SERIES, order: 1},
+      },
+    });
+
+    renderEmbed({
+      data: {
+        query: 'span.op:http.server',
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        yAxes: ['p95(span.duration)'],
+        sort: '-p95_span_duration',
+        statsPeriod: '24h',
+        title: 'p95 by span op',
+      },
+    });
+
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+
+    // The grouping column has to reach events-stats: `field` is what makes the
+    // endpoint break the result into a series per group, and `topEvents` is
+    // what caps how many come back. This is the split Explore's own chart
+    // shows, and it lines the series up with the table's rows.
+    await waitFor(() => {
+      expect(statsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'spans',
+            excludeOther: '1',
+            field: ['span.op', 'p95(span.duration)'],
+            query: 'span.op:http.server',
+            sort: '-p95_span_duration',
+            statsPeriod: '24h',
+            topEvents: '5',
+            yAxis: ['p95(span.duration)'],
+          }),
+        })
+      );
+    });
+  });
+
+  it('ranks top groups by the charted aggregate when the sort names another', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'span.op': 'http.server', count_span_duration: 12}]},
+    });
+    const statsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {'http.server': {data: SERIES, order: 0}},
+    });
+
+    renderEmbed({
+      data: {
+        query: '',
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        // Grouping already spends a series per group, so only the first y-axis
+        // is charted — and the sort naming the second cannot rank it.
+        yAxes: ['count(span.duration)', 'p95(span.duration)'],
+        sort: '-p95_span_duration',
+        statsPeriod: '24h',
+      },
+    });
+
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(statsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-stats/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            field: ['span.op', 'count(span.duration)'],
+            sort: '-count_span_duration',
+            topEvents: '5',
+            yAxis: ['count(span.duration)'],
+          }),
+        })
+      );
+    });
+  });
+
   it('renders a chart instead of a table when aggregate mode has no groupBy', async () => {
     const eventsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
@@ -125,12 +257,7 @@ describe('spans query embed', () => {
     });
     const statsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
-      body: {
-        data: [
-          [1_700_000_000, [{count: 5}]],
-          [1_700_003_600, [{count: 8}]],
-        ],
-      },
+      body: {data: SERIES},
     });
 
     renderEmbed({
@@ -146,7 +273,7 @@ describe('spans query embed', () => {
     expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
     expect(screen.getAllByLabelText('span.op:http.server').length).toBeGreaterThan(0);
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
-    // The table's own fetch is skipped entirely in chart mode.
+    // The table's own fetch is skipped entirely in chart-only mode.
     expect(eventsRequest).not.toHaveBeenCalled();
 
     await waitFor(() => {
@@ -162,12 +289,19 @@ describe('spans query embed', () => {
         })
       );
     });
+
+    const [, options] = statsRequest.mock.calls.at(-1)!;
+    expect(options.query).not.toHaveProperty('topEvents');
   });
 
   it('does not fetch data for an inline embed', () => {
     const request = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {data: []},
+    });
+    const statsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {data: SERIES},
     });
 
     renderEmbed({
@@ -177,5 +311,6 @@ describe('spans query embed', () => {
 
     expect(screen.getByRole('link', {name: 'Span search'})).toBeInTheDocument();
     expect(request).not.toHaveBeenCalled();
+    expect(statsRequest).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
@@ -160,6 +160,108 @@ describe('spans query embed', () => {
     });
   });
 
+  it('links an aggregate sort in the spelling Explore validates', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'span.op': 'http.server', p95_span_duration: 1234}]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {'http.server': {data: SERIES, order: 0}},
+    });
+
+    renderEmbed({
+      data: {
+        query: '',
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        yAxes: ['p95(span.duration)'],
+        // The spelling the events API wants, which Explore's URL param does not.
+        sort: '-p95_span_duration',
+        statsPeriod: '7d',
+        title: 'p95 by span op',
+      },
+    });
+
+    const link = await screen.findByRole('link', {name: 'p95 by span op'});
+    const {searchParams} = new URL(
+      link.getAttribute('href')!,
+      'https://sentry.io' // the href is relative; the base is only to parse it
+    );
+
+    // Explore validates `aggregateSort` by exact match against its own group-by
+    // and y-axis values, so an alias here is dropped and the page silently
+    // falls back to its default ordering.
+    expect(searchParams.get('aggregateSort')).toBe('-p95(span.duration)');
+  });
+
+  it('sends an aggregate sort to the events API in its alias spelling', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'span.op': 'http.server', p95_span_duration: 1234}]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {'http.server': {data: SERIES, order: 0}},
+    });
+
+    renderEmbed({
+      data: {
+        query: '',
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        yAxes: ['p95(span.duration)'],
+        // The spelling Explore's URL wants, which the events API does not.
+        sort: '-p95(span.duration)',
+        statsPeriod: '7d',
+        title: 'p95 by span op',
+      },
+    });
+
+    expect(await screen.findByText('http.server')).toBeInTheDocument();
+
+    // Seer may send either spelling, so each edge normalizes rather than
+    // trusting what arrived.
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({sort: '-p95_span_duration'}),
+        })
+      );
+    });
+  });
+
+  it('drops an aggregate sort that names no aggregate field', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'span.op': 'http.server', p95_span_duration: 1234}]},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {'http.server': {data: SERIES, order: 0}},
+    });
+
+    renderEmbed({
+      data: {
+        query: '',
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        yAxes: ['p95(span.duration)'],
+        sort: '-count_span_duration',
+        statsPeriod: '7d',
+        title: 'p95 by span op',
+      },
+    });
+
+    const link = await screen.findByRole('link', {name: 'p95 by span op'});
+    const {searchParams} = new URL(link.getAttribute('href')!, 'https://sentry.io');
+
+    // Explore would reject it anyway, so leave it off rather than ship a param
+    // that does nothing.
+    expect(searchParams.get('aggregateSort')).toBeNull();
+  });
+
   it('charts a grouped query as one series per top group', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
@@ -1,51 +1,126 @@
-import {getEmbedLinkHref} from './resourceEmbedTestUtils';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+
+function renderEmbed({
+  data,
+  level = 'block',
+}: {
+  data: Record<string, unknown>;
+  level?: 'block' | 'inline';
+}) {
+  const tag = `{% spansQuery %}${JSON.stringify(data)}{% /spansQuery %}`;
+  return render(<SeerMarkdown raw={level === 'inline' ? `See ${tag}` : tag} />);
+}
 
 describe('spans query embed', () => {
-  it('builds a samples-mode query', () => {
-    const href = getEmbedLinkHref('spansQuery', 'Span search', {
-      query: 'span.op:http.client',
-      mode: 'samples',
-      sort: '-span.duration',
-      statsPeriod: '24h',
+  it('previews five span samples', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: Array.from({length: 6}, (_, index) => ({
+          id: String(index + 1),
+          'span.description': `GET /api/${index + 1}`,
+          'span.duration': 100 + index,
+          'span.op': 'http.server',
+        })),
+      },
     });
 
-    expect(href).toContain('/organizations/org-slug/explore/traces/');
-    expect(href).toContain('mode=samples');
-    expect(href).toContain('query=span.op%3Ahttp.client');
-    expect(href).toContain('sort=-span.duration');
+    renderEmbed({
+      data: {
+        query: 'span.op:http.server',
+        mode: 'samples',
+        fields: ['span.description', 'span.op', 'span.duration'],
+        sort: '-span.duration',
+        statsPeriod: '24h',
+        title: 'Slow HTTP spans',
+      },
+    });
+
+    expect(await screen.findByText('GET /api/1')).toBeInTheDocument();
+    expect(screen.getByText('GET /api/5')).toBeInTheDocument();
+    expect(screen.queryByText('GET /api/6')).not.toBeInTheDocument();
+    expect(screen.getByText('Spans')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Slow HTTP spans'})).toHaveAttribute(
+      'href',
+      expect.stringContaining('/explore/traces/')
+    );
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'spans',
+            field: ['span.description', 'span.op', 'span.duration'],
+            per_page: 5,
+            query: 'span.op:http.server',
+            sort: '-span.duration',
+            statsPeriod: '24h',
+          }),
+        })
+      );
+    });
   });
 
-  it('encodes group-bys and aggregates for aggregate mode', () => {
-    const href = getEmbedLinkHref('spansQuery', 'p95 by op', {
-      mode: 'aggregate',
-      groupBy: ['span.op'],
-      yAxes: ['p95(span.duration)'],
-      title: 'p95 by op',
+  it('previews aggregate spans using API field aliases', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {
+            'span.op': 'http.server',
+            p95_span_duration: 1234,
+          },
+        ],
+      },
     });
 
-    expect(href).toContain('mode=aggregate');
+    renderEmbed({
+      data: {
+        query: '',
+        mode: 'aggregate',
+        groupBy: ['span.op'],
+        yAxes: ['p95(span.duration)'],
+        sort: '-p95_span_duration',
+        statsPeriod: '7d',
+        title: 'p95 by span op',
+      },
+    });
 
-    const params = new URL(href, 'https://sentry.io').searchParams;
-    expect(params.getAll('aggregateField').map(field => JSON.parse(field))).toEqual([
-      {groupBy: 'span.op'},
-      {yAxes: ['p95(span.duration)']},
-    ]);
+    expect(await screen.findByText('http.server')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('Aggregate')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'spans',
+            field: ['span.op', 'p95(span.duration)'],
+            per_page: 5,
+            sort: '-p95_span_duration',
+            statsPeriod: '7d',
+          }),
+        })
+      );
+    });
   });
 
-  it('coerces numeric project IDs so agent payloads still render', () => {
-    const href = getEmbedLinkHref('spansQuery', 'Issue Pageloads (Last 30 Days)', {
-      mode: 'aggregate',
-      query: 'span.op:pageload transaction:*issues*',
-      groupBy: ['transaction'],
-      yAxes: ['count()'],
-      statsPeriod: '30d',
-      projects: [11276],
-      title: 'Issue Pageloads (Last 30 Days)',
+  it('does not fetch data for an inline embed', () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
     });
 
-    expect(href).toContain('/organizations/org-slug/explore/traces/');
-    expect(href).toContain('project=11276');
-    expect(href).toContain('statsPeriod=30d');
-    expect(href).toContain('mode=aggregate');
+    renderEmbed({
+      data: {query: 'span.op:http.client', mode: 'samples'},
+      level: 'inline',
+    });
+
+    expect(screen.getByRole('link', {name: 'Span search'})).toBeInTheDocument();
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.spec.tsx
@@ -232,8 +232,8 @@ describe('spans query embed', () => {
     });
   });
 
-  it('drops an aggregate sort that names no aggregate field', async () => {
-    MockApiClient.addMockResponse({
+  it('falls back when an aggregate sort names no aggregate field', async () => {
+    const request = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {data: [{'span.op': 'http.server', p95_span_duration: 1234}]},
     });
@@ -260,6 +260,19 @@ describe('spans query embed', () => {
     // Explore would reject it anyway, so leave it off rather than ship a param
     // that does nothing.
     expect(searchParams.get('aggregateSort')).toBeNull();
+
+    // The events API is stricter still: an orderby that names no selected
+    // column fails the request outright, so the table falls back to the
+    // charted aggregate rather than showing an error where the link and the
+    // chart both quietly degrade.
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({sort: '-p95_span_duration'}),
+        })
+      );
+    });
   });
 
   it('charts a grouped query as one series per top group', async () => {

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.tsx
@@ -1,15 +1,18 @@
-import {SpansQueryBlock} from 'sentry/components/seer/markdown/embeds/components/spansQueryBlock';
+import {lazy} from 'react';
+
+import {LazyLoad} from 'sentry/components/lazyLoad';
 import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
 import {SpansQueryLink} from './spansQueryLink';
 
+const LazySpansQueryBlock = lazy(() => import('./spansQueryBlock'));
+
 export const SpansQuery = defineSeerEmbed({
   name: 'spansQuery',
   render(props, level) {
-    return level === 'block' ? (
-      <SpansQueryBlock data={props} />
-    ) : (
-      <SpansQueryLink data={props} />
-    );
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazySpansQueryBlock} data={props} />;
+    }
+    return <SpansQueryLink data={props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/spansQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQuery.tsx
@@ -1,38 +1,15 @@
-import {
-  toAggregateFields,
-  toMode,
-  toPageFilters,
-} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
-import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {
-  defineSeerEmbed,
-  type EmbedOutput,
-} from 'sentry/components/seer/markdown/embeds/utils';
-import {IconSpan} from 'sentry/icons';
-import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {getExploreUrl} from 'sentry/views/explore/utils';
+import {SpansQueryBlock} from 'sentry/components/seer/markdown/embeds/components/spansQueryBlock';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
-function SpansQueryLink(props: EmbedOutput<'spansQuery'>) {
-  const organization = useOrganization();
-  const {query, mode, sort, fields, groupBy, yAxes, title} = props;
-
-  const href = getExploreUrl({
-    organization,
-    selection: toPageFilters(props),
-    query,
-    mode: toMode(mode),
-    field: fields,
-    sort,
-    aggregateField: toAggregateFields({groupBy, yAxes}),
-  });
-
-  return <ResourceLink icon={IconSpan} href={href} title={title ?? t('Span search')} />;
-}
+import {SpansQueryLink} from './spansQueryLink';
 
 export const SpansQuery = defineSeerEmbed({
   name: 'spansQuery',
-  render(props) {
-    return <SpansQueryLink {...props} />;
+  render(props, level) {
+    return level === 'block' ? (
+      <SpansQueryBlock data={props} />
+    ) : (
+      <SpansQueryLink data={props} />
+    );
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
@@ -1,21 +1,35 @@
-import {useQuery} from '@tanstack/react-query';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
+import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
-import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {aggregateOutputType, getAggregateAlias} from 'sentry/utils/discover/fields';
 import {formatNumber} from 'sentry/utils/number/formatNumber';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  isEventsStats,
+  isMultiSeriesEventsStats,
+} from 'sentry/views/dashboards/utils/isEventsStats';
+import {transformEventsStatsToSeries} from 'sentry/views/dashboards/utils/transformEventsStatsToSeries';
 
 import {SpansQueryLink} from './spansQueryLink';
 import {
+  buildSpansChartQuery,
   buildSpansEventView,
   getSpansQueryFields,
+  hasNoGroupBy,
+  resolveChartYAxes,
+  toChartUnit,
   type SpansQueryData,
 } from './spansQueryUtils';
 
@@ -41,13 +55,101 @@ function formatCellValue(value: unknown): string {
   return JSON.stringify(value) ?? '—';
 }
 
-export function SpansQueryBlock({data}: {data: SpansQueryData}) {
+function chartSeriesFromStatsResponse(
+  responseData: EventsStats | MultiSeriesEventsStats,
+  yAxisFields: string[]
+) {
+  if (isEventsStats(responseData)) {
+    const field = yAxisFields[0] ?? t('Count');
+    return [transformEventsStatsToSeries(responseData, field, field)];
+  }
+
+  if (isMultiSeriesEventsStats(responseData)) {
+    return Object.entries(responseData)
+      .filter(([key]) => key !== 'order')
+      .map(([seriesName, stats]) =>
+        transformEventsStatsToSeries(stats, seriesName, seriesName)
+      );
+  }
+
+  return [];
+}
+
+function SpansQueryChart({
+  data,
+  eventView,
+  fields,
+}: {
+  data: SpansQueryData;
+  eventView: ReturnType<typeof buildSpansEventView>;
+  fields: string[];
+}) {
+  const organization = useOrganization();
+  const yAxisFields = resolveChartYAxes(data, fields);
+
+  const query = useQuery({
+    ...apiOptions.as<EventsStats | MultiSeriesEventsStats>()(
+      '/organizations/$organizationIdOrSlug/events-stats/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: buildSpansChartQuery(eventView, yAxisFields),
+        staleTime: 30_000,
+      }
+    ),
+    retry: false,
+  });
+
+  if (query.isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (query.isError) {
+    return (
+      <Alert role="alert" variant="danger">
+        {t('Unable to load chart data')}
+      </Alert>
+    );
+  }
+
+  const series = chartSeriesFromStatsResponse(query.data, yAxisFields).map(item => ({
+    label: item.seriesName,
+    data: item.data.map(point => ({
+      x: new Date(point.name).toISOString(),
+      y: point.value,
+    })),
+  }));
+
+  if (series.every(item => item.data.length === 0)) {
+    return (
+      <Alert role="alert" variant="muted">
+        {t('No matching spans')}
+      </Alert>
+    );
+  }
+
+  return (
+    <ChartContent
+      data={{
+        title: data.title ?? t('Spans over time'),
+        visualization: 'line',
+        x_axis: 'time',
+        y_axis_unit: toChartUnit(aggregateOutputType(yAxisFields[0])),
+        series,
+      }}
+      showHeader={false}
+    />
+  );
+}
+
+export default function SpansQueryBlock({data}: {data: SpansQueryData}) {
   const organization = useOrganization();
   const eventView = buildSpansEventView(data);
   const fields = getSpansQueryFields(data);
-  const query = useQuery({
+  const isChartMode = hasNoGroupBy(data);
+
+  const tableQuery = useQuery({
     ...apiOptions.as<TableData>()('/organizations/$organizationIdOrSlug/events/', {
-      path: {organizationIdOrSlug: organization.slug},
+      path: isChartMode ? skipToken : {organizationIdOrSlug: organization.slug},
       query: {
         ...eventView.generateQueryStringObject(),
         per_page: ROW_LIMIT,
@@ -57,6 +159,7 @@ export function SpansQueryBlock({data}: {data: SpansQueryData}) {
     }),
     retry: false,
   });
+
   const columns = fields.map((field, index) => ({
     key: field,
     width: index === 0 ? 'minmax(0, 2fr)' : 'minmax(0, 1fr)',
@@ -78,38 +181,43 @@ export function SpansQueryBlock({data}: {data: SpansQueryData}) {
             {data.mode === 'aggregate' ? t('Aggregate') : t('Spans')}
           </Tag>
         </Flex>
-        <SimpleTable
-          columns={columns}
-          header={
-            <SimpleTable.HeaderRow>
-              {fields.map(field => (
-                <SimpleTable.HeaderCell key={field}>
-                  <Text ellipsis>{field}</Text>
-                </SimpleTable.HeaderCell>
-              ))}
-            </SimpleTable.HeaderRow>
-          }
-        >
-          {query.isPending ? (
-            <SimpleTable.Loading />
-          ) : query.isError ? (
-            <SimpleTable.Empty>{t('Unable to load spans')}</SimpleTable.Empty>
-          ) : query.data.data.length === 0 ? (
-            <SimpleTable.Empty>{t('No matching spans')}</SimpleTable.Empty>
-          ) : (
-            query.data.data.slice(0, ROW_LIMIT).map((row, rowIndex) => (
-              <SimpleTable.Row key={row.id ?? rowIndex}>
+        {data.query ? <ProvidedFormattedQuery query={data.query} /> : null}
+        {isChartMode ? (
+          <SpansQueryChart data={data} eventView={eventView} fields={fields} />
+        ) : (
+          <SimpleTable
+            columns={columns}
+            header={
+              <SimpleTable.HeaderRow>
                 {fields.map(field => (
-                  <SimpleTable.RowCell key={field}>
-                    <Text ellipsis>
-                      {formatCellValue(row[field] ?? row[getAggregateAlias(field)])}
-                    </Text>
-                  </SimpleTable.RowCell>
+                  <SimpleTable.HeaderCell key={field}>
+                    <Text ellipsis>{field}</Text>
+                  </SimpleTable.HeaderCell>
                 ))}
-              </SimpleTable.Row>
-            ))
-          )}
-        </SimpleTable>
+              </SimpleTable.HeaderRow>
+            }
+          >
+            {tableQuery.isPending ? (
+              <SimpleTable.Loading />
+            ) : tableQuery.isError ? (
+              <SimpleTable.Empty>{t('Unable to load spans')}</SimpleTable.Empty>
+            ) : tableQuery.data.data.length === 0 ? (
+              <SimpleTable.Empty>{t('No matching spans')}</SimpleTable.Empty>
+            ) : (
+              tableQuery.data.data.slice(0, ROW_LIMIT).map((row, rowIndex) => (
+                <SimpleTable.Row key={row.id ?? rowIndex}>
+                  {fields.map(field => (
+                    <SimpleTable.RowCell key={field}>
+                      <Text ellipsis>
+                        {formatCellValue(row[field] ?? row[getAggregateAlias(field)])}
+                      </Text>
+                    </SimpleTable.RowCell>
+                  ))}
+                </SimpleTable.Row>
+              ))
+            )}
+          </SimpleTable>
+        )}
       </Stack>
     </Container>
   );

--- a/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
@@ -1,0 +1,116 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {t} from 'sentry/locale';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {TableData} from 'sentry/utils/discover/discoverQuery';
+import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {formatNumber} from 'sentry/utils/number/formatNumber';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {SpansQueryLink} from './spansQueryLink';
+import {
+  buildSpansEventView,
+  getSpansQueryFields,
+  type SpansQueryData,
+} from './spansQueryUtils';
+
+const ROW_LIMIT = 5;
+
+function formatCellValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  if (typeof value === 'number') {
+    return String(formatNumber(value));
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'boolean' || typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  return JSON.stringify(value) ?? '—';
+}
+
+export function SpansQueryBlock({data}: {data: SpansQueryData}) {
+  const organization = useOrganization();
+  const eventView = buildSpansEventView(data);
+  const fields = getSpansQueryFields(data);
+  const query = useQuery({
+    ...apiOptions.as<TableData>()('/organizations/$organizationIdOrSlug/events/', {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {
+        ...eventView.generateQueryStringObject(),
+        per_page: ROW_LIMIT,
+        referrer: 'seer-spans-query-embed',
+      },
+      staleTime: 30_000,
+    }),
+    retry: false,
+  });
+  const columns = fields.map((field, index) => ({
+    key: field,
+    width: index === 0 ? 'minmax(0, 2fr)' : 'minmax(0, 1fr)',
+  }));
+
+  return (
+    <Container
+      background="primary"
+      border="primary"
+      data-test-id={`seer-spans-query-${data.mode}-embed`}
+      padding="lg"
+      radius="md"
+      width="100%"
+    >
+      <Stack gap="md">
+        <Flex align="center" gap="md" justify="between">
+          <SpansQueryLink data={data} />
+          <Tag variant="muted">
+            {data.mode === 'aggregate' ? t('Aggregate') : t('Spans')}
+          </Tag>
+        </Flex>
+        <SimpleTable
+          columns={columns}
+          header={
+            <SimpleTable.HeaderRow>
+              {fields.map(field => (
+                <SimpleTable.HeaderCell key={field}>
+                  <Text ellipsis>{field}</Text>
+                </SimpleTable.HeaderCell>
+              ))}
+            </SimpleTable.HeaderRow>
+          }
+        >
+          {query.isPending ? (
+            <SimpleTable.Loading />
+          ) : query.isError ? (
+            <SimpleTable.Empty>{t('Unable to load spans')}</SimpleTable.Empty>
+          ) : query.data.data.length === 0 ? (
+            <SimpleTable.Empty>{t('No matching spans')}</SimpleTable.Empty>
+          ) : (
+            query.data.data.slice(0, ROW_LIMIT).map((row, rowIndex) => (
+              <SimpleTable.Row key={row.id ?? rowIndex}>
+                {fields.map(field => (
+                  <SimpleTable.RowCell key={field}>
+                    <Text ellipsis>
+                      {formatCellValue(row[field] ?? row[getAggregateAlias(field)])}
+                    </Text>
+                  </SimpleTable.RowCell>
+                ))}
+              </SimpleTable.Row>
+            ))
+          )}
+        </SimpleTable>
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
@@ -35,6 +35,10 @@ import {
 
 const ROW_LIMIT = 5;
 
+// Matches the height `ChartContent` renders into, so the chart's loading state
+// holds the block's shape instead of collapsing it.
+const CHART_HEIGHT = '220px';
+
 function formatCellValue(value: unknown): string {
   if (value === undefined || value === null || value === '') {
     return '—';
@@ -64,6 +68,8 @@ function chartSeriesFromStatsResponse(
     return [transformEventsStatsToSeries(responseData, field, field)];
   }
 
+  // A grouped query comes back keyed by group name — one entry per top group —
+  // and a multi-axis query keyed by aggregate. Either way the key is the label.
   if (isMultiSeriesEventsStats(responseData)) {
     return Object.entries(responseData)
       .filter(([key]) => key !== 'order')
@@ -78,21 +84,21 @@ function chartSeriesFromStatsResponse(
 function SpansQueryChart({
   data,
   eventView,
-  fields,
+  hasTable,
 }: {
   data: SpansQueryData;
   eventView: ReturnType<typeof buildSpansEventView>;
-  fields: string[];
+  hasTable: boolean;
 }) {
   const organization = useOrganization();
-  const yAxisFields = resolveChartYAxes(data, fields);
+  const yAxisFields = resolveChartYAxes(data);
 
   const query = useQuery({
     ...apiOptions.as<EventsStats | MultiSeriesEventsStats>()(
       '/organizations/$organizationIdOrSlug/events-stats/',
       {
         path: {organizationIdOrSlug: organization.slug},
-        query: buildSpansChartQuery(eventView, yAxisFields),
+        query: buildSpansChartQuery(eventView, data, yAxisFields),
         staleTime: 30_000,
       }
     ),
@@ -100,7 +106,11 @@ function SpansQueryChart({
   });
 
   if (query.isPending) {
-    return <LoadingIndicator />;
+    return (
+      <Flex align="center" height={CHART_HEIGHT} justify="center" width="100%">
+        <LoadingIndicator />
+      </Flex>
+    );
   }
 
   if (query.isError) {
@@ -120,7 +130,9 @@ function SpansQueryChart({
   }));
 
   if (series.every(item => item.data.length === 0)) {
-    return (
+    // When a table follows, its own empty state already says this — drop the
+    // chart rather than repeat the message.
+    return hasTable ? null : (
       <Alert role="alert" variant="muted">
         {t('No matching spans')}
       </Alert>
@@ -145,11 +157,14 @@ export default function SpansQueryBlock({data}: {data: SpansQueryData}) {
   const organization = useOrganization();
   const eventView = buildSpansEventView(data);
   const fields = getSpansQueryFields(data);
-  const isChartMode = hasNoGroupBy(data);
+  // An aggregate with no grouping columns collapses to a single row, so the
+  // chart already says everything a table would. Every other query keeps its
+  // table and gains the chart above it.
+  const isChartOnly = hasNoGroupBy(data);
 
   const tableQuery = useQuery({
     ...apiOptions.as<TableData>()('/organizations/$organizationIdOrSlug/events/', {
-      path: isChartMode ? skipToken : {organizationIdOrSlug: organization.slug},
+      path: isChartOnly ? skipToken : {organizationIdOrSlug: organization.slug},
       query: {
         ...eventView.generateQueryStringObject(),
         per_page: ROW_LIMIT,
@@ -167,9 +182,11 @@ export default function SpansQueryBlock({data}: {data: SpansQueryData}) {
 
   return (
     <Container
+      as="section"
       background="primary"
       border="primary"
       data-test-id={`seer-spans-query-${data.mode}-embed`}
+      margin="lg 0"
       padding="lg"
       radius="md"
       width="100%"
@@ -182,9 +199,8 @@ export default function SpansQueryBlock({data}: {data: SpansQueryData}) {
           </Tag>
         </Flex>
         {data.query ? <ProvidedFormattedQuery query={data.query} /> : null}
-        {isChartMode ? (
-          <SpansQueryChart data={data} eventView={eventView} fields={fields} />
-        ) : (
+        <SpansQueryChart data={data} eventView={eventView} hasTable={!isChartOnly} />
+        {isChartOnly ? null : (
           <SimpleTable
             columns={columns}
             header={

--- a/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryBlock.tsx
@@ -1,85 +1,31 @@
-import {skipToken, useQuery} from '@tanstack/react-query';
-
-import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
 
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
-import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
-import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import {t} from 'sentry/locale';
-import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {TableData} from 'sentry/utils/discover/discoverQuery';
-import {aggregateOutputType, getAggregateAlias} from 'sentry/utils/discover/fields';
-import {formatNumber} from 'sentry/utils/number/formatNumber';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {QueryEmbedCard} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard';
 import {
-  isEventsStats,
-  isMultiSeriesEventsStats,
-} from 'sentry/views/dashboards/utils/isEventsStats';
-import {transformEventsStatsToSeries} from 'sentry/views/dashboards/utils/transformEventsStatsToSeries';
+  QueryEmbedChart,
+  seriesFromEventsStats,
+  toChartUnit,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart';
+import {
+  useQueryEmbedEventsStats,
+  useQueryEmbedEventsTable,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedQueries';
+import {
+  eventColumns,
+  eventRowKey,
+  QueryEmbedTable,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable';
+import {t} from 'sentry/locale';
+import {aggregateOutputType} from 'sentry/utils/discover/fields';
 
 import {SpansQueryLink} from './spansQueryLink';
 import {
   buildSpansChartQuery,
   buildSpansEventView,
-  getSpansQueryFields,
   hasNoGroupBy,
   resolveChartYAxes,
-  toChartUnit,
   type SpansQueryData,
 } from './spansQueryUtils';
-
-const ROW_LIMIT = 5;
-
-// Matches the height `ChartContent` renders into, so the chart's loading state
-// holds the block's shape instead of collapsing it.
-const CHART_HEIGHT = '220px';
-
-function formatCellValue(value: unknown): string {
-  if (value === undefined || value === null || value === '') {
-    return '—';
-  }
-
-  if (typeof value === 'number') {
-    return String(formatNumber(value));
-  }
-
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (typeof value === 'boolean' || typeof value === 'bigint') {
-    return value.toString();
-  }
-
-  return JSON.stringify(value) ?? '—';
-}
-
-function chartSeriesFromStatsResponse(
-  responseData: EventsStats | MultiSeriesEventsStats,
-  yAxisFields: string[]
-) {
-  if (isEventsStats(responseData)) {
-    const field = yAxisFields[0] ?? t('Count');
-    return [transformEventsStatsToSeries(responseData, field, field)];
-  }
-
-  // A grouped query comes back keyed by group name — one entry per top group —
-  // and a multi-axis query keyed by aggregate. Either way the key is the label.
-  if (isMultiSeriesEventsStats(responseData)) {
-    return Object.entries(responseData)
-      .filter(([key]) => key !== 'order')
-      .map(([seriesName, stats]) =>
-        transformEventsStatsToSeries(stats, seriesName, seriesName)
-      );
-  }
-
-  return [];
-}
 
 function SpansQueryChart({
   data,
@@ -90,151 +36,60 @@ function SpansQueryChart({
   eventView: ReturnType<typeof buildSpansEventView>;
   hasTable: boolean;
 }) {
-  const organization = useOrganization();
   const yAxisFields = resolveChartYAxes(data);
-
-  const query = useQuery({
-    ...apiOptions.as<EventsStats | MultiSeriesEventsStats>()(
-      '/organizations/$organizationIdOrSlug/events-stats/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: buildSpansChartQuery(eventView, data, yAxisFields),
-        staleTime: 30_000,
-      }
-    ),
-    retry: false,
-  });
-
-  if (query.isPending) {
-    return (
-      <Flex align="center" height={CHART_HEIGHT} justify="center" width="100%">
-        <LoadingIndicator />
-      </Flex>
-    );
-  }
-
-  if (query.isError) {
-    return (
-      <Alert role="alert" variant="danger">
-        {t('Unable to load chart data')}
-      </Alert>
-    );
-  }
-
-  const series = chartSeriesFromStatsResponse(query.data, yAxisFields).map(item => ({
-    label: item.seriesName,
-    data: item.data.map(point => ({
-      x: new Date(point.name).toISOString(),
-      y: point.value,
-    })),
-  }));
-
-  if (series.every(item => item.data.length === 0)) {
-    // When a table follows, its own empty state already says this — drop the
-    // chart rather than repeat the message.
-    return hasTable ? null : (
-      <Alert role="alert" variant="muted">
-        {t('No matching spans')}
-      </Alert>
-    );
-  }
+  const query = useQueryEmbedEventsStats(
+    buildSpansChartQuery(eventView, data, yAxisFields)
+  );
 
   return (
-    <ChartContent
-      data={{
-        title: data.title ?? t('Spans over time'),
-        visualization: 'line',
-        x_axis: 'time',
-        y_axis_unit: toChartUnit(aggregateOutputType(yAxisFields[0])),
-        series,
-      }}
-      showHeader={false}
+    <QueryEmbedChart
+      emptyMessage={t('No matching spans')}
+      hasTable={hasTable}
+      isError={query.isError}
+      isPending={query.isPending}
+      series={query.data ? seriesFromEventsStats(query.data, yAxisFields) : []}
+      title={data.title ?? t('Spans over time')}
+      unit={toChartUnit(aggregateOutputType(yAxisFields[0]))}
     />
   );
 }
 
 export default function SpansQueryBlock({data}: {data: SpansQueryData}) {
-  const organization = useOrganization();
   const eventView = buildSpansEventView(data);
-  const fields = getSpansQueryFields(data);
-  // An aggregate with no grouping columns collapses to a single row, so the
-  // chart already says everything a table would. Every other query keeps its
-  // table and gains the chart above it.
+  const fields = eventView.getFields();
+  // An aggregate with no grouping columns collapses to a single row per
+  // y-axis, so the chart already says everything a table would.
   const isChartOnly = hasNoGroupBy(data);
 
-  const tableQuery = useQuery({
-    ...apiOptions.as<TableData>()('/organizations/$organizationIdOrSlug/events/', {
-      path: isChartOnly ? skipToken : {organizationIdOrSlug: organization.slug},
-      query: {
-        ...eventView.generateQueryStringObject(),
-        per_page: ROW_LIMIT,
-        referrer: 'seer-spans-query-embed',
-      },
-      staleTime: 30_000,
-    }),
-    retry: false,
+  const tableQuery = useQueryEmbedEventsTable({
+    enabled: !isChartOnly,
+    eventView,
+    referrer: 'seer-spans-query-embed',
   });
 
-  const columns = fields.map((field, index) => ({
-    key: field,
-    width: index === 0 ? 'minmax(0, 2fr)' : 'minmax(0, 1fr)',
-  }));
-
   return (
-    <Container
-      as="section"
-      background="primary"
-      border="primary"
-      data-test-id={`seer-spans-query-${data.mode}-embed`}
-      margin="lg 0"
-      padding="lg"
-      radius="md"
-      width="100%"
+    <QueryEmbedCard
+      badge={
+        <Tag variant="muted">
+          {data.mode === 'aggregate' ? t('Aggregate') : t('Spans')}
+        </Tag>
+      }
+      link={<SpansQueryLink data={data} />}
+      query={data.query}
+      testId={`seer-spans-query-${data.mode}-embed`}
     >
-      <Stack gap="md">
-        <Flex align="center" gap="md" justify="between">
-          <SpansQueryLink data={data} />
-          <Tag variant="muted">
-            {data.mode === 'aggregate' ? t('Aggregate') : t('Spans')}
-          </Tag>
-        </Flex>
-        {data.query ? <ProvidedFormattedQuery query={data.query} /> : null}
-        <SpansQueryChart data={data} eventView={eventView} hasTable={!isChartOnly} />
-        {isChartOnly ? null : (
-          <SimpleTable
-            columns={columns}
-            header={
-              <SimpleTable.HeaderRow>
-                {fields.map(field => (
-                  <SimpleTable.HeaderCell key={field}>
-                    <Text ellipsis>{field}</Text>
-                  </SimpleTable.HeaderCell>
-                ))}
-              </SimpleTable.HeaderRow>
-            }
-          >
-            {tableQuery.isPending ? (
-              <SimpleTable.Loading />
-            ) : tableQuery.isError ? (
-              <SimpleTable.Empty>{t('Unable to load spans')}</SimpleTable.Empty>
-            ) : tableQuery.data.data.length === 0 ? (
-              <SimpleTable.Empty>{t('No matching spans')}</SimpleTable.Empty>
-            ) : (
-              tableQuery.data.data.slice(0, ROW_LIMIT).map((row, rowIndex) => (
-                <SimpleTable.Row key={row.id ?? rowIndex}>
-                  {fields.map(field => (
-                    <SimpleTable.RowCell key={field}>
-                      <Text ellipsis>
-                        {formatCellValue(row[field] ?? row[getAggregateAlias(field)])}
-                      </Text>
-                    </SimpleTable.RowCell>
-                  ))}
-                </SimpleTable.Row>
-              ))
-            )}
-          </SimpleTable>
-        )}
-      </Stack>
-    </Container>
+      <SpansQueryChart data={data} eventView={eventView} hasTable={!isChartOnly} />
+      {isChartOnly ? null : (
+        <QueryEmbedTable
+          columns={eventColumns(fields)}
+          emptyMessage={t('No matching spans')}
+          errorMessage={t('Unable to load spans')}
+          isError={tableQuery.isError}
+          isPending={tableQuery.isPending}
+          rowKey={eventRowKey}
+          rows={tableQuery.data?.data ?? []}
+        />
+      )}
+    </QueryEmbedCard>
   );
 }

--- a/static/app/components/seer/markdown/embeds/components/spansQueryLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryLink.tsx
@@ -1,0 +1,22 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {getSpansQueryHref, type SpansQueryData} from './spansQueryUtils';
+
+export function SpansQueryLink({data}: {data: SpansQueryData}) {
+  const organization = useOrganization();
+  const href = getSpansQueryHref(data, organization);
+
+  return (
+    <ResourceLink
+      icon={IconSpan}
+      href={href}
+      title={
+        data.title ??
+        (data.mode === 'aggregate' ? t('Aggregated span search') : t('Span search'))
+      }
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
@@ -1,0 +1,67 @@
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import type {Organization, NewQuery} from 'sentry/types/organization';
+import {EventView} from 'sentry/utils/discover/eventView';
+import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+import {toAggregateFields, toMode, toPageFilters} from './queryEmbedParams';
+
+export type SpansQueryData = EmbedOutput<'spansQuery'>;
+
+const DEFAULT_SAMPLE_FIELDS = [
+  'span.description',
+  'span.op',
+  'span.duration',
+  'transaction',
+  'timestamp',
+];
+const DEFAULT_AGGREGATE = 'count(span.duration)';
+
+export function getSpansQueryFields(data: SpansQueryData): string[] {
+  if (data.mode === 'samples') {
+    return data.fields?.length ? data.fields : DEFAULT_SAMPLE_FIELDS;
+  }
+
+  const yAxes = data.yAxes?.length ? data.yAxes : [DEFAULT_AGGREGATE];
+  return Array.from(new Set([...(data.groupBy ?? []).filter(Boolean), ...yAxes]));
+}
+
+export function buildSpansEventView(data: SpansQueryData): EventView {
+  const fields = getSpansQueryFields(data);
+  const defaultSort =
+    data.mode === 'aggregate'
+      ? `-${getAggregateAlias(data.yAxes?.[0] ?? DEFAULT_AGGREGATE)}`
+      : '-timestamp';
+  const query: NewQuery = {
+    id: undefined,
+    name: data.title ?? 'Spans',
+    fields,
+    orderby: [data.sort ?? defaultSort],
+    query: data.query,
+    version: 2,
+    dataset: DiscoverDatasets.SPANS,
+  };
+
+  return EventView.fromNewQueryWithPageFilters(query, toPageFilters(data));
+}
+
+export function getSpansQueryHref(
+  data: SpansQueryData,
+  organization: Organization
+): string {
+  const {query, mode, sort, fields, groupBy, yAxes} = data;
+  const aggregateYAxes =
+    mode === 'aggregate' && !yAxes?.length ? [DEFAULT_AGGREGATE] : yAxes;
+
+  return getExploreUrl({
+    organization,
+    selection: toPageFilters(data),
+    query,
+    mode: toMode(mode),
+    field: fields,
+    sort: mode === 'samples' ? sort : undefined,
+    aggregateSort: mode === 'aggregate' ? sort : undefined,
+    aggregateField: toAggregateFields({groupBy, yAxes: aggregateYAxes}),
+  });
+}

--- a/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
@@ -20,7 +20,19 @@ const DEFAULT_SAMPLE_FIELDS = [
   'transaction',
   'timestamp',
 ];
+
+/**
+ * Explore's own default visualization, so a query that names no aggregate
+ * charts the same series it would on the page the embed links to.
+ */
 const DEFAULT_AGGREGATE = 'count(span.duration)';
+
+/**
+ * How many groups a grouped chart plots. Explore allows nine; the preview
+ * matches the row limit of the table underneath it instead, so every series
+ * in the legend has a row to read it against.
+ */
+const CHART_TOP_EVENTS = 5;
 
 export function getSpansQueryFields(data: SpansQueryData): string[] {
   if (data.mode === 'samples') {
@@ -71,37 +83,90 @@ export function getSpansQueryHref(
 }
 
 /**
+ * The columns the chart splits its series on. Only an aggregate query groups;
+ * a samples query always charts a single total series for the period.
+ */
+function getChartGroupBy(data: SpansQueryData): string[] {
+  return data.mode === 'aggregate' ? (data.groupBy ?? []).filter(Boolean) : [];
+}
+
+/**
  * An aggregate spans query has "no group by" when the schema's explicit
  * `groupBy` is empty or absent. That collapses the results to a single row
  * per y-axis today, which reads better as a chart than a one-row table.
  */
 export function hasNoGroupBy(data: SpansQueryData): boolean {
-  return data.mode === 'aggregate' && !data.groupBy?.length;
+  return data.mode === 'aggregate' && getChartGroupBy(data).length === 0;
 }
 
 /**
- * Resolves which fields should drive the chart's y-axis: the schema's
- * explicit `yAxes` hint when provided, otherwise the resolved query fields
- * themselves (all of `fields` is aggregate when there is no group by).
+ * Resolves which aggregates drive the chart's y-axis: the schema's explicit
+ * `yAxes` hint when provided, otherwise Explore's default visualization —
+ * which is also what a samples query, having named no aggregate at all,
+ * charts.
  */
-export function resolveChartYAxes(data: SpansQueryData, fields: string[]): string[] {
-  return data.yAxes?.length ? data.yAxes : fields;
+export function resolveChartYAxes(data: SpansQueryData): string[] {
+  return data.yAxes?.length ? data.yAxes : [DEFAULT_AGGREGATE];
+}
+
+function sortsOneOf(sort: string, fields: string[]): boolean {
+  const field = sort.startsWith('-') ? sort.slice(1) : sort;
+  return fields.some(item => item === field || getAggregateAlias(item) === field);
 }
 
 /**
  * Builds the query params for the events-stats timeseries request, reusing
  * the same query/page-filter params already built for the events table
  * fetch and swapping in the aggregate fields as the y-axis.
+ *
+ * A grouped query charts the way Explore does: `field` carries the grouping
+ * columns, which is what makes the endpoint break the result into a series
+ * per group, and `topEvents` keeps only the leading few. An ungrouped query
+ * drops `field` and `sort` instead — the endpoint groups by whatever `field`
+ * it is given, so passing the table's columns along would split a plain total
+ * into a series per column value.
  */
-export function buildSpansChartQuery(eventView: EventView, yAxis: string[]): Query {
+export function buildSpansChartQuery(
+  eventView: EventView,
+  data: SpansQueryData,
+  yAxes: string[]
+): Query {
   const {
     field: _field,
-    sort: _sort,
+    sort,
     widths: _widths,
     ...rest
   } = eventView.generateQueryStringObject();
 
-  return {...rest, yAxis};
+  const groupBy = getChartGroupBy(data);
+  if (groupBy.length === 0) {
+    return {...rest, yAxis: yAxes};
+  }
+
+  // Grouping already spends a series per group, so the chart plots a single
+  // aggregate rather than multiplying that out by every y-axis.
+  const yAxis = yAxes[0] ?? DEFAULT_AGGREGATE;
+  const fields = [...groupBy, yAxis];
+
+  // The endpoint ranks the top groups by `sort`, which has to name one of the
+  // fields it was given. A query sorted by a y-axis this chart left out does
+  // not, so fall back to ranking by the aggregate actually being plotted.
+  const sorts = (Array.isArray(sort) ? sort : [sort]).filter(
+    (item): item is string => typeof item === 'string' && item !== ''
+  );
+  const chartSort =
+    sorts.find(item => sortsOneOf(item, fields)) ?? `-${getAggregateAlias(yAxis)}`;
+
+  return {
+    ...rest,
+    yAxis: [yAxis],
+    field: fields,
+    sort: chartSort,
+    topEvents: String(CHART_TOP_EVENTS),
+    // The table below lists these same leading groups, so an "Other" series
+    // would be the one line in the legend with no row to read it against.
+    excludeOther: '1',
+  };
 }
 
 export function toChartUnit(outputType: AggregationOutputType): ChartUnit {

--- a/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
@@ -43,6 +43,40 @@ export function getSpansQueryFields(data: SpansQueryData): string[] {
   return Array.from(new Set([...(data.groupBy ?? []).filter(Boolean), ...yAxes]));
 }
 
+// Seer sends one `sort`, but its two consumers spell an aggregate
+// differently: the events API wants the alias `p95_span_duration`, while
+// Explore's `aggregateSort` param is validated by exact match against the
+// page's own y-axis and group-by values and so only accepts
+// `p95(span.duration)`. Neither side reports a mismatch — the events API is
+// fed the sort verbatim, and Explore silently drops one it doesn't recognise
+// and falls back to its default ordering. So normalize at each edge instead
+// of trusting the spelling that arrived.
+
+/** Finds which of `fields` a sort names, in either spelling. */
+function findSortedField(sort: string, fields: string[]): string | undefined {
+  const field = sort.startsWith('-') ? sort.slice(1) : sort;
+  return fields.find(item => item === field || getAggregateAlias(item) === field);
+}
+
+/** Alias spelling, for the events API. Unrecognised sorts pass through. */
+function toEventsApiSort(sort: string, fields: string[]): string {
+  const field = findSortedField(sort, fields);
+  return field ? `${sort.startsWith('-') ? '-' : ''}${getAggregateAlias(field)}` : sort;
+}
+
+/** Field spelling, for Explore's URL. Unrecognised sorts are dropped. */
+function toExploreAggregateSort(
+  sort: string | undefined,
+  aggregateFields: string[]
+): string | undefined {
+  if (!sort) {
+    return undefined;
+  }
+
+  const field = findSortedField(sort, aggregateFields);
+  return field ? `${sort.startsWith('-') ? '-' : ''}${field}` : undefined;
+}
+
 export function buildSpansEventView(data: SpansQueryData): EventView {
   const fields = getSpansQueryFields(data);
   const defaultSort =
@@ -53,7 +87,7 @@ export function buildSpansEventView(data: SpansQueryData): EventView {
     id: undefined,
     name: data.title ?? 'Spans',
     fields,
-    orderby: [data.sort ?? defaultSort],
+    orderby: [data.sort ? toEventsApiSort(data.sort, fields) : defaultSort],
     query: data.query,
     version: 2,
     dataset: DiscoverDatasets.SPANS,
@@ -77,7 +111,13 @@ export function getSpansQueryHref(
     mode: toMode(mode),
     field: fields,
     sort: mode === 'samples' ? sort : undefined,
-    aggregateSort: mode === 'aggregate' ? sort : undefined,
+    aggregateSort:
+      mode === 'aggregate'
+        ? toExploreAggregateSort(sort, [
+            ...(groupBy ?? []).filter(Boolean),
+            ...(aggregateYAxes ?? []),
+          ])
+        : undefined,
     aggregateField: toAggregateFields({groupBy, yAxes: aggregateYAxes}),
   });
 }
@@ -107,11 +147,6 @@ export function hasNoGroupBy(data: SpansQueryData): boolean {
  */
 export function resolveChartYAxes(data: SpansQueryData): string[] {
   return data.yAxes?.length ? data.yAxes : [DEFAULT_AGGREGATE];
-}
-
-function sortsOneOf(sort: string, fields: string[]): boolean {
-  const field = sort.startsWith('-') ? sort.slice(1) : sort;
-  return fields.some(item => item === field || getAggregateAlias(item) === field);
 }
 
 /**
@@ -151,11 +186,14 @@ export function buildSpansChartQuery(
   // The endpoint ranks the top groups by `sort`, which has to name one of the
   // fields it was given. A query sorted by a y-axis this chart left out does
   // not, so fall back to ranking by the aggregate actually being plotted.
+  //
+  // Unlike the Explore link, the sort stays in its alias spelling here — the
+  // events API is what Explore's own `formatSort` aliases for.
   const sorts = (Array.isArray(sort) ? sort : [sort]).filter(
     (item): item is string => typeof item === 'string' && item !== ''
   );
   const chartSort =
-    sorts.find(item => sortsOneOf(item, fields)) ?? `-${getAggregateAlias(yAxis)}`;
+    sorts.find(item => findSortedField(item, fields)) ?? `-${getAggregateAlias(yAxis)}`;
 
   return {
     ...rest,

--- a/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
@@ -1,6 +1,10 @@
+import type {Query} from 'history';
+
+import type {ChartUnit} from 'sentry/components/seer/markdown/embeds/components/chartTypes';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import type {Organization, NewQuery} from 'sentry/types/organization';
 import {EventView} from 'sentry/utils/discover/eventView';
+import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -64,4 +68,51 @@ export function getSpansQueryHref(
     aggregateSort: mode === 'aggregate' ? sort : undefined,
     aggregateField: toAggregateFields({groupBy, yAxes: aggregateYAxes}),
   });
+}
+
+/**
+ * An aggregate spans query has "no group by" when the schema's explicit
+ * `groupBy` is empty or absent. That collapses the results to a single row
+ * per y-axis today, which reads better as a chart than a one-row table.
+ */
+export function hasNoGroupBy(data: SpansQueryData): boolean {
+  return data.mode === 'aggregate' && !data.groupBy?.length;
+}
+
+/**
+ * Resolves which fields should drive the chart's y-axis: the schema's
+ * explicit `yAxes` hint when provided, otherwise the resolved query fields
+ * themselves (all of `fields` is aggregate when there is no group by).
+ */
+export function resolveChartYAxes(data: SpansQueryData, fields: string[]): string[] {
+  return data.yAxes?.length ? data.yAxes : fields;
+}
+
+/**
+ * Builds the query params for the events-stats timeseries request, reusing
+ * the same query/page-filter params already built for the events table
+ * fetch and swapping in the aggregate fields as the y-axis.
+ */
+export function buildSpansChartQuery(eventView: EventView, yAxis: string[]): Query {
+  const {
+    field: _field,
+    sort: _sort,
+    widths: _widths,
+    ...rest
+  } = eventView.generateQueryStringObject();
+
+  return {...rest, yAxis};
+}
+
+export function toChartUnit(outputType: AggregationOutputType): ChartUnit {
+  switch (outputType) {
+    case 'duration':
+      return 'duration';
+    case 'percentage':
+      return 'percentage';
+    case 'size':
+      return 'bytes';
+    default:
+      return 'number';
+  }
 }

--- a/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
@@ -45,10 +45,12 @@ function getSpansQueryFields(data: SpansQueryData): string[] {
 // differently: the events API wants the alias `p95_span_duration`, while
 // Explore's `aggregateSort` param is validated by exact match against the
 // page's own y-axis and group-by values and so only accepts
-// `p95(span.duration)`. Neither side reports a mismatch — the events API is
-// fed the sort verbatim, and Explore silently drops one it doesn't recognise
-// and falls back to its default ordering. So normalize at each edge instead
-// of trusting the spelling that arrived.
+// `p95(span.duration)`. Neither side reports a mismatch, and neither tolerates
+// a sort that names no selected field — Explore silently drops one and falls
+// back to its default ordering, while the events API rejects the whole request
+// with "Cannot sort by a field that is not selected". So normalize at each
+// edge instead of trusting the spelling that arrived, and fall back to the
+// default ordering rather than forwarding a sort the fields don't name.
 
 /** Finds which of `fields` a sort names, in either spelling. */
 function findSortedField(sort: string, fields: string[]): string | undefined {
@@ -56,10 +58,20 @@ function findSortedField(sort: string, fields: string[]): string | undefined {
   return fields.find(item => item === field || getAggregateAlias(item) === field);
 }
 
-/** Alias spelling, for the events API. Unrecognised sorts pass through. */
-function toEventsApiSort(sort: string, fields: string[]): string {
+/** Alias spelling, for the events API. Unrecognised sorts fall back. */
+function toEventsApiSort(
+  sort: string | undefined,
+  fields: string[],
+  fallback: string
+): string {
+  if (!sort) {
+    return fallback;
+  }
+
   const field = findSortedField(sort, fields);
-  return field ? `${sort.startsWith('-') ? '-' : ''}${getAggregateAlias(field)}` : sort;
+  return field
+    ? `${sort.startsWith('-') ? '-' : ''}${getAggregateAlias(field)}`
+    : fallback;
 }
 
 /** Field spelling, for Explore's URL. Unrecognised sorts are dropped. */
@@ -85,7 +97,7 @@ export function buildSpansEventView(data: SpansQueryData): EventView {
     id: undefined,
     name: data.title ?? 'Spans',
     fields,
-    orderby: [data.sort ? toEventsApiSort(data.sort, fields) : defaultSort],
+    orderby: [toEventsApiSort(data.sort, fields, defaultSort)],
     query: data.query,
     version: 2,
     dataset: DiscoverDatasets.SPANS,

--- a/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/spansQueryUtils.ts
@@ -1,10 +1,8 @@
 import type {Query} from 'history';
 
-import type {ChartUnit} from 'sentry/components/seer/markdown/embeds/components/chartTypes';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import type {Organization, NewQuery} from 'sentry/types/organization';
 import {EventView} from 'sentry/utils/discover/eventView';
-import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -34,7 +32,7 @@ const DEFAULT_AGGREGATE = 'count(span.duration)';
  */
 const CHART_TOP_EVENTS = 5;
 
-export function getSpansQueryFields(data: SpansQueryData): string[] {
+function getSpansQueryFields(data: SpansQueryData): string[] {
   if (data.mode === 'samples') {
     return data.fields?.length ? data.fields : DEFAULT_SAMPLE_FIELDS;
   }
@@ -205,17 +203,4 @@ export function buildSpansChartQuery(
     // would be the one line in the legend with no row to read it against.
     excludeOther: '1',
   };
-}
-
-export function toChartUnit(outputType: AggregationOutputType): ChartUnit {
-  switch (outputType) {
-    case 'duration':
-      return 'duration';
-    case 'percentage':
-      return 'percentage';
-    case 'size':
-      return 'bytes';
-    default:
-      return 'number';
-  }
 }

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -580,9 +580,11 @@ export const SEER_EMBED_SCHEMAS = {
   },
   spansQuery: {
     description:
-      'Link to an Explore > Traces (spans) query. ' +
-      'Use mode "samples" to show individual spans and "aggregate" to group and ' +
-      'chart them. In aggregate mode supply `groupBy` and `yAxes`. ' +
+      'Preview an Explore > Traces (spans) query. ' +
+      'Use mode "samples" for individual spans; inline renders a link and block ' +
+      'renders the first five matching rows. ' +
+      'Use mode "aggregate" for grouped results; supply `groupBy` and `yAxes`, and ' +
+      'the block renders the first five grouped rows. ' +
       '`query` uses span search syntax, e.g. "span.op:http.client".',
     level: ['inline', 'block'],
     schema: z.object(exploreQueryFields),
@@ -592,8 +594,10 @@ export const SEER_EMBED_SCHEMAS = {
         data: {
           query: 'span.op:http.client',
           mode: 'samples',
+          fields: ['span.description', 'span.op', 'span.duration', 'timestamp'],
           sort: '-span.duration',
           statsPeriod: '24h',
+          title: 'Slow HTTP spans',
         },
       },
       {
@@ -603,7 +607,9 @@ export const SEER_EMBED_SCHEMAS = {
           mode: 'aggregate',
           groupBy: ['span.op'],
           yAxes: ['p95(span.duration)'],
+          sort: '-p95_span_duration',
           statsPeriod: '7d',
+          title: 'p95 by span op',
         },
       },
     ],

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -581,11 +581,16 @@ export const SEER_EMBED_SCHEMAS = {
   spansQuery: {
     description:
       'Preview an Explore > Traces (spans) query. ' +
-      'Use mode "samples" for individual spans; inline renders a link and block ' +
-      'renders the first five matching rows. ' +
-      'Use mode "aggregate" for grouped results; supply `groupBy` and `yAxes`, and ' +
-      'the block renders the first five grouped rows. ' +
-      '`query` uses span search syntax, e.g. "span.op:http.client".',
+      'Use mode "samples" for individual spans and mode "aggregate" for grouped ' +
+      'results, supplying `groupBy` and `yAxes`. ' +
+      '`query` uses span search syntax, e.g. "span.op:http.client". ' +
+      'Inline renders a link; block renders the first five matching rows beneath ' +
+      'a timeseries chart of the same query. A query with `groupBy` charts the ' +
+      'top five groups as one series each, matching the rows below it; every ' +
+      'other query charts a single total for the period. Provide `yAxes` to pick ' +
+      'which aggregate is charted — samples mode, and any query naming none, ' +
+      'charts "count(span.duration)". When aggregate mode supplies no `groupBy` ' +
+      'there is only one row to show, so the chart replaces the table.',
     level: ['inline', 'block'],
     schema: z.object(exploreQueryFields),
     examples: [
@@ -610,6 +615,18 @@ export const SEER_EMBED_SCHEMAS = {
           sort: '-p95_span_duration',
           statsPeriod: '7d',
           title: 'p95 by span op',
+        },
+      },
+      {
+        // No group-by columns, so there is only ever one row to show and the
+        // chart stands in for the table.
+        label: 'Total spans',
+        data: {
+          query: 'span.op:http.client',
+          mode: 'aggregate',
+          yAxes: ['count(span.duration)'],
+          statsPeriod: '24h',
+          title: 'Total spans',
         },
       },
     ],


### PR DESCRIPTION
Adds rich block previews for the existing `spansQuery` embed. Sample mode displays the first five matching spans, aggregate mode displays the first five grouped results with API aggregate aliases resolved, and inline usage remains a compact link to the complete Explore results.

The preview preserves project, environment, time, field, group-by, axis, query, and sort state through the existing Explore builders. Aggregate links now send their sort through `aggregateSort`, and the Storybook examples and generated agent contract describe both supported modes.

Refs [CW-1947](https://linear.app/getsentry/issue/CW-1947/add-spans-query-aggregate-embed)
