### PR TITLE
perf(crons): Small query optimization in clock tasks consumer

### DIFF
--- a/src/sentry/monitors/logic/incidents.py
+++ b/src/sentry/monitors/logic/incidents.py
@@ -58,10 +58,13 @@ def try_incident_threshold(
     if not failure_issue_threshold:
         failure_issue_threshold = 1
 
+    resolved_checkins: list[MonitorCheckIn] | None = None
+
     # check to see if we need to update the status
     if monitor_env.status in [MonitorStatus.OK, MonitorStatus.ACTIVE]:
         if failure_issue_threshold == 1:
             previous_checkins: list[SimpleCheckIn] = [SimpleCheckIn.from_checkin(failed_checkin)]
+            resolved_checkins = [failed_checkin]
         else:
             previous_checkins = [
                 SimpleCheckIn(**row)
@@ -104,6 +107,7 @@ def try_incident_threshold(
         # If the monitor was already in an incident there are no previous
         # check-ins to pass long when creating the occurrence
         previous_checkins = [SimpleCheckIn.from_checkin(failed_checkin)]
+        resolved_checkins = [failed_checkin]
 
         # get the active incident from the monitor environment
         incident = monitor_env.active_incident
@@ -115,7 +119,11 @@ def try_incident_threshold(
     # - We have an active incident and fingerprint
     # - The environment is not muted
     if not monitor_env.is_muted and incident:
-        checkins = list(MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins]))
+        checkins = (
+            resolved_checkins
+            if resolved_checkins is not None
+            else list(MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins]))
+        )
         for checkin in checkins:
             dispatch_incident_occurrence(checkin, checkins, incident, received, clock_tick)
 


### PR DESCRIPTION
In some cases we don't need to refetch the checkins from postgres. Just a minor efficiency improvement

<!-- Describe your PR here. -->