### PR TITLE
chore(incidents): Remove orphaned metric aggregate query

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -4,8 +4,8 @@ import bisect
 import logging
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass, replace
-from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from re import Match
 from typing import Any, TypedDict
 from uuid import UUID, uuid4
@@ -16,12 +16,11 @@ from django.db.models import QuerySet
 from django.db.models.signals import post_save
 from django.forms import ValidationError
 from django.utils import timezone as django_timezone
-from snuba_sdk import Column, Condition, Limit, Op
 
-from sentry import analytics, audit_log, features, options, quotas
+from sentry import analytics, audit_log, features, options
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.auth.access import SystemAccess
-from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, ObjectStatus
+from sentry.constants import ObjectStatus
 from sentry.db.models import Model
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
@@ -57,14 +56,11 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionService, ActionTarget
 from sentry.relay.config.metric_extraction import on_demand_metrics_feature_flags
-from sentry.search.eap.types import SearchResolverConfig
-from sentry.search.events.builder.base import BaseQueryBuilder
 from sentry.search.events.constants import (
     METRICS_LAYER_UNSUPPORTED_TRANSACTION_METRICS_FUNCTIONS,
     SPANS_METRICS_FUNCTIONS,
 )
 from sentry.search.events.fields import is_function, resolve_field
-from sentry.search.events.types import SnubaParams
 from sentry.seer.anomaly_detection.delete_rule import delete_rule_in_seer
 from sentry.seer.anomaly_detection.store_data import send_new_rule_data, update_rule_data_legacy
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation, app_service
@@ -73,14 +69,7 @@ from sentry.shared_integrations.exceptions import (
     DuplicateDisplayNameError,
     IntegrationError,
 )
