### PR TITLE
Revert "ref(ci): switch to internal github app (sentry-release-bot) #123034"

### DIFF
--- a/.github/workflows/bump-sentry-in-getsentry.yml
+++ b/.github/workflows/bump-sentry-in-getsentry.yml
@@ -19,17 +19,6 @@ jobs:
   bump-sentry:
     runs-on: ubuntu-24.04
     steps:
-      - name: getsentry token
-        id: getsentry
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            sentry
-            getsentry
-
       - name: checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -41,7 +30,9 @@ jobs:
         with:
           repository: 'getsentry/getsentry'
           path: getsentry
-          token: ${{ steps.getsentry.outputs.token }}
+          # This PAT (Personal Access Token) belongs to getsentry-bot,
+          # who can write to getsentry and is SAML+SSO ready.
+          token: ${{ secrets.BUMP_SENTRY_TOKEN }}
 
       - name: bump-sentry ${{ github.sha }}
         run: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,7 +12,7 @@ on:
       pr_options:
         type: string
         default: ''
-        description: space-delimited additional options for gh pr create, such as asking for specific reviewers
+        description: additional options for gh pr create, such as for asking for specific reviewers
 
   # for use in other (cron/scheduled) workflows to bump specific
   # company-internal dependencies on a more aggressive schedule
@@ -27,27 +27,17 @@ on:
       pr_options:
         type: string
         default: ''
-    secrets:
-      SENTRY_RELEASE_BOT_PRIVATE_KEY:
-        required: true
 
-# Disable the default token permissions; the GitHub App token below supplies access.
+# disable all permissions -- we use the PAT's permissions instead
 permissions: {}
 
 jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-      - name: getsentry token
-        id: getsentry
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          token: ${{ steps.getsentry.outputs.token }}
+          token: ${{ secrets.BUMP_SENTRY_TOKEN }}
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
           version: '0.9.28'
@@ -76,17 +66,10 @@ jobs:
 
           git push origin HEAD --quiet
 
-          # Keep caller-provided options as arguments rather than interpolating them into shell source.
-          if [[ -n "$PR_OPTIONS" ]]; then
-            read -r -a PR_OPTION_ARGS <<< "$PR_OPTIONS"
-            gh pr create --fill "${PR_OPTION_ARGS[@]}"
-          else
-            gh pr create --fill
-          fi
+          gh pr create --fill ${{ inputs.pr_options }}
         env:
-          GH_TOKEN: ${{ steps.getsentry.outputs.token }}
+          GH_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
           PACKAGE: ${{ inputs.package }}
           VERSION: ${{ inputs.version }}
-          PR_OPTIONS: ${{ inputs.pr_options }}
           SENDER: ${{ github.event.sender.login }}
           SENDER_ID: ${{ github.event.sender.id }}

--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -10,45 +10,31 @@ on:
         required: true
         description: '`name <email>` for triggering user'
 
-# Disable the default token permissions; the GitHub App token below supplies access.
+# disable all permissions -- we use the PAT's permissions instead
 permissions: {}
 
 jobs:
   revert:
     runs-on: ubuntu-latest
-    environment: fast-revert
     if: |
       github.event_name == 'workflow_dispatch' || github.event.label.name == 'Trigger: Revert'
     steps:
-      - name: fast-revert bot token
-        id: fast-revert-bot-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.SENTRY_FAST_REVERT_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.SENTRY_FAST_REVERT_BOT_PRIVATE_KEY }}
-
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          token: ${{ steps.fast-revert-bot-token.outputs.token }}
+          token: ${{ secrets.BUMP_SENTRY_TOKEN }}
       - uses: getsentry/action-fast-revert@35b4b6c1f8f91b5911159568b3b15e531b5b8174 # v2.0.1
         with:
           pr: ${{ github.event.number || github.event.inputs.pr }}
           co_authored_by: ${{ github.event.inputs.co_authored_by || format('{0} <{1}+{0}@users.noreply.github.com>', github.event.sender.login, github.event.sender.id) }}
-          committer_name: sentry-fast-revert-bot[bot]
-          committer_email: 322273150+sentry-fast-revert-bot[bot]@users.noreply.github.com
-          token: ${{ steps.fast-revert-bot-token.outputs.token }}
+          committer_name: getsentry-bot
+          committer_email: bot@sentry.io
+          token: ${{ secrets.BUMP_SENTRY_TOKEN }}
       - name: comment on failure
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          REPOSITORY_ID: ${{ github.event.repository.id }}
-          ISSUE_NUMBER: ${{ github.event.number || github.event.inputs.pr }}
-          GITHUB_TOKEN: ${{ steps.fast-revert-bot-token.outputs.token }}
         run: |
           curl \
               --silent \
               -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -d"{\"body\": \"revert failed (conflict? already reverted?) -- [check the logs](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)\"}" \
-              "https://api.github.com/repositories/$REPOSITORY_ID/issues/$ISSUE_NUMBER/comments"
+              -H 'Authorization: token ${{ secrets.BUMP_SENTRY_TOKEN }}' \
+              -d'{"body": "revert failed (conflict? already reverted?) -- [check the logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
+              https://api.github.com/repositories/${{ github.event.repository.id }}/issues/${{ github.event.number || github.event.inputs.pr }}/comments
         if: failure()

--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -9,16 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: React to product-owners.yml changes
     steps:
-      - name: getsentry token
-        id: getsentry
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
-          private-key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          token: ${{ steps.getsentry.outputs.token }}
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
@@ -34,7 +25,7 @@ jobs:
       - name: React to product-owners.yml changes
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ steps.getsentry.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
           COMMITTER_NAME: getsentry-bot
           COMMITTER_EMAIL: bot@sentry.io
         run: |


### PR DESCRIPTION
This reverts commit 9534adc08a37c1651bdbe708639f74da25a3bacb.

didn't work: https://github.com/getsentry/sentry/actions/runs/33218675449/job/99007886742 

fast-revert failed in the same way too: https://github.com/getsentry/sentry/actions/runs/33218732756/job/99008061873

so have to manual revert