### PR TITLE
ref(autofix): Use a colon instead of an em dash in PR command hints

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -1012,8 +1012,8 @@ def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
         lines.append(
             # One command per line, and one `<sub>` tag per line: a blank line
             # would close the tag and leave the next line full size.
-            "\n<sub>`@sentry <feedback>` — Autofix iterates on these changes</sub>"
-            "\n<sub>`@sentry stop iterating` — Autofix stops iterating on this run</sub>"
+            "\n<sub>`@sentry <feedback>`: Autofix iterates on these changes</sub>"
+            "\n<sub>`@sentry stop iterating`: Autofix stops iterating on this run</sub>"
         )
 
     seer_run = SeerRun.objects.filter(


### PR DESCRIPTION
let's not use emdashes for customer-facing text, it sounds/looks too sloppy

changing manual pr iteration hints in PR descriptions.

before:
<img width="339" height="68" alt="image" src="https://github.com/user-attachments/assets/f69fb2aa-5400-402a-9de9-edc3e155614c" />

after:
<img width="318" height="56" alt="image" src="https://github.com/user-attachments/assets/9e1dae03-934c-477d-a7b4-47b6210f2d0b" />
