### PR TITLE
fix(api): Honor scope hierarchy in permission scope audit

### DIFF
--- a/src/sentry/auth/scope_declaration.py
+++ b/src/sentry/auth/scope_declaration.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any
 
+from django.conf import settings
 from sentry_sdk import capture_message, new_scope
 
 from sentry import options
@@ -21,6 +22,7 @@ class EndpointScopeDeclaration:
     permission_classes: tuple[str, ...]
     permission_scopes: dict[str, frozenset[str]]
     declared_scopes: frozenset[str]
+    effective_scopes: frozenset[str]
     reported_scopes: set[str] = field(default_factory=set)
     audit_enabled: bool | None = None
 
@@ -33,6 +35,14 @@ _endpoint_scope_declaration: ContextVar[EndpointScopeDeclaration | None] = Conte
 def _qualified_name(value: object) -> str:
     value_type = value if isinstance(value, type) else type(value)
     return f"{value_type.__module__}.{value_type.__qualname__}"
+
+
+def _expand_scope_hierarchy(scopes: Iterable[str]) -> frozenset[str]:
+    return frozenset(
+        effective_scope
+        for scope in scopes
+        for effective_scope in settings.SENTRY_SCOPE_HIERARCHY_MAPPING.get(scope, (scope,))
+    )
 
 
 @contextmanager
@@ -61,13 +71,15 @@ def bind_endpoint_scope_declaration(
         else:
             permission_scopes[permission_class_name] = frozenset()
 
+    frozen_declared_scopes = frozenset(declared_scopes)
     token = _endpoint_scope_declaration.set(
         EndpointScopeDeclaration(
             endpoint=endpoint,
             method=method,
             permission_classes=tuple(permission_class_names),
             permission_scopes=permission_scopes,
-            declared_scopes=frozenset(declared_scopes),
+            declared_scopes=frozen_declared_scopes,
+            effective_scopes=_expand_scope_hierarchy(frozen_declared_scopes),
         )
     )
     try:
@@ -90,16 +102,18 @@ def update_permission_scope_declaration(
     declaration.permission_scopes[permission_class_name] = frozenset(
         scope_map.get(declaration.method, ())
     )
-    declaration.declared_scopes = frozenset(
+    declared_scopes = frozenset(
         scope
         for permission_scopes in declaration.permission_scopes.values()
         for scope in permission_scopes
     )
+    declaration.declared_scopes = declared_scopes
+    declaration.effective_scopes = _expand_scope_hierarchy(declared_scopes)
 
 
 def check_scope_declaration(scope: str) -> None:
     declaration = _endpoint_scope_declaration.get()
-    if declaration is None or scope in declaration.declared_scopes:
+    if declaration is None or scope in declaration.effective_scopes:
         return
     if scope in declaration.reported_scopes:
         return

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -8,7 +8,10 @@ from django.utils import timezone
 from sentry.auth import access
 from sentry.auth.access import Access, NoAccess
 from sentry.auth.providers.dummy import DummyProvider
-from sentry.auth.scope_declaration import bind_endpoint_scope_declaration
+from sentry.auth.scope_declaration import (
+    bind_endpoint_scope_declaration,
+    update_permission_scope_declaration,
+)
 from sentry.auth.services.access.service import access_service
 from sentry.auth.superuser import SUPERUSER_READONLY_SCOPES, SUPERUSER_SCOPES
 from sentry.constants import ObjectStatus
@@ -937,6 +940,52 @@ class DefaultAccessTest(TestCase):
             assert not access.DEFAULT.has_scope("org:read")
 
         options_get.assert_not_called()
+
+    @patch("sentry.auth.scope_declaration.options.get")
+    def test_implied_scope_checks_do_not_read_audit_option(self, options_get: Mock) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:admin",)}
+
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+        ):
+            assert not access.DEFAULT.has_scope("org:read")
+            assert not access.DEFAULT.has_scope("org:write")
+            assert not access.DEFAULT.has_scope("org:integrations")
+
+        options_get.assert_not_called()
+
+    @patch("sentry.auth.scope_declaration.options.get")
+    def test_runtime_scope_map_expands_implied_scopes(self, options_get: Mock) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:read",)}
+
+        permission = Permission()
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+        ):
+            update_permission_scope_declaration(permission, {"GET": ("org:admin",)})
+            assert not access.DEFAULT.has_scope("org:write")
+
+        options_get.assert_not_called()
+
+    @patch("sentry.auth.scope_declaration.capture_message")
+    @patch("sentry.auth.scope_declaration.logger.warning")
+    @override_options({"api.permission-scope-audit.enabled": True})
+    def test_stronger_scope_check_is_still_reported(
+        self, warning: Mock, capture_message: Mock
+    ) -> None:
+        class Permission:
+            scope_map = {"GET": ("org:write",)}
+
+        with bind_endpoint_scope_declaration(
+            endpoint="test.Endpoint", method="GET", permission_classes=(Permission,)
+        ):
+            assert not access.DEFAULT.has_scope("org:admin")
+
+        assert warning.call_count == 1
+        assert warning.call_args.kwargs["extra"]["scope"] == "org:admin"
+        assert capture_message.call_count == 1
 
     def test_disabled_scope_audit_reads_option_once_per_endpoint(self) -> None:
         class Permission:


### PR DESCRIPTION
Treat scopes implied by stronger declared scopes as covered by the endpoint permission-scope audit. For example, an `org:admin` declaration now satisfies runtime checks for `org:write`, `org:read`, and `org:integrations`, while the inverse still reports a mismatch.

The audit precomputes a hierarchy-expanded effective scope set for both static and runtime permission maps while preserving literal declarations in event context. This prevents false-positive production events without weakening the underlying permission checks.

Follow-up to #122046.
