### PR TITLE
fix(auth): set sso flags on invite accept

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -300,9 +300,6 @@ class AuthIdentityHandler:
             if invite_helper.invite_approved:
                 rpc_om = invite_helper.accept_invite(user)
                 assert rpc_om
-                # accept_invite only attaches the user; SSO validity still requires
-                # sso:linked. Without this, the first post-login org hit bounces
-                # back through needs_sso and forces a second IdP round-trip.
                 self._set_linked_flag(rpc_om)
                 return user, rpc_om
 

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -300,6 +300,10 @@ class AuthIdentityHandler:
             if invite_helper.invite_approved:
                 rpc_om = invite_helper.accept_invite(user)
                 assert rpc_om
+                # accept_invite only attaches the user; SSO validity still requires
+                # sso:linked. Without this, the first post-login org hit bounces
+                # back through needs_sso and forces a second IdP round-trip.
+                self._set_linked_flag(rpc_om)
                 return user, rpc_om
 
             # It's possible the user has an _invite request_ that hasn't been approved yet,

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -288,6 +288,10 @@ class HandleNewUserTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
             )
 
         assert assigned_member.id == member.id
+        # Invite acceptance must still mark SSO linked, otherwise the first
+        # org page load fails sso_is_valid and bounces back to org login.
+        assert getattr(assigned_member.flags, "sso:linked")
+        assert not getattr(assigned_member.flags, "sso:invalid")
 
     def test_demo_user_can_be_added_new_user_when_demo_org(self) -> None:
         # Force demo user behavior, and mark org as demo org

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -288,8 +288,6 @@ class HandleNewUserTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
             )
 
         assert assigned_member.id == member.id
-        # Invite acceptance must still mark SSO linked, otherwise the first
-        # org page load fails sso_is_valid and bounces back to org login.
         assert getattr(assigned_member.flags, "sso:linked")
         assert not getattr(assigned_member.flags, "sso:invalid")
 

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -59,20 +59,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(response, "sentry/base-react.html")
         self.assertTemplateNotUsed(response, "sentry/organization-login.html")
 
-    @with_feature("system:multi-region")
-    def test_customer_domain_login_redirects_to_primary_domain(self) -> None:
-        self.client.cookies["sentry_react_auth"] = "1"
-
-        response = self.client.get(
-            f"{self.path}?next=%2Fsettings%2Faccount%2F",
-            HTTP_HOST=f"{self.organization.slug}.testserver",
-        )
-
-        assert response.status_code == 302
-        assert response["Location"] == (
-            f"http://testserver/auth/login/{self.organization.slug}/?next=%2Fsettings%2Faccount%2F"
-        )
-
     def test_cannot_get_request_join_link_with_setting_disabled(self) -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             OrganizationOption.objects.create(

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -844,6 +844,57 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert not getattr(test_member.flags, "sso:invalid")
         assert not getattr(test_member.flags, "member-limit:restricted")
 
+    def test_flow_as_anonymous_with_pending_invite(self) -> None:
+        """New SSO user with a pending org invite should land once, with sso:linked."""
+        auth_provider = AuthProvider.objects.create(
+            organization_id=self.organization.id, provider="dummy"
+        )
+        invite = self.create_member(
+            email="invited@example.com",
+            organization=self.organization,
+            token="abcdef",
+        )
+
+        # Invite accept stores these before the user is bounced into SSO.
+        self.session["invite_token"] = invite.token
+        self.session["invite_member_id"] = invite.id
+        self.session["invite_organization_id"] = invite.organization_id
+        self.save_session()
+
+        resp = self.client.post(self.path, {"init": True})
+
+        assert resp.status_code == 200
+        assert PLACEHOLDER_TEMPLATE in resp.content.decode("utf-8")
+
+        path = reverse("sentry-auth-sso")
+
+        resp = self.client.post(path, {"email": "invited@example.com"})
+
+        self.assertTemplateUsed(resp, "sentry/auth-confirm-identity.html")
+        assert resp.status_code == 200
+
+        frontend_events = {"event_name": "Sign Up", "event_label": "dummy"}
+        marketing_query = urlencode({"frontend_events": json.dumps(frontend_events)})
+
+        resp = self.client.post(path, {"op": "newuser"}, follow=True)
+        assert resp.redirect_chain == [
+            (reverse("sentry-login") + f"?{marketing_query}", 302),
+            ("/organizations/foo/issues/", 302),
+        ]
+
+        auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
+        user = auth_identity.user
+        assert user.email == "invited@example.com"
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            member = OrganizationMember.objects.get(
+                organization=self.organization, user_id=user.id
+            )
+
+        assert member.id == invite.id
+        assert getattr(member.flags, "sso:linked")
+        assert not getattr(member.flags, "sso:invalid")
+
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
     @with_feature({"organizations:create": False})
     def test_basic_auth_flow_as_not_invited_user(self) -> None:

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -59,6 +59,20 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(response, "sentry/base-react.html")
         self.assertTemplateNotUsed(response, "sentry/organization-login.html")
 
+    @with_feature("system:multi-region")
+    def test_customer_domain_login_redirects_to_primary_domain(self) -> None:
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        response = self.client.get(
+            f"{self.path}?next=%2Fsettings%2Faccount%2F",
+            HTTP_HOST=f"{self.organization.slug}.testserver",
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == (
+            f"http://testserver/auth/login/{self.organization.slug}/?next=%2Fsettings%2Faccount%2F"
+        )
+
     def test_cannot_get_request_join_link_with_setting_disabled(self) -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             OrganizationOption.objects.create(
@@ -887,9 +901,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert user.email == "invited@example.com"
 
         with assume_test_silo_mode(SiloMode.CELL):
-            member = OrganizationMember.objects.get(
-                organization=self.organization, user_id=user.id
-            )
+            member = OrganizationMember.objects.get(organization=self.organization, user_id=user.id)
 
         assert member.id == invite.id
         assert getattr(member.flags, "sso:linked")


### PR DESCRIPTION
When a new user accepted an invite to an SSO Org, we take them through the initial login and confirmation screen where we create a new user. Instead of bringing them into the app, we brought them back to the `login` page where they needed to click `login with SSO` again because we weren't setting `sso__linked = True` on invite acceptance.