### PR TITLE
skip deletion watermark for empty tables

### DIFF
--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -48,6 +48,7 @@ class WatermarkBatch:
     up: int
     has_more: bool
     transaction_id: str
+    table_max: int = 0
 
 
 def _get_redis_client() -> RedisCluster[str] | StrictRedis[str]:
@@ -131,7 +132,11 @@ def _chunk_watermark_batch(
     )
 
     return WatermarkBatch(
-        low=lower, up=capped, has_more=batch_upper < upper, transaction_id=transaction_id
+        low=lower,
+        up=capped,
+        has_more=batch_upper < upper,
+        transaction_id=transaction_id,
+        table_max=upper,
     )
 
 
@@ -304,6 +309,18 @@ def _process_tombstone_reconciliation(
     )
     has_more = watermark_batch.has_more
     if watermark_batch.low < watermark_batch.up:
+        if not row_after_tombstone and not model._base_manager.exists():
+            # The model table holds no rows, so no tombstone can cascade to
+            # anything. Move the watermark to the top of the tombstone table
+            # instead of walking the range batch by batch.
+            set_watermark(prefix, field, watermark_batch.table_max, watermark_batch.transaction_id)
+            metrics.incr(
+                "deletion.hybrid_cloud.empty_model_skip",
+                tags=dict(field_name=f"{model._meta.db_table}.{field.name}"),
+                sample_rate=1.0,
+            )
+            return False
+
         to_delete_ids, oldest_seen = _get_model_ids_for_tombstone_cascade(
             tombstone_cls=tombstone_cls,
             model=model,

--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -48,7 +48,7 @@ class WatermarkBatch:
     up: int
     has_more: bool
     transaction_id: str
-    table_max: int = 0
+    table_max: int
 
 
 def _get_redis_client() -> RedisCluster[str] | StrictRedis[str]:
@@ -113,15 +113,15 @@ def _chunk_watermark_batch(
     lower, transaction_id = get_watermark(prefix, field)
     agg = manager.aggregate(Min("id"), Max("id"))
     lower = lower or ((agg["id__min"] or 1) - 1)
-    upper = agg["id__max"] or 0
-    batch_upper = min(upper, lower + batch_size)
+    table_max = agg["id__max"] or 0
+    batch_upper = min(table_max, lower + batch_size)
 
     # cap to batch size so that query timeouts don't get us.
-    capped = upper
-    if upper >= batch_upper:
+    capped = table_max
+    if table_max >= batch_upper:
         capped = batch_upper
 
-    watermark_delta = max(upper - lower, 0)
+    watermark_delta = max(table_max - lower, 0)
     metric_field_name = f"{model._meta.db_table}:{field.name}"
     metric_tags = dict(field_name=metric_field_name, watermark_type=prefix)
     metrics.gauge(
@@ -134,9 +134,9 @@ def _chunk_watermark_batch(
     return WatermarkBatch(
         low=lower,
         up=capped,
-        has_more=batch_upper < upper,
+        has_more=batch_upper < table_max,
         transaction_id=transaction_id,
-        table_max=upper,
+        table_max=table_max,
     )
 
 

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -2,17 +2,19 @@ from __future__ import annotations
 
 from collections.abc import Callable, Generator
 from operator import itemgetter
-from typing import Any, ContextManager, NotRequired, TypedDict, cast
+from typing import Any, ClassVar, ContextManager, NotRequired, TypedDict, cast
 from unittest.mock import Mock, patch
 
 import pytest
 from django.apps import apps
 from django.db import connections, router, transaction
-from django.db.models import Max, QuerySet
+from django.db.models import BooleanField, Max, QuerySet
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, cell_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.db.models.manager.base import BaseManager
+from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.deletions.tasks.hybrid_cloud import (
     ROW_WATERMARK,
     TOMBSTONE_WATERMARK,
@@ -60,6 +62,28 @@ from sentry.users.models.user import User
 class DoNothingIntegrationModel(Model):
     __relocation_scope__ = RelocationScope.Excluded
     integration_id = HybridCloudForeignKey("sentry.Integration", on_delete="DO_NOTHING")
+
+    class Meta:
+        app_label = "fixtures"
+
+
+class VisibleOnlyManager(BaseManager["FilteredIntegrationModel"]):
+    def get_queryset(self) -> BaseQuerySet[FilteredIntegrationModel]:
+        return super().get_queryset().filter(hidden=False)
+
+
+@cell_silo_model
+class FilteredIntegrationModel(Model):
+    """
+    Stands in for the models whose default manager hides rows, such as a soft
+    deleted SentryApp or a Workflow that is pending deletion.
+    """
+
+    __relocation_scope__ = RelocationScope.Excluded
+    integration_id = HybridCloudForeignKey("sentry.Integration", on_delete="DO_NOTHING")
+    hidden = BooleanField(default=False)
+
+    objects: ClassVar[BaseManager[FilteredIntegrationModel]] = VisibleOnlyManager()
 
     class Meta:
         app_label = "fixtures"
@@ -220,6 +244,118 @@ def test_watermark_and_transaction_id(
     assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field) == (wm, new_tid1)
 
 
+@django_db_all
+def test_empty_model_table_fast_forwards_tombstone_watermark() -> None:
+    field = cast(
+        HybridCloudForeignKey[int, int],
+        DoNothingIntegrationModel._meta.get_field("integration_id"),
+    )
+    DoNothingIntegrationModel.objects.all().delete()
+    set_watermark("tombstone", field, 0, "abc123")
+    set_watermark("row", field, 0, "abc123")
+
+    for i in range(5):
+        CellTombstone.objects.create(
+            table_name=Integration._meta.db_table, object_identifier=1000 + i
+        )
+    tombstone_max = CellTombstone.objects.aggregate(Max("id"))["id__max"]
+    assert tombstone_max is not None
+
+    process_task = Mock()
+    with patch(
+        "sentry.deletions.tasks.hybrid_cloud._get_model_ids_for_tombstone_cascade"
+    ) as get_ids:
+        _process_hybrid_cloud_foreign_key_cascade(
+            app_name="fixtures",
+            model_name=DoNothingIntegrationModel.__name__,
+            field_name=field.name,
+            process_task=process_task,
+            silo_mode=SiloMode.CELL,
+        )
+
+    # One cycle, straight to the maximum, with no batch scanned and no reschedule.
+    assert get_watermark("tombstone", field)[0] == tombstone_max
+    assert not get_ids.called
+    assert not process_task.delay.called
+
+    # A later cycle with no new tombstones does nothing at all.
+    with patch(
+        "sentry.deletions.tasks.hybrid_cloud._get_model_ids_for_tombstone_cascade"
+    ) as get_ids:
+        _process_hybrid_cloud_foreign_key_cascade(
+            app_name="fixtures",
+            model_name=DoNothingIntegrationModel.__name__,
+            field_name=field.name,
+            process_task=process_task,
+            silo_mode=SiloMode.CELL,
+        )
+
+    assert get_watermark("tombstone", field)[0] == tombstone_max
+    assert not get_ids.called
+    assert not process_task.delay.called
+
+
+@django_db_all
+def test_populated_model_table_does_not_fast_forward() -> None:
+    field = cast(
+        HybridCloudForeignKey[int, int],
+        DoNothingIntegrationModel._meta.get_field("integration_id"),
+    )
+    DoNothingIntegrationModel.objects.all().delete()
+    DoNothingIntegrationModel.objects.create(integration_id=1)
+    set_watermark("tombstone", field, 0, "abc123")
+
+    for i in range(5):
+        CellTombstone.objects.create(
+            table_name=Integration._meta.db_table, object_identifier=1000 + i
+        )
+    tombstone_max = CellTombstone.objects.aggregate(Max("id"))["id__max"]
+    assert tombstone_max is not None
+
+    _process_hybrid_cloud_foreign_key_cascade(
+        app_name="fixtures",
+        model_name=DoNothingIntegrationModel.__name__,
+        field_name=field.name,
+        process_task=Mock(),
+        silo_mode=SiloMode.CELL,
+    )
+
+    # get_batch_size is patched to 1 for this module, so one cycle moves one id.
+    assert get_watermark("tombstone", field)[0] < tombstone_max
+
+
+@django_db_all
+def test_rows_hidden_by_the_default_manager_are_not_an_empty_table() -> None:
+    field = cast(
+        HybridCloudForeignKey[int, int],
+        FilteredIntegrationModel._meta.get_field("integration_id"),
+    )
+    FilteredIntegrationModel._base_manager.all().delete()
+    FilteredIntegrationModel._base_manager.create(integration_id=1, hidden=True)
+    assert not FilteredIntegrationModel.objects.exists()
+    assert FilteredIntegrationModel._base_manager.exists()
+
+    set_watermark("tombstone", field, 0, "abc123")
+    set_watermark("row", field, 0, "abc123")
+
+    for i in range(5):
+        CellTombstone.objects.create(
+            table_name=Integration._meta.db_table, object_identifier=1000 + i
+        )
+    tombstone_max = CellTombstone.objects.aggregate(Max("id"))["id__max"]
+    assert tombstone_max is not None
+
+    _process_hybrid_cloud_foreign_key_cascade(
+        app_name="fixtures",
+        model_name=FilteredIntegrationModel.__name__,
+        field_name=field.name,
+        process_task=Mock(),
+        silo_mode=SiloMode.CELL,
+    )
+
+    assert get_watermark("tombstone", field)[0] < tombstone_max
+
+
 @assume_test_silo_mode(SiloMode.MONOLITH)
 def setup_deletable_objects(
     count: int = 1, send_tombstones: bool = True, u_id: int | None = None
@@ -285,6 +421,40 @@ def test_cell_processing(task_runner: Callable[[], ContextManager[None]]) -> Non
     with task_runner():
         schedule_hybrid_cloud_foreign_key_jobs()
     assert not results3.exists()
+
+
+@django_db_all
+def test_row_created_after_fast_forward_still_cascades(
+    task_runner: Callable[[], ContextManager[None]],
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    reset_watermarks()
+    ProjectBookmark.objects.all().delete()
+    set_watermark("tombstone", project_bookmark_user_id_field, 0, "abc123")
+    set_watermark("row", project_bookmark_user_id_field, 0, "abc123")
+
+    # A deleted user with a tombstone, and no rows in the model table.
+    empty_results, shard = setup_deletable_objects(0)
+    assert not empty_results.exists()
+    assert not ProjectBookmark.objects.exists()
+
+    with task_runner():
+        schedule_hybrid_cloud_foreign_key_jobs()
+
+    tombstone_max = CellTombstone.objects.aggregate(Max("id"))["id__max"]
+    assert tombstone_max is not None
+    assert get_watermark("tombstone", project_bookmark_user_id_field)[0] == tombstone_max
+
+    # Rows written after the fast forward that point at the tombstoned user.
+    results, _ = setup_deletable_objects(10, u_id=shard.shard_identifier)
+    assert results.exists()
+    # No new tombstone, so only the row watermark side can remove these rows.
+    assert CellTombstone.objects.aggregate(Max("id"))["id__max"] == tombstone_max
+
+    with task_runner():
+        schedule_hybrid_cloud_foreign_key_jobs()
+
+    assert not results.exists()
 
 
 @django_db_all

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 from django.apps import apps
 from django.db import connections, router, transaction
-from django.db.models import BooleanField, Max, QuerySet
+from django.db.models import BooleanField, Max, Min, QuerySet
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, cell_silo_model
@@ -309,8 +309,8 @@ def test_populated_model_table_does_not_fast_forward() -> None:
         CellTombstone.objects.create(
             table_name=Integration._meta.db_table, object_identifier=1000 + i
         )
-    tombstone_max = CellTombstone.objects.aggregate(Max("id"))["id__max"]
-    assert tombstone_max is not None
+    tombstone_min = CellTombstone.objects.aggregate(Min("id"))["id__min"]
+    assert tombstone_min is not None
 
     _process_hybrid_cloud_foreign_key_cascade(
         app_name="fixtures",
@@ -320,8 +320,9 @@ def test_populated_model_table_does_not_fast_forward() -> None:
         silo_mode=SiloMode.CELL,
     )
 
-    # get_batch_size is patched to 1 for this module, so one cycle moves one id.
-    assert get_watermark("tombstone", field)[0] < tombstone_max
+    # get_batch_size is patched to 1 for this module, so one cycle walks a single
+    # id instead of jumping to the top of the tombstone table.
+    assert get_watermark("tombstone", field)[0] == tombstone_min
 
 
 @django_db_all
@@ -342,8 +343,8 @@ def test_rows_hidden_by_the_default_manager_are_not_an_empty_table() -> None:
         CellTombstone.objects.create(
             table_name=Integration._meta.db_table, object_identifier=1000 + i
         )
-    tombstone_max = CellTombstone.objects.aggregate(Max("id"))["id__max"]
-    assert tombstone_max is not None
+    tombstone_min = CellTombstone.objects.aggregate(Min("id"))["id__min"]
+    assert tombstone_min is not None
 
     _process_hybrid_cloud_foreign_key_cascade(
         app_name="fixtures",
@@ -353,7 +354,8 @@ def test_rows_hidden_by_the_default_manager_are_not_an_empty_table() -> None:
         silo_mode=SiloMode.CELL,
     )
 
-    assert get_watermark("tombstone", field)[0] < tombstone_max
+    # The hidden row keeps the table non-empty, so the watermark walks one id.
+    assert get_watermark("tombstone", field)[0] == tombstone_min
 
 
 @assume_test_silo_mode(SiloMode.MONOLITH)
@@ -788,6 +790,7 @@ class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
                 up=highest_tombstone_id["id__max"] + 1,
                 has_more=False,
                 transaction_id="foobar",
+                table_max=0,
             ),
         )
         assert ids == [monitor.id]
@@ -849,6 +852,7 @@ class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
                     up=bounds["up"],
                     has_more=False,
                     transaction_id="foobar",
+                    table_max=0,
                 ),
             )
             assert ids == bounds_with_expected_results
@@ -886,6 +890,7 @@ class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
                 up=highest_tombstone_id["id__max"] + 1,
                 has_more=False,
                 transaction_id="foobar",
+                table_max=0,
             ),
         )
         assert ids == [monitor.id]
@@ -938,6 +943,7 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
                 up=highest_model_id["id__max"] + 1,
                 has_more=False,
                 transaction_id="foobar",
+                table_max=0,
             ),
         )
 
