### PR TITLE
fix(issues): Route suspect commit detection per project

### DIFF
--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -191,7 +191,7 @@ def _create_commit_from_blame(
             commitMessage=commit.get("message"),
             commitAuthorName=commit.get("author_name"),
             commitAuthorEmail=commit.get("author_email"),
-            committedDate=datetime.fromisoformat(committed_date).astimezone(timezone.utc),
+            committedDate=datetime.fromisoformat(committed_date).replace(tzinfo=timezone.utc),
         )
     except Exception:
         logger.warning("get_blame_for_files.invalid_commit_response", extra=extra)

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -191,7 +191,7 @@ def _create_commit_from_blame(
             commitMessage=commit.get("message"),
             commitAuthorName=commit.get("author_name"),
             commitAuthorEmail=commit.get("author_email"),
-            committedDate=datetime.fromisoformat(committed_date).replace(tzinfo=timezone.utc),
+            committedDate=datetime.fromisoformat(committed_date).astimezone(timezone.utc),
         )
     except Exception:
         logger.warning("get_blame_for_files.invalid_commit_response", extra=extra)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1140,7 +1140,6 @@ def _project_has_usable_code_mapping(project: Project) -> bool:
             organization_integration_id__isnull=False,
             organization_id=project.organization_id,
             project_repository__project_id=project.id,
-            project_repository__repository__integration_id__in=integration_ids,
             project_repository__repository__organization_id=project.organization_id,
             project_repository__repository__status=ObjectStatus.ACTIVE,
         ).exists()

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from google.api_core.exceptions import ServiceUnavailable
 
 from sentry import features, options, projectoptions
+from sentry.constants import ObjectStatus
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -68,6 +69,16 @@ locks = LockManager(
 
 ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 50
 HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT = 200
+COMMIT_CONTEXT_INTEGRATION_PROVIDERS = [
+    IntegrationProviderSlug.GITHUB.value,
+    IntegrationProviderSlug.GITLAB.value,
+    IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+    IntegrationProviderSlug.PERFORCE.value,
+]
+# Keep project mapping changes responsive without querying on every event.
+COMMIT_CONTEXT_PROJECT_CACHE_TIMEOUT = 300
+# Match the previous integration-status cache window for this path.
+COMMIT_CONTEXT_ORG_INTEGRATION_CACHE_TIMEOUT = 14400
 
 
 class PostProcessJob(TypedDict, total=False):
@@ -1091,6 +1102,53 @@ def process_code_mappings(job: PostProcessJob) -> None:
         logger.exception("Failed to process automatic source code config")
 
 
+def _project_has_usable_code_mapping(project: Project) -> bool:
+    from sentry.integrations.models.repository_project_path_config import (
+        RepositoryProjectPathConfig,
+    )
+    from sentry.integrations.services.integration import integration_service
+
+    cache_key = f"commit-context-code-mapping:{project.id}"
+    cached_result = cache.get(cache_key)
+    if cached_result is not None:
+        return bool(cached_result)
+
+    integration_cache_key = f"commit-context-active-scm-integration-ids:{project.organization_id}"
+    integration_ids = cache.get(integration_cache_key)
+    if integration_ids is None:
+        # Integration eligibility is shared by every project in the organization.
+        integration_ids = [
+            integration.id
+            for integration in integration_service.get_integrations(
+                organization_id=project.organization_id,
+                providers=COMMIT_CONTEXT_INTEGRATION_PROVIDERS,
+                status=ObjectStatus.ACTIVE,
+                org_integration_status=ObjectStatus.ACTIVE,
+            )
+        ]
+        cache.set(
+            integration_cache_key,
+            integration_ids,
+            COMMIT_CONTEXT_ORG_INTEGRATION_CACHE_TIMEOUT,
+        )
+
+    # Code mappings and repositories are project-scoped even though integrations are not.
+    has_usable_code_mapping = (
+        bool(integration_ids)
+        and RepositoryProjectPathConfig.objects.filter(
+            integration_id__in=integration_ids,
+            organization_integration_id__isnull=False,
+            organization_id=project.organization_id,
+            project_repository__project_id=project.id,
+            project_repository__repository__integration_id__in=integration_ids,
+            project_repository__repository__organization_id=project.organization_id,
+            project_repository__repository__status=ObjectStatus.ACTIVE,
+        ).exists()
+    )
+    cache.set(cache_key, has_usable_code_mapping, COMMIT_CONTEXT_PROJECT_CACHE_TIMEOUT)
+    return has_usable_code_mapping
+
+
 def process_commits(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
@@ -1099,6 +1157,7 @@ def process_commits(job: PostProcessJob) -> None:
     from sentry.tasks.commit_context import process_commit_context
     from sentry.tasks.groupowner import DEBOUNCE_CACHE_KEY as SUSPECT_COMMITS_DEBOUNCE_CACHE_KEY
     from sentry.tasks.groupowner import process_suspect_commits
+    from sentry.utils.committers import get_frame_paths
 
     event = job["event"]
 
@@ -1109,6 +1168,22 @@ def process_commits(job: PostProcessJob) -> None:
             name="post_process_w_o",
         )
         with lock.acquire():
+            # Git blame can create the Commit row it finds, so it does not require imported commits.
+            if _project_has_usable_code_mapping(event.project):
+                if not job["group_state"]["is_new"]:
+                    return
+
+                process_commit_context.delay(
+                    event_id=event.event_id,
+                    event_platform=event.platform or "",
+                    event_frames=get_frame_paths(event),
+                    group_id=event.group_id,
+                    project_id=event.project_id,
+                    sdk_name=get_sdk_name(event.data),
+                )
+                return
+
+            # The release-based fallback still depends on commits already stored in Sentry.
             has_commit_key = f"w-o:{event.project.organization_id}-h-c"
             org_has_commit = cache.get(has_commit_key)
             if org_has_commit is None:
@@ -1117,57 +1192,21 @@ def process_commits(job: PostProcessJob) -> None:
                 ).exists()
                 cache.set(has_commit_key, org_has_commit, 3600)
 
