### PR TITLE
ref(workflow_engine): Add types to the evaluation artifacts

### DIFF
--- a/src/sentry/workflow_engine/processors/evaluation_logging.py
+++ b/src/sentry/workflow_engine/processors/evaluation_logging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+from dataclasses import asdict
 from logging import Logger
 from typing import TYPE_CHECKING, cast
 
@@ -87,7 +88,7 @@ def emit_workflow_evaluation_logs(
         return False
 
     artifacts = (
-        [evaluation.to_artifact() for evaluation in result.evaluations.values()]
+        [asdict(evaluation.to_artifact()) for evaluation in result.evaluations.values()]
         if result.evaluations
         else [result.to_artifact()]
     )

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
-from typing import Any
+from typing import Any, final
 
 from sentry.workflow_engine.types import ConditionError
 
@@ -18,8 +18,8 @@ class EvaluationPhase(StrEnum):
 
 
 def _find_error(
-    items: list["BaseWorkflowEngineEvaluation[Any, Any]"],
-    predicate: Callable[["BaseWorkflowEngineEvaluation[Any, Any]"], bool],
+    items: list["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
+    predicate: Callable[["BaseWorkflowEngineEvaluation[Any, Any, Any]"], bool],
 ) -> ConditionError | None:
     """Helper to find an error from items matching the predicate."""
     return next((item.error for item in items if predicate(item)), None)
@@ -28,11 +28,11 @@ def _find_error(
 @dataclass(frozen=True)
 class BaseWorkflowEngineEvaluationArtifact:
     triggered: bool
-    error: ConditionError | None
+    error: str | None
 
 
 @dataclass(frozen=True, kw_only=True)
-class BaseWorkflowEngineEvaluation[R, D, A](ABC):
+class BaseWorkflowEngineEvaluation[R, D, A: BaseWorkflowEngineEvaluationArtifact](ABC):
     """
     This is a shared base class for all Evaluation classes.
 
@@ -49,8 +49,8 @@ class BaseWorkflowEngineEvaluation[R, D, A](ABC):
     algebra over evaluations: when an input had an error that could affect the result, the returned
     `(triggered, error)` carries a representative error so the taint propagates.
 
-    Concrete evaluations provide `artifact_fields` to select safe, useful fields from their
-    result and data. `to_artifact` combines those fields with the common evaluation state.
+    `to_artifact` provides the common evaluation state to each concrete evaluation's
+    `_build_artifact` implementation.
     """
 
     result: R
@@ -66,20 +66,19 @@ class BaseWorkflowEngineEvaluation[R, D, A](ABC):
         """
         return self.error is not None
 
+    @final
     def to_artifact(self) -> A:
-        return {
-            **self.artifact_fields,
-            "triggered": self.triggered,
-            "error": self.error.msg if self.error else None,
-        }
+        return self._build_artifact(
+            triggered=self.triggered,
+            error=self.error.msg if self.error else None,
+        )
 
-    @property
     @abstractmethod
-    def artifact_fields(self) -> dict[str, Any]:
-        """The evaluation-specific fields included in the artifact."""
+    def _build_artifact(self, *, triggered: bool, error: str | None) -> A:
+        """Build an artifact with the common evaluation fields provided by the base class."""
         raise NotImplementedError
 
-    def with_error(self, error: ConditionError) -> "BaseWorkflowEngineEvaluation[R, D]":
+    def with_error(self, error: ConditionError) -> "BaseWorkflowEngineEvaluation[R, D, A]":
         """
         Returns a copy of this evaluation with the given error. If the evaluation is
         already tainted, the error is ignored.
@@ -89,7 +88,7 @@ class BaseWorkflowEngineEvaluation[R, D, A](ABC):
         return replace(self, error=error)
 
     @staticmethod
-    def choose_tainted[E: "BaseWorkflowEngineEvaluation[Any, Any]"](a: E, b: E) -> E:
+    def choose_tainted[E: "BaseWorkflowEngineEvaluation[Any, Any, Any]"](a: E, b: E) -> E:
         """
         Returns the first tainted evaluation, or `a` if neither is tainted.
         Useful for tracking whether any evaluation in a series was tainted.
@@ -102,7 +101,7 @@ class BaseWorkflowEngineEvaluation[R, D, A](ABC):
 
     @staticmethod
     def any(
-        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any]"],
+        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
     ) -> tuple[bool, ConditionError | None]:
         """
         Like `any()`, but taint-aware. Returns the combined `(triggered, error)`; if any inputs
@@ -124,7 +123,7 @@ class BaseWorkflowEngineEvaluation[R, D, A](ABC):
 
     @staticmethod
     def all(
-        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any]"],
+        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
     ) -> tuple[bool, ConditionError | None]:
         """
         Like `all()`, but taint-aware. Returns the combined `(triggered, error)`; if any inputs
@@ -146,7 +145,7 @@ class BaseWorkflowEngineEvaluation[R, D, A](ABC):
 
     @staticmethod
     def none(
-        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any]"],
+        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
     ) -> tuple[bool, ConditionError | None]:
         """
         Like `not any()`, but taint-aware. Returns the combined `(triggered, error)`; if any inputs

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -17,9 +17,12 @@ class EvaluationPhase(StrEnum):
     DELAYED = "delayed"
 
 
+type AnyWorkflowEngineEvaluation = BaseWorkflowEngineEvaluation[Any, Any, Any]
+
+
 def _find_error(
-    items: list["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
-    predicate: Callable[["BaseWorkflowEngineEvaluation[Any, Any, Any]"], bool],
+    items: list[AnyWorkflowEngineEvaluation],
+    predicate: Callable[[AnyWorkflowEngineEvaluation], bool],
 ) -> ConditionError | None:
     """Helper to find an error from items matching the predicate."""
     return next((item.error for item in items if predicate(item)), None)
@@ -88,7 +91,7 @@ class BaseWorkflowEngineEvaluation[R, D, A: BaseWorkflowEngineEvaluationArtifact
         return replace(self, error=error)
 
     @staticmethod
-    def choose_tainted[E: "BaseWorkflowEngineEvaluation[Any, Any, Any]"](a: E, b: E) -> E:
+    def choose_tainted[E: AnyWorkflowEngineEvaluation](a: E, b: E) -> E:
         """
         Returns the first tainted evaluation, or `a` if neither is tainted.
         Useful for tracking whether any evaluation in a series was tainted.
@@ -101,7 +104,7 @@ class BaseWorkflowEngineEvaluation[R, D, A: BaseWorkflowEngineEvaluationArtifact
 
     @staticmethod
     def any(
-        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
+        items: Iterable[AnyWorkflowEngineEvaluation],
     ) -> tuple[bool, ConditionError | None]:
         """
         Like `any()`, but taint-aware. Returns the combined `(triggered, error)`; if any inputs
@@ -123,7 +126,7 @@ class BaseWorkflowEngineEvaluation[R, D, A: BaseWorkflowEngineEvaluationArtifact
 
     @staticmethod
     def all(
-        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
+        items: Iterable[AnyWorkflowEngineEvaluation],
     ) -> tuple[bool, ConditionError | None]:
         """
         Like `all()`, but taint-aware. Returns the combined `(triggered, error)`; if any inputs
@@ -145,7 +148,7 @@ class BaseWorkflowEngineEvaluation[R, D, A: BaseWorkflowEngineEvaluationArtifact
 
     @staticmethod
     def none(
-        items: Iterable["BaseWorkflowEngineEvaluation[Any, Any, Any]"],
+        items: Iterable[AnyWorkflowEngineEvaluation],
     ) -> tuple[bool, ConditionError | None]:
         """
         Like `not any()`, but taint-aware. Returns the combined `(triggered, error)`; if any inputs

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -25,8 +25,14 @@ def _find_error(
     return next((item.error for item in items if predicate(item)), None)
 
 
+@dataclass(frozen=True)
+class BaseWorkflowEngineEvaluationArtifact:
+    triggered: bool
+    error: ConditionError | None
+
+
 @dataclass(frozen=True, kw_only=True)
-class BaseWorkflowEngineEvaluation[R, D](ABC):
+class BaseWorkflowEngineEvaluation[R, D, A](ABC):
     """
     This is a shared base class for all Evaluation classes.
 
@@ -60,7 +66,7 @@ class BaseWorkflowEngineEvaluation[R, D](ABC):
         """
         return self.error is not None
 
-    def to_artifact(self) -> dict[str, Any]:
+    def to_artifact(self) -> A:
         return {
             **self.artifact_fields,
             "triggered": self.triggered,

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -23,7 +23,7 @@ class DataConditionEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     condition_id: int
     condition_type: str
     input_type: str
-    input: bool | int | float | str
+    input: bool | int | float | str | None
     result: DataConditionResult
 
 
@@ -56,13 +56,16 @@ class DataConditionEvaluation(
     result: DataConditionResult = None
     condition: DataCondition
 
-    @property
-    def artifact_fields(self) -> dict[str, Any]:
+    def _build_artifact(
+        self, *, triggered: bool, error: str | None
+    ) -> DataConditionEvaluationArtifact:
         safe_input = self.data if isinstance(self.data, (bool, int, float, str)) else None
-        return {
-            "condition_id": self.condition.id,
-            "condition_type": self.condition.type,
-            "input_type": type(self.data).__name__,
-            "input": safe_input,
-            "result": getattr(self.result, "value", self.result),
-        }
+        return DataConditionEvaluationArtifact(
+            triggered=triggered,
+            error=error,
+            condition_id=self.condition.id,
+            condition_type=self.condition.type,
+            input_type=type(self.data).__name__,
+            input=safe_input,
+            result=getattr(self.result, "value", self.result),
+        )

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 from sentry.workflow_engine.types import DataConditionResult
 
-from .base import BaseWorkflowEngineEvaluation
+from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArtifact
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models.data_condition import DataCondition
@@ -18,9 +18,22 @@ class DataConditionEvaluationException(Exception):
 ConditionEvaluationData: TypeAlias = Any
 
 
+@dataclass(frozen=True)
+class DataConditionEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
+    condition_id: int
+    condition_type: str
+    input_type: str
+    input: bool | int | float | str
+    result: DataConditionResult
+
+
 @dataclass(frozen=True, kw_only=True)
 class DataConditionEvaluation(
-    BaseWorkflowEngineEvaluation[DataConditionResult, ConditionEvaluationData]
+    BaseWorkflowEngineEvaluation[
+        DataConditionResult,
+        ConditionEvaluationData,
+        DataConditionEvaluationArtifact,
+    ]
 ):
     """
     This class is used to track the evaluation of a DataCondition's logic.

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArtifact
 from .condition import DataConditionEvaluation, DataConditionEvaluationArtifact
@@ -19,7 +20,7 @@ class GroupEvaluationData(TypedDict):
 class DataConditionGroupEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     logic_type: str
     result: bool
-    condition_evaluations: DataConditionEvaluationArtifact
+    condition_evaluations: Sequence[DataConditionEvaluationArtifact]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -27,7 +28,7 @@ class DataConditionGroupEvaluation(
     BaseWorkflowEngineEvaluation[
         bool,
         GroupEvaluationData,
-        DataConditionEvaluationArtifact,
+        DataConditionGroupEvaluationArtifact,
     ]
 ):
     """
@@ -44,13 +45,16 @@ class DataConditionGroupEvaluation(
     - triggered: bool - whether the group's conditions passed
     """
 
-    @property
-    def artifact_fields(self) -> dict[str, Any]:
+    def _build_artifact(
+        self, *, triggered: bool, error: str | None
+    ) -> DataConditionGroupEvaluationArtifact:
         logic_type = self.data["logic_type"]
-        return {
-            "logic_type": getattr(logic_type, "value", logic_type),
-            "result": self.result,
-            "condition_evaluations": [
+        return DataConditionGroupEvaluationArtifact(
+            triggered=triggered,
+            error=error,
+            logic_type=getattr(logic_type, "value", logic_type),
+            result=self.result,
+            condition_evaluations=[
                 evaluation.to_artifact() for evaluation in self.data["condition_evaluations"]
             ],
-        }
+        )

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
-from .base import BaseWorkflowEngineEvaluation
-from .condition import DataConditionEvaluation
+from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArtifact
+from .condition import DataConditionEvaluation, DataConditionEvaluationArtifact
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
@@ -15,8 +15,21 @@ class GroupEvaluationData(TypedDict):
     logic_type: DataConditionGroup.Type | str
 
 
+@dataclass(frozen=True)
+class DataConditionGroupEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
+    logic_type: str
+    result: bool
+    condition_evaluations: DataConditionEvaluationArtifact
+
+
 @dataclass(frozen=True, kw_only=True)
-class DataConditionGroupEvaluation(BaseWorkflowEngineEvaluation[bool, GroupEvaluationData]):
+class DataConditionGroupEvaluation(
+    BaseWorkflowEngineEvaluation[
+        bool,
+        GroupEvaluationData,
+        DataConditionEvaluationArtifact,
+    ]
+):
     """
     This class is used to track the evaluation of a DataConditionGroup.
 

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -4,6 +4,7 @@ from typing import Any, TypedDict
 
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.workflow_engine.processors.evaluations.condition import DataConditionEvaluationArtifact
 from sentry.workflow_engine.types import (
     ConditionError,
     DetectorGroupKey,
@@ -11,7 +12,7 @@ from sentry.workflow_engine.types import (
     DetectorResult,
 )
 
-from .base import BaseWorkflowEngineEvaluation, EvaluationType
+from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArtifact, EvaluationType
 from .condition_group import DataConditionGroupEvaluation
 
 
@@ -30,11 +31,20 @@ class DetectorEvaluationOutcome(StrEnum):
     TRIGGERED = "triggered"
 
 
+@dataclass(frozen=True)
+class DetectorEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
+    event_id: str | None
+    group_key: DetectorGroupKey
+    priority: DetectorPriorityLevel
+    trigger_evaluation: DataConditionEvaluationArtifact
+
+
 @dataclass(frozen=True, kw_only=True)
 class DetectorEvaluation(
     BaseWorkflowEngineEvaluation[
         DetectorResult,
         DetectorEvaluationData,
+        DetectorEvaluationArtifact,
     ]
 ):
     """
@@ -77,7 +87,7 @@ class DetectorEvaluation(
             "event_id": str(event_id) if event_id else None,
             "group_key": self.data["group_key"],
             "priority": self.priority.value,
-            "trigger_group_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
+            "trigger_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
         }
 
 

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -1,10 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import StrEnum
 from typing import Any, TypedDict
 
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
-from sentry.workflow_engine.processors.evaluations.condition import DataConditionEvaluationArtifact
 from sentry.workflow_engine.types import (
     ConditionError,
     DetectorGroupKey,
@@ -13,7 +12,7 @@ from sentry.workflow_engine.types import (
 )
 
 from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArtifact, EvaluationType
-from .condition_group import DataConditionGroupEvaluation
+from .condition_group import DataConditionGroupEvaluation, DataConditionGroupEvaluationArtifact
 
 
 class DetectorEvaluationData(TypedDict):
@@ -35,8 +34,8 @@ class DetectorEvaluationOutcome(StrEnum):
 class DetectorEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     event_id: str | None
     group_key: DetectorGroupKey
-    priority: DetectorPriorityLevel
-    trigger_evaluation: DataConditionEvaluationArtifact
+    priority: int
+    trigger_evaluation: DataConditionGroupEvaluationArtifact
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -77,18 +76,19 @@ class DetectorEvaluation(
             return DetectorEvaluationOutcome.TRIGGERED
         return DetectorEvaluationOutcome.NOT_TRIGGERED
 
-    @property
-    def artifact_fields(self) -> dict[str, Any]:
+    def _build_artifact(self, *, triggered: bool, error: str | None) -> DetectorEvaluationArtifact:
         # Each trigger group evaluation will log the value used in evaluation
         # We only need to extract the top level detector items for tracking here.
         event_data = self.data["event_data"] or {}
         event_id = event_data.get("event_id")
-        return {
-            "event_id": str(event_id) if event_id else None,
-            "group_key": self.data["group_key"],
-            "priority": self.priority.value,
-            "trigger_evaluation": self.data["trigger_group_evaluation"].to_artifact(),
-        }
+        return DetectorEvaluationArtifact(
+            triggered=triggered,
+            error=error,
+            event_id=str(event_id) if event_id else None,
+            group_key=self.data["group_key"],
+            priority=self.priority.value,
+            trigger_evaluation=self.data["trigger_group_evaluation"].to_artifact(),
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -135,7 +135,7 @@ class ProcessDetectorsResult:
         return [
             {
                 **self.artifact_data,
-                **evaluation.to_artifact(),
+                **asdict(evaluation.to_artifact()),
                 "outcome": evaluation.outcome,
             }
             for evaluation in self.evaluations.values()

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -7,13 +7,21 @@ from typing import TYPE_CHECKING, TypedDict
 
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.types import (
+    ActionId,
     DataConditionGroupId,
+    DetectorId,
+    GroupId,
     WorkflowEventData,
     WorkflowId,
 )
 
-from .base import BaseWorkflowEngineEvaluation, EvaluationPhase, EvaluationType
-from .condition_group import DataConditionGroupEvaluation
+from .base import (
+    BaseWorkflowEngineEvaluation,
+    BaseWorkflowEngineEvaluationArtifact,
+    EvaluationPhase,
+    EvaluationType,
+)
+from .condition_group import DataConditionGroupEvaluation, DataConditionGroupEvaluationArtifact
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models import Action
@@ -60,11 +68,29 @@ class WorkflowEvaluationData(TypedDict):
     event: WorkflowEventData
 
 
+@dataclass(frozen=True)
+class WorkflowEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
+    detector_type: str
+    evaluation_phase: EvaluationPhase
+    evaluation_type: EvaluationType
+    filter_evaluations: Sequence[DataConditionGroupEvaluationArtifact]
+    group_id: GroupId
+    outcome: WorkflowEvaluationOutcome
+    project_id: int
+    trigger_evaluation: DataConditionGroupEvaluationArtifact
+    triggered_action_ids: Sequence[ActionId]
+    workflow_id: WorkflowId
+    deferred: DeferredWorkflowEvaluationResult | None = None
+    detector_id: DetectorId | None = None
+    event_id: str | None = None
+
+
 @dataclass(frozen=True, kw_only=True)
 class WorkflowEvaluation(
     BaseWorkflowEngineEvaluation[
         WorkflowEvaluationResult,
         WorkflowEvaluationData,
+        WorkflowEvaluationArtifact,
     ]
 ):
     """
@@ -78,9 +104,9 @@ class WorkflowEvaluation(
     - `triggered`: bool - Whether the workflow's trigger (WHEN) conditions passed.
     """
 
-    workflow_id: WorkflowId
     detector_id: int
     detector_type: str
+    workflow_id: WorkflowId
 
     @property
     def outcome(self) -> WorkflowEvaluationOutcome:
@@ -115,33 +141,33 @@ class WorkflowEvaluation(
             else event_data.event.id
         )
         return {
-            "evaluation_type": EvaluationType.WORKFLOW,
-            "evaluation_phase": EvaluationPhase.INITIAL,
-            "workflow_id": self.workflow_id,
+            **({"deferred": deferred} if deferred else {}),
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
-            "project_id": event_data.event.project_id,
+            "evaluation_phase": EvaluationPhase.INITIAL,
+            "evaluation_type": EvaluationType.WORKFLOW,
             "event_id": str(event_id) if event_id else None,
-            "group_id": event_data.group.id,
-            "outcome": self.outcome,
-            "triggered_action_ids": triggered_action_ids,
-            **({"deferred": deferred} if deferred else {}),
-            "trigger_group_evaluation": self.data.get("trigger_group_eval").to_artifact(),
-            "filter_group_evaluations": [
+            "filter_evaluations": [
                 evaluation.to_artifact() for evaluation in self.data.get("filter_group_evals")
             ],
+            "group_id": event_data.group.id,
+            "outcome": self.outcome,
+            "project_id": event_data.event.project_id,
+            "trigger_evaluation": self.data.get("trigger_group_eval").to_artifact(),
+            "triggered_action_ids": triggered_action_ids,
+            "workflow_id": self.workflow_id,
         }
 
 
 @dataclass(frozen=True, kw_only=True)
 class ProcessWorkflowsResult:
-    evaluations: dict[WorkflowId, WorkflowEvaluation]
-    outcome: WorkflowEvaluationOutcome
-    project_id: int
-    group_id: int
-    event_id: str | None
     detector_id: int | None = None
     detector_type: str | None = None
+    evaluations: dict[WorkflowId, WorkflowEvaluation]
+    event_id: str | None
+    group_id: int
+    outcome: WorkflowEvaluationOutcome
+    project_id: int
 
     def has_triggered_actions(self) -> bool:
         return any(
@@ -152,13 +178,13 @@ class ProcessWorkflowsResult:
 
     def to_artifact(self) -> dict[str, object]:
         return {
-            "evaluation_type": EvaluationType.WORKFLOW,
-            "evaluation_phase": EvaluationPhase.INITIAL,
-            "outcome": self.outcome,
-            "project_id": self.project_id,
-            "group_id": self.group_id,
-            "event_id": self.event_id,
             "detector_id": self.detector_id,
             "detector_type": self.detector_type,
             "error": None,
+            "evaluation_phase": EvaluationPhase.INITIAL,
+            "evaluation_type": EvaluationType.WORKFLOW,
+            "event_id": self.event_id,
+            "group_id": self.group_id,
+            "outcome": self.outcome,
+            "project_id": self.project_id,
         }

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -69,7 +69,7 @@ class WorkflowEvaluationData(TypedDict):
 
 
 @dataclass(frozen=True)
-class DeferredWorkflowEvaluationArtifact:
+class DeferredWorkflowData:
     trigger_group_id: DataConditionGroupId | None
     filter_group_ids: Sequence[DataConditionGroupId]
     passing_filter_group_ids: Sequence[DataConditionGroupId]
@@ -87,7 +87,7 @@ class WorkflowEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     trigger_evaluation: DataConditionGroupEvaluationArtifact
     triggered_action_ids: Sequence[ActionId]
     workflow_id: WorkflowId
-    deferred: DeferredWorkflowEvaluationArtifact | None = None
+    deferred: DeferredWorkflowData | None = None
     detector_id: DetectorId | None = None
     event_id: str | None = None
 
@@ -131,12 +131,10 @@ class WorkflowEvaluation(
     def _build_artifact(self, *, triggered: bool, error: str | None) -> WorkflowEvaluationArtifact:
         if isinstance(self.result, DeferredWorkflowEvaluationResult):
             triggered_action_ids: list[int] = []
-            deferred: DeferredWorkflowEvaluationArtifact | None = (
-                DeferredWorkflowEvaluationArtifact(
-                    trigger_group_id=self.result.delayed_when_group_id,
-                    filter_group_ids=sorted(self.result.delayed_if_group_ids),
-                    passing_filter_group_ids=sorted(self.result.passing_if_group_ids),
-                )
+            deferred: DeferredWorkflowData | None = DeferredWorkflowData(
+                trigger_group_id=self.result.delayed_when_group_id,
+                filter_group_ids=sorted(self.result.delayed_if_group_ids),
+                passing_filter_group_ids=sorted(self.result.passing_if_group_ids),
             )
         else:
             triggered_action_ids = [action.id for action in self.result]

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -69,6 +69,13 @@ class WorkflowEvaluationData(TypedDict):
 
 
 @dataclass(frozen=True)
+class DeferredWorkflowEvaluationArtifact:
+    trigger_group_id: DataConditionGroupId | None
+    filter_group_ids: Sequence[DataConditionGroupId]
+    passing_filter_group_ids: Sequence[DataConditionGroupId]
+
+
+@dataclass(frozen=True)
 class WorkflowEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     detector_type: str
     evaluation_phase: EvaluationPhase
@@ -80,7 +87,7 @@ class WorkflowEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     trigger_evaluation: DataConditionGroupEvaluationArtifact
     triggered_action_ids: Sequence[ActionId]
     workflow_id: WorkflowId
-    deferred: DeferredWorkflowEvaluationResult | None = None
+    deferred: DeferredWorkflowEvaluationArtifact | None = None
     detector_id: DetectorId | None = None
     event_id: str | None = None
 
@@ -121,15 +128,16 @@ class WorkflowEvaluation(
             return WorkflowEvaluationOutcome.ACTIONS_TRIGGERED
         return WorkflowEvaluationOutcome.NO_ACTIONS
 
-    @property
-    def artifact_fields(self) -> dict[str, object]:
+    def _build_artifact(self, *, triggered: bool, error: str | None) -> WorkflowEvaluationArtifact:
         if isinstance(self.result, DeferredWorkflowEvaluationResult):
             triggered_action_ids: list[int] = []
-            deferred: dict[str, object] | None = {
-                "trigger_group_id": self.result.delayed_when_group_id,
-                "filter_group_ids": sorted(self.result.delayed_if_group_ids),
-                "passing_filter_group_ids": sorted(self.result.passing_if_group_ids),
-            }
+            deferred: DeferredWorkflowEvaluationArtifact | None = (
+                DeferredWorkflowEvaluationArtifact(
+                    trigger_group_id=self.result.delayed_when_group_id,
+                    filter_group_ids=sorted(self.result.delayed_if_group_ids),
+                    passing_filter_group_ids=sorted(self.result.passing_if_group_ids),
+                )
+            )
         else:
             triggered_action_ids = [action.id for action in self.result]
             deferred = None
@@ -140,23 +148,25 @@ class WorkflowEvaluation(
             if isinstance(event_data.event, GroupEvent)
             else event_data.event.id
         )
-        return {
-            **({"deferred": deferred} if deferred else {}),
-            "detector_id": self.detector_id,
-            "detector_type": self.detector_type,
-            "evaluation_phase": EvaluationPhase.INITIAL,
-            "evaluation_type": EvaluationType.WORKFLOW,
-            "event_id": str(event_id) if event_id else None,
-            "filter_evaluations": [
+        return WorkflowEvaluationArtifact(
+            triggered=triggered,
+            error=error,
+            deferred=deferred,
+            detector_id=self.detector_id,
+            detector_type=self.detector_type,
+            evaluation_phase=EvaluationPhase.INITIAL,
+            evaluation_type=EvaluationType.WORKFLOW,
+            event_id=str(event_id) if event_id else None,
+            filter_evaluations=[
                 evaluation.to_artifact() for evaluation in self.data.get("filter_group_evals")
             ],
-            "group_id": event_data.group.id,
-            "outcome": self.outcome,
-            "project_id": event_data.event.project_id,
-            "trigger_evaluation": self.data.get("trigger_group_eval").to_artifact(),
-            "triggered_action_ids": triggered_action_ids,
-            "workflow_id": self.workflow_id,
-        }
+            group_id=event_data.group.id,
+            outcome=self.outcome,
+            project_id=event_data.event.project_id,
+            trigger_evaluation=self.data.get("trigger_group_eval").to_artifact(),
+            triggered_action_ids=triggered_action_ids,
+            workflow_id=self.workflow_id,
+        )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/sentry/workflow_engine/processors/evaluations/test_base.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_base.py
@@ -1,3 +1,5 @@
+from dataclasses import asdict
+
 from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
 from sentry.workflow_engine.processors.evaluations.base import BaseWorkflowEngineEvaluation
@@ -142,7 +144,7 @@ class TestWithError:
         assert _ev(True, ERR).with_error(OTHER_ERR).error == ERR
 
     def test_to_artifact_includes_common_fields(self) -> None:
-        assert _ev(True, ERR).to_artifact() == {
+        assert asdict(_ev(True, ERR).to_artifact()) == {
             "triggered": True,
             "error": ERR.msg,
             "logic_type": DataConditionGroup.Type.ANY,

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from unittest import mock
 
 from sentry.testutils.cases import TestCase
@@ -99,7 +100,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             triggered=True, error=ConditionError(msg="evaluation failed")
         )
 
-        assert evaluation.to_artifact() == {
+        assert asdict(evaluation.to_artifact()) == {
             "triggered": True,
             "error": "evaluation failed",
             "evaluation_type": EvaluationType.WORKFLOW,
@@ -112,6 +113,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             "group_id": self.group.id,
             "outcome": WorkflowEvaluationOutcome.ERROR,
             "triggered_action_ids": [],
+            "deferred": None,
             "trigger_evaluation": {
                 "triggered": True,
                 "error": "evaluation failed",
@@ -125,7 +127,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
     def test_to_artifact_includes_deferred_conditions(self) -> None:
         evaluation = self._build_evaluation(deferred=True)
 
-        artifact = evaluation.to_artifact()
+        artifact = asdict(evaluation.to_artifact())
 
         assert artifact["outcome"] == WorkflowEvaluationOutcome.DEFERRED
         assert artifact["deferred"] == {
@@ -168,7 +170,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             data={"email": "user@example.com"},
         )
 
-        artifact = evaluation.to_artifact()
+        artifact = asdict(evaluation.to_artifact())
 
         assert artifact == {
             "triggered": True,
@@ -190,7 +192,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
             data="production",
         )
 
-        assert evaluation.to_artifact()["input"] == "production"
+        assert evaluation.to_artifact().input == "production"
 
     def test_emitter_always_logs_with_feature_enabled(self) -> None:
         evaluation = self._build_evaluation()
@@ -270,7 +272,10 @@ class TestWorkflowEvaluationArtifact(TestCase):
 
         mock_sentry_logger.info.assert_called_once_with(
             "workflow_engine.process_workflows.evaluation",
-            attributes={**evaluation.to_artifact(), "organization_id": self.organization.id},
+            attributes={
+                **asdict(evaluation.to_artifact()),
+                "organization_id": self.organization.id,
+            },
         )
         mock_logger.info.assert_not_called()
 

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -112,14 +112,14 @@ class TestWorkflowEvaluationArtifact(TestCase):
             "group_id": self.group.id,
             "outcome": WorkflowEvaluationOutcome.ERROR,
             "triggered_action_ids": [],
-            "trigger_group_evaluation": {
+            "trigger_evaluation": {
                 "triggered": True,
                 "error": "evaluation failed",
-                "logic_type": DataConditionGroup.Type.ANY,
+                "logic_type": DataConditionGroup.Type.ANY.value,
                 "result": True,
                 "condition_evaluations": [],
             },
-            "filter_group_evaluations": [],
+            "filter_evaluations": [],
         }
 
     def test_to_artifact_includes_deferred_conditions(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -133,7 +133,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 "event_id": None,
                 "group_key": None,
                 "priority": DetectorPriorityLevel.HIGH.value,
-                "trigger_group_evaluation": {
+                "trigger_evaluation": {
                     "logic_type": "any",
                     "result": True,
                     "condition_evaluations": [],


### PR DESCRIPTION
# Description
As I started to work with the artifacts, i found it awkward that these we could edit them and that they are untyped dicts.

This PR changes them into frozen dataclasses to address both of those problems.