### PR TITLE
feat(seer-infra-telemetry): Report and store monitoring provider connection health on installation

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
@@ -29,6 +29,7 @@ from sentry.integrations.gcp.utils import resolve_project_error_detail
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
+from sentry.seer.agent.monitoring_providers import ConnectionHealth
 from sentry.shared_integrations.exceptions import IntegrationError
 
 logger = logging.getLogger(__name__)
@@ -87,21 +88,22 @@ def _record_verification_result(
     if set(config.get("projects", [])) != set(verified["gcp_project_ids"]):
         return
 
+    connection_health: ConnectionHealth = {
+        "status": result["connection_status"],
+        "last_checked_at": timezone.now().isoformat(),
+        "error_detail": result.get("error_detail"),
+        "resources": [
+            {
+                "resource_id": project["gcp_project_id"],
+                "status": project["connection_status"],
+                "error_detail": project.get("error_detail"),
+            }
+            for project in result["projects"]
+        ],
+    }
     integration_service.update_organization_integration(
         org_integration_id=org_integration.id,
-        config={
-            **config,
-            "connection_status": result["connection_status"],
-            "project_statuses": [
-                {
-                    "gcp_project_id": project["gcp_project_id"],
-                    "connection_status": project["connection_status"],
-                    "error_detail": project.get("error_detail"),
-                }
-                for project in result["projects"]
-            ],
-            "last_verified_at": timezone.now().isoformat(),
-        },
+        config={**config, "connection_health": connection_health},
     )
 
 

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, MutableMapping
-from typing import Any, TypedDict, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 from django.http.request import HttpRequest
 from django.utils import timezone
@@ -39,6 +39,7 @@ from sentry.organizations.services.organization import RpcOrganization
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps
 from sentry.seer.agent.monitoring_providers import (
+    ConnectionHealth,
     OrgMonitoringProvider,
     org_monitoring_provider_registry,
 )
@@ -74,9 +75,7 @@ class GcpConfig(TypedDict):
     sentry_sa_email: str
     customer_sa_email: str
     projects: list[str]
-    connection_status: str
-    project_statuses: list[GcpProjectVerification]
-    last_verified_at: str | None
+    connection_health: NotRequired[ConnectionHealth]
 
 
 class GcpConfigInputSerializer(CamelSnakeSerializer["GcpConfigInput"]):
@@ -264,9 +263,13 @@ class GcpIntegration(IntegrationInstallation):
             "sentry_sa_email": config.get("sentry_sa_email", ""),
             "customer_sa_email": config.get("customer_sa_email", ""),
             "projects": list(config.get("projects", [])),
-            "connection_status": config.get("connection_status", GCP_STATUS_UNVERIFIED),
-            "project_statuses": config.get("project_statuses", []),
-            "last_verified_at": config.get("last_verified_at"),
+            "connection_health": config.get("connection_health")
+            or {
+                "status": GCP_STATUS_UNVERIFIED,
+                "last_checked_at": None,
+                "error_detail": None,
+                "resources": [],
+            },
         }
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
@@ -292,16 +295,19 @@ class GcpIntegration(IntegrationInstallation):
         if not changed:
             return
 
-        new_config["connection_status"] = GCP_STATUS_UNVERIFIED
-        new_config["project_statuses"] = [
-            {
-                "gcp_project_id": project_id,
-                "connection_status": GCP_STATUS_UNVERIFIED,
-                "error_detail": None,
-            }
-            for project_id in new_config["projects"]
-        ]
-        new_config["last_verified_at"] = None
+        new_config["connection_health"] = {
+            "status": GCP_STATUS_UNVERIFIED,
+            "last_checked_at": None,
+            "error_detail": None,
+            "resources": [
+                {
+                    "resource_id": project_id,
+                    "status": GCP_STATUS_UNVERIFIED,
+                    "error_detail": None,
+                }
+                for project_id in new_config["projects"]
+            ],
+        }
 
         integration_service.update_organization_integration(
             org_integration_id=self.org_integration.id,
@@ -370,6 +376,7 @@ class GcpIntegrationProvider(IntegrationProvider):
         )
         verification: GcpVerification | None = extra.get("verification")
         last_verified_at = timezone.now().isoformat() if verification is not None else None
+        connection_error: str | None = None
         if verification is None:
             logger.error(
                 "gcp.post_install_missing_verification",
@@ -378,25 +385,37 @@ class GcpIntegrationProvider(IntegrationProvider):
                     "integration_id": integration.id,
                 },
             )
