### PR TITLE
feat(control) Add the ability to cache multi-parameter RPC calls

### DIFF
--- a/src/sentry/hybridcloud/rpc/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/caching/service.py
@@ -3,8 +3,10 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 import abc
+import hashlib
+import re
 from collections.abc import Callable, Generator, Mapping
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, TypeVarTuple
 
 import pydantic
 
@@ -40,21 +42,37 @@ class CellCachingService(RpcService):
 
 
 _R = TypeVar("_R", bound=pydantic.BaseModel)
+_Params = TypeVarTuple("_Params")
+
+# Cache keys are stored in ``CacheVersionBase.key``, a varchar(64). Keys longer than
+# this raise a DataError when a version row is created during cache invalidation.
+MAX_CACHE_KEY_LENGTH = 64
+
+# We can go as low as 16 bytes of md5 without risking collisions
+MAX_BASE_KEY_LENGTH = MAX_CACHE_KEY_LENGTH - 16
+
+# Memcached rejects whitespace and control characters in keys, so any parameter
+# encoding containing them has to be hashed rather than used verbatim.
+_UNSAFE_KEY_CHARS = re.compile(r"[^\x21-\x7e]")
 
 
-class SiloCacheBackedCallable(Generic[_R]):
+class SiloCacheBackedCallable(Generic[*_Params, _R]):
     """
     Get a single record from cache or wrapped function.
 
     When cache read returns no data, the wrapped function will be
     invoked. The result of the wrapped function is then stored in cache.
 
-    Ideal for 'get by id' style methods
+    Ideal for 'get by id' style methods.
+
+    Cache keys vary based on the parameters, so all parameters must be JSON
+    serializable. Parameters that don't fit in the remaining key budget, or that
+    contain characters memcached rejects, are hashed instead.
     """
 
     silo_mode: SiloMode
     base_key: str
-    cb: Callable[[int], _R | None]
+    cb: Callable[[*_Params], _R | None]
     type_: type[_R]
     timeout: int | None
 
@@ -62,33 +80,56 @@ class SiloCacheBackedCallable(Generic[_R]):
         self,
         base_key: str,
         silo_mode: SiloMode,
-        cb: Callable[[int], _R | None],
+        cb: Callable[[*_Params], _R | None],
         t: type[_R],
         timeout: int | None = None,
     ):
+        if len(base_key) > MAX_BASE_KEY_LENGTH:
+            raise ValueError(
+                f"base_key {base_key!r} is {len(base_key)} characters; it must be at most "
+                f"{MAX_BASE_KEY_LENGTH} so that hashed parameters fit within the "
+                f"{MAX_CACHE_KEY_LENGTH} character CacheVersion.key column"
+            )
         self.base_key = base_key
         self.silo_mode = silo_mode
         self.cb = cb
         self.type_ = t
         self.timeout = timeout
 
-    def __call__(self, object_id: int) -> _R | None:
+    def __call__(self, *args: *_Params) -> _R | None:
         if (
             SiloMode.get_current_mode() != self.silo_mode
             and SiloMode.get_current_mode() != SiloMode.MONOLITH
         ):
-            return self.cb(object_id)
-        return self.get_one(object_id)
+            return self.cb(*args)
+        return self.get_one(*args)
 
-    def key_from(self, object_id: int) -> str:
-        return f"{self.base_key}:{object_id}"
+    def key_from(self, *args: *_Params) -> str:
+        """
+        Generate a cache key for this call.
+        Keys must fit within CacheVersion.key column, and not contain whitespace.
+        """
+        # Preserve compatibility with historical cache keys
+        if len(args) == 1:
+            arg_str = str(args[0])
+        else:
+            arg_str = json.dumps(args)
+
+        # Replace parameters that would overflow the key column, or that memcached
+        # would reject, with a digest of the same parameters.
+        if len(arg_str) + len(self.base_key) > MAX_CACHE_KEY_LENGTH or _UNSAFE_KEY_CHARS.search(
+            arg_str
+        ):
+            arg_str = hashlib.md5(arg_str.encode("utf-8")).hexdigest()
+
+        return f"{self.base_key}:{arg_str}"[:MAX_CACHE_KEY_LENGTH]
 
     def resolve_from(
-        self, i: int, values: Mapping[str, int | str]
+        self, values: Mapping[str, int | str], *args: *_Params
     ) -> Generator[None, None, _R | None]:
         from .impl import _consume_generator, _delete_cache, _set_cache
 
-        key = self.key_from(i)
+        key = self.key_from(*args)
         value = values[key]
         version: int
         if isinstance(value, str):
