### PR TITLE
test(admin): Speed up customer details tests

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -12,7 +12,6 @@ import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {OwnerFixture} from 'getsentry-test/fixtures/owner';
 import {PoliciesFixture} from 'getsentry-test/fixtures/policies';
 import {ProjectFixture} from 'getsentry-test/fixtures/project';
-import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {PlanTier} from 'getsentry-test/planTier';
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -678,11 +677,30 @@ function setUpMocks(
   });
 }
 
+function renderCustomerDetails(organization: Organization) {
+  render(<CustomerDetails />, {
+    initialRouterConfig: {
+      location: {pathname: `/customers/${organization.slug}`},
+      route: '/customers/:orgId',
+    },
+    organization,
+  });
+}
+
+async function openCustomerActions() {
+  await screen.findByRole('heading', {name: 'Customers'});
+  await userEvent.click(screen.getAllByRole('button', {name: 'Customers Actions'})[0]!);
+}
+
 describe('Customer Details', () => {
   const {organization} = initializeOrg();
 
   const mockUser = UserFixture({permissions: new Set()});
   ConfigStore.loadInitialData(ConfigFixture({user: mockUser}));
+
+  beforeEach(() => {
+    ConfigStore.set('user', mockUser);
+  });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
@@ -1100,80 +1118,14 @@ describe('Customer Details', () => {
     ]);
   });
 
