### PR TITLE
fix(gitlab): Preserve timezone offsets in blame timestamps

### DIFF
--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -191,7 +191,7 @@ def _create_commit_from_blame(
             commitMessage=commit.get("message"),
             commitAuthorName=commit.get("author_name"),
             commitAuthorEmail=commit.get("author_email"),
-            committedDate=datetime.fromisoformat(committed_date).replace(tzinfo=timezone.utc),
+            committedDate=datetime.fromisoformat(committed_date).astimezone(timezone.utc),
         )
     except Exception:
         logger.warning("get_blame_for_files.invalid_commit_response", extra=extra)

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -483,13 +483,13 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         return f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/{quote(file.path.strip('/'), safe='')}/blame?ref={file.ref}&range[start]={file.lineno}&range[end]={file.lineno}"
 
     def make_blame_response(self, **kwargs) -> list[GitLabFileBlameResponseItem]:
-        # GitLab blame responses preserve the commit's timezone offset.
         return [
             GitLabFileBlameResponseItem(
                 lines=[],
                 commit=GitLabCommitResponse(
                     id=kwargs.get("id", "1"),
                     message=kwargs.get("message", "test message"),
+                    # GitLab blame responses preserve the commit's timezone offset.
                     committed_date=kwargs.get("committed_date", "2023-01-01T05:30:00.000+05:30"),
                     author_name=kwargs.get("author_name", "Marvin"),
                     author_email=kwargs.get("author_email", "marvin@place.com"),

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -483,13 +483,14 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         return f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/{quote(file.path.strip('/'), safe='')}/blame?ref={file.ref}&range[start]={file.lineno}&range[end]={file.lineno}"
 
     def make_blame_response(self, **kwargs) -> list[GitLabFileBlameResponseItem]:
+        # GitLab blame responses preserve the commit's timezone offset.
         return [
             GitLabFileBlameResponseItem(
                 lines=[],
                 commit=GitLabCommitResponse(
                     id=kwargs.get("id", "1"),
                     message=kwargs.get("message", "test message"),
-                    committed_date=kwargs.get("committed_date", "2023-01-01T00:00:00.000Z"),
+                    committed_date=kwargs.get("committed_date", "2023-01-01T05:30:00.000+05:30"),
                     author_name=kwargs.get("author_name", "Marvin"),
                     author_email=kwargs.get("author_email", "marvin@place.com"),
                     committer_email=None,


### PR DESCRIPTION
GitLab blame timestamps can include non-UTC offsets. We were replacing the timezone with UTC instead of converting the timestamp.

Use astimezone(UTC), matching GitHub blame, and update the existing success fixture to cover a +05:30 timestamp. GitLab's [blame response entity](https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/api/entities/blame_range_commit.rb) defines committed_date as a DateTime and uses an offset-bearing example.