### PR TITLE
feat(aci): Rename evaluate_impl to evaluate

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -216,7 +216,7 @@ class PreprodSizeAnalysisDetectorHandler(
             )
             return False
 
-    def evaluate_impl(self, data_packet: SizeAnalysisDataPacket) -> GroupedDetectorEvaluationResult:
+    def evaluate(self, data_packet: SizeAnalysisDataPacket) -> GroupedDetectorEvaluationResult:
         if not self._matches_query(data_packet):
             return GroupedDetectorEvaluationResult(result={}, tainted=False)
 

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -116,7 +116,7 @@ class ProcessingErrorDetectorHandler(
 
     @override
     def extract_dedupe_value(self, data_packet: DataPacket[ProcessingErrorPacketValue]) -> int:
-        # Not used — we override evaluate_impl and skip dedupe logic
+        # Not used — we override evaluate and skip dedupe logic
         return 0
 
     @override
@@ -167,7 +167,7 @@ class ProcessingErrorDetectorHandler(
         return (occurrence, event_data)
 
     @override
-    def evaluate_impl(
+    def evaluate(
         self, data_packet: DataPacket[ProcessingErrorPacketValue]
     ) -> GroupedDetectorEvaluationResult:
         """

--- a/src/sentry/workflow_engine/docs/adding-detectors.md
+++ b/src/sentry/workflow_engine/docs/adding-detectors.md
@@ -30,7 +30,7 @@ flowchart TD
     State -->|No| Shared{Can use shared condition loading and metrics?}
     Shared -->|Yes| Base[Inherit BaseDetectorHandler]
     Shared -->|No| Interface[Implement DetectorHandler]
-    Base --> Own[Implement full evaluate_impl orchestration]
+    Base --> Own[Implement full evaluate orchestration]
     Interface --> OwnAll[Implement complete evaluate contract]
 ```
 
@@ -56,7 +56,7 @@ Uptime and metric issues are canonical examples.
 
 [`BaseDetectorHandler`](../handlers/detector/base.py) provides condition-group loading
 and common evaluation metrics, but it does not provide a general stateless evaluation
-algorithm. A concrete subclass must implement `evaluate_impl`, `create_occurrence`,
+algorithm. A concrete subclass must implement `evaluate`, `create_occurrence`,
 `extract_value`, and `extract_dedupe_value`; custom orchestration can provide trivial
 implementations for hooks it does not use. The subclass owns its state and output
 semantics.

--- a/src/sentry/workflow_engine/docs/conditions.md
+++ b/src/sentry/workflow_engine/docs/conditions.md
@@ -252,7 +252,7 @@ A [`Detector`](../models/detector.py) represents configured detection. A runtime
 is selected through the detector type's [`DetectorSettings`](../types.py).
 
 The common stateful path is
-[`StatefulDetectorHandler.evaluate_impl`](../handlers/detector/stateful.py):
+[`StatefulDetectorHandler.evaluate`](../handlers/detector/stateful.py):
 
 1. Extract one packet-wide positive integer dedupe value.
 2. Extract one evaluation value or a mapping of `DetectorGroupKey` to value.

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -147,7 +147,7 @@ class DetectorHandler(
             "result": "unknown",
         }
         try:
-            value = self.evaluate_impl(data_packet)
+            value = self.evaluate(data_packet)
             tags["result"] = "tainted" if value.tainted else "success"
             metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
             return value.result
@@ -157,9 +157,7 @@ class DetectorHandler(
             raise
 
     @abc.abstractmethod
-    def evaluate_impl(
-        self, data_packet: DataPacket[DataPacketType]
-    ) -> GroupedDetectorEvaluationResult:
+    def evaluate(self, data_packet: DataPacket[DataPacketType]) -> GroupedDetectorEvaluationResult:
         """
         This method is used to evaluate the data packet's value against the conditions on the detector.
         """

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -410,9 +410,7 @@ class StatefulDetectorHandler(
 
         return base
 
-    def evaluate_impl(
-        self, data_packet: DataPacket[DataPacketType]
-    ) -> GroupedDetectorEvaluationResult:
+    def evaluate(self, data_packet: DataPacket[DataPacketType]) -> GroupedDetectorEvaluationResult:
         dedupe_value = self.extract_dedupe_value(data_packet)
         group_data_values = self._extract_value_from_packet(data_packet)
         state = self.state_manager.get_state_data(list(group_data_values.keys()))

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -43,7 +43,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
         self.registry_patcher.start()
 
         class MockDetectorHandler(DetectorHandler[dict[Never, Never], bool]):
-            def evaluate_impl(
+            def evaluate(
                 self, data_packet: DataPacket[dict[Never, Never]]
             ) -> GroupedDetectorEvaluationResult:
                 return GroupedDetectorEvaluationResult(

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -110,7 +110,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             category = GroupCategory.METRIC.value
 
         class MockDetectorHandler(DetectorHandler[dict[str, Any], int]):
-            def evaluate_impl(
+            def evaluate(
                 self, data_packet: DataPacket[dict[str, Any]]
             ) -> GroupedDetectorEvaluationResult:
                 return GroupedDetectorEvaluationResult(
@@ -145,7 +145,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
                 return data_packet.packet.get("dedupe", 0)
 
         class MockDetectorWithUpdateHandler(DetectorHandler[dict[str, Any], int]):
-            def evaluate_impl(
+            def evaluate(
                 self, data_packet: DataPacket[dict[str, Any]]
             ) -> GroupedDetectorEvaluationResult:
                 status_change = StatusChangeMessage(


### PR DESCRIPTION
This is the "public" non-workflow engine function that consumers must implement so it is public. The _evaluate function that actually gets called is internal to the workflow engine.

But it seems wrong to me that a "private" method (_evaluate) is calling the public one (evaluate)

I may evaluate naming it better in the future, but not in this PR

Fixes ID-1799