### PR TITLE
feat(replay): up inner_limit from 1k-10k when verify_replay_exists flag is on

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -372,6 +372,10 @@ def get_oldest_or_latest_event(
 # recommended event whose session replay is verified to exist.
 RECOMMENDED_EVENT_REPLAY_CANDIDATES = 10
 
+# Upping the inner limit to 10k samples if the verify_replay_exists flag is set.
+RECOMMENDED_EVENT_INNER_LIMIT = 1000
+RECOMMENDED_EVENT_REPLAY_INNER_LIMIT = 10000
+
 
 def get_recommended_event(
     group: Group,
@@ -409,6 +413,11 @@ def get_recommended_event(
         return None
 
     limit = RECOMMENDED_EVENT_REPLAY_CANDIDATES if verify_replay_exists else 1
+    inner_limit = (
+        RECOMMENDED_EVENT_REPLAY_INNER_LIMIT
+        if verify_replay_exists
+        else RECOMMENDED_EVENT_INNER_LIMIT
+    )
 
     events = eventstore.backend.get_events_snql(
         organization_id=group.project.organization_id,
@@ -421,7 +430,7 @@ def get_recommended_event(
         referrer="Group.get_helpful",
         dataset=dataset,
         tenant_ids={"organization_id": group.project.organization_id},
-        inner_limit=1000,
+        inner_limit=inner_limit,
     )
 
     if not events:

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -429,6 +429,28 @@ class GroupTestSnubaErrorIssue(TestCase, SnubaTestCase):
             == self.event_b.event_id
         )
 
+    @patch("sentry.models.group.eventstore.backend.get_events_snql")
+    def test_recommended_event_inner_limit_with_and_without_replay_verification_feature_flag(
+        self, mock_get_events_snql: MagicMock
+    ) -> None:
+        mock_get_events_snql.return_value = []
+
+        def _helpful_inner_limit() -> int:
+            (helpful_call,) = [
+                call
+                for call in mock_get_events_snql.call_args_list
+                if call.kwargs["referrer"] == "Group.get_helpful"
+            ]
+            return helpful_call.kwargs["inner_limit"]
+
+        self.group.get_recommended_event(verify_replay_exists=True)
+        assert _helpful_inner_limit() == 10000
+
+        mock_get_events_snql.reset_mock()
+
+        self.group.get_recommended_event(verify_replay_exists=False)
+        assert _helpful_inner_limit() == 1000
+
     def test_normalize_replay_id_handles_dashed_and_dashless(self) -> None:
         assert (
             _normalize_replay_id("550e8400-e29b-41d4-a716-446655440000")


### PR DESCRIPTION
I'm upping the value for `inner_limit` if the `issue-details-verify-recommended-replay` flag is on. This is to increase the odds/windows for a recommended event to have a replay id, increasing the odds for a recommended event in the issues page to show a valid replay