### PR TITLE
perf(crons): Prefetch some queries in clock tasks consumer

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MarkMissing
 
 from sentry.constants import ObjectStatus
+from sentry.monitors.clock_tasks.prefetch import ClockTaskPrefetch
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.logic.monitor_environment import update_monitor_environment
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment, MonitorStatus
@@ -81,8 +82,21 @@ def dispatch_check_missing(ts: datetime) -> None:
         produce_task(payload)
 
 
-def mark_environment_missing(monitor_environment_id: int, ts: datetime) -> None:
+def mark_environment_missing(
+    monitor_environment_id: int, ts: datetime, prefetch: ClockTaskPrefetch | None = None
+) -> None:
     logger.info("mark_missing", extra={"monitor_environment_id": monitor_environment_id})
+
+    if prefetch is not None:
+        monitor_environment = prefetch.monitor_environments.get(monitor_environment_id)
+        # Mirrors the next_checkin_latest filter in the query below.
+        if (
+            monitor_environment is None
+            or monitor_environment.next_checkin_latest is None
+            or monitor_environment.next_checkin_latest > ts
+        ):
+            return None
+        return _mark_environment_missing(monitor_environment, ts)
 
     try:
         monitor_environment = MonitorEnvironment.objects.select_related("monitor").get(
@@ -100,6 +114,10 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime) -> None:
         # (or the environment was deleted)
         return None
 
+    return _mark_environment_missing(monitor_environment, ts)
+
+
+def _mark_environment_missing(monitor_environment: MonitorEnvironment, ts: datetime) -> None:
     monitor = monitor_environment.monitor
     # next_checkin must be set, since detecting this monitor as missed means
     # there must have been an initial user check-in.

--- a/src/sentry/monitors/clock_tasks/check_timeout.py
+++ b/src/sentry/monitors/clock_tasks/check_timeout.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from arroyo.backends.kafka import KafkaPayload
 from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MarkTimeout
 
+from sentry.monitors.clock_tasks.prefetch import ClockTaskPrefetch
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.logic.monitor_environment import monitor_has_newer_status_affecting_checkins
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn
@@ -63,16 +64,25 @@ def dispatch_check_timeout(ts: datetime) -> None:
         produce_task(payload)
 
 
-def mark_checkin_timeout(checkin_id: int, ts: datetime) -> None:
+def mark_checkin_timeout(
+    checkin_id: int, ts: datetime, prefetch: ClockTaskPrefetch | None = None
+) -> None:
     logger.info("checkin_timeout", extra={"checkin_id": checkin_id})
 
-    try:
-        checkin: MonitorCheckIn = (
-            MonitorCheckIn.objects.select_related("monitor_environment")
-            .select_related("monitor_environment__monitor")
-            .get(id=checkin_id)
-        )
-    except MonitorCheckIn.DoesNotExist:
+    checkin: MonitorCheckIn | None
+    if prefetch is not None:
+        checkin = prefetch.checkins.get(checkin_id)
+    else:
+        try:
+            checkin = (
+                MonitorCheckIn.objects.select_related("monitor_environment")
+                .select_related("monitor_environment__monitor")
+                .get(id=checkin_id)
+            )
+        except MonitorCheckIn.DoesNotExist:
+            checkin = None
+
+    if checkin is None:
         # The monitor may have been deleted or the timeout may have reached
         # it's retention period (less likely)
         metrics.incr("sentry.monitors.tasks.check_timeout.not_found")
@@ -88,7 +98,15 @@ def mark_checkin_timeout(checkin_id: int, ts: datetime) -> None:
 
     # If the monitor has had any newer OK/ERROR status check-ins than this
     # timeout, then this timeout cannot affect the status of the monitor.
-    if monitor_has_newer_status_affecting_checkins(monitor_environment, checkin.date_added):
+    if prefetch is not None:
+        has_newer = prefetch.has_newer_status_affecting_checkin(
+            monitor_environment.id, checkin.date_added
+        )
+    else:
+        has_newer = monitor_has_newer_status_affecting_checkins(
+            monitor_environment, checkin.date_added
+        )
+    if has_newer:
         return
 
     # Similar to mark_missed we compute when the most recent check-in should

