### PR TITLE
feat(dashboards): add dashboard name to the deletion popup modal

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -75,7 +75,9 @@ export function DashboardActionBar({
         </Button>
         <Confirm
           priority="danger"
-          message={t('Are you sure you want to delete this dashboard?')}
+          message={tct('Are you sure you want to delete the [title] dashboard?', {
+            title: <strong>{dashboard.title}</strong>,
+          })}
           onConfirm={onDelete}
         >
           <Button size="sm" variant="danger" data-test-id="dashboard-delete">

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -193,9 +193,16 @@ describe('Dashboards - DashboardTable', () => {
 
     expect(deleteMock).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      within(screen.getByRole('dialog')).getByRole('button', {name: /confirm/i})
-    );
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByText(
+        (_, element) =>
+          element?.textContent ===
+          'Are you sure you want to delete the Dashboard 2 dashboard?'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', {name: /confirm/i}));
 
     await waitFor(() => {
       expect(deleteMock).toHaveBeenCalled();

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -187,7 +187,9 @@ function DashboardTable({
           onClick={e => {
             e.stopPropagation();
             openConfirmModal({
-              message: t('Are you sure you want to delete this dashboard?'),
+              message: tct('Are you sure you want to delete the [title] dashboard?', {
+                title: <strong>{dataRow[ResponseKeys.NAME]}</strong>,
+              }),
               priority: 'danger',
               onConfirm: () => handleDeleteDashboard(dataRow, 'table'),
             });


### PR DESCRIPTION
This adds the dashboard name to the deletion modal in the dashboard edit and dashboard table, as per requested in DAIN-1798

<img width="1488" height="319" alt="Screenshot 2026-08-28 at 4 22 07 PM" src="https://github.com/user-attachments/assets/94f8fa83-b6f6-4630-b15c-de3ac0c6a2b6" />

Closes DAIN-1798