### PR TITLE
feat(seer): Add trace waterfall embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -675,13 +675,6 @@
     },
     "examples": [
       {
-        "label": "Trace link",
-        "data": {
-          "traceId": "a1b2c3d4e5f678901234567890abcdef",
-          "timestamp": "2026-08-25T16:37:12Z"
-        }
-      },
-      {
         "label": "Trace waterfall",
         "data": {
           "traceId": "a1b2c3d4e5f678901234567890abcdef",

--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -650,7 +650,7 @@
   },
   {
     "name": "trace",
-    "description": "The ONLY way to reference a Sentry trace (the trace waterfall view). Use the 32-character trace ID. Provide `timestamp` when known so the waterfall opens on the right time range, and `spanId` to focus a span. Never use a markdown link for trace references.",
+    "description": "The ONLY way to reference a Sentry trace (the trace waterfall view). Use the 32-character trace ID. Provide `timestamp` when known so the waterfall opens on the right time range, and `spanId` to focus a span. Inline: renders a compact link. Block: renders the live trace waterfall. Do not duplicate the waterfall spans or duration details as text. Never use a markdown link for trace references.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -675,7 +675,14 @@
     },
     "examples": [
       {
-        "label": "Trace",
+        "label": "Trace link",
+        "data": {
+          "traceId": "a1b2c3d4e5f678901234567890abcdef",
+          "timestamp": "2026-08-25T16:37:12Z"
+        }
+      },
+      {
+        "label": "Trace waterfall",
         "data": {
           "traceId": "a1b2c3d4e5f678901234567890abcdef",
           "timestamp": "2026-08-25T16:37:12Z"

--- a/static/app/components/seer/markdown/__stories__/traceEmbedStory.spec.tsx
+++ b/static/app/components/seer/markdown/__stories__/traceEmbedStory.spec.tsx
@@ -1,0 +1,61 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
+
+import {TraceEmbedStory} from './traceEmbedStory';
+
+jest.mock('sentry/components/seer/markdown', () => ({
+  SeerMarkdown: ({raw}: {raw: string}) => <div aria-label="Rendered markdown">{raw}</div>,
+}));
+
+function createTraceResult(trace: Partial<TraceResult>): TraceResult {
+  return {
+    breakdowns: [],
+    duration: 300,
+    end: Date.UTC(2026, 7, 28, 16, 37, 12),
+    matchingSpans: 1,
+    name: 'Example trace',
+    numErrors: 0,
+    numOccurrences: 1,
+    numSpans: 2,
+    project: 'example-project',
+    rootDuration: 300,
+    slices: 10,
+    start: Date.UTC(2026, 7, 28, 16, 37, 11),
+    trace: '11111111111111111111111111111111',
+    ...trace,
+  };
+}
+
+describe('TraceEmbedStory', () => {
+  it('uses a recent trace with spans for the example', async () => {
+    const emptyTrace = createTraceResult({
+      numSpans: 0,
+      trace: '00000000000000000000000000000000',
+    });
+    const trace = createTraceResult({
+      trace: '1234567890abcdef1234567890abcdef',
+    });
+    const traceRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/traces/',
+      body: {data: [emptyTrace, trace], meta: {}},
+      match: [
+        MockApiClient.matchQuery({
+          breakdownSlices: 40,
+          dataset: 'spans',
+          per_page: 25,
+          sort: '-timestamp',
+          statsPeriod: '7d',
+        }),
+      ],
+    });
+
+    render(<TraceEmbedStory />);
+
+    const renderedMarkdown = await screen.findByLabelText('Rendered markdown');
+    expect(renderedMarkdown).toHaveTextContent(trace.trace);
+    expect(renderedMarkdown).toHaveTextContent(new Date(trace.end).toISOString());
+    expect(renderedMarkdown).not.toHaveTextContent(emptyTrace.trace);
+    expect(traceRequest).toHaveBeenCalled();
+  });
+});

--- a/static/app/components/seer/markdown/__stories__/traceEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/traceEmbedStory.tsx
@@ -1,0 +1,39 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {useTracesApiOptions} from 'sentry/views/explore/hooks/useTraces';
+
+import {EmbedStory, EmbedVariant} from './embedStory';
+
+export function TraceEmbedStory() {
+  const {data, isError, isPending} = useQuery(
+    useTracesApiOptions({
+      datetime: {period: '7d', start: null, end: null, utc: null},
+      limit: 25,
+      sort: '-timestamp',
+    })
+  );
+  const trace = data?.data.find(candidate => candidate.numSpans > 0);
+
+  return (
+    <EmbedStory name="trace">
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <Text variant="muted">Unable to load a trace example.</Text>
+      ) : trace ? (
+        <EmbedVariant
+          name="trace"
+          label="Trace"
+          data={{traceId: trace.trace, timestamp: new Date(trace.end).toISOString()}}
+        />
+      ) : (
+        <Text variant="muted">
+          No trace with spans is available for this organization.
+        </Text>
+      )}
+    </EmbedStory>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
@@ -1,16 +1,19 @@
-import {getEmbedLinkHref} from './resourceEmbedTestUtils';
+import {screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {getEmbedLinkHref, renderEmbed} from './resourceEmbedTestUtils';
 
 describe('trace embed', () => {
   const traceId = 'a1b2c3d4e5f678901234567890abcdef';
+  const timestamp = '2026-08-25T16:37:12Z';
 
   it('converts the ISO timestamp to unix seconds for the waterfall', () => {
     const href = getEmbedLinkHref('trace', 'Trace a1b2c3d4', {
       traceId,
-      timestamp: '2026-08-25T16:37:12Z',
+      timestamp,
     });
 
     expect(href).toContain(`/explore/traces/trace/${traceId}/`);
-    expect(href).toContain(`timestamp=${Date.parse('2026-08-25T16:37:12Z') / 1000}`);
+    expect(href).toContain(`timestamp=${Date.parse(timestamp) / 1000}`);
   });
 
   it('focuses a span when one is given', () => {
@@ -23,5 +26,50 @@ describe('trace embed', () => {
     expect(getEmbedLinkHref('trace', 'Trace a1b2c3d4', {traceId})).toBe(
       `/organizations/org-slug/explore/traces/trace/${traceId}/`
     );
+  });
+
+  it('renders the trace waterfall at block level', async () => {
+    const traceRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace/${traceId}/`,
+      body: {transactions: [], orphan_errors: []},
+    });
+    const metaRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace-meta/${traceId}/`,
+      body: {
+        errors: 0,
+        performance_issues: 0,
+        projects: 0,
+        transactions: 0,
+        transaction_child_count_map: [],
+        span_count: 0,
+        span_count_map: {},
+      },
+    });
+
+    renderEmbed({name: 'trace', data: {traceId, timestamp}});
+
+    expect(
+      await screen.findByText(
+        /We were unable to find any spans for this trace/,
+        {},
+        {timeout: 10_000}
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Trace a1b2c3d4'})).toHaveAttribute(
+      'href',
+      expect.stringContaining(`/explore/traces/trace/${traceId}/`)
+    );
+    await waitFor(() => {
+      expect(traceRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({
+            referrer: 'api.seer.trace-waterfall-embed',
+            timestamp: String(Date.parse(timestamp) / 1000),
+          }),
+        })
+      );
+      expect(metaRequest).toHaveBeenCalled();
+    });
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
@@ -6,6 +6,33 @@ describe('trace embed', () => {
   const traceId = 'a1b2c3d4e5f678901234567890abcdef';
   const timestamp = '2026-08-25T16:37:12Z';
 
+  const originalSearch = window.location.search;
+
+  afterEach(() => {
+    window.history.replaceState({}, '', `/${originalSearch}`);
+  });
+
+  function mockTraceRequests() {
+    const traceRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace/${traceId}/`,
+      body: {transactions: [], orphan_errors: []},
+    });
+    const metaRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace-meta/${traceId}/`,
+      body: {
+        errors: 0,
+        performance_issues: 0,
+        projects: 0,
+        transactions: 0,
+        transaction_child_count_map: [],
+        span_count: 0,
+        span_count_map: {},
+      },
+    });
+
+    return {traceRequest, metaRequest};
+  }
+
   it('converts the ISO timestamp to unix seconds for the waterfall', () => {
     const href = getEmbedLinkHref('trace', 'Trace a1b2c3d4', {
       traceId,
@@ -29,22 +56,7 @@ describe('trace embed', () => {
   });
 
   it('renders the trace waterfall at block level', async () => {
-    const traceRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/events-trace/${traceId}/`,
-      body: {transactions: [], orphan_errors: []},
-    });
-    const metaRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/events-trace-meta/${traceId}/`,
-      body: {
-        errors: 0,
-        performance_issues: 0,
-        projects: 0,
-        transactions: 0,
-        transaction_child_count_map: [],
-        span_count: 0,
-        span_count_map: {},
-      },
-    });
+    const {traceRequest, metaRequest} = mockTraceRequests();
 
     renderEmbed({name: 'trace', data: {traceId, timestamp}});
 
@@ -71,5 +83,18 @@ describe('trace embed', () => {
       );
       expect(metaRequest).toHaveBeenCalled();
     });
+  });
+
+  it('does not seed the embed search box from the host page query string', async () => {
+    // The embed is rendered inside another page (a Seer response), so the surrounding page's
+    // `?search=`/`?node=` must not steer it.
+    window.history.replaceState({}, '', '/?search=http.client&node=span-hostspan');
+    mockTraceRequests();
+
+    renderEmbed({name: 'trace', data: {traceId, timestamp}});
+
+    expect(
+      await screen.findByPlaceholderText('Search in trace', {}, {timeout: 10_000})
+    ).toHaveValue('');
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
@@ -85,6 +85,61 @@ describe('trace embed', () => {
     });
   });
 
+  it('does not let the host page query string steer the trace fetch', async () => {
+    // `useTrace`/`useTraceMeta` parse `location.search` themselves, so opting the waterfall out of
+    // URL sync is not enough — the fetches need their own opt-out or the host page's event and
+    // window params ride along.
+    window.history.replaceState(
+      {},
+      '',
+      '/?eventId=hosteventid&node=span-hostspan&limit=5&statsPeriod=90d'
+    );
+    const {traceRequest} = mockTraceRequests();
+
+    renderEmbed({name: 'trace', data: {traceId}});
+
+    await waitFor(() => {
+      expect(traceRequest).toHaveBeenCalled();
+    });
+
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({targetId: 'hosteventid'}),
+      })
+    );
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({limit: 5}),
+      })
+    );
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({statsPeriod: '90d'}),
+      })
+    );
+  });
+
+  it('ignores a host page timestamp when the embed carries none', async () => {
+    window.history.replaceState({}, '', '/?timestamp=1111111111');
+    const {traceRequest} = mockTraceRequests();
+
+    renderEmbed({name: 'trace', data: {traceId}});
+
+    await waitFor(() => {
+      expect(traceRequest).toHaveBeenCalled();
+    });
+
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({timestamp: '1111111111'}),
+      })
+    );
+  });
+
   it('does not seed the embed search box from the host page query string', async () => {
     // The embed is rendered inside another page (a Seer response), so the surrounding page's
     // `?search=`/`?node=` must not steer it.

--- a/static/app/components/seer/markdown/embeds/components/trace.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.tsx
@@ -1,47 +1,18 @@
-import queryString from 'query-string';
+import {lazy} from 'react';
 
-import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {
-  defineSeerEmbed,
-  type EmbedOutput,
-} from 'sentry/components/seer/markdown/embeds/utils';
-import {IconSpan} from 'sentry/icons';
-import {t} from 'sentry/locale';
-import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
-import {getShortEventId} from 'sentry/utils/events';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
-function TraceLink({traceId, timestamp, spanId}: EmbedOutput<'trace'>) {
-  const organization = useOrganization();
-  const pathname = makeTracesPathname({
-    organization,
-    path: `/trace/${traceId}/`,
-  });
+import {TraceLink} from './traceLink';
 
-  // Seer reports ISO timestamps but the waterfall reads unix seconds. Without
-  // one it falls back to scanning a default window, so pass it through whenever
-  // Seer knows when the trace happened.
-  const href = queryString.stringifyUrl({
-    url: pathname,
-    query: {
-      timestamp: getTimeStampFromTableDateField(timestamp),
-      node: spanId ? `span-${spanId}` : undefined,
-    },
-  });
-
-  return (
-    <ResourceLink
-      icon={IconSpan}
-      href={href}
-      title={t('Trace %s', getShortEventId(traceId))}
-    />
-  );
-}
+const LazyTraceBlock = lazy(() => import('./traceBlock'));
 
 export const Trace = defineSeerEmbed({
   name: 'trace',
-  render(props) {
+  render(props, level) {
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazyTraceBlock} {...props} />;
+    }
     return <TraceLink {...props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
@@ -1,0 +1,95 @@
+import {Container, Stack} from '@sentry/scraps/layout';
+
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useTrace} from 'sentry/views/performance/newTraceDetails/traceApi/useTrace';
+import {useTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
+import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
+import {useTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceTree';
+import {
+  DEFAULT_TRACE_VIEW_PREFERENCES,
+  type TracePreferencesState,
+} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
+import {useTraceEventView} from 'sentry/views/performance/newTraceDetails/useTraceEventView';
+import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
+
+import {TraceLink} from './traceLink';
+
+const TRACE_EMBED_PREFERENCES = {
+  ...DEFAULT_TRACE_VIEW_PREFERENCES,
+  compressed_timeline: false,
+  drawer: {
+    ...DEFAULT_TRACE_VIEW_PREFERENCES.drawer,
+    layoutOptions: [],
+    minimized: true,
+  },
+  layout: 'drawer bottom',
+} satisfies TracePreferencesState;
+
+const TRACE_ADDITIONAL_ATTRIBUTES = [
+  'thread.id',
+  'tags[performance.timeOrigin,number]',
+  'gen_ai.operation.type',
+  'http.response.status_code',
+  'span.status',
+];
+
+function TraceWaterfallEmbed({traceId, timestamp}: EmbedOutput<'trace'>) {
+  const organization = useOrganization();
+  const timestampSeconds = getTimeStampFromTableDateField(timestamp);
+  const queryParams = useTraceQueryParams({timestamp: timestampSeconds});
+  const traceEventView = useTraceEventView(traceId, queryParams);
+  const trace = useTrace({
+    additionalAttributes: TRACE_ADDITIONAL_ATTRIBUTES,
+    referrer: 'api.seer.trace-waterfall-embed',
+    timestamp: timestampSeconds,
+    traceSlug: traceId,
+  });
+  const meta = useTraceMeta({traceSlug: traceId, timestamp: timestampSeconds});
+  const tree = useTraceTree({trace, replay: null});
+  const rootEventResults = useTraceRootEvent({
+    tree,
+    logs: undefined,
+    timestamp: timestampSeconds,
+    traceId,
+  });
+
+  return (
+    <TraceWaterfall
+      hideIfNoData={false}
+      meta={meta}
+      organization={organization}
+      replay={null}
+      rootEventResults={rootEventResults}
+      source="seer_embed"
+      trace={trace}
+      traceEventView={traceEventView}
+      traceSlug={traceId}
+      tree={tree}
+    />
+  );
+}
+
+export default function TraceBlock(props: EmbedOutput<'trace'>) {
+  return (
+    <Container
+      background="primary"
+      border="primary"
+      overflow="hidden"
+      padding="md"
+      radius="md"
+    >
+      <Stack gap="md">
+        <TraceLink {...props} />
+        <Container display="flex" height="400px" minWidth="0">
+          <TraceStateProvider initialPreferences={TRACE_EMBED_PREFERENCES}>
+            <TraceWaterfallEmbed {...props} />
+          </TraceStateProvider>
+        </Container>
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import {Container, Stack} from '@sentry/scraps/layout';
 
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
@@ -14,7 +16,8 @@ import {
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
 import {useTraceEventView} from 'sentry/views/performance/newTraceDetails/useTraceEventView';
-import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
+import type {TraceViewQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
+import type {UseTraceScrollToPath} from 'sentry/views/performance/newTraceDetails/useTraceScrollToPath';
 
 import {TraceLink} from './traceLink';
 
@@ -37,14 +40,31 @@ const TRACE_ADDITIONAL_ATTRIBUTES = [
   'span.status',
 ];
 
-function TraceWaterfallEmbed({traceId, timestamp}: EmbedOutput<'trace'>) {
+function TraceWaterfallEmbed({traceId, timestamp, spanId}: EmbedOutput<'trace'>) {
   const organization = useOrganization();
   const timestampSeconds = getTimeStampFromTableDateField(timestamp);
-  const queryParams = useTraceQueryParams({timestamp: timestampSeconds});
+
+  // Deliberately not `useTraceQueryParams` — that reads the host page's query string first and
+  // only falls back to what it is handed, so an embed rendered on a page that already carries
+  // `?timestamp=`/`?statsPeriod=` would silently fetch the wrong window. The embed knows its own
+  // bounds, so it passes them straight through.
+  const queryParams = useMemo(
+    (): TraceViewQueryParams => ({
+      start: undefined,
+      end: undefined,
+      statsPeriod: undefined,
+      timestamp: timestampSeconds,
+    }),
+    [timestampSeconds]
+  );
   const traceEventView = useTraceEventView(traceId, queryParams);
+
   const trace = useTrace({
     additionalAttributes: TRACE_ADDITIONAL_ATTRIBUTES,
     referrer: 'api.seer.trace-waterfall-embed',
+    // Guarantees the focused span survives the trace's node limit, so a truncated trace does not
+    // drop the one span Seer is pointing at.
+    targetEventId: spanId,
     timestamp: timestampSeconds,
     traceSlug: traceId,
   });
@@ -57,13 +77,23 @@ function TraceWaterfallEmbed({traceId, timestamp}: EmbedOutput<'trace'>) {
     traceId,
   });
 
+  // Same encoding the compact trace link puts in `?node=`, handed to the waterfall directly
+  // rather than through the URL.
+  const scrollToNode = useMemo(
+    (): UseTraceScrollToPath =>
+      spanId ? {eventId: spanId, path: [`span-${spanId}`]} : null,
+    [spanId]
+  );
+
   return (
     <TraceWaterfall
+      disableUrlSync
       hideIfNoData={false}
       meta={meta}
       organization={organization}
       replay={null}
       rootEventResults={rootEventResults}
+      scrollToNode={scrollToNode}
       source="seer_embed"
       trace={trace}
       traceEventView={traceEventView}
@@ -85,7 +115,7 @@ export default function TraceBlock(props: EmbedOutput<'trace'>) {
       <Stack gap="md">
         <TraceLink {...props} />
         <Container display="flex" height="400px" minWidth="0">
-          <TraceStateProvider initialPreferences={TRACE_EMBED_PREFERENCES}>
+          <TraceStateProvider disableUrlSync initialPreferences={TRACE_EMBED_PREFERENCES}>
             <TraceWaterfallEmbed {...props} />
           </TraceStateProvider>
         </Container>

--- a/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
@@ -78,7 +78,12 @@ function TraceWaterfallEmbed({traceId, timestamp, spanId}: EmbedOutput<'trace'>)
   });
 
   // Same encoding the compact trace link puts in `?node=`, handed to the waterfall directly
-  // rather than through the URL.
+  // rather than through the URL. Seer only knows the span id, so the path cannot name the
+  // parent transaction and `ExpandToPath` — which reads `txn-` segments only — fetches nothing
+  // from here. That is inert for EAP traces, whose spans all arrive with the trace itself, and
+  // for small non-EAP ones, which `maybeAutoExpandTrace` zooms before the scroll lookup runs. A
+  // non-EAP trace too large to auto-expand can still fail to scroll, exactly as following the
+  // link above into the standalone view does.
   const scrollToNode = useMemo(
     (): UseTraceScrollToPath =>
       spanId ? {eventId: spanId, path: [`span-${spanId}`]} : null,

--- a/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceBlock.tsx
@@ -61,6 +61,10 @@ function TraceWaterfallEmbed({traceId, timestamp, spanId}: EmbedOutput<'trace'>)
 
   const trace = useTrace({
     additionalAttributes: TRACE_ADDITIONAL_ATTRIBUTES,
+    // Both fetches read `location.search` on their own, independently of the query params built
+    // above, so they need their own opt-out — otherwise a host `?eventId=`/`?node=`/`?start=`
+    // still pins the wrong event or window.
+    disableUrlSync: true,
     referrer: 'api.seer.trace-waterfall-embed',
     // Guarantees the focused span survives the trace's node limit, so a truncated trace does not
     // drop the one span Seer is pointing at.
@@ -68,7 +72,10 @@ function TraceWaterfallEmbed({traceId, timestamp, spanId}: EmbedOutput<'trace'>)
     timestamp: timestampSeconds,
     traceSlug: traceId,
   });
-  const meta = useTraceMeta({traceSlug: traceId, timestamp: timestampSeconds});
+  const meta = useTraceMeta(
+    {traceSlug: traceId, timestamp: timestampSeconds},
+    {disableUrlSync: true}
+  );
   const tree = useTraceTree({trace, replay: null});
   const rootEventResults = useTraceRootEvent({
     tree,

--- a/static/app/components/seer/markdown/embeds/components/traceLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceLink.tsx
@@ -1,0 +1,37 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
+import {getShortEventId} from 'sentry/utils/events';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+
+export function TraceLink({traceId, timestamp, spanId}: EmbedOutput<'trace'>) {
+  const organization = useOrganization();
+  const pathname = makeTracesPathname({
+    organization,
+    path: `/trace/${traceId}/`,
+  });
+
+  // Seer reports ISO timestamps but the waterfall reads unix seconds. Without
+  // one it falls back to scanning a default window, so pass it through whenever
+  // Seer knows when the trace happened.
+  const href = queryString.stringifyUrl({
+    url: pathname,
+    query: {
+      timestamp: getTimeStampFromTableDateField(timestamp),
+      node: spanId ? `span-${spanId}` : undefined,
+    },
+  });
+
+  return (
+    <ResourceLink
+      icon={IconSpan}
+      href={href}
+      title={t('Trace %s', getShortEventId(traceId))}
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -486,13 +486,6 @@ export const SEER_EMBED_SCHEMAS = {
     }),
     examples: [
       {
-        label: 'Trace link',
-        data: {
-          traceId: 'a1b2c3d4e5f678901234567890abcdef',
-          timestamp: '2026-08-25T16:37:12Z',
-        },
-      },
-      {
         label: 'Trace waterfall',
         level: 'block',
         data: {

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -475,6 +475,8 @@ export const SEER_EMBED_SCHEMAS = {
       'The ONLY way to reference a Sentry trace (the trace waterfall view). ' +
       'Use the 32-character trace ID. Provide `timestamp` when known so the ' +
       'waterfall opens on the right time range, and `spanId` to focus a span. ' +
+      'Inline: renders a compact link. Block: renders the live trace waterfall. ' +
+      'Do not duplicate the waterfall spans or duration details as text. ' +
       'Never use a markdown link for trace references.',
     level: ['inline', 'block'],
     schema: z.object({
@@ -484,7 +486,15 @@ export const SEER_EMBED_SCHEMAS = {
     }),
     examples: [
       {
-        label: 'Trace',
+        label: 'Trace link',
+        data: {
+          traceId: 'a1b2c3d4e5f678901234567890abcdef',
+          timestamp: '2026-08-25T16:37:12Z',
+        },
+      },
+      {
+        label: 'Trace waterfall',
+        level: 'block',
         data: {
           traceId: 'a1b2c3d4e5f678901234567890abcdef',
           timestamp: '2026-08-25T16:37:12Z',

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -17,6 +17,7 @@ import {ReleaseEmbedStory} from './__stories__/releaseEmbedStory';
 import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
 import {SavedIssueViewEmbedStory} from './__stories__/savedIssueViewEmbedStory';
 import {SavedQueryEmbedStory} from './__stories__/savedQueryEmbedStory';
+import {TraceEmbedStory} from './__stories__/traceEmbedStory';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
 
@@ -106,7 +107,7 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 
 ### trace
 
-<EmbedStory name="trace" />
+<TraceEmbedStory />
 
 ### profile
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -20,6 +20,8 @@ import type {TraceSplitResults} from './types';
 const DEFAULT_TIMESTAMP_LIMIT = 10_000;
 const DEFAULT_LIMIT = 1_000;
 
+const EMPTY_QUERY: Location['query'] = {};
+
 type TraceQueryParamOptions = {
   limit?: number;
   targetId?: string;
@@ -126,6 +128,13 @@ export function getTraceQueryParams(
 
 type UseTraceOptions = {
   additionalAttributes?: string[];
+  /**
+   * Ignore the host page's query string entirely. Waterfalls embedded in another page (e.g. a
+   * Seer response) set this so the host's `?eventId=`/`?node=`/`?start=`/`?end=`/`?timestamp=` —
+   * which usually describe a different trace — cannot steer this fetch. The caller then supplies
+   * the whole window itself via `timestamp`/`targetEventId`.
+   */
+  disableUrlSync?: boolean;
   limit?: number;
   referrer?: string;
   /**
@@ -142,7 +151,7 @@ export type TraceQueryResult = UseApiQueryResult<TraceTree.Trace, RequestError>;
 export function useTrace(options: UseTraceOptions): TraceQueryResult {
   const filters = usePageFilters();
   const organization = useOrganization();
-  const query = qs.parse(location.search);
+  const query = options.disableUrlSync ? EMPTY_QUERY : qs.parse(location.search);
 
   const isEAPEnabled = useIsEAPTraceEnabled();
   const hasValidTrace = Boolean(options.traceSlug && organization.slug);
@@ -164,6 +173,7 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     // clicking on a span, that updates the url.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    options.disableUrlSync,
     options.limit,
     options.timestamp,
     options.targetEventId,

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -324,20 +324,30 @@ function getTraceMetaTraces(options: UseTraceMetaOptions): TraceMetaTrace[] {
   return Array.isArray(options) ? options : [options];
 }
 
-export function useTraceMeta(options: UseTraceMetaOptions): TraceMetaQueryResults {
+export function useTraceMeta(
+  options: UseTraceMetaOptions,
+  /**
+   * `disableUrlSync` ignores the host page's query string. Waterfalls embedded in another page
+   * (e.g. a Seer response) set this so a host `?statsPeriod=`/`?start=` cannot widen or narrow
+   * the embed's meta window. It is part of the query key so an embed and the surrounding page
+   * can ask about the same trace without sharing a cache entry.
+   */
+  {disableUrlSync = false}: {disableUrlSync?: boolean} = {}
+): TraceMetaQueryResults {
   const filters = usePageFilters();
   const organization = useOrganization();
   const isEAP = useIsEAPTraceEnabled();
   const maxPickableDays = useDefaultMaxPickableDays();
   const traces = getTraceMetaTraces(options);
 
-  const normalizedParams = normalizeDateTimeParams(qs.parse(location.search), {
-    allowAbsolutePageDatetime: true,
-  });
+  const normalizedParams = normalizeDateTimeParams(
+    disableUrlSync ? {} : qs.parse(location.search),
+    {allowAbsolutePageDatetime: true}
+  );
 
   // eslint-disable-next-line @tanstack/query/exhaustive-deps
   const {data, isLoading, status} = useQuery({
-    queryKey: ['traceData', traces.map(trace => trace.traceSlug)],
+    queryKey: ['traceData', traces.map(trace => trace.traceSlug), disableUrlSync],
     queryFn: async context => {
       const result = await fetchTraceMetaInBatches(
         isEAP ? 'eap' : 'non-eap',

--- a/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
+++ b/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
@@ -156,6 +156,10 @@ export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
       }
       onChange={onChange}
       menuWidth={300}
+      // The trigger sits flush against the toolbar's right edge, so the menu has
+      // to grow leftward. Popper is configured not to flip start/end variations,
+      // and embedded waterfalls clip the overlay at their own boundary.
+      position="bottom-end"
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
+++ b/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react';
+import type {Placement} from '@popperjs/core';
 
 import {
   CompactSelect,
@@ -23,13 +24,6 @@ import {getCustomInstrumentationLink} from 'sentry/views/performance/newTraceDet
 import {TraceShortcutsModal} from 'sentry/views/performance/newTraceDetails/traceShortcutsModal';
 import {TRACE_WATERFALL_TIME_COMPRESSION_FEATURE} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 
-// The settings trigger is the toolbar's last item and the search input beside it grows to
-// fill, so the trigger always sits flush right and the 300px menu can run past the edge of
-// whatever contains the waterfall. Keep the default `bottom-start` and let Popper fall back
-// to right-aligned only when that would actually overflow — `useOverlay` sets
-// `flipVariations: false`, so without a fallback nothing re-aligns on its own.
-const MENU_FLIP_OPTIONS = {fallbackPlacements: ['bottom-end' as const]};
-
 interface TracePreferencesDropdownProps {
   autogroup: boolean;
   compressedTimeline: boolean;
@@ -38,6 +32,12 @@ interface TracePreferencesDropdownProps {
   onCompressedTimelineChange: () => void;
   onMissingInstrumentationChange: () => void;
   rootEventResults: TraceRootEventQueryResults;
+  /**
+   * Placements Popper may fall back to when the default `bottom-start` would overflow the
+   * menu's clipping container. `useOverlay` sets `flipVariations: false`, so without this the
+   * menu never re-aligns on its own. Pass a stable reference.
+   */
+  fallbackPlacements?: Placement[];
 }
 
 export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
@@ -95,6 +95,12 @@ export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
     props.compressedTimeline,
     props.missingInstrumentation,
   ]);
+
+  const fallbackPlacements = props.fallbackPlacements;
+  const flipOptions = useMemo(
+    () => (fallbackPlacements ? {fallbackPlacements} : undefined),
+    [fallbackPlacements]
+  );
 
   const onAutogroupChange = props.onAutogroupChange;
   const onMissingInstrumentationChange = props.onMissingInstrumentationChange;
@@ -163,7 +169,7 @@ export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
       }
       onChange={onChange}
       menuWidth={300}
-      flipOptions={MENU_FLIP_OPTIONS}
+      flipOptions={flipOptions}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
+++ b/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
@@ -23,6 +23,13 @@ import {getCustomInstrumentationLink} from 'sentry/views/performance/newTraceDet
 import {TraceShortcutsModal} from 'sentry/views/performance/newTraceDetails/traceShortcutsModal';
 import {TRACE_WATERFALL_TIME_COMPRESSION_FEATURE} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 
+// The settings trigger is the toolbar's last item and the search input beside it grows to
+// fill, so the trigger always sits flush right and the 300px menu can run past the edge of
+// whatever contains the waterfall. Keep the default `bottom-start` and let Popper fall back
+// to right-aligned only when that would actually overflow — `useOverlay` sets
+// `flipVariations: false`, so without a fallback nothing re-aligns on its own.
+const MENU_FLIP_OPTIONS = {fallbackPlacements: ['bottom-end' as const]};
+
 interface TracePreferencesDropdownProps {
   autogroup: boolean;
   compressedTimeline: boolean;
@@ -156,10 +163,7 @@ export function TracePreferencesDropdown(props: TracePreferencesDropdownProps) {
       }
       onChange={onChange}
       menuWidth={300}
-      // The trigger sits flush against the toolbar's right edge, so the menu has
-      // to grow leftward. Popper is configured not to flip start/end variations,
-      // and embedded waterfalls clip the overlay at their own boundary.
-      position="bottom-end"
+      flipOptions={MENU_FLIP_OPTIONS}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/traceStateProvider.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {createContext, useContext, useLayoutEffect, useMemo} from 'react';
+import {createContext, useContext, useLayoutEffect, useState} from 'react';
 import * as qs from 'query-string';
 
 import {
@@ -52,19 +52,28 @@ export function useTraceStateEmitter(): DispatchingReducerEmitter<typeof TraceRe
 interface TraceStateProviderProps {
   children: React.ReactNode;
   initialPreferences: TracePreferencesState;
+  /**
+   * Embedded waterfalls set this so the host page's `?search=` does not seed the embed's
+   * search box. Paired with `disableUrlSync` on `TraceWaterfall`, which stops the write side.
+   */
+  disableUrlSync?: boolean;
   preferencesStorageKey?: string;
 }
 
 export function TraceStateProvider(props: TraceStateProviderProps): React.ReactNode {
-  const initialQuery = useMemo((): string | undefined => {
+  // We only want to decode on load, hence the lazy initializer.
+  const [initialQuery] = useState((): string | undefined => {
+    if (props.disableUrlSync) {
+      return undefined;
+    }
+
     const query = qs.parse(location.search);
 
     if (typeof query.search === 'string') {
       return query.search;
     }
     return undefined;
-    // We only want to decode on load
-  }, []);
+  });
 
   const [traceState, traceDispatch, traceStateEmitter] = useDispatchingReducer(
     TraceReducer,

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -77,6 +77,7 @@ export type TraceWaterfallSource =
   | 'issues'
   | 'performance'
   | 'replay'
+  | 'seer_embed'
   | 'trace_view';
 
 export interface TraceWaterfallProps {
@@ -756,7 +757,9 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
 
   // On the standalone trace page these two moved into the page-title crumb.
   // Embedded waterfalls (issues, replay) have no such crumb, so they keep them.
-  const showToolbarTraceActions = props.source !== 'performance';
+  // The Seer embed supplies its own compact trace link above the waterfall.
+  const showToolbarTraceActions =
+    props.source !== 'performance' && props.source !== 'seer_embed';
 
   return (
     <Stack flex={1}>

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -69,7 +69,7 @@ import type {TraceReducer} from './traceState';
 import {TraceWaterfallState} from './traceWaterfallState';
 import {useTraceOnLoad} from './useTraceOnLoad';
 import {useTraceQueryParamStateSync} from './useTraceQueryParamStateSync';
-import {useTraceScrollToPath} from './useTraceScrollToPath';
+import {useTraceScrollToPath, type UseTraceScrollToPath} from './useTraceScrollToPath';
 import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
 
 export type TraceWaterfallSource =
@@ -90,12 +90,25 @@ export interface TraceWaterfallProps {
   traceEventView: EventView;
   traceSlug: string;
   tree: TraceTree;
+  /**
+   * Embedded waterfalls (e.g. a Seer response) set this to stop the waterfall reading from and
+   * writing to the host page's query string. Without it, clicking a span or typing in the
+   * waterfall search rewrites `?node=`/`?search=` on the surrounding page, so several embeds on
+   * one page fight over the same params. Pair it with `disableUrlSync` on `TraceStateProvider`,
+   * and pass `scrollToNode` to focus a span instead of relying on `?node=`.
+   */
+  disableUrlSync?: boolean;
   // If set to true, the entire waterfall will not render if it is empty.
   hideIfNoData?: boolean;
   replayTraces?: ReplayTrace[];
+  /**
+   * Node to focus on load. Overrides the URL-derived target; must be referentially stable.
+   */
+  scrollToNode?: UseTraceScrollToPath;
 }
 
 export function TraceWaterfall(props: TraceWaterfallProps) {
+  const disableUrlSync = props.disableUrlSync ?? false;
   const api = useApi();
   const routerLocation = useLocation();
   const navigate = useNavigate();
@@ -125,7 +138,12 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const projectsRef = useRef(projects);
   projectsRef.current = projects;
 
-  const scrollQueueRef = useTraceScrollToPath({traceSlug: props.traceSlug});
+  const scrollQueueRef = useTraceScrollToPath({
+    traceSlug: props.traceSlug,
+    // `null` (rather than undefined) keeps the hook from falling back to the host page's
+    // `?node=`/`?eventId=`, which may point at a span in a completely different trace.
+    scrollToNode: disableUrlSync ? (props.scrollToNode ?? null) : props.scrollToNode,
+  });
   const forceRerender = useCallback(() => {
     flushSync(rerender);
   }, []);
@@ -281,6 +299,23 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
           cancelAnimationTimeout(queryStringAnimationTimeoutRef.current);
         }
 
+        if (disableUrlSync) {
+          if (resultsLookup.has(node) && typeof index === 'number') {
+            traceDispatch({
+              type: 'set search iterator index',
+              resultIndex: index,
+              resultIteratorIndex: resultsLookup.get(node)!,
+            });
+          }
+
+          traceDispatch({
+            type: 'activate tab',
+            payload: node,
+            pin_previous: event?.metaKey,
+          });
+          return;
+        }
+
         queryStringAnimationTimeoutRef.current = requestAnimationTimeout(() => {
           const currentQueryStringPath = qs.parse(location.search).node;
           const nextNodePath = node.pathToNode();
@@ -318,7 +353,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         });
       }
     },
-    [navigate, traceDispatch]
+    [disableUrlSync, navigate, traceDispatch]
   );
 
   const onRowClick = useCallback(
@@ -429,9 +464,11 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     // We will autogroup and inject missing instrumentation if the preferences are set.
     // and then we will perform a search to find the node the user is interested in.
 
-    const query = qs.parse(location.search);
-    if (query.fov && typeof query.fov === 'string') {
-      viewManager.maybeInitializeTraceViewFromQS(query.fov);
+    if (!disableUrlSync) {
+      const query = qs.parse(location.search);
+      if (query.fov && typeof query.fov === 'string') {
+        viewManager.maybeInitializeTraceViewFromQS(query.fov);
+      }
     }
 
     // Construct the visual representation of the tree
@@ -487,6 +524,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       });
     });
   }, [
+    disableUrlSync,
     setRowAsFocused,
     traceDispatch,
     onTraceSearch,
@@ -587,6 +625,10 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
 
   const handledZoomQueryRef = useRef<string | null>(null);
   useEffect(() => {
+    if (disableUrlSync) {
+      return;
+    }
+
     const query = qs.parse(routerLocation.search);
     if (typeof query.zoomToNode !== 'string') {
       handledZoomQueryRef.current = null;
@@ -637,6 +679,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       viewManager.onZoomIntoSpace(node.space);
     }
   }, [
+    disableUrlSync,
     navigate,
     onLoadScrollStatus,
     onTabScrollToNode,
@@ -650,7 +693,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const traceQueryStateSync = useMemo(() => {
     return {search: traceState.search.query};
   }, [traceState.search.query]);
-  useTraceQueryParamStateSync(traceQueryStateSync);
+  useTraceQueryParamStateSync(traceQueryStateSync, {disabled: disableUrlSync});
 
   const onAutogroupChange = useCallback(() => {
     const value = !traceState.preferences.autogroup.parent;

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import {flushSync} from 'react-dom';
 import styled from '@emotion/styled';
+import type {Placement} from '@popperjs/core';
 import * as Sentry from '@sentry/react';
 import * as qs from 'query-string';
 
@@ -71,6 +72,11 @@ import {useTraceOnLoad} from './useTraceOnLoad';
 import {useTraceQueryParamStateSync} from './useTraceQueryParamStateSync';
 import {useTraceScrollToPath, type UseTraceScrollToPath} from './useTraceScrollToPath';
 import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
+
+// The settings trigger is the toolbar's last item and the search input beside it grows to
+// fill, so the trigger always sits flush right. In the narrow Seer embed the 300px menu would
+// run past the embed's `overflow: hidden` edge, so let it right-align there instead.
+const SEER_EMBED_MENU_FALLBACKS: Placement[] = ['bottom-end'];
 
 export type TraceWaterfallSource =
   | 'feedback'
@@ -826,6 +832,9 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
           organization={props.organization}
         />
         <TracePreferencesDropdown
+          fallbackPlacements={
+            props.source === 'seer_embed' ? SEER_EMBED_MENU_FALLBACKS : undefined
+          }
           rootEventResults={props.rootEventResults}
           autogroup={
             traceState.preferences.autogroup.parent &&

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -800,7 +800,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
 
   // On the standalone trace page these two moved into the page-title crumb.
   // Embedded waterfalls (issues, replay) have no such crumb, so they keep them.
-  // The Seer embed supplies its own compact trace link above the waterfall.
   const showToolbarTraceActions =
     props.source !== 'performance' && props.source !== 'seer_embed';
 

--- a/static/app/views/performance/newTraceDetails/useTraceQueryParamStateSync.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceQueryParamStateSync.spec.tsx
@@ -1,0 +1,46 @@
+import {useEffect, useState} from 'react';
+
+import {act, render} from 'sentry-test/reactTestingLibrary';
+
+import {useTraceQueryParamStateSync} from './useTraceQueryParamStateSync';
+
+// Mounts with no search, then transitions to one — the shape the waterfall produces when
+// somebody types into the trace search box.
+function Probe({disabled}: {disabled?: boolean}) {
+  const [search, setSearch] = useState<string | undefined>(undefined);
+  useTraceQueryParamStateSync({search}, {disabled});
+
+  useEffect(() => {
+    setSearch('db');
+  }, []);
+
+  return null;
+}
+
+describe('useTraceQueryParamStateSync', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('syncs changed state into the query string', async () => {
+    const {router} = render(<Probe />);
+
+    await act(() => jest.runAllTimersAsync());
+
+    expect(router.location.query).toEqual(expect.objectContaining({search: 'db'}));
+  });
+
+  it('does not touch the query string when disabled', async () => {
+    // Embedded waterfalls opt out so they cannot rewrite the host page's URL.
+    const {router} = render(<Probe disabled />);
+
+    await act(() => jest.runAllTimersAsync());
+
+    expect(router.location.query).not.toHaveProperty('search');
+  });
+});

--- a/static/app/views/performance/newTraceDetails/useTraceQueryParamStateSync.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceQueryParamStateSync.tsx
@@ -4,12 +4,22 @@ import * as qs from 'query-string';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 // Syncs query params with URL state. Only performs a state sync if the query params have changed.
-export function useTraceQueryParamStateSync(query: Record<string, string | undefined>) {
+// Waterfalls embedded in another page (e.g. a Seer response) opt out with `disabled` so they do
+// not rewrite the host page's query string.
+export function useTraceQueryParamStateSync(
+  query: Record<string, string | undefined>,
+  options?: {disabled?: boolean}
+) {
   const previousQueryRef = useRef(query);
   const syncStateTimeoutRef = useRef<number | null>(null);
   const navigate = useNavigate();
+  const disabled = options?.disabled ?? false;
 
   useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
     const keys = Object.keys(query);
     const previousKeys = Object.keys(previousQueryRef.current);
 
@@ -40,5 +50,5 @@ export function useTraceQueryParamStateSync(query: Record<string, string | undef
         {replace: true}
       );
     }, 1000);
-  }, [navigate, query]);
+  }, [disabled, navigate, query]);
 }

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.spec.tsx
@@ -1,0 +1,50 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import type {TraceTree} from './traceModels/traceTree';
+import {useTraceScrollToPath} from './useTraceScrollToPath';
+
+describe('useTraceScrollToPath', () => {
+  const originalSearch = window.location.search;
+
+  afterEach(() => {
+    window.history.replaceState({}, '', `/${originalSearch}`);
+  });
+
+  function setSearch(search: string) {
+    window.history.replaceState({}, '', `/${search}`);
+  }
+
+  it('reads the scroll target from the URL when the caller does not provide one', () => {
+    setSearch('?node=span-abc123');
+
+    const {result} = renderHook(() => useTraceScrollToPath({traceSlug: 'trace-slug'}));
+
+    expect(result.current.current).toEqual({eventId: undefined, path: ['span-abc123']});
+  });
+
+  it('prefers an explicit scroll target over the URL', () => {
+    setSearch('?node=span-fromurl');
+
+    const scrollToNode = {
+      eventId: 'fromprops',
+      path: ['span-fromprops'] as TraceTree.NodePath[],
+    };
+    const {result} = renderHook(() =>
+      useTraceScrollToPath({traceSlug: 'trace-slug', scrollToNode})
+    );
+
+    expect(result.current.current).toBe(scrollToNode);
+  });
+
+  it('ignores the URL entirely when the caller passes null', () => {
+    // Embedded waterfalls pass null so the host page's `?node=` — which may belong to a
+    // different trace — cannot steer them.
+    setSearch('?node=span-fromurl&eventId=abc123');
+
+    const {result} = renderHook(() =>
+      useTraceScrollToPath({traceSlug: 'trace-slug', scrollToNode: null})
+    );
+
+    expect(result.current.current).toBeNull();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -15,7 +15,7 @@ function decodeScrollQueue(maybePath: unknown): TraceTree.NodePath[] | null {
   return null;
 }
 
-type UseTraceScrollToPath =
+export type UseTraceScrollToPath =
   | {eventId?: string; path?: TraceTree.NodePath[]}
   | null
   | undefined;
@@ -39,20 +39,28 @@ export function getScrollToPath(): UseTraceScrollToPath {
 
 export function useTraceScrollToPath({
   traceSlug,
+  scrollToNode,
 }: {
   traceSlug: string;
+  /**
+   * When set, the caller owns the scroll target and the URL is never read. Pass `null` for
+   * "no target" — embedded waterfalls use this so the host page's `?node=`/`?eventId=` (which
+   * may belong to an entirely different trace) cannot steer them. Must be referentially stable.
+   */
+  scrollToNode?: UseTraceScrollToPath;
 }): React.MutableRefObject<UseTraceScrollToPath> {
   const scrollQueueRef = useRef<
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
   useEffect(() => {
-    scrollQueueRef.current = getScrollToPath();
+    scrollQueueRef.current =
+      scrollToNode === undefined ? getScrollToPath() : scrollToNode;
 
     // Only re-run this effect when the traceSlug changes, not on every render since we manage
     // scroll internally in the traceWaterfall component, and only update the url for state consistency across
     // subsequent loads
-  }, [traceSlug]);
+  }, [traceSlug, scrollToNode]);
 
   return scrollQueueRef;
 }


### PR DESCRIPTION
We had to make two changes to the tracewaterfall component:

- disable reading/writing of window.location (otherwise users poking around an embed will lose their place in app) 
- adds prop to configure tracewaterfall's settings dropdown, since the embed will have a container with overflow: hidden to make sure components within it do not expand and break outer layout. (I have not looked into removing overflow: hidden from it)

## Slop

Block-level `trace` embeds now render a live trace waterfall while inline trace mentions remain compact links. The preview reuses the trace view's data hooks and renderer, forwards the known timestamp to bound data fetching, and lazy-loads the waterfall bundle so ordinary Seer responses do not pay its loading cost.

Waterfall renders reuse the existing trace-view page-load event with a `seer_embed` source, and the generated agent schema now explains and demonstrates the block rendering contract. [CW-1943](https://linear.app/getsentry/issue/CW-1943/add-trace-waterfall-embed)

