### PR TITLE
fix(ai-monitoring): Repair conversation span trees

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta
 from typing import Any, TypedDict
@@ -23,16 +23,29 @@ from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace import SpanIssueMeta, get_issues_by_span_for_traces
+from sentry.utils import metrics
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.tracing import trace
 
 logger = logging.getLogger(__name__)
 
 type SpanRow = dict[str, Any]
+type SpanKey = tuple[str, str]
 
 MAX_RETENTION_DAYS = 30
+MAX_PARENT_REPAIR_DEPTH = 5
 
 _WIDENING_STEPS = [timedelta(days=7), timedelta(days=14), timedelta(days=MAX_RETENTION_DAYS)]
+
+PARENT_SPAN_ATTRIBUTES = [
+    "span_id",
+    "trace",
+    "parent_span",
+    "span.op",
+    "span.name",
+    "gen_ai.operation.type",
+    "gen_ai.conversation.id",
+]
 
 AI_CONVERSATION_ATTRIBUTES = [
     "span_id",
@@ -123,11 +136,11 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                 )
 
             def data_fn(offset: int, limit: int) -> list[SpanRow]:
-                spans = self._fetch_spans(resolved_params, conversation_id, offset, limit)
-                self._annotate_issues(spans, resolved_params, organization)
-                return spans
+                return self._fetch_spans(resolved_params, conversation_id, offset, limit)
 
             def on_results(spans: list[SpanRow]) -> AIConversationDetailsResponse:
+                self._repair_parent_links(spans, resolved_params, conversation_id)
+                self._annotate_issues(spans, resolved_params, organization)
                 return {
                     "conversationId": conversation_id,
                     "title": self._resolve_title(conversation_id, spans, organization),
@@ -262,6 +275,126 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             if bucket:
                 span["errors"] = bucket["errors"]
                 span["occurrences"] = bucket["occurrences"]
+
+    def _is_gen_ai_span(self, span: Mapping[str, Any]) -> bool:
+        if span.get("gen_ai.operation.type"):
+            return True
+        return any(
+            isinstance(value := span.get(field), str) and value.startswith("gen_ai.")
+            for field in ("span.op", "span.name")
+        )
+
+    def _span_key(self, span: Mapping[str, Any], id_field: str = "span_id") -> SpanKey | None:
+        trace_id = span.get("trace")
+        span_id = span.get(id_field)
+        if not isinstance(trace_id, str) or not isinstance(span_id, str) or not span_id:
+            return None
+        return trace_id, span_id
+
+    def _fetch_parent_spans(
+        self,
+        snuba_params: SnubaParams,
+        parent_keys: Collection[SpanKey],
+    ) -> dict[SpanKey, SpanRow]:
+        if not parent_keys:
+            return {}
+
+        requested_keys = set(parent_keys)
+        query_string = " OR ".join(
+            f"({build_escaped_term_filter('trace', [trace_id])} "
+            f"{build_escaped_term_filter('span_id', [span_id])})"
+            for trace_id, span_id in sorted(requested_keys)
+        )
+        result = Spans.run_table_query(
+            params=snuba_params,
+            query_string=query_string,
+            selected_columns=PARENT_SPAN_ATTRIBUTES,
+            orderby=[],
+            offset=0,
+            limit=len(requested_keys),
+            referrer=Referrer.API_AI_CONVERSATION_DETAILS.value,
+            config=SearchResolverConfig(auto_fields=True),
+            sampling_mode="HIGHEST_ACCURACY",
+        )
+
+        return {
+            key: row
+            for row in result.get("data", [])
+            if (key := self._span_key(row)) in requested_keys
+        }
+
+    def _repair_parent_links(
+        self, spans: list[SpanRow], snuba_params: SnubaParams, conversation_id: str
+    ) -> None:
+        anchors: set[SpanKey] = set()
+        for span in spans:
+            if span.get("gen_ai.conversation.id") != conversation_id or not self._is_gen_ai_span(
+                span
+            ):
+                continue
+            if (key := self._span_key(span)) is not None:
+                anchors.add(key)
+
+        pending: dict[SpanKey, tuple[SpanRow, SpanKey, set[SpanKey]]] = {}
+        for span in spans:
+            child_key = self._span_key(span)
+            parent_key = self._span_key(span, "parent_span")
+            if (
+                child_key is not None
+                and parent_key is not None
+                and parent_key != child_key
+                and parent_key not in anchors
+                and span.get("gen_ai.conversation.id") == conversation_id
+                and self._is_gen_ai_span(span)
+            ):
+                pending[child_key] = (span, parent_key, {child_key})
+
+        cache: dict[SpanKey, SpanRow] = {}
+        fetched_keys: set[SpanKey] = set()
+        for depth in range(1, MAX_PARENT_REPAIR_DEPTH + 1):
+            if not pending:
+                break
+
+            missing_keys = {parent_key for _, parent_key, _ in pending.values()} - fetched_keys
+            fetched_keys.update(missing_keys)
+            try:
+                cache.update(self._fetch_parent_spans(snuba_params, missing_keys))
+            except Exception:
+                logger.exception("Failed to repair AI conversation span parents")
+                return
+            next_pending: dict[SpanKey, tuple[SpanRow, SpanKey, set[SpanKey]]] = {}
+
+            for child_key, (child, parent_key, visited) in pending.items():
+                parent = cache.get(parent_key)
+                if parent is None:
+                    continue
+
+                repair_depth = depth
+                if parent.get("gen_ai.conversation.id") == conversation_id and self._is_gen_ai_span(
+                    parent
+                ):
+                    ancestor_key = parent_key
+                else:
+                    next_ancestor_key = self._span_key(parent, "parent_span")
+                    repair_depth += 1
+                    visited = visited | {parent_key}
+                    if next_ancestor_key is None or next_ancestor_key in visited:
+                        continue
+                    if repair_depth > MAX_PARENT_REPAIR_DEPTH:
+                        metrics.incr("ai_monitoring.conversation_details.parent_repair_max_depth")
+                        continue
+                    if next_ancestor_key not in anchors:
+                        next_pending[child_key] = (child, next_ancestor_key, visited)
+                        continue
+                    ancestor_key = next_ancestor_key
+
+                if child.get("parent_span") != ancestor_key[1]:
+                    child["parent_span"] = ancestor_key[1]
+                    metrics.distribution(
+                        "ai_monitoring.conversation_details.parent_repair_depth", repair_depth
+                    )
+
+            pending = next_pending
 
     @trace
     def _fetch_spans(

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1,20 +1,283 @@
 from datetime import timedelta
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
 from django.urls import reverse
 from urllib3.exceptions import ReadTimeoutError
 
+from sentry.ai_monitoring.endpoints.organization_ai_conversation_details import (
+    PARENT_SPAN_ATTRIBUTES,
+    OrganizationAIConversationDetailsEndpoint,
+)
 from sentry.issues.grouptype import PerformanceFileIOMainThreadGroupType
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.snuba.spans_rpc import Spans
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
 from sentry.utils.snuba_rpc import SnubaRPCTimeout
 
 from .test_organization_ai_conversations_base import BaseAIConversationsTestCase
+
+
+def test_parent_repair_stops_after_five_hops() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    trace_id = uuid4().hex
+    root_id = "root"
+    child = {
+        "trace": trace_id,
+        "span_id": "child",
+        "parent_span": "bridge-1",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "ai_client",
+    }
+    root = {
+        "trace": trace_id,
+        "span_id": root_id,
+        "parent_span": None,
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "invoke_agent",
+    }
+    parent_rows = {
+        (trace_id, f"bridge-{depth}"): {
+            "trace": trace_id,
+            "span_id": f"bridge-{depth}",
+            "parent_span": f"bridge-{depth + 1}" if depth < 5 else root_id,
+            "span.op": "http.client",
+        }
+        for depth in range(1, 6)
+    }
+
+    with (
+        patch.object(
+            endpoint,
+            "_fetch_parent_spans",
+            side_effect=lambda _params, keys: {key: parent_rows[key] for key in keys},
+        ) as mock_fetch_parent_spans,
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+        ) as mock_distribution,
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.incr"
+        ) as mock_incr,
+    ):
+        endpoint._repair_parent_links([root, child], MagicMock(), conversation_id)
+
+    assert child["parent_span"] == "bridge-1"
+    assert mock_fetch_parent_spans.call_count == 5
+    mock_distribution.assert_not_called()
+    mock_incr.assert_called_once_with("ai_monitoring.conversation_details.parent_repair_max_depth")
+
+
+def test_parent_repair_is_best_effort() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    child = {
+        "trace": uuid4().hex,
+        "span_id": "child",
+        "parent_span": "missing-parent",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "ai_client",
+    }
+
+    with patch.object(endpoint, "_fetch_parent_spans", side_effect=Exception("unavailable")):
+        endpoint._repair_parent_links([child], MagicMock(), conversation_id)
+
+    assert child["parent_span"] == "missing-parent"
+
+
+def test_parent_repair_skips_gen_ai_ancestors_from_other_conversations() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    trace_id = uuid4().hex
+    root = {
+        "trace": trace_id,
+        "span_id": "root",
+        "gen_ai.conversation.id": conversation_id,
+        "span.name": "gen_ai.invoke_agent",
+    }
+    child = {
+        "trace": trace_id,
+        "span_id": "child",
+        "parent_span": "bridge",
+        "gen_ai.conversation.id": conversation_id,
+        "span.op": "gen_ai.chat",
+    }
+    parent_rows = {
+        (trace_id, "bridge"): {
+            "trace": trace_id,
+            "span_id": "bridge",
+            "parent_span": "nested",
+            "span.op": "http.client",
+        },
+        (trace_id, "nested"): {
+            "trace": trace_id,
+            "span_id": "nested",
+            "parent_span": "root",
+            "gen_ai.conversation.id": "nested-conversation",
+            "span.name": "gen_ai.invoke_agent",
+        },
+    }
+
+    with (
+        patch.object(
+            endpoint,
+            "_fetch_parent_spans",
+            side_effect=lambda _params, keys: {
+                key: parent_rows[key] for key in keys if key in parent_rows
+            },
+        ),
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+        ) as mock_distribution,
+    ):
+        endpoint._repair_parent_links([root, child], MagicMock(), conversation_id)
+
+    assert child["parent_span"] == "root"
+    mock_distribution.assert_called_once_with(
+        "ai_monitoring.conversation_details.parent_repair_depth", 3
+    )
+
+
+def test_parent_repair_fetches_shared_parent_once() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    trace_id = uuid4().hex
+    root = {
+        "trace": trace_id,
+        "span_id": "root",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "invoke_agent",
+    }
+    children = [
+        {
+            "trace": trace_id,
+            "span_id": f"child-{index}",
+            "parent_span": "bridge",
+            "gen_ai.conversation.id": conversation_id,
+            "gen_ai.operation.type": "ai_client",
+        }
+        for index in range(2)
+    ]
+    bridge_key = (trace_id, "bridge")
+    bridge = {
+        "trace": trace_id,
+        "span_id": "bridge",
+        "parent_span": "root",
+        "span.op": "http.client",
+    }
+
+    snuba_params = MagicMock()
+    with (
+        patch.object(endpoint, "_fetch_parent_spans", return_value={bridge_key: bridge}) as fetch,
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+        ),
+    ):
+        endpoint._repair_parent_links([root, *children], snuba_params, conversation_id)
+
+    fetch.assert_called_once_with(snuba_params, {bridge_key})
+    assert [child["parent_span"] for child in children] == ["root", "root"]
+
+
+def test_parent_repair_repairs_at_depth_five() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    trace_id = uuid4().hex
+    child = {
+        "trace": trace_id,
+        "span_id": "child",
+        "parent_span": "bridge-1",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "ai_client",
+    }
+    root = {
+        "trace": trace_id,
+        "span_id": "root",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "invoke_agent",
+    }
+    parent_rows = {
+        (trace_id, f"bridge-{depth}"): {
+            "trace": trace_id,
+            "span_id": f"bridge-{depth}",
+            "parent_span": f"bridge-{depth + 1}" if depth < 4 else "root",
+            "span.op": "http.client",
+        }
+        for depth in range(1, 5)
+    }
+
+    with (
+        patch.object(
+            endpoint,
+            "_fetch_parent_spans",
+            side_effect=lambda _params, keys: {key: parent_rows[key] for key in keys},
+        ) as fetch,
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+        ) as mock_distribution,
+    ):
+        endpoint._repair_parent_links([root, child], MagicMock(), conversation_id)
+
+    assert child["parent_span"] == "root"
+    assert fetch.call_count == 4
+    mock_distribution.assert_called_once_with(
+        "ai_monitoring.conversation_details.parent_repair_depth", 5
+    )
+
+
+def test_parent_repair_stops_on_missing_parents_and_cycles() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    trace_id = uuid4().hex
+    missing_child = {
+        "trace": trace_id,
+        "span_id": "missing-child",
+        "parent_span": "missing",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "ai_client",
+    }
+    cycle_child = {
+        "trace": trace_id,
+        "span_id": "cycle-child",
+        "parent_span": "cycle-a",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "ai_client",
+    }
+    parent_rows = {
+        (trace_id, "cycle-a"): {
+            "trace": trace_id,
+            "span_id": "cycle-a",
+            "parent_span": "cycle-b",
+        },
+        (trace_id, "cycle-b"): {
+            "trace": trace_id,
+            "span_id": "cycle-b",
+            "parent_span": "cycle-a",
+        },
+    }
+
+    with (
+        patch.object(
+            endpoint,
+            "_fetch_parent_spans",
+            side_effect=lambda _params, keys: {
+                key: parent_rows[key] for key in keys if key in parent_rows
+            },
+        ) as fetch,
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+        ) as mock_distribution,
+    ):
+        endpoint._repair_parent_links([missing_child, cycle_child], MagicMock(), conversation_id)
+
+    assert missing_child["parent_span"] == "missing"
+    assert cycle_child["parent_span"] == "cycle-a"
+    assert fetch.call_count == 2
+    mock_distribution.assert_not_called()
 
 
 class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase):
