### PR TITLE
fix(issues): Carry `received` into buffered-spans occurrences

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -114,6 +114,9 @@ def create_event(project_id: int, event_id: str, event_data: dict[str, Any]) -> 
     return Event(
         event_id=event_id,
         project_id=project_id,
+        # `snuba_data` only backs the `Event` property accessors. The eventstream serializes
+        # `event.data`, where the `generic-events` schema requires `received`.
+        data={"received": event_data["received"]},
         snuba_data={
             "event_id": event_data["event_id"],
             "project_id": event_data["project_id"],
@@ -121,8 +124,8 @@ def create_event(project_id: int, event_id: str, event_data: dict[str, Any]) -> 
             "release": event_data.get("release"),
             "environment": event_data.get("environment"),
             "platform": event_data.get("platform"),
-            "tags.key": [tag[0] for tag in event_data.get("tags", [])],
-            "tags.value": [tag[1] for tag in event_data.get("tags", [])],
+            "tags.key": [tag[0] for tag in event_data.get("tags") or []],
+            "tags.value": [tag[1] for tag in event_data.get("tags") or []],
         },
     )
 
@@ -258,7 +261,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "level": occurrence_data["level"],
                     "project_id": event_payload.get("project_id"),
                     "platform": event_payload.get("platform"),
-                    "received": event_payload.get("received", timezone.now().isoformat()),
+                    "received": event_payload.get("received") or timezone.now().isoformat(),
                     "tags": event_payload.get("tags"),
                     "timestamp": event_payload.get("timestamp"),
                 }

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -24,6 +24,7 @@ from sentry.issues.occurrence_consumer import (
 )
 from sentry.issues.producer import _prepare_status_change_message
 from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.ratelimits.sliding_windows import Quota
@@ -307,6 +308,51 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert rate_limit_quota.window_seconds == 3600
         assert rate_limit_quota.granularity_seconds == 60
         assert rate_limit_quota.limit == 1000
+
+
+class IssueOccurrenceBufferedSpansTest(IssueOccurrenceTestBase):
+    """Occurrences from the span segment processor never get saved to nodestore, so the eventstream
+    payload has to be built entirely from the event data on the message.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Nothing on this path saves an event, so the default environment is never created for us
+        Environment.get_or_create(self.project, None)
+
+    def run_buffered_spans_message(self, **event_overrides: Any) -> dict[str, Any]:
+        message = get_test_message(self.project.id, is_buffered_spans=True)
+        message["event"].update(event_overrides)
+
+        with mock.patch("sentry.issues.ingest.eventstream.backend.insert") as mock_insert:
+            with self.feature("organizations:profile-file-io-main-thread-ingest"):
+                result = _process_message(message)
+
+        assert result is not None
+        assert mock_insert.call_count == 1
+        group_event = mock_insert.call_args.kwargs["event"]
+        return dict(group_event.get_raw_data(for_stream=True))
+
+    @django_db_all
+    def test_received_reaches_the_eventstream(self) -> None:
+        received = before_now(minutes=1)
+        stream_data = self.run_buffered_spans_message(received=received.isoformat())
+
+        assert stream_data["received"] == pytest.approx(received.timestamp())
+
+    @django_db_all
+    def test_received_reaches_the_eventstream_when_sent_as_a_timestamp(self) -> None:
+        received = before_now(minutes=1).timestamp()
+        stream_data = self.run_buffered_spans_message(received=received)
+
+        assert stream_data["received"] == pytest.approx(received)
+
+    @django_db_all
+    @freeze_time()
+    def test_null_received_falls_back_to_now(self) -> None:
+        stream_data = self.run_buffered_spans_message(received=None)
+
+        assert stream_data["received"] == pytest.approx(datetime.datetime.now().timestamp())
 
 
 class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):


### PR DESCRIPTION
Occurrences from the span segment processor are produced with `is_buffered_spans=True`, which routes them to `create_event_and_issue_occurrence`. That builds a lightweight `Event` with only `snuba_data` populated, so `event.data` falls back to an empty nodestore lookup. The eventstream serializes `event.data` into the payload's `data` field, and `generic-events.v1` requires `received` there, so these messages were rejected.

The value was available the whole time though, `build_shim_event_data` sets it from the segment span, and the consumer preserves it, `create_event` just didn't propagate it. Pass it through as the event's `data`, which also means the payload no longer needs a nodestore read that always misses.

`_get_kwargs` used `.get(key, default)`, which doesn't fire the default when `received` is present but null (event schema allows this). Switch to `or` so the fallback applies, same for `tags`.