### PR TITLE
fix(issues): Prefer project repositories for code mapping

### DIFF
--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -71,6 +71,7 @@ class RepoTreesIntegration(ABC):
         with metrics.timer(f"{METRICS_KEY_PREFIX}.populate_repositories.duration"):
             repositories = self._populate_repositories()
             if repository_names is not None:
+                # Preserve the caller's repository priority while filtering.
                 repository_order = {name: index for index, name in enumerate(repository_names)}
                 repositories = sorted(
                     (

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -64,10 +64,22 @@ class RepoTreesIntegration(ABC):
     def integration_name(self) -> str:
         raise NotImplementedError
 
-    def get_trees_for_org(self) -> dict[str, RepoTree]:
+    def get_trees_for_org(
+        self, repository_names: Sequence[str] | None = None
+    ) -> dict[str, RepoTree]:
         trees = {}
         with metrics.timer(f"{METRICS_KEY_PREFIX}.populate_repositories.duration"):
             repositories = self._populate_repositories()
+            if repository_names is not None:
+                repository_order = {name: index for index, name in enumerate(repository_names)}
+                repositories = sorted(
+                    (
+                        repository
+                        for repository in repositories
+                        if repository["full_name"] in repository_order
+                    ),
+                    key=lambda repository: repository_order[repository["full_name"]],
+                )
         if not repositories:
             logger.warning("Fetching repositories returned an empty list.")
         else:

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -44,8 +44,6 @@ class CodeMapping(NamedTuple):
 SLASH = "/"
 BACKSLASH = "\\"  # This is the Python representation of a single backslash
 
-CodeMappingKey = tuple[str, str]
-
 
 def derive_code_mappings(
     organization: Organization,
@@ -73,7 +71,7 @@ class CodeMappingTreesHelper:
     def __init__(self, trees: Mapping[str, RepoTree]):
         self.trees = trees
         # Multiple source roots may legitimately share the same stack root in one monorepo.
-        self.code_mappings: dict[CodeMappingKey, CodeMapping] = {}
+        self.code_mappings: dict[CodeMapping, CodeMapping] = {}
 
     def generate_code_mappings(
         self, frames: Sequence[Mapping[str, Any]], platform: str | None = None
@@ -171,12 +169,11 @@ class CodeMappingTreesHelper:
         for stackframes in buckets.values():
             for frame_filename in stackframes:
                 for code_mapping in self._find_code_mappings(frame_filename):
-                    mapping_key = (code_mapping.stacktrace_root, code_mapping.source_path)
-                    if mapping_key not in self.code_mappings:
+                    if code_mapping not in self.code_mappings:
                         # This allows processing some stack frames that
                         # were matching more than one file
                         reprocess = True
-                        self.code_mappings[mapping_key] = code_mapping
+                        self.code_mappings[code_mapping] = code_mapping
         return reprocess
 
     def _find_code_mappings(self, frame_filename: FrameInfo) -> list[CodeMapping]:
@@ -201,15 +198,12 @@ class CodeMappingTreesHelper:
             logger.warning("No files matched for %s", frame_filename.raw_path)
             return []
 
-        unique_code_mappings = {
-            (code_mapping.stacktrace_root, code_mapping.source_path): code_mapping
-            for code_mapping in code_mappings
-        }
-        if len({code_mapping.repo.name for code_mapping in unique_code_mappings.values()}) > 1:
+        unique_code_mappings = list(dict.fromkeys(code_mappings))
+        if len({code_mapping.repo for code_mapping in unique_code_mappings}) > 1:
             logger.warning("More than one repo matched %s", frame_filename.raw_path)
             return []
 
-        return list(unique_code_mappings.values())
+        return unique_code_mappings
 
     def _generate_code_mapping_from_tree(
         self,
@@ -303,7 +297,7 @@ class CodeMappingTreesHelper:
         return any(
             code_mapping.source_path
             for code_mapping in self.code_mappings.values()
-            if src_file.startswith(f"{code_mapping.source_path}/")
+            if src_file.startswith(f"{code_mapping.source_path.rstrip('/')}/")
         )
 
     def __repr__(self) -> str:

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -198,6 +198,7 @@ class CodeMappingTreesHelper:
             logger.warning("No files matched for %s", frame_filename.raw_path)
             return []
 
+        # Keep repository identity so equal roots in different repositories stay ambiguous.
         unique_code_mappings = list(dict.fromkeys(code_mappings))
         if len({code_mapping.repo for code_mapping in unique_code_mappings}) > 1:
             logger.warning("More than one repo matched %s", frame_filename.raw_path)

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -101,6 +101,7 @@ def process_event(
     if not frames_to_process:
         return [], []
 
+    # Java also uses inferred mappings to restore missing derived in-app rules.
     if not platform_config.creates_in_app_stack_trace_rules():
         frames_to_process = _get_uncovered_frames(
             frames_to_process,

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -145,6 +145,8 @@ def _get_usable_code_mappings(project: Project) -> list[RepositoryProjectPathCon
             organization_id=project.organization_id,
             organization_integration_id__isnull=False,
         )
+        # A generated empty root only proves the single file that produced it matched.
+        .exclude(automatically_generated=True, stack_root="")
         .select_related("project_repository__repository")
         .order_by("id")
     )

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any
 
@@ -10,23 +10,34 @@ from django.db import router, transaction
 from google.api_core.exceptions import DeadlineExceeded
 from sentry_sdk import set_tag, set_user
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcOrganizationIntegration
 from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionEvent,
     SCMIntegrationInteractionType,
 )
-from sentry.issues.auto_source_code_config.code_mapping import CodeMapping, CodeMappingTreesHelper
+from sentry.issues.auto_source_code_config.code_mapping import (
+    CodeMapping,
+    CodeMappingTreesHelper,
+    convert_stacktrace_frame_path_to_source_path,
+)
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
+from sentry.models.projectrepository import (
+    SOURCE_PRIORITY,
+    ProjectRepository,
+    ProjectRepositorySource,
+)
 from sentry.models.repository import Repository
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import metrics
+from sentry.utils.event_frames import EventFrame, get_sdk_name
 from sentry.utils.locking import UnableToAcquireLock
 
 from .constants import METRIC_PREFIX
@@ -90,13 +101,31 @@ def process_event(
     if not frames_to_process:
         return [], []
 
+    if not platform_config.creates_in_app_stack_trace_rules():
+        frames_to_process = _get_uncovered_frames(
+            frames_to_process,
+            _get_usable_code_mappings(project),
+            platform,
+            get_sdk_name(event.data),
+        )
+        if not frames_to_process:
+            return [], []
+
     code_mappings: list[CodeMapping] = []
     in_app_stack_trace_rules: list[str] = []
     try:
         installation = get_installation(org)
-        trees = get_trees_for_org(installation, org, extra)
-        trees_helper = CodeMappingTreesHelper(trees)
-        code_mappings = trees_helper.generate_code_mappings(frames_to_process, platform)
+        linked_repository_names = _get_linked_repository_names(project)
+        # Prefer project-linked repositories, then fall back to everything the integration exposes.
+        repository_searches = [linked_repository_names, None] if linked_repository_names else [None]
+        for repository_names in repository_searches:
+            trees = get_trees_for_org(installation, org, extra, repository_names=repository_names)
+            code_mappings = CodeMappingTreesHelper(trees).generate_code_mappings(
+                frames_to_process, platform
+            )
+            if code_mappings:
+                break
+
         _, in_app_stack_trace_rules = create_configurations(
             code_mappings, installation, project, platform_config
         )
@@ -105,6 +134,82 @@ def process_event(
         pass
 
     return code_mappings, in_app_stack_trace_rules
+
+
+def _get_usable_code_mappings(project: Project) -> list[RepositoryProjectPathConfig]:
+    code_mappings = list(
+        RepositoryProjectPathConfig.objects.filter(
+            project_repository__project_id=project.id,
+            project_repository__repository__organization_id=project.organization_id,
+            project_repository__repository__status=ObjectStatus.ACTIVE,
+            organization_id=project.organization_id,
+            organization_integration_id__isnull=False,
+        )
+        .select_related("project_repository__repository")
+        .order_by("id")
+    )
+    if not code_mappings:
+        return []
+
+    active_organization_integrations = integration_service.get_organization_integrations(
+        org_integration_ids=list(
+            {code_mapping.organization_integration_id for code_mapping in code_mappings}
+        ),
+        organization_id=project.organization_id,
+        status=ObjectStatus.ACTIVE,
+    )
+    active_organization_integration_ids = {
+        organization_integration.id for organization_integration in active_organization_integrations
+    }
+    return [
+        code_mapping
+        for code_mapping in code_mappings
+        if code_mapping.organization_integration_id in active_organization_integration_ids
+    ]
+
+
+def _get_uncovered_frames(
+    frames: Sequence[dict[str, Any]],
+    code_mappings: Sequence[RepositoryProjectPathConfig],
+    platform: str,
+    sdk_name: str | None,
+) -> list[dict[str, Any]]:
+    frames_requiring_inference: list[dict[str, Any]] = []
+    for frame in frames:
+        event_frame = EventFrame.from_dict(frame)
+        is_covered = any(
+            convert_stacktrace_frame_path_to_source_path(
+                frame=event_frame,
+                code_mapping=code_mapping,
+                platform=platform,
+                sdk_name=sdk_name,
+            )
+            is not None
+            for code_mapping in code_mappings
+        )
+        if not is_covered:
+            frames_requiring_inference.append(frame)
+
+    return frames_requiring_inference
+
+
+def _get_linked_repository_names(project: Project) -> list[str]:
+    project_repositories = ProjectRepository.objects.filter(
+        project_id=project.id,
+        repository__organization_id=project.organization_id,
+        repository__status=ObjectStatus.ACTIVE,
+    ).select_related("repository")
+    return [
+        project_repository.repository.name
+        for project_repository in sorted(
+            project_repositories,
+            key=lambda project_repository: (
+                -SOURCE_PRIORITY.get(ProjectRepositorySource(project_repository.source), 0),
+                project_repository.repository.name,
+                project_repository.repository_id,
+            ),
+        )
+    ]
 
 
 def fetch_event(
@@ -167,7 +272,10 @@ def process_error(error: ApiError, extra: dict[str, Any]) -> None:
 
 
 def get_trees_for_org(
-    installation: IntegrationInstallation, org: Organization, extra: dict[str, Any]
+    installation: IntegrationInstallation,
+    org: Organization,
+    extra: dict[str, Any],
+    repository_names: list[str] | None = None,
 ) -> dict[str, Any]:
     trees: dict[str, Any] = {}
     if not hasattr(installation, "get_trees_for_org"):
@@ -184,7 +292,7 @@ def get_trees_for_org(
     ).capture() as lifecycle:
         try:
             with lock.acquire():
-                trees = installation.get_trees_for_org()
+                trees = installation.get_trees_for_org(repository_names=repository_names)
                 if not trees:
                     lifecycle.record_halt(DeriveCodeMappingsErrorReason.EMPTY_TREES, extra=extra)
         except ApiError as error:

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -182,6 +182,7 @@ class TestDerivedCodeMappings(TestCase):
         ]
         code_mappings = self.code_mapping_helper.generate_code_mappings(frames)
         assert code_mappings == self.expected_code_mappings
+        assert self.code_mapping_helper._matches_existing_code_mappings("src/sentry/web/urls.py")
 
     def test_more_than_one_match_works_with_different_order(self) -> None:
         frames = [
@@ -196,10 +197,15 @@ class TestDerivedCodeMappings(TestCase):
     @patch("sentry.issues.auto_source_code_config.code_mapping.logger")
     def test_more_than_one_repo_match(self, logger: Any) -> None:
         # XXX: There's a chance that we could infer package names but that is risky
-        # repo 1: src/sentry/web/urls.py
-        # repo 2: sentry/web/urls.py
+        path = "src/sentry/web/urls.py"
+        helper = CodeMappingTreesHelper(
+            {
+                self.foo_repo.name: RepoTree(self.foo_repo, files=[path]),
+                self.bar_repo.name: RepoTree(self.bar_repo, files=[path]),
+            }
+        )
         frames = [{"filename": "sentry/web/urls.py"}]
-        code_mappings = self.code_mapping_helper.generate_code_mappings(frames)
+        code_mappings = helper.generate_code_mappings(frames)
         # The file appears in more than one repo, thus, we are unable to determine the code mapping
         assert code_mappings == []
         logger.warning.assert_called_with("More than one repo matched %s", "sentry/web/urls.py")

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, TypedDict, cast
 from unittest.mock import patch
 
+from sentry.constants import ObjectStatus
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.source_code_management.repo_trees import RepoAndBranch
@@ -89,7 +90,7 @@ class BaseDeriveCodeMappings(TestCase):
         source_root: str,
         automatically_generated: bool = False,
         default_branch: str = "master",
-    ) -> None:
+    ) -> RepositoryProjectPathConfig:
         with assume_test_silo_mode_of(OrganizationIntegration):
             organization_integration = OrganizationIntegration.objects.get(
                 organization_id=self.organization.id, integration=self.integration
@@ -105,7 +106,7 @@ class BaseDeriveCodeMappings(TestCase):
             repository=repository,
             defaults={"source": ProjectRepositorySource.MANUAL},
         )
-        RepositoryProjectPathConfig.objects.create(
+        return RepositoryProjectPathConfig.objects.create(
             stack_root=stack_root,
             source_root=source_root,
             default_branch=default_branch,
@@ -116,6 +117,24 @@ class BaseDeriveCodeMappings(TestCase):
             project_repository=project_repo,
         )
 
+    def create_project_repository(
+        self,
+        repo_name: str,
+        source: ProjectRepositorySource = ProjectRepositorySource.MANUAL,
+    ) -> ProjectRepository:
+        repository = self.create_repo(
+            project=self.project,
+            name=repo_name,
+            integration_id=self.integration.id,
+            external_id=repo_name,
+        )
+        project_repository, _ = ProjectRepository.objects.get_or_create(
+            project=self.project,
+            repository=repository,
+            defaults={"source": source},
+        )
+        return project_repository
+
     def _process_and_assert_configuration_changes(
         self,
         *,  # Force keyword arguments
@@ -124,12 +143,15 @@ class BaseDeriveCodeMappings(TestCase):
         platform: str,
         expected_new_code_mappings: Sequence[ExpectedCodeMapping] | None = None,
         expected_new_in_app_stack_trace_rules: list[str] | None = None,
+        expected_tree_requests: Sequence[str] | None = None,
     ) -> GroupEvent:
         platform_config = PlatformConfig(platform)
         dry_run = platform_config.is_dry_run_platform(self.organization)
         tags = {"dry_run": dry_run, "platform": platform}
         with (
-            patch(f"{CLIENT}.get_tree", side_effect=create_mock_get_tree(repo_trees)),
+            patch(
+                f"{CLIENT}.get_tree", side_effect=create_mock_get_tree(repo_trees)
+            ) as mock_get_tree,
             patch(f"{CLIENT}.get_remaining_api_requests", return_value=500),
             patch(
                 f"{REPO_TREES_INTEGRATION}._populate_repositories",
@@ -144,6 +166,11 @@ class BaseDeriveCodeMappings(TestCase):
             code_mappings, in_app_stack_trace_rules = process_event(
                 self.project.id, event.group_id, event.event_id
             )
+
+            if expected_tree_requests is not None:
+                assert [call.args[0] for call in mock_get_tree.call_args_list] == list(
+                    expected_tree_requests
+                )
 
             current_code_mappings = RepositoryProjectPathConfig.objects.all()
             current_repositories = Repository.objects.all()
@@ -183,6 +210,7 @@ class BaseDeriveCodeMappings(TestCase):
                     for expected_cm in expected_new_code_mappings:
                         code_mapping = current_code_mappings.get(
                             project_repository__project_id=self.project.id,
+                            project_repository__repository__name=expected_cm["repo_name"],
                             stack_root=expected_cm["stack_root"],
                             source_root=expected_cm["source_root"],
                         )
@@ -311,14 +339,108 @@ class TestGenericBehaviour(BaseDeriveCodeMappings):
             )
 
     def test_handle_existing_code_mapping(self) -> None:
-        self.create_repo_and_code_mapping("repo", "foo/", "src/foo/")
-        # The platform & frames are irrelevant for this test
-        event = self.create_event([self.frame("foo/bar/baz.py", True)], "python")
-        assert event.group_id is not None
-        process_event(self.project.id, event.group_id, event.event_id)
+        self.create_repo_and_code_mapping(REPO1, "foo/", "src/foo/")
+
+        with patch(f"{REPO_TREES_INTEGRATION}.get_trees_for_org") as get_trees_for_org:
+            self._process_and_assert_configuration_changes(
+                repo_trees={REPO1: ["src/foo/bar.py"]},
+                frames=[self.frame("foo/bar.py", True)],
+                platform="python",
+                expected_tree_requests=[],
+            )
+
+        get_trees_for_org.assert_not_called()
         all_cm = RepositoryProjectPathConfig.objects.all()
         assert len(all_cm) == 1
         assert all_cm[0].automatically_generated is False
+
+    def test_mapping_with_inactive_repository_does_not_suppress_discovery(self) -> None:
+        code_mapping = self.create_repo_and_code_mapping("inactive-repo", "foo/", "src/foo/")
+        code_mapping.project_repository.repository.update(status=ObjectStatus.DISABLED)
+
+        self._process_and_assert_configuration_changes(
+            repo_trees={REPO1: ["src/foo/bar.py"]},
+            frames=[self.frame("foo/bar.py", True)],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("foo/", "src/foo/")],
+            expected_tree_requests=[REPO1, REPO2],
+        )
+
+    def test_mapping_with_inactive_organization_integration_is_not_usable(self) -> None:
+        self.create_repo_and_code_mapping("inactive-repo", "foo/", "src/foo/")
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            organization_integration = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id,
+                integration=self.integration,
+            )
+            organization_integration.update(status=ObjectStatus.DISABLED)
+
+        self._process_and_assert_configuration_changes(
+            repo_trees={REPO1: ["src/foo/bar.py"]},
+            frames=[self.frame("foo/bar.py", True)],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("foo/", "src/foo/")],
+            expected_tree_requests=[REPO1, REPO2],
+        )
+
+    def test_linked_repository_match_avoids_unrelated_trees(self) -> None:
+        self.create_project_repository(REPO2)
+
+        self._process_and_assert_configuration_changes(
+            repo_trees={
+                REPO1: ["src/foo/bar.py"],
+                REPO2: ["src/foo/bar.py"],
+            },
+            frames=[self.frame("foo/bar.py", True)],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("foo/", "src/foo/", REPO2)],
+            expected_tree_requests=[REPO2],
+        )
+
+    def test_no_linked_match_falls_back_to_organization_repositories(self) -> None:
+        self.create_project_repository(REPO1)
+
+        self._process_and_assert_configuration_changes(
+            repo_trees={
+                REPO1: ["src/not-a-match.py"],
+                REPO2: ["src/foo/bar.py"],
+            },
+            frames=[self.frame("foo/bar.py", True)],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("foo/", "src/foo/", REPO2)],
+            expected_tree_requests=[REPO1, REPO2],
+        )
+
+    def test_same_path_in_two_linked_repositories_is_ambiguous(self) -> None:
+        self.create_project_repository(REPO1, ProjectRepositorySource.AUTO_NAME_MATCH)
+        self.create_project_repository(REPO2)
+
+        self._process_and_assert_configuration_changes(
+            repo_trees={
+                REPO1: ["src/foo/bar.py"],
+                REPO2: ["src/foo/bar.py"],
+            },
+            frames=[self.frame("foo/bar.py", True)],
+            platform="python",
+            expected_tree_requests=[REPO2, REPO1],
+        )
+
+    def test_partially_covered_event_only_processes_uncovered_frames(self) -> None:
+        covered_frame = self.frame("covered/file.py", True)
+        uncovered_frame = self.frame("uncovered/file.py", True)
+        self.create_repo_and_code_mapping(REPO1, "covered/", "existing/covered/")
+
+        self._process_and_assert_configuration_changes(
+            repo_trees={
+                REPO1: [
+                    "different/covered/file.py",
+                    "src/uncovered/file.py",
+                ]
+            },
+            frames=[covered_frame, uncovered_frame],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("uncovered/", "src/uncovered/")],
+        )
 
     def test_single_file_path(self) -> None:
         """Test that single-file paths like Program.cs are handled correctly."""
@@ -716,13 +838,14 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
                 "stack.module:com.example.** +app",
             ],
         )