--- a/src/sentry/monitors/clock_tasks/prefetch.py
+++ b/src/sentry/monitors/clock_tasks/prefetch.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from django.db.models import OuterRef, Subquery
+from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MonitorsClockTasks
+
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment
+
+
+@dataclass
+class ClockTaskPrefetch:
+    """Reads bulk-loaded for an entire batch of clock tasks."""
+
+    checkins: dict[int, MonitorCheckIn] = field(default_factory=dict)
+    """Check-ins referenced by mark_timeout tasks, by id."""
+
+    monitor_environments: dict[int, MonitorEnvironment] = field(default_factory=dict)
+    """Monitor environments referenced by mark_missing tasks, by id."""
+
+    newest_status_affecting: dict[int, datetime] = field(default_factory=dict)
+    """Most recent OK/ERROR check-in per monitor environment."""
+
+    def has_newer_status_affecting_checkin(
+        self, monitor_environment_id: int, timestamp: datetime
+    ) -> bool:
+        newest = self.newest_status_affecting.get(monitor_environment_id)
+        return newest is not None and newest > timestamp
+
+
+def prefetch_clock_tasks(
+    task_mapping: dict[int, list[MonitorsClockTasks]],
+) -> ClockTaskPrefetch:
+    """
+    Bulk-load the reads a batch of clock tasks will need.
+
+    Reads only -- writes stay in the per-environment path, which is ordered.
+    """
+    prefetch = ClockTaskPrefetch()
+
+    canonical_environments: dict[int, MonitorEnvironment] = {}
+    timeout_checkin_ids: set[int] = set()
+    missing_env_ids: set[int] = set()
+
+    for monitor_environment_id, tasks in task_mapping.items():
+        for task in tasks:
+            if task["type"] == "mark_timeout":
+                timeout_checkin_ids.add(int(task["checkin_id"]))
+            elif task["type"] == "mark_missing":
+                missing_env_ids.add(monitor_environment_id)
+
+    if timeout_checkin_ids:
+        prefetch.checkins = {
+            checkin.id: checkin
+            for checkin in MonitorCheckIn.objects.select_related(
+                "monitor_environment", "monitor_environment__monitor"
+            ).filter(id__in=timeout_checkin_ids)
+        }
+        # Tasks in a group mutate the environment row, so they must share one
+        # instance. `select_related` gives each check-in its own.
+        for checkin in prefetch.checkins.values():
+            canonical = canonical_environments.setdefault(
+                checkin.monitor_environment_id, checkin.monitor_environment
+            )
+            checkin.monitor_environment = canonical
+
+    if prefetch.checkins:
+        env_ids = {checkin.monitor_environment_id for checkin in prefetch.checkins.values()}
+
+        # Safe floor: every date compared later is itself >= this.
+        oldest = min(checkin.date_added for checkin in prefetch.checkins.values())
+
+        newest_checkin = (
+            MonitorCheckIn.objects.filter(
+                monitor_environment_id=OuterRef("id"),
+                status__in=[CheckInStatus.OK, CheckInStatus.ERROR],
+                date_added__gt=oldest,
+            )
+            .order_by("-date_added")
+            .values("date_added")[:1]
+        )
+        prefetch.newest_status_affecting = {
+            environment_id: newest
+            for environment_id, newest in MonitorEnvironment.objects.filter(id__in=env_ids)
+            .annotate(newest=Subquery(newest_checkin))
+            .values_list("id", "newest")
+            if newest is not None
+        }
+
+    if missing_env_ids:
+        from sentry.monitors.clock_tasks.check_missed import IGNORE_MONITORS
+
+        for monitor_environment in MonitorEnvironment.objects.select_related("monitor").filter(
+            IGNORE_MONITORS,
+            id__in=missing_env_ids,
+        ):
+            prefetch.monitor_environments[monitor_environment.id] = (
+                canonical_environments.setdefault(monitor_environment.id, monitor_environment)
+            )
+
+    return prefetch