@@ -101,17 +142,17 @@ class SiloCacheBackedCallable(Generic[_R]):
             version = value
 
         metrics.incr("hybridcloud.caching.one.rpc", tags={"base_key": self.base_key})
-        r = self.cb(i)
+        r = self.cb(*args)
         if r is not None:
             _consume_generator(_set_cache(key, r.json(), version, self.timeout))
         return r
 
-    def get_one(self, object_id: int) -> _R | None:
+    def get_one(self, *args: *_Params) -> _R | None:
         from .impl import _consume_generator, _get_cache
 
-        key = self.key_from(object_id)
+        key = self.key_from(*args)
         values = _consume_generator(_get_cache([key], self.silo_mode))
-        return _consume_generator(self.resolve_from(object_id, values))
+        return _consume_generator(self.resolve_from(values, *args))
 
 
 class SiloCacheBackedListCallable(Generic[_R]):
@@ -287,7 +328,7 @@ class SiloCacheManyBackedCallable(Generic[_R]):
 
 def back_with_silo_cache(
     base_key: str, silo_mode: SiloMode, t: type[_R], timeout: int | None = None
-) -> Callable[[Callable[[int], _R | None]], "SiloCacheBackedCallable[_R]"]:
+) -> Callable[[Callable[[*_Params], _R | None]], "SiloCacheBackedCallable[*_Params, _R]"]:
     """
     Decorator for adding local caching to RPC operations on a single record.
 
@@ -300,7 +341,7 @@ def back_with_silo_cache(
     See user_service.get_user() for an example usage.
     """
 
-    def wrapper(cb: Callable[[int], _R | None]) -> "SiloCacheBackedCallable[_R]":
+    def wrapper(cb: Callable[[*_Params], _R | None]) -> "SiloCacheBackedCallable[*_Params, _R]":
         return SiloCacheBackedCallable(base_key, silo_mode, cb, t, timeout)
 
     return wrapper

