### PR TITLE
ref(scraps): do not export ReactSelect

### DIFF
--- a/static/app/components/core/select/index.tsx
+++ b/static/app/components/core/select/index.tsx
@@ -7,7 +7,7 @@ export {
 } from './select';
 
 export {SelectOption} from './option';
-export {ReactSelect, components, createFilter} from './reactSelectWrapper';
+export {components, createFilter} from './reactSelectWrapper';
 export type {
   MultiValueProps,
   OptionsType,

--- a/static/app/gettingStartedDocs/node-awslambda/awslambdaArnSelector.tsx
+++ b/static/app/gettingStartedDocs/node-awslambda/awslambdaArnSelector.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {CodeBlock} from '@sentry/scraps/code';
-import {ReactSelect as Select} from '@sentry/scraps/select';
+import {Container} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
 
 import {t} from 'sentry/locale';
 
@@ -69,20 +70,16 @@ export function AwsLambdaArnSelector({
 
   return (
     <div>
-      <Select
-        styles={{
-          control: base => ({...base, width: 300}),
-          menu: base => ({...base, zIndex: 2}),
-        }}
-        placeholder={t('Select Region')}
-        options={options}
-        value={regionOption}
-        onChange={value => {
-          if (value) {
-            setRegion(value);
-          }
-        }}
-      />
+      <Container maxWidth="300px">
+        <Select
+          placeholder={t('Select Region')}
+          options={options}
+          value={regionOption?.value}
+          onChange={option => {
+            setRegion(option);
+          }}
+        />
+      </Container>
 
       <ArnWrapper>
         <ArnLabel>ARN</ArnLabel>


### PR DESCRIPTION
it was only used in one place and that was actually buggy because it wasn’t theme aware:

before:
<img width="1250" height="736" alt="Screenshot 2026-08-31 at 12 11 39" src="https://github.com/user-attachments/assets/a2be0ecc-9c83-4e91-baa8-f1b578a744a2" />

after:
<img width="1243" height="628" alt="Screenshot 2026-08-31 at 12 12 01" src="https://github.com/user-attachments/assets/fb7f1565-bd39-4eba-bbc1-d9d5c1a460ee" />