+            connection_error = "Verification failed to run during setup."
             verification = {
                 "connection_status": "error",
                 "projects": [
                     {
                         "gcp_project_id": project_id,
                         "connection_status": "error",
-                        "error_detail": "Verification failed to run during setup.",
+                        "error_detail": None,
                     }
                     for project_id in extra["projects"]
                 ],
             }
 
+        connection_health: ConnectionHealth = {
+            "status": verification["connection_status"],
+            "last_checked_at": last_verified_at,
+            "error_detail": connection_error,
+            "resources": [
+                {
+                    "resource_id": project["gcp_project_id"],
+                    "status": project["connection_status"],
+                    "error_detail": project.get("error_detail"),
+                }
+                for project in verification["projects"]
+            ],
+        }
         gcp_config: GcpConfig = {
             "sentry_sa_email": extra["sentry_sa_email"],
             "customer_sa_email": extra["customer_sa_email"],
             "projects": extra["projects"],
-            "connection_status": verification["connection_status"],
-            "project_statuses": verification["projects"],
-            "last_verified_at": last_verified_at,
+            "connection_health": connection_health,
         }
         org_integration.update(config=gcp_config)
 

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -24,7 +24,6 @@ from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.gcp.client import delete_sentry_sa, generate_sentry_sa
 from sentry.integrations.gcp.utils import (
     GCP_MCP_URLS,
-    GCP_STATUS_UNVERIFIED,
     parse_customer_sa_email,
     parse_gcp_project_ids,
     validate_gcp_project_id,
@@ -39,6 +38,7 @@ from sentry.organizations.services.organization import RpcOrganization
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps
 from sentry.seer.agent.monitoring_providers import (
+    MONITORING_STATUS_UNVERIFIED,
     ConnectionHealth,
     OrgMonitoringProvider,
     org_monitoring_provider_registry,
@@ -265,7 +265,7 @@ class GcpIntegration(IntegrationInstallation):
             "projects": list(config.get("projects", [])),
             "connection_health": config.get("connection_health")
             or {
-                "status": GCP_STATUS_UNVERIFIED,
+                "status": MONITORING_STATUS_UNVERIFIED,
                 "last_checked_at": None,
                 "error_detail": None,
                 "resources": [],
@@ -296,13 +296,13 @@ class GcpIntegration(IntegrationInstallation):
             return
 
         new_config["connection_health"] = {
-            "status": GCP_STATUS_UNVERIFIED,
+            "status": MONITORING_STATUS_UNVERIFIED,
             "last_checked_at": None,
             "error_detail": None,
             "resources": [
                 {
                     "resource_id": project_id,
-                    "status": GCP_STATUS_UNVERIFIED,
+                    "status": MONITORING_STATUS_UNVERIFIED,
                     "error_detail": None,
                 }
                 for project_id in new_config["projects"]

--- a/src/sentry/integrations/gcp/utils.py
+++ b/src/sentry/integrations/gcp/utils.py
@@ -30,8 +30,6 @@ GCP_CONNECTION_STATUSES: tuple[str, ...] = (
     "error",
 )
 
-GCP_STATUS_UNVERIFIED = "unverified"
-
 MAX_CUSTOMER_SA_EMAIL_LENGTH = 255
 
 

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 from collections.abc import Sequence
+from typing import TypedDict
 
 from sentry import features
 from sentry.hybridcloud.rpc.service import RpcException
@@ -20,6 +21,25 @@ from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.utils.registry import Registry
 
 logger = logging.getLogger(__name__)
+
+
+class ResourceHealth(TypedDict):
+    """Health of a single resource within a connection."""
+
+    resource_id: str
+    status: str
+    error_detail: str | None
+
+
+class ConnectionHealth(TypedDict):
+    """Health of an org-level monitoring connection, stored in config.
+    Seeded at install and updated by Seer as it uses the connection.
+    """
+
+    status: str
+    last_checked_at: str | None
+    error_detail: str | None
+    resources: list[ResourceHealth]
 
 
 class OrgMonitoringProvider(abc.ABC):

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -23,6 +23,9 @@ from sentry.utils.registry import Registry
 logger = logging.getLogger(__name__)
 
 
+MONITORING_STATUS_UNVERIFIED = "unverified"
+
+
 class ResourceHealth(TypedDict):
     """Health of a single resource within a connection."""
 

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
@@ -63,16 +63,19 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
                     "sentry_sa_email": _SENTRY_SA,
                     "customer_sa_email": customer_sa,
                     "projects": project_ids,
-                    "connection_status": "unverified",
-                    "project_statuses": [
-                        {
-                            "gcp_project_id": project_id,
-                            "connection_status": "unverified",
-                            "error_detail": None,
-                        }
-                        for project_id in project_ids
-                    ],
-                    "last_verified_at": None,
+                    "connection_health": {
+                        "status": "unverified",
+                        "last_checked_at": None,
+                        "error_detail": None,
+                        "resources": [
+                            {
+                                "resource_id": project_id,
+                                "status": "unverified",
+                                "error_detail": None,
+                            }
+                            for project_id in project_ids
+                        ],
+                    },
                 }
             },
         )
@@ -276,15 +279,16 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert response.data["projects"][0]["errorDetail"] == ("Cloud Trace: IAM roles not granted")
 
         config = self._config()
-        assert config["connection_status"] == "permission_denied"
-        assert config["project_statuses"] == [
+        health = config["connection_health"]
+        assert health["status"] == "permission_denied"
+        assert health["resources"] == [
             {
-                "gcp_project_id": "proj-a",
-                "connection_status": "permission_denied",
+                "resource_id": "proj-a",
+                "status": "permission_denied",
                 "error_detail": "Cloud Trace: IAM roles not granted",
             }
         ]
-        assert config["last_verified_at"] is not None
+        assert health["last_checked_at"] is not None
         assert config["customer_sa_email"] == _CUSTOMER_SA
         assert config["sentry_sa_email"] == _SENTRY_SA
 
@@ -324,15 +328,16 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert response.data["projects"][0]["errorDetail"] is None
 
         config = self._config()
-        assert config["connection_status"] == "connected"
-        assert config["project_statuses"] == [
+        health = config["connection_health"]
+        assert health["status"] == "connected"
+        assert health["resources"] == [
             {
-                "gcp_project_id": "proj-a",
-                "connection_status": "connected",
+                "resource_id": "proj-a",
+                "status": "connected",
                 "error_detail": None,
             }
         ]
-        assert config["last_verified_at"] is not None
+        assert health["last_checked_at"] is not None
 
     @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY, return_value=_denied_result())
@@ -348,7 +353,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
                 gcp_project_ids=["proj-a"],
             )
 
-        assert self._config()["connection_status"] == "unverified"
+        assert self._config()["connection_health"]["status"] == "unverified"
 
     @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY, return_value=_denied_result())
@@ -364,4 +369,4 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
                 gcp_project_ids=["proj-a"],
             )
 
