### PR TITLE
feat(admin): Identify gifted reserved budgets by apiName

### DIFF
--- a/static/gsAdmin/components/addGiftBudgetAction.spec.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.spec.tsx
@@ -1,0 +1,63 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {addGiftBudgetAction} from 'admin/components/addGiftBudgetAction';
+
+describe('addGiftBudgetAction', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('identifies the gifted budget by apiName', async () => {
+    const organization = OrganizationFixture();
+    const budget = SeerReservedBudgetFixture({id: 'platform-pool-uid'});
+    const subscription = SubscriptionFixture({
+      organization,
+      reservedBudgets: [budget],
+    });
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/`,
+      method: 'PUT',
+      body: subscription,
+    });
+
+    addGiftBudgetAction({
+      organization,
+      subscription,
+      onSuccess: jest.fn(),
+    });
+    renderGlobalModal();
+
+    await userEvent.clear(screen.getByRole('spinbutton', {name: 'Gift Amount ($)'}));
+    await userEvent.type(screen.getByRole('spinbutton', {name: 'Gift Amount ($)'}), '5');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Notes'}), 'Support request');
+    await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith(
+        `/customers/${organization.slug}/`,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {
+            freeReservedBudget: {
+              apiName: budget.apiName,
+              id: budget.id,
+              freeBudget: 500,
+              categories: Object.keys(budget.categories),
+            },
+            ticketUrl: null,
+            notes: 'Support request',
+          },
+        })
+      )
+    );
+  });
+});

--- a/static/gsAdmin/components/addGiftBudgetAction.spec.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.spec.tsx
@@ -49,9 +49,7 @@ describe('addGiftBudgetAction', () => {
           data: {
             freeReservedBudget: {
               apiName: budget.apiName,
-              id: budget.id,
               freeBudget: 500,
-              categories: Object.keys(budget.categories),
             },
             ticketUrl: null,
             notes: 'Support request',

--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -65,10 +65,7 @@ function AddGiftBudgetModal({
     const data = {
       freeReservedBudget: {
         apiName: selectedBudget.apiName,
-        // Keep the old target fields while getsentry deployments transition to apiName.
-        id: selectedBudget.id,
         freeBudget: giftAmount * 100, // convert to cents
-        categories: Object.keys(selectedBudget.categories),
       },
       ticketUrl,
       notes,

--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -34,7 +34,7 @@ function AddGiftBudgetModal({
   Body,
 }: ModalProps) {
   const api = useApi();
-  const [selectedBudgetId, setSelectedBudgetId] = useState<string | null>(null);
+  const [selectedBudgetApiName, setSelectedBudgetApiName] = useState<string | null>(null);
   const [giftAmount, setGiftAmount] = useState(0);
   const [ticketUrl, setTicketUrl] = useState<string | null>(null);
   const [notes, setNotes] = useState<string | null>(null);
@@ -45,25 +45,30 @@ function AddGiftBudgetModal({
   );
 
   useEffect(() => {
-    if (reservedBudgetOptions.length > 0 && !selectedBudgetId) {
-      setSelectedBudgetId(reservedBudgetOptions[0]?.id ?? null);
+    if (reservedBudgetOptions.length > 0 && !selectedBudgetApiName) {
+      setSelectedBudgetApiName(reservedBudgetOptions[0]?.apiName ?? null);
     }
-  }, [reservedBudgetOptions, selectedBudgetId]);
+  }, [reservedBudgetOptions, selectedBudgetApiName]);
 
   const onSubmit = () => {
-    if (!selectedBudgetId || giftAmount <= 0) {
+    if (!selectedBudgetApiName || giftAmount <= 0) {
       return;
     }
 
     const selectedBudget = reservedBudgetOptions.find(
-      budget => budget.id === selectedBudgetId
+      budget => budget.apiName === selectedBudgetApiName
     );
+    if (!selectedBudget) {
+      return;
+    }
 
     const data = {
       freeReservedBudget: {
-        id: selectedBudgetId,
+        apiName: selectedBudget.apiName,
+        // Keep the old target fields while getsentry deployments transition to apiName.
+        id: selectedBudget.id,
         freeBudget: giftAmount * 100, // convert to cents
-        categories: Object.keys(selectedBudget?.categories ?? []),
+        categories: Object.keys(selectedBudget.categories),
       },
       ticketUrl,
       notes,
@@ -105,8 +110,8 @@ function AddGiftBudgetModal({
           {reservedBudgetOptions.map(budget => (
             <BudgetCard
               key={budget.id}
-              isSelected={selectedBudgetId === budget.id}
-              onClick={() => setSelectedBudgetId(budget.id)}
+              isSelected={selectedBudgetApiName === budget.apiName}
+              onClick={() => setSelectedBudgetApiName(budget.apiName)}
             >
               <Flex justify="between" marginBottom="md">
                 <div>
@@ -131,7 +136,7 @@ function AddGiftBudgetModal({
                   )
                   .join(', ') || 'None'}
               </Container>
-              {selectedBudgetId === budget.id && (
+              {selectedBudgetApiName === budget.apiName && (
                 <NumberField
                   inline={false}
                   stacked


### PR DESCRIPTION
The admin gift-budget modal submits only `apiName` and `freeBudget`. It no longer echoes GET `id` or `categories`.

Land together with [getsentry/getsentry#21703](https://github.com/getsentry/getsentry/pull/21703). A short window where gifting fails is expected if they are not deployed at the same time.
