### PR TITLE
fix(admin): move the region probe spinner to stop layout shifts

### DIFF
--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -677,11 +677,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       return null;
     }
 
-    if (this.state.probingRegions) {
-      return <RegionHintNote>Checking other regions…</RegionHintNote>;
-    }
-
-    if (this.state.regionMatches.length === 0) {
+    if (this.state.probingRegions || this.state.regionMatches.length === 0) {
       return null;
     }
 
@@ -833,25 +829,30 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       <Container data-test-id="result-grid">
         <SortSearchForm onSubmit={this.onSearch}>
           {needsRegion && (
-            <CompactSelect
-              trigger={triggerProps => (
-                <OverlayTrigger.Button {...triggerProps} prefix="Region" />
+            <Flex align="center" gap="md">
+              <CompactSelect
+                trigger={triggerProps => (
+                  <OverlayTrigger.Button {...triggerProps} prefix="Region" />
+                )}
+                value={this.state.cell ? this.state.cell.locality_url : undefined}
+                options={cells.map(c => {
+                  const hasMatch = this.state.regionMatches.some(
+                    m => m.locality_url === c.locality_url
+                  );
+                  return {
+                    label: c.name,
+                    value: c.locality_url,
+                    trailingItems: hasMatch ? (
+                      <Tag variant="success">found</Tag>
+                    ) : undefined,
+                  };
+                })}
+                onChange={opt => this.onChangeCell(opt.value)}
+              />
+              {this.state.probingRegions && (
+                <RegionHintNote>Checking other regions…</RegionHintNote>
               )}
-              value={this.state.cell ? this.state.cell.locality_url : undefined}
-              options={cells.map(c => {
-                const hasMatch = this.state.regionMatches.some(
-                  m => m.locality_url === c.locality_url
-                );
-                return {
-                  label: c.name,
-                  value: c.locality_url,
-                  trailingItems: hasMatch ? (
-                    <Tag variant="success">found</Tag>
-                  ) : undefined,
-                };
-              })}
-              onChange={opt => this.onChangeCell(opt.value)}
-            />
+            </Flex>
           )}
           {sortOptions && sortOptions.length > 0 && (
             <SortBy
@@ -969,9 +970,9 @@ const RegionHintAlert = styled(Alert)`
 `;
 
 const RegionHintNote = styled('div')`
-  margin-bottom: ${p => p.theme.space.md};
   color: ${p => p.theme.tokens.content.secondary};
   font-size: ${p => p.theme.font.size.sm};
+  white-space: nowrap;
 `;
 
 type ResultGridWrapperProps = Omit<ResultGridProps, 'api' | 'location' | 'navigate'> & {

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -825,34 +825,35 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     const cells = getCells();
     const needsRegion = this.props.isRegional || this.props.isCellScoped;
 
+    // The note shares the row of the selectors and stays at the right end. It
+    // never renders above the results, so nothing moves while the probe runs.
+    const probeNote = this.state.probingRegions ? (
+      <RegionHintNote>Checking other regions…</RegionHintNote>
+    ) : null;
+
     return (
       <Container data-test-id="result-grid">
         <SortSearchForm onSubmit={this.onSearch}>
           {needsRegion && (
-            <Flex align="center" gap="md">
-              <CompactSelect
-                trigger={triggerProps => (
-                  <OverlayTrigger.Button {...triggerProps} prefix="Region" />
-                )}
-                value={this.state.cell ? this.state.cell.locality_url : undefined}
-                options={cells.map(c => {
-                  const hasMatch = this.state.regionMatches.some(
-                    m => m.locality_url === c.locality_url
-                  );
-                  return {
-                    label: c.name,
-                    value: c.locality_url,
-                    trailingItems: hasMatch ? (
-                      <Tag variant="success">found</Tag>
-                    ) : undefined,
-                  };
-                })}
-                onChange={opt => this.onChangeCell(opt.value)}
-              />
-              {this.state.probingRegions && (
-                <RegionHintNote>Checking other regions…</RegionHintNote>
+            <CompactSelect
+              trigger={triggerProps => (
+                <OverlayTrigger.Button {...triggerProps} prefix="Region" />
               )}
-            </Flex>
+              value={this.state.cell ? this.state.cell.locality_url : undefined}
+              options={cells.map(c => {
+                const hasMatch = this.state.regionMatches.some(
+                  m => m.locality_url === c.locality_url
+                );
+                return {
+                  label: c.name,
+                  value: c.locality_url,
+                  trailingItems: hasMatch ? (
+                    <Tag variant="success">found</Tag>
+                  ) : undefined,
+                };
+              })}
+              onChange={opt => this.onChangeCell(opt.value)}
+            />
           )}
           {sortOptions && sortOptions.length > 0 && (
             <SortBy
@@ -862,6 +863,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
               location={location}
             />
           )}
+          {probeNote}
           {hasSearch && (
             <Flex align="center" gap="xs" width="100%">
               <SearchInput
@@ -970,6 +972,9 @@ const RegionHintAlert = styled(Alert)`
 `;
 
 const RegionHintNote = styled('div')`
+  align-self: center;
+  flex-shrink: 0;
+  margin-left: auto;
   color: ${p => p.theme.tokens.content.secondary};
   font-size: ${p => p.theme.font.size.sm};
   white-space: nowrap;


### PR DESCRIPTION
- The "Checking other regions…" note rendered between the search bar and the results table in the admin customer view, which causes a layout shift. I misclicked on a user instead of an org probably 10 times today because of this, so moving it to where it doesn't shift the content.
- Ideal pattern would probably putting the spinner where the "No results" sits, but this loading indicator also exists when the current region already has results, so we can't put it there.

Before:
<img width="503" height="268" alt="Screenshot 2026-08-31 at 15 09 36" src="https://github.com/user-attachments/assets/180cc21d-38a0-4f9f-98c7-a6062a520ef6" />

After:
<img width="1304" height="430" alt="image" src="https://github.com/user-attachments/assets/dbedeedd-98e6-4020-94b4-1e135ab34e71" />