-  it('renders correct sections', async () => {
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_f',
-    });
-    subscription.reservedBudgets = [
-      SeerReservedBudgetFixture({
-        id: '0',
-        reservedBudget: 0,
-      }),
-    ];
-    setUpMocks(organization, subscription);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-  });
-
-  it('renders Legacy Billing badge for default subscriptions', async () => {
-    setUpMocks(organization);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-    expect(screen.getByText('Legacy Billing')).toBeInTheDocument();
-    expect(screen.queryByText('Billing Platform')).not.toBeInTheDocument();
-  });
-
-  it('renders Billing Platform badge for migrated subscriptions', async () => {
-    setUpMocks(organization, {hasMigratedToBillingPlatform: true});
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-    expect(screen.getByText('Billing Platform')).toBeInTheDocument();
-    expect(screen.queryByText('Legacy Billing')).not.toBeInTheDocument();
-  });
-
   it('renders correct dropdown options', async () => {
     setUpMocks(organization);
+    renderCustomerDetails(organization);
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    expect(await screen.findByText('Legacy Billing')).toBeInTheDocument();
+    expect(screen.queryByText('Billing Platform')).not.toBeInTheDocument();
 
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
+    await openCustomerActions();
 
     expect(screen.getByRole('option', {name: /Start Trial/})).toBeInTheDocument();
     expect(
@@ -1185,6 +1137,9 @@ describe('Customer Details', () => {
     expect(
       screen.queryByRole('option', {name: /Gift to reserved budget/})
     ).not.toBeInTheDocument();
+    expect(screen.queryByText('Clear Pending Changes')).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: /Allow Trial/})).not.toBeInTheDocument();
+    expect(screen.getByTestId('endTrialEarly')).toHaveAttribute('aria-disabled', 'true');
     expect(screen.getByRole('option', {name: /Change Plan/})).toBeInTheDocument();
     expect(
       screen.getByRole('option', {name: /Start Enterprise Trial/})
@@ -1193,26 +1148,17 @@ describe('Customer Details', () => {
       screen.getByRole('option', {name: /Change Google Domain/})
     ).toBeInTheDocument();
     expect(screen.getByRole('option', {name: /Suspend Account/})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: /Generate Spike Projections/})
+    ).toBeInTheDocument();
   });
 
   it('shows limited events help text for free plan enterprise trial', async () => {
     setUpMocks(organization, {plan: 'am1_f', isFree: true});
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    renderCustomerDetails(organization);
 
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
+    await openCustomerActions();
 
     expect(
       screen.getByRole('option', {name: /Start Enterprise Trial/})
@@ -1223,62 +1169,13 @@ describe('Customer Details', () => {
   it('hides Start Enterprise Trial for paid plans', async () => {
     setUpMocks(organization, {plan: 'am3_business', isFree: false});
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    renderCustomerDetails(organization);
 
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
+    await openCustomerActions();
 
     expect(
       screen.queryByRole('option', {name: /Start Enterprise Trial/})
     ).not.toBeInTheDocument();
-  });
-
-  it('renders and hides generic confirmation modals', async () => {
-    setUpMocks(organization);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
-
-    await userEvent.click(screen.getByText('Convert to Sponsored'));
-
-    const {waitForModalToHide} = renderGlobalModal();
-
-    expect(
-      screen.getByRole('heading', {name: 'Convert to Sponsored'})
-    ).toBeInTheDocument();
-
-    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Confirm'})).toBeInTheDocument();
-
-    // Close Modal
-    await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
-    await waitForModalToHide();
-
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   describe('clear pending changes', () => {
@@ -1287,116 +1184,16 @@ describe('Customer Details', () => {
     it('renders in the dropdown when there are pending changes', async () => {
       setUpMocks(pendingChangesOrg, {pendingChanges: true});
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${pendingChangesOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: pendingChangesOrg,
-      });
+      renderCustomerDetails(pendingChangesOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       expect(screen.getByText('Clear Pending Changes')).toBeInTheDocument();
-    });
-
-    it('is hidden when there are no changes', async () => {
-      setUpMocks(organization);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.queryByText('Clear Pending Changes')).not.toBeInTheDocument();
     });
   });
 
   describe('allow trial', () => {
     const cannotTrialOrg = OrganizationFixture({slug: 'cannot-trial-org'});
-
-    it('renders Allow Trial in the dropdown', async () => {
-      setUpMocks(cannotTrialOrg, {canTrial: false, trialPlan: null});
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${cannotTrialOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: cannotTrialOrg,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.getByRole('option', {name: /Allow Trial/})).toBeInTheDocument();
-    });
-
-    it('hides Allow Trial in the dropdown when not eligible', async () => {
-      setUpMocks(organization, {canTrial: true, trialPlan: null});
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.queryByRole('option', {name: /Allow Trial/})).not.toBeInTheDocument();
-    });
-
-    it('hides Allow Trial in the dropdown when on active trial', async () => {
-      setUpMocks(organization, {canTrial: false, trialPlan: 'am1_t'});
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.queryByRole('option', {name: /Allow Trial/})).not.toBeInTheDocument();
-    });
 
     it('allows an org to trial', async () => {
       const trialMock = MockApiClient.addMockResponse({
@@ -1407,21 +1204,9 @@ describe('Customer Details', () => {
 
       setUpMocks(cannotTrialOrg, {canTrial: false, trialPlan: null});
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${cannotTrialOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: cannotTrialOrg,
-      });
+      renderCustomerDetails(cannotTrialOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -1455,21 +1240,9 @@ describe('Customer Details', () => {
         isBillingAdmin: false,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${terminateOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: terminateOrg,
-      });
+      renderCustomerDetails(terminateOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       expect(screen.getByTestId('terminateContract')).toHaveAttribute(
         'aria-disabled',
@@ -1483,38 +1256,6 @@ describe('Customer Details', () => {
       expect(
         await screen.findByText('Requires billing admin permissions.')
       ).toBeInTheDocument();
-    });
-
-    it('renders dropdown enabled with billing.admin permissions', async () => {
-      const mockBillingAdminUser = UserFixture({
-        permissions: new Set(['billing.admin']),
-      });
-
-      ConfigStore.set('user', mockBillingAdminUser);
-
-      setUpMocks(terminateOrg, {
-        billingInterval: 'annual',
-        canCancel: true,
-        isBillingAdmin: false,
-      });
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${terminateOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: terminateOrg,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.getByTestId('terminateContract')).toBeEnabled();
     });
 
     it("terminates an organization's contract", async () => {
@@ -1536,21 +1277,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${terminateOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: terminateOrg,
-      });
+      renderCustomerDetails(terminateOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       await userEvent.click(screen.getByText('Terminate Contract'));
 
@@ -1587,21 +1316,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${recreateOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: recreateOrg,
-      });
+      renderCustomerDetails(recreateOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       await userEvent.click(screen.getByText('Recreate Billing Platform Models'));
 
@@ -1631,15 +1348,17 @@ describe('Customer Details', () => {
     });
 
     async function openMigrationAction(name: string) {
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${migrationOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: migrationOrg,
-      });
+      renderCustomerDetails(migrationOrg);
 
       await screen.findByRole('heading', {name: 'Customers'});
+
+      const isMigrated = name.includes('Unmigrate');
+      expect(
+        screen.getByText(isMigrated ? 'Billing Platform' : 'Legacy Billing')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(isMigrated ? 'Legacy Billing' : 'Billing Platform')
+      ).not.toBeInTheDocument();
 
       await userEvent.click(
         screen.getAllByRole('button', {
@@ -1708,21 +1427,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -1769,21 +1476,9 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, subscription);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -1838,21 +1533,9 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, subscription);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -1877,21 +1560,9 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, subscription);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -1950,21 +1621,9 @@ describe('Customer Details', () => {
         },
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -1996,28 +1655,6 @@ describe('Customer Details', () => {
   describe('cancel subscription', () => {
     const cancelSubOrg = OrganizationFixture();
 
-    it('renders in the dropdown', async () => {
-      setUpMocks(cancelSubOrg);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${cancelSubOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: cancelSubOrg,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.getByText('Cancel Subscription')).toBeInTheDocument();
-    });
-
     it('cancels a subscription', async () => {
       setUpMocks(cancelSubOrg);
       const apiMock = MockApiClient.addMockResponse({
@@ -2026,21 +1663,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${cancelSubOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: cancelSubOrg,
-      });
+      renderCustomerDetails(cancelSubOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       await userEvent.click(screen.getByText('Cancel Subscription'));
 
@@ -2096,13 +1721,7 @@ describe('Customer Details', () => {
         body: Subscription,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
       renderGlobalModal();
 
@@ -2144,13 +1763,7 @@ describe('Customer Details', () => {
         body: sub,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
       renderGlobalModal();
 
@@ -2182,13 +1795,7 @@ describe('Customer Details', () => {
 
       setUpMocks(organization, partnerSubscription);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
       await screen.findByRole('heading', {name: 'Customers'});
       await userEvent.click(
@@ -2213,21 +1820,11 @@ describe('Customer Details', () => {
         body: trialOrg,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${trialOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: trialOrg,
-      });
+      renderCustomerDetails(trialOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
+      await openCustomerActions();
 
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      expect(screen.queryByRole('option', {name: /Allow Trial/})).not.toBeInTheDocument();
 
       renderGlobalModal();
 
@@ -2247,31 +1844,6 @@ describe('Customer Details', () => {
         );
       });
     });
-
-    it('is disabled for non-trial org', async () => {
-      setUpMocks(organization);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.getByTestId('endTrialEarly')).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
-    });
   });
 
   describe('on demand invoices', () => {
@@ -2280,80 +1852,6 @@ describe('Customer Details', () => {
 
     const mockBillingAdminUser = UserFixture({
       permissions: new Set(['billing.admin']),
-    });
-
-    ConfigStore.set('user', mockBillingAdminUser);
-
-    it('renders disable on demand invoices when enabled', async () => {
-      ConfigStore.set('user', mockBillingAdminUser);
-
-      setUpMocks(invoicedOrg, {onDemandInvoiced: true});
-      setUpMocks(onDemandInvoicedOrg, {
-        onDemandInvoiced: true,
-        type: BillingType.INVOICED,
-        paymentSource: {
-          last4: '4242',
-          zipCode: '12345',
-          countryCode: 'US',
-          expMonth: 12,
-          expYear: 2028,
-          brand: 'Visa',
-        },
-      });
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: onDemandInvoicedOrg,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.getByText('Disable On Demand Billing')).toBeInTheDocument();
-    });
-
-    it('renders enable on demand invoices when disabled', async () => {
-      ConfigStore.set('user', mockBillingAdminUser);
-
-      setUpMocks(invoicedOrg, {onDemandInvoiced: false});
-      setUpMocks(onDemandInvoicedOrg, {
-        onDemandInvoiced: false,
-        type: BillingType.INVOICED,
-        paymentSource: {
-          last4: '4242',
-          zipCode: '12345',
-          countryCode: 'US',
-          expMonth: 12,
-          expYear: 2028,
-          brand: 'Visa',
-        },
-      });
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: onDemandInvoicedOrg,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.getByText('Enable On Demand Billing')).toBeInTheDocument();
     });
 
     it('does not render on-demand invoices actions when manually invoiced on-demand flag is True', async () => {
@@ -2373,21 +1871,9 @@ describe('Customer Details', () => {
         },
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: onDemandInvoicedOrg,
-      });
+      renderCustomerDetails(onDemandInvoicedOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       expect(screen.queryByText('Enable On Demand Billing')).not.toBeInTheDocument();
     });
@@ -2414,21 +1900,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${invoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: invoicedOrg,
-      });
+      renderCustomerDetails(invoicedOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -2471,21 +1945,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: onDemandInvoicedOrg,
-      });
+      renderCustomerDetails(onDemandInvoicedOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -2508,57 +1970,6 @@ describe('Customer Details', () => {
   });
 
   describe('converting to sponsored', () => {
-    it('converts a plan to sponsored', async () => {
-      setUpMocks(organization);
-
-      const apiMock = MockApiClient.addMockResponse({
-        url: `/customers/${organization.slug}/`,
-        method: 'PUT',
-        body: OrganizationFixture(),
-      });
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      await userEvent.click(screen.getByText('Convert to Sponsored'));
-
-      renderGlobalModal();
-
-      const selectSponsoredType = await screen.findByRole('textbox', {
-        name: 'Sponsored Type',
-      });
-      // Click for dropdown
-      await userEvent.click(selectSponsoredType);
-      await userEvent.click(screen.getByTestId('open_source'));
-
-      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
-
-      await waitFor(() =>
-        expect(apiMock).toHaveBeenCalledWith(
-          `/customers/${organization.slug}/`,
-          expect.objectContaining({
-            method: 'PUT',
-            data: {
-              sponsoredType: 'open_source',
-            },
-          })
-        )
-      );
-    });
-
     it('can convert subscription with active partner account to sponsored', async () => {
       const partnerSubscription = SubscriptionFixture({
         organization,
@@ -2583,21 +1994,9 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       await userEvent.click(screen.getByText('Convert to Sponsored'));
 
@@ -2632,21 +2031,9 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, partnerSubscription);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       expect(screen.getByTestId('convertToSponsored')).toHaveAttribute(
         'aria-disabled',
@@ -2656,151 +2043,43 @@ describe('Customer Details', () => {
   });
 
   describe('AddGiftEventsAction', () => {
-    it('renders and hides modal', async () => {
-      setUpMocks(organization);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      const {waitForModalToHide} = renderGlobalModal();
+    it('gifts error and transaction events', async () => {
+      const subscription = SubscriptionFixture({organization});
+      setUpMocks(organization, subscription);
+      renderCustomerDetails(organization);
+      renderGlobalModal();
 
       for (const dataCategory of [DataCategory.ERRORS, DataCategory.TRANSACTIONS]) {
-        await userEvent.click(
-          screen.getAllByRole('button', {
-            name: 'Customers Actions',
-          })[0]!
-        );
+        await openCustomerActions();
+
+        const freeEventsKey = getFreeEventsKey(dataCategory);
+        const updateMock = MockApiClient.addMockResponse({
+          url: `/customers/${organization.slug}/`,
+          method: 'PUT',
+          body: {...subscription, [freeEventsKey]: 26000},
+        });
 
         await userEvent.click(screen.getByTestId(`gift-${dataCategory}`));
+        expect(screen.getByText('Total: 0')).toBeInTheDocument();
 
-        expect(
-          await screen.findByText(
-            `How many ${dataCategory} in multiples of 1,000s? (50 is 50,000 ${dataCategory})`
+        const input = await screen.findByRole('textbox', {
+          name: `How many ${dataCategory} in multiples of 1,000s? (50 is 50,000 ${dataCategory})`,
+        });
+        await userEvent.type(input, '26{enter}');
+
+        expect(screen.getByText('Total: 26,000')).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+        await waitFor(() =>
+          expect(updateMock).toHaveBeenCalledWith(
+            `/customers/${organization.slug}/`,
+            expect.objectContaining({
+              method: 'PUT',
+              data: {[freeEventsKey]: 26000},
+            })
           )
-        ).toBeInTheDocument();
-
-        await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
-        await waitForModalToHide();
+        );
       }
-    });
-
-    it('can gift events - ERRORS', async () => {
-      setUpMocks(organization);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      renderGlobalModal();
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      const freeEventsKey = getFreeEventsKey(DataCategory.ERRORS);
-      const updateMock = MockApiClient.addMockResponse({
-        url: `/customers/${organization.slug}/`,
-        method: 'PUT',
-        body: {...organization, [freeEventsKey]: 26000},
-      });
-
-      await userEvent.click(screen.getByTestId(`gift-${DataCategory.ERRORS}`));
-
-      expect(screen.getByText('Total: 0')).toBeInTheDocument();
-
-      // enter a number of events to gift
-      const input = await screen.findByRole('textbox', {
-        name: `How many ${DataCategory.ERRORS} in multiples of 1,000s? (50 is 50,000 ${DataCategory.ERRORS})`,
-      });
-
-      await userEvent.type(input, '26{enter}');
-
-      expect(screen.getByText('Total: 26,000')).toBeInTheDocument();
-
-      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
-
-      await waitFor(() =>
-        expect(updateMock).toHaveBeenCalledWith(
-          `/customers/${organization.slug}/`,
-          expect.objectContaining({
-            method: 'PUT',
-            data: {
-              [freeEventsKey]: 26000,
-            },
-          })
-        )
-      );
-    });
-
-    it('can gift events - TRANSACTIONS', async () => {
-      setUpMocks(organization);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      renderGlobalModal();
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      const freeEventsKey = getFreeEventsKey(DataCategory.TRANSACTIONS);
-      const updateMock = MockApiClient.addMockResponse({
-        url: `/customers/${organization.slug}/`,
-        method: 'PUT',
-        body: {...organization, [freeEventsKey]: 26000},
-      });
-
-      await userEvent.click(screen.getByTestId(`gift-${DataCategory.TRANSACTIONS}`));
-
-      expect(screen.getByText('Total: 0')).toBeInTheDocument();
-
-      // enter a number of events to gift
-      const input = await screen.findByRole('textbox', {
-        name: 'How many transactions in multiples of 1,000s? (50 is 50,000 transactions)',
-      });
-
-      await userEvent.type(input, '26{enter}');
-
-      expect(screen.getByText('Total: 26,000')).toBeInTheDocument();
-
-      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
-
-      await waitFor(() =>
-        expect(updateMock).toHaveBeenCalledWith(
-          `/customers/${organization.slug}/`,
-          expect.objectContaining({
-            method: 'PUT',
-            data: {
-              [freeEventsKey]: 26000,
-            },
-          })
-        )
-      );
     });
   });
 
@@ -2808,13 +2087,7 @@ describe('Customer Details', () => {
     const am2Sub = SubscriptionFixture({organization, plan: 'am2_f'});
     setUpMocks(organization, am2Sub);
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    renderCustomerDetails(organization);
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2865,13 +2138,7 @@ describe('Customer Details', () => {
     const am3Sub = SubscriptionFixture({organization, plan: 'am3_f'});
     setUpMocks(organization, am3Sub);
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    renderCustomerDetails(organization);
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2921,13 +2188,7 @@ describe('Customer Details', () => {
     const am3Sub = SubscriptionFixture({organization, plan: 'am3_team'});
     setUpMocks(organization, am3Sub);
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    renderCustomerDetails(organization);
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2947,13 +2208,7 @@ describe('Customer Details', () => {
     const am2Sub = SubscriptionFixture({organization, plan: 'am2_f'});
     setUpMocks(organization, am2Sub);
 
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
+    renderCustomerDetails(organization);
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -3005,28 +2260,18 @@ describe('Customer Details', () => {
       permissions: new Set(['billing.admin']),
     });
 
-    ConfigStore.set('user', mockBillingAdminUser);
+    beforeEach(() => {
+      ConfigStore.set('user', mockBillingAdminUser);
+    });
 
     it('ChangeContractEndDateAction not rendered for monthly contract interval', async () => {
       const invoicedOrg = OrganizationFixture();
 
       setUpMocks(invoicedOrg, {billingInterval: 'monthly', type: BillingType.INVOICED});
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${invoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: invoicedOrg,
-      });
+      renderCustomerDetails(invoicedOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       expect(
         screen.queryByRole('button', {name: 'Oct 24, 2018'})
@@ -3038,21 +2283,9 @@ describe('Customer Details', () => {
 
       setUpMocks(invoicedOrg, {billingInterval: 'annual', type: BillingType.INVOICED});
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${invoicedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: invoicedOrg,
-      });
+      renderCustomerDetails(invoicedOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       expect(screen.getByRole('button', {name: 'Oct 24, 2018'})).toBeInTheDocument();
     });
@@ -3060,34 +2293,6 @@ describe('Customer Details', () => {
 
   describe('unsuspend organization', () => {
     const suspendedOrg = OrganizationFixture({slug: 'suspended'});
-
-    const mockBillingAdminUser = UserFixture({
-      permissions: new Set(['billing.admin']),
-    });
-
-    ConfigStore.set('user', mockBillingAdminUser);
-
-    it("doesn't render in the dropdown if already suspended", async () => {
-      setUpMocks(suspendedOrg, {isSuspended: true});
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${suspendedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: suspendedOrg,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(screen.queryByText('Suspend Account')).not.toBeInTheDocument();
-    });
 
     it('unsuspends an organization', async () => {
       setUpMocks(suspendedOrg, {isSuspended: true});
@@ -3098,21 +2303,11 @@ describe('Customer Details', () => {
         body: suspendedOrg,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${suspendedOrg.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: suspendedOrg,
-      });
+      renderCustomerDetails(suspendedOrg);
 
-      await screen.findByRole('heading', {name: 'Customers'});
+      await openCustomerActions();
 
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      expect(screen.queryByText('Suspend Account')).not.toBeInTheDocument();
 
       renderGlobalModal();
 
@@ -3142,21 +2337,9 @@ describe('Customer Details', () => {
         body: organization,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -3199,21 +2382,9 @@ describe('Customer Details', () => {
         body: organization,
       });
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
+      renderCustomerDetails(organization);
 
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
+      await openCustomerActions();
 
       renderGlobalModal();
 
@@ -3246,31 +2417,6 @@ describe('Customer Details', () => {
     });
   });
 
-  describe('AddGiftBudgetAction', () => {
-    it('hides gift budget action when org has no reserved budgets', async () => {
-      const nonDsSub = SubscriptionFixture({
-        organization,
-      });
-      setUpMocks(organization, nonDsSub);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${organization.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {name: 'Customers Actions'})[0]!
-      );
-
-      expect(screen.queryByText('Gift to reserved budget')).not.toBeInTheDocument();
-    });
-  });
-
   describe('delete billing metric history', () => {
     // Add afterEach to clean up after tests
     afterEach(() => {
@@ -3285,13 +2431,7 @@ describe('Customer Details', () => {
       });
       setUpMocks(orgWithDeleteFeature);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${orgWithDeleteFeature.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: orgWithDeleteFeature,
-      });
+      renderCustomerDetails(orgWithDeleteFeature);
 
       await screen.findByRole('heading', {name: 'Customers'});
       renderGlobalModal();
@@ -3312,13 +2452,7 @@ describe('Customer Details', () => {
       });
       setUpMocks(orgWithoutDeleteFeature);
 
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${orgWithoutDeleteFeature.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: orgWithoutDeleteFeature,
-      });
+      renderCustomerDetails(orgWithoutDeleteFeature);
 
       await screen.findByRole('heading', {name: 'Customers'});
 
@@ -3329,34 +2463,6 @@ describe('Customer Details', () => {
 
       // The delete option should not be present
       expect(screen.queryByText('Delete Billing Metric History')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('generate spike projections', () => {
-    const org = OrganizationFixture({});
-
-    it('renders generate spike projections in the dropdown', async () => {
-      setUpMocks(org);
-
-      render(<CustomerDetails />, {
-        initialRouterConfig: {
-          location: {pathname: `/customers/${org.slug}`},
-          route: '/customers/:orgId',
-        },
-        organization: org,
-      });
-
-      await screen.findByRole('heading', {name: 'Customers'});
-
-      await userEvent.click(
-        screen.getAllByRole('button', {
-          name: 'Customers Actions',
-        })[0]!
-      );
-
-      expect(
-        screen.getByRole('option', {name: /Generate Spike Projections/})
-      ).toBeInTheDocument();
     });
   });
 });
@@ -3416,157 +2522,27 @@ describe('Gift Categories Availability', () => {
     },
   });
 
-  it('enables categories in checkoutCategories but not in onDemandCategories', async () => {
+  it('sets availability for every gift category', async () => {
     setUpMocks(organization, customSubscription);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    renderGlobalModal();
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
+    renderCustomerDetails(organization);
+    await openCustomerActions();
 
     expect(screen.getByTestId(`gift-${DataCategory.REPLAYS}`)).not.toHaveAttribute(
       'aria-disabled'
     );
-  });
-
-  it('enables categories in onDemandCategories but not in checkoutCategories', async () => {
-    setUpMocks(organization, customSubscription);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    renderGlobalModal();
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
-
     expect(
       screen.getByTestId(`gift-${DataCategory.PROFILE_DURATION}`)
     ).not.toHaveAttribute('aria-disabled');
-  });
-
-  it('enables categories in both checkoutCategories and onDemandCategories', async () => {
-    setUpMocks(organization, customSubscription);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    renderGlobalModal();
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
-
     expect(screen.getByTestId(`gift-${DataCategory.ERRORS}`)).not.toHaveAttribute(
       'aria-disabled'
     );
-  });
-
-  it('disables categories with unlimited quota', async () => {
-    setUpMocks(organization, customSubscription);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    renderGlobalModal();
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
-
     expect(screen.getByTestId(`gift-${DataCategory.SPANS}`)).toHaveAttribute(
       'aria-disabled',
       'true'
     );
-  });
-
-  it('filters out categories in neither checkoutCategories nor onDemandCategories', async () => {
-    setUpMocks(organization, customSubscription);
-
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    renderGlobalModal();
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
-
     expect(
       screen.queryByTestId(`gift-${DataCategory.PROFILE_DURATION_UI}`)
     ).not.toBeInTheDocument();
-  });
-
-  it('filters out categories that are not giftable', async () => {
-    setUpMocks(organization, customSubscription);
-    render(<CustomerDetails />, {
-      initialRouterConfig: {
-        location: {pathname: `/customers/${organization.slug}`},
-        route: '/customers/:orgId',
-      },
-      organization,
-    });
-
-    await screen.findByRole('heading', {name: 'Customers'});
-
-    renderGlobalModal();
-
-    await userEvent.click(
-      screen.getAllByRole('button', {
-        name: 'Customers Actions',
-      })[0]!
-    );
-
     expect(
       screen.queryByTestId(`gift-${DataCategory.SEER_AUTOFIX}`)
     ).not.toBeInTheDocument();

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -677,16 +677,6 @@ function setUpMocks(
   });
 }
 
-function renderCustomerDetails(organization: Organization) {
-  render(<CustomerDetails />, {
-    initialRouterConfig: {
-      location: {pathname: `/customers/${organization.slug}`},
-      route: '/customers/:orgId',
-    },
-    organization,
-  });
-}
-
 async function openCustomerActions() {
   await screen.findByRole('heading', {name: 'Customers'});
   await userEvent.click(screen.getAllByRole('button', {name: 'Customers Actions'})[0]!);
@@ -1120,7 +1110,13 @@ describe('Customer Details', () => {
 
   it('renders correct dropdown options', async () => {
     setUpMocks(organization);
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     expect(await screen.findByText('Legacy Billing')).toBeInTheDocument();
     expect(screen.queryByText('Billing Platform')).not.toBeInTheDocument();
@@ -1156,7 +1152,13 @@ describe('Customer Details', () => {
   it('shows limited events help text for free plan enterprise trial', async () => {
     setUpMocks(organization, {plan: 'am1_f', isFree: true});
 
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     await openCustomerActions();
 
@@ -1169,7 +1171,13 @@ describe('Customer Details', () => {
   it('hides Start Enterprise Trial for paid plans', async () => {
     setUpMocks(organization, {plan: 'am3_business', isFree: false});
 
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     await openCustomerActions();
 
@@ -1184,7 +1192,13 @@ describe('Customer Details', () => {
     it('renders in the dropdown when there are pending changes', async () => {
       setUpMocks(pendingChangesOrg, {pendingChanges: true});
 
-      renderCustomerDetails(pendingChangesOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${pendingChangesOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: pendingChangesOrg,
+      });
 
       await openCustomerActions();
 
@@ -1204,7 +1218,13 @@ describe('Customer Details', () => {
 
       setUpMocks(cannotTrialOrg, {canTrial: false, trialPlan: null});
 
-      renderCustomerDetails(cannotTrialOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${cannotTrialOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: cannotTrialOrg,
+      });
 
       await openCustomerActions();
 
@@ -1240,7 +1260,13 @@ describe('Customer Details', () => {
         isBillingAdmin: false,
       });
 
-      renderCustomerDetails(terminateOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${terminateOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: terminateOrg,
+      });
 
       await openCustomerActions();
 
@@ -1277,7 +1303,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(terminateOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${terminateOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: terminateOrg,
+      });
 
       await openCustomerActions();
 
@@ -1316,7 +1348,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(recreateOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${recreateOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: recreateOrg,
+      });
 
       await openCustomerActions();
 
@@ -1348,7 +1386,13 @@ describe('Customer Details', () => {
     });
 
     async function openMigrationAction(name: string) {
-      renderCustomerDetails(migrationOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${migrationOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: migrationOrg,
+      });
 
       await screen.findByRole('heading', {name: 'Customers'});
 
@@ -1427,7 +1471,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -1476,7 +1526,13 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, subscription);
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -1533,7 +1589,13 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, subscription);
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -1560,7 +1622,13 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, subscription);
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -1621,7 +1689,13 @@ describe('Customer Details', () => {
         },
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -1663,7 +1737,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(cancelSubOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${cancelSubOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: cancelSubOrg,
+      });
 
       await openCustomerActions();
 
@@ -1721,7 +1801,13 @@ describe('Customer Details', () => {
         body: Subscription,
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       renderGlobalModal();
 
@@ -1763,7 +1849,13 @@ describe('Customer Details', () => {
         body: sub,
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       renderGlobalModal();
 
@@ -1795,7 +1887,13 @@ describe('Customer Details', () => {
 
       setUpMocks(organization, partnerSubscription);
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await screen.findByRole('heading', {name: 'Customers'});
       await userEvent.click(
@@ -1820,7 +1918,13 @@ describe('Customer Details', () => {
         body: trialOrg,
       });
 
-      renderCustomerDetails(trialOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${trialOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: trialOrg,
+      });
 
       await openCustomerActions();
 
@@ -1871,7 +1975,13 @@ describe('Customer Details', () => {
         },
       });
 
-      renderCustomerDetails(onDemandInvoicedOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: onDemandInvoicedOrg,
+      });
 
       await openCustomerActions();
 
@@ -1900,7 +2010,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(invoicedOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${invoicedOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: invoicedOrg,
+      });
 
       await openCustomerActions();
 
@@ -1945,7 +2061,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(onDemandInvoicedOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${onDemandInvoicedOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: onDemandInvoicedOrg,
+      });
 
       await openCustomerActions();
 
@@ -1994,7 +2116,13 @@ describe('Customer Details', () => {
         body: OrganizationFixture(),
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -2031,7 +2159,13 @@ describe('Customer Details', () => {
       });
       setUpMocks(organization, partnerSubscription);
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -2046,7 +2180,13 @@ describe('Customer Details', () => {
     it('gifts error and transaction events', async () => {
       const subscription = SubscriptionFixture({organization});
       setUpMocks(organization, subscription);
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
       renderGlobalModal();
 
       for (const dataCategory of [DataCategory.ERRORS, DataCategory.TRANSACTIONS]) {
@@ -2087,7 +2227,13 @@ describe('Customer Details', () => {
     const am2Sub = SubscriptionFixture({organization, plan: 'am2_f'});
     setUpMocks(organization, am2Sub);
 
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2138,7 +2284,13 @@ describe('Customer Details', () => {
     const am3Sub = SubscriptionFixture({organization, plan: 'am3_f'});
     setUpMocks(organization, am3Sub);
 
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2188,7 +2340,13 @@ describe('Customer Details', () => {
     const am3Sub = SubscriptionFixture({organization, plan: 'am3_team'});
     setUpMocks(organization, am3Sub);
 
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2208,7 +2366,13 @@ describe('Customer Details', () => {
     const am2Sub = SubscriptionFixture({organization, plan: 'am2_f'});
     setUpMocks(organization, am2Sub);
 
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
 
     await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2269,7 +2433,13 @@ describe('Customer Details', () => {
 
       setUpMocks(invoicedOrg, {billingInterval: 'monthly', type: BillingType.INVOICED});
 
-      renderCustomerDetails(invoicedOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${invoicedOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: invoicedOrg,
+      });
 
       await openCustomerActions();
 
@@ -2283,7 +2453,13 @@ describe('Customer Details', () => {
 
       setUpMocks(invoicedOrg, {billingInterval: 'annual', type: BillingType.INVOICED});
 
-      renderCustomerDetails(invoicedOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${invoicedOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: invoicedOrg,
+      });
 
       await openCustomerActions();
 
@@ -2303,7 +2479,13 @@ describe('Customer Details', () => {
         body: suspendedOrg,
       });
 
-      renderCustomerDetails(suspendedOrg);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${suspendedOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: suspendedOrg,
+      });
 
       await openCustomerActions();
 
@@ -2337,7 +2519,13 @@ describe('Customer Details', () => {
         body: organization,
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -2382,7 +2570,13 @@ describe('Customer Details', () => {
         body: organization,
       });
 
-      renderCustomerDetails(organization);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
 
       await openCustomerActions();
 
@@ -2431,7 +2625,13 @@ describe('Customer Details', () => {
       });
       setUpMocks(orgWithDeleteFeature);
 
-      renderCustomerDetails(orgWithDeleteFeature);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${orgWithDeleteFeature.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: orgWithDeleteFeature,
+      });
 
       await screen.findByRole('heading', {name: 'Customers'});
       renderGlobalModal();
@@ -2452,7 +2652,13 @@ describe('Customer Details', () => {
       });
       setUpMocks(orgWithoutDeleteFeature);
 
-      renderCustomerDetails(orgWithoutDeleteFeature);
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${orgWithoutDeleteFeature.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: orgWithoutDeleteFeature,
+      });
 
       await screen.findByRole('heading', {name: 'Customers'});
 
@@ -2524,7 +2730,13 @@ describe('Gift Categories Availability', () => {
 
   it('sets availability for every gift category', async () => {
     setUpMocks(organization, customSubscription);
-    renderCustomerDetails(organization);
+    render(<CustomerDetails />, {
+      initialRouterConfig: {
+        location: {pathname: `/customers/${organization.slug}`},
+        route: '/customers/:orgId',
+      },
+      organization,
+    });
     await openCustomerActions();
 
     expect(screen.getByTestId(`gift-${DataCategory.REPLAYS}`)).not.toHaveAttribute(


### PR DESCRIPTION
This suite was mounting the full customer details page over and over to check the same action menu and modal plumbing.

Consolidates overlapping cases around the distinct visibility and mutation behavior they cover, and resets ConfigStore per test so permissions do not leak between cases.

| | Before | After |
|---|---:|---:|
| Tests | 63 | 39 |
| Focused suite | 8.75s | 5.97s |

about a third faster and a thousand lines less test noise.