### PR TITLE
feat(seer): Call the Autofix completion hook when a run fails

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -166,10 +166,8 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
     Handles:
     - Sending webhooks for completed steps (root_cause_completed, solution_completed, etc.)
     - Continuing the automated pipeline if stopping_point hasn't been reached
-
-    Keep dispatching this hook without ``call_on_failure`` until the failure
-    handling below is fully deployed: a mixed rollout that fired this hook on
-    error used to continue the pipeline as if the step succeeded.
+    - No-op'ing when the run did not complete (errors / timeouts), so Seer can
+      invoke this hook with ``call_on_failure=True`` without advancing the pipeline
     """
 
     @classmethod

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -53,7 +53,7 @@ def trigger_autofix_rca_feature(
         short_id=group.qualified_short_id or str(group.id),
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",
-        on_completion_hook=extract_hook_definition(AutofixOnCompletionHook),
+        on_completion_hook=extract_hook_definition(AutofixOnCompletionHook, call_on_failure=True),
         tweaks=AutofixRCATweaks(
             intelligence_level=intelligence_level,
             reasoning_effort=reasoning_effort,

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -62,7 +62,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         # completions continue through the Autofix completion flow.
         assert payload["on_completion_hook"] == {
             "module_path": AutofixOnCompletionHook.get_module_path(),
-            "call_on_failure": False,
+            "call_on_failure": True,
         }
         assert run_kwargs["extras"] == {
             "referrer": AutofixReferrer.NIGHT_SHIFT.value,


### PR DESCRIPTION
Pass call_on_failure=True from RCA dispatch so timeouts and errors
reach the hook now that it no-ops instead of treating the step as
success.

Merge only after the handling PR is fully deployed.

<!--
  Sentry employees and contractors can delete or ignore the following.
-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.