@@ -963,6 +969,7 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
                 up=highest_model_id + 1,
                 has_more=False,
                 transaction_id="foobar",
+                table_max=0,
             ),
         )
 
@@ -1032,6 +1039,7 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
                     up=bounds["up"],
                     has_more=False,
                     transaction_id="foobar",
+                    table_max=0,
                 ),
             )
             assert ids == bounds_with_expected_results, (
@@ -1071,6 +1079,7 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
                 up=highest_model_id + 1,
                 has_more=False,
                 transaction_id="foobar",
+                table_max=0,
             ),
         )
         assert ids == [monitor.id]


### PR DESCRIPTION
Part 2 of migrating hybrid cloud deletion watermarks from Redis->Postgres

Problem:
The hybrid cloud tombstone cascade keeps "row" and "tombstone" watermarks per foreign key field. The row watermark walks the model table, and the tombstone watermark walks the tombstone table. A field whose model table has no rows is a cheap walk on the row side because the batch is empty. The tombstone side is not. Its watermark starts at zero, so it walks the whole tombstone range from the bottom, joining each step against a table that holds nothing.

tldr; every time we add a new hybrid cloud foreign key, we have to traverse the whole tombstone table batch by batch, and since we don't have tombstone pruning this gets worse over time.

Fix
Ask whether the model table holds any row. If it does not, set the watermark straight to the current maximum id of the tombstone table and return without scanning a batch.

Notes:
- emptiness question goes to `model._base_manager`, not `model.objects` because some tables hide rows behind their default manager.

Refs INFRENG-558