### PR TITLE
ref(hybrid-cloud): rewrite both hybrid cloud watermark keys every cycle

### DIFF
--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -37,7 +37,9 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import deletion_control_tasks, deletion_tasks
 from sentry.utils import json, metrics, redis
 
-WATERMARK_PREFIXES = ("tombstone", "row")
+TOMBSTONE_WATERMARK = "tombstone"
+ROW_WATERMARK = "row"
+WATERMARK_PREFIXES = (TOMBSTONE_WATERMARK, ROW_WATERMARK)
 
 
 @dataclass
@@ -56,20 +58,6 @@ def get_watermark_key(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> st
     return f"{prefix}.{field.model._meta.db_table}.{field.name}"
 
 
-def get_watermark(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> tuple[int, str]:
-    client = _get_redis_client()
-    key = get_watermark_key(prefix, field)
-    v = client.get(key)
-    if v is None:
-        result = (0, uuid4().hex)
-        client.set(key, json.dumps(result))
-        return result
-    lower, transaction_id = json.loads(v)
-    if not (isinstance(lower, int) and isinstance(transaction_id, str)):
-        raise TypeError("Expected watermarks data to be a tuple of (int, str)")
-    return lower, transaction_id
-
-
 def _write_watermark(
     prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, transaction_id: str
 ) -> None:
@@ -77,12 +65,6 @@ def _write_watermark(
         get_watermark_key(prefix, field),
         json.dumps((value, transaction_id)),
     )
-
-
-def set_watermark(
-    prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, prev_transaction_id: str
-) -> None:
-    _write_watermark(prefix, field, value, sha1(prev_transaction_id.encode("utf8")).hexdigest())
     metrics.gauge(
         "deletion.hybrid_cloud.low_bound",
         value,
@@ -91,6 +73,26 @@ def set_watermark(
             watermark=prefix,
         ),
     )
+
+
+def get_watermark(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> tuple[int, str]:
+    client = _get_redis_client()
+    key = get_watermark_key(prefix, field)
+    v = client.get(key)
+    if v is None:
+        result = (0, uuid4().hex)
+        _write_watermark(prefix, field, *result)
+        return result
+    lower, transaction_id = json.loads(v)
+    if not (isinstance(lower, int) and isinstance(transaction_id, str)):
+        raise TypeError("Expected watermarks data to be a tuple of (int, str)")
+    return lower, transaction_id
+
+
+def set_watermark(
+    prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, prev_transaction_id: str
+) -> None:
+    _write_watermark(prefix, field, value, sha1(prev_transaction_id.encode("utf8")).hexdigest())
 
 
 def refresh_watermarks(field: HybridCloudForeignKey[Any, Any]) -> None:
@@ -291,10 +293,10 @@ def _process_tombstone_reconciliation(
 ) -> bool:
     from sentry import deletions
 
-    prefix = "tombstone"
+    prefix = TOMBSTONE_WATERMARK
     watermark_manager: Manager[Any] = tombstone_cls.objects
     if row_after_tombstone:
-        prefix = "row"
+        prefix = ROW_WATERMARK
         watermark_manager = field.model.objects
 
     watermark_batch = _chunk_watermark_batch(

--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -37,6 +37,8 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import deletion_control_tasks, deletion_tasks
 from sentry.utils import json, metrics, redis
 
+WATERMARK_PREFIXES = ("tombstone", "row")
+
 
 @dataclass
 class WatermarkBatch:
@@ -68,13 +70,19 @@ def get_watermark(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> tuple[
     return lower, transaction_id
 
 
-def set_watermark(
-    prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, prev_transaction_id: str
+def _write_watermark(
+    prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, transaction_id: str
 ) -> None:
     _get_redis_client().set(
         get_watermark_key(prefix, field),
-        json.dumps((value, sha1(prev_transaction_id.encode("utf8")).hexdigest())),
+        json.dumps((value, transaction_id)),
     )
+
+
+def set_watermark(
+    prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, prev_transaction_id: str
+) -> None:
+    _write_watermark(prefix, field, value, sha1(prev_transaction_id.encode("utf8")).hexdigest())
     metrics.gauge(
         "deletion.hybrid_cloud.low_bound",
         value,
@@ -83,6 +91,12 @@ def set_watermark(
             watermark=prefix,
         ),
     )
+
+
+def refresh_watermarks(field: HybridCloudForeignKey[Any, Any]) -> None:
+    for prefix in WATERMARK_PREFIXES:
+        low_bound, transaction_id = get_watermark(prefix, field)
+        _write_watermark(prefix, field, low_bound, transaction_id)
 
 
 def _chunk_watermark_batch(
@@ -231,6 +245,8 @@ def _process_hybrid_cloud_foreign_key_cascade(
 
         tombstone_cls = TombstoneBase.class_for_silo_mode(silo_mode)
         assert tombstone_cls, "A tombstone class is required"
+
+        refresh_watermarks(field)
 
         # We rely on the return value of _process_tombstone_reconciliation
         # to short circuit the second half of this `or` so that the terminal batch

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Generator
 from operator import itemgetter
 from typing import Any, ContextManager, NotRequired, TypedDict, cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from django.apps import apps
@@ -14,10 +14,14 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, cell_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.deletions.tasks.hybrid_cloud import (
+    WATERMARK_PREFIXES,
     WatermarkBatch,
+    _get_redis_client,
+    _process_hybrid_cloud_foreign_key_cascade,
     get_ids_cross_db_for_row_watermark,
     get_ids_cross_db_for_tombstone_watermark,
     get_watermark,
+    get_watermark_key,
     schedule_hybrid_cloud_foreign_key_jobs,
     schedule_hybrid_cloud_foreign_key_jobs_control,
     set_watermark,
@@ -111,6 +115,84 @@ def test_no_work_is_no_op(
         schedule_hybrid_cloud_foreign_key_jobs()
 
     assert get_watermark("tombstone", project_bookmark_user_id_field) == (level, tid)
+
+
+@django_db_all
+def test_no_work_rewrites_both_watermarks(
+    task_runner: Callable[[], ContextManager[None]],
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    reset_watermarks()
+
+    before = {
+        prefix: get_watermark(prefix, project_bookmark_user_id_field)
+        for prefix in WATERMARK_PREFIXES
+    }
+    prefix_by_key = {
+        get_watermark_key(prefix, project_bookmark_user_id_field): prefix
+        for prefix in WATERMARK_PREFIXES
+    }
+
+    recording_client = Mock(wraps=_get_redis_client())
+    with patch(
+        "sentry.deletions.tasks.hybrid_cloud._get_redis_client", return_value=recording_client
+    ):
+        with task_runner():
+            schedule_hybrid_cloud_foreign_key_jobs()
+
+    written = {
+        prefix_by_key[call.args[0]]
+        for call in recording_client.set.call_args_list
+        if call.args[0] in prefix_by_key
+    }
+    assert written == set(WATERMARK_PREFIXES)
+
+    for prefix, watermark in before.items():
+        assert get_watermark(prefix, project_bookmark_user_id_field) == watermark
+
+
+@django_db_all
+def test_catch_up_rewrites_both_watermarks(
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    """
+    The `or` in _process_hybrid_cloud_foreign_key_cascade skips the second
+    reconciliation while the first one still has work. Both keys must be
+    written on such a cycle.
+    """
+    reset_watermarks()
+
+    prefix_by_key = {
+        get_watermark_key(prefix, project_bookmark_user_id_field): prefix
+        for prefix in WATERMARK_PREFIXES
+    }
+
+    recording_client = Mock(wraps=_get_redis_client())
+    with (
+        patch(
+            "sentry.deletions.tasks.hybrid_cloud._get_redis_client", return_value=recording_client
+        ),
+        patch(
+            "sentry.deletions.tasks.hybrid_cloud._process_tombstone_reconciliation",
+            return_value=True,
+        ) as reconciliation,
+    ):
+        _process_hybrid_cloud_foreign_key_cascade(
+            app_name=ProjectBookmark._meta.app_label,
+            model_name=ProjectBookmark.__name__,
+            field_name=project_bookmark_user_id_field.name,
+            process_task=Mock(),
+            silo_mode=SiloMode.CELL,
+        )
+
+    assert reconciliation.call_count == 1
+
+    written = {
+        prefix_by_key[call.args[0]]
+        for call in recording_client.set.call_args_list
+        if call.args[0] in prefix_by_key
+    }
+    assert written == set(WATERMARK_PREFIXES)
 
 
 @django_db_all

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -14,6 +14,8 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, cell_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.deletions.tasks.hybrid_cloud import (
+    ROW_WATERMARK,
+    TOMBSTONE_WATERMARK,
     WATERMARK_PREFIXES,
     WatermarkBatch,
     _get_redis_client,
@@ -91,8 +93,8 @@ def reset_watermarks() -> None:
                 if not isinstance(field, HybridCloudForeignKey):
                     continue
                 max_val = model.objects.aggregate(Max("id"))["id__max"] or 0
-                set_watermark("tombstone", field, max_val, "abc123")
-                set_watermark("row", field, max_val, "abc123")
+                set_watermark(TOMBSTONE_WATERMARK, field, max_val, "abc123")
+                set_watermark(ROW_WATERMARK, field, max_val, "abc123")
 
 
 @pytest.fixture
@@ -109,12 +111,12 @@ def test_no_work_is_no_op(
 
     # Transaction id should not change when no processing occurs.  (this would happen if setting the next cursor
     # to the same, previous value.)
-    level, tid = get_watermark("tombstone", project_bookmark_user_id_field)
+    level, tid = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
 
     with task_runner():
         schedule_hybrid_cloud_foreign_key_jobs()
 
-    assert get_watermark("tombstone", project_bookmark_user_id_field) == (level, tid)
+    assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field) == (level, tid)
 
 
 @django_db_all
@@ -200,22 +202,22 @@ def test_watermark_and_transaction_id(
     task_runner: Callable[[], ContextManager[None]],
     project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
 ) -> None:
-    _, tid1 = get_watermark("tombstone", project_bookmark_user_id_field)
+    _, tid1 = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
     # TODO: Add another test to validate the tid is unique per field
 
-    _, tid2 = get_watermark("row", project_bookmark_user_id_field)
+    _, tid2 = get_watermark(ROW_WATERMARK, project_bookmark_user_id_field)
 
     assert tid1
     assert tid2
     assert tid1 != tid2
 
-    set_watermark("tombstone", project_bookmark_user_id_field, 5, tid1)
-    wm, new_tid1 = get_watermark("tombstone", project_bookmark_user_id_field)
+    set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 5, tid1)
+    wm, new_tid1 = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
 
     assert new_tid1 != tid1
     assert wm == 5
 
-    assert get_watermark("tombstone", project_bookmark_user_id_field) == (wm, new_tid1)
+    assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field) == (wm, new_tid1)
 
 
 @assume_test_silo_mode(SiloMode.MONOLITH)


### PR DESCRIPTION
Part 1 of migrating hybrid cloud deletion watermarks from Redis->Postgres

Problem: a hybrid cloud foreign key field only writes its watermark keys when it has work, so a caught-up field can sit in Redis untouched for months. The migration approach is to dual-write Redis+Postgres, so those untouched keys would never get written into Postgres if we just leave this as-is.

Fix: refresh watermarks every run. We read the two prefixes and write them straight back without changes.

Notes:
- `set_watermark` does not store the id it is given, it stores `sha1(prev_transaction_id)`. Going through it would rotate the id on a cycle that did no work, so `set_watermark` is now a thin wrapper over a new `_write_watermark`, and the refresh uses `_write_watermark` directly, so it writes the stored value and id verbatim
- Writes on the `default` cluster go from "only fields with work" to "every pair, every run". Basically 2 writes per task execution.
- The whole path returns early when the `hybrid_cloud.disable_tombstone_cleanup` option is on. A region with that option set refreshes nothing. But luckily no regions have this enabled so we're good there.

Refs INFRENG-557