### PR TITLE
fix(derived data): Make heal_stale_derived_data stale group selection more efficient

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -433,6 +433,7 @@ def _discover_stale_pipeline_hashes(current_hash: str, limit: int) -> list[str]:
     name="sentry.issues.derived.tasks.heal_stale_derived_data",
     namespace=issues_tasks,
     silo_mode=SiloMode.CELL,
+    processing_deadline_duration=60,
 )
 def heal_stale_derived_data(**kwargs: object) -> None:
     """Rebuild a chunk of GroupDerivedData rows whose ``pipeline_hash`` is stale/NULL."""

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef
 
 from sentry.silo.base import SiloMode
 
@@ -39,9 +39,6 @@ _MAX_PROJECT_GROUPS = 10_000
 # Hard cap on distinct stale pipeline hashes handled per heal invocation.
 # In practice we expect a handful at most; truncating still makes progress.
 _MAX_STALE_HASHES = 5
-# Hard cap on stale group IDs loaded per heal invocation, across all
-# stale hashes combined. The task runs every 15 minutes; overflow waits.
-_MAX_STALE_GROUPS = 10_000
 
 
 def _stale_pipeline_filter(qs: BaseQuerySet[Group], pipeline_hash: str) -> BaseQuerySet[Group]:
@@ -432,14 +429,6 @@ def _discover_stale_pipeline_hashes(current_hash: str, limit: int) -> list[str]:
     return results
 
 
