### PR TITLE
ref(ai-monitoring): Unregister one-shot title rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1297,13 +1297,6 @@ register(
     default=0.0,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Deterministic % of organizations that use Seer's one-shot title generator.
-register(
-    "ai-monitoring.conversation-title-generation.oneshot-rollout-rate",
-    type=Float,
-    default=0.0,
-    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "seer.night_shift.enable",
     type=Bool,


### PR DESCRIPTION
One-shot conversation title generation is fully rolled out, and Sentry no longer reads its rollout option. Remove the retired registration after the automator unsets the stored override.

Merge only after getsentry/sentry-options-automator#9464 deploys successfully to all environments.

Refs TET-2877