### PR TITLE
feat(seer): Add structured Night Shift errors

### DIFF
--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -159,17 +159,18 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
         extras = obj.extras or {}
         # A dispatch failure records on the run; per-shard delivery failures record
         # on the shard, so surface either so a failed shard doesn't read as healthy.
-        shard_error: Mapping[str, Any] = next(
-            (
-                s.extras
-                for s in obj.shards.all()
-                if (s.extras or {}).get("error_message") or (s.extras or {}).get("error_type")
-            ),
-            {},
-        )
-        error_message = extras.get("error_message") or shard_error.get("error_message")
-        raw_error_type = extras.get("error_type") or shard_error.get("error_type")
-        error_type = _resolve_error_type(raw_error_type, error_message)
+        error_details: Mapping[str, Any] = extras
+        if not error_details.get("error_message") and not error_details.get("error_type"):
+            error_details = next(
+                (
+                    s.extras
+                    for s in obj.shards.all()
+                    if (s.extras or {}).get("error_message") or (s.extras or {}).get("error_type")
+                ),
+                {},
+            )
+        error_message = error_details.get("error_message")
+        error_type = _resolve_error_type(error_details.get("error_type"), error_message)
         status = _get_status(error_type)
         group_titles_by_id = attrs.get("group_titles_by_id", {})
         group_short_ids_by_id = attrs.get("group_short_ids_by_id", {})

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, TypedDict
+from typing import Any, TypedDict
 
 from django.db.models import Prefetch, prefetch_related_objects
 
@@ -67,7 +67,6 @@ class SeerNightShiftRunResponse(TypedDict):
     extras: dict[str, Any]
     errorMessage: str | None
     errorType: SeerNightShiftRunErrorType | None
-    status: Literal["succeeded", "failed", "skipped"]
     results: list[SeerNightShiftRunResultResponse]
     issues: list[SeerNightShiftRunIssueResponse]
     seerRuns: list[SeerNightShiftSeerRunResponse]
@@ -172,7 +171,6 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
         error_message: str | None = error_details.get("error_message")
         raw_error_type: str | None = error_details.get("error_type")
         error_type = _resolve_error_type(raw_error_type, error_message)
-        status = _get_status(error_type)
         group_titles_by_id = attrs.get("group_titles_by_id", {})
         group_short_ids_by_id = attrs.get("group_short_ids_by_id", {})
         pull_requests_by_result_id = attrs.get("pull_requests_by_result_id", {})
@@ -182,7 +180,6 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "extras": extras,
             "errorMessage": error_message,
             "errorType": error_type,
