### PR TITLE
perf(pr-metrics): Let the budget, not the batch cap, bound an activity sweep

### DIFF
--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -50,11 +50,17 @@ DELAY_BETWEEN_RETRIES = 60  # seconds
 _ActivityStore = TypeVar("_ActivityStore", PullRequestActivity, PullRequestActivityLog)
 
 # Per-run bounds on one store's sweep. The batch bounds cap the delete pressure a
-# run applies (50k rows); the budget caps how long it may spend applying it. Size
+# run applies (250k rows); the budget caps how long it may spend applying it. Size
 # them off backlog_lag_seconds — a run pinned at the batch cap says more work
 # exists, not how much.
+#
+# The cap sits high enough that the budget is what a backlogged run hits first, so
+# a run ending early reports a slow database rather than a deep backlog. It is
+# sized for the legacy store: one row per event there against one document per PR,
+# so an identical row cap buys it a fraction of the document's reach in PRs. The
+# document drains far inside the cap either way.
 _SWEEP_BATCH_SIZE = 1000
-_SWEEP_MAX_BATCHES = 50
+_SWEEP_MAX_BATCHES = 250
 SWEEP_STORE_BUDGET = timedelta(seconds=240)
 
 # Both stores' budgets plus room to report on them. An overrun is a broker kill,

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -49,16 +49,9 @@ DELAY_BETWEEN_RETRIES = 60  # seconds
 # hang off a PR and carry a date to age them by.
 _ActivityStore = TypeVar("_ActivityStore", PullRequestActivity, PullRequestActivityLog)
 
-# Per-run bounds on one store's sweep. The batch bounds cap the delete pressure a
-# run applies (250k rows); the budget caps how long it may spend applying it. Size
-# them off backlog_lag_seconds — a run pinned at the batch cap says more work
-# exists, not how much.
-#
-# The cap sits high enough that the budget is what a backlogged run hits first, so
-# a run ending early reports a slow database rather than a deep backlog. It is
-# sized for the legacy store: one row per event there against one document per PR,
-# so an identical row cap buys it a fraction of the document's reach in PRs. The
-# document drains far inside the cap either way.
+# Per-run bounds on one store's sweep: the batch bounds cap delete pressure, the
+# budget caps time. The cap sits above what the budget allows so runs end on time,
+# not on rows — the legacy store holds a row per event, the document one per PR.
 _SWEEP_BATCH_SIZE = 1000
 _SWEEP_MAX_BATCHES = 250
 SWEEP_STORE_BUDGET = timedelta(seconds=240)


### PR DESCRIPTION
The legacy `PullRequestActivity` sweep ends on `_SWEEP_MAX_BATCHES` every run with `backlog_lag_seconds` climbing; `PullRequestActivityLog` finishes inside the same cap at zero lag. O

`capped` fires every run and `timed_out` never has, so runs end on rows well inside their allowed time. Raise the cap so `SWEEP_STORE_BUDGET` binds instead, and a backlogged run reports a slow database rather than a low cap.

`SWEEP_PROCESSING_DEADLINE` derives from the budget and already covers both stores at full spend. The document store is unaffected.

Follow-up: the dashboard's "Sweep capacity" cap marker is drawn at `y = 50`.