--- a/src/sentry/monitors/consumers/clock_tasks_consumer.py
+++ b/src/sentry/monitors/consumers/clock_tasks_consumer.py
@@ -22,10 +22,12 @@ from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import (
     MonitorsClockTasks,
 )
 
+from sentry import options
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.monitors.clock_tasks.check_missed import mark_environment_missing
 from sentry.monitors.clock_tasks.check_timeout import mark_checkin_timeout
 from sentry.monitors.clock_tasks.mark_unknown import mark_checkin_unknown
+from sentry.monitors.clock_tasks.prefetch import ClockTaskPrefetch, prefetch_clock_tasks
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.tracing import start_span
@@ -47,13 +49,15 @@ def is_mark_missing(wrapper: MonitorsClockTasks) -> TypeGuard[MarkMissing]:
     return wrapper["type"] == "mark_missing"
 
 
-def dispatch_clock_task(wrapper: MonitorsClockTasks) -> None:
+def dispatch_clock_task(
+    wrapper: MonitorsClockTasks, prefetch: ClockTaskPrefetch | None = None
+) -> None:
     """Execute a single decoded clock task."""
     try:
         ts = datetime.fromtimestamp(wrapper["ts"], tz=timezone.utc)
 
         if is_mark_timeout(wrapper):
-            mark_checkin_timeout(int(wrapper["checkin_id"]), ts)
+            mark_checkin_timeout(int(wrapper["checkin_id"]), ts, prefetch)
             return
 
         if is_mark_unknown(wrapper):
@@ -61,7 +65,7 @@ def dispatch_clock_task(wrapper: MonitorsClockTasks) -> None:
             return
 
         if is_mark_missing(wrapper):
-            mark_environment_missing(int(wrapper["monitor_environment_id"]), ts)
+            mark_environment_missing(int(wrapper["monitor_environment_id"]), ts, prefetch)
             return
 
         logger.error("Unsupported clock-tick task type: %s", wrapper["type"])
@@ -82,13 +86,15 @@ def process_clock_task(message: Message[KafkaPayload | FilteredPayload]) -> None
     dispatch_clock_task(wrapper)
 
 
-def process_clock_task_group(tasks: list[MonitorsClockTasks]) -> None:
+def process_clock_task_group(
+    tasks: list[MonitorsClockTasks], prefetch: ClockTaskPrefetch | None = None
+) -> None:
     """
     Process a group of clock tasks for the same monitor environment completely
     serially.
     """
     for wrapper in tasks:
