### PR TITLE
feat(auth): Apply Auth V2 rollout to login cookie

### DIFF
--- a/static/app/utils/useAuthV2Rollout.spec.tsx
+++ b/static/app/utils/useAuthV2Rollout.spec.tsx
@@ -1,0 +1,89 @@
+import Cookies from 'js-cookie';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {useAuthV2Rollout} from 'sentry/utils/useAuthV2Rollout';
+import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
+
+describe('useAuthV2Rollout', () => {
+  beforeEach(() => {
+    OrganizationStore.init();
+    Cookies.remove('sentry_react_auth', {path: '/'});
+  });
+
+  it('enables Auth V2 when a member organization has the rollout feature', async () => {
+    renderHook(useAuthV2Rollout);
+
+    act(() => {
+      OrganizationStore.onUpdate(OrganizationFixture({features: ['authv2-rollout']}));
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
+  });
+
+  it('preserves an explicit opt-out while the organization has the rollout feature', async () => {
+    Cookies.set('sentry_react_auth', '0', {path: '/'});
+    renderHook(useAuthV2Rollout);
+
+    act(() => {
+      OrganizationStore.onUpdate(OrganizationFixture({features: ['authv2-rollout']}));
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('0'));
+  });
+
+  it('preserves cookie state when organization loading fails', async () => {
+    Cookies.set('sentry_react_auth', '1', {path: '/'});
+    renderHook(useAuthV2Rollout);
+
+    act(() => {
+      OrganizationStore.onFetchOrgError(
+        new RequestError('GET', '/api/0/organizations/acme/', new Error('network error'))
+      );
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
+  });
+
+  it('preserves an explicit opt-out outside the rollout', async () => {
+    Cookies.set('sentry_react_auth', '0', {path: '/'});
+    renderHook(useAuthV2Rollout);
+
+    act(() => {
+      OrganizationStore.onUpdate(OrganizationFixture());
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('0'));
+  });
+
+  it('reads an opt-out written by another hook instance', async () => {
+    renderHook(useAuthV2Rollout);
+    const {result: override} = renderHook(useEnableAuthV2);
+
+    act(() => {
+      OrganizationStore.onUpdate(OrganizationFixture({features: ['authv2-rollout']}));
+    });
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
+
+    act(() => {
+      override.current.setAuthV2CookieState(AuthV2CookieState.DISABLED);
+      OrganizationStore.onUpdate(OrganizationFixture());
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('0'));
+  });
+
+  it('clears an enabled cookie outside the rollout', async () => {
+    Cookies.set('sentry_react_auth', '1', {path: '/'});
+    renderHook(useAuthV2Rollout);
+
+    act(() => {
+      OrganizationStore.onUpdate(OrganizationFixture());
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBeUndefined());
+  });
+});

--- a/static/app/utils/useAuthV2Rollout.ts
+++ b/static/app/utils/useAuthV2Rollout.ts
@@ -1,0 +1,33 @@
+import {useEffect} from 'react';
+
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {
+  AuthV2CookieState,
+  getAuthV2CookieState,
+  useEnableAuthV2,
+} from 'sentry/utils/useEnableAuthV2';
+
+export function useAuthV2Rollout() {
+  const {loading, organization} = useLegacyStore(OrganizationStore);
+  const {setAuthV2CookieState} = useEnableAuthV2();
+
+  useEffect(() => {
+    if (loading || !organization) {
+      return;
+    }
+
+    const authV2CookieState = getAuthV2CookieState();
+
+    if (!organization.features.includes('authv2-rollout')) {
+      if (authV2CookieState === AuthV2CookieState.ENABLED) {
+        setAuthV2CookieState(AuthV2CookieState.UNSET);
+      }
+      return;
+    }
+
+    if (authV2CookieState === AuthV2CookieState.UNSET) {
+      setAuthV2CookieState(AuthV2CookieState.ENABLED);
+    }
+  }, [loading, organization, setAuthV2CookieState]);
+}

--- a/static/app/utils/useEnableAuthV2.ts
+++ b/static/app/utils/useEnableAuthV2.ts
@@ -3,6 +3,26 @@ import Cookies from 'js-cookie';
 
 const REACT_AUTH_COOKIE = 'sentry_react_auth';
 
+export enum AuthV2CookieState {
+  DISABLED = 'disabled',
+  ENABLED = 'enabled',
+  UNSET = 'unset',
+}
+
+export function getAuthV2CookieState() {
+  const value = Cookies.get(REACT_AUTH_COOKIE);
+
+  if (value === '1') {
+    return AuthV2CookieState.ENABLED;
+  }
+
+  if (value === '0') {
+    return AuthV2CookieState.DISABLED;
+  }
+
+  return AuthV2CookieState.UNSET;
+}
+
 function getCookieDomain() {
   const {hostname} = window.location;
 
@@ -18,11 +38,10 @@ function getCookieDomain() {
 }
 
 export function useEnableAuthV2() {
-  const [isAuthV2Enabled, setIsAuthV2Enabled] = useState(
-    () => Cookies.get(REACT_AUTH_COOKIE) === '1'
-  );
+  const [authV2CookieState, setAuthV2CookieStateValue] = useState(getAuthV2CookieState);
+  const isAuthV2Enabled = authV2CookieState === AuthV2CookieState.ENABLED;
 
-  const setAuthV2Enabled = useCallback((enabled: boolean) => {
+  const setAuthV2CookieState = useCallback((state: AuthV2CookieState) => {
     const domain = getCookieDomain();
     const options = {
       path: '/',
@@ -30,15 +49,20 @@ export function useEnableAuthV2() {
       ...(domain ? {domain} : {}),
     };
 
-    if (enabled) {
-      Cookies.set(REACT_AUTH_COOKIE, '1', options);
-    } else {
+    Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});
+
+    if (state === AuthV2CookieState.UNSET) {
       Cookies.remove(REACT_AUTH_COOKIE, options);
-      Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});
+    } else {
+      Cookies.set(
+        REACT_AUTH_COOKIE,
+        state === AuthV2CookieState.ENABLED ? '1' : '0',
+        options
+      );
     }
 
-    setIsAuthV2Enabled(enabled);
+    setAuthV2CookieStateValue(state);
   }, []);
 
-  return {isAuthV2Enabled, setAuthV2Enabled};
+  return {authV2CookieState, isAuthV2Enabled, setAuthV2CookieState};
 }

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -23,6 +23,7 @@ import {onRenderCallback, Profiler} from 'sentry/utils/performanceForSentry';
 import {shouldPreloadData} from 'sentry/utils/shouldPreloadData';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
+import {useAuthV2Rollout} from 'sentry/utils/useAuthV2Rollout';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
@@ -95,6 +96,7 @@ export function App() {
   const user = useUser();
   const config = useLegacyStore(ConfigStore);
   const preloadData = shouldPreloadData(config);
+  useAuthV2Rollout();
 
   /**
    * Loads the users organization list into the OrganizationsStore

--- a/static/app/views/authV2/authLogin/index.tsx
+++ b/static/app/views/authV2/authLogin/index.tsx
@@ -13,7 +13,7 @@ import {t, tct} from 'sentry/locale';
 import type {AuthConfig} from 'sentry/types/auth';
 import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
-import {useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
+import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
@@ -41,10 +41,10 @@ const AUTH_PROVIDER_CONFIG = {
 export default function AuthLogin() {
   const {orgSlug} = useParams<{orgSlug?: string}>();
   const location = useLocation();
-  const {setAuthV2Enabled} = useEnableAuthV2();
+  const {setAuthV2CookieState} = useEnableAuthV2();
 
   const returnToLegacyLogin = () => {
-    setAuthV2Enabled(false);
+    setAuthV2CookieState(AuthV2CookieState.DISABLED);
     testableWindowLocation.reload();
   };
 

--- a/static/app/views/navigation/primary/helpMenu.spec.tsx
+++ b/static/app/views/navigation/primary/helpMenu.spec.tsx
@@ -52,7 +52,7 @@ describe('PrimaryNavigationHelpMenu', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Help'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Disable new login'}));
 
-    expect(Cookies.get('sentry_react_auth')).toBeUndefined();
+    expect(Cookies.get('sentry_react_auth')).toBe('0');
   });
 
   it('hides the new login toggle when the feature is disabled', async () => {

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -27,7 +27,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {showIntercom} from 'sentry/utils/intercom';
-import {useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
+import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {PrimaryNavigation} from 'sentry/views/navigation/primary/components';
@@ -49,7 +49,7 @@ export function PrimaryNavigationHelpMenu({
   const contactSupportItem = getContactSupportItem(organization);
   const openForm = useFeedbackForm();
   const {privacyUrl, termsUrl} = useLegacyStore(ConfigStore);
-  const {isAuthV2Enabled, setAuthV2Enabled} = useEnableAuthV2();
+  const {isAuthV2Enabled, setAuthV2CookieState} = useEnableAuthV2();
 
   useEffect(() => {
     trackAnalytics('intercom_link.viewed', {organization, source: 'sidebar'});
@@ -200,7 +200,9 @@ export function PrimaryNavigationHelpMenu({
             </MenuIcon>
           ),
           onAction() {
-            setAuthV2Enabled(!isAuthV2Enabled);
+            setAuthV2CookieState(
+              isAuthV2Enabled ? AuthV2CookieState.DISABLED : AuthV2CookieState.ENABLED
+            );
           },
         },
       ],


### PR DESCRIPTION
Use the Auth V2 organization feature flag to enable the React login experience while retaining explicit user overrides in a three-state cookie.

Enrolled users transition from an unset cookie to enabled. Explicit enable and disable choices remain stable while enrolled. Leaving the rollout clears an automatically enabled cookie, while preserving an explicit opt-out. Rollout reconciliation reads the current cookie so overrides written by another hook instance remain authoritative across organization changes. Loading and failed organization requests leave the cookie untouched until a concrete organization is available.

Depends on #123040, which registers and API-exposes the rollout flag.
