### PR TITLE
fix(autofix): Send the triggering user with feature runs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -590,15 +590,23 @@ class SeerAgentClient:
         if agent_run_options is not None:
             resolved_agent_run_options.update(agent_run_options)
 
+        body = SeerFeatureRunRequest(
+            feature_id=feature_id,
+            payload=payload,
+            agent_run_options=resolved_agent_run_options,
+        )
+        # Only for human-triggered runs: this is what attributes the run to its user in
+        # Seer's tracing, and collecting it costs several queries an automated trigger
+        # has no use for. ViewerContext carries ids alone, so without this the run
+        # reports no user at all.
+        if self.user is not None and not isinstance(self.user, AnonymousUser):
+            body["user_org_context"] = collect_user_org_context(self.user, self.organization)
+
         return enqueue_seer_run(
             organization=self.organization,
             run_type=SeerRunType.FEATURE_RUN,
             on_run_created=_create_agent_run,
-            body=SeerFeatureRunRequest(
-                feature_id=feature_id,
-                payload=payload,
-                agent_run_options=resolved_agent_run_options,
-            ),
+            body=body,
             viewer_context=self.viewer_context,
             user_id=user_id,
             referrer=referrer,

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -123,6 +123,9 @@ class SeerFeatureRunRequest(TypedDict):
     feature_id: str
     payload: dict[str, Any]
     agent_run_options: NotRequired[AgentRunOptions]
+    # Present only for human-triggered runs. Seer attributes the run to this user in
+    # tracing; an automated trigger has no user to report.
+    user_org_context: NotRequired[dict[str, Any]]
 
 
 class SeerFeatureRunWireRequest(SeerFeatureRunRequest):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 from pydantic import BaseModel
 
@@ -1477,6 +1478,56 @@ class TestStartFeatureRun(TestCase):
         # ref/external_idempotency_key are stamped by the handler at dispatch, not enqueue.
         assert "ref" not in body
         assert outbox.payload["viewer_context"]["organization_id"] == self.organization.id
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    def test_sends_user_org_context_for_human_trigger(self, mock_request, _mock_access) -> None:
+        """Seer builds its tracing user from this alone -- without it the run reports none."""
+        client = SeerAgentClient(self.organization, self.user)
+        run = client.start_feature_run(
+            feature_id="autofix_root_cause",
+            payload={"group_id": 1},
+            title="Autofix RCA",
+            flush=False,
+        )
+
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        user_org_context = outbox.payload["body"]["user_org_context"]
+        assert user_org_context["user_id"] == self.user.id
+        assert user_org_context["user_email"] == self.user.email
+        assert user_org_context["org_slug"] == self.organization.slug
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    def test_omits_user_org_context_for_automated_trigger(self, mock_request, _mock_access) -> None:
+        """Night shift and the scanner have no user, and pay none of the lookup cost."""
+        client = SeerAgentClient(self.organization, user=None)
+        run = client.start_feature_run(
+            feature_id="night_shift",
+            payload={"candidates": [1, 2]},
+            title="Agentic triage",
+            flush=False,
+        )
+
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        assert "user_org_context" not in outbox.payload["body"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    def test_omits_user_org_context_for_anonymous_user(self, mock_request, _mock_access) -> None:
+        client = SeerAgentClient(self.organization, user=AnonymousUser())
+        run = client.start_feature_run(
+            feature_id="night_shift",
+            payload={},
+            title="Agentic triage",
+            flush=False,
+        )
+
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        assert "user_org_context" not in outbox.payload["body"]
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")


### PR DESCRIPTION
## Problem

Autofix RCA runs report no user in Seer's tracing — no email on the run's spans.

#121990 routed every new `ROOT_CAUSE` run through `trigger_autofix_rca_feature`, which calls `SeerAgentClient.start_feature_run`. Unlike `start_run`, that method never collected a `user_org_context`, so nothing identifying the user crossed the wire. On the Seer side `ExplorerMainStep` builds its `sentry_user` from `user_org_context` alone, and `ViewerContext` can't cover for it — it carries org/project/user **ids**, no email.

Only the root-cause step moved, so within a single autofix run the RCA spans are unattributed while the solution and coding spans (still on `start_run`) carry the email.

## Changes

`start_feature_run` now collects and sends `user_org_context`, the same way `start_run` does — but only when a real user triggered the run. `collect_user_org_context` costs several queries (all org projects, bulk preferences, org member, teams), and an automated trigger has no user to report, so night shift and the scanner shouldn't pay for it. `None` and `AnonymousUser` both skip it.

## Rollout

Depends on getsentry/seer#7951, which adds the field to `FeatureRunRequest`. That one is optional and a no-op on its own, so it lands first; until it does, Seer ignores the extra key.

## Testing

Three cases added to `TestStartFeatureRun`: a human trigger sends the context with the user's email, and `user=None` / `AnonymousUser` both omit the key.


Agent transcript: https://claudescope.sentry.dev/share/AyHMWEAZqoUEJl1TUTVOAZoegWNYKw6_ENS3xNp5jtQ