### PR TITLE
feat(seer): Add saved issue view previews

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -578,7 +578,7 @@
   },
   {
     "name": "savedIssueView",
-    "description": "The ONLY way to reference a saved Sentry issue view. Use the view ID exactly as the issue-views API returns it. Include the API-provided name when available. Never use a markdown link for issue view references.",
+    "description": "The ONLY way to reference a saved Sentry issue view. Use the view ID exactly as the issue-views API returns it. Include the API-provided name when available. Inline: renders a compact link. Block: loads the saved filters and renders a live preview of matching issues. Do not duplicate the issue titles, event counts, users, priorities, or assignees as text. Never use a markdown link for issue view references.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/app/components/seer/markdown/__stories__/savedIssueViewEmbedStory.spec.tsx
+++ b/static/app/components/seer/markdown/__stories__/savedIssueViewEmbedStory.spec.tsx
@@ -1,0 +1,46 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SavedIssueViewEmbedStory} from './savedIssueViewEmbedStory';
+
+describe('SavedIssueViewEmbedStory', () => {
+  it('uses an organization-shared view when the current user owns none', async () => {
+    const view = GroupSearchViewFixture({id: '42', name: 'Shared issue view'});
+    const ownedViewsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/',
+      body: [],
+      match: [MockApiClient.matchQuery({createdBy: 'me'})],
+    });
+    const sharedViewsRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/',
+      body: [view],
+      match: [MockApiClient.matchQuery({createdBy: 'others'})],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/group-search-views/${view.id}/`,
+      body: view,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [],
+    });
+
+    render(<SavedIssueViewEmbedStory />);
+
+    expect(
+      (await screen.findAllByRole('link', {name: view.name}, {timeout: 10_000})).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByText('No saved issue view is available for this organization.')
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(ownedViewsRequest).toHaveBeenCalled();
+      expect(sharedViewsRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/static/app/components/seer/markdown/__stories__/savedIssueViewEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/savedIssueViewEmbedStory.tsx
@@ -1,0 +1,45 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {groupSearchViewsApiOptions} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+
+import {EmbedStory, EmbedVariant} from './embedStory';
+
+export function SavedIssueViewEmbedStory() {
+  const organization = useOrganization();
+  const {
+    data: views,
+    isError,
+    isPending,
+  } = useQuery(
+    groupSearchViewsApiOptions({
+      orgSlug: organization.slug,
+      limit: 1,
+      sort: ['-visited'],
+    })
+  );
+  const view = views?.[0];
+
+  return (
+    <EmbedStory name="savedIssueView">
+      {isPending ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <Text variant="muted">Unable to load a saved issue view example.</Text>
+      ) : view ? (
+        <EmbedVariant
+          name="savedIssueView"
+          label="Saved issue view"
+          data={{id: view.id, name: view.name}}
+        />
+      ) : (
+        <Text variant="muted">
+          No saved issue view is available for this organization.
+        </Text>
+      )}
+    </EmbedStory>
+  );
+}

--- a/static/app/components/seer/markdown/__stories__/savedIssueViewEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/savedIssueViewEmbedStory.tsx
@@ -5,23 +5,32 @@ import {Text} from '@sentry/scraps/text';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupSearchViewsApiOptions} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import {GroupSearchViewCreatedBy} from 'sentry/views/issueList/types';
 
 import {EmbedStory, EmbedVariant} from './embedStory';
 
 export function SavedIssueViewEmbedStory() {
   const organization = useOrganization();
-  const {
-    data: views,
-    isError,
-    isPending,
-  } = useQuery(
+  const ownedViewsQuery = useQuery(
     groupSearchViewsApiOptions({
       orgSlug: organization.slug,
+      createdBy: GroupSearchViewCreatedBy.ME,
       limit: 1,
-      sort: ['-visited'],
+      sort: ['-visited', '-popularity', '-created'],
     })
   );
-  const view = views?.[0];
+  const sharedViewsQuery = useQuery({
+    ...groupSearchViewsApiOptions({
+      orgSlug: organization.slug,
+      createdBy: GroupSearchViewCreatedBy.OTHERS,
+      limit: 1,
+      sort: ['-popularity', '-visited', '-created'],
+    }),
+    enabled: !ownedViewsQuery.isPending && !ownedViewsQuery.data?.length,
+  });
+  const view = ownedViewsQuery.data?.[0] ?? sharedViewsQuery.data?.[0];
+  const isPending = !view && (ownedViewsQuery.isPending || sharedViewsQuery.isPending);
+  const isError = !view && (ownedViewsQuery.isError || sharedViewsQuery.isError);
 
   return (
     <EmbedStory name="savedIssueView">

--- a/static/app/components/seer/markdown/embeds/components/savedIssueView.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueView.spec.tsx
@@ -1,9 +1,64 @@
-import {getEmbedLinkHref} from './resourceEmbedTestUtils';
+import {GroupFixture} from 'sentry-fixture/group';
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+
+import {screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {getEmbedLinkHref, renderEmbed} from './resourceEmbedTestUtils';
 
 describe('saved issue view embed', () => {
   it('links a saved issue view to the view route', () => {
     expect(
       getEmbedLinkHref('savedIssueView', 'Unresolved', {id: '77', name: 'Unresolved'})
     ).toBe('/organizations/org-slug/issues/views/77/');
+  });
+
+  it('renders issues using the saved view filters', async () => {
+    const view = GroupSearchViewFixture({
+      id: '77',
+      name: 'Unresolved in checkout',
+      query: 'is:unresolved level:error',
+      projects: [1],
+      environments: ['production'],
+    });
+    const issue = GroupFixture({
+      id: '991',
+      shortId: 'JAVASCRIPT-991',
+      title: 'Checkout request failed',
+    });
+    const viewRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/77/',
+      body: view,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    const issuesRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [issue],
+    });
+
+    renderEmbed({name: 'savedIssueView', data: {id: view.id}});
+
+    expect(
+      await screen.findByRole('link', {name: view.name}, {timeout: 10_000})
+    ).toHaveAttribute('href', '/organizations/org-slug/issues/views/77/');
+    expect(await screen.findByText(issue.shortId)).toBeInTheDocument();
+    expect(viewRequest).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(issuesRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: ['production'],
+            limit: 5,
+            project: ['1'],
+            query: 'is:unresolved level:error',
+            sort: view.querySort,
+            statsPeriod: '7d',
+          }),
+        })
+      )
+    );
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/savedIssueView.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueView.spec.tsx
@@ -61,4 +61,36 @@ describe('saved issue view embed', () => {
       )
     );
   });
+
+  it('renders the view query as formatted search tokens', async () => {
+    const view = GroupSearchViewFixture({
+      id: '77',
+      name: 'Unresolved in checkout',
+      query: 'is:unresolved level:error',
+    });
+    const issue = GroupFixture({
+      id: '991',
+      shortId: 'JAVASCRIPT-991',
+      title: 'Checkout request failed',
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/group-search-views/77/',
+      body: view,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/',
+      body: [issue],
+    });
+
+    renderEmbed({name: 'savedIssueView', data: {id: view.id}});
+
+    expect(await screen.findByText(issue.shortId)).toBeInTheDocument();
+
+    expect(screen.getByLabelText('is:unresolved')).toBeInTheDocument();
+    expect(screen.getByLabelText('level:error')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/seer/markdown/embeds/components/savedIssueView.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueView.tsx
@@ -1,25 +1,18 @@
-import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {
-  defineSeerEmbed,
-  type EmbedOutput,
-} from 'sentry/components/seer/markdown/embeds/utils';
-import {IconStar} from 'sentry/icons';
-import {t} from 'sentry/locale';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {lazy} from 'react';
 
-function SavedIssueViewLink({id, name}: EmbedOutput<'savedIssueView'>) {
-  const organization = useOrganization();
-  const href = normalizeUrl(`/organizations/${organization.slug}/issues/views/${id}/`);
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
-  return (
-    <ResourceLink icon={IconStar} href={href} title={name ?? t('Issue view %s', id)} />
-  );
-}
+import {SavedIssueViewLink} from './savedIssueViewLink';
+
+const LazySavedIssueViewBlock = lazy(() => import('./savedIssueViewBlock'));
 
 export const SavedIssueView = defineSeerEmbed({
   name: 'savedIssueView',
-  render(props) {
+  render(props, level) {
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazySavedIssueViewBlock} {...props} />;
+    }
     return <SavedIssueViewLink {...props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/savedIssueViewBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueViewBlock.tsx
@@ -1,0 +1,85 @@
+import {lazy, useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import type {GroupListColumn} from 'sentry/components/issues/groupList';
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getIssueViewQueryParams} from 'sentry/views/issueList/issueViews/getIssueViewQueryParams';
+import {groupSearchViewApiOptions} from 'sentry/views/issueList/queries/groupSearchView';
+
+import {SavedIssueViewLink} from './savedIssueViewLink';
+
+const LazyGroupList = lazy(async () => {
+  const {GroupList} = await import('sentry/components/issues/groupList');
+  return {default: GroupList};
+});
+
+const MAX_PREVIEW_ISSUES = 5;
+const PREVIEW_COLUMNS: GroupListColumn[] = [
+  'graph',
+  'firstSeen',
+  'lastSeen',
+  'event',
+  'users',
+  'priority',
+  'assignee',
+];
+
+export default function SavedIssueViewBlock({id, name}: EmbedOutput<'savedIssueView'>) {
+  const organization = useOrganization();
+  const {
+    data: view,
+    isError,
+    isPending,
+  } = useQuery(groupSearchViewApiOptions({id, orgSlug: organization.slug}));
+  const queryParams = useMemo(
+    () =>
+      view ? {...getIssueViewQueryParams({view}), limit: MAX_PREVIEW_ISSUES} : undefined,
+    [view]
+  );
+
+  return (
+    <Container
+      background="primary"
+      border="primary"
+      containerType="inline-size"
+      padding="md"
+      radius="md"
+      width="100%"
+    >
+      <Stack gap="md">
+        <SavedIssueViewLink id={id} name={view?.name ?? name} />
+        {isPending ? (
+          <Flex justify="center" padding="md">
+            <LoadingIndicator mini />
+          </Flex>
+        ) : isError || !view || !queryParams ? (
+          <Text variant="muted">{t('Unable to load saved issue view.')}</Text>
+        ) : (
+          <ErrorBoundary mini>
+            <LazyLoad
+              LazyComponent={LazyGroupList}
+              canSelectGroups={false}
+              numPlaceholderRows={3}
+              query={view.query}
+              queryParams={queryParams}
+              source="seer-saved-issue-view-embed"
+              staleTime={30_000}
+              useFilteredStats
+              withChart
+              withColumns={PREVIEW_COLUMNS}
+              withPagination={false}
+            />
+          </ErrorBoundary>
+        )}
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/savedIssueViewBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueViewBlock.tsx
@@ -1,4 +1,4 @@
-import {lazy, useMemo} from 'react';
+import {Fragment, lazy, useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -8,6 +8,7 @@ import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {LazyLoad} from 'sentry/components/lazyLoad';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -63,21 +64,24 @@ export default function SavedIssueViewBlock({id, name}: EmbedOutput<'savedIssueV
         ) : isError || !view || !queryParams ? (
           <Text variant="muted">{t('Unable to load saved issue view.')}</Text>
         ) : (
-          <ErrorBoundary mini>
-            <LazyLoad
-              LazyComponent={LazyGroupList}
-              canSelectGroups={false}
-              numPlaceholderRows={3}
-              query={view.query}
-              queryParams={queryParams}
-              source="seer-saved-issue-view-embed"
-              staleTime={30_000}
-              useFilteredStats
-              withChart
-              withColumns={PREVIEW_COLUMNS}
-              withPagination={false}
-            />
-          </ErrorBoundary>
+          <Fragment>
+            {view.query ? <ProvidedFormattedQuery query={view.query} /> : null}
+            <ErrorBoundary mini>
+              <LazyLoad
+                LazyComponent={LazyGroupList}
+                canSelectGroups={false}
+                numPlaceholderRows={3}
+                query={view.query}
+                queryParams={queryParams}
+                source="seer-saved-issue-view-embed"
+                staleTime={30_000}
+                useFilteredStats
+                withChart
+                withColumns={PREVIEW_COLUMNS}
+                withPagination={false}
+              />
+            </ErrorBoundary>
+          </Fragment>
         )}
       </Stack>
     </Container>

--- a/static/app/components/seer/markdown/embeds/components/savedIssueViewLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedIssueViewLink.tsx
@@ -1,0 +1,15 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function SavedIssueViewLink({id, name}: EmbedOutput<'savedIssueView'>) {
+  const organization = useOrganization();
+  const href = normalizeUrl(`/organizations/${organization.slug}/issues/views/${id}/`);
+
+  return (
+    <ResourceLink icon={IconStar} href={href} title={name ?? t('Issue view %s', id)} />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -423,6 +423,9 @@ export const SEER_EMBED_SCHEMAS = {
       'The ONLY way to reference a saved Sentry issue view. ' +
       'Use the view ID exactly as the issue-views API returns it. ' +
       'Include the API-provided name when available. ' +
+      'Inline: renders a compact link. ' +
+      'Block: loads the saved filters and renders a live preview of matching issues. ' +
+      'Do not duplicate the issue titles, event counts, users, priorities, or assignees as text. ' +
       'Never use a markdown link for issue view references.',
     level: ['inline', 'block'],
     schema: z.object({

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -15,6 +15,7 @@ import {EmbedStory} from './__stories__/embedStory';
 import {MonitorEmbedStory} from './__stories__/monitorEmbedStory';
 import {ReleaseEmbedStory} from './__stories__/releaseEmbedStory';
 import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
+import {SavedIssueViewEmbedStory} from './__stories__/savedIssueViewEmbedStory';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
 
@@ -96,7 +97,7 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 
 ### savedIssueView
 
-<EmbedStory name="savedIssueView" />
+<SavedIssueViewEmbedStory />
 
 ### savedQuery
 


### PR DESCRIPTION
Saved Issue Views now render live issue-stream previews in block-level Seer responses while retaining compact links inline. The preview resolves the saved view from the API and applies its query, project, environment, sort, and time filters to up to five matching issues.

The embed uses the API-provided name, handles unavailable views without breaking the response, and provides a dynamic component story backed by a real view.

Refs [CW-1941](https://linear.app/getsentry/issue/CW-1941/add-saved-issue-views-embed)
