### PR TITLE
ref(hybridcloud): Remove legacy outbox model setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -442,8 +442,6 @@ SENTRY_HYBRIDCLOUD_OUTBOX_MODELS: Mapping[str, list[str]] = {
     "CONTROL": ["sentry.ControlOutbox"],
     "CELL": ["sentry.CellOutbox"],
 }
-# Backwards-compatible alias for getsentry, which extends this mapping with UsageOutbox.
-SENTRY_OUTBOX_MODELS = SENTRY_HYBRIDCLOUD_OUTBOX_MODELS
 
 # Do not modify reordering
 # The applications listed first in INSTALLED_APPS have precedence

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -2,7 +2,6 @@ import types
 from unittest.mock import patch
 
 import pytest
-from django.conf import settings as django_settings
 from django.core.cache import caches
 from django.test import override_settings
 
@@ -266,10 +265,6 @@ def test_validate_outbox_config_includes_group_action_log_outbox() -> None:
         validate_outbox_config()
 
     validate_cell_outbox.assert_any_call(GroupActionLogOutbox._meta.label)
-
-
-def test_legacy_outbox_model_setting_alias() -> None:
-    assert django_settings.SENTRY_OUTBOX_MODELS is django_settings.SENTRY_HYBRIDCLOUD_OUTBOX_MODELS
 
 
 def test_require_secret_key(settings) -> None:


### PR DESCRIPTION
Cleanup from https://github.com/getsentry/getsentry/pull/21693 and https://github.com/getsentry/sentry/pull/122408