@@ -143,6 +406,105 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         trace_ids = {span["trace"] for span in response.data["spans"]}
         assert len(trace_ids) == 1
         assert trace_id in trace_ids
+
+    def test_repairs_parent_links_with_bulk_fetch(self) -> None:
+        now = before_now(days=5).replace(microsecond=0)
+        trace_id = uuid4().hex
+        conversation_id = uuid4().hex
+
+        root = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=5),
+            op="gen_ai.invoke_agent",
+            operation_type="invoke_agent",
+            trace_id=trace_id,
+            store=False,
+        )
+        root["parent_span_id"] = None
+        bridge_a = self.create_span(
+            {
+                "trace_id": trace_id,
+                "parent_span_id": root["span_id"],
+                "sentry_tags": {"op": "http.client"},
+            },
+            start_ts=now - timedelta(seconds=4),
+        )
+        bridge_b = self.create_span(
+            {
+                "trace_id": trace_id,
+                "parent_span_id": root["span_id"],
+                "sentry_tags": {"op": "db"},
+            },
+            start_ts=now - timedelta(seconds=3),
+        )
+        child_a = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=2),
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            trace_id=trace_id,
+            store=False,
+        )
+        child_a["parent_span_id"] = bridge_a["span_id"]
+        child_b = self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=now - timedelta(seconds=1),
+            op="gen_ai.execute_tool",
+            operation_type="tool",
+            trace_id=trace_id,
+            store=False,
+        )
+        child_b["parent_span_id"] = bridge_b["span_id"]
+        self.store_spans([root, bridge_a, bridge_b, child_a, child_b])
+
+        query = {
+            "project": [self.project.id],
+            "per_page": 3,
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+        run_table_query = Spans.run_table_query
+
+        with (
+            patch(
+                "sentry.snuba.spans_rpc.Spans.run_table_query",
+                side_effect=run_table_query,
+            ) as mock_run_table_query,
+            patch(
+                "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+            ) as mock_distribution,
+        ):
+            response = self.do_request(conversation_id, query)
+
+        assert response.status_code == 200
+        assert {span["span_id"] for span in response.data["spans"]} == {
+            root["span_id"],
+            child_a["span_id"],
+            child_b["span_id"],
+        }
+        spans_by_id = {span["span_id"]: span for span in response.data["spans"]}
+        assert spans_by_id[child_a["span_id"]]["parent_span"] == root["span_id"]
+        assert spans_by_id[child_b["span_id"]]["parent_span"] == root["span_id"]
+        links = parse_link_header(response.headers["Link"])
+        next_link = next(link for link in links.values() if link["rel"] == "next")
+        assert next_link["results"] == "false"
+
+        parent_queries = [
+            query_call
+            for query_call in mock_run_table_query.call_args_list
+            if query_call.kwargs.get("selected_columns") == PARENT_SPAN_ATTRIBUTES
+        ]
+        assert len(parent_queries) == 1
+        assert parent_queries[0].kwargs["limit"] == 2
+        repair_metric_calls = [
+            metric_call
+            for metric_call in mock_distribution.call_args_list
+            if metric_call.args[0] == "ai_monitoring.conversation_details.parent_repair_depth"
+        ]
+        assert repair_metric_calls == [
+            call("ai_monitoring.conversation_details.parent_repair_depth", 2),
+            call("ai_monitoring.conversation_details.parent_repair_depth", 2),
+        ]
 
     def test_multi_trace_conversation(self) -> None:
         now = before_now(days=10).replace(microsecond=0)


### PR DESCRIPTION
Conversation details now preserve gen-AI hierarchy when regular spans sit between conversation spans. The endpoint follows missing parent links in bounded batches, connects each affected span to the nearest gen-AI ancestor from the same conversation, and stops after five levels instead of fetching full traces.

Repair depth and max-depth telemetry show how much work each request needs. Parent lookup failures leave original links intact so conversation details remain available.

## Algorithm/execution Flow chart
Since this is slightly more complex change this is how it works.

 Endpoint first fetches only spans with matching conversation ID.

 For each visible gen-AI span:

 1. Check whether its parent is another visible gen-AI span.
 2. If parent is missing, add (trace_id, parent_span_id) to next lookup batch.
 3. Fetch all missing parents for that depth in one Snuba query.
 4. If fetched parent is regular span, follow its parent.
 5. Stop at nearest matching gen-AI ancestor.
 6. Rewrite original span’s parent_span to that ancestor.
 7. Stop after five parent edges.

 Example:

 ```text
   gen-AI root
   └─ regular span
      └─ gen-AI child
 ```

 Child initially points to regular span. Repair changes it to:

 ```text
   gen-AI root
   └─ gen-AI child
 ```
