### PR TITLE
fix(api): Skip issue mutations without project access

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -522,8 +522,12 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         examples=IssueExamples.ORGANIZATION_GROUP_INDEX_PUT,
     )
     @track_slo_response("workflow")
-    def put(self, request: Request, organization: Organization) -> Response[MutateIssueResponse]:
+    def put(
+        self, request: Request, organization: Organization
+    ) -> Response[MutateIssueResponse] | Response[None]:
         projects = self.get_projects(request, organization)
+        if not projects:
+            return Response(status=204)
 
         search_fn = functools.partial(
             self._search,
@@ -568,6 +572,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         self, request: Request, organization: Organization
     ) -> Response[None] | Response[DetailResponse] | Response[ValidationErrorResponse]:
         projects = self.get_projects(request, organization)
+        if not projects:
+            return Response(status=204)
 
         search_fn = functools.partial(
             self._search,

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3225,6 +3225,17 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def assertNoResolution(self, group: Group) -> None:
         assert not GroupResolution.objects.filter(group=group).exists()
 
+    def test_no_accessible_projects(self) -> None:
+        organization = self.create_organization()
+        self.create_project(organization=organization)
+        user = self.create_user()
+        self.create_member(organization=organization, user=user, has_global_access=False)
+        self.login_as(user=user)
+
+        response = self.get_response(organization.slug, status="resolved")
+
+        assert response.status_code == 204
+
     def test_global_resolve(self) -> None:
         group1 = self.create_group(status=GroupStatus.RESOLVED)
         group2 = self.create_group(status=GroupStatus.UNRESOLVED)
@@ -4653,6 +4664,17 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         for group in groups:
             assert not Group.objects.filter(id=group.id).exists()
             assert not GroupHash.objects.filter(group_id=group.id).exists()
+
+    def test_no_accessible_projects(self) -> None:
+        organization = self.create_organization()
+        self.create_project(organization=organization)
+        user = self.create_user()
+        self.create_member(organization=organization, user=user, has_global_access=False)
+        self.login_as(user=user)
+
+        response = self.get_response(organization.slug)
+
+        assert response.status_code == 204
 
     @patch("sentry.eventstream.snuba.SnubaEventStream._send")
     @patch("sentry.eventstream.snuba.datetime")


### PR DESCRIPTION
If an org doesn't have open team membership on (or generally has no projects), `get_projects` will return an empty list, and error when we try to reference projects inside of it. We should just return 204 in those situations instead.

Fixes SENTRY-5P2G