### PR TITLE
fix(search): Preserve grouped aggregate filter values

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -638,6 +638,14 @@ describe('utils/tokenizeSearch', () => {
         string: 'country:>canada OR coronaFree():<newzealand',
       },
       {
+        name: 'preserves grouping parens after aggregate filters',
+        object: new MutableSearch(
+          '(transaction:"Example Transaction" count(span.duration):>100) AND is_transaction:1'
+        ),
+        string:
+          '( transaction:"Example Transaction" count(span.duration):>100 ) AND is_transaction:1',
+      },
+      {
         name: 'should quote tags with parens and spaces',
         object: new MutableSearch(['release:4.9.0 build (0.0.01)', 'error.handled:0']),
         string: 'release:"4.9.0 build (0.0.01)" error.handled:0',

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -646,6 +646,11 @@ describe('utils/tokenizeSearch', () => {
           '( transaction:"Example Transaction" count(span.duration):>100 ) AND is_transaction:1',
       },
       {
+        name: 'preserves grouping parens when a quoted value ends with a backslash',
+        object: new MutableSearch('(key:"value\\\\")'),
+        string: '( key:"value\\\\" )',
+      },
+      {
         name: 'should quote tags with parens and spaces',
         object: new MutableSearch(['release:4.9.0 build (0.0.01)', 'error.handled:0']),
         string: 'release:"4.9.0 build (0.0.01)" error.handled:0',

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -51,17 +51,27 @@ function isParen(token: Token, character: '(' | ')') {
   );
 }
 
-function hasUnquotedOpenParen(s: string): boolean {
+function countUnquotedUnmatchedClosingParens(s: string): number {
   let inQuotes = false;
+  let openParenCount = 0;
+  let unmatchedClosingParenCount = 0;
+
   for (let i = 0; i < s.length; i++) {
     const char = s[i];
     if (char === '"' && (i === 0 || s[i - 1] !== '\\')) {
       inQuotes = !inQuotes;
     } else if (char === '(' && !inQuotes) {
-      return true;
+      openParenCount++;
+    } else if (char === ')' && !inQuotes) {
+      if (openParenCount > 0) {
+        openParenCount--;
+      } else {
+        unmatchedClosingParenCount++;
+      }
     }
   }
-  return false;
+
+  return unmatchedClosingParenCount;
 }
 
 function isProperlyBracketed(value: string): boolean {
@@ -226,11 +236,15 @@ export class MutableSearch {
       }
 
       let trailingParen = '';
-      if (token.endsWith(')') && !hasUnquotedOpenParen(token)) {
+      if (token.endsWith(')')) {
         const parenMatch = token.match(/\)+$/g);
-        if (parenMatch) {
-          trailingParen = parenMatch[0];
-          token = token.replace(/\)+$/g, '');
+        const trailingParenCount = Math.min(
+          parenMatch?.[0].length ?? 0,
+          countUnquotedUnmatchedClosingParens(token)
+        );
+        if (trailingParenCount > 0) {
+          trailingParen = ')'.repeat(trailingParenCount);
+          token = token.slice(0, -trailingParenCount);
         }
       }
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -51,6 +51,15 @@ function isParen(token: Token, character: '(' | ')') {
   );
 }
 
+function isCharacterEscaped(value: ArrayLike<string>, index: number): boolean {
+  let precedingBackslashCount = 0;
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i--) {
+    precedingBackslashCount++;
+  }
+
+  return precedingBackslashCount % 2 === 1;
+}
+
 function countUnquotedUnmatchedClosingParens(s: string): number {
   let inQuotes = false;
   let openParenCount = 0;
@@ -58,7 +67,7 @@ function countUnquotedUnmatchedClosingParens(s: string): number {
 
   for (let i = 0; i < s.length; i++) {
     const char = s[i];
-    if (char === '"' && (i === 0 || s[i - 1] !== '\\')) {
+    if (char === '"' && !isCharacterEscaped(s, i)) {
       inQuotes = !inQuotes;
     } else if (char === '(' && !inQuotes) {
       openParenCount++;
@@ -189,7 +198,7 @@ export class MutableSearch {
       for (let i = 0, len = token.length; i < len; i++) {
         const char = token[i];
 
-        if (char === '"' && (i === 0 || token[i - 1] !== '\\')) {
+        if (char === '"' && !isCharacterEscaped(token, i)) {
           quoted = !quoted;
           continue;
         }
@@ -623,16 +632,15 @@ function splitSearchIntoTokens(query: string) {
       token = '';
     }
 
-    if (["'", '"'].includes(char) && (!quoteEnclosed || quoteType === char)) {
+    if (
+      ["'", '"'].includes(char) &&
+      !isCharacterEscaped(queryChars, idx) &&
+      (!quoteEnclosed || quoteType === char)
+    ) {
       quoteEnclosed = !quoteEnclosed;
       if (quoteEnclosed) {
         quoteType = char;
       }
-    }
-
-    if (quoteEnclosed && char === '\\' && nextChar === quoteType) {
-      token += nextChar;
-      idx++;
     }
   }
 
@@ -664,7 +672,7 @@ function parseFilter(filter: string) {
   for (; idx < filter.length; idx++) {
     const c = filter[idx];
 
-    if (c === '"') {
+    if (c === '"' && !isCharacterEscaped(filter, idx)) {
       quoted = !quoted;
       continue;
     }
@@ -724,7 +732,7 @@ function removeSurroundingQuotes(text: string) {
 
   let right = length - 1;
   for (; right >= length / 2; right--) {
-    if (text.charAt(right) !== '"' || text.charAt(right - 1) === '\\') {
+    if (text.charAt(right) !== '"' || isCharacterEscaped(text, right)) {
       break;
     }
   }


### PR DESCRIPTION
Grouped search queries now preserve their closing boolean-group delimiter when the final filter uses an aggregate function key. The legacy tokenizer balances unquoted parentheses, preventing comparison values from absorbing the group delimiter and being rewritten as quoted strings.

Quote scanning now also uses odd/even backslash parity consistently across token splitting, filter parsing, and serialization. This preserves grouping when a quoted filter value ends in a literal backslash while leaving legitimate parenthesized values unchanged.
