### PR TITLE
feat(seer): No-op the Autofix completion hook on failed runs

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -263,6 +263,11 @@ class SeerRunState(BaseModel):
     run_id: int
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
+    # Set only for the failures Seer can classify (currently "timeout" and
+    # "stalled"); every other failure leaves it None, so `status` is the signal
+    # for whether a run failed and this is only ever extra detail. Kept as a
+    # plain str so a new Seer reason does not fail validation mid-deploy.
+    failure_reason: str | None = None
     updated_at: str
     owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None

--- a/src/sentry/seer/agent/on_completion_hook.py
+++ b/src/sentry/seer/agent/on_completion_hook.py
@@ -12,12 +12,17 @@ class OnCompletionHookDefinition(BaseModel):
     """Definition of an on-completion hook to pass to Seer."""
 
     module_path: str
+    call_on_failure: bool = False
 
 
 class AgentOnCompletionHook(ABC):
     """Base class for the agent on-completion hooks.
 
-    Hooks are called when an agent run completes (regardless of status).
+    Hooks are called when an agent run finishes successfully. Pass
+    ``call_on_failure=True`` to :func:`extract_hook_definition` to also be
+    called when a run errors or times out; such a hook must read the run status
+    itself and handle a failed run, since ``execute`` is not told which outcome
+    it was called for.
 
     Example:
         class MyCompletionHook(AgentOnCompletionHook):
@@ -57,8 +62,15 @@ class AgentOnCompletionHook(ABC):
 
 def extract_hook_definition(
     hook_class: type[AgentOnCompletionHook],
+    *,
+    call_on_failure: bool = False,
 ) -> OnCompletionHookDefinition:
-    """Extract hook definition from an AgentOnCompletionHook class."""
+    """Extract hook definition from an AgentOnCompletionHook class.
+
+    Args:
+        hook_class: The hook to run when the run finishes
+        call_on_failure: Also run the hook when the run errors or times out
+    """
     # Enforce module-level classes only (no nested classes)
     if "." in hook_class.__qualname__:
         raise ValueError(
@@ -66,7 +78,10 @@ def extract_hook_definition(
             f"Nested classes are not supported. (qualname: {hook_class.__qualname__})"
         )
 
-    return OnCompletionHookDefinition(module_path=hook_class.get_module_path())
+    return OnCompletionHookDefinition(
+        module_path=hook_class.get_module_path(),
+        call_on_failure=call_on_failure,
+    )
 
 
 def call_on_completion_hook(

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -154,6 +154,10 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
     Handles:
     - Sending webhooks for completed steps (root_cause_completed, solution_completed, etc.)
     - Continuing the automated pipeline if stopping_point hasn't been reached
+
+    Keep dispatching this hook without ``call_on_failure`` until the failure
+    handling below is fully deployed: a mixed rollout that fired this hook on
+    error used to continue the pipeline as if the step succeeded.
     """
 
     @classmethod
@@ -171,6 +175,22 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             logger.exception(
                 "autofix.on_completion_hook.fetch_state_failed",
                 extra={"run_id": run_id, "organization_id": organization.id},
+            )
+            return
+
+        if state.status != "completed":
+            logger.info(
+                "autofix.on_completion_hook.run_not_completed",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": organization.id,
+                    "status": state.status,
+                    "failure_reason": state.failure_reason,
+                },
+            )
+            metrics.incr(
+                "autofix.on_completion_hook.run_not_completed",
+                tags={"status": state.status},
             )
             return
 

--- a/tests/sentry/seer/agent/test_client_models_failure_reason.py
+++ b/tests/sentry/seer/agent/test_client_models_failure_reason.py
@@ -1,0 +1,41 @@
+"""SeerRunState.failure_reason pass-through.
+
+Seer classifies some run failures (currently "timeout" and "stalled") on the run state. The sentry
+client model must declare the field or `Config.extra = "ignore"` silently drops it, leaving hooks
+that fire on failure unable to tell why. It is additive/optional, so old seer responses still parse.
+"""
+
+from __future__ import annotations
+
+from sentry.seer.agent.client_models import SeerRunState
+
+
+def _state(**kwargs) -> SeerRunState:
+    return SeerRunState(
+        run_id=1,
+        blocks=[],
+        updated_at="2024-01-01T00:00:00Z",
+        **kwargs,
+    )
+
+
+def test_failure_reason_is_parsed_from_seer():
+    assert _state(status="error", failure_reason="timeout").failure_reason == "timeout"
+
+
+def test_failure_reason_defaults_to_none_for_old_seer():
+    assert _state(status="error").failure_reason is None
+
+
+def test_unclassified_failures_are_still_failures():
+    # Most failures leave failure_reason unset, so status is what says a run failed.
+    state = _state(status="error")
+    assert state.status == "error"
+    assert state.failure_reason is None
+
+
+def test_unknown_failure_reason_still_parses():
+    # A reason added on the seer side must not fail validation mid-deploy.
+    assert _state(status="error", failure_reason="brand_new_reason").failure_reason == (
+        "brand_new_reason"
+    )

--- a/tests/sentry/seer/agent/test_on_completion_hook.py
+++ b/tests/sentry/seer/agent/test_on_completion_hook.py
@@ -18,6 +18,12 @@ class SampleCompletionHook(AgentOnCompletionHook):
         organization.update_option("test_hook_run_id", run_id)
 
 
+class FailureAwareCompletionHook(AgentOnCompletionHook):
+    @classmethod
+    def execute(cls, organization: Organization, run_id: int) -> None:
+        organization.update_option("test_failure_hook_run_id", run_id)
+
+
 class OnCompletionHookTest(TestCase):
     def test_extract_hook_definition(self) -> None:
         """Test extracting hook definition from a hook class."""
@@ -25,6 +31,24 @@ class OnCompletionHookTest(TestCase):
 
         assert isinstance(hook_def, OnCompletionHookDefinition)
         assert hook_def.module_path.endswith("test_on_completion_hook.SampleCompletionHook")
+
+    def test_extract_hook_definition_defaults_to_success_only(self) -> None:
+        """A hook that does not opt in is not called on failure."""
+        assert extract_hook_definition(SampleCompletionHook).call_on_failure is False
+        assert extract_hook_definition(SampleCompletionHook).dict() == {
+            "module_path": SampleCompletionHook.get_module_path(),
+            "call_on_failure": False,
+        }
+
+    def test_extract_hook_definition_propagates_call_on_failure(self) -> None:
+        """A dispatch opting in has the flag carried onto the Seer payload."""
+        hook_def = extract_hook_definition(FailureAwareCompletionHook, call_on_failure=True)
+
+        assert hook_def.call_on_failure is True
+        assert hook_def.dict() == {
+            "module_path": FailureAwareCompletionHook.get_module_path(),
+            "call_on_failure": True,
+        }
 
     def test_extract_hook_definition_nested_class_raises(self) -> None:
         """Test that nested classes are rejected."""

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -43,11 +43,18 @@ from sentry.types.activity import ActivityType
 from sentry.utils import json
 
 
-def run_state(run_id=123, blocks: list[MemoryBlock] | None = None, metadata=None):
+def run_state(
+    run_id=123,
+    blocks: list[MemoryBlock] | None = None,
+    metadata=None,
+    status="completed",
+    failure_reason=None,
+):
     return SeerRunState(
         run_id=run_id,
         blocks=blocks if blocks is not None else [],
-        status="completed",
+        status=status,
+        failure_reason=failure_reason,
         updated_at="2026-02-10T00:00:00Z",
         metadata=metadata,
     )
@@ -1037,6 +1044,43 @@ class AutofixOnCompletionHookTest(TestCase):
         seer_run.refresh_from_db()
         group.refresh_from_db()
         assert seer_run.last_triggered_at == group.seer_explorer_autofix_last_triggered
+
+    @patch(
+        "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._maybe_continue_pipeline"
+    )
+    @patch("sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._send_step_webhook")
+    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
+    def test_error_status_skips_success_path(
+        self, mock_fetch_run_status, mock_send_webhook, mock_continue_pipeline
+    ):
+        mock_fetch_run_status.return_value = run_state(
+            status="error",
+            failure_reason="timeout",
+            metadata={"group_id": 1},
+        )
+
+        AutofixOnCompletionHook.execute(self.organization, 123)
+
+        mock_send_webhook.assert_not_called()
+        mock_continue_pipeline.assert_not_called()
+
+    @patch(
+        "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._maybe_continue_pipeline"
+    )
+    @patch("sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._send_step_webhook")
+    @patch("sentry.seer.autofix.on_completion_hook.fetch_run_status")
+    def test_unclassified_error_still_skips_success_path(
+        self, mock_fetch_run_status, mock_send_webhook, mock_continue_pipeline
+    ):
+        mock_fetch_run_status.return_value = run_state(
+            status="error",
+            metadata={"group_id": 1},
+        )
+
+        AutofixOnCompletionHook.execute(self.organization, 123)
+
+        mock_send_webhook.assert_not_called()
+        mock_continue_pipeline.assert_not_called()
 
 
 REACT_PATH = "sentry.seer.autofix.on_completion_hook"

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -56,7 +56,8 @@ class TestTriggerAutofixRCAFeature(TestCase):
         # Seer persists this hook on the Explorer run so later PR iteration
         # completions continue through the Autofix completion flow.
         assert payload["on_completion_hook"] == {
-            "module_path": AutofixOnCompletionHook.get_module_path()
+            "module_path": AutofixOnCompletionHook.get_module_path(),
+            "call_on_failure": False,
         }
         assert run_kwargs["extras"] == {
             "referrer": AutofixReferrer.NIGHT_SHIFT.value,


### PR DESCRIPTION
Parse optional failure_reason from Seer run state and skip pipeline
continue / step webhooks when status is not completed. The hook
payload still defaults call_on_failure to false so a mixed sentry
rollout cannot fire this path until the handler is everywhere.

Depends on getsentry/seer#7949.

<!--
  Sentry employees and contractors can delete or ignore the following.
-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.