-            if org_has_commit:
-                from sentry.utils.committers import get_frame_paths
+            if not org_has_commit:
+                return
 
-                event_frames = get_frame_paths(event)
-                sdk_name = get_sdk_name(event.data)
-
-                integration_cache_key = (
-                    f"commit-context-scm-integration:{event.project.organization_id}"
-                )
-                has_integrations = cache.get(integration_cache_key)
-                if has_integrations is None:
-                    from sentry.integrations.services.integration import integration_service
-
-                    org_integrations = integration_service.get_organization_integrations(
-                        organization_id=event.project.organization_id,
-                        providers=[
-                            IntegrationProviderSlug.GITHUB.value,
-                            IntegrationProviderSlug.GITLAB.value,
-                            IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
-                            IntegrationProviderSlug.PERFORCE.value,
-                        ],
-                    )
-                    has_integrations = len(org_integrations) > 0
-                    # Cache the integrations check for 4 hours
-                    cache.set(integration_cache_key, has_integrations, 14400)
-
-                if has_integrations:
-                    if not job["group_state"]["is_new"]:
-                        return
-
-                    process_commit_context.delay(
-                        event_id=event.event_id,
-                        event_platform=event.platform or "",
-                        event_frames=event_frames,
-                        group_id=event.group_id,
-                        project_id=event.project_id,
-                        sdk_name=sdk_name,
-                    )
-                else:
-                    cache_key = SUSPECT_COMMITS_DEBOUNCE_CACHE_KEY(event.group_id)
-                    if cache.get(cache_key):
-                        metrics.incr("sentry.tasks.process_suspect_commits.debounce")
-                        return
-                    process_suspect_commits.delay(
-                        event_id=event.event_id,
-                        event_platform=event.platform,
-                        event_frames=event_frames,
-                        group_id=event.group_id,
-                        project_id=event.project_id,
-                        sdk_name=sdk_name,
-                    )
+            cache_key = SUSPECT_COMMITS_DEBOUNCE_CACHE_KEY(event.group_id)
+            if cache.get(cache_key):
+                metrics.incr("sentry.tasks.process_suspect_commits.debounce")
+                return
+            process_suspect_commits.delay(
+                event_id=event.event_id,
+                event_platform=event.platform,
+                event_frames=get_frame_paths(event),
+                group_id=event.group_id,
+                project_id=event.project_id,
+                sdk_name=get_sdk_name(event.data),
+            )
     except UnableToAcquireLock:
         pass
 

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -483,13 +483,13 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         return f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/{quote(file.path.strip('/'), safe='')}/blame?ref={file.ref}&range[start]={file.lineno}&range[end]={file.lineno}"
 
     def make_blame_response(self, **kwargs) -> list[GitLabFileBlameResponseItem]:
-        # GitLab blame responses preserve the commit's timezone offset.
         return [
             GitLabFileBlameResponseItem(
                 lines=[],
                 commit=GitLabCommitResponse(
                     id=kwargs.get("id", "1"),
                     message=kwargs.get("message", "test message"),
+                    # GitLab blame responses preserve the commit's timezone offset.
                     committed_date=kwargs.get("committed_date", "2023-01-01T05:30:00.000+05:30"),
                     author_name=kwargs.get("author_name", "Marvin"),
                     author_email=kwargs.get("author_email", "marvin@place.com"),

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -483,13 +483,14 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         return f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/{quote(file.path.strip('/'), safe='')}/blame?ref={file.ref}&range[start]={file.lineno}&range[end]={file.lineno}"
 
     def make_blame_response(self, **kwargs) -> list[GitLabFileBlameResponseItem]:
+        # GitLab blame responses preserve the commit's timezone offset.
         return [
             GitLabFileBlameResponseItem(
                 lines=[],
                 commit=GitLabCommitResponse(
                     id=kwargs.get("id", "1"),
                     message=kwargs.get("message", "test message"),
-                    committed_date=kwargs.get("committed_date", "2023-01-01T00:00:00.000Z"),
+                    committed_date=kwargs.get("committed_date", "2023-01-01T05:30:00.000+05:30"),
                     author_name=kwargs.get("author_name", "Marvin"),
                     author_email=kwargs.get("author_email", "marvin@place.com"),
                     committer_email=None,

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -489,8 +489,7 @@ class GitLabBlameForFilesTest(GitLabClientTest):
                 commit=GitLabCommitResponse(
                     id=kwargs.get("id", "1"),
                     message=kwargs.get("message", "test message"),
-                    # GitLab blame responses preserve the commit's timezone offset.
-                    committed_date=kwargs.get("committed_date", "2023-01-01T05:30:00.000+05:30"),
+                    committed_date=kwargs.get("committed_date", "2023-01-01T00:00:00.000Z"),
                     author_name=kwargs.get("author_name", "Marvin"),
                     author_email=kwargs.get("author_email", "marvin@place.com"),
                     committer_email=None,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 
 from sentry import buffer, killswitches
 from sentry.analytics.events.first_flag_sent import FirstFlagSentEvent
+from sentry.constants import ObjectStatus
 from sentry.eventstream.types import EventStreamEventType
 from sentry.feedback.lib.utils import FeedbackCreationSource
 from sentry.integrations.models.integration import Integration
@@ -31,6 +32,7 @@ from sentry.issues.grouptype import (
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.models.activity import Activity, ActivityIntegration
+from sentry.models.commit import Commit
 from sentry.models.environment import Environment
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -1676,16 +1678,61 @@ class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
             )
         ]
 
-    @patch(
-        "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
-        return_value=github_blame_return_value,
-    )
-    def test_logic_fallback_no_scm(self, mock_get_commit_context: MagicMock) -> None:
+    @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
+    @patch("sentry.tasks.commit_context.process_commit_context.delay")
+    def test_release_fallback_when_project_has_no_code_mapping(
+        self,
+        mock_process_commit_context: MagicMock,
+        mock_process_suspect_commits: MagicMock,
+    ) -> None:
+        other_project = self.create_project(organization=self.organization)
+        other_event = self.create_event(
+            data={
+                "message": "Kaboom!",
+                "platform": "python",
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "filename": "sentry/models/release.py",
+                            "in_app": True,
+                            "lineno": 39,
+                        }
+                    ]
+                },
+            },
+            project_id=other_project.id,
+        )
+
+        with patch(
+            "sentry.integrations.services.integration.integration_service.get_integrations",
+            return_value=[Mock(id=self.integration.id)],
+        ) as mock_get_integrations:
+            assert post_process_module._project_has_usable_code_mapping(self.project)
+            assert not post_process_module._project_has_usable_code_mapping(other_project)
+
+        # Projects share the organization-level integration lookup.
+        mock_get_integrations.assert_called_once()
+
+        with self.tasks():
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=other_event,
+            )
+
+        mock_process_commit_context.assert_not_called()
+        mock_process_suspect_commits.assert_called_once()
+
+    @patch("sentry.tasks.groupowner.process_suspect_commits.delay")
+    @patch("sentry.tasks.commit_context.process_commit_context.delay")
+    def test_release_fallback_when_code_mapping_integration_is_inactive(
+        self,
+        mock_process_commit_context: MagicMock,
+        mock_process_suspect_commits: MagicMock,
+    ) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
-            with unguarded_write(using=router.db_for_write(Integration)):
-                Integration.objects.all().delete()
-            integration = self.create_provider_integration(provider="bitbucket")
-            integration.add_organization(self.organization)
+            self.organization_integration.update(status=ObjectStatus.DISABLED)
 
         with self.tasks():
             self.call_post_process_group(
@@ -1695,7 +1742,8 @@ class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
                 event=self.created_event,
             )
 
-        assert not mock_get_commit_context.called
+        mock_process_commit_context.assert_not_called()
+        mock_process_suspect_commits.assert_called_once()
 
     @patch(
         "sentry.integrations.github_enterprise.integration.GitHubEnterpriseIntegration.get_commit_context_all_frames",
@@ -1718,7 +1766,10 @@ class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
         assert organization_integration is not None
 
         self.repo.update(integration_id=integration.id, provider="integrations:github_enterprise")
-        self.code_mapping.update(organization_integration_id=organization_integration.id)
+        self.code_mapping.update(
+            integration_id=integration.id,
+            organization_integration_id=organization_integration.id,
+        )
 
         with self.tasks():
             self.call_post_process_group(
@@ -1757,11 +1808,13 @@ class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
     )
-    def test_does_not_skip_when_is_new(self, mock_get_commit_context: MagicMock) -> None:
-        """
-        Tests that the commit context should be processed when the group is new.
-        """
+    def test_git_blame_when_is_new_without_stored_commits(
+        self, mock_get_commit_context: MagicMock
+    ) -> None:
+        Commit.objects.filter(organization_id=self.organization.id).delete()
+        cache.set(f"w-o:{self.organization.id}-h-c", False, 3600)
         mock_get_commit_context.return_value = self.github_blame_all_files_return_value
+
         with self.tasks():
             self.call_post_process_group(
                 is_new=True,
@@ -1769,7 +1822,9 @@ class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
                 is_new_group_environment=True,
                 event=self.created_event,
             )
+
         assert mock_get_commit_context.called
+        assert Commit.objects.filter(key="asdfwreqr").exists()
         assert GroupOwner.objects.get(
             group=self.created_event.group,
             project=self.created_event.project,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1703,6 +1703,8 @@ class ProcessCommitsTestMixin(BasePostProcessGroupMixin):
             project_id=other_project.id,
         )
 
+        # Blame uses the integration on the mapping, not the repository.
+        self.repo.update(integration_id=None)
         with patch(
             "sentry.integrations.services.integration.integration_service.get_integrations",
             return_value=[Mock(id=self.integration.id)],


### PR DESCRIPTION
**About 50,000 organizations have 136,000 recently active projects routed to Git blame without a usable project code mapping.**

Suspect commit routing was decided at the organization level. If any project in an organization had a supported SCM integration, every project in that organization was sent through Git blame. Projects without their own code mapping could not produce blame results, but they also never reached the release-based fallback.

This moves the decision to the project. Git blame is used only when that project has a usable code mapping backed by an active repository and integration. Other projects continue through release-based suspect commit detection.

Git blame is also no longer gated on an existing Commit row, since it can create one from the blame response. Integration eligibility remains cached per organization for four hours, while the project mapping check is cached separately for five minutes.

[Redash impact query](https://redash.getsentry.net/queries/11959/source)