### PR TITLE
fix(api): Align team project creation permissions

### DIFF
--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -1,11 +1,12 @@
 import time
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from django.db import IntegrityError, router, transaction
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
@@ -129,12 +130,23 @@ their own alerts to be notified of new issues.
 class TeamProjectPermission(TeamPermission):
     scope_map = {
         "GET": ["project:read", "project:write", "project:admin"],
-        # Intentionally lowered: team members can create projects when
-        # allowMemberProjectCreation is enabled on the organization.
-        "POST": ["project:read", "project:write", "project:admin"],
+        "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
         "DELETE": ["project:admin"],
     }
+
+    def has_object_permission(self, request: Request, view: APIView, team: Any) -> bool:
+        if super().has_object_permission(request, view, team):
+            return True
+
+        # Members hold project:read. A member of this team may create a project
+        # on it, matching OrganizationProjectsEndpoint. The handler enforces
+        # disable_member_project_creation so the response carries its message.
+        return (
+            request.method == "POST"
+            and request.access.has_scope("project:read")
+            and request.access.has_team_membership(team)
+        )
 
 
 class AuditData(TypedDict):

--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -33,8 +33,10 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import PROJECT_SLUG_MAX_LENGTH, RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.issue_detection.detectors.disable_detectors import set_default_disabled_detectors
 from sentry.models.organization import Organization
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.team import Team
+from sentry.roles import team_roles
 from sentry.seer.similarity.utils import (
     project_is_seer_eligible,
     set_default_project_autofix_automation_tuning,
@@ -149,6 +151,28 @@ class TeamProjectPermission(TeamPermission):
         )
 
 
+def _has_team_admin_membership(request: Request, team: Team) -> bool:
+    """Whether the caller holds a team role with team:admin on this team.
+
+    Access.has_team_scope honors team roles only when the organization has the
+    team-roles feature. Project creation does not depend on that feature, so
+    this reads the stored membership role instead.
+    """
+    if not request.user.is_authenticated:
+        return False
+    if (
+        request.access.scopes_upper_bound is not None
+        and "team:admin" not in request.access.scopes_upper_bound
+    ):
+        return False
+    return OrganizationMemberTeam.objects.filter(
+        team=team,
+        organizationmember__user_id=request.user.id,
+        is_active=True,
+        role__in=[role.id for role in team_roles.with_scope("team:admin")],
+    ).exists()
+
+
 class AuditData(TypedDict):
     request: Request
     organization: Organization
@@ -243,7 +267,7 @@ class TeamProjectsEndpoint(TeamEndpoint):
         examples=ProjectExamples.CREATE_PROJECT,
         description="""Create a new project bound to a team.
 
-        Note: If your organization has disabled member project creation, the `org:write` or `team:admin` scope is required.
+        Note: If your organization has disabled member project creation, the `org:write` scope or the Team Admin role on the team is required.
         """,
     )
     def post(
@@ -266,10 +290,10 @@ class TeamProjectsEndpoint(TeamEndpoint):
 
         if team.organization.flags.disable_member_project_creation and not (
             request.access.has_scope("org:write")
+            or request.access.has_team_scope(team, "team:admin")
+            or _has_team_admin_membership(request, team)
         ):
-            # Only allow project creation if the user is an admin of the team
-            if not request.access.has_team_scope(team, "team:admin"):
-                return Response({"detail": DISABLED_FEATURE_ERROR_STRING}, status=403)
+            return Response({"detail": DISABLED_FEATURE_ERROR_STRING}, status=403)
 
         result = serializer.validated_data
         with transaction.atomic(router.db_for_write(Project)):

--- a/src/sentry/core/endpoints/team_projects.py
+++ b/src/sentry/core/endpoints/team_projects.py
@@ -129,7 +129,9 @@ their own alerts to be notified of new issues.
 class TeamProjectPermission(TeamPermission):
     scope_map = {
         "GET": ["project:read", "project:write", "project:admin"],
-        "POST": ["project:write", "project:admin"],
+        # Intentionally lowered: team members can create projects when
+        # allowMemberProjectCreation is enabled on the organization.
+        "POST": ["project:read", "project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
         "DELETE": ["project:admin"],
     }

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -1,6 +1,8 @@
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, Mock, patch
 
+from django.test import override_settings
+
 from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.core.endpoints.organization_projects import DISABLED_FEATURE_ERROR_STRING
 from sentry.ingest import inbound_filters
@@ -199,31 +201,32 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
             status_code=201,
         )
 
-    def test_member_can_create_project_on_any_team_with_open_membership(self) -> None:
-        organization = self.create_organization(flags=1)  # allow_joinleave
-        team = self.create_team(organization=organization)
+    def test_member_cannot_create_project_on_other_team(self) -> None:
         user = self.create_user(is_superuser=False)
-        self.create_member(user=user, organization=organization, role="member", teams=[])
         self.login_as(user=user)
 
-        self.get_success_response(
-            organization.slug,
-            team.slug,
-            **self.data,
-            status_code=201,
-        )
-
-    def test_member_cannot_create_project_on_other_team(self) -> None:
-        # No team membership means no team role to honor, so team-roles cannot change this.
         organization = self.create_organization(flags=0)
         team = self.create_team(organization=organization)
-        user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=organization, role="member", teams=[])
-        self.login_as(user=user)
+        self.get_error_response(organization.slug, team.slug, **self.data, status_code=403)
+
+        # Open membership grants team access, not team membership.
+        open_organization = self.create_organization(flags=1)  # allow_joinleave
+        open_team = self.create_team(organization=open_organization)
+        self.create_member(user=user, organization=open_organization, role="member", teams=[])
+        self.get_error_response(
+            open_organization.slug, open_team.slug, **self.data, status_code=403
+        )
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @override_options({"superuser.read-write.ga-rollout": True})
+    def test_readonly_superuser_cannot_create_project(self) -> None:
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(superuser, superuser=True)
 
         self.get_error_response(
-            organization.slug,
-            team.slug,
+            self.organization.slug,
+            self.team.slug,
             **self.data,
             status_code=403,
         )

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -166,12 +166,7 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         organization = self.create_organization(flags=0)
         team = self.create_team(organization=organization)
         user = self.create_user(is_superuser=False)
