### PR TITLE
fix(performance): Query replacement telemetry attributes

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -44,6 +44,7 @@ import {
 } from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {toRoundedPercent} from 'sentry/utils/number/toRoundedPercent';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -507,6 +508,10 @@ function SlowDBQueryEvidence({
   const groupHash = sentryTags?.group ?? span.hash ?? '';
   const hasExplore = organization.features.includes('visibility-explore-view');
 
+  const codeFilepath = getAttributeValue(span.data ?? {}, 'code.file.path', 'string');
+  const codeLineNumber = getAttributeValue(span.data ?? {}, 'code.line.number', 'number');
+  const codeFunction = getAttributeValue(span.data ?? {}, 'code.function', 'string');
+
   const queryValue = (
     <QueryCard>
       <Stack minWidth={0}>
@@ -515,14 +520,14 @@ function SlowDBQueryEvidence({
             {formatter.toString(span.description ?? '')}
           </StyledCodeSnippet>
         </NoPaddingClippedBox>
-        {span.data?.['code.filepath'] ? (
+        {codeFilepath ? (
           <StackTraceMiniFrame
             projectId={event.projectID}
             event={event}
             frame={{
-              filename: span.data['code.filepath'],
-              lineNo: span.data['code.lineno'],
-              function: span.data['code.function'],
+              filename: codeFilepath,
+              lineNo: codeLineNumber === undefined ? undefined : Number(codeLineNumber),
+              function: codeFunction,
             }}
           />
         ) : (

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -509,11 +509,7 @@ function SlowDBQueryEvidence({
   const hasExplore = organization.features.includes('visibility-explore-view');
 
   const codeFilepath = getAttributeValue(span.data ?? {}, 'code.file.path', 'string');
-  const codeLineNumber = getAttributeValue(
-    span.data ?? {},
-    'code.line.number',
-    'number'
-  )?.toString();
+  const codeLineNumber = getAttributeValue(span.data ?? {}, 'code.line.number', 'number');
   const codeFunction = getAttributeValue(span.data ?? {}, 'code.function', 'string');
 
   const queryValue = (

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -509,7 +509,7 @@ function SlowDBQueryEvidence({
   const hasExplore = organization.features.includes('visibility-explore-view');
 
   const codeFilepath = getAttributeValue(span.data ?? {}, 'code.file.path', 'string');
-  const codeLineNumber = getAttributeValue(span.data ?? {}, 'code.line.number', 'number');
+  const codeLineNumber = getAttributeValue(span.data ?? {}, 'code.line.number', 'number')?.toString();
   const codeFunction = getAttributeValue(span.data ?? {}, 'code.function', 'string');
 
   const queryValue = (

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -509,7 +509,11 @@ function SlowDBQueryEvidence({
   const hasExplore = organization.features.includes('visibility-explore-view');
 
   const codeFilepath = getAttributeValue(span.data ?? {}, 'code.file.path', 'string');
-  const codeLineNumber = getAttributeValue(span.data ?? {}, 'code.line.number', 'number')?.toString();
+  const codeLineNumber = getAttributeValue(
+    span.data ?? {},
+    'code.line.number',
+    'number'
+  )?.toString();
   const codeFunction = getAttributeValue(span.data ?? {}, 'code.function', 'string');
 
   const queryValue = (

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -13,16 +13,16 @@ export type GapSpanType = {
 
 interface SpanSourceCodeAttributes {
   'code.column'?: number;
-  'code.filepath'?: string;
+  'code.file.path'?: string;
   'code.function'?: string;
-  'code.lineno'?: number;
+  'code.line.number'?: number;
   'code.namespace'?: string;
 }
 
 interface SpanDatabaseAttributes {
   'db.name'?: string;
   'db.operation'?: string;
-  'db.system'?: string;
+  'db.system.name'?: string;
   'db.user'?: string;
 }
 

--- a/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
@@ -94,7 +94,7 @@ describe('FullSpanDescription', () => {
             span_id: spanId,
             'span.description':
               '{"insert": "my_cool_collection😎", "a": {}, "uh_oh":"the_query_is_truncated", "ohno*',
-            'db.system': 'mongodb',
+            'db.system.name': 'mongodb',
           },
         ],
       },

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -7,6 +7,7 @@ import {ClippedBox} from 'sentry/components/clippedBox';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -42,16 +43,24 @@ export function FullSpanDescription({
         SpanFields.PROJECT_ID,
         SpanFields.TRANSACTION_SPAN_ID,
         SpanFields.SPAN_DESCRIPTION,
-        SpanFields.DB_SYSTEM,
+        SpanFields.DB_SYSTEM_NAME,
       ],
     },
     'api.insights.span-description'
   );
 
   const indexedSpan = indexedSpans?.[0];
-
-  const description = indexedSpan?.['span.description'] ?? shortDescription;
-  const system = indexedSpan?.['db.system'];
+  const indexedSpanDescription = getAttributeValue(
+    indexedSpan ?? {},
+    SpanFields.SPAN_DESCRIPTION,
+    'string'
+  );
+  const description = indexedSpanDescription ?? shortDescription;
+  const system = getAttributeValue(
+    indexedSpan ?? {},
+    SpanFields.DB_SYSTEM_NAME,
+    'string'
+  );
 
   if (areIndexedSpansLoading) {
     return (
@@ -70,8 +79,8 @@ export function FullSpanDescription({
       let stringifiedQuery = '';
       let result: ReturnType<typeof prettyPrintJsonString> | undefined;
 
-      if (indexedSpan?.['span.description']) {
-        result = prettyPrintJsonString(indexedSpan?.['span.description']);
+      if (indexedSpanDescription) {
+        result = prettyPrintJsonString(indexedSpanDescription);
       } else if (description) {
         result = prettyPrintJsonString(description);
       } else {

--- a/static/app/views/insights/common/components/spanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/spanDescription.spec.tsx
@@ -121,7 +121,7 @@ describe('DatabaseSpanDescription', () => {
             project: project.slug,
             span_id: spanId,
             'span.description': sampleMongoDBQuery,
-            'db.system': 'mongodb',
+            'db.system.name': 'mongodb',
           },
         ],
       },

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -7,6 +7,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {ClippedBox} from 'sentry/components/clippedBox';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {releaseApiOptions} from 'sentry/utils/releaseApiOptions';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -54,16 +55,16 @@ export function DatabaseSpanDescription({
       fields: [
         SpanFields.PROJECT_ID,
         SpanFields.SPAN_DESCRIPTION,
-        SpanFields.DB_SYSTEM,
-        SpanFields.CODE_FILEPATH,
-        SpanFields.CODE_LINENO,
+        SpanFields.DB_SYSTEM_NAME,
+        SpanFields.CODE_FILE_PATH,
+        SpanFields.CODE_LINE_NUMBER,
         SpanFields.CODE_FUNCTION,
         SpanFields.SDK_NAME,
         SpanFields.SDK_VERSION,
         SpanFields.RELEASE,
         SpanFields.PLATFORM,
       ],
-      sorts: [{field: SpanFields.CODE_FILEPATH, kind: 'desc'}],
+      sorts: [{field: SpanFields.CODE_FILE_PATH, kind: 'desc'}],
     },
     'api.insights.span-description'
   );
@@ -108,10 +109,27 @@ export function DatabaseSpanDescription({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigate]);
 
-  const system = indexedSpan?.['db.system'];
-  const codeFilepath = indexedSpan?.['code.filepath'];
-  const codeLineno = indexedSpan?.['code.lineno'];
-  const codeFunction = indexedSpan?.['code.function'];
+  const system = getAttributeValue(
+    indexedSpan ?? {},
+    SpanFields.DB_SYSTEM_NAME,
+    'string'
+  );
+  const codeFilepath = getAttributeValue(
+    indexedSpan ?? {},
+    SpanFields.CODE_FILE_PATH,
+    'string'
+  );
+  const codeLineNumber = getAttributeValue(
+    indexedSpan ?? {},
+    SpanFields.CODE_LINE_NUMBER,
+    'number'
+  );
+  const codeLineno = codeLineNumber === undefined ? undefined : Number(codeLineNumber);
+  const codeFunction = getAttributeValue(
+    indexedSpan ?? {},
+    SpanFields.CODE_FUNCTION,
+    'string'
+  );
 
   const formattedDescription = useMemo(() => {
     const rawDescription = indexedSpan?.['span.description'] || preliminaryDescription;

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -58,12 +58,12 @@ export enum SpanFields {
   PROFILEID = 'profile.id',
   REPLAYID = 'replayId',
   REPLAY_ID = 'replay.id',
-  CODE_FILEPATH = 'code.filepath',
+  CODE_FILE_PATH = 'code.file.path',
   CODE_FUNCTION = 'code.function',
   SDK_NAME = 'sdk.name',
   SDK_VERSION = 'sdk.version',
   PLATFORM = 'platform',
-  CODE_LINENO = 'code.lineno',
+  CODE_LINE_NUMBER = 'code.line.number',
   SPAN_ACTION = 'span.action',
   SPAN_DOMAIN = 'span.domain',
   NORMALIZED_DESCRIPTION = 'sentry.normalized_description',
@@ -141,7 +141,7 @@ export enum SpanFields {
   SPANS_UI = 'spans.ui',
 
   // DB fields
-  DB_SYSTEM = 'db.system', // TODO: this is a duplicate of `SPAN_SYSTEM`
+  DB_SYSTEM_NAME = 'db.system.name', // TODO: this is a duplicate of `SPAN_SYSTEM`
 
   // Mobile fields
   DEVICE_CLASS = 'device.class',
@@ -279,7 +279,7 @@ type SpanNumberFields =
   | SpanFields.FCP_SCORE
   | SpanFields.FCP_SCORE_RATIO
   | SpanFields.FCP_SCORE_WEIGHT
-  | SpanFields.CODE_LINENO
+  | SpanFields.CODE_LINE_NUMBER
   | SpanFields.APP_START_COLD
   | SpanFields.APP_START_WARM
   | SpanFields.PRECISE_START_TS
@@ -335,8 +335,8 @@ type NonNullableStringFields =
   | SpanFields.BROWSER_WEB_VITAL_CLS_SOURCE_1
   | SpanFields.TRANSACTION_SPAN_ID
   | SpanFields.TRANSACTION_EVENT_ID
-  | SpanFields.DB_SYSTEM
-  | SpanFields.CODE_FILEPATH
+  | SpanFields.DB_SYSTEM_NAME
+  | SpanFields.CODE_FILE_PATH
   | SpanFields.CODE_FUNCTION
   | SpanFields.SDK_NAME
   | SpanFields.SDK_VERSION
@@ -504,7 +504,7 @@ type HttpResponseFunctions =
 type CustomResponseFields = {
   [SpanFields.USER_GEO_SUBREGION]: SubregionCode;
   [SpanFields.PLATFORM]: PlatformKey;
-  [SpanFields.DB_SYSTEM]: SupportedDatabaseSystem;
+  [SpanFields.DB_SYSTEM_NAME]: SupportedDatabaseSystem;
   [SpanFields.SPAN_STATUS]:
     | 'ok'
     | 'cancelled'

--- a/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
+++ b/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
@@ -76,7 +76,7 @@ function getSpanCodeLocation(span: EvidenceSpan): string | null {
   if (!filepath) {
     return null;
   }
-  const lineno = getAttributeValue(data, 'code.line.number', 'number');
+  const lineno = getAttributeValue(data, 'code.line.number', 'number')?.toString();
   const fn = getAttributeValue(data, 'code.function', 'string');
   const location = lineno === undefined ? filepath : `${filepath}:${lineno}`;
   return fn ? `${location} ${fn}` : location;

--- a/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
+++ b/static/app/views/issueDetails/hooks/spanEvidenceMarkdown.tsx
@@ -20,6 +20,7 @@ import {
   isTransactionBased,
   IssueType,
 } from 'sentry/types/group';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {toRoundedPercent} from 'sentry/utils/number/toRoundedPercent';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
@@ -70,13 +71,13 @@ function normalizeSpanDescription(span: EvidenceSpan): string {
 
 /** Mirrors the `code.*` span data the UI's SlowDBQueryEvidence renders. */
 function getSpanCodeLocation(span: EvidenceSpan): string | null {
-  const data = span?.data;
-  const filepath = data?.['code.filepath'];
+  const data = span?.data ?? {};
+  const filepath = getAttributeValue(data, 'code.file.path', 'string');
   if (!filepath) {
     return null;
   }
-  const lineno = data?.['code.lineno'];
-  const fn = data?.['code.function'];
+  const lineno = getAttributeValue(data, 'code.line.number', 'number');
+  const fn = getAttributeValue(data, 'code.function', 'string');
   const location = lineno === undefined ? filepath : `${filepath}:${lineno}`;
   return fn ? `${location} ${fn}` : location;
 }

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -122,6 +122,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
     additionalAttributes: [
       'thread.id',
       'tags[browser.performance.time_origin,number]',
+      'tags[performance.timeOrigin,number]',
       'gen_ai.operation.type',
       'http.response.status_code',
       'span.status',

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -121,7 +121,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
     timestamp: queryParams.timestamp,
     additionalAttributes: [
       'thread.id',
-      'tags[performance.timeOrigin,number]',
+      'tags[browser.performance.time_origin,number]',
       'gen_ai.operation.type',
       'http.response.status_code',
       'span.status',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -14,6 +14,7 @@ import {IconGraph} from 'sentry/icons/iconGraph';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {SQLishFormatter} from 'sentry/utils/sqlish';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {ResourceSize} from 'sentry/views/insights/browser/resources/components/resourceSize';
@@ -66,13 +67,21 @@ export function SpanDescription({
     projectSlug: project?.slug,
   });
   const span = node.value;
+  const spanData = span.data ?? {};
   const hasExploreEnabled = organization.features.includes('visibility-explore-view');
   const resolvedModule = resolveSpanModule(
     span.sentry_tags?.op,
     span.sentry_tags?.category
   );
 
-  const system = span?.data?.['db.system'];
+  const system = getAttributeValue(spanData, SpanFields.DB_SYSTEM_NAME, 'string');
+  const codeFilepath = getAttributeValue(spanData, SpanFields.CODE_FILE_PATH, 'string');
+  const codeLineNumber = getAttributeValue(
+    spanData,
+    SpanFields.CODE_LINE_NUMBER,
+    'number'
+  );
+  const codeFunction = getAttributeValue(spanData, SpanFields.CODE_FUNCTION, 'string');
   const formattedDescription = useMemo(() => {
     if (resolvedModule !== ModuleName.DB) {
       return span.description ?? '';
@@ -142,14 +151,14 @@ export function SpanDescription({
         >
           {formattedDescription}
         </StyledCodeSnippet>
-        {span?.data?.['code.filepath'] ? (
+        {codeFilepath ? (
           <StackTraceMiniFrame
             projectId={node.event?.projectID}
             event={event}
             frame={{
-              filename: span?.data?.['code.filepath'],
-              lineNo: span?.data?.['code.lineno'],
-              function: span?.data?.['code.function'],
+              filename: codeFilepath,
+              lineNo: codeLineNumber === undefined ? undefined : Number(codeLineNumber),
+              function: codeFunction,
             }}
           />
         ) : (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -80,7 +80,7 @@ export function SpanDescription({
     spanData,
     SpanFields.CODE_LINE_NUMBER,
     'number'
-  )?.toString();
+  );
   const codeFunction = getAttributeValue(spanData, SpanFields.CODE_FUNCTION, 'string');
   const formattedDescription = useMemo(() => {
     if (resolvedModule !== ModuleName.DB) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -80,7 +80,7 @@ export function SpanDescription({
     spanData,
     SpanFields.CODE_LINE_NUMBER,
     'number'
-  );
+  )?.toString();
   const codeFunction = getAttributeValue(spanData, SpanFields.CODE_FUNCTION, 'string');
   const formattedDescription = useMemo(() => {
     if (resolvedModule !== ModuleName.DB) {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -1042,42 +1042,59 @@ describe('TraceTree', () => {
       expect(lcpIndicators[0]!.node.id).toBe('standalone-lcp-span');
     });
 
-    it('applies standalone LCP measurement offset from trace origin when present', () => {
-      const tree = TraceTree.FromTrace(
-        makeEAPTrace([
-          makeEAPSpan({
-            event_id: 'pageload-span',
-            op: 'pageload',
-            start_timestamp: start,
-            end_timestamp: start + 2,
-            is_transaction: true,
-            additional_attributes: {
-              'tags[browser.performance.time_origin,number]': start,
-            },
-            measurements: {
-              'measurements.lcp': 500,
-            },
-            children: [],
-          }),
-          makeEAPSpan({
-            event_id: 'standalone-lcp-span',
-            op: 'ui.webvital.lcp',
-            start_timestamp: start + 1.5,
-            end_timestamp: start + 1.6,
-            is_transaction: false,
-            measurements: {
-              'measurements.lcp': 1240,
-            },
-            children: [],
-          }),
-        ]),
-        {meta: null, replay: null, organization}
-      );
+    it.each<{
+      additionalAttributes: Record<string, string | number>;
+      attributeName: string;
+    }>([
+      {
+        additionalAttributes: {
+          'tags[browser.performance.time_origin,number]': start,
+        },
+        attributeName: 'replacement',
+      },
+      {
+        additionalAttributes: {
+          'tags[performance.timeOrigin,number]': start,
+        },
+        attributeName: 'deprecated',
+      },
+    ])(
+      'applies standalone LCP measurement offset using the $attributeName trace origin attribute',
+      ({additionalAttributes}) => {
+        const tree = TraceTree.FromTrace(
+          makeEAPTrace([
+            makeEAPSpan({
+              event_id: 'pageload-span',
+              op: 'pageload',
+              start_timestamp: start,
+              end_timestamp: start + 2,
+              is_transaction: true,
+              additional_attributes: additionalAttributes,
+              measurements: {
+                'measurements.lcp': 500,
+              },
+              children: [],
+            }),
+            makeEAPSpan({
+              event_id: 'standalone-lcp-span',
+              op: 'ui.webvital.lcp',
+              start_timestamp: start + 1.5,
+              end_timestamp: start + 1.6,
+              is_transaction: false,
+              measurements: {
+                'measurements.lcp': 1240,
+              },
+              children: [],
+            }),
+          ]),
+          {meta: null, replay: null, organization}
+        );
 
-      const lcpIndicators = tree.indicators.filter(i => i.type === 'lcp');
-      expect(lcpIndicators).toHaveLength(1);
-      expect(lcpIndicators[0]!.start).toBe(start * 1e3 + 1240);
-    });
+        const lcpIndicators = tree.indicators.filter(i => i.type === 'lcp');
+        expect(lcpIndicators).toHaveLength(1);
+        expect(lcpIndicators[0]!.start).toBe(start * 1e3 + 1240);
+      }
+    );
 
     it('handles cycles in EAP trace structure without infinite loop', () => {
       const cyclicSpan = makeEAPSpan({

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -1052,7 +1052,7 @@ describe('TraceTree', () => {
             end_timestamp: start + 2,
             is_transaction: true,
             additional_attributes: {
-              'tags[performance.timeOrigin,number]': start,
+              'tags[browser.performance.time_origin,number]': start,
             },
             measurements: {
               'measurements.lcp': 500,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -4,6 +4,7 @@ import type {Client} from 'sentry/api';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import type {Level, Measurement} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 import type {TraceMetaQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
@@ -379,16 +380,21 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
   }
 
   get traceOrigin(): number {
-    return (
-      ((this.value &&
-        Array.isArray(this.value) &&
-        this.value[0] &&
-        'additional_attributes' in this.value[0] &&
-        (this.value[0].additional_attributes?.[
-          'tags[performance.timeOrigin,number]'
-        ] as number)) ||
-        0) * 1000
+    if (
+      !Array.isArray(this.value) ||
+      !this.value[0] ||
+      !('additional_attributes' in this.value[0])
+    ) {
+      return 0;
+    }
+
+    const timeOrigin = getAttributeValue(
+      this.value[0].additional_attributes ?? {},
+      'browser.performance.time_origin',
+      'number'
     );
+
+    return Number(timeOrigin ?? 0) * 1000;
   }
 
   isRootNodeChild(): boolean {


### PR DESCRIPTION
Span descriptions, span evidence, and trace timing now use the Sentry Conventions replacements for code locations, database systems, and browser performance time origin.

Refs TET-2814