### PR TITLE
chore(seer-infra-telemetry): Place user-level auth monitoring connections under their own feature flag (backend)

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_details.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_details.py
@@ -49,7 +49,11 @@ class OrganizationMonitoringProviderDetailsEndpoint(ControlSiloOrganizationEndpo
         self, request: Request, organization: RpcOrganization, provider_key: str, **kwargs: object
     ) -> Response:
         """Connect a monitoring provider."""
-        if not features.has("organizations:seer-infra-telemetry", organization, actor=request.user):
+        if not features.has(
+            "organizations:seer-infra-telemetry", organization, actor=request.user
+        ) or not features.has(
+            "organizations:seer-infra-telemetry-user-level-auth", organization, actor=request.user
+        ):
             return Response(status=404)
 
         if provider_key not in MONITORING_PROVIDERS:
@@ -67,7 +71,11 @@ class OrganizationMonitoringProviderDetailsEndpoint(ControlSiloOrganizationEndpo
         self, request: Request, organization: RpcOrganization, provider_key: str, **kwargs: object
     ) -> Response:
         """Reauthenticate an existing monitoring provider connection."""
-        if not features.has("organizations:seer-infra-telemetry", organization, actor=request.user):
+        if not features.has(
+            "organizations:seer-infra-telemetry", organization, actor=request.user
+        ) or not features.has(
+            "organizations:seer-infra-telemetry-user-level-auth", organization, actor=request.user
+        ):
             return Response(status=404)
 
         if provider_key not in MONITORING_PROVIDERS:

--- a/src/sentry/api/endpoints/organization_monitoring_provider_index.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_index.py
@@ -39,7 +39,11 @@ class OrganizationMonitoringProviderIndexEndpoint(ControlSiloOrganizationEndpoin
     permission_classes = (MonitoringProviderPermission,)
 
     def get(self, request: Request, organization: RpcOrganization, **kwargs: object) -> Response:
-        if not features.has("organizations:seer-infra-telemetry", organization, actor=request.user):
+        if not features.has(
+            "organizations:seer-infra-telemetry", organization, actor=request.user
+        ) or not features.has(
+            "organizations:seer-infra-telemetry-user-level-auth", organization, actor=request.user
+        ):
             return Response(status=404)
 
         connected_providers = set(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -315,6 +315,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Gate infra telemetry provider connections (Datadog MCP, GCP MCP)
     manager.add("organizations:seer-infra-telemetry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable user-level (personal identity) monitoring provider auth
+    manager.add("organizations:seer-infra-telemetry-user-level-auth", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disables the enableSeerCoding setting, preventing orgs from changing code generation behavior
     manager.add("organizations:seer-disable-coding-setting", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GitLab as a supported SCM provider for Seer

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -123,7 +123,9 @@ def get_available_monitoring_providers(
     Omits any provider that the user has permanently dismissed ("don't ask again").
     Does not mark which providers are already connected.
     """
-    if not features.has("organizations:seer-infra-telemetry", organization):
+    if not features.has("organizations:seer-infra-telemetry", organization) or not features.has(
+        "organizations:seer-infra-telemetry-user-level-auth", organization
+    ):
         return []
 
     feature_to_provider_map = {

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -153,7 +153,10 @@ def get_monitoring_provider_connections(
         return []
 
     personal_connections = (
-        _get_personal_monitoring_connections(organization, user_id) if user_id is not None else []
+        _get_personal_monitoring_connections(organization, user_id)
+        if features.has("organizations:seer-infra-telemetry-user-level-auth", organization)
+        and user_id is not None
+        else []
     )
     connected_families = {provider_family(c.provider_key) for c in personal_connections}
     org_connections = [

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_details.py
@@ -6,10 +6,12 @@ from django.http import HttpResponseRedirect
 from requests.exceptions import HTTPError
 
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import control_silo_test
 from sentry.users.models.identity import Identity, IdentityProvider, OrganizationIdentity
 
 
+@with_feature("organizations:seer-infra-telemetry-user-level-auth")
 @control_silo_test
 class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
     endpoint = "sentry-api-0-organization-monitoring-provider-details"
@@ -21,6 +23,16 @@ class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
 
     def test_connect_requires_feature_flag(self) -> None:
         response = self.get_response(self.organization.slug, "datadog")
+        assert response.status_code == 404
+
+    def test_connect_requires_user_level_flag(self) -> None:
+        with self.feature(
+            {
+                "organizations:seer-infra-telemetry": True,
+                "organizations:seer-infra-telemetry-user-level-auth": False,
+            }
+        ):
+            response = self.get_response(self.organization.slug, "datadog", site="datadoghq.com")
         assert response.status_code == 404
 
     @patch(
@@ -281,6 +293,7 @@ class OrganizationMonitoringProviderDetailsConnectTest(APITestCase):
         assert not Identity.objects.filter(idp=idp, user=self.user).exists()
 
 
+@with_feature("organizations:seer-infra-telemetry-user-level-auth")
 @control_silo_test
 class OrganizationMonitoringProviderDetailsReauthenticateTest(APITestCase):
     endpoint = "sentry-api-0-organization-monitoring-provider-details"
@@ -303,6 +316,19 @@ class OrganizationMonitoringProviderDetailsReauthenticateTest(APITestCase):
 
     def test_reauthenticate_requires_feature_flag(self) -> None:
         response = self.get_response(self.organization.slug, "datadog_pat")
+        assert response.status_code == 404
+
+    def test_reauthenticate_requires_user_level_flag(self) -> None:
+        self._connect_datadog_pat(site="datadoghq.com")
+        with self.feature(
+            {
+                "organizations:seer-infra-telemetry": True,
+                "organizations:seer-infra-telemetry-user-level-auth": False,
+            }
+        ):
+            response = self.get_response(
+                self.organization.slug, "datadog_pat", access_token="pat-new"
+            )
         assert response.status_code == 404
 
     def test_reauthenticate_not_connected(self) -> None:
@@ -435,6 +461,27 @@ class OrganizationMonitoringProviderDetailsDisconnectTest(APITestCase):
     def test_disconnect_requires_feature_flag(self) -> None:
         response = self.get_response(self.organization.slug, "datadog")
         assert response.status_code == 404
+
+    def test_disconnect_does_not_require_user_level_flag(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="dd-org-456")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-123",
+            data={"access_token": "token"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=identity)
+
+        with self.feature(
+            {
+                "organizations:seer-infra-telemetry": True,
+                "organizations:seer-infra-telemetry-user-level-auth": False,
+            }
+        ):
+            response = self.get_response(self.organization.slug, "datadog")
+
+        assert response.status_code == 204
+        assert not Identity.objects.filter(id=identity.id).exists()
 
     def test_disconnect_deletes_identity_datadog(self) -> None:
         idp = self.create_identity_provider(type="datadog", external_id="dd-org-456")

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_index.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_index.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
+@with_feature("organizations:seer-infra-telemetry-user-level-auth")
 @control_silo_test
 class OrganizationMonitoringProviderIndexEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-monitoring-providers"
@@ -15,6 +17,16 @@ class OrganizationMonitoringProviderIndexEndpointTest(APITestCase):
 
     def test_list_requires_feature_flag(self) -> None:
         response = self.get_response(self.organization.slug)
+        assert response.status_code == 404
+
+    def test_list_requires_user_level_flag(self) -> None:
+        with self.feature(
+            {
+                "organizations:seer-infra-telemetry": True,
+                "organizations:seer-infra-telemetry-user-level-auth": False,
+            }
+        ):
+            response = self.get_response(self.organization.slug)
         assert response.status_code == 404
 
     def test_list_providers(self) -> None:

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1749,6 +1749,7 @@ class TestSeerAgentClientLatestRun(TestCase):
 
 
 @with_feature("organizations:seer-infra-telemetry")
+@with_feature("organizations:seer-infra-telemetry-user-level-auth")
 class TestGetAvailableMonitoringProviders(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/seer/agent/test_monitoring_providers.py
+++ b/tests/sentry/seer/agent/test_monitoring_providers.py
@@ -14,6 +14,7 @@ TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
 
 @override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)
 @with_feature("organizations:seer-infra-telemetry")
+@with_feature("organizations:seer-infra-telemetry-user-level-auth")
 class TestGetMonitoringProviderConnections(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -541,3 +542,21 @@ class TestGetMonitoringProviderConnections(TestCase):
         dd_conns = [c for c in result if c["provider_key"] == "datadog"]
         assert len(gcp_conns) == 3
         assert len(dd_conns) == 1
+
+    @with_feature({"organizations:seer-infra-telemetry-user-level-auth": False})
+    def test_personal_identity_ignored_when_user_level_auth_disabled(self) -> None:
+        self._create_org_datadog_integration()
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "personal-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        assert result[0]["identity_id"] is None
+        assert result[0]["auth_method"] == "api_key"

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -882,6 +882,7 @@ class TestGetOrganizationFeatures(APITestCase):
 @with_feature("organizations:seer-infra-telemetry")
 @cell_silo_test
 class TestGetMonitoringProviderConnections(APITestCase):
+    @with_feature("organizations:seer-infra-telemetry-user-level-auth")
     def test_returns_connections(self) -> None:
         idp = self.create_identity_provider(type="datadog", external_id="org-uuid-1")
         identity = self.create_identity(


### PR DESCRIPTION
Relates to CW-1966

In prep for rollout, we are going to be using org-level auth connections. Let's put the user-level auth connections under their own feature flag `organizations:seer-infra-telemetry-user-level-auth` to be turned off, with `organizations:seer-infra-telemetry` remaining as the master killswitch.

Corresponding frontend PR: https://github.com/getsentry/sentry/pull/123027