-        assert self._config()["connection_status"] == "unverified"
+        assert self._config()["connection_health"]["status"] == "unverified"

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -86,16 +86,19 @@ class GcpIntegrationTest(TestCase):
             "sentry_sa_email": sa_email,
             "customer_sa_email": _CUSTOMER_SA,
             "projects": project_ids,
-            "connection_status": connection_status,
-            "project_statuses": [
-                {
-                    "gcp_project_id": project_id,
-                    "connection_status": connection_status,
-                    "error_detail": None,
-                }
-                for project_id in project_ids
-            ],
-            "last_verified_at": "2026-08-01T00:00:00+00:00",
+            "connection_health": {
+                "status": connection_status,
+                "last_checked_at": "2026-08-01T00:00:00+00:00",
+                "error_detail": None,
+                "resources": [
+                    {
+                        "resource_id": project_id,
+                        "status": connection_status,
+                        "error_detail": None,
+                    }
+                    for project_id in project_ids
+                ],
+            },
         }
         integration = self.create_integration(
             organization=self.organization,
@@ -495,15 +498,17 @@ class GcpIntegrationTest(TestCase):
             organization_id=self.organization.id,
             integration_id=integration.id,
         )
-        assert org_integration.config["connection_status"] == "permission_denied"
-        assert org_integration.config["project_statuses"] == [
+        health = org_integration.config["connection_health"]
+        assert health["status"] == "permission_denied"
+        assert health["error_detail"] is None
+        assert health["resources"] == [
             {
-                "gcp_project_id": "my-gcp-project",
-                "connection_status": "permission_denied",
+                "resource_id": "my-gcp-project",
+                "status": "permission_denied",
                 "error_detail": "IAM roles not granted",
             }
         ]
-        assert org_integration.config["last_verified_at"]
+        assert health["last_checked_at"]
 
     def test_post_install_records_error_when_verification_missing(self) -> None:
         integration = self.create_integration(
@@ -529,13 +534,15 @@ class GcpIntegrationTest(TestCase):
             organization_id=self.organization.id,
             integration_id=integration.id,
         )
-        assert org_integration.config["connection_status"] == "error"
-        assert org_integration.config["last_verified_at"] is None
-        assert org_integration.config["project_statuses"] == [
+        health = org_integration.config["connection_health"]
+        assert health["status"] == "error"
+        assert health["last_checked_at"] is None
+        assert health["error_detail"] == "Verification failed to run during setup."
+        assert health["resources"] == [
             {
-                "gcp_project_id": "my-gcp-project",
-                "connection_status": "error",
-                "error_detail": "Verification failed to run during setup.",
+                "resource_id": "my-gcp-project",
+                "status": "error",
+                "error_detail": None,
             }
         ]
 
@@ -579,12 +586,14 @@ class GcpIntegrationTest(TestCase):
         config = self._stored_config()
         assert config["customer_sa_email"] == "new@customer.com"
         assert config["sentry_sa_email"] == _SA_EMAIL
-        assert config["connection_status"] == GCP_STATUS_UNVERIFIED
-        assert config["last_verified_at"] is None
-        assert config["project_statuses"] == [
+        health = config["connection_health"]
+        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["last_checked_at"] is None
+        assert health["error_detail"] is None
+        assert health["resources"] == [
             {
-                "gcp_project_id": "my-gcp-project",
-                "connection_status": GCP_STATUS_UNVERIFIED,
+                "resource_id": "my-gcp-project",
+                "status": GCP_STATUS_UNVERIFIED,
                 "error_detail": None,
             }
         ]
@@ -598,11 +607,12 @@ class GcpIntegrationTest(TestCase):
 
         config = self._stored_config()
         assert config["projects"] == ["project-prod", "project-staging"]
-        assert [p["gcp_project_id"] for p in config["project_statuses"]] == [
+        health = config["connection_health"]
+        assert [d["resource_id"] for d in health["resources"]] == [
             "project-prod",
             "project-staging",
         ]
-        assert config["connection_status"] == GCP_STATUS_UNVERIFIED
+        assert health["status"] == GCP_STATUS_UNVERIFIED
 
     def test_update_config_reordering_projects_is_not_a_change(self) -> None:
         installation = self._create_installed_integration(
@@ -613,8 +623,9 @@ class GcpIntegrationTest(TestCase):
 
         config = self._stored_config()
         assert config["projects"] == ["project-prod", "project-staging"]
-        assert config["connection_status"] == "connected"
-        assert config["last_verified_at"] == "2026-08-01T00:00:00+00:00"
+        health = config["connection_health"]
+        assert health["status"] == "connected"
+        assert health["last_checked_at"] == "2026-08-01T00:00:00+00:00"
 
     def test_update_config_changing_the_project_set_marks_unverified(self) -> None:
         installation = self._create_installed_integration(
@@ -624,8 +635,9 @@ class GcpIntegrationTest(TestCase):
         installation.update_organization_config({"projects": ["project-staging", "project-new"]})
 
         config = self._stored_config()
-        assert config["connection_status"] == GCP_STATUS_UNVERIFIED
-        assert config["last_verified_at"] is None
+        health = config["connection_health"]
+        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["last_checked_at"] is None
 
     def test_update_config_rejects_a_string_of_projects(self) -> None:
         installation = self._create_installed_integration()
@@ -672,8 +684,9 @@ class GcpIntegrationTest(TestCase):
         )
 
         config = self._stored_config()
-        assert config["connection_status"] == "connected"
-        assert config["last_verified_at"] == "2026-08-01T00:00:00+00:00"
+        health = config["connection_health"]
+        assert health["status"] == "connected"
+        assert health["last_checked_at"] == "2026-08-01T00:00:00+00:00"
 
     def test_update_config_requires_existing_config(self) -> None:
         self._create_installed_integration()
@@ -713,16 +726,17 @@ class GcpIntegrationTest(TestCase):
         assert data["customer_sa_email"] == _CUSTOMER_SA
         assert data["projects"] == ["project-a", "project-b", "project-c"]
 
-    def test_get_config_data_exposes_the_connection_status(self) -> None:
+    def test_get_config_data_exposes_connection_health(self) -> None:
         installation = self._create_installed_integration()
         data = installation.get_config_data()
 
-        assert data["connection_status"] == "connected"
-        assert data["last_verified_at"] == "2026-08-01T00:00:00+00:00"
-        assert data["project_statuses"] == [
+        health = data["connection_health"]
+        assert health["status"] == "connected"
+        assert health["last_checked_at"] == "2026-08-01T00:00:00+00:00"
+        assert health["resources"] == [
             {
-                "gcp_project_id": "my-gcp-project",
-                "connection_status": "connected",
+                "resource_id": "my-gcp-project",
+                "status": "connected",
                 "error_detail": None,
             }
         ]
@@ -742,9 +756,11 @@ class GcpIntegrationTest(TestCase):
         assert isinstance(installation, GcpIntegration)
         data = installation.get_config_data()
 
-        assert data["connection_status"] == GCP_STATUS_UNVERIFIED
-        assert data["project_statuses"] == []
-        assert data["last_verified_at"] is None
+        health = data["connection_health"]
+        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["resources"] == []
+        assert health["last_checked_at"] is None
+        assert health["error_detail"] is None
 
     def test_get_config_data_empty_without_config(self) -> None:
         self._create_installed_integration()

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -17,7 +17,6 @@ from sentry.integrations.gcp.integration import (
     GcpVerificationInputSerializer,
 )
 from sentry.integrations.gcp.utils import (
-    GCP_STATUS_UNVERIFIED,
     parse_customer_sa_email,
     parse_gcp_project_ids,
     resolve_project_error_detail,
@@ -26,6 +25,7 @@ from sentry.integrations.gcp.utils import (
 from sentry.integrations.models.gcp_service_account import GcpServiceAccount
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.pipeline.types import PipelineStepAction, PipelineStepResult
+from sentry.seer.agent.monitoring_providers import MONITORING_STATUS_UNVERIFIED
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError, IntegrationError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -587,13 +587,13 @@ class GcpIntegrationTest(TestCase):
         assert config["customer_sa_email"] == "new@customer.com"
         assert config["sentry_sa_email"] == _SA_EMAIL
         health = config["connection_health"]
-        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["status"] == MONITORING_STATUS_UNVERIFIED
         assert health["last_checked_at"] is None
         assert health["error_detail"] is None
         assert health["resources"] == [
             {
                 "resource_id": "my-gcp-project",
-                "status": GCP_STATUS_UNVERIFIED,
+                "status": MONITORING_STATUS_UNVERIFIED,
                 "error_detail": None,
             }
         ]
@@ -612,7 +612,7 @@ class GcpIntegrationTest(TestCase):
             "project-prod",
             "project-staging",
         ]
-        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["status"] == MONITORING_STATUS_UNVERIFIED
 
     def test_update_config_reordering_projects_is_not_a_change(self) -> None:
         installation = self._create_installed_integration(
@@ -636,7 +636,7 @@ class GcpIntegrationTest(TestCase):
 
         config = self._stored_config()
         health = config["connection_health"]
-        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["status"] == MONITORING_STATUS_UNVERIFIED
         assert health["last_checked_at"] is None
 
     def test_update_config_rejects_a_string_of_projects(self) -> None:
@@ -757,7 +757,7 @@ class GcpIntegrationTest(TestCase):
         data = installation.get_config_data()
 
         health = data["connection_health"]
-        assert health["status"] == GCP_STATUS_UNVERIFIED
+        assert health["status"] == MONITORING_STATUS_UNVERIFIED
         assert health["resources"] == []
         assert health["last_checked_at"] is None
         assert health["error_detail"] is None


### PR DESCRIPTION
relates to CW-1972

Defines the shared `ConnectionHealth` shape (`status`, `last_checked_at`, `error_detail`, `resources: list[ResourceHealth]`) and seeds it into `OrganizationIntegration.config["connection_health"]` at install for Datadog and GCP, so the Seer Connectors page can surface connection health.

For GCP this also consolidates the old flat config fields (`connection_status` / `project_statuses` / `last_verified_at`) into `connection_health` across `post_install`, `get_config_data`, and `update_organization_config`.

Needs frontend followup to read the new fields.