-        dispatch_clock_task(wrapper)
+        dispatch_clock_task(wrapper, prefetch)
 
 
 def process_clock_task_batch(
@@ -132,8 +138,24 @@ def process_clock_task_batch(
         name="monitors.clock_tasks_consumer",
         transaction=True,
     ):
+        # Bulk-load across the batch, before groups fan out. On failure tasks
+        # fall back to their own reads rather than losing the batch.
+        prefetch: ClockTaskPrefetch | None = None
+        if options.get("crons.clock_tasks.prefetch_batch"):
+            try:
+                with start_span(op="prefetch", name="monitors.clock_tasks_consumer"):
+                    prefetch = prefetch_clock_tasks(task_mapping)
+            except Exception:
+                logger.exception("Failed to prefetch clock task batch")
+                prefetch = None
+            metrics.incr(
+                "monitors.clock_tasks.prefetch",
+                tags={"result": "miss" if prefetch is None else "hit"},
+            )
+
         futures = [
-            executor.submit(process_clock_task_group, group) for group in task_mapping.values()
+            executor.submit(process_clock_task_group, group, prefetch)
+            for group in task_mapping.values()
         ]
         wait(futures)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2720,6 +2720,15 @@ register(
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enables bulk-loading the reads a batch of clock tasks needs before fanning
+# out to the thread pool, instead of each task issuing its own. Only has an
+# effect when the clock tasks consumer runs in batched-parallel mode.
+register(
+    "crons.clock_tasks.prefetch_batch",
+    default=False,
+    flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Enables recording tick volume metrics and tick decisions based on those
 # metrics. Decisions are used to delay notifications in a system incident.
 register(

--- a/tests/sentry/monitors/consumers/test_clock_tasks_consumer.py
+++ b/tests/sentry/monitors/consumers/test_clock_tasks_consumer.py
@@ -1,6 +1,7 @@
 import time
 from collections.abc import Callable, Mapping
 from concurrent.futures import Future
+from contextlib import ExitStack
 from datetime import UTC, datetime, timedelta
 from typing import Any, TypeVar
 from unittest import mock
@@ -9,6 +10,8 @@ import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.types import BrokerValue, Message, Partition, Topic
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from sentry_kafka_schemas.schema_types.monitors_clock_tasks_v1 import MonitorsClockTasks
 
@@ -20,9 +23,15 @@ from sentry.monitors.models import (
     CheckInStatus,
     MonitorCheckIn,
     MonitorEnvironment,
+    MonitorIncident,
     MonitorStatus,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+
+# The batched-parallel path bulk-loads from the database before fanning out,
+# so even tests that mock the task functions need database access.
+pytestmark = pytest.mark.django_db(databases=["default", "secondary"])
 
 partition = Partition(Topic("test"), 0)
 
@@ -92,7 +101,7 @@ def test_dispatch_mark_missing(mock_mark_environment_missing: mock.MagicMock, mo
     flush(consumer)
 
     assert mock_mark_environment_missing.call_count == 1
-    assert mock_mark_environment_missing.mock_calls[0] == mock.call(1, ts)
+    assert mock_mark_environment_missing.mock_calls[0] == mock.call(1, ts, mock.ANY)
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
@@ -114,7 +123,7 @@ def test_dispatch_mark_timeout(mock_mark_checkin_timeout: mock.MagicMock, mode: 
     flush(consumer)
 
     assert mock_mark_checkin_timeout.call_count == 1
-    assert mock_mark_checkin_timeout.mock_calls[0] == mock.call(1, ts)
+    assert mock_mark_checkin_timeout.mock_calls[0] == mock.call(1, ts, mock.ANY)
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
@@ -218,7 +227,7 @@ def test_offsets_commit_only_after_every_group_finishes(
     finished_groups: list[int] = []
     groups_finished_at_commit: list[int] = []
 
-    def slow_group(tasks: list[MonitorsClockTasks]) -> None:
+    def slow_group(tasks: list[MonitorsClockTasks], prefetch: Any = None) -> None:
         time.sleep(0.05)
         finished_groups.append(len(tasks))
 
@@ -271,8 +280,8 @@ def test_failed_task_does_not_stop_the_batch(
     # Every task was attempted. A failure aborted neither the rest of its own
     # group nor the other group in the batch.
     assert mock_mark_environment_missing.call_count == 3
-    assert mock.call(1, TASK_TS) in mock_mark_environment_missing.mock_calls
-    assert mock.call(2, TASK_TS) in mock_mark_environment_missing.mock_calls
+    assert mock.call(1, TASK_TS, mock.ANY) in mock_mark_environment_missing.mock_calls
+    assert mock.call(2, TASK_TS, mock.ANY) in mock_mark_environment_missing.mock_calls
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
@@ -298,7 +307,7 @@ def test_undecodable_message_is_skipped(
     flush(consumer)
 
     assert mock_mark_environment_missing.call_count == 1
-    assert mock_mark_environment_missing.mock_calls[0] == mock.call(1, ts)
+    assert mock_mark_environment_missing.mock_calls[0] == mock.call(1, ts, mock.ANY)
 
 
 T = TypeVar("T")
@@ -443,3 +452,341 @@ class MonitorClockTasksConsumerOrderingTest(TestCase):
             ).exists()
             monitor_environment.refresh_from_db()
             assert monitor_environment.status == MonitorStatus.ERROR
+
+    def test_newer_checkin_guard_is_per_checkin_not_per_batch(self) -> None:
+        """
+        A timeout is ignored when the environment has a newer OK/ERROR check-in.
+
+        The batched path bulk-loads the newest status-affecting check-in per
+        environment using a single scan floor for the whole batch. That floor
+        must not leak across environments: the comparison stays per check-in.
+        """
+        ts = timezone.now().replace(second=0, microsecond=0)
+
+        # Superseded by a later OK check-in. Also sets the batch scan floor.
+        superseded = self._create_monitor_environment(ts, "superseded")
+        superseded_checkin = MonitorCheckIn.objects.create(
+            project_id=superseded.monitor.project_id,
+            monitor=superseded.monitor,
+            monitor_environment=superseded,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=ts - timedelta(minutes=30),
+        )
+        MonitorCheckIn.objects.create(
+            project_id=superseded.monitor.project_id,
+            monitor=superseded.monitor,
+            monitor_environment=superseded,
+            status=CheckInStatus.OK,
+            date_added=ts - timedelta(minutes=20),
+        )
+
+        # Still failing, and well after the floor set above.
+        failing = self._create_monitor_environment(ts, "still-failing")
+        failing_checkin = MonitorCheckIn.objects.create(
+            project_id=failing.monitor.project_id,
+            monitor=failing.monitor,
+            monitor_environment=failing,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=ts - timedelta(minutes=5),
+        )
+
+        # The discriminating case: has an OK check-in, but older than the
+        # timed-out one. Comparing against the batch floor would miss this.
+        stale_ok = self._create_monitor_environment(ts, "stale-ok")
+        MonitorCheckIn.objects.create(
+            project_id=stale_ok.monitor.project_id,
+            monitor=stale_ok.monitor,
+            monitor_environment=stale_ok,
+            status=CheckInStatus.OK,
+            date_added=ts - timedelta(minutes=25),
+        )
+        stale_ok_checkin = MonitorCheckIn.objects.create(
+            project_id=stale_ok.monitor.project_id,
+            monitor=stale_ok.monitor,
+            monitor_environment=stale_ok,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=ts - timedelta(minutes=10),
+        )
+
+        consumer = create_consumer("batched-parallel", {"max_batch_size": 3, "max_workers": 4})
+        for offset, checkin in enumerate(
+            (superseded_checkin, failing_checkin, stale_ok_checkin), start=1
+        ):
+            send_task(
+                consumer,
+                ts,
+                {
+                    "type": "mark_timeout",
+                    "ts": ts.timestamp(),
+                    "monitor_environment_id": checkin.monitor_environment_id,
+                    "checkin_id": checkin.id,
+                },
+                offset=offset,
+            )
+        flush(consumer)
+
+        # All rows are timed out regardless
+        for checkin in (superseded_checkin, failing_checkin, stale_ok_checkin):
+            checkin.refresh_from_db()
+            assert checkin.status == CheckInStatus.TIMEOUT
+
+        # ...but only the one with nothing newer affects monitor status
+        superseded.refresh_from_db()
+        failing.refresh_from_db()
+        stale_ok.refresh_from_db()
+        assert superseded.status == MonitorStatus.OK
+        assert failing.status == MonitorStatus.ERROR
+        assert stale_ok.status == MonitorStatus.ERROR
+
+    @override_options({"crons.clock_tasks.prefetch_batch": True})
+    @mock.patch(
+        "sentry.monitors.consumers.clock_tasks_consumer.prefetch_clock_tasks",
+        side_effect=Exception("boom"),
+    )
+    def test_batch_still_processes_when_prefetch_fails(self, mock_prefetch: mock.MagicMock) -> None:
+        """
+        A failed prefetch must not lose the batch.
+
+        Every task can fall back to issuing its own reads, so a transient read
+        error degrades throughput rather than dropping work.
+        """
+        ts = timezone.now().replace(second=0, microsecond=0)
+        monitor_environment = self._create_monitor_environment(ts, "prefetch-fails")
+
+        consumer = create_consumer("batched-parallel", {"max_batch_size": 1, "max_workers": 2})
+        send_task(
+            consumer,
+            ts,
+            {
+                "type": "mark_missing",
+                "ts": ts.timestamp(),
+                "monitor_environment_id": monitor_environment.id,
+            },
+            offset=1,
+        )
+        flush(consumer)
+
+        assert mock_prefetch.call_count == 1
+
+        # The miss was still recorded via the per-task fallback
+        assert MonitorCheckIn.objects.filter(
+            monitor_environment=monitor_environment, status=CheckInStatus.MISSED
+        ).exists()
+        monitor_environment.refresh_from_db()
+        assert monitor_environment.status == MonitorStatus.ERROR
+
+    def test_multiple_timeouts_in_one_group_judged_individually(self) -> None:
+        """
+        Several timeouts for the SAME environment share one group, and the
+        batched path answers all of them from a single loaded value.
+
+        That value is the newest OK/ERROR check-in; each task must still be
+        judged against its own date_added, so one can be superseded while
+        another is not.
+        """
+        ts = timezone.now().replace(second=0, microsecond=0)
+        monitor_environment = self._create_monitor_environment(ts, "two-timeouts")
+
+        # Superseded: an OK check-in landed after it
+        older = MonitorCheckIn.objects.create(
+            project_id=monitor_environment.monitor.project_id,
+            monitor=monitor_environment.monitor,
+            monitor_environment=monitor_environment,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=ts - timedelta(minutes=60),
+        )
+        MonitorCheckIn.objects.create(
+            project_id=monitor_environment.monitor.project_id,
+            monitor=monitor_environment.monitor,
+            monitor_environment=monitor_environment,
+            status=CheckInStatus.OK,
+            date_added=ts - timedelta(minutes=40),
+        )
+        # Not superseded: nothing OK/ERROR after it
+        newer = MonitorCheckIn.objects.create(
+            project_id=monitor_environment.monitor.project_id,
+            monitor=monitor_environment.monitor,
+            monitor_environment=monitor_environment,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=ts - timedelta(minutes=20),
+        )
+
+        consumer = create_consumer("batched-parallel", {"max_batch_size": 2, "max_workers": 4})
+        for offset, checkin in enumerate((older, newer), start=1):
+            send_task(
+                consumer,
+                ts,
+                {
+                    "type": "mark_timeout",
+                    "ts": ts.timestamp(),
+                    "monitor_environment_id": monitor_environment.id,
+                    "checkin_id": checkin.id,
+                },
+                offset=offset,
+            )
+        flush(consumer)
+
+        for checkin in (older, newer):
+            checkin.refresh_from_db()
+            assert checkin.status == CheckInStatus.TIMEOUT
+
+        # The un-superseded one drove the incident. A single shared answer
+        # for the group would not produce this.
+        monitor_environment.refresh_from_db()
+        assert monitor_environment.status == MonitorStatus.ERROR
+
+    def test_mixed_tasks_for_one_environment_share_state(self) -> None:
+        """
+        A timeout and a miss for the SAME environment land in one batch and one
+        group. The first mutates the environment row; the second must observe
+        that, not a stale copy of it.
+        """
+        ts = timezone.now().replace(second=0, microsecond=0)
+        monitor_environment = self._create_monitor_environment(ts, "mixed-monitor")
+
+        checkin = MonitorCheckIn.objects.create(
+            project_id=monitor_environment.monitor.project_id,
+            monitor=monitor_environment.monitor,
+            monitor_environment=monitor_environment,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=ts - timedelta(minutes=5),
+        )
+
+        consumer = create_consumer("batched-parallel", {"max_batch_size": 2, "max_workers": 4})
+        send_task(
+            consumer,
+            ts,
+            {
+                "type": "mark_timeout",
+                "ts": ts.timestamp(),
+                "monitor_environment_id": monitor_environment.id,
+                "checkin_id": checkin.id,
+            },
+            offset=1,
+        )
+        send_task(
+            consumer,
+            ts,
+            {
+                "type": "mark_missing",
+                "ts": ts.timestamp(),
+                "monitor_environment_id": monitor_environment.id,
+            },
+            offset=2,
+        )
+        flush(consumer)
+
+        checkin.refresh_from_db()
+        assert checkin.status == CheckInStatus.TIMEOUT
+
+        # The miss was still recorded, and the environment ended in an incident
+        assert MonitorCheckIn.objects.filter(
+            monitor_environment=monitor_environment, status=CheckInStatus.MISSED
+        ).exists()
+
+        monitor_environment.refresh_from_db()
+        assert monitor_environment.status == MonitorStatus.ERROR
+
+        # Exactly one open incident, not one per task
+        assert (
+            MonitorIncident.objects.filter(
+                monitor_environment=monitor_environment, resolving_checkin=None
+            ).count()
+            == 1
+        )
+
+    @override_options({"crons.clock_tasks.prefetch_batch": True})
+    def test_timeout_reads_do_not_scale_with_batch_size(self) -> None:
+        """
+        Per-task reads are bulk-loaded once for the whole batch, so the query
+        cost per message must fall as the batch grows.
+
+        Without the prefetch each mark_timeout issues its own check-in fetch,
+        status write and "newer status-affecting check-in" existence check,
+        which measures at a flat ~4 queries per message no matter the batch
+        size. Bulk-loading the two reads brings that to ~2.
+        """
+        ts = timezone.now().replace(second=0, microsecond=0)
+
+        def run(count: int, label: str) -> float:
+            checkins = []
+            for i in range(count):
+                monitor_environment = self._create_monitor_environment(ts, f"{label}-{i}")
+                # Already in an incident, which is the state a backlogged
+                # monitor is in by the time its timeouts are processed.
+                MonitorEnvironment.objects.filter(id=monitor_environment.id).update(
+                    status=MonitorStatus.ERROR
+                )
+                checkins.append(
+                    MonitorCheckIn.objects.create(
+                        project_id=monitor_environment.monitor.project_id,
+                        monitor=monitor_environment.monitor,
+                        monitor_environment=monitor_environment,
+                        status=CheckInStatus.IN_PROGRESS,
+                        date_added=ts - timedelta(minutes=5),
+                    )
+                )
+
+            consumer = create_consumer(
+                "batched-parallel", {"max_batch_size": count, "max_workers": 4}
+            )
+            with ExitStack() as stack:
+                captured = [
+                    stack.enter_context(CaptureQueriesContext(connections[alias]))
+                    for alias in connections
+                ]
+                for offset, checkin in enumerate(checkins, start=1):
+                    send_task(
+                        consumer,
+                        ts,
+                        {
+                            "type": "mark_timeout",
+                            "ts": ts.timestamp(),
+                            "monitor_environment_id": checkin.monitor_environment_id,
+                            "checkin_id": checkin.id,
+                        },
+                        offset=offset,
+                    )
+                flush(consumer)
+                queries = sum(len(capture) for capture in captured)
+
+            # The work really happened
+            assert (
+                MonitorCheckIn.objects.filter(
+                    id__in=[checkin.id for checkin in checkins],
+                    status=CheckInStatus.TIMEOUT,
+                ).count()
+                == count
+            )
+            return queries / count
+
+        small = run(4, "timeout-small")
+        large = run(16, "timeout-large")
+
+        # Amortising the bulk loads means a bigger batch costs less per message
+        assert large < small, f"queries per message did not improve: {small} -> {large}"
+
+        # Under the ~4/message the unbatched path costs. What remains is the
+        # status UPDATE and `active_incident`, which this does not touch.
+        assert large < 3, f"{large} queries per message"
+
+
+@mock.patch(
+    "sentry.monitors.consumers.clock_tasks_consumer.ContextPropagatingThreadPoolExecutor",
+    InlineExecutor,
+)
+class MonitorClockTasksConsumerOrderingPrefetchTest(MonitorClockTasksConsumerOrderingTest):
+    """
+    The same end-to-end coverage with the batch prefetch enabled.
+
+    Bulk-loading must not change any observable behaviour, so the entire
+    ordering suite is re-run against it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # `override_options` is a context manager, decorating the class with it
+        # would replace the class and stop pytest collecting it.
+        overridden = override_options({"crons.clock_tasks.prefetch_batch": True})
+        overridden.__enter__()
+        self.addCleanup(overridden.__exit__, None, None, None)


### PR DESCRIPTION
When we're backlogged we are making a lot of queries here attempting to catch up. We can instead preload a bunch of them for the batch and pass them along.

<!-- Describe your PR here. -->