### PR TITLE
fix(auth): Send Auth V2 cookie through SAML callbacks

### DIFF
--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -162,7 +162,7 @@
         : null;
     const domainAttribute = cookieDomain ? `; Domain=${cookieDomain}` : '';
 
-    document.cookie = `sentry_react_auth=1; Path=/auth/; SameSite=Lax${domainAttribute}`;
+    document.cookie = `sentry_react_auth=1; Path=/auth/; SameSite=None; Secure${domainAttribute}`;
     window.location.reload();
   };
 </script>

--- a/static/app/utils/useEnableAuthV2.ts
+++ b/static/app/utils/useEnableAuthV2.ts
@@ -26,7 +26,8 @@ export function useEnableAuthV2() {
     const domain = getCookieDomain();
     const options = {
       path: '/',
-      sameSite: 'lax' as const,
+      sameSite: 'none' as const,
+      secure: true,
       ...(domain ? {domain} : {}),
     };
 

--- a/static/app/views/navigation/primary/helpMenu.spec.tsx
+++ b/static/app/views/navigation/primary/helpMenu.spec.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
+import {setWindowLocation} from 'sentry-test/utils';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ModalStore} from 'sentry/stores/modalStore';
@@ -36,6 +37,7 @@ describe('PrimaryNavigationHelpMenu', () => {
     jest.clearAllMocks();
     ModalStore.reset();
     ConfigStore.set('supportEmail', 'support@sentry.io');
+    setWindowLocation('https://example.test');
     Cookies.remove('sentry_react_auth', {path: '/'});
   });
 


### PR DESCRIPTION
SAML identity providers return to Sentry with a cross-site POST. The `SameSite=Lax` Auth V2 preference cookie is omitted from that callback, causing users with 2FA to be redirected to the legacy 2FA route.

Set the preference cookie to `SameSite=None; Secure` so the callback retains the selected Auth V2 login experience and redirects pending 2FA through `/auth/login/`.