### PR TITLE
feat(seer): Add a get_user_details RPC for user id -> identity

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -148,6 +148,7 @@ from sentry.seer.sentry_data_models import (
     SendSeerWebhookSuccessResponse,
     SpanAttribute,
     SpanAttributesResponse,
+    UserDetailsResponse,
 )
 from sentry.seer.utils import encrypt_access_token_for_seer, filter_repo_by_provider
 from sentry.sentry_apps.event_types import SentryAppEventType
@@ -884,6 +885,33 @@ def get_monitoring_provider_connections(
     )
 
 
+def get_user_details(*, organization_id: int, user_id: int) -> UserDetailsResponse | None:
+    """Resolve a user id to their identity fields.
+
+    Seer holds a bare ``user_id`` from the viewer context and needs a name/email to
+    attribute a run to a person. Scoped to members of ``organization_id``: a user id from
+    outside the org resolves to ``None``, exactly as one that does not exist does, so a
+    caller cannot use this to probe for accounts.
+    """
+    users = user_service.get_many(
+        filter={
+            "user_ids": [user_id],
+            "organization_id": organization_id,
+            "is_active": True,
+        }
+    )
+    if not users:
+        return None
+
+    user = users[0]
+    return UserDetailsResponse(
+        id=user.id,
+        email=user.email,
+        username=user.username,
+        name=user.get_display_name(),
+    )
+
+
 def refresh_monitoring_provider_token(
     *, identity_id: int
 ) -> RefreshMonitoringProviderTokenSuccessResponse | RefreshMonitoringProviderTokenErrorResponse:
@@ -979,6 +1007,7 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     "get_github_enterprise_integration_config": seer_rpc(get_github_enterprise_integration_config),
     "get_organization_projects": seer_rpc(get_organization_projects),
     "get_organization_features": seer_rpc(get_organization_features),
+    "get_user_details": seer_rpc(get_user_details),
     "get_repo_installation_id": seer_rpc(get_repo_installation_id),
     #
     # Autofix

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -559,6 +559,20 @@ class GroupAssigneesResponse(_DictProxyMixin):
     assignees: dict[str, UserIdentity]
 
 
+class UserDetailsResponse(BaseModel):
+    """`get_user_details` returns the identity fields for one user.
+
+    Separate from `UserIdentity`, which several responses embed for many users at a time
+    and deliberately keeps to id/username. This one is asked for by user id, one at a
+    time, and carries the email.
+    """
+
+    id: int
+    email: str
+    username: str
+    name: str
+
+
 class TransactionsForProjectResponse(BaseModel):
     """`get_transactions_for_project` returns `{"transactions": [...]}` over the
     project-scoped registry. Wraps the existing `Transaction` model so the SDK

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -28,8 +28,10 @@ from sentry.seer.endpoints.seer_rpc import (
     get_organization_features,
     get_project_preferences,
     get_repo_installation_id,
+    get_user_details,
     has_repo_code_mappings,
     refresh_monitoring_provider_token,
+    seer_method_registry,
 )
 from sentry.seer.sentry_data_models import (
     GitHubEnterpriseConfigErrorResponse,
@@ -932,6 +934,41 @@ class TestGetMonitoringProviderConnections(APITestCase):
         )
 
         assert result.connections == []
+
+
+class TestGetUserDetails(APITestCase):
+    def test_returns_identity_for_org_member(self) -> None:
+        result = get_user_details(organization_id=self.organization.id, user_id=self.user.id)
+
+        assert result is not None
+        assert result.id == self.user.id
+        assert result.email == self.user.email
+        assert result.username == self.user.username
+        assert result.name == self.user.get_display_name()
+
+    def test_non_member_returns_none(self) -> None:
+        """Same answer as a missing user, so this can't be used to probe for accounts."""
+        other_org = self.create_organization()
+
+        result = get_user_details(organization_id=other_org.id, user_id=self.user.id)
+
+        assert result is None
+
+    def test_unknown_user_returns_none(self) -> None:
+        result = get_user_details(organization_id=self.organization.id, user_id=999999)
+
+        assert result is None
+
+    def test_inactive_user_returns_none(self) -> None:
+        inactive = self.create_user(is_active=False)
+        self.create_member(organization=self.organization, user=inactive)
+
+        result = get_user_details(organization_id=self.organization.id, user_id=inactive.id)
+
+        assert result is None
+
+    def test_registered_in_rpc_method_registry(self) -> None:
+        assert seer_method_registry["get_user_details"] is not None
 
 
 @override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)


### PR DESCRIPTION
## Why

Seer holds a bare `user_id` — the viewer context propagates `organization_id`, `project_id`, `user_id`, `actor_type` and nothing else — and has no way to turn it into a name or email.

Nothing in either RPC registry closes that gap today:

| RPC | Keyed by | Returns |
|---|---|---|
| `get_organization_features` | **`user_id`** | flags only; the user is just the flag actor |
| `get_group_assignees` | group ids | `UserIdentity(id, username)` — deliberately no email |
| `get_team_members` | `team_slug` | emails, but you need a team |
| `get_issue_ownership` / `get_issue_committers` | issue id | emails of owners/authors, not of the viewer |

So `get_organization_features` is the only method that speaks user ids, and it's the one that returns no identity.

## What

`get_user_details(organization_id, user_id) -> UserDetailsResponse | None`, registered in `seer_method_registry`.

Scoped to members of the organization via the user service's `organization_id` filter ("Organization to check membership in"), the same scoping `get_group_assignees` uses. A user id from outside the org resolves to `None` **exactly as a missing one does**, so the RPC can't be used to probe for accounts. Inactive users resolve to `None` too.

`UserDetailsResponse` is a new model rather than a reuse of `UserIdentity` — that one is embedded in responses covering many users at a time and is intentionally id/username only. This one is asked for by user id, one at a time, and carries the email.

## Callers

None yet. It unblocks attributing Seer feature runs to the user who triggered them (see getsentry/seer#7951 for the surrounding problem) without adding an email to the viewer-context JWT.

## Testing

Five cases: org member resolves, non-member returns `None`, unknown id returns `None`, inactive member returns `None`, and the method is registered.


Agent transcript: https://claudescope.sentry.dev/share/lcAmsvX2zAZ_lSQ2YzywX4lNlTU2ugoEjHScissew6Q