--- a/src/sentry/hybridcloud/rpc/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/caching/service.py
@@ -111,13 +111,13 @@ class SiloCacheBackedCallable(Generic[*_Params, _R]):
         """
         # Preserve compatibility with historical cache keys
         if len(args) == 1:
-            arg_str = str(args[0])
+            arg_str = str(args[0])  # type: ignore[misc]
         else:
             arg_str = json.dumps(args)
 
         # Replace parameters that would overflow the key column, or that memcached
-        # would reject, with a digest of the same parameters.
-        if len(arg_str) + len(self.base_key) > MAX_CACHE_KEY_LENGTH or _UNSAFE_KEY_CHARS.search(
+        # would reject, with a digest of the same parameters. Add 1 for the :
+        if len(arg_str) + len(self.base_key) + 1 > MAX_CACHE_KEY_LENGTH or _UNSAFE_KEY_CHARS.search(
             arg_str
         ):
             arg_str = hashlib.md5(arg_str.encode("utf-8")).hexdigest()

--- a/tests/sentry/hybridcloud/rpc/test_caching.py
+++ b/tests/sentry/hybridcloud/rpc/test_caching.py
@@ -71,6 +71,26 @@ def get_active_user(user_id: int, is_active: bool) -> RpcUser | None:
     return None
 
 
+@back_with_silo_cache(
+    base_key="this-base-key-is-quite-long-and-will-overflow", silo_mode=SiloMode.CELL, t=RpcUser
+)
+def get_active_user_long_basekey(user_id: int, is_active: bool) -> RpcUser | None:
+    results = user_service.get_many(filter=dict(user_ids=[user_id], is_active=is_active))
+    if len(results):
+        return results[0]
+    return None
+
+
+@back_with_silo_cache(
+    base_key="this-base-key-is-32-chars-loonng", silo_mode=SiloMode.CELL, t=RpcUser
+)
+def get_active_user_equal(user_id: int, padding: str) -> RpcUser | None:
+    results = user_service.get_many(filter=dict(user_ids=[user_id]))
+    if len(results):
+        return results[0]
+    return None
+
+
 @django_db_all(transaction=True)
 def test_caching_function_multiple_parameters() -> None:
     cache.clear()
@@ -102,6 +122,38 @@ def test_caching_function_multiple_parameters() -> None:
 
     assert get_active_user.key_from(user.id, True) != get_active_user.key_from(user.id, False)
     assert get_active_user.key_from(user.id, True) != get_active_user.key_from(user.id + 1, True)
+
+
+@django_db_all(transaction=True)
+def test_caching_function_long_base_key() -> None:
+    cache.clear()
+    user = Factories.create_user()
+
+    first = get_active_user_long_basekey(user.id, True)
+    assert first
+    assert first.id == user.id
+    assert first.username == user.username
+
+    cached = get_active_user_long_basekey(user.id, True)
+    assert cached
+    assert cached.id == user.id
+
+
+@django_db_all(transaction=True)
+def test_caching_function_equal_length() -> None:
+    cache.clear()
+    user = Factories.create_user()
+    id_len = len(str(user.id))
+
+    # 6 accounts for :[,""]
+    first = get_active_user_equal(user.id, "a" * (32 - id_len - 6))
+    assert first
+    assert first.id == user.id
+    assert first.username == user.username
+
+    cached = get_active_user_long_basekey(user.id, True)
+    assert cached
+    assert cached.id == user.id
 
 
 @django_db_all(transaction=True)

--- a/tests/sentry/hybridcloud/rpc/test_caching.py
+++ b/tests/sentry/hybridcloud/rpc/test_caching.py
@@ -151,7 +151,7 @@ def test_caching_function_equal_length() -> None:
     assert first.id == user.id
     assert first.username == user.username
 
-    cached = get_active_user_long_basekey(user.id, True)
+    cached = get_active_user_equal(user.id, "a" * (32 - id_len - 6))
     assert cached
     assert cached.id == user.id
 

--- a/tests/sentry/hybridcloud/rpc/test_caching.py
+++ b/tests/sentry/hybridcloud/rpc/test_caching.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator, Iterator
 from random import Random
 
+import pytest
 from django.core.cache import cache
 
 from sentry.hybridcloud.rpc.caching import (
@@ -11,6 +12,7 @@ from sentry.hybridcloud.rpc.caching import (
     control_caching_service,
 )
 from sentry.hybridcloud.rpc.caching.impl import CacheBackend, _consume_generator
+from sentry.hybridcloud.rpc.caching.service import MAX_BASE_KEY_LENGTH, MAX_CACHE_KEY_LENGTH
 from sentry.organizations.services.organization.model import (
     RpcOrganizationMember,
     RpcOrganizationSummary,
@@ -59,6 +61,187 @@ def test_caching_function() -> None:
     for u, cached in zip(users, cached_users):
         assert cached
         assert cached.username == u.username
+
+
+@back_with_silo_cache(base_key="multiple-params", silo_mode=SiloMode.CELL, t=RpcUser)
+def get_active_user(user_id: int, is_active: bool) -> RpcUser | None:
+    results = user_service.get_many(filter=dict(user_ids=[user_id], is_active=is_active))
+    if len(results):
+        return results[0]
+    return None
+
+
+@django_db_all(transaction=True)
+def test_caching_function_multiple_parameters() -> None:
+    cache.clear()
+
+    user = Factories.create_user()
+
+    first = get_active_user(user.id, True)
+    assert first
+    assert first.id == user.id
+    assert first.username == user.username
+
+    # Each parameter combination is a separate cache entry, so the non-matching
+    # combination is a miss rather than a hit on the entry written above.
+    assert get_active_user(user.id, False) is None
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        user.update(username=user.username + "moocow")
+
+    # The second read of the same parameters is served from cache, so it does not
+    # observe the update. Calling through to the wrapped function does.
+    cached = get_active_user(user.id, True)
+    assert cached
+    assert cached.username == first.username
+    assert cached.username != user.username
+
+    direct = get_active_user.cb(user.id, True)
+    assert direct
+    assert direct.username == user.username
+
+    assert get_active_user.key_from(user.id, True) != get_active_user.key_from(user.id, False)
+    assert get_active_user.key_from(user.id, True) != get_active_user.key_from(user.id + 1, True)
+
+
+@django_db_all(transaction=True)
+def test_caching_function_multiple_parameters_clear_key() -> None:
+    cache.clear()
+
+    users = [Factories.create_user() for _ in range(2)]
+    before = [get_active_user(u.id, True) for u in users]
+    assert all(before)
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        for u in users:
+            u.update(username=u.username + "moocow")
+
+    # Clearing a key built from the same parameters evicts that entry only.
+    cell_caching_service.clear_key(
+        cell_name=get_local_cell().name, key=get_active_user.key_from(users[0].id, True)
+    )
+
+    cleared = get_active_user(users[0].id, True)
+    assert cleared
+    assert cleared.username == users[0].username
+
+    untouched = get_active_user(users[1].id, True)
+    assert untouched == before[1]
+
+
+@django_db_all(transaction=True)
+def test_caching_function_other_silo_mode() -> None:
+    cache.clear()
+
+    user = Factories.create_user()
+    cached = get_active_user(user.id, True)
+    assert cached
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        user.update(username=user.username + "moocow")
+
+    # A silo that does not own this cache bypasses it and forwards every parameter
+    # to the wrapped function.
+    with assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
+        fresh = get_active_user(user.id, True)
+    assert fresh
+    assert fresh.username == user.username
+    assert fresh.username != cached.username
+
+
+@back_with_silo_cache(base_key="key-encoding", silo_mode=SiloMode.CELL, t=RpcUser)
+def get_by_one_param(value: object) -> RpcUser | None:
+    return None
+
+
+@back_with_silo_cache(base_key="key-encoding-two", silo_mode=SiloMode.CELL, t=RpcUser)
+def get_by_two_params(first: object, second: object) -> RpcUser | None:
+    return None
+
+
+def test_key_from_distinguishes_parameters() -> None:
+    # Single key signature work with str representation so these keys are the same.
+    # In practice this doesn't matter as a function's signature should prevent shadowing
+    assert get_by_one_param.key_from(1) == get_by_one_param.key_from("1")
+
+    # Multi-parameters signatures distinguish types
+    assert get_by_two_params.key_from("1", "a") != get_by_two_params.key_from(1, "a")
+
+    # Separators inside a parameter cannot be confused for parameter boundaries.
+    assert get_by_two_params.key_from("a:b", "c") != get_by_two_params.key_from("a", "b:c")
+
+
+def test_key_from_fits_cache_version_column() -> None:
+    base_key = "a" * MAX_BASE_KEY_LENGTH
+
+    @back_with_silo_cache(base_key=base_key, silo_mode=SiloMode.CELL, t=RpcUser)
+    def get_thing(value: str) -> RpcUser | None:
+        return None
+
+    # Single parameter keys need to retain compatiblity with historical keys
+    short_key = get_thing.key_from("1")
+    assert short_key == f"{base_key}:1"
+
+    # Parameters that would overflow CacheVersion.key are hashed down to fit.
+    long_key = get_thing.key_from("x" * 500)
+    assert len(long_key) <= MAX_CACHE_KEY_LENGTH
+    assert long_key != short_key
+    assert long_key != get_thing.key_from("y" * 500)
+
+
+def test_key_from_is_memcached_safe() -> None:
+    @back_with_silo_cache(base_key="unsafe-chars", silo_mode=SiloMode.CELL, t=RpcUser)
+    def get_thing(value: str) -> RpcUser | None:
+        return None
+
+    # Memcached rejects whitespace and control characters, so parameters containing
+    # them are hashed rather than embedded in the key.
+    for value in ("has a space", "has\ttab", "has\nnewline", "café"):
+        key = get_thing.key_from(value)
+        assert all(0x21 <= ord(c) <= 0x7E for c in key), f"unsafe key for {value!r}: {key!r}"
+
+    assert get_thing.key_from("has a space") != get_thing.key_from("has-a-space")
+
+
+def test_base_key_too_long_is_rejected() -> None:
+    with pytest.raises(ValueError):
+
+        @back_with_silo_cache(
+            base_key="a" * (MAX_BASE_KEY_LENGTH + 1), silo_mode=SiloMode.CELL, t=RpcUser
+        )
+        def get_thing(value: int) -> RpcUser | None:
+            return None
+
+
+@django_db_all(transaction=True)
+def test_clear_key_with_hashed_parameters() -> None:
+    cache.clear()
+
+    @back_with_silo_cache(base_key="a" * MAX_BASE_KEY_LENGTH, silo_mode=SiloMode.CELL, t=RpcUser)
+    def get_user_by_long_key(user_id: int, padding: str) -> RpcUser | None:
+        results = user_service.get_many(filter=dict(user_ids=[user_id]))
+        if len(results):
+            return results[0]
+        return None
+
+    user = Factories.create_user()
+    padding = "x" * 500
+
+    before = get_user_by_long_key(user.id, padding)
+    assert before
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        user.update(username=user.username + "moocow")
+
+    # Writing a version row for a hashed key must not overflow CacheVersion.key.
+    cell_caching_service.clear_key(
+        cell_name=get_local_cell().name,
+        key=get_user_by_long_key.key_from(user.id, padding),
+    )
+
+    after = get_user_by_long_key(user.id, padding)
+    assert after
+    assert after.username == user.username
 
 
 @control_silo_test


### PR DESCRIPTION
Currently RPC caching can only be applied to methods with a singular integer parameter. I'd like to be able to cache integration RPC calls as they are high volume, and integration data changes infrequently.

The highest volume integration queries use multiple parameters. With this change we can introduce new service wrappers that enable our highest volume integration RPC calls to be cached.

Refs INFRENG-568