### PR TITLE
test(settings): Slim down project performance test

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -75,6 +75,14 @@ async function expandAllDetectorSettings() {
   }
 }
 
+function getDetectorSlider({label, index}: {index: number; label: string}) {
+  const slider = screen.getAllByRole('slider', {name: label}).at(index);
+  if (!slider) {
+    throw new Error(`Slider "${label}" at index ${index} was not rendered`);
+  }
+  return slider;
+}
+
 describe('projectPerformance', () => {
   const org = OrganizationFixture({
     features: [
@@ -535,163 +543,152 @@ describe('projectPerformance', () => {
     ).toBeDisabled();
   });
 
-  it.each([
-    {
-      title: IssueTitle.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-      threshold: DetectorConfigCustomer.N_PLUS_DB_DURATION,
-      allowedValues: allowedDurationValues,
-      defaultValue: 100,
-      newValue: 500,
-      sliderIdentifier: {
-        label: 'Minimum Total Duration',
-        index: 0,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-      threshold: DetectorConfigCustomer.N_PLUS_DB_COUNT,
-      allowedValues: allowedCountValues,
-      defaultValue: 5,
-      newValue: 10,
-      sliderIdentifier: {
-        label: 'Minimum Query Count',
-        index: 0,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_SLOW_DB_QUERY,
-      threshold: DetectorConfigCustomer.SLOW_DB_DURATION,
-      allowedValues: allowedDurationValues.slice(5),
-      defaultValue: 1000,
-      newValue: 3000,
-      sliderIdentifier: {
-        label: 'Minimum Duration',
-        index: 0,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_N_PLUS_ONE_API_CALLS,
-      threshold: DetectorConfigCustomer.N_PLUS_API_CALLS_DURATION,
-      allowedValues: allowedDurationValues.slice(5),
-      defaultValue: 300,
-      newValue: 500,
-      sliderIdentifier: {
-        label: 'Minimum Total Duration',
-        index: 1,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_RENDER_BLOCKING_ASSET,
-      threshold: DetectorConfigCustomer.RENDER_BLOCKING_ASSET_RATIO,
-      allowedValues: allowedPercentageValues,
-      defaultValue: 0.33,
-      newValue: 0.5,
-      sliderIdentifier: {
-        label: 'Minimum FCP Ratio',
-        index: 0,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_LARGE_HTTP_PAYLOAD,
-      threshold: DetectorConfigCustomer.LARGE_HTTP_PAYLOAD_SIZE,
-      allowedValues: allowedSizeValues.slice(1),
-      defaultValue: 1000000,
-      newValue: 5000000,
-      sliderIdentifier: {
-        label: 'Minimum Size',
-        index: 0,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_DB_MAIN_THREAD,
-      threshold: DetectorConfigCustomer.DB_ON_MAIN_THREAD_DURATION,
-      allowedValues: [10, 16, 33, 50],
-      defaultValue: 16,
-      newValue: 33,
-      sliderIdentifier: {
-        label: 'Frame Rate Drop',
-        index: 0,
-      },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_FILE_IO_MAIN_THREAD,
-      threshold: DetectorConfigCustomer.FILE_IO_MAIN_THREAD_DURATION,
-      allowedValues: [10, 16, 33, 50],
-      defaultValue: 16,
-      newValue: 50,
-      sliderIdentifier: {
-        label: 'Frame Rate Drop',
-        index: 1,
-      },
-    },
-    {
+  it('renders configured detector thresholds and updates a threshold', async () => {
+    const consecutiveDbThreshold = {
       title: IssueTitle.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
       threshold: DetectorConfigCustomer.CONSECUTIVE_DB_MIN_TIME_SAVED,
       allowedValues: allowedDurationValues.slice(0, 23),
-      defaultValue: 100,
-      newValue: 5000,
+      configuredValue: 5000,
+      updateValue: 100,
       sliderIdentifier: {
         label: 'Minimum Time Saved',
         index: 0,
       },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET,
-      threshold: DetectorConfigCustomer.UNCOMPRESSED_ASSET_SIZE,
-      allowedValues: allowedSizeValues.slice(1),
-      defaultValue: 512000,
-      newValue: 700000,
-      sliderIdentifier: {
-        label: 'Minimum Size',
-        index: 1,
+    };
+    const detectorThresholdData = [
+      {
+        title: IssueTitle.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+        threshold: DetectorConfigCustomer.N_PLUS_DB_DURATION,
+        allowedValues: allowedDurationValues,
+        configuredValue: 500,
+        sliderIdentifier: {
+          label: 'Minimum Total Duration',
+          index: 0,
+        },
       },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET,
-      threshold: DetectorConfigCustomer.UNCOMPRESSED_ASSET_DURATION,
-      allowedValues: allowedDurationValues.slice(5),
-      defaultValue: 500,
-      newValue: 400,
-      sliderIdentifier: {
-        label: 'Minimum Duration',
-        index: 1,
+      {
+        title: IssueTitle.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+        threshold: DetectorConfigCustomer.N_PLUS_DB_COUNT,
+        allowedValues: allowedCountValues,
+        configuredValue: 10,
+        sliderIdentifier: {
+          label: 'Minimum Query Count',
+          index: 0,
+        },
       },
-    },
-    {
-      title: IssueTitle.PERFORMANCE_CONSECUTIVE_HTTP,
-      threshold: DetectorConfigCustomer.CONSECUTIVE_HTTP_MIN_TIME_SAVED,
-      allowedValues: allowedDurationValues.slice(14),
-      defaultValue: 2000,
-      newValue: 4000,
-      sliderIdentifier: {
-        label: 'Minimum Time Saved',
-        index: 1,
+      {
+        title: IssueTitle.PERFORMANCE_SLOW_DB_QUERY,
+        threshold: DetectorConfigCustomer.SLOW_DB_DURATION,
+        allowedValues: allowedDurationValues.slice(5),
+        configuredValue: 3000,
+        sliderIdentifier: {
+          label: 'Minimum Duration',
+          index: 0,
+        },
       },
-    },
-    {
-      title: IssueTitle.WEB_VITALS,
-      threshold: DetectorConfigCustomer.WEB_VITALS_COUNT,
-      allowedValues: allowedCountValues,
-      defaultValue: 10,
-      newValue: 20,
-      sliderIdentifier: {
-        label: 'Minimum Sample Count',
-        index: 0,
+      {
+        title: IssueTitle.PERFORMANCE_N_PLUS_ONE_API_CALLS,
+        threshold: DetectorConfigCustomer.N_PLUS_API_CALLS_DURATION,
+        allowedValues: allowedDurationValues.slice(5),
+        configuredValue: 500,
+        sliderIdentifier: {
+          label: 'Minimum Total Duration',
+          index: 1,
+        },
       },
-    },
-  ])(
-    'renders detector thresholds settings for $title issue',
-    async ({
-      title,
-      threshold,
-      allowedValues,
-      defaultValue,
-      newValue,
-      sliderIdentifier,
-    }) => {
-      // Mock endpoints
-      const mockGETBody = {
-        [threshold]: defaultValue,
+      {
+        title: IssueTitle.PERFORMANCE_RENDER_BLOCKING_ASSET,
+        threshold: DetectorConfigCustomer.RENDER_BLOCKING_ASSET_RATIO,
+        allowedValues: allowedPercentageValues,
+        configuredValue: 0.5,
+        sliderIdentifier: {
+          label: 'Minimum FCP Ratio',
+          index: 0,
+        },
+      },
+      {
+        title: IssueTitle.PERFORMANCE_LARGE_HTTP_PAYLOAD,
+        threshold: DetectorConfigCustomer.LARGE_HTTP_PAYLOAD_SIZE,
+        allowedValues: allowedSizeValues.slice(1),
+        configuredValue: 5000000,
+        sliderIdentifier: {
+          label: 'Minimum Size',
+          index: 0,
+        },
+      },
+      {
+        title: IssueTitle.PERFORMANCE_DB_MAIN_THREAD,
+        threshold: DetectorConfigCustomer.DB_ON_MAIN_THREAD_DURATION,
+        allowedValues: [10, 16, 33, 50],
+        configuredValue: 33,
+        sliderIdentifier: {
+          label: 'Frame Rate Drop',
+          index: 0,
+        },
+      },
+      {
+        title: IssueTitle.PERFORMANCE_FILE_IO_MAIN_THREAD,
+        threshold: DetectorConfigCustomer.FILE_IO_MAIN_THREAD_DURATION,
+        allowedValues: [10, 16, 33, 50],
+        configuredValue: 50,
+        sliderIdentifier: {
+          label: 'Frame Rate Drop',
+          index: 1,
+        },
+      },
+      consecutiveDbThreshold,
+      {
+        title: IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET,
+        threshold: DetectorConfigCustomer.UNCOMPRESSED_ASSET_SIZE,
+        allowedValues: allowedSizeValues.slice(1),
+        configuredValue: 700000,
+        sliderIdentifier: {
+          label: 'Minimum Size',
+          index: 1,
+        },
+      },
+      {
+        title: IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET,
+        threshold: DetectorConfigCustomer.UNCOMPRESSED_ASSET_DURATION,
+        allowedValues: allowedDurationValues.slice(5),
+        configuredValue: 400,
+        sliderIdentifier: {
+          label: 'Minimum Duration',
+          index: 1,
+        },
+      },
+      {
+        title: IssueTitle.PERFORMANCE_CONSECUTIVE_HTTP,
+        threshold: DetectorConfigCustomer.CONSECUTIVE_HTTP_MIN_TIME_SAVED,
+        allowedValues: allowedDurationValues.slice(14),
+        configuredValue: 4000,
+        sliderIdentifier: {
+          label: 'Minimum Time Saved',
+          index: 1,
+        },
+      },
+      {
+        title: IssueTitle.WEB_VITALS,
+        threshold: DetectorConfigCustomer.WEB_VITALS_COUNT,
+        allowedValues: allowedCountValues,
+        configuredValue: 20,
+        sliderIdentifier: {
+          label: 'Minimum Sample Count',
+          index: 0,
+        },
+      },
+    ];
+    const configuredThresholds = Object.fromEntries(
+      detectorThresholdData.map(({threshold, configuredValue}) => [
+        threshold,
+        configuredValue,
+      ])
+    );
+    const performanceIssuesGetMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/performance-issues/configure/',
+      method: 'GET',
+      body: {
+        ...configuredThresholds,
         n_plus_one_db_queries_detection_enabled: true,
         slow_db_queries_detection_enabled: true,
         db_on_main_thread_detection_enabled: true,
@@ -703,81 +700,63 @@ describe('projectPerformance', () => {
         n_plus_one_api_calls_detection_enabled: true,
         consecutive_http_spans_detection_enabled: true,
         web_vitals_detection_enabled: true,
-      };
-      const performanceIssuesGetMock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/performance-issues/configure/',
-        method: 'GET',
-        body: mockGETBody,
-        statusCode: 200,
-      });
-      const performanceIssuesPutMock = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/performance-issues/configure/',
-        method: 'PUT',
-      });
+      },
+      statusCode: 200,
+    });
+    const performanceIssuesPutMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/performance-issues/configure/',
+      method: 'PUT',
+    });
 
-      render(<ProjectPerformance />, {
-        organization: org,
+    render(<ProjectPerformance />, {organization: org, initialRouterConfig});
 
-        initialRouterConfig,
-      });
+    expect(
+      await screen.findByText('Performance Issues - Detector Threshold Settings')
+    ).toBeInTheDocument();
+    await expandAllDetectorSettings();
 
-      expect(
-        await screen.findByText('Performance Issues - Detector Threshold Settings')
-      ).toBeInTheDocument();
+    for (const {
+      title,
+      allowedValues,
+      configuredValue,
+      sliderIdentifier,
+    } of detectorThresholdData) {
       expect(screen.getByText(title)).toBeInTheDocument();
-
-      // Open collapsed panels
-      await expandAllDetectorSettings();
-
-      // Some of the sliders have the same label, so use an index as well
-      const slider = screen
-        .getAllByRole('slider', {name: sliderIdentifier.label})
-        .at(sliderIdentifier.index);
-      if (!slider) {
-        throw new Error(`Slider ${sliderIdentifier.index} was not rendered`);
-      }
-      const indexOfValue = allowedValues.indexOf(defaultValue);
-      const newValueIndex = allowedValues.indexOf(newValue);
-
-      // The value of the slider should be equal to the index
-      // of the value returned from the GET method,
-      // passed to it in the allowedValues array.
-      expect(performanceIssuesGetMock).toHaveBeenCalled();
-      expect(slider).toHaveValue(indexOfValue.toString());
-
-      // Per-key presses: hold syntax (`{ArrowRight>N}`) under-steps the scraps
-      // slider. delay:null keeps large deltas under the default 5s timeout.
-      const ue = userEvent.setup({delay: null});
-      await ue.click(slider);
-      const indexDelta = newValueIndex - indexOfValue;
-      for (let index = 0; index < Math.abs(indexDelta); index++) {
-        await ue.keyboard(indexDelta > 0 ? '{ArrowRight}' : '{ArrowLeft}');
-      }
-      await ue.tab();
-
-      expect(slider).toHaveValue(newValueIndex.toString());
-
-      // Ensure that PUT request is fired to update
-      // project settings
-      const expectedPUTPayload: Record<string, number> = {};
-      expectedPUTPayload[threshold] = newValue;
-      expect(performanceIssuesPutMock).toHaveBeenCalledWith(
-        '/projects/org-slug/project-slug/performance-issues/configure/',
-        expect.objectContaining({
-          data: expectedPUTPayload,
-        })
-      );
-      expect(trackAnalytics).toHaveBeenCalledWith(
-        'performance_views.project_issue_detection_threshold_changed',
-        {
-          organization: org,
-          project_slug: project.slug,
-          threshold_key: threshold,
-          threshold_value: newValue,
-        }
+      expect(getDetectorSlider(sliderIdentifier)).toHaveValue(
+        allowedValues.indexOf(configuredValue).toString()
       );
     }
-  );
+
+    expect(performanceIssuesGetMock).toHaveBeenCalledTimes(1);
+
+    const {allowedValues, configuredValue, sliderIdentifier, threshold, updateValue} =
+      consecutiveDbThreshold;
+    const slider = getDetectorSlider(sliderIdentifier);
+    const indexDelta =
+      allowedValues.indexOf(updateValue) - allowedValues.indexOf(configuredValue);
+    const key = indexDelta > 0 ? '{ArrowRight}' : '{ArrowLeft}';
+    const ue = userEvent.setup({delay: null});
+    await ue.click(slider);
+    for (let index = 0; index < Math.abs(indexDelta); index++) {
+      await ue.keyboard(key);
+    }
+    await ue.tab();
+
+    expect(slider).toHaveValue(allowedValues.indexOf(updateValue).toString());
+    expect(performanceIssuesPutMock).toHaveBeenCalledWith(
+      '/projects/org-slug/project-slug/performance-issues/configure/',
+      expect.objectContaining({data: {[threshold]: updateValue}})
+    );
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'performance_views.project_issue_detection_threshold_changed',
+      {
+        organization: org,
+        project_slug: project.slug,
+        threshold_key: threshold,
+        threshold_value: updateValue,
+      }
+    );
+  });
 
   it('positions detector sliders at nonstandard configured values', async () => {
     MockApiClient.addMockResponse({
@@ -871,69 +850,39 @@ describe('projectPerformance', () => {
     });
   });
 
-  it.each(manageDetectorData)(
-    'allows project admins to manage $label',
-    async ({label, key}) => {
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/',
-        method: 'GET',
-        body: ProjectFixture({access: ['project:admin']}),
-        statusCode: 200,
-      });
+  it('allows project admins to disable detectors', async () => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'GET',
+      body: ProjectFixture({access: ['project:admin']}),
+      statusCode: 200,
+    });
+    const mockPut = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/performance-issues/configure/',
+      method: 'PUT',
+    });
 
-      render(<ProjectPerformance />, {
-        organization: OrganizationFixture({
-          features: [
-            'performance-view',
-            'performance-web-vitals-seer-suggestions',
-            'gen-ai-features',
-          ],
-        }),
-        initialRouterConfig,
-      });
-      await screen.findByText('Performance Issues - Detector Threshold Settings');
+    render(<ProjectPerformance />, {organization: org, initialRouterConfig});
+    await screen.findByText('Performance Issues - Detector Threshold Settings');
 
-      // Hidden by form panels being collapsed
-      let toggle = screen.queryByRole<HTMLInputElement>('checkbox', {name: label});
-      expect(toggle).not.toBeInTheDocument();
-
-      await expandAllDetectorSettings();
-
-      const mockPut = MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/performance-issues/configure/',
-        method: 'PUT',
-      });
-
-      // Enabled by default
-      toggle = screen.getByRole<HTMLInputElement>('checkbox', {name: label});
-      expect(toggle).toBeChecked();
-
-      // Disable the detector
-      await userEvent.click(toggle);
-      expect(mockPut).toHaveBeenCalledWith(
-        '/projects/org-slug/project-slug/performance-issues/configure/',
-        expect.objectContaining({
-          data: {
-            [key]: false,
-          },
-        })
-      );
-      mockPut.mockClear();
-      expect(toggle).not.toBeChecked();
-
-      // Re-enable the detector
-      await userEvent.click(toggle);
-      expect(mockPut).toHaveBeenCalledWith(
-        '/projects/org-slug/project-slug/performance-issues/configure/',
-        expect.objectContaining({
-          data: {
-            [key]: true,
-          },
-        })
-      );
-      expect(toggle).toBeChecked();
+    for (const {label} of manageDetectorData) {
+      expect(screen.queryByRole('checkbox', {name: label})).not.toBeInTheDocument();
     }
-  );
+
+    await expandAllDetectorSettings();
+
+    for (const {label, key} of manageDetectorData) {
+      const toggle = screen.getByRole('checkbox', {name: label});
+      expect(toggle).toBeChecked();
+
+      await userEvent.click(toggle);
+      expect(mockPut).toHaveBeenLastCalledWith(
+        '/projects/org-slug/project-slug/performance-issues/configure/',
+        expect.objectContaining({data: {[key]: false}})
+      );
+      expect(toggle).not.toBeChecked();
+    }
+  });
 
   it('disables detector thresholds while the detector update is pending', async () => {
     MockApiClient.addMockResponse({
@@ -1044,37 +993,32 @@ describe('projectPerformance', () => {
     );
   });
 
-  it.each(manageDetectorData)(
-    'does not allow non-admins to manage $label',
-    async ({label}) => {
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/',
-        method: 'GET',
-        body: ProjectFixture({access: ['project:read']}),
-        statusCode: 200,
-      });
+  it('does not allow non-admins to manage detectors', async () => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'GET',
+      body: ProjectFixture({access: ['project:read']}),
+      statusCode: 200,
+    });
 
-      render(<ProjectPerformance />, {
-        organization: OrganizationFixture({
-          features: [
-            'performance-view',
-            'performance-web-vitals-seer-suggestions',
-            'gen-ai-features',
-          ],
-          access: ['project:read'],
-        }),
-        initialRouterConfig,
-      });
+    render(<ProjectPerformance />, {
+      organization: OrganizationFixture({
+        features: org.features,
+        access: ['project:read'],
+      }),
+      initialRouterConfig,
+    });
 
-      await screen.findByText('Performance Issues - Detector Threshold Settings');
+    await screen.findByText('Performance Issues - Detector Threshold Settings');
 
-      let toggle = screen.queryByRole<HTMLInputElement>('checkbox', {name: label});
-      expect(toggle).not.toBeInTheDocument();
-
-      await expandAllDetectorSettings();
-
-      toggle = screen.queryByRole<HTMLInputElement>('checkbox', {name: label});
-      expect(toggle).toBeDisabled();
+    for (const {label} of manageDetectorData) {
+      expect(screen.queryByRole('checkbox', {name: label})).not.toBeInTheDocument();
     }
-  );
+
+    await expandAllDetectorSettings();
+
+    for (const {label} of manageDetectorData) {
+      expect(screen.getByRole('checkbox', {name: label})).toBeDisabled();
+    }
+  });
 });


### PR DESCRIPTION
in ci this file is timing out and takes 60 seconds. slim down the number of .each for roughly the same coverage

refs #123078

local performance is better, takes a lot longer in ci

| Focused suite | Before | After |
|---|---:|---:|
| Jest time | 13.7s | 6.0s |
| Test cases | 50 | 16 |