### PR TITLE
fix(ui): Let Tag ellipsize instead of overflowing its container

### DIFF
--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -119,8 +119,10 @@ function makeTagPillTheme(type: TagVariant, theme: Theme): React.CSSProperties {
 
 const Text = styled('div')`
   /* text-overflow only takes effect on a block container, so the label cannot be
-     a flex box. TagPill already centers it, and the occurrences that pass
-     elements rather than a string bring their own layout. */
+     a flex box. Dropping the flex layout is safe: TagPill already centers this
+     box, and no call site passes sibling elements that needed it. It also drops
+     a gap that was splitting concatenated labels: preprodBuildsTableCommon
+     rendered "+ 3" where it meant "+3". */
   display: block;
   overflow: hidden;
   white-space: nowrap;

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -60,9 +60,10 @@ const TagPill = styled('div')<{
   height: 20px;
   font-size: ${p => p.theme.font.size.sm};
   display: inline-flex;
-  /* Flex and grid items default to min-width: auto, which pins the pill to its
-     content width. Zero lets it shrink so the label ellipsizes instead. */
-  min-width: 0;
+  /* Caps the pill at its container so the label ellipsizes rather than spilling
+     out. Unlike min-width: 0, this leaves the pill's content-based minimum
+     intact, so a shrinking sibling cannot squeeze it. */
+  max-width: 100%;
   gap: ${p => p.theme.space.xs};
   align-items: center;
   border-radius: ${p => p.theme.radius.xs};

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -118,15 +118,14 @@ function makeTagPillTheme(type: TagVariant, theme: Theme): React.CSSProperties {
 }
 
 const Text = styled('div')`
+  /* text-overflow only takes effect on a block container, so the label cannot be
+     a flex box. TagPill already centers it, and the occurrences that pass
+     elements rather than a string bring their own layout. */
+  display: block;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: 0;
-
-  /* @TODO(jonasbadalic): Some occurrences pass other things than strings into the children prop. */
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
 `;
 
 const IconWrapper = styled('span')`

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -60,6 +60,9 @@ const TagPill = styled('div')<{
   height: 20px;
   font-size: ${p => p.theme.font.size.sm};
   display: inline-flex;
+  /* Flex and grid items default to min-width: auto, which pins the pill to its
+     content width. Zero lets it shrink so the label ellipsizes instead. */
+  min-width: 0;
   gap: ${p => p.theme.space.xs};
   align-items: center;
   border-radius: ${p => p.theme.radius.xs};

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -117,7 +117,6 @@ function makeTagPillTheme(type: TagVariant, theme: Theme): React.CSSProperties {
 }
 
 const Text = styled('div')`
-  /* Block, not flex: text-overflow has no effect on a flex container. */
   display: block;
   overflow: hidden;
   white-space: nowrap;

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -60,9 +60,8 @@ const TagPill = styled('div')<{
   height: 20px;
   font-size: ${p => p.theme.font.size.sm};
   display: inline-flex;
-  /* Caps the pill at its container so the label ellipsizes rather than spilling
-     out. Unlike min-width: 0, this leaves the pill's content-based minimum
-     intact, so a shrinking sibling cannot squeeze it. */
+  /* Caps the pill at its container. min-width: 0 would do this too, but would
+     also let a shrinking sibling squeeze it. */
   max-width: 100%;
   gap: ${p => p.theme.space.xs};
   align-items: center;
@@ -118,11 +117,7 @@ function makeTagPillTheme(type: TagVariant, theme: Theme): React.CSSProperties {
 }
 
 const Text = styled('div')`
-  /* text-overflow only takes effect on a block container, so the label cannot be
-     a flex box. Dropping the flex layout is safe: TagPill already centers this
-     box, and no call site passes sibling elements that needed it. It also drops
-     a gap that was splitting concatenated labels: preprodBuildsTableCommon
-     rendered "+ 3" where it meant "+3". */
+  /* Block, not flex: text-overflow has no effect on a flex container. */
   display: block;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
`Tag` styles its label to truncate with an ellipsis, but that never took effect: the pill has no width cap, so it keeps its content width and spills out of whatever is sizing it. Capping it at its container makes long tag text clip inside, as the existing styling always intended.

`min-width: 0` is the more obvious fix but also drops the pill's content-based minimum, which lets a tag sharing a flex row with a truncating label get squeezed and clipped. Capping the width contains long tags without making short ones shrinkable.
