### PR TITLE
fix(ui): Hide project creation from team admins without team roles

### DIFF
--- a/static/app/components/projects/canCreateProject.spec.tsx
+++ b/static/app/components/projects/canCreateProject.spec.tsx
@@ -45,6 +45,7 @@ describe('ProjectCreationAccess', () => {
   it('passes for team admins when allowMemberProjectCreation is disabled', () => {
     const memberOrg = OrganizationFixture({
       access: ['org:read', 'team:read', 'project:read'],
+      features: ['team-roles'],
       allowMemberProjectCreation: false,
     });
     const teams = [
@@ -56,5 +57,22 @@ describe('ProjectCreationAccess', () => {
 
     const result = canCreateProject(memberOrg, teams);
     expect(result).toBeTruthy();
+  });
+
+  it('fails for team admins without team-roles when allowMemberProjectCreation is disabled', () => {
+    const memberOrg = OrganizationFixture({
+      access: ['org:read', 'team:read', 'project:read'],
+      features: [],
+      allowMemberProjectCreation: false,
+    });
+    const teams = [
+      TeamFixture({
+        teamRole: 'admin',
+        access: ['team:admin', 'team:write', 'team:read'],
+      }),
+    ];
+
+    const result = canCreateProject(memberOrg, teams);
+    expect(result).toBeFalsy();
   });
 });

--- a/static/app/components/projects/canCreateProject.tsx
+++ b/static/app/components/projects/canCreateProject.tsx
@@ -13,6 +13,12 @@ export function canCreateProject(organization: Organization, teams?: Team[]) {
     return true;
   }
 
+  // The API reports team-role scopes even on plans without the feature, where the
+  // endpoint honors none of them, so this button would only lead to a 403.
+  if (!organization.features.includes('team-roles')) {
+    return false;
+  }
+
   // Team admins can still create projects for their teams when member creation is disabled
   return Boolean(
     teams?.some(team => team.teamRole === 'admin' && team.access.includes('team:admin'))


### PR DESCRIPTION
`canCreateProject` shows the create project button to a team admin when the organization disables member project creation. On a plan without the `team-roles` feature the team serializer still reports `teamRole: "admin"` and `team:admin` in `team.access`, while `OrganizationMemberTeam.get_scopes` returns an empty set, so the endpoint denies the request. The button leads to a 403 every time. This gates that branch on the feature, so the button matches what the API allows.

This is the second branch of VDY-187. #123050 fixes the first one, where member project creation is enabled and the endpoint rejected a plain team member. That change deliberately keeps this deny in place, because an unhonored team role must not bypass a disabled setting. The remaining fix is to stop offering the action.

Nothing changes when member project creation is enabled, because `allowMemberProjectCreation` returns true before this check. Nothing changes on plans with team roles.

Ref VDY-187
