### PR TITLE
fix(issues): Handle Snuba query errors in GroupTagsEndpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -12,7 +12,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.serializers import serialize
-from sentry.api.utils import get_date_range_from_params
+from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.ratelimits.config import RateLimitConfig
@@ -70,15 +70,16 @@ class GroupTagsEndpoint(GroupEndpoint):
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
 
         start, end = get_date_range_from_params(request.GET, optional=True)
-        tag_keys = backend.get_group_tag_keys_and_top_values(
-            group,
-            environment_ids,
-            keys=keys,
-            value_limit=value_limit,
-            tenant_ids={"organization_id": group.project.organization_id},
-            start=start,
-            end=end,
-        )
+        with handle_query_errors():
+            tag_keys = backend.get_group_tag_keys_and_top_values(
+                group,
+                environment_ids,
+                keys=keys,
+                value_limit=value_limit,
+                tenant_ids={"organization_id": group.project.organization_id},
+                start=start,
+                end=end,
+            )
 
         data = serialize(tag_keys, request.user)
 


### PR DESCRIPTION
The group tags endpoint aggregates over a 90 day window by default, and on a large, long-lived groups the top-values query exceeds the ClickHouse memory limit. The tagstore call was not wrapped in handle_query_errors(), so QueryMemoryLimitExceeded escaped as an unhandled 500.

This should really just be instrumented automatically but this will unblock the current callsite so it maps to a 504 instead, matching every other Snuba-backed endpoint in this package.