-        self.create_member(
-            user=user,
-            organization=organization,
-            role="member",
-            team_roles=[(team, "admin")],
-        )
+        self.create_member(user=user, organization=organization, role="member", teams=[team])
         self.login_as(user=user)
 
         self.get_success_response(
@@ -232,7 +227,7 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         )
 
     @with_feature({"organizations:team-roles": False})
-    def test_team_admin_cannot_override_disabled_member_creation_without_team_roles(
+    def test_team_admin_can_create_project_when_member_creation_disabled_without_team_roles(
         self,
     ) -> None:
         organization = self.create_organization(flags=256)
@@ -245,6 +240,29 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
             team_roles=[(team, "admin")],
         )
         self.login_as(user=user)
+
+        self.get_success_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=201,
+        )
+
+    @with_feature({"organizations:team-roles": False})
+    def test_token_without_team_admin_scope_cannot_bypass_disabled_member_creation(
+        self,
+    ) -> None:
+        organization = self.create_organization(flags=256)
+        team = self.create_team(organization=organization)
+        user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user,
+            organization=organization,
+            role="member",
+            team_roles=[(team, "admin")],
+        )
+        token = self.create_user_auth_token(user=user, scope_list=["project:read", "project:write"])
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.plaintext_token}")
 
         response = self.get_error_response(
             organization.slug,

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -226,6 +226,26 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
             status_code=403,
         )
 
+    def test_integration_token_with_project_read_cannot_create_project(self) -> None:
+        # Integration access simulates membership of every team. The unchanged POST
+        # scope map rejects a read-only token before that membership is consulted.
+        organization = self.create_organization(flags=0)
+        team = self.create_team(organization=organization)
+        internal_integration = self.create_internal_integration(
+            name="read-only", organization=organization, scopes=("project:read",)
+        )
+        token = self.create_internal_integration_token(
+            user=self.user, internal_integration=internal_integration
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.token}")
+
+        self.get_error_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=403,
+        )
+
     @with_feature({"organizations:team-roles": False})
     def test_team_admin_can_create_project_when_member_creation_disabled_without_team_roles(
         self,

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -199,23 +199,22 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
             status_code=201,
         )
 
-    @with_feature({"organizations:team-roles": False})
-    def test_member_cannot_create_project_on_other_team_without_team_roles(self) -> None:
-        organization = self.create_organization(flags=0)
+    def test_member_can_create_project_on_any_team_with_open_membership(self) -> None:
+        organization = self.create_organization(flags=1)  # allow_joinleave
         team = self.create_team(organization=organization)
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=organization, role="member", teams=[])
         self.login_as(user=user)
 
