### PR TITLE
feat(issue-search): Add attachment filter

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -968,6 +968,7 @@ SKIP_SNUBA_FIELDS = frozenset(
         "issue.seer_last_run",
         "issue.progress",
         "issue.autofix_state",
+        "has_attachments",
     )
 )
 

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -65,6 +65,7 @@ issue_search_config = SearchConfig.create_from(
     allow_boolean=False,
     is_filter_translation=is_filter_translation,
     numeric_keys=default_config.numeric_keys | {"times_seen", "user_count"},
+    boolean_keys=default_config.boolean_keys | {"has_attachments"},
     date_keys=default_config.date_keys | {"date", "first_seen", "last_seen", "issue.seer_last_run"},
     key_mappings={
         "assigned_to": ["assigned"],

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 
@@ -18,6 +18,7 @@ from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.progress_state import IssueProgressState
 from sentry.models.environment import Environment
+from sentry.models.eventattachment import EventAttachment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupenvironment import GroupEnvironment
@@ -407,6 +408,31 @@ class RecentDateCondition(ScalarCondition):
         return super().apply(queryset, search_filter)
 
 
+class HasAttachmentsCondition(Condition):
+    """Filter issues by whether they have any retained attachment rows."""
+
+    def apply(
+        self, queryset: BaseQuerySet[Group, Group], search_filter: SearchFilter
+    ) -> BaseQuerySet[Group, Group]:
+        value = search_filter.value.raw_value
+        if value == "" and search_filter.operator in ("=", "!="):
+            has_attachments = search_filter.operator == "!="
+        elif isinstance(value, int) and value in (0, 1) and search_filter.operator == "=":
+            has_attachments = bool(value)
+        else:
+            raise InvalidSearchQuery(
+                f"Operator {search_filter.operator} not valid for search {search_filter}"
+            )
+
+        attachments = EventAttachment.objects.filter(
+            group_id=OuterRef("pk"),
+            project_id=OuterRef("project_id"),
+        )
+        return queryset.alias(_has_attachments=Exists(attachments)).filter(
+            _has_attachments=has_attachments
+        )
+
+
 class QuerySetBuilder:
     def __init__(self, conditions: Mapping[str, Condition]):
         self.conditions = conditions
@@ -661,6 +687,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "issue.seer_last_run": RecentDateCondition(
                 "seer_explorer_autofix_last_triggered", SEER_LAST_RUN_RECENCY_WINDOW
             ),
+            "has_attachments": HasAttachmentsCondition(),
             "issue.id": QCallbackCondition(
                 lambda ids: Q(id__in=[int(v) for v in (ids if isinstance(ids, list) else [ids])])
             ),

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -115,6 +115,7 @@ from sentry.models.dashboard_widget import (
 )
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.environment import Environment
+from sentry.models.eventattachment import EventAttachment
 from sentry.models.files.control_file import ControlFile
 from sentry.models.files.file import File
 from sentry.models.group import Group
@@ -1419,6 +1420,24 @@ class Factories:
                 )
 
         return group
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_event_attachment(
+        project: Project,
+        group: Group | None = None,
+        event_id: str | None = None,
+        **kwargs: Any,
+    ) -> EventAttachment:
+        kwargs.setdefault("type", "event.attachment")
+        kwargs.setdefault("name", "attachment.txt")
+        kwargs.setdefault("content_type", "text/plain")
+        return EventAttachment.objects.create(
+            project_id=project.id,
+            group_id=group.id if group else None,
+            event_id=event_id or uuid.uuid4().hex,
+            **kwargs,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -409,6 +409,11 @@ class Fixtures:
             project = self.project
         return Factories.create_group(project, *args, **kwargs)
 
+    def create_event_attachment(self, project=None, *args, **kwargs):
+        if project is None:
+            project = self.project
+        return Factories.create_event_attachment(project, *args, **kwargs)
+
     def create_group_activity(self, group=None, *args, **kwargs):
         if group is None:
             group = self.group

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -644,6 +644,71 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             str(group_without_seer.id),
         }
 
+    def test_has_attachments_search(self) -> None:
+        event_with_attachment = self.store_event(
+            data={
+                "fingerprint": ["group-with-attachment"],
+                "timestamp": before_now(seconds=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.create_event_attachment(
+            project=self.project,
+            group=event_with_attachment.group,
+            event_id=event_with_attachment.event_id,
+        )
+
+        event_without_attachment = self.store_event(
+            data={
+                "fingerprint": ["group-without-attachment"],
+                "timestamp": before_now(seconds=2).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+        event_with_unresolved_attachment = self.store_event(
+            data={
+                "fingerprint": ["group-with-unresolved-attachment"],
+                "timestamp": before_now(seconds=3).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        self.create_event_attachment(
+            project=self.project,
+            event_id=event_with_unresolved_attachment.event_id,
+        )
+
+        other_project = self.create_project(organization=self.organization)
+        self.create_event_attachment(
+            project=other_project,
+            group=event_without_attachment.group,
+        )
+
+        self.login_as(user=self.user)
+        response = self.get_success_response(
+            query="has_attachments:true", project=[self.project.id]
+        )
+        assert {row["id"] for row in response.data} == {str(event_with_attachment.group.id)}
+
+        response = self.get_success_response(query="has:has_attachments", project=[self.project.id])
+        assert {row["id"] for row in response.data} == {str(event_with_attachment.group.id)}
+
+        response = self.get_success_response(
+            query="has_attachments:false", project=[self.project.id]
+        )
+        assert {row["id"] for row in response.data} == {
+            str(event_without_attachment.group.id),
+            str(event_with_unresolved_attachment.group.id),
+        }
+
+        response = self.get_success_response(
+            query="!has:has_attachments", project=[self.project.id]
+        )
+        assert {row["id"] for row in response.data} == {
+            str(event_without_attachment.group.id),
+            str(event_with_unresolved_attachment.group.id),
+        }
+
     def test_lookup_by_event_id(self) -> None:
         event_id = "c" * 32
         event = self.store_event(

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -166,6 +166,16 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
 
+def test_parse_has_attachments_filter() -> None:
+    assert parse_search_query("has_attachments:true") == [
+        SearchFilter(
+            key=SearchKey(name="has_attachments"),
+            operator="=",
+            value=SearchValue(raw_value=1),
+        )
+    ]
+
+
 class ConvertQueryValuesTest(TestCase):
     def test_valid_assign_me_converter(self) -> None:
         raw_value = "me"


### PR DESCRIPTION
Adds `has_attachments:true/false`, `has:has_attachments`, and `!has:has_attachments` filters to issue search. Uses attachment metadata in Postgres without adding attachment state to Snuba.

Fixes #48680