### PR TITLE
feat(investigations): Add agentic investigation creation

### DIFF
--- a/src/sentry/investigations/endpoints/organization_investigation_candidates.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_candidates.py
@@ -21,6 +21,7 @@ from sentry.investigations.models import (
     InvestigationStatus,
 )
 from sentry.investigations.services import (
+    agentic_breached_metric_lineage_key,
     investigation_legacy_source_key,
     investigation_lineage_key,
     resolve_investigation_sources,
@@ -68,6 +69,11 @@ class OrganizationInvestigationCandidatesEndpoint(OrganizationInvestigationsBase
             for source in resolved_sources
             if source is not None
         }
+        agentic_lineage_keys = {
+            agentic_breached_metric_lineage_key(source.source)
+            for source in resolved_sources
+            if source is not None
+        }
         legacy_source_keys = {
             investigation_legacy_source_key(source.source)
             for source in resolved_sources
@@ -78,7 +84,7 @@ class OrganizationInvestigationCandidatesEndpoint(OrganizationInvestigationsBase
                 organization=organization,
                 status=InvestigationStatus.ACTIVE,
             ).filter(
-                Q(lineage_key__in=lineage_keys)
+                Q(lineage_key__in=lineage_keys | agentic_lineage_keys)
                 | Q(
                     template_key=template.key,
                     source_type=InvestigationSourceType.BREACHED_METRIC,
@@ -105,9 +111,13 @@ class OrganizationInvestigationCandidatesEndpoint(OrganizationInvestigationsBase
             if source is None:
                 items.append({"status": "unavailable"})
                 continue
-            investigation = existing_by_lineage_key.get(
-                investigation_lineage_key(template.key, source.source)
-            ) or existing_by_legacy_source_key.get(investigation_legacy_source_key(source.source))
+            investigation = (
+                existing_by_lineage_key.get(agentic_breached_metric_lineage_key(source.source))
+                or existing_by_lineage_key.get(
+                    investigation_lineage_key(template.key, source.source)
+                )
+                or existing_by_legacy_source_key.get(investigation_legacy_source_key(source.source))
+            )
             if investigation is not None:
                 if investigation.id in viewable_ids:
                     items.append({"status": "view", "investigationId": str(investigation.id)})

--- a/src/sentry/investigations/endpoints/organization_investigation_index.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_index.py
@@ -29,8 +29,11 @@ from sentry.investigations.models import (
     InvestigationStatus,
 )
 from sentry.investigations.services import (
+    create_agentic_breached_metric_investigation,
+    create_agentic_manual_investigation,
     create_manual_investigation,
     create_template_investigation,
+    resolve_investigation_source,
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
 from sentry.investigations.telemetry import record_investigation_started
@@ -88,7 +91,49 @@ class OrganizationInvestigationsIndexEndpoint(OrganizationInvestigationsBaseEndp
         values = validator.validated_data
         project_ids = request.access.accessible_project_ids
         try:
-            if "template_key" in values:
+            if "source" in values and "template_key" not in values:
+                source = values["source"]
+                requested_project_ids = values.get("project_ids", [])
+                if source["type"] == "metric_open_period":
+                    resolved_source = resolve_investigation_source(
+                        organization=organization,
+                        source=source,
+                        accessible_project_ids=project_ids,
+                    )
+                    requested_project_ids = sorted(
+                        set(requested_project_ids) | {resolved_source.project_id}
+                    )
+                    if not set(requested_project_ids).issubset(project_ids):
+                        return Response(
+                            {"detail": "One or more projects are inaccessible."},
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
+                    investigation, created = create_agentic_breached_metric_investigation(
+                        organization=organization,
+                        user_id=user_id(request),
+                        title=values.get("title"),
+                        resolved_source=resolved_source,
+                        project_ids=requested_project_ids,
+                        filters=values.get("filters", {}),
+                    )
+                    if not created:
+                        require_investigation_project_access(investigation, project_ids)
+                else:
+                    if not set(requested_project_ids).issubset(project_ids):
+                        return Response(
+                            {"detail": "One or more projects are inaccessible."},
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
+                    created = True
+                    investigation, _ = create_agentic_manual_investigation(
+                        organization=organization,
+                        user_id=user_id(request),
+                        title=values.get("title"),
+                        source=source,
+                        project_ids=requested_project_ids,
+                        filters=values.get("filters", {}),
+                    )
+            elif "template_key" in values:
                 with transaction.atomic(using=router.db_for_write(Investigation)):
                     investigation, created = create_template_investigation(
                         organization=organization,

--- a/src/sentry/investigations/endpoints/validators/investigation.py
+++ b/src/sentry/investigations/endpoints/validators/investigation.py
@@ -5,6 +5,7 @@ from typing import Any
 from rest_framework import serializers
 
 from sentry.investigations.endpoints.validators.base import StrictCamelSnakeValidator
+from sentry.investigations.endpoints.validators.orchestration import validate_agentic_source
 from sentry.investigations.models import InvestigationStatus
 
 
@@ -20,6 +21,7 @@ class InvestigationCreateValidator(StrictCamelSnakeValidator):
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         has_key = "template_key" in attrs
         has_version = "template_version" in attrs
+        has_source = "source" in attrs
         if has_key != has_version:
             raise serializers.ValidationError(
                 {"template_key": "templateKey and templateVersion must be provided together."}
@@ -36,10 +38,16 @@ class InvestigationCreateValidator(StrictCamelSnakeValidator):
                 raise serializers.ValidationError(
                     {field: "Template creation controls this field." for field in forbidden}
                 )
+        elif has_source:
+            validate_agentic_source(attrs["source"])
+            if "parameters" in attrs:
+                raise serializers.ValidationError(
+                    {"parameters": "Agentic investigations do not use template parameters."}
+                )
         else:
             if "title" not in attrs:
                 raise serializers.ValidationError({"title": "This field is required."})
-            forbidden = set(attrs).intersection({"source", "parameters"})
+            forbidden = set(attrs).intersection({"parameters"})
             if forbidden:
                 raise serializers.ValidationError(
                     {field: "Requires a template." for field in forbidden}

--- a/src/sentry/investigations/endpoints/validators/orchestration.py
+++ b/src/sentry/investigations/endpoints/validators/orchestration.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+from rest_framework import serializers
+
+from sentry.investigations.contracts import StrictContractSerializer
+from sentry.utils import json
+
+MAX_AGENTIC_SOURCE_BYTES = 200_000
+
+
+def _validate_time_range(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict) or set(value) != {"start", "end"}:
+        raise serializers.ValidationError("Must contain only start and end.")
+    start_value = value.get("start")
+    end_value = value.get("end")
+    start = parse_datetime(start_value) if isinstance(start_value, str) else None
+    end = parse_datetime(end_value) if isinstance(end_value, str) else None
+    if (
+        start is None
+        or end is None
+        or not timezone.is_aware(start)
+        or not timezone.is_aware(end)
+        or end <= start
+    ):
+        raise serializers.ValidationError("Must be an ordered timezone-aware range.")
+    return value
+
+
+class ManualSourceSchema(StrictContractSerializer):
+    """Free-form investigation context supplied by the requesting user."""
+
+    type = serializers.ChoiceField(choices=["manual"])
+    prompt = serializers.CharField(required=False, allow_blank=True, max_length=20_000)
+    timeRange = serializers.JSONField(required=False)
+    seed = serializers.DictField(required=False)
+
+    def validate_timeRange(self, value: Any) -> dict[str, str]:
+        return _validate_time_range(value)
+
+
+class MetricOpenPeriodRefSchema(StrictContractSerializer):
+    """The server-resolved identity of the breached metric being investigated."""
+
+    groupId = serializers.IntegerField(min_value=1)
+    openPeriodId = serializers.IntegerField(min_value=1)
+
+
+class MetricOpenPeriodSourceSchema(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["metric_open_period"])
+    ref = MetricOpenPeriodRefSchema()
+
+
+SOURCE_SCHEMAS: dict[str, type[StrictContractSerializer]] = {
+    "manual": ManualSourceSchema,
+    "metric_open_period": MetricOpenPeriodSourceSchema,
+}
+
+
+def validate_agentic_source(source: Any) -> dict[str, Any]:
+    if not isinstance(source, dict):
+        raise serializers.ValidationError({"source": "Must be an object."})
+    if len(json.dumps(source).encode()) > MAX_AGENTIC_SOURCE_BYTES:
+        raise serializers.ValidationError({"source": "Investigation context is too large."})
+
+    source_type = source.get("type")
+    schema = SOURCE_SCHEMAS.get(source_type) if isinstance(source_type, str) else None
+    if schema is None:
+        raise serializers.ValidationError(
+            {"source": "Agentic source type must be manual or metric_open_period."}
+        )
+
+    validator = schema(data=source)
+    if not validator.is_valid():
+        raise serializers.ValidationError({"source": validator.errors})
+    return source

--- a/src/sentry/investigations/services/__init__.py
+++ b/src/sentry/investigations/services/__init__.py
@@ -1,3 +1,4 @@
 from .executions import *  # NOQA
 from .investigations import *  # NOQA
+from .orchestration import *  # NOQA
 from .parameters import *  # NOQA

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from django.db import IntegrityError, router, transaction
+from django.db.models import Max
+
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationOrchestrationRun,
+    InvestigationOrchestrationStatus,
+    InvestigationSourceType,
+    InvestigationStatus,
+)
+from sentry.investigations.services.breached_metrics import BreachedMetricSource
+from sentry.investigations.services.investigations import (
+    DEFAULT_INVESTIGATION_TITLE,
+    _create_project_links,
+    _legacy_storage_filters,
+    investigation_lineage_key,
+)
+from sentry.models.organization import Organization
+
+__all__ = [
+    "agentic_breached_metric_lineage_key",
+    "create_agentic_breached_metric_investigation",
+    "create_agentic_manual_investigation",
+]
+
+
+def _initial_projection(
+    *, investigation_id: int, source: dict[str, Any]
+) -> tuple[str, str, dict[str, Any]]:
+    source_type = source["type"]
+    missing_fields: list[str] = []
+    if source_type == "manual":
+        prompt = source.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            missing_fields.append("prompt")
+
+    awaiting_input = bool(missing_fields)
+    phase = "intake" if awaiting_input else "broad_scan"
+    status = (
+        InvestigationOrchestrationStatus.AWAITING_INPUT
+        if awaiting_input
+        else InvestigationOrchestrationStatus.PENDING
+    )
+    return (
+        phase,
+        status,
+        {
+            "runId": None,
+            "investigationId": str(investigation_id),
+            "sourceType": source_type,
+            "workflowVersion": 1,
+            "generation": 1,
+            "phase": phase,
+            "status": status,
+            "broadScan": {
+                "status": "blocked" if awaiting_input else "queued",
+                "summary": None,
+                "error": None,
+            },
+            "hypotheses": [],
+            "report": {
+                "revision": 0,
+                "status": "not_started",
+                "includedHypothesisIds": [],
+                "primaryHypothesisId": None,
+                "currentBlockKey": None,
+                "notebookRevision": 0,
+                "metadata": {
+                    "status": "not_started",
+                    "title": None,
+                    "summary": None,
+                    "summaryDescription": None,
+                    "error": None,
+                },
+                "error": None,
+            },
+            "pendingInput": (
+                {
+                    "missingFields": missing_fields,
+                    "prompt": "Provide the missing investigation context to begin the broad scan.",
+                }
+                if awaiting_input
+                else None
+            ),
+            "errors": [],
+            "heartbeatAt": None,
+        },
+    )
+
+
+def _create_agentic_investigation(
+    *,
+    organization: Organization,
+    user_id: int,
+    title: str | None,
+    source: dict[str, Any],
+    orchestration_source: dict[str, Any],
+    project_ids: list[int],
+    filters: dict[str, Any],
+    source_type: str = InvestigationSourceType.MANUAL,
+    source_ref: dict[str, Any] | None = None,
+    source_key: str | None = None,
+    lineage_key: str | None = None,
+    source_revision: int | None = None,
+) -> tuple[Investigation, InvestigationOrchestrationRun]:
+    """Create the notebook and its parent control-plane aggregate atomically."""
+
+    with transaction.atomic(using=router.db_for_write(Investigation)):
+        investigation = Investigation.objects.create(
+            organization=organization,
+            created_by_id=user_id,
+            title=title or DEFAULT_INVESTIGATION_TITLE,
+            source_type=source_type,
+            source_ref=deepcopy(source_ref or {}),
+            source_key=source_key,
+            source=deepcopy(source),
+            lineage_key=lineage_key,
+            source_revision=source_revision,
+            filters=deepcopy(filters),
+        )
+        _create_project_links(investigation, project_ids)
+        phase, status, projection = _initial_projection(
+            investigation_id=investigation.id, source=orchestration_source
+        )
+        orchestration_run = InvestigationOrchestrationRun.objects.create(
+            investigation=investigation,
+            phase=phase,
+            status=status,
+            source=deepcopy(orchestration_source),
+            projection=projection,
+        )
+    return investigation, orchestration_run
+
+
+def _manual_orchestration_source(source: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {
+        "type": "manual",
+        "projectScope": {"type": "investigation"},
+        "seed": deepcopy(source.get("seed", {})),
+    }
+    for key in ("prompt", "timeRange"):
+        if key in source:
+            normalized[key] = deepcopy(source[key])
+    return normalized
+
+
+def create_agentic_manual_investigation(
+    *,
+    organization: Organization,
+    user_id: int,
+    title: str | None,
+    source: dict[str, Any],
+    project_ids: list[int],
+    filters: dict[str, Any],
+) -> tuple[Investigation, InvestigationOrchestrationRun]:
+    return _create_agentic_investigation(
+        organization=organization,
+        user_id=user_id,
+        title=title,
+        source=source,
+        orchestration_source=_manual_orchestration_source(source),
+        project_ids=project_ids,
+        filters=filters,
+    )
+
+
+def _breached_metric_orchestration_source(source: dict[str, Any]) -> dict[str, Any]:
+    """Build internal orchestration context from Sentry's canonical metric snapshot."""
+
+    snapshot = source["snapshot"]
+    monitor = snapshot["monitor"]
+    project = snapshot["project"]
+    window = snapshot["analysisWindow"]
+    conditions = monitor["conditions"]
+    threshold = next(
+        (
+            condition.get("comparison")
+            for condition in conditions
+            if isinstance(condition, dict)
+            and isinstance(condition.get("comparison"), int | float)
+            and not isinstance(condition.get("comparison"), bool)
+        ),
+        None,
+    )
+    project_id = int(project["id"])
+    breach_start = window["breachStart"]
+    baseline_start = window["baselineStart"]
+    end = window["end"]
+    return {
+        "type": "breached_metric",
+        "metricIssueId": snapshot["groupId"],
+        "openPeriodId": snapshot["openPeriodId"],
+        "detectorId": monitor["id"],
+        "monitorId": monitor["id"],
+        "monitorName": monitor["name"],
+        "metricQuery": monitor["query"],
+        "projectIds": [project_id],
+        "monitor": deepcopy(monitor),
+        "project": deepcopy(project),
+        "analysisWindow": deepcopy(window),
+        "environment": monitor["environment"],
+        "threshold": threshold,
+        "thresholdDirection": monitor["direction"],
+        "openPeriod": {"start": breach_start, "end": end},
+        "baselinePeriod": {"start": baseline_start, "end": breach_start},
+        "seed": {
+            "groupTitle": snapshot["groupTitle"],
+            "sentrySource": deepcopy(source),
+        },
+    }
+
+
+def agentic_breached_metric_lineage_key(source: dict[str, Any]) -> str:
+    return investigation_lineage_key("agentic_breached_metric", source)
+
+
+def create_agentic_breached_metric_investigation(
+    *,
+    organization: Organization,
+    user_id: int,
+    title: str | None,
+    resolved_source: BreachedMetricSource,
+    project_ids: list[int],
+    filters: dict[str, Any],
+) -> tuple[Investigation, bool]:
+    normalized_source = resolved_source.source
+    lineage_key = agentic_breached_metric_lineage_key(normalized_source)
+    # Uniqueness on active lineage and revision arbitrates concurrent launches.
+    for attempt in range(3):
+        active = (
+            Investigation.objects.filter(
+                organization=organization,
+                lineage_key=lineage_key,
+                status=InvestigationStatus.ACTIVE,
+            )
+            .order_by("-source_revision", "-id")
+            .first()
+        )
+        if active is not None:
+            return active, False
+        latest_revision = Investigation.objects.filter(
+            organization=organization,
+            lineage_key=lineage_key,
+        ).aggregate(latest=Max("source_revision"))["latest"]
+        try:
+            investigation, _ = _create_agentic_investigation(
+                organization=organization,
+                user_id=user_id,
+                title=title,
+                source=normalized_source,
+                orchestration_source=_breached_metric_orchestration_source(normalized_source),
+                project_ids=project_ids,
+                filters=_legacy_storage_filters(normalized_source, filters),
+                source_type=InvestigationSourceType.METRIC_OPEN_PERIOD,
+                source_ref=normalized_source["ref"],
+                source_key=lineage_key,
+                lineage_key=lineage_key,
+                source_revision=(latest_revision or 0) + 1,
+            )
+            return investigation, True
+        except IntegrityError:
+            if attempt == 2:
+                active = Investigation.objects.filter(
+                    organization=organization,
+                    lineage_key=lineage_key,
+                    status=InvestigationStatus.ACTIVE,
+                ).first()
+                if active is not None:
+                    return active, False
+                raise
+    raise AssertionError("unreachable")

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
@@ -10,7 +10,11 @@ from django.utils import timezone
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
-from sentry.investigations.models import Investigation, InvestigationSourceType
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationOrchestrationRun,
+    InvestigationSourceType,
+)
 from sentry.investigations.services import investigation_legacy_source_key
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.seer.anomaly_detection.types import (
@@ -158,6 +162,68 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         assert response.data == {
             "items": [{"status": "view", "investigationId": launched.data["id"]}]
         }
+
+    @mock.patch(
+        "sentry.investigations.endpoints.organization_investigation_index.schedule_eligible_auto_run_blocks"
+    )
+    def test_metric_open_period_launches_agentic_and_candidates_report_its_run(
+        self, schedule_auto_run: mock.Mock
+    ) -> None:
+        group, open_period = self.create_metric_open_period()
+        source = {
+            "type": "metric_open_period",
+            "ref": {"groupId": str(group.id), "openPeriodId": str(open_period.id)},
+        }
+        template_investigation = self.client.post(
+            self.collection_url,
+            {
+                "templateKey": "breached_metric",
+                "templateVersion": 1,
+                "source": source,
+            },
+            format="json",
+        )
+        assert template_investigation.status_code == 201, template_investigation.data
+
+        launched = self.client.post(
+            self.collection_url,
+            {"source": source},
+            format="json",
+        )
+
+        assert launched.status_code == 201, launched.data
+        assert launched.data["id"] != template_investigation.data["id"]
+        assert launched.data["template"] is None
+        assert launched.data["source"]["ref"] == source["ref"]
+        investigation = Investigation.objects.get(id=launched.data["id"])
+        assert investigation.source_type == InvestigationSourceType.METRIC_OPEN_PERIOD
+        run = InvestigationOrchestrationRun.objects.get(investigation=investigation)
+        assert run.source["type"] == "breached_metric"
+        assert run.source["projectIds"] == [self.project.id]
+        assert run.source["monitor"] == investigation.source["snapshot"]["monitor"]
+        assert run.source["analysisWindow"] == investigation.source["snapshot"]["analysisWindow"]
+        assert run.source["metricQuery"] == investigation.source["snapshot"]["monitor"]["query"]
+        assert run.source["seed"]["sentrySource"] == investigation.source
+
+        candidate = self.client.post(
+            self.candidates_url,
+            {
+                "templateKey": "breached_metric",
+                "templateVersion": 1,
+                "sources": [source],
+            },
+            format="json",
+        )
+
+        assert candidate.status_code == 200, candidate.data
+        assert candidate.data == {
+            "items": [{"status": "view", "investigationId": launched.data["id"]}]
+        }
+
+        duplicate = self.client.post(self.collection_url, {"source": source}, format="json")
+        assert duplicate.status_code == 200, duplicate.data
+        assert duplicate.data["id"] == launched.data["id"]
+        schedule_auto_run.assert_called_once()
 
     @mock.patch(
         "sentry.investigations.endpoints.organization_investigation_index.schedule_eligible_auto_run_blocks"

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from sentry.investigations.models import (
     Investigation,
+    InvestigationOrchestrationRun,
     InvestigationSourceType,
     InvestigationStatus,
 )
@@ -59,6 +60,63 @@ class OrganizationInvestigationIndexTest(APITestCase):
         assert [item["title"] for item in response.data] == ["Checkout follow-up"]
         assert response.data[0]["blockCount"] == 0
         assert response.data[0]["isFavorited"] is False
+
+    def test_create_agentic_manual_investigation_awaiting_a_prompt(self) -> None:
+        response = self.client.post(
+            self.collection_url,
+            data={
+                "title": "Checkout investigation",
+                "source": {"type": "manual", "seed": {"release": "example-release"}},
+                "projectIds": [self.project.id],
+                "filters": {"environment": ["production"]},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 201, response.data
+        assert "mode" not in response.data
+        run = InvestigationOrchestrationRun.objects.get(investigation_id=response.data["id"])
+        assert run.source == {
+            "type": "manual",
+            "projectScope": {"type": "investigation"},
+            "seed": {"release": "example-release"},
+        }
+        assert run.schema_version == 1
+        assert run.workflow_version == 1
+        assert run.generation == 1
+        assert run.notebook_revision == 0
+        assert run.projection["report"]["revision"] == 0
+        assert run.projection["pendingInput"]["missingFields"] == ["prompt"]
+        assert run.projection["broadScan"]["status"] == "blocked"
+
+    def test_create_agentic_manual_investigation_without_a_time_range_starts_scan(self) -> None:
+        response = self.client.post(
+            self.collection_url,
+            data={"source": {"type": "manual", "prompt": "Investigate checkout latency"}},
+            format="json",
+        )
+
+        assert response.status_code == 201, response.data
+        run = InvestigationOrchestrationRun.objects.get(investigation_id=response.data["id"])
+        assert run.phase == "broad_scan"
+        assert run.status == "pending"
+        assert run.projection["pendingInput"] is None
+        assert run.projection["broadScan"]["status"] == "queued"
+
+    def test_agentic_creation_rejects_an_inaccessible_project_atomically(self) -> None:
+        foreign_project = self.create_project(organization=self.create_organization())
+
+        response = self.client.post(
+            self.collection_url,
+            data={
+                "source": {"type": "manual", "prompt": "Investigate latency"},
+                "projectIds": [foreign_project.id],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert not InvestigationOrchestrationRun.objects.exists()
 
     def test_list_includes_summary_when_projects_are_accessible(self) -> None:
         investigation = self.create_investigation(

--- a/tests/sentry/investigations/endpoints/validators/test_investigation.py
+++ b/tests/sentry/investigations/endpoints/validators/test_investigation.py
@@ -69,9 +69,115 @@ class TestInvestigationCreateValidator:
         assert not validator.is_valid()
         assert "projectIds" in validator.errors
 
-    def test_rejects_a_source_without_a_template(self) -> None:
+    def test_accepts_an_agentic_manual_source_without_a_template(self) -> None:
+        data = assert_valid(
+            InvestigationCreateValidator(
+                data={
+                    "source": {
+                        "type": "manual",
+                        "prompt": "Investigate checkout latency",
+                        "timeRange": {
+                            "start": "2025-01-01T00:00:00Z",
+                            "end": "2025-01-01T01:00:00Z",
+                        },
+                        "seed": {"release": "example-release"},
+                    }
+                }
+            )
+        )
+
+        assert "template_key" not in data
+        assert data["source"]["seed"] == {"release": "example-release"}
+
+    def test_rejects_a_malformed_agentic_source(self) -> None:
         validator = InvestigationCreateValidator(
             data={"title": "T", "source": {"type": "metric_open_period", "ref": {}}}
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_template_parameters_for_an_agentic_source(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"source": {"type": "manual"}, "parameters": {"environment": "prod"}}
+        )
+
+        assert not validator.is_valid()
+        assert "parameters" in validator.errors
+
+    def test_rejects_the_removed_mode_discriminator(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"mode": "agentic", "source": {"type": "manual"}}
+        )
+
+        assert not validator.is_valid()
+        assert "mode" in validator.errors
+
+    def test_rejects_an_untrusted_breached_metric_snapshot(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"source": {"type": "breached_metric", "projectIds": [1]}}
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_untrusted_top_level_manual_source_fields(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={
+                "source": {
+                    "type": "manual",
+                    "prompt": "Investigate latency",
+                    "snapshot": {"monitor": {"name": "caller supplied"}},
+                }
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_an_unordered_manual_time_range(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={
+                "source": {
+                    "type": "manual",
+                    "timeRange": {
+                        "start": "2025-01-01T02:00:00Z",
+                        "end": "2025-01-01T01:00:00Z",
+                    },
+                }
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_non_object_seed_context(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"source": {"type": "manual", "seed": ["not", "an", "object"]}}
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_an_overlong_manual_prompt(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"source": {"type": "manual", "prompt": "x" * 20_001}}
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_a_null_manual_prompt(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"source": {"type": "manual", "prompt": None}}
+        )
+
+        assert not validator.is_valid()
+        assert "source" in validator.errors
+
+    def test_rejects_oversized_source_context(self) -> None:
+        validator = InvestigationCreateValidator(
+            data={"source": {"type": "manual", "seed": {"context": "x" * 200_000}}}
         )
 
         assert not validator.is_valid()
@@ -123,33 +229,3 @@ class TestInvestigationUpdateValidator:
 
         assert not validator.is_valid()
         assert "projectIds" in validator.errors
-
-
-class TestFiltersMustBeAnObject:
-    """The model types `filters` as dict[str, Any], so non-objects must not pass."""
-
-    def test_create_rejects_a_non_object(self) -> None:
-        validator = InvestigationCreateValidator(data={"title": "T", "filters": ["nope"]})
-
-        assert not validator.is_valid()
-        assert "filters" in validator.errors
-
-    def test_create_accepts_an_object(self) -> None:
-        validator = InvestigationCreateValidator(data={"title": "T", "filters": {"env": "prod"}})
-
-        assert validator.is_valid(), validator.errors
-
-    def test_update_rejects_a_non_object(self) -> None:
-        validator = InvestigationUpdateValidator(
-            data={"investigationVersion": 1, "filters": "nope"}
-        )
-
-        assert not validator.is_valid()
-        assert "filters" in validator.errors
-
-    def test_update_accepts_an_object(self) -> None:
-        validator = InvestigationUpdateValidator(
-            data={"investigationVersion": 1, "filters": {"env": "prod"}}
-        )
-
-        assert validator.is_valid(), validator.errors

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -9,6 +9,7 @@ from sentry.db.models.fields.bounded import I64_MAX
 from sentry.investigations.models import (
     Investigation,
     InvestigationBlockDependency,
+    InvestigationOrchestrationRun,
     InvestigationProject,
     InvestigationSourceType,
 )
@@ -25,6 +26,9 @@ from sentry.investigations.services.investigations import (
     lock_investigation,
     resolve_investigation_source,
     update_investigation,
+)
+from sentry.investigations.services.orchestration import (
+    create_agentic_manual_investigation,
 )
 from sentry.testutils.cases import TestCase
 
@@ -357,3 +361,28 @@ class UpdateFieldAllowlistTest(TestCase):
 
         assert updated.title == "Renamed"
         assert updated.filters == {"environment": ["prod"]}
+
+
+class OrchestrationControlServiceTest(TestCase):
+    def test_agentic_creation_rolls_back_the_entire_aggregate(self) -> None:
+        investigation_count = Investigation.objects.count()
+        project_link_count = InvestigationProject.objects.count()
+
+        with (
+            mock.patch.object(
+                InvestigationOrchestrationRun.objects, "create", side_effect=RuntimeError
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            create_agentic_manual_investigation(
+                organization=self.organization,
+                user_id=self.user.id,
+                title=None,
+                source={"type": "manual", "prompt": "Investigate latency"},
+                project_ids=[self.project.id],
+                filters={},
+            )
+
+        assert Investigation.objects.count() == investigation_count
+        assert InvestigationProject.objects.count() == project_link_count
+        assert not InvestigationOrchestrationRun.objects.exists()


### PR DESCRIPTION
`POST /organizations/{org}/investigations/` now accepts a `source` object without a `templateKey`. It creates the investigation, its project links, and its orchestration run in one transaction. Existing manual and template creation are untouched.

Two source types. `manual` carries an optional prompt, time range, and seed. `metric_open_period` carries only a server-resolved `ref`, resolved against the caller's accessible projects before anything is written. Concurrent launches for the same metric converge on one investigation through the existing lineage constraints, so a second launch returns the first with a 200 instead of creating a duplicate.

Sources are validated by strict per-type schemas dispatched on `source.type`, and the object is stored as-is rather than as `validated_data` so its camelCase keys survive into the JSON columns. The candidates endpoint now resolves the agentic lineage key ahead of the template one.

No new routes, migrations, workers, or Seer calls. Models landed in #122972; the read and command APIs follow in separate PRs.