-        self.get_error_response(
+        self.get_success_response(
             organization.slug,
             team.slug,
             **self.data,
-            status_code=403,
+            status_code=201,
         )
 
-    @with_feature("organizations:team-roles")
-    def test_member_cannot_create_project_on_other_team_with_team_roles(self) -> None:
+    def test_member_cannot_create_project_on_other_team(self) -> None:
+        # No team membership means no team role to honor, so team-roles cannot change this.
         organization = self.create_organization(flags=0)
         team = self.create_team(organization=organization)
         user = self.create_user(is_superuser=False)

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -2,12 +2,14 @@ from unittest import TestCase, mock
 from unittest.mock import MagicMock, Mock, patch
 
 from sentry.constants import RESERVED_PROJECT_SLUGS
+from sentry.core.endpoints.organization_projects import DISABLED_FEATURE_ERROR_STRING
 from sentry.ingest import inbound_filters
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.signals import alert_rule_created, project_created
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.workflow_engine.defaults.workflows import DEFAULT_WORKFLOW_LABEL
@@ -157,6 +159,101 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
         project = Project.objects.get(id=response.data["id"])
         assert not Rule.objects.filter(project=project).exists()
 
+    @with_feature({"organizations:team-roles": False})
+    def test_member_can_create_project_on_team_without_team_roles(self) -> None:
+        organization = self.create_organization(flags=0)
+        team = self.create_team(organization=organization)
+        user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user,
+            organization=organization,
+            role="member",
+            team_roles=[(team, "admin")],
+        )
+        self.login_as(user=user)
+
+        self.get_success_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=201,
+        )
+
+    @with_feature("organizations:team-roles")
+    def test_member_can_create_project_on_team_with_team_roles(self) -> None:
+        organization = self.create_organization(flags=0)
+        team = self.create_team(organization=organization)
+        user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user,
+            organization=organization,
+            role="member",
+            team_roles=[(team, "contributor")],
+        )
+        self.login_as(user=user)
+
+        self.get_success_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=201,
+        )
+
+    @with_feature({"organizations:team-roles": False})
+    def test_member_cannot_create_project_on_other_team_without_team_roles(self) -> None:
+        organization = self.create_organization(flags=0)
+        team = self.create_team(organization=organization)
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=organization, role="member", teams=[])
+        self.login_as(user=user)
+
+        self.get_error_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=403,
+        )
+
+    @with_feature("organizations:team-roles")
+    def test_member_cannot_create_project_on_other_team_with_team_roles(self) -> None:
+        organization = self.create_organization(flags=0)
+        team = self.create_team(organization=organization)
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=organization, role="member", teams=[])
+        self.login_as(user=user)
+
+        self.get_error_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=403,
+        )
+
+    @with_feature({"organizations:team-roles": False})
+    def test_team_admin_cannot_override_disabled_member_creation_without_team_roles(
+        self,
+    ) -> None:
+        organization = self.create_organization(flags=256)
+        team = self.create_team(organization=organization)
+        user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user,
+            organization=organization,
+            role="member",
+            team_roles=[(team, "admin")],
+        )
+        self.login_as(user=user)
+
+        response = self.get_error_response(
+            organization.slug,
+            team.slug,
+            **self.data,
+            status_code=403,
+        )
+
+        assert response.data["detail"] == DISABLED_FEATURE_ERROR_STRING
+
+    @with_feature("organizations:team-roles")
     def test_disable_member_project_creation(self) -> None:
         test_org = self.create_organization(flags=256)
         test_team = self.create_team(organization=test_org)


### PR DESCRIPTION
Team project creation now lets an organization member with `project:read` create a project on a team they belong to, so the project picker no longer routes valid users to a 403. The check lives in `TeamProjectPermission.has_object_permission` instead of a lowered POST scope map. Any token that holds only `project:read` still fails the unchanged scope map at the view level, and read-only superusers and members of open-membership organizations do not pass for teams they never joined.

When the organization disables member project creation, the endpoint still requires `org:write` or team admin on the team. The team admin check now also reads the stored membership role, bounded by the token scopes, because `Access.has_team_scope` returns no team scopes on plans without the `team-roles` feature while the frontend reports the stored role either way. This covers the second branch of VDY-187 and replaces #123060, which is closed. The org projects endpoint still bypasses the setting with `org:write` only, as it does today. VDY-200 tracks making both endpoints use one rule.

The first two commits are the original scope map version kept for reference. The last three commits are the rewrite discussed in #discuss-security.

Fixes VDY-187
