### PR TITLE
chore(seer-infra-telemetry): Place user-level auth monitoring connections under their own feature flag (frontend)

### DIFF
--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -322,7 +322,9 @@ export function SeerExplorerContent({
   });
 
   const showReauth =
-    isReauthPending && !!organization?.features.includes('seer-infra-telemetry');
+    isReauthPending &&
+    !!organization?.features.includes('seer-infra-telemetry') &&
+    !!organization?.features.includes('seer-infra-telemetry-user-level-auth');
 
   // - Topbar, menu, and slash command handlers -------------------------------
   const copySessionEnabled = runId !== null && !!organization?.slug;

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -222,7 +222,8 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           show: ({organization}) =>
             !!organization &&
             showNewSeer(organization) &&
-            organization.features.includes('seer-infra-telemetry'),
+            organization.features.includes('seer-infra-telemetry') &&
+            organization.features.includes('seer-infra-telemetry-user-level-auth'),
         },
         {
           path: `${organizationSettingsPathPrefix}/seer/advanced/`,

--- a/static/gsApp/views/seerAutomation/connectors.spec.tsx
+++ b/static/gsApp/views/seerAutomation/connectors.spec.tsx
@@ -15,11 +15,26 @@ import SeerConnectors from 'getsentry/views/seerAutomation/connectors';
 
 describe('SeerConnectors', () => {
   const organization = OrganizationFixture({
-    features: ['seer-infra-telemetry'],
+    features: ['seer-infra-telemetry', 'seer-infra-telemetry-user-level-auth'],
   });
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+  });
+
+  it('redirects to Seer settings when user-level auth flag is missing', () => {
+    const orgWithoutUserAuth = OrganizationFixture({
+      features: ['seer-infra-telemetry'],
+    });
+
+    const {router} = render(<SeerConnectors />, {
+      organization: orgWithoutUserAuth,
+      initialRouterConfig: {
+        location: {pathname: `/settings/${orgWithoutUserAuth.slug}/seer/connectors/`},
+      },
+    });
+
+    expect(router.location.pathname).toBe(`/settings/${orgWithoutUserAuth.slug}/seer/`);
   });
 
   it('renders page with header and provider list', async () => {

--- a/static/gsApp/views/seerAutomation/connectors.tsx
+++ b/static/gsApp/views/seerAutomation/connectors.tsx
@@ -48,7 +48,10 @@ function monitoringProvidersQueryOptions(orgSlug: string) {
 export default function SeerConnectors() {
   const organization = useOrganization();
 
-  if (!organization.features.includes('seer-infra-telemetry')) {
+  if (
+    !organization.features.includes('seer-infra-telemetry') ||
+    !organization.features.includes('seer-infra-telemetry-user-level-auth')
+  ) {
     return <Redirect to={normalizeUrl(`/settings/${organization.slug}/seer/`)} />;
   }
 


### PR DESCRIPTION
Fixes CW-1966

In prep for rollout, we are going to be using org-level auth connections. Let's put the user-level auth connections under their own feature flag `organizations:seer-infra-telemetry-user-level-auth` to be turned off, with `organizations:seer-infra-telemetry` remaining as the master killswitch.

Redirect the connectors page (shows user-level monitoring connections) to Seer settings if the flag is off. Put any reauth flow under the flag. 

Corresponding backend PR: https://github.com/getsentry/sentry/pull/123025

https://github.com/user-attachments/assets/a2505b32-319c-49f6-8ca0-dd36c318e27a

