### PR TITLE
fix(auth): Reject static asset paths as post-login redirects

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -220,12 +220,63 @@ def get_login_redirect(request: HttpRequest, default: str | None = None) -> str:
     return login_redirect
 
 
+# Path suffixes that are static assets, not app destinations. Used so a poisoned
+# session `_next` (e.g. a service-worker source map requested while logged out)
+# cannot become the post-login redirect for a real user.
+_STATIC_LOGIN_REDIRECT_SUFFIXES = (
+    ".js",
+    ".css",
+    ".map",
+    ".json",
+    ".txt",
+    ".xml",
+    ".ico",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".webp",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".eot",
+    ".wasm",
+    ".pdf",
+    ".html",
+    ".htm",
+)
+
+
+def _path_is_static_asset_redirect(path: str) -> bool:
+    """True if path is a static/asset URL that should never be a login destination."""
+    # Strip trailing slashes so `/foo.js.map/` still matches suffixes.
+    normalized = path.lower().rstrip("/") or "/"
+    basename = normalized.rsplit("/", 1)[-1]
+
+    static_prefixes = getattr(settings, "ANONYMOUS_STATIC_PREFIXES", ())
+    for prefix in static_prefixes:
+        prefix_norm = prefix.lower()
+        prefix_root = prefix_norm.rstrip("/")
+        if normalized == prefix_root or normalized.startswith(prefix_norm):
+            return True
+
+    # Service worker is served at /service-worker.js; browsers also request hashed
+    # siblings and source maps that are not real app routes.
+    if basename == "service-worker.js" or basename.startswith("service-worker."):
+        return True
+
+    return any(basename.endswith(suffix) for suffix in _STATIC_LOGIN_REDIRECT_SUFFIXES)
+
+
 def is_valid_redirect(url: str, allowed_hosts: Iterable[str] | None = None) -> bool:
     if not url:
         return False
     if url.startswith(get_login_url()):
         return False
     parsed_url = urlparse(url)
+    if _path_is_static_asset_redirect(parsed_url.path or ""):
+        return False
     url_host = parsed_url.netloc
     base_hostname = settings.SENTRY_BASE_HOSTNAME
     if url_host.endswith(f".{base_hostname}"):

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os.path
 from collections.abc import Collection, Iterable, Mapping
 from datetime import datetime, timedelta, timezone
 from time import time
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger("sentry.auth")
 
 _LOGIN_URL: str | None = None
+# Path suffixes that are static assets, not app destinations
+_STATIC_LOGIN_REDIRECT_SUFFIXES = frozenset({".js", ".css", ".map"})
 
 MFA_SESSION_KEY = "mfa"
 REACT_AUTH_COOKIE = "sentry_react_auth"
@@ -220,53 +223,21 @@ def get_login_redirect(request: HttpRequest, default: str | None = None) -> str:
     return login_redirect
 
 
-# Path suffixes that are static assets, not app destinations. Used so a poisoned
-# session `_next` (e.g. a service-worker source map requested while logged out)
-# cannot become the post-login redirect for a real user.
-_STATIC_LOGIN_REDIRECT_SUFFIXES = (
-    ".js",
-    ".css",
-    ".map",
-    ".json",
-    ".txt",
-    ".xml",
-    ".ico",
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".gif",
-    ".svg",
-    ".webp",
-    ".woff",
-    ".woff2",
-    ".ttf",
-    ".eot",
-    ".wasm",
-    ".pdf",
-    ".html",
-    ".htm",
-)
-
-
 def _path_is_static_asset_redirect(path: str) -> bool:
-    """True if path is a static/asset URL that should never be a login destination."""
+    """True if path is a static/asset URL that should never be a redirect destination."""
     # Strip trailing slashes so `/foo.js.map/` still matches suffixes.
     normalized = path.lower().rstrip("/") or "/"
     basename = normalized.rsplit("/", 1)[-1]
 
-    static_prefixes = getattr(settings, "ANONYMOUS_STATIC_PREFIXES", ())
+    static_prefixes = settings.ANONYMOUS_STATIC_PREFIXES
     for prefix in static_prefixes:
         prefix_norm = prefix.lower()
         prefix_root = prefix_norm.rstrip("/")
         if normalized == prefix_root or normalized.startswith(prefix_norm):
             return True
 
-    # Service worker is served at /service-worker.js; browsers also request hashed
-    # siblings and source maps that are not real app routes.
-    if basename == "service-worker.js" or basename.startswith("service-worker."):
-        return True
-
-    return any(basename.endswith(suffix) for suffix in _STATIC_LOGIN_REDIRECT_SUFFIXES)
+    extension = os.path.splitext(basename)[1]
+    return extension in _STATIC_LOGIN_REDIRECT_SUFFIXES
 
 
 def is_valid_redirect(url: str, allowed_hosts: Iterable[str] | None = None) -> bool:

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os.path
 from collections.abc import Collection, Iterable, Mapping
 from datetime import datetime, timedelta, timezone
 from time import time
@@ -236,7 +235,8 @@ def _path_is_static_asset_redirect(path: str) -> bool:
         if normalized == prefix_root or normalized.startswith(prefix_norm):
             return True
 
-    extension = os.path.splitext(basename)[1]
+    last_dot = basename.rfind(".")
+    extension = basename[last_dot:] if last_dot != -1 else ""
     return extension in _STATIC_LOGIN_REDIRECT_SUFFIXES
 
 

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -167,15 +167,9 @@ class GetLoginRedirectTest(TestCase):
         assert result == f"http://orgslug.testserver{reverse('sentry-login')}"
 
     def test_static_asset_next_uses_default(self) -> None:
-        """Asset paths must not win as post-login destinations (e.g. SW source maps)."""
         default = reverse("sentry-login")
 
-        result = get_login_redirect(
-            self._make_request("/org-slug/service-worker.abc123.js.map/")
-        )
-        assert result == default
-
-        result = get_login_redirect(self._make_request("/service-worker.js"))
+        result = get_login_redirect(self._make_request("/org-slug/service-worker.abc123.js.map/"))
         assert result == default
 
         result = get_login_redirect(self._make_request("/_static/sentry/entrypoints/app.js"))
@@ -191,7 +185,6 @@ class GetLoginRedirectTest(TestCase):
         result = get_login_redirect(request)
         assert result == f"http://orgslug.testserver{default}"
 
-        # Normal app paths still honor _next.
         result = get_login_redirect(self._make_request("/organizations/org-slug/issues/"))
         assert result == "/organizations/org-slug/issues/"
 

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -166,6 +166,35 @@ class GetLoginRedirectTest(TestCase):
         result = get_login_redirect(request)
         assert result == f"http://orgslug.testserver{reverse('sentry-login')}"
 
+    def test_static_asset_next_uses_default(self) -> None:
+        """Asset paths must not win as post-login destinations (e.g. SW source maps)."""
+        default = reverse("sentry-login")
+
+        result = get_login_redirect(
+            self._make_request("/org-slug/service-worker.abc123.js.map/")
+        )
+        assert result == default
+
+        result = get_login_redirect(self._make_request("/service-worker.js"))
+        assert result == default
+
+        result = get_login_redirect(self._make_request("/_static/sentry/entrypoints/app.js"))
+        assert result == default
+
+        result = get_login_redirect(
+            self._make_request("http://testserver/org-slug/service-worker.abc123.js.map")
+        )
+        assert result == default
+
+        request = self._make_request("/org-slug/service-worker.abc123.js.map")
+        request.subdomain = "orgslug"
+        result = get_login_redirect(request)
+        assert result == f"http://orgslug.testserver{default}"
+
+        # Normal app paths still honor _next.
+        result = get_login_redirect(self._make_request("/organizations/org-slug/issues/"))
+        assert result == "/organizations/org-slug/issues/"
+
 
 @control_silo_test
 class LoginTest(TestCase):


### PR DESCRIPTION
During my testing of the new user SSO flow (in prod), I was able to repeatedly trigger a bug where we try to redirect you to a service worker source map after you successfully login for the first time.

Unauthenticated requests for static assets can be stored as session `_next`. After login, we send users to those paths, which the SPA treated as org/project routes, leaving the new user on the `The project you were looking for was not found` page.

To prevent any other new users from experiencing this erroneous redirect, extend the checks in `is_valid_redirect()`