### PR TITLE
fix(issues): Prevent view hierarchy from loading forever

### DIFF
--- a/static/app/components/events/eventViewHierarchy.spec.tsx
+++ b/static/app/components/events/eventViewHierarchy.spec.tsx
@@ -3,7 +3,7 @@ import {EventAttachmentFixture} from 'sentry-fixture/eventAttachment';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {EventViewHierarchy} from './eventViewHierarchy';
 
@@ -102,5 +102,25 @@ describe('Event View Hierarchy', () => {
     rerender(<EventViewHierarchy project={mockProject} event={event} />);
 
     expect(await screen.findByText('Nested Container - nested')).toBeInTheDocument();
+  });
+
+  it('renders an error without automatically retrying when the download fails', async () => {
+    const downloadMock = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${mockProject.slug}/events/${mockAttachment.event_id}/attachments/${mockAttachment.id}/`,
+      body: {detail: 'View hierarchy attachment is unavailable.'},
+      statusCode: 500,
+      match: [MockApiClient.matchQuery({download: true})],
+    });
+
+    render(<EventViewHierarchy project={mockProject} event={event} />, {organization});
+
+    expect(
+      await screen.findByText('View hierarchy attachment is unavailable.')
+    ).toBeInTheDocument();
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    await waitFor(() => expect(downloadMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -125,7 +125,7 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
   );
 }
 
-function EventViewHierarchy(props: Props) {
+export function EventViewHierarchy(props: Props) {
   const organization = useOrganization();
 
   if (!organization.features.includes('event-attachments')) {
@@ -134,5 +134,3 @@ function EventViewHierarchy(props: Props) {
 
   return <EventViewHierarchyContent {...props} />;
 }
-
-export {EventViewHierarchy};

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -1,19 +1,20 @@
 import {useMemo} from 'react';
 import * as Sentry from '@sentry/react';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {useFetchEventAttachments} from 'sentry/actionCreators/events';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
-import {getAttachmentUrl} from 'sentry/components/events/attachmentViewers/utils';
 import {
   getPlatform,
   getPlatformViewConfig,
 } from 'sentry/components/events/viewHierarchy/utils';
+import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Project} from 'sentry/types/project';
-import type {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {defined} from 'sentry/utils/defined';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getRequestErrorUserMessage} from 'sentry/utils/requestError/getRequestErrorUserMessage';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
@@ -38,58 +39,56 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
     },
     {notifyOnChangeProps: ['data']}
   );
-  const viewHierarchies =
-    attachments?.filter(attachment => attachment.type === 'event.view_hierarchy') ?? [];
-  const hierarchyMeta = viewHierarchies[0];
+  const hierarchyMeta = attachments?.find(
+    attachment => attachment.type === 'event.view_hierarchy'
+  );
 
-  // There should be only one view hierarchy
-  const {isPending, data} = useApiQuery<string | ViewHierarchyData>(
-    [
-      defined(hierarchyMeta)
-        ? getAttachmentUrl({
-            attachment: hierarchyMeta,
-            eventId: hierarchyMeta.event_id,
-            orgSlug: organization.slug,
-            projectSlug: project.slug,
-          })
-        : ('' as unknown as ReturnType<typeof getApiUrl>),
+  // There should be only one view hierarchy.
+  const hierarchyQuery = useQuery({
+    ...apiOptions.as<string | ViewHierarchyData>()(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/attachments/$attachmentId/',
       {
+        path: hierarchyMeta
+          ? {
+              organizationIdOrSlug: organization.slug,
+              projectIdOrSlug: project.slug,
+              eventId: hierarchyMeta.event_id,
+              attachmentId: hierarchyMeta.id,
+            }
+          : skipToken,
         headers: {
           Accept: '*/*; charset=utf-8',
         },
         query: {
           download: true,
         },
-      },
-    ],
-    {staleTime: Infinity, enabled: defined(hierarchyMeta)}
-  );
+        staleTime: Infinity,
+      }
+    ),
+    retry: false,
+  });
 
   // Memoize the JSON parsing because downstream hooks depend on
   // referential equality of objects in the data
   const hierarchy = useMemo(() => {
-    if (!data) {
+    if (!hierarchyQuery.data) {
       return null;
     }
 
-    if (data && typeof data !== 'string') {
-      return data;
+    if (typeof hierarchyQuery.data !== 'string') {
+      return hierarchyQuery.data;
     }
 
     try {
-      return JSON.parse(data) as ViewHierarchyData;
+      return JSON.parse(hierarchyQuery.data) as ViewHierarchyData;
     } catch (err) {
       Sentry.captureException(err);
       return null;
     }
-  }, [data]);
+  }, [hierarchyQuery.data]);
 
-  if (viewHierarchies.length === 0) {
+  if (!hierarchyMeta) {
     return null;
-  }
-
-  if (isPending || !data) {
-    return <LoadingIndicator />;
   }
 
   const platform = getPlatform({event, project});
@@ -101,15 +100,27 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
       title={platformViewConfig.title}
       disableCollapsePersistence={disableCollapsePersistence}
     >
-      <ErrorBoundary mini>
-        <ViewHierarchy
-          viewHierarchy={hierarchy}
-          platform={platform}
-          emptyMessage={platformViewConfig.emptyMessage}
-          showWireframe={platformViewConfig.showWireframe}
-          nodeField={platformViewConfig.nodeField}
+      {hierarchyQuery.isPending ? (
+        <LoadingIndicator />
+      ) : hierarchyQuery.isError ? (
+        <LoadingError
+          message={getRequestErrorUserMessage(
+            hierarchyQuery.error,
+            t('Failed to load view hierarchy.')
+          )}
+          onRetry={hierarchyQuery.refetch}
         />
-      </ErrorBoundary>
+      ) : (
+        <ErrorBoundary mini>
+          <ViewHierarchy
+            viewHierarchy={hierarchy}
+            platform={platform}
+            emptyMessage={platformViewConfig.emptyMessage}
+            showWireframe={platformViewConfig.showWireframe}
+            nodeField={platformViewConfig.nodeField}
+          />
+        </ErrorBoundary>
+      )}
     </FoldSection>
   );
 }

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef} from 'react';
+import {Fragment, lazy, Suspense, useMemo, useRef} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -22,7 +22,6 @@ import {EventRegressionSummary} from 'sentry/components/events/eventStatisticalD
 import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
 import {ScreenshotDataSection} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection';
 import {EventTagsDataSection} from 'sentry/components/events/eventTagsAndScreenshot/tags';
-import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventXrayDiff} from 'sentry/components/events/eventXrayDiff';
 import {EventFeatureFlagSection} from 'sentry/components/events/featureFlags/eventFeatureFlagSection';
 import {EventGroupingInfoSection} from 'sentry/components/events/groupingInfo/groupingInfoSection';
@@ -88,6 +87,12 @@ import {SizeAnalysisTriggeredSection} from 'sentry/views/issueDetails/sidebar/si
 import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+const EventViewHierarchy = lazy(() =>
+  import('sentry/components/events/eventViewHierarchy').then(module => ({
+    default: module.EventViewHierarchy,
+  }))
+);
 
 export interface EventDetailsContentProps {
   group: Group;
@@ -349,7 +354,9 @@ export function EventDetailsContent({
         <EventFeatureFlagSection group={group} project={project} event={event} />
       </ErrorBoundary>
       <EventExtraData event={event} />
-      <EventViewHierarchy event={event} project={project} />
+      <Suspense fallback={null}>
+        <EventViewHierarchy event={event} project={project} />
+      </Suspense>
       <EventInsightDiff event={event} project={project} />
       <EventXrayDiff event={event} project={project} />
       <EventPackageData event={event} />

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, lazy, Suspense, useMemo, useRef} from 'react';
+import {Fragment, lazy, useMemo, useRef} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -51,6 +51,7 @@ import {OurlogsSection} from 'sentry/components/events/ourlogs/ourlogsSection';
 import {EventPackageData} from 'sentry/components/events/packageData';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
+import {LazyLoad} from 'sentry/components/lazyLoad';
 import {IssueStackTrace} from 'sentry/components/stackTrace/issueStackTrace';
 import {t} from 'sentry/locale';
 import type {Entry, EntryMap, Event, EventTransaction} from 'sentry/types/event';
@@ -88,7 +89,7 @@ import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
-const EventViewHierarchy = lazy(() =>
+const LazyEventViewHierarchy = lazy(() =>
   import('sentry/components/events/eventViewHierarchy').then(module => ({
     default: module.EventViewHierarchy,
   }))
@@ -354,9 +355,12 @@ export function EventDetailsContent({
         <EventFeatureFlagSection group={group} project={project} event={event} />
       </ErrorBoundary>
       <EventExtraData event={event} />
-      <Suspense fallback={null}>
-        <EventViewHierarchy event={event} project={project} />
-      </Suspense>
+      <LazyLoad
+        LazyComponent={LazyEventViewHierarchy}
+        event={event}
+        project={project}
+        loadingFallback={null}
+      />
       <EventInsightDiff event={event} project={project} />
       <EventXrayDiff event={event} project={project} />
       <EventPackageData event={event} />


### PR DESCRIPTION
View hierarchy attachment failures could leave issue details stuck on a spinner.

Switches the download to a non-retrying TanStack query, shows the request error with a manual retry, and handles empty responses without spinning forever.

Also going to start lazy loading some of the bigger components on this page.

[example issue](https://demo.sentry.io/issues/7380931766/)