-        # Second run: the code mapping already exists, but the in-app rule is still applied
+        self.project.delete_option(DERIVED_ENHANCEMENTS_OPTION_KEY)
+
+        # A covered Java frame still needs discovery when its derived rule is missing.
         self._process_and_assert_configuration_changes(
             repo_trees={REPO1: ["src/com/example/foo/Bar.kt"]},
             frames=[self.frame_from_module("com.example.foo.Bar", "Bar.kt", in_app=True)],
             platform=self.platform,
-            expected_new_code_mappings=[],
-            expected_new_in_app_stack_trace_rules=[],
+            expected_new_in_app_stack_trace_rules=["stack.module:com.example.** +app"],
         )
 
     def test_short_packages(self) -> None:

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -339,7 +339,7 @@ class TestGenericBehaviour(BaseDeriveCodeMappings):
             )
 
     def test_handle_existing_code_mapping(self) -> None:
-        self.create_repo_and_code_mapping(REPO1, "foo/", "src/foo/")
+        self.create_repo_and_code_mapping(REPO1, "", "src/")
 
         with patch(f"{REPO_TREES_INTEGRATION}.get_trees_for_org") as get_trees_for_org:
             self._process_and_assert_configuration_changes(
@@ -445,10 +445,18 @@ class TestGenericBehaviour(BaseDeriveCodeMappings):
     def test_single_file_path(self) -> None:
         """Test that single-file paths like Program.cs are handled correctly."""
         self._process_and_assert_configuration_changes(
-            repo_trees={REPO1: ["src/foo/bar.py"]},
+            repo_trees={REPO1: ["src/foo/bar.py", "src/other/baz.py"]},
             frames=[self.frame("bar.py", True)],
             platform="python",
             expected_new_code_mappings=[self.code_mapping("", "src/foo/")],
+        )
+
+        # The inferred empty stack root is not enough evidence to cover unrelated frames.
+        self._process_and_assert_configuration_changes(
+            repo_trees={REPO1: ["src/foo/bar.py", "src/other/baz.py"]},
+            frames=[self.frame("other/baz.py", True)],
+            platform="python",
+            expected_new_code_mappings=[self.code_mapping("other/", "src/other/")],
         )
 
     def test_dry_run_platform(self) -> None:


### PR DESCRIPTION
Automatic code mapping was searching every repository an organization's GitHub installation could see before checking whether the project already had a working mapping. That meant extra tree requests, and repositories unrelated to the project were considered alongside repositories already linked to it.

This checks active project mappings first and skips files they already cover. If discovery is still needed, it searches active repositories linked to the project through `ProjectRepository` (`sentry_projectrepository`) first, then falls back to the full organization repository list when none match.

When the same file exists in multiple linked repositories, it stays ambiguous instead of picking one. Java still performs discovery when it needs to rebuild a missing derived in-app rule.