-def _stale_hash_filter(pipeline_hashes: Sequence[str]) -> Q:
-    """Q filter matching GroupDerivedData rows whose ``pipeline_hash`` is NULL or in ``pipeline_hashes``."""
-    stale = Q(pipeline_hash__isnull=True)
-    if pipeline_hashes:
-        stale |= Q(pipeline_hash__in=list(pipeline_hashes))
-    return stale
-
-
 @instrumented_task(
     name="sentry.issues.derived.tasks.heal_stale_derived_data",
     namespace=issues_tasks,
@@ -449,8 +438,10 @@ def heal_stale_derived_data(**kwargs: object) -> None:
     """Rebuild a chunk of GroupDerivedData rows whose ``pipeline_hash`` is stale/NULL."""
     from sentry import options
     from sentry.issues.derived.processing import PIPELINE
-    from sentry.issues.derived.tasks_util import _pick_random_fresh_group_ranges
-    from sentry.issues.models.groupderiveddata import GroupDerivedData
+    from sentry.issues.derived.tasks_util import (
+        _pick_random_fresh_group_ranges,
+        group_id_ranges_for_hash,
+    )
 
     if not options.get("issues.derived.heal-enabled"):
         logger.info("heal_stale_derived_data.disabled")
@@ -460,17 +451,49 @@ def heal_stale_derived_data(**kwargs: object) -> None:
     max_tasks = options.get("issues.derived.heal-max-tasks")
     current_hash = PIPELINE.pipeline_hash
 
+    if batch_size <= 0 or max_tasks <= 0:
+        logger.error(
+            "heal_stale_derived_data.invalid_batch_configuration",
+            extra={"batch_size": batch_size, "max_tasks": max_tasks},
+        )
+        return
+
     # We fetch known stale hashes and match on those for better index usage.
     # Querying for rows that aren't the fresh hash ends up being a full index scan,
     # whereas providing positive examples to match lets us do more efficient btree walking.
     stale_hashes = _discover_stale_pipeline_hashes(current_hash, _MAX_STALE_HASHES)
 
-    group_ids = list(
-        GroupDerivedData.objects.filter(_stale_hash_filter(stale_hashes))
-        .order_by("group_id")
-        .values_list("group_id", flat=True)[:_MAX_STALE_GROUPS]
-    )
-    if not group_ids:
+    # TODO: Track highest scheduled between runs so we don't risk duplicating work if
+    # run again before previouslly scheduled clean-ups are finished.
+    remaining = max_tasks
+    scheduled_per_hash: dict[str, int] = {}
+    # Per-hash scheduling for efficient (pipeline_hash, group_id) index use.
+    for stale_hash in [None, *stale_hashes]:
+        if remaining <= 0:
+            break
+        ranges = group_id_ranges_for_hash(stale_hash, chunk_size=batch_size, max_chunks=remaining)
+        if not ranges:
+            continue
+        for start, end in ranges:
+            regenerate_stale_derived_data_batch.delay(
+                # ``stale_pipeline_hashes`` is only here so workers still running the
+                # previous release can read it; ``target_hash`` is the real argument.
+                stale_pipeline_hashes=[] if stale_hash is None else [stale_hash],
+                target_hash=stale_hash,
+                group_id_start=start,
+                group_id_end=end,
+            )
+        remaining -= len(ranges)
+        scheduled_per_hash["null" if stale_hash is None else stale_hash] = len(ranges)
+        metrics.incr(
+            "issues.derived.heal_ranges_scheduled",
+            amount=len(ranges),
+            sample_rate=1.0,
+            tags={"hash_kind": "null" if stale_hash is None else "stale"},
+        )
+
+    task_count = max_tasks - remaining
+    if task_count == 0:
         logger.info("heal_stale_derived_data.nothing_to_heal")
         check_ranges = _pick_random_fresh_group_ranges(
             current_hash,
@@ -492,21 +515,13 @@ def heal_stale_derived_data(**kwargs: object) -> None:
         )
         return
 
-    ranges = _chunk_group_ids_into_ranges(group_ids, batch_size)[:max_tasks]
-
-    for start, end in ranges:
-        regenerate_stale_derived_data_batch.delay(
-            stale_pipeline_hashes=stale_hashes,
-            group_id_start=start,
-            group_id_end=end,
-        )
-
     logger.info(
         "heal_stale_derived_data.scheduled",
         extra={
             "stale_hashes": stale_hashes,
-            "task_count": len(ranges),
-            "group_count": len(group_ids),
+            "task_count": task_count,
+            "tasks_per_hash": scheduled_per_hash,
+            "batch_size": batch_size,
             "pipeline_hash": current_hash,
         },
     )
@@ -637,14 +652,19 @@ def regenerate_stale_derived_data_batch(
     stale_pipeline_hashes: list[str],
     group_id_start: int,
     group_id_end: int,
+    target_hash: str | None = None,  # None targets the NULL hash, not "unset"
     resume_generated_at: str | None = None,
     resume_pipeline_hash: str | None = None,
     **kwargs: object,
 ) -> None:
-    """Rebuild GroupDerivedData rows in ``[group_id_start, group_id_end)`` whose ``pipeline_hash`` is NULL or in ``stale_pipeline_hashes``.
+    """Rebuild GroupDerivedData rows in ``[group_id_start, group_id_end)`` whose ``pipeline_hash`` is ``target_hash``.
 
-    Rows that have raced to the current hash are filtered out naturally.
-    Reschedules the remaining range on batch or per-group timeout.
+    A *target_hash* of None targets rows with no hash, i.e. ones explicitly
+    invalidated. Rows that have raced to the current hash are filtered out
+    naturally. Reschedules the remaining range on batch or per-group timeout.
+
+    *stale_pipeline_hashes* is the superseded interface, kept only so activations
+    in flight across the deploy still run. Callers should pass *target_hash*.
     """
     from taskbroker_client.state import current_task
 
@@ -652,13 +672,21 @@ def regenerate_stale_derived_data_batch(
     from sentry.issues.models.groupderiveddata import GroupDerivedData
     from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 
+    # Transitional: activations enqueued before ``target_hash`` existed carry a list
+    # of hashes and no target. The current scheduler only ever pairs an empty list
+    # with a None target, so a non-empty list here means we're running one of those.
+    # Targeting just the first hash under-covers the range for this one run, which
+    # the next scheduled run picks up.
+    if target_hash is None and stale_pipeline_hashes:
+        target_hash = stale_pipeline_hashes[0]
+
     task_state = current_task()
     activation_id = task_state.id if task_state else None
     if activation_id and already_spawned(_REGENERATE_STALE_BATCH_TASK_KEY, activation_id):
         logger.info(
             "regenerate_stale_derived_data_batch.duplicate_skipped",
             extra={
-                "stale_pipeline_hashes": stale_pipeline_hashes,
+                "target_hash": target_hash,
                 "activation_id": activation_id,
             },
         )
@@ -675,7 +703,7 @@ def regenerate_stale_derived_data_batch(
 
     group_ids = list(
         GroupDerivedData.objects.filter(
-            _stale_hash_filter(stale_pipeline_hashes),
+            pipeline_hash=target_hash,  # a None target renders as IS NULL
             group_id__gte=group_id_start,
             group_id__lt=group_id_end,
         )
@@ -702,6 +730,7 @@ def regenerate_stale_derived_data_batch(
         gen_id = result.resume_generation_id
         regenerate_stale_derived_data_batch.delay(
             stale_pipeline_hashes=stale_pipeline_hashes,
+            target_hash=target_hash,
             group_id_start=result.resume_from_group_id,
             group_id_end=group_id_end,
             resume_generated_at=gen_id.generated_at.isoformat() if gen_id else None,
@@ -717,7 +746,7 @@ def regenerate_stale_derived_data_batch(
     logger.info(
         "regenerate_stale_derived_data_batch.complete",
         extra={
-            "stale_pipeline_hashes": stale_pipeline_hashes,
+            "target_hash": target_hash,
             "group_id_start": group_id_start,
             "group_id_end": group_id_end,
             "processed": {r.value: c for r, c in result.processed.items()},

--- a/src/sentry/issues/derived/tasks_util.py
+++ b/src/sentry/issues/derived/tasks_util.py
@@ -99,7 +99,9 @@ def group_id_ranges_for_hash(
                 "max_scan_limit": _MAX_SCANNED_GROUP_IDS,
             },
         )
-        scan_limit = _MAX_SCANNED_GROUP_IDS
+        # Never clamp below two chunks: a lone boundary can't close a range, so we'd
+        # return nothing and the caller would take that to mean there was nothing to do.
+        scan_limit = max(_MAX_SCANNED_GROUP_IDS, chunk_size * 2)
 
     hash_predicate = "pipeline_hash IS NULL" if pipeline_hash is None else "pipeline_hash = %s"
     # The LIMIT lives in the innermost subquery to encourage Postgres to enforce

--- a/src/sentry/issues/derived/tasks_util.py
+++ b/src/sentry/issues/derived/tasks_util.py
@@ -2,6 +2,7 @@ import logging
 import random
 from datetime import datetime, timezone
 
+from django.db import connections, router
 from django.db.models import Max, Min
 
 from sentry.issues.derived.check import CheckFailure, CheckId, CheckInvalidated, CheckResult
@@ -11,6 +12,10 @@ from sentry.utils import metrics
 logger = logging.getLogger(__name__)
 
 _MAX_CHECK_GROUPS = 10_000
+
+# Safety valve on the number of group IDs one ``group_id_ranges_for_hash`` call may
+# walk, however large the requested chunking is.
+_MAX_SCANNED_GROUP_IDS = 2_000_000
 
 
 def _record_check_result(result: CheckResult) -> None:
@@ -68,6 +73,79 @@ def _pick_random_fresh_group_ranges(
         chunk = group_ids[i : i + batch_size]
         ranges.append((chunk[0], chunk[-1] + 1))
     return ranges
+
+
+def group_id_ranges_for_hash(
+    pipeline_hash: str | None, *, chunk_size: int, max_chunks: int
+) -> list[tuple[int, int]]:
+    """Partition the group IDs of GroupDerivedData rows with a pipeline_hash into ranges.
+
+    Returns at most max_chunks of ascending disjoint [start, end) ranges, each
+    covering chunk_size group IDs but possibly the last.
+    """
+    if chunk_size <= 0 or max_chunks <= 0:
+        return []
+
+    # One boundary per chunk, plus one extra to close the final range (or, if we ran
+    # out of matching rows first, to tell us we did).
+    scan_limit = chunk_size * (max_chunks + 1)
+    if scan_limit > _MAX_SCANNED_GROUP_IDS:
+        logger.warning(
+            "group_id_ranges_for_hash.scan_budget_clamped",
+            extra={
+                "chunk_size": chunk_size,
+                "max_chunks": max_chunks,
+                "requested_scan_limit": scan_limit,
+                "max_scan_limit": _MAX_SCANNED_GROUP_IDS,
+            },
+        )
+        scan_limit = _MAX_SCANNED_GROUP_IDS
+
+    hash_predicate = "pipeline_hash IS NULL" if pipeline_hash is None else "pipeline_hash = %s"
+    # The LIMIT lives in the innermost subquery to encourage Postgres to enforce
+    # the limit before doing the window function stuff. ``cnt`` tells us whether we
+    # hit the limit, and pulls out the last row we saw so we can close the final
+    # chunk without a second query.
+    sql = f"""
+        SELECT group_id, rn, cnt FROM (
+            SELECT group_id,
+                   row_number() OVER () - 1 AS rn,
+                   count(*) OVER () AS cnt
+            FROM (
+                SELECT group_id
+                FROM {GroupDerivedData._meta.db_table}
+                WHERE {hash_predicate}
+                ORDER BY group_id
+                LIMIT %s
+            ) scanned
+        ) numbered
+        WHERE mod(rn, %s) = 0 OR rn = cnt - 1
+        ORDER BY rn
+    """
+    params: list[str | int] = [] if pipeline_hash is None else [pipeline_hash]
+    params += [scan_limit, chunk_size]
+
+    using = router.db_for_read(GroupDerivedData)
+    with (
+        metrics.timer("issues.derived.group_id_range_query"),
+        connections[using].cursor() as cursor,
+    ):
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+
+    if not rows:
+        return []
+
+    scanned = rows[0][2]
+    boundaries = [group_id for group_id, rn, _ in rows if rn % chunk_size == 0]
+
+    if scanned == scan_limit:
+        # We got more than enough rows; the trailing boundary closes the last range.
+        ends = boundaries[1:]
+    else:
+        # We didn't fill out the final chunk, so the last row we scanned closes it.
+        ends = boundaries[1:] + [rows[-1][0] + 1]
+    return list(zip(boundaries, ends))[:max_chunks]
 
 
 def _resume_check_id(

--- a/src/sentry/issues/derived/tasks_util.py
+++ b/src/sentry/issues/derived/tasks_util.py
@@ -111,7 +111,10 @@ def group_id_ranges_for_hash(
     sql = f"""
         SELECT group_id, rn, cnt FROM (
             SELECT group_id,
-                   row_number() OVER () - 1 AS rn,
+                   -- Ordered so the numbering is defined rather than dependent on the
+                   -- order the subquery happens to emit. count(*) stays unordered; an
+                   -- ORDER BY there would turn it into a running count.
+                   row_number() OVER (ORDER BY group_id) - 1 AS rn,
                    count(*) OVER () AS cnt
             FROM (
                 SELECT group_id

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -15,7 +15,10 @@ from sentry.issues.derived.tasks import (
     heal_stale_derived_data,
     regenerate_stale_derived_data_batch,
 )
-from sentry.issues.derived.tasks_util import _pick_random_fresh_group_ranges
+from sentry.issues.derived.tasks_util import (
+    _pick_random_fresh_group_ranges,
+    group_id_ranges_for_hash,
+)
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
@@ -253,6 +256,7 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
 
         mock_delay.assert_called_once_with(
             stale_pipeline_hashes=[stale],
+            target_hash=stale,
             group_id_start=group_ids[0],
             group_id_end=group_ids[0] + 1,
         )
@@ -315,7 +319,25 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
 
         mock_delay.assert_not_called()
 
-    def test_dispatches_all_stale_hashes_in_one_batch_range(self) -> None:
+    def test_bails_on_invalid_batch_configuration(self) -> None:
+        groups = self.create_unprocessed_groups(1)
+        process_group_log(groups[0].id)
+        GroupDerivedData.objects.filter(group_id=groups[0].id).update(
+            pipeline_hash=self._pick_stale_hash()
+        )
+
+        with (
+            override_options({"issues.derived.heal-max-tasks": 0}),
+            patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay,
+            patch.object(check_fresh_derived_data_batch, "delay") as mock_check,
+        ):
+            heal_stale_derived_data()
+
+        # Neither healing nor the "nothing to heal" check fan-out should fire.
+        mock_delay.assert_not_called()
+        mock_check.assert_not_called()
+
+    def test_dispatches_one_task_per_stale_hash(self) -> None:
         groups = self.create_unprocessed_groups(3)
         group_ids = sorted(g.id for g in groups)
 
@@ -330,12 +352,63 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
         with patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay:
             heal_stale_derived_data()
 
-        # One batch covering the whole ID range, with both stale hashes.
+        # Ranges are computed per hash, so each hash gets its own task targeting
+        # just that hash.
+        assert [c.kwargs["target_hash"] for c in mock_delay.call_args_list] == [hash_a, hash_b]
+        assert [
+            (c.kwargs["group_id_start"], c.kwargs["group_id_end"])
+            for c in mock_delay.call_args_list
+        ] == [(group_ids[0], group_ids[1] + 1), (group_ids[2], group_ids[2] + 1)]
+
+    def test_null_range_does_not_overlap_stale_hash_range(self) -> None:
+        # NULL and stale-hash rows interleave in ID space, so the ranges overlap.
+        # Each task must be scoped so the overlap isn't processed twice.
+        groups = self.create_unprocessed_groups(4)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+
+        stale = self._pick_stale_hash()
+        GroupDerivedData.objects.filter(group_id__in=group_ids[::2]).update(pipeline_hash=None)
+        GroupDerivedData.objects.filter(group_id__in=group_ids[1::2]).update(pipeline_hash=stale)
+
+        with patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay:
+            heal_stale_derived_data()
+
+        # NULL is scheduled first — it means an explicit invalidation. The two
+        # ranges overlap, but their targets are disjoint.
+        assert [
+            (
+                c.kwargs["target_hash"],
+                c.kwargs["group_id_start"],
+                c.kwargs["group_id_end"],
+            )
+            for c in mock_delay.call_args_list
+        ] == [
+            (None, group_ids[0], group_ids[2] + 1),
+            (stale, group_ids[1], group_ids[3] + 1),
+        ]
+
+    def test_null_hash_is_prioritized_over_stale_hashes(self) -> None:
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+
+        stale = self._pick_stale_hash()
+        # The stale-hash row sorts first, so ordering alone wouldn't pick NULL.
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash=stale)
+        GroupDerivedData.objects.filter(group_id=group_ids[1]).update(pipeline_hash=None)
+
+        with (
+            override_options({"issues.derived.heal-max-tasks": 1}),
+            patch.object(regenerate_stale_derived_data_batch, "delay") as mock_delay,
+        ):
+            heal_stale_derived_data()
+
         mock_delay.assert_called_once()
-        kwargs = mock_delay.call_args.kwargs
-        assert sorted(kwargs["stale_pipeline_hashes"]) == sorted([hash_a, hash_b])
-        assert kwargs["group_id_start"] == group_ids[0]
-        assert kwargs["group_id_end"] == group_ids[2] + 1
+        assert mock_delay.call_args.kwargs["target_hash"] is None
+        assert mock_delay.call_args.kwargs["group_id_start"] == group_ids[1]
 
     def test_null_hash_is_always_stale_without_being_listed(self) -> None:
         groups = self.create_unprocessed_groups(1)
@@ -347,7 +420,8 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
 
         mock_delay.assert_called_once()
         kwargs = mock_delay.call_args.kwargs
-        # NULL is handled unconditionally by the batch task; the list is empty.
+        # A None target means the NULL hash; the legacy list stays empty.
+        assert kwargs["target_hash"] is None
         assert kwargs["stale_pipeline_hashes"] == []
         assert kwargs["group_id_start"] == groups[0].id
         assert kwargs["group_id_end"] == groups[0].id + 1
@@ -371,8 +445,12 @@ class HealStaleDerivedDataTest(DerivedDataTaskTestBase):
         ):
             heal_stale_derived_data()
 
-        # 3 chunks would be produced, but max_tasks caps to 2.
-        assert mock_delay.call_count == 2
+        # 3 chunks would be produced, but max_tasks caps to 2 and the third group
+        # is left for the next invocation rather than folded into the last range.
+        assert [
+            (c.kwargs["group_id_start"], c.kwargs["group_id_end"])
+            for c in mock_delay.call_args_list
+        ] == [(group_ids[0], group_ids[1]), (group_ids[1], group_ids[2])]
 
 
 @with_feature("projects:issue-action-log-write-to-db")
@@ -542,6 +620,81 @@ class PickRandomFreshGroupRangesTest(DerivedDataTaskTestBase):
 
 
 @with_feature("projects:issue-action-log-write-to-db")
+class GroupIdRangesForHashTest(DerivedDataTaskTestBase):
+    HASH = "a" * 16
+    OTHER_HASH = "b" * 16
+
+    def _seed(self, count: int, pipeline_hash: str | None) -> list[int]:
+        groups = self.create_unprocessed_groups(count)
+        for group in groups:
+            GroupDerivedData.objects.create(group_id=group.id, pipeline_hash=pipeline_hash)
+        return sorted(group.id for group in groups)
+
+    def test_no_matching_rows(self) -> None:
+        self._seed(2, self.OTHER_HASH)
+
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=2, max_chunks=5) == []
+        assert group_id_ranges_for_hash(None, chunk_size=2, max_chunks=5) == []
+
+    def test_short_tail_is_one_range(self) -> None:
+        null_ids = self._seed(3, None)
+        hash_ids = self._seed(3, self.HASH)
+
+        # Fewer rows than chunk_size, for both the NULL and the concrete-hash
+        # predicate, and neither picks up the other's rows.
+        assert group_id_ranges_for_hash(None, chunk_size=10, max_chunks=5) == [
+            (null_ids[0], null_ids[-1] + 1)
+        ]
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=10, max_chunks=5) == [
+            (hash_ids[0], hash_ids[-1] + 1)
+        ]
+
+    def test_exact_chunk_boundaries(self) -> None:
+        group_ids = self._seed(5, self.HASH)
+
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=2, max_chunks=5) == [
+            (group_ids[0], group_ids[2]),
+            (group_ids[2], group_ids[4]),
+            (group_ids[4], group_ids[4] + 1),
+        ]
+
+    def test_truncates_to_max_chunks(self) -> None:
+        group_ids = self._seed(5, self.HASH)
+
+        # The 5th group is left out rather than folded into an oversized last range.
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=2, max_chunks=2) == [
+            (group_ids[0], group_ids[2]),
+            (group_ids[2], group_ids[4]),
+        ]
+
+    def test_truncates_when_scan_limit_is_reached(self) -> None:
+        # 6 rows exactly fills the scan budget of chunk_size * (max_chunks + 1), so
+        # the tail is known to be incomplete and waits for the next call.
+        group_ids = self._seed(6, self.HASH)
+
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=2, max_chunks=2) == [
+            (group_ids[0], group_ids[2]),
+            (group_ids[2], group_ids[4]),
+        ]
+
+    def test_invalid_chunking(self) -> None:
+        self._seed(2, self.HASH)
+
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=0, max_chunks=5) == []
+        assert group_id_ranges_for_hash(self.HASH, chunk_size=2, max_chunks=0) == []
+
+    def test_clamps_scan_budget(self) -> None:
+        group_ids = self._seed(3, self.HASH)
+
+        with patch("sentry.issues.derived.tasks_util._MAX_SCANNED_GROUP_IDS", 2):
+            ranges = group_id_ranges_for_hash(self.HASH, chunk_size=1, max_chunks=5)
+
+        # Only 2 rows were scanned, so the clamp must not be mistaken for having
+        # reached the end — the tail may not run past what we scanned.
+        assert ranges == [(group_ids[0], group_ids[1])]
+
+
+@with_feature("projects:issue-action-log-write-to-db")
 class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
     @staticmethod
     def _stale() -> str:
@@ -559,6 +712,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
 
         regenerate_stale_derived_data_batch(
             stale_pipeline_hashes=[stale],
+            target_hash=stale,
             group_id_start=group_ids[0],
             group_id_end=group_ids[-1] + 1,
         )
@@ -567,7 +721,71 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
             gdd = GroupDerivedData.objects.get(group_id=gid)
             assert gdd.pipeline_hash == PIPELINE.pipeline_hash
 
-    def test_rebuilds_null_hash_rows_even_when_list_is_empty(self) -> None:
+    def test_rebuilds_null_hash_rows_when_target_is_none(self) -> None:
+        groups = self.create_unprocessed_groups(1)
+        gid = groups[0].id
+        process_group_log(gid)
+        GroupDerivedData.objects.filter(group_id=gid).update(pipeline_hash=None)
+
+        regenerate_stale_derived_data_batch(
+            stale_pipeline_hashes=[],
+            target_hash=None,
+            group_id_start=gid,
+            group_id_end=gid + 1,
+        )
+
+        gdd = GroupDerivedData.objects.get(group_id=gid)
+        assert gdd.pipeline_hash == PIPELINE.pipeline_hash
+
+    def test_targets_only_the_given_hash(self) -> None:
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+
+        stale = self._stale()
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash=None)
+        GroupDerivedData.objects.filter(group_id=group_ids[1]).update(pipeline_hash=stale)
+
+        regenerate_stale_derived_data_batch(
+            stale_pipeline_hashes=[stale],
+            target_hash=stale,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )
+
+        # The NULL row belongs to the task targeting None, not this one.
+        assert GroupDerivedData.objects.get(group_id=group_ids[0]).pipeline_hash is None
+        assert (
+            GroupDerivedData.objects.get(group_id=group_ids[1]).pipeline_hash
+            == PIPELINE.pipeline_hash
+        )
+
+    def test_legacy_activation_targets_first_listed_hash(self) -> None:
+        # Enqueued by the previous release: a list of hashes and no target.
+        groups = self.create_unprocessed_groups(2)
+        group_ids = sorted(g.id for g in groups)
+        for gid in group_ids:
+            process_group_log(gid)
+
+        first, second = self._stale(), "y" * 16
+        GroupDerivedData.objects.filter(group_id=group_ids[0]).update(pipeline_hash=first)
+        GroupDerivedData.objects.filter(group_id=group_ids[1]).update(pipeline_hash=second)
+
+        regenerate_stale_derived_data_batch(
+            stale_pipeline_hashes=[first, second],
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )
+
+        # Only the first hash is covered; the rest waits for the next scheduled run.
+        assert (
+            GroupDerivedData.objects.get(group_id=group_ids[0]).pipeline_hash
+            == PIPELINE.pipeline_hash
+        )
+        assert GroupDerivedData.objects.get(group_id=group_ids[1]).pipeline_hash == second
+
+    def test_legacy_activation_with_empty_list_targets_null(self) -> None:
         groups = self.create_unprocessed_groups(1)
         gid = groups[0].id
         process_group_log(gid)
@@ -579,8 +797,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
             group_id_end=gid + 1,
         )
 
-        gdd = GroupDerivedData.objects.get(group_id=gid)
-        assert gdd.pipeline_hash == PIPELINE.pipeline_hash
+        assert GroupDerivedData.objects.get(group_id=gid).pipeline_hash == PIPELINE.pipeline_hash
 
     def test_skips_rows_no_longer_stale(self) -> None:
         # Row now has the current hash — the range query should return
@@ -592,6 +809,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
         with patch("sentry.issues.derived.promote.build_and_promote_derived_data") as mock_build:
             regenerate_stale_derived_data_batch(
                 stale_pipeline_hashes=[self._stale()],
+                target_hash=self._stale(),
                 group_id_start=gid,
                 group_id_end=gid + 1,
             )
@@ -618,6 +836,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
 
             regenerate_stale_derived_data_batch(
                 stale_pipeline_hashes=[stale],
+                target_hash=stale,
                 group_id_start=group_ids[0],
                 group_id_end=group_ids[-1] + 1,
             )
@@ -625,7 +844,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
         mock_build.assert_called_once()
         mock_delay.assert_called_once()
         kwargs = mock_delay.call_args.kwargs
-        assert kwargs["stale_pipeline_hashes"] == [stale]
+        assert kwargs["target_hash"] == stale
         assert kwargs["group_id_start"] == group_ids[0] + 1
         assert kwargs["group_id_end"] == group_ids[-1] + 1
 
@@ -647,6 +866,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
         ):
             regenerate_stale_derived_data_batch(
                 stale_pipeline_hashes=[stale],
+                target_hash=stale,
                 group_id_start=group_ids[0],
                 group_id_end=group_ids[-1] + 1,
             )
@@ -655,7 +875,7 @@ class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):
         kwargs = mock_delay.call_args.kwargs
         # Resume from the SAME group on a per-group timeout.
         assert kwargs["group_id_start"] == group_ids[0]
-        assert kwargs["stale_pipeline_hashes"] == [stale]
+        assert kwargs["target_hash"] == stale
 
 
 @with_feature("projects:issue-action-log-write-to-db")

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -693,6 +693,19 @@ class GroupIdRangesForHashTest(DerivedDataTaskTestBase):
         # reached the end — the tail may not run past what we scanned.
         assert ranges == [(group_ids[0], group_ids[1])]
 
+    def test_clamp_never_drops_below_one_chunk(self) -> None:
+        group_ids = self._seed(3, self.HASH)
+
+        # Clamping below chunk_size would leave a single boundary, which can't close
+        # a range — the caller would read the empty result as "nothing to do".
+        with patch("sentry.issues.derived.tasks_util._MAX_SCANNED_GROUP_IDS", 1):
+            ranges = group_id_ranges_for_hash(self.HASH, chunk_size=2, max_chunks=5)
+
+        assert ranges == [
+            (group_ids[0], group_ids[2]),
+            (group_ids[2], group_ids[2] + 1),
+        ]
+
 
 @with_feature("projects:issue-action-log-write-to-db")
 class RegenerateStaleDerivedDataBatchTest(DerivedDataTaskTestBase):


### PR DESCRIPTION
Rather than querying for N group_ids in a not-that-efficient way, hit the (pipeline_hash, group_id) index directly and have Postgres only give us the ID ranges.