-from sentry.snuba.dataset import Dataset, EntityKey
-from sentry.snuba.entity_subscription import (
-    ENTITY_TIME_COLUMNS,
-    EntitySubscription,
-    get_entity_from_query_builder,
-    get_entity_key_from_query_builder,
-    get_entity_subscription_from_snuba_query,
-)
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import should_use_on_demand_metrics
 from sentry.snuba.metrics.naming_layer.mri import get_available_operations, is_mri, parse_mri
 from sentry.snuba.models import (
@@ -89,8 +78,6 @@ from sentry.snuba.models import (
     SnubaQuery,
     SnubaQueryEventType,
 )
-from sentry.snuba.referrer import Referrer
-from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
     bulk_delete_snuba_subscriptions,
@@ -103,7 +90,6 @@ from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.types.actor import Actor
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.not_set import NOT_SET, NotSet
 from sentry.utils.snuba import is_measurement
@@ -284,185 +270,6 @@ def _unpack_organization(alert_rule: AlertRule) -> Organization:
     if organization is None:
         raise ValueError("The alert rule must have a non-null organization")
     return organization
-
-
-@dataclass
-class BaseMetricIssueQueryParams:
-    snuba_query: SnubaQuery
-    date_started: datetime
-    current_end_date: datetime
-    organization: Organization
-
-
-@dataclass
-class CalculateOpenPeriodTimeRangeParams(BaseMetricIssueQueryParams):
-    start_arg: datetime | None = None
-    end_arg: datetime | None = None
-
-
-@dataclass
-class BuildMetricQueryBuilderParams(BaseMetricIssueQueryParams):
-    project_ids: list[int]
-    entity_subscription: EntitySubscription
-    start_arg: datetime | None = None
-    end_arg: datetime | None = None
-
-
-@dataclass
-class GetMetricIssueAggregatesParams(BaseMetricIssueQueryParams):
-    project_ids: list[int]
-    start_arg: datetime | None = None
-    end_arg: datetime | None = None
-
-
-def _build_metric_query_builder(
-    params: BuildMetricQueryBuilderParams,
-) -> BaseQueryBuilder:
-    start, end = _calculate_open_period_time_range(
-        CalculateOpenPeriodTimeRangeParams(
-            snuba_query=params.snuba_query,
-            date_started=params.date_started,
-            current_end_date=params.current_end_date,
-            organization=params.organization,
-            start_arg=params.start_arg,
-            end_arg=params.end_arg,
-        )
-    )
-
-    query_builder = params.entity_subscription.build_query_builder(
-        query=params.snuba_query.query,
-        project_ids=params.project_ids,
-        environment=params.snuba_query.environment,
-        params={
-            "organization_id": params.organization.id,
-            "project_id": params.project_ids,
-            "start": start,
-            "end": end,
-        },
-    )
-    for i, column in enumerate(query_builder.columns):
-        if column.alias == CRASH_RATE_ALERT_AGGREGATE_ALIAS:
-            query_builder.columns[i] = replace(column, alias="count")
-    entity_key = get_entity_key_from_query_builder(query_builder)
-    time_col = ENTITY_TIME_COLUMNS[entity_key]
-    entity = get_entity_from_query_builder(query_builder)
-    query_builder.add_conditions(
-        [
-            Condition(Column(time_col, entity=entity), Op.GTE, start),
-            Condition(Column(time_col, entity=entity), Op.LT, end),
-        ]
-    )
-    query_builder.limit = Limit(10000)
-    return query_builder
-
-
-def _calculate_open_period_time_range(
-    params: CalculateOpenPeriodTimeRangeParams,
-) -> tuple[datetime, datetime]:
-    time_window = params.snuba_query.time_window
-    time_window_delta = timedelta(seconds=time_window)
-    start = (
-        (params.date_started - time_window_delta) if params.start_arg is None else params.start_arg
-    )
-    end = (
-        (params.current_end_date + time_window_delta) if params.end_arg is None else params.end_arg
-    )
-
-    retention = quotas.backend.get_event_retention(organization=params.organization) or 90
-    start = max(
-        start.replace(tzinfo=timezone.utc),
-        datetime.now(timezone.utc) - timedelta(days=retention),
-    )
-    end = max(start, end.replace(tzinfo=timezone.utc))
-
-    return start, end
-
-
-def get_metric_issue_aggregates(
-    params: GetMetricIssueAggregatesParams,
-) -> dict[str, float | int]:
-    """
-    Calculates aggregate stats across the life of an incident, or the provided range.
-    """
-    entity_subscription = get_entity_subscription_from_snuba_query(
-        params.snuba_query,
-        params.organization.id,
-    )
-
-    if entity_subscription.dataset == Dataset.EventsAnalyticsPlatform:
-        start, end = _calculate_open_period_time_range(
-            CalculateOpenPeriodTimeRangeParams(
-                snuba_query=params.snuba_query,
-                date_started=params.date_started,
-                current_end_date=params.current_end_date,
-                organization=params.organization,
-                start_arg=params.start_arg,
-                end_arg=params.end_arg,
-            )
-        )
-
-        snuba_params = SnubaParams(
-            environments=[params.snuba_query.environment],
-            projects=[
-                Project.objects.get_from_cache(id=project_id) for project_id in params.project_ids
-            ],
-            organization=params.organization,
-            start=start,
-            end=end,
-        )
-
-        try:
-            results = Spans.run_table_query(
-                params=snuba_params,
-                query_string=params.snuba_query.query,
-                selected_columns=[entity_subscription.aggregate],
-                orderby=None,
-                offset=0,
-                limit=1,
-                referrer=Referrer.API_ALERTS_ALERT_RULE_CHART.value,
-                sampling_mode=None,
-                config=SearchResolverConfig(
-                    auto_fields=True,
-                ),
-            )
-
-        except Exception:
-            entity_key = EntityKey.EAPItems
-            metrics.incr(
-                "incidents.get_incident_aggregates.snql.query.error",
-                tags={
-                    "dataset": params.snuba_query.dataset,
-                    "entity": entity_key.value,
-                },
-            )
-            raise
-    else:
-        query_builder = _build_metric_query_builder(
-            BuildMetricQueryBuilderParams(
-                snuba_query=params.snuba_query,
-                organization=params.organization,
-                project_ids=params.project_ids,
-                entity_subscription=entity_subscription,
-                date_started=params.date_started,
-                current_end_date=params.current_end_date,
-                start_arg=params.start_arg,
-                end_arg=params.end_arg,
-            )
-        )
-        try:
-            results = query_builder.run_query(referrer="incidents.get_incident_aggregates")
-        except Exception:
-            metrics.incr(
-                "incidents.get_incident_aggregates.snql.query.error",
-                tags={
-                    "dataset": params.snuba_query.dataset,
-                    "entity": get_entity_key_from_query_builder(query_builder).value,
-                },
-            )
-            raise
-
-    aggregated_result = entity_subscription.aggregate_query_results(results["data"], alias="count")
-    return aggregated_result[0]
 
 
 class AlertRuleNameAlreadyUsedError(Exception):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -30,7 +30,6 @@ from sentry.incidents.logic import (
     AlertRuleTriggerLabelAlreadyUsedError,
     AlertTarget,
     ChannelLookupTimeoutError,
-    GetMetricIssueAggregatesParams,
     InvalidTriggerActionError,
     create_alert_rule,
     create_alert_rule_trigger,
@@ -46,7 +45,6 @@ from sentry.incidents.logic import (
     get_actions_for_trigger,
     get_alert_resolution,
     get_available_action_integrations_for_org,
-    get_metric_issue_aggregates,
     get_triggers_for_alert_rule,
     snapshot_alert_rule,
     translate_aggregate_field,
@@ -82,7 +80,6 @@ from sentry.integrations.discord.utils.channel import ChannelType
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.integrations.services.integration.serial import serialize_integration
-from sentry.models.group import GroupStatus
 from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiTimeoutError
@@ -90,7 +87,7 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
-from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, TestCase
+from sentry.testutils.cases import BaseIncidentsTest, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
@@ -273,86 +270,6 @@ class BaseIncidentEventStatsTest(BaseIncidentsTest, BaseIncidentsValidation):
             projects=[],
             groups=[event.group],
         )
-
-
-class GetMetricIssueAggregatesTest(TestCase, BaseIncidentsTest):
-    def test_projects(self) -> None:
-        incident = self.create_incident(
-            date_started=self.now - timedelta(minutes=5), query="", projects=[self.project]
-        )
-        self.create_event(self.now - timedelta(minutes=1))
-        self.create_event(self.now - timedelta(minutes=2), user={"id": 123})
-        self.create_event(self.now - timedelta(minutes=2), user={"id": 123})
-        self.create_event(self.now - timedelta(minutes=2), user={"id": 124})
-        snuba_query = incident.alert_rule.snuba_query
-        params = GetMetricIssueAggregatesParams(
-            snuba_query=snuba_query,
-            date_started=incident.date_started,
-            current_end_date=incident.current_end_date,
-            organization=incident.organization,
-            project_ids=[self.project.id],
-        )
-        assert get_metric_issue_aggregates(params) == {"count": 4}
-
-    def test_is_unresolved_query(self) -> None:
-        incident = self.create_incident(
-            date_started=self.now - timedelta(minutes=5),
-            query="is:unresolved",
-            projects=[self.project],
-        )
-        event = self.create_event(self.now - timedelta(minutes=1))
-        self.create_event(self.now - timedelta(minutes=2))
-        self.create_event(self.now - timedelta(minutes=3))
-        self.create_event(self.now - timedelta(minutes=4))
-
-        event.group.update(status=GroupStatus.UNRESOLVED)
-
-        snuba_query = incident.alert_rule.snuba_query
-        params = GetMetricIssueAggregatesParams(
-            snuba_query=snuba_query,
-            date_started=incident.date_started,
-            current_end_date=incident.current_end_date,
-            organization=incident.organization,
-            project_ids=[self.project.id],
-        )
-        assert get_metric_issue_aggregates(params) == {"count": 4}
-
-
-class GetCrashRateMetricsIncidentAggregatesTest(TestCase, BaseMetricsTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
-        for _ in range(2):
-            self.store_session(self.build_session(status="exited"))
-        self.dataset = Dataset.Metrics
-
-    def test_sessions(self) -> None:
-        incident = self.create_incident(
-            date_started=self.now - timedelta(minutes=120), query="", projects=[self.project]
-        )
-        alert_rule = self.create_alert_rule(
-            self.organization,
-            [self.project],
-            query="",
-            time_window=1,
-            dataset=self.dataset,
-            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
-        )
-        incident.update(alert_rule=alert_rule)
-        snuba_query = incident.alert_rule.snuba_query
-        project_ids = list(
-            IncidentProject.objects.filter(incident=incident).values_list("project_id", flat=True)
-        )
-        params = GetMetricIssueAggregatesParams(
-            snuba_query=snuba_query,
-            date_started=incident.date_started,
-            current_end_date=incident.current_end_date,
-            organization=incident.organization,
-            project_ids=project_ids,
-        )
-        incident_aggregates = get_metric_issue_aggregates(params)
-        assert "count" in incident_aggregates
-        assert incident_aggregates["count"] == 100.0
 
 
 @freeze_time()


### PR DESCRIPTION
Remove the incident metric aggregate query left behind after its Slack consumer was retired.

[Sentry PR #121564](https://github.com/getsentry/sentry/pull/121564) removed the Slack metric alert message builder and its last production call to `get_metric_issue_aggregates`. The aggregate function, private query helpers, parameter types, and dedicated tests remained without a runtime caller.