### PR TITLE
ref(db): Remove final create_or_update caller

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any
 
 import psycopg2.errors
-from django.db import DataError
+from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
 from sentry.db import models
@@ -187,7 +187,20 @@ class Buffer(Service):
                                 raise
                 created = False
             elif model:
-                _, created = model.objects.create_or_update(values=update_kwargs, **filters)
+                # update_or_create cannot insert F() expressions. Create with raw increments,
+                # then retry the update if a concurrent insert wins.
+                using = router.db_for_write(model)
+                objects = model.objects.using(using)
+                affected = objects.filter(**filters).update(**update_kwargs)
+                if not affected:
+                    create_kwargs = {**filters, **columns, **(extra or {})}
+                    try:
+                        with transaction.atomic(using=using):
+                            objects.create(**create_kwargs)
+                    except IntegrityError:
+                        objects.filter(**filters).update(**update_kwargs)
+                    else:
+                        created = True
 
         buffer_incr_complete.send_robust(
             model=model,

--- a/tests/sentry/buffer/test_base.py
+++ b/tests/sentry/buffer/test_base.py
@@ -44,11 +44,19 @@ class BufferTest(TestCase):
         self.buf.process(Group, columns, filters)
         assert Group.objects.get(id=group.id).times_seen == group.times_seen + 1
 
-    def test_process_saves_data_without_existing_row(self) -> None:
+    @mock.patch("sentry.buffer.base.buffer_incr_complete.send_robust")
+    def test_process_saves_data_without_existing_row(self, send_robust: mock.MagicMock) -> None:
         columns = {"new_groups": 1}
         filters = {"project_id": self.project.id, "release_id": self.release.id}
-        self.buf.process(ReleaseProject, columns, filters)
-        assert ReleaseProject.objects.filter(new_groups=1, **filters).exists()
+        ReleaseProject.objects.filter(**filters).delete()
+        adopted = timezone.now()
+
+        self.buf.process(ReleaseProject, columns, filters, {"adopted": adopted})
+
+        release_project = ReleaseProject.objects.get(**filters)
+        assert release_project.new_groups == 1
+        assert release_project.adopted == adopted
+        assert send_robust.call_args.kwargs["created"] is True
 
     def test_process_saves_extra(self) -> None:
         group = Group.objects.create(project=Project(id=1))
@@ -75,8 +83,7 @@ class BufferTest(TestCase):
         release_project_ = ReleaseProject.objects.get(id=release_project.id)
         assert release_project_.new_groups == 1
 
-    @mock.patch("sentry.models.Group.objects.create_or_update")
-    def test_signal_only(self, create_or_update: mock.MagicMock) -> None:
+    def test_signal_only(self) -> None:
         group = Group.objects.create(project=Project(id=1))
         columns = {"times_seen": 1}
         filters = {"id": group.id, "project_id": 1}

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -10,7 +10,6 @@ from typing import Any
 # create_or_update. Instead, use Django's update_or_create.
 # Reduce over time as code is refactored. DO NOT add new files here.
 ALLOWLIST_FILES: set[str] = {
-    "src/sentry/buffer/base.py",
     "src/sentry/db/models/manager/base.py",
 }
 


### PR DESCRIPTION
`Buffer.process` no longer calls legacy `create_or_update` for non-`Group` models. It updates existing rows with `F()` expressions, inserts raw counter and extra values when no row exists, and retries update after a concurrent insert. This preserves existing create signals and race behavior while leaving only helper definition for later removal.

Django's `update_or_create` cannot handle these `F()` expressions on insert, so this keeps explicit update/create flow. 