-            "status": status,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [
                 _serialize_issue(
@@ -205,10 +202,6 @@ _LEGACY_ERROR_TYPES = {
     "Invalid Night Shift shard plan": SeerNightShiftRunErrorType.INVALID_SHARD_PLAN,
 }
 _ERROR_TYPES_BY_VALUE = {error_type.value: error_type for error_type in SeerNightShiftRunErrorType}
-_SKIPPED_ERROR_TYPES = {
-    SeerNightShiftRunErrorType.NO_QUOTA,
-    SeerNightShiftRunErrorType.NO_SEER_ACCESS,
-}
 
 
 def _resolve_error_type(
@@ -224,16 +217,6 @@ def _resolve_error_type(
     if re.fullmatch(r"Failed to dispatch \d+ of \d+ triage shards", error_message):
         return SeerNightShiftRunErrorType.SHARD_DISPATCH_FAILED
     return SeerNightShiftRunErrorType.UNKNOWN
-
-
-def _get_status(
-    error_type: SeerNightShiftRunErrorType | None,
-) -> Literal["succeeded", "failed", "skipped"]:
-    if error_type in _SKIPPED_ERROR_TYPES:
-        return "skipped"
-    if error_type is not None:
-        return "failed"
-    return "succeeded"
 
 
 def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResultResponse:

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -169,8 +169,9 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
                 ),
                 {},
             )
-        error_message = error_details.get("error_message")
-        error_type = _resolve_error_type(error_details.get("error_type"), error_message)
+        error_message: str | None = error_details.get("error_message")
+        raw_error_type: str | None = error_details.get("error_type")
+        error_type = _resolve_error_type(raw_error_type, error_message)
         status = _get_status(error_type)
         group_titles_by_id = attrs.get("group_titles_by_id", {})
         group_short_ids_by_id = attrs.get("group_short_ids_by_id", {})
@@ -203,6 +204,7 @@ _LEGACY_ERROR_TYPES = {
     "Organization does not have Seer access": SeerNightShiftRunErrorType.NO_SEER_ACCESS,
     "Invalid Night Shift shard plan": SeerNightShiftRunErrorType.INVALID_SHARD_PLAN,
 }
+_ERROR_TYPES_BY_VALUE = {error_type.value: error_type for error_type in SeerNightShiftRunErrorType}
 _SKIPPED_ERROR_TYPES = {
     SeerNightShiftRunErrorType.NO_QUOTA,
     SeerNightShiftRunErrorType.NO_SEER_ACCESS,
@@ -210,15 +212,12 @@ _SKIPPED_ERROR_TYPES = {
 
 
 def _resolve_error_type(
-    raw_error_type: object, error_message: object
+    raw_error_type: str | None, error_message: str | None
 ) -> SeerNightShiftRunErrorType | None:
-    if isinstance(raw_error_type, str):
-        try:
-            return SeerNightShiftRunErrorType(raw_error_type)
-        except ValueError:
-            return SeerNightShiftRunErrorType.UNKNOWN
+    if raw_error_type is not None:
+        return _ERROR_TYPES_BY_VALUE.get(raw_error_type, SeerNightShiftRunErrorType.UNKNOWN)
 
-    if not isinstance(error_message, str):
+    if error_message is None:
         return None
     if error_type := _LEGACY_ERROR_TYPES.get(error_message):
         return error_type

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 from django.db.models import Prefetch, prefetch_related_objects
 
@@ -15,6 +16,7 @@ from sentry.models.group import Group
 from sentry.models.pullrequest import PullRequest
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
+    SeerNightShiftRunErrorType,
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
@@ -64,6 +66,8 @@ class SeerNightShiftRunResponse(TypedDict):
     dateAdded: str
     extras: dict[str, Any]
     errorMessage: str | None
+    errorType: SeerNightShiftRunErrorType | None
+    status: Literal["succeeded", "failed", "skipped"]
     results: list[SeerNightShiftRunResultResponse]
     issues: list[SeerNightShiftRunIssueResponse]
     seerRuns: list[SeerNightShiftSeerRunResponse]
@@ -155,14 +159,18 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
         extras = obj.extras or {}
         # A dispatch failure records on the run; per-shard delivery failures record
         # on the shard, so surface either so a failed shard doesn't read as healthy.
-        shard_error = next(
+        shard_error: Mapping[str, Any] = next(
             (
-                s.extras["error_message"]
+                s.extras
                 for s in obj.shards.all()
-                if (s.extras or {}).get("error_message")
+                if (s.extras or {}).get("error_message") or (s.extras or {}).get("error_type")
             ),
-            None,
+            {},
         )
+        error_message = extras.get("error_message") or shard_error.get("error_message")
+        raw_error_type = extras.get("error_type") or shard_error.get("error_type")
+        error_type = _resolve_error_type(raw_error_type, error_message)
+        status = _get_status(error_type)
         group_titles_by_id = attrs.get("group_titles_by_id", {})
         group_short_ids_by_id = attrs.get("group_short_ids_by_id", {})
         pull_requests_by_result_id = attrs.get("pull_requests_by_result_id", {})
@@ -170,7 +178,9 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "id": str(obj.id),
             "dateAdded": obj.date_added.isoformat(),
             "extras": extras,
-            "errorMessage": extras.get("error_message") or shard_error,
+            "errorMessage": error_message,
+            "errorType": error_type,
+            "status": status,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [
                 _serialize_issue(
@@ -184,6 +194,46 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             # other kinds can produce runs.
             "triageStrategy": SeerWorkflowStrategy.AGENTIC_TRIAGE.value,
         }
+
+
+_LEGACY_ERROR_TYPES = {
+    "No Seer quota available": SeerNightShiftRunErrorType.NO_QUOTA,
+    "Failed to get eligible projects": SeerNightShiftRunErrorType.ELIGIBLE_PROJECTS_FAILED,
+    "Organization does not have Seer access": SeerNightShiftRunErrorType.NO_SEER_ACCESS,
+    "Invalid Night Shift shard plan": SeerNightShiftRunErrorType.INVALID_SHARD_PLAN,
+}
+_SKIPPED_ERROR_TYPES = {
+    SeerNightShiftRunErrorType.NO_QUOTA,
+    SeerNightShiftRunErrorType.NO_SEER_ACCESS,
+}
+
+
+def _resolve_error_type(
+    raw_error_type: object, error_message: object
+) -> SeerNightShiftRunErrorType | None:
+    if isinstance(raw_error_type, str):
+        try:
+            return SeerNightShiftRunErrorType(raw_error_type)
+        except ValueError:
+            return SeerNightShiftRunErrorType.UNKNOWN
+
+    if not isinstance(error_message, str):
+        return None
+    if error_type := _LEGACY_ERROR_TYPES.get(error_message):
+        return error_type
+    if re.fullmatch(r"Failed to dispatch \d+ of \d+ triage shards", error_message):
+        return SeerNightShiftRunErrorType.SHARD_DISPATCH_FAILED
+    return SeerNightShiftRunErrorType.UNKNOWN
+
+
+def _get_status(
+    error_type: SeerNightShiftRunErrorType | None,
+) -> Literal["succeeded", "failed", "skipped"]:
+    if error_type in _SKIPPED_ERROR_TYPES:
+        return "skipped"
+    if error_type is not None:
+        return "failed"
+    return "succeeded"
 
 
 def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResultResponse:

--- a/src/sentry/seer/models/night_shift.py
+++ b/src/sentry/seer/models/night_shift.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+from enum import StrEnum
+
 from django.db import models
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, cell_silo_model, sane_repr
 from sentry.db.models.base import DefaultFieldsModel
 from sentry.seer.models.workflow import SeerWorkflowStrategy
+
+
+class SeerNightShiftRunErrorType(StrEnum):
+    NO_QUOTA = "no_quota"
+    ELIGIBLE_PROJECTS_FAILED = "eligible_projects_failed"
+    NO_SEER_ACCESS = "no_seer_access"
+    INVALID_SHARD_PLAN = "invalid_shard_plan"
+    SHARD_DISPATCH_FAILED = "shard_dispatch_failed"
+    SHARD_DELIVERY_FAILED = "shard_delivery_failed"
+    UNKNOWN = "unknown"
 
 
 @cell_silo_model

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -26,6 +26,7 @@ from sentry.seer.autofix.utils import (
 )
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
+    SeerNightShiftRunErrorType,
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
@@ -70,7 +71,13 @@ def deliver_night_shift_result(
     # Per-delivery error_message lives on the shard so a sibling shard's success
     # can't clear it.
     if error:
-        shard.update(extras={**(shard.extras or {}), "error_message": error})
+        shard.update(
+            extras={
+                **(shard.extras or {}),
+                "error_type": SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value,
+                "error_message": error,
+            }
+        )
 
     log_extra: dict[str, object] = {
         "organization_id": run.organization_id,
@@ -100,10 +107,11 @@ def deliver_night_shift_result(
     options = (run.extras or {}).get("options") or {}
     dry_run = bool(options.get("dry_run", False))
 
-    # Clear any stale error_message now that this delivery has succeeded.
+    # Clear any stale delivery error now that this delivery has succeeded.
     if (shard.extras or {}).get("error_message"):
         extras = {**shard.extras}
         del extras["error_message"]
+        extras.pop("error_type", None)
         shard.update(extras=extras)
 
     _process_verdicts(

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -41,6 +41,7 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
+    SeerNightShiftRunErrorType,
     SeerNightShiftRunShard,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
@@ -362,7 +363,11 @@ def run_night_shift_for_org(
 
     if not has_seer_quota and schedule_id is None:
         logger.info("night_shift.no_seer_quota", extra={"organization_id": organization.id})
-        _record_run_error(run, "No Seer quota available")
+        _record_run_error(
+            run,
+            SeerNightShiftRunErrorType.NO_QUOTA,
+            "No Seer quota available",
+        )
         return run.id
 
     task_kwargs: dict[str, Any] = {"options": dict(resolved_options)}
@@ -438,6 +443,7 @@ def run_night_shift_execution(
     except Exception:
         _fail_run(
             run,
+            error_type=SeerNightShiftRunErrorType.ELIGIBLE_PROJECTS_FAILED,
             message="Failed to get eligible projects",
             event="night_shift.failed_to_get_eligible_projects",
             extra=log_extra,
@@ -621,23 +627,27 @@ def _complete_run(run: SeerNightShiftRun) -> None:
 
         extras = dict(locked_run.extras or {})
         extras.pop("error_message", None)
+        extras.pop("error_type", None)
         locked_run.update(extras=extras, date_completed=timezone.now())
 
 
-def _record_run_error(run: SeerNightShiftRun, message: str) -> None:
-    _update_run_extras(run, {"error_message": message})
+def _record_run_error(
+    run: SeerNightShiftRun, error_type: SeerNightShiftRunErrorType, message: str
+) -> None:
+    _update_run_extras(run, {"error_type": error_type.value, "error_message": message})
 
 
 def _fail_run(
     run: SeerNightShiftRun,
     *,
+    error_type: SeerNightShiftRunErrorType,
     message: str,
     event: str,
     extra: dict[str, object],
 ) -> None:
     """Log an exception and record an error message on the run."""
     logger.exception(event, extra=extra)
-    _record_run_error(run, message)
+    _record_run_error(run, error_type, message)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -821,7 +831,11 @@ def _dispatch_pending_shards(
         client = SeerAgentClient(organization)
     except SeerPermissionError:
         logger.info("night_shift.no_seer_access", extra=log_extra)
-        _record_run_error(run, "Organization does not have Seer access")
+        _record_run_error(
+            run,
+            SeerNightShiftRunErrorType.NO_SEER_ACCESS,
+            "Organization does not have Seer access",
+        )
         return ShardDispatchStatus.NO_SEER_ACCESS
 
     using = router.db_for_write(SeerNightShiftRunShard)
@@ -840,7 +854,11 @@ def _dispatch_pending_shards(
                     "night_shift.invalid_shard_plan",
                     extra={**log_extra, "shard_index": shard_index},
                 )
-                _record_run_error(run, "Invalid Night Shift shard plan")
+                _record_run_error(
+                    run,
+                    SeerNightShiftRunErrorType.INVALID_SHARD_PLAN,
+                    "Invalid Night Shift shard plan",
+                )
                 return ShardDispatchStatus.INVALID_SHARD_PLAN
 
             def _link_shard(created: SeerRun) -> None:
@@ -872,7 +890,9 @@ def _dispatch_pending_shards(
         failed_shards = len(planned_shards) - dispatched
         sentry_sdk.metrics.count("night_shift.shard_dispatch_failure", failed_shards)
         _record_run_error(
-            run, f"Failed to dispatch {failed_shards} of {len(planned_shards)} triage shards"
+            run,
+            SeerNightShiftRunErrorType.SHARD_DISPATCH_FAILED,
+            f"Failed to dispatch {failed_shards} of {len(planned_shards)} triage shards",
         )
         logger.warning(
             "night_shift.partial_dispatch_failure",

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -41,7 +41,6 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert response.data[0]["id"] == str(run.id)
         assert response.data[0]["errorMessage"] is None
         assert response.data[0]["errorType"] is None
-        assert response.data[0]["status"] == "succeeded"
         assert response.data[0]["extras"] == {"foo": "bar"}
         assert len(response.data[0]["results"]) == 1
 
@@ -248,9 +247,8 @@ class OrganizationSeerWorkflowsTest(APITestCase):
 
         assert response.data[0]["errorMessage"] == "shard failed"
         assert response.data[0]["errorType"] == "unknown"
-        assert response.data[0]["status"] == "failed"
 
-    def test_returns_structured_error_type_and_status(self) -> None:
+    def test_returns_structured_error_type(self) -> None:
         run = SeerNightShiftRun.objects.create(
             organization=self.organization,
             extras={
@@ -265,7 +263,6 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert response.data[0]["id"] == str(run.id)
         assert response.data[0]["errorMessage"] == "Diagnostic details"
         assert response.data[0]["errorType"] == "no_quota"
-        assert response.data[0]["status"] == "skipped"
 
     def test_derives_structured_fields_for_legacy_errors(self) -> None:
         run = SeerNightShiftRun.objects.create(
@@ -278,9 +275,8 @@ class OrganizationSeerWorkflowsTest(APITestCase):
 
         assert response.data[0]["id"] == str(run.id)
         assert response.data[0]["errorType"] == "shard_dispatch_failed"
-        assert response.data[0]["status"] == "failed"
 
-    def test_derives_skipped_status_for_legacy_errors(self) -> None:
+    def test_derives_error_type_for_legacy_errors(self) -> None:
         run = SeerNightShiftRun.objects.create(
             organization=self.organization,
             extras={"error_message": "Organization does not have Seer access"},
@@ -291,7 +287,6 @@ class OrganizationSeerWorkflowsTest(APITestCase):
 
         assert response.data[0]["id"] == str(run.id)
         assert response.data[0]["errorType"] == "no_seer_access"
-        assert response.data[0]["status"] == "skipped"
 
     def test_runs_ordered_by_date_added_desc(self) -> None:
         older = SeerNightShiftRun.objects.create(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -240,13 +240,19 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         # surface them so a failed shard doesn't read as a healthy run.
         run = SeerNightShiftRun.objects.create(organization=self.organization)
         SeerNightShiftRunShard.objects.create(run=run)
-        SeerNightShiftRunShard.objects.create(run=run, extras={"error_message": "shard failed"})
+        SeerNightShiftRunShard.objects.create(
+            run=run,
+            extras={
+                "error_type": SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value,
+                "error_message": "shard failed",
+            },
+        )
 
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
         assert response.data[0]["errorMessage"] == "shard failed"
-        assert response.data[0]["errorType"] == "unknown"
+        assert response.data[0]["errorType"] == "shard_delivery_failed"
 
     def test_returns_structured_error_type(self) -> None:
         run = SeerNightShiftRun.objects.create(
@@ -264,29 +270,27 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert response.data[0]["errorMessage"] == "Diagnostic details"
         assert response.data[0]["errorType"] == "no_quota"
 
-    def test_derives_structured_fields_for_legacy_errors(self) -> None:
-        run = SeerNightShiftRun.objects.create(
+    def test_derives_error_types_for_legacy_messages(self) -> None:
+        dispatch_run = SeerNightShiftRun.objects.create(
             organization=self.organization,
             extras={"error_message": "Failed to dispatch 1 of 3 triage shards"},
         )
-
-        with self.feature("organizations:seer-night-shift"):
-            response = self.get_success_response(self.organization.slug)
-
-        assert response.data[0]["id"] == str(run.id)
-        assert response.data[0]["errorType"] == "shard_dispatch_failed"
-
-    def test_derives_error_type_for_legacy_errors(self) -> None:
-        run = SeerNightShiftRun.objects.create(
+        no_access_run = SeerNightShiftRun.objects.create(
             organization=self.organization,
             extras={"error_message": "Organization does not have Seer access"},
+        )
+        unknown_run = SeerNightShiftRun.objects.create(
+            organization=self.organization,
+            extras={"error_message": "Unexpected error"},
         )
 
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        assert response.data[0]["id"] == str(run.id)
-        assert response.data[0]["errorType"] == "no_seer_access"
+        by_run_id = {item["id"]: item for item in response.data}
+        assert by_run_id[str(dispatch_run.id)]["errorType"] == "shard_dispatch_failed"
+        assert by_run_id[str(no_access_run.id)]["errorType"] == "no_seer_access"
+        assert by_run_id[str(unknown_run.id)]["errorType"] == "unknown"
 
     def test_runs_ordered_by_date_added_desc(self) -> None:
         older = SeerNightShiftRun.objects.create(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -1,6 +1,7 @@
 from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
+    SeerNightShiftRunErrorType,
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
@@ -39,6 +40,8 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(run.id)
         assert response.data[0]["errorMessage"] is None
+        assert response.data[0]["errorType"] is None
+        assert response.data[0]["status"] == "succeeded"
         assert response.data[0]["extras"] == {"foo": "bar"}
         assert len(response.data[0]["results"]) == 1
 
@@ -244,6 +247,51 @@ class OrganizationSeerWorkflowsTest(APITestCase):
             response = self.get_success_response(self.organization.slug)
 
         assert response.data[0]["errorMessage"] == "shard failed"
+        assert response.data[0]["errorType"] == "unknown"
+        assert response.data[0]["status"] == "failed"
+
+    def test_returns_structured_error_type_and_status(self) -> None:
+        run = SeerNightShiftRun.objects.create(
+            organization=self.organization,
+            extras={
+                "error_type": SeerNightShiftRunErrorType.NO_QUOTA.value,
+                "error_message": "Diagnostic details",
+            },
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response.data[0]["id"] == str(run.id)
+        assert response.data[0]["errorMessage"] == "Diagnostic details"
+        assert response.data[0]["errorType"] == "no_quota"
+        assert response.data[0]["status"] == "skipped"
+
+    def test_derives_structured_fields_for_legacy_errors(self) -> None:
+        run = SeerNightShiftRun.objects.create(
+            organization=self.organization,
+            extras={"error_message": "Failed to dispatch 1 of 3 triage shards"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response.data[0]["id"] == str(run.id)
+        assert response.data[0]["errorType"] == "shard_dispatch_failed"
+        assert response.data[0]["status"] == "failed"
+
+    def test_derives_skipped_status_for_legacy_errors(self) -> None:
+        run = SeerNightShiftRun.objects.create(
+            organization=self.organization,
+            extras={"error_message": "Organization does not have Seer access"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response.data[0]["id"] == str(run.id)
+        assert response.data[0]["errorType"] == "no_seer_access"
+        assert response.data[0]["status"] == "skipped"
 
     def test_runs_ordered_by_date_added_desc(self) -> None:
         older = SeerNightShiftRun.objects.create(organization=self.organization)

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -9,6 +9,7 @@ from sentry.models.project import Project
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
+    SeerNightShiftRunErrorType,
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
@@ -80,6 +81,7 @@ class TestDeliverNightShiftResult(TestCase):
 
         shard = run.shards.get()
         assert shard.extras["error_message"] == "Seer exploded"
+        assert shard.extras["error_type"] == SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value
         assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
 
     def test_sibling_shard_success_keeps_other_shard_error(self) -> None:
@@ -119,6 +121,10 @@ class TestDeliverNightShiftResult(TestCase):
 
         failed_shard.refresh_from_db()
         assert failed_shard.extras["error_message"] == "shard failed"
+        assert (
+            failed_shard.extras["error_type"]
+            == SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value
+        )
 
     def test_invalid_result_logs_exception(self) -> None:
         """When result can't be parsed as TriageResponse, log and return."""
@@ -659,7 +665,12 @@ class TestDeliverNightShiftResult(TestCase):
         group = self.create_group(project=project)
         run = self._create_night_shift_run(organization=org)
         shard = run.shards.get()
-        shard.update(extras={"error_message": "Night shift run failed"})
+        shard.update(
+            extras={
+                "error_type": SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value,
+                "error_message": "Night shift run failed",
+            }
+        )
 
         result = {
             "verdicts": [
@@ -681,6 +692,7 @@ class TestDeliverNightShiftResult(TestCase):
 
         shard.refresh_from_db()
         assert "error_message" not in shard.extras
+        assert "error_type" not in shard.extras
 
     def test_redelivery_is_idempotent(self) -> None:
         """Redelivering the same shard result must not re-trigger autofix or

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -16,6 +16,7 @@ from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
+    SeerNightShiftRunErrorType,
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
@@ -606,12 +607,13 @@ class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
 
         assert run_id is not None
         run = SeerNightShiftRun.objects.get(id=run_id)
-        _record_run_error(run, "transient failure")
+        _record_run_error(run, SeerNightShiftRunErrorType.UNKNOWN, "transient failure")
         _complete_run(run)
         _update_run_extras(run, {"num_candidates": 1})
 
         run.refresh_from_db()
         assert run.extras.get("error_message") is None
+        assert run.extras.get("error_type") is None
         assert "num_candidates" not in run.extras
 
     def test_extras_update_refreshes_run_instance(self) -> None:
@@ -675,6 +677,7 @@ class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
 
         run = SeerNightShiftRun.objects.get(organization=org)
         assert run.extras["error_message"] == "Failed to get eligible projects"
+        assert run.extras["error_type"] == SeerNightShiftRunErrorType.ELIGIBLE_PROJECTS_FAILED.value
         assert run.date_completed is None
 
         run_night_shift_for_org(org.id, schedule_id=schedule_id)
@@ -1180,6 +1183,7 @@ class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCa
         assert run.shards.filter(seer_run__isnull=True).count() == 1
         assert run.date_completed is None
         assert run.extras["error_message"] == "Organization does not have Seer access"
+        assert run.extras["error_type"] == SeerNightShiftRunErrorType.NO_SEER_ACCESS.value
         assert not SeerRun.objects.filter(organization=org).exists()
         incomplete_log = next(
             call.kwargs["extra"]
@@ -1209,6 +1213,7 @@ class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCa
         assert run.shards.filter(seer_run__isnull=True).count() == 1
         assert run.date_completed is None
         assert run.extras["error_message"] == "Failed to dispatch 1 of 1 triage shards"
+        assert run.extras["error_type"] == SeerNightShiftRunErrorType.SHARD_DISPATCH_FAILED.value
 
     def test_outbox_drain_mirrors_run_against_seer(self) -> None:
         org = self.create_organization()
@@ -1306,6 +1311,7 @@ class TestRunNightShiftForOrgManualPath(NightShiftFixtures, TestCase):
         assert run_id is not None
         run = SeerNightShiftRun.objects.get(id=run_id)
         assert run.extras["error_message"] == "No Seer quota available"
+        assert run.extras["error_type"] == SeerNightShiftRunErrorType.NO_QUOTA.value
         mock_execute.assert_not_called()
 
     def test_extras_contain_options_and_target_project_ids(self) -> None:


### PR DESCRIPTION
Night Shift now persists a machine-readable `error_type` alongside diagnostic error text. The workflows API exposes that value as `errorType`, allowing the history UI to present errors such as `no_quota` and `no_seer_access` as skipped without treating backend prose as an API contract.

Historical records that only contain `error_message` are classified in the serializer for compatibility. New run and shard errors write stable codes at their source, while unknown diagnostics remain failed with `errorType: "unknown"`.

This is the backend prerequisite for the frontend cleanup in #122675 and should deploy first.
