### PR TITLE
fix(seer): Drain the PR-iteration feedback queue atomically

### DIFF
--- a/src/sentry/scripts/utils/drain_list.lua
+++ b/src/sentry/scripts/utils/drain_list.lua
@@ -1,0 +1,6 @@
+assert(#KEYS == 1, "provide exactly one list key")
+
+local key = KEYS[1]
+local items = redis.call("LRANGE", key, 0, -1)
+redis.call("DEL", key)
+return items

--- a/src/sentry/seer/autofix/pr_iteration/queue.py
+++ b/src/sentry/seer/autofix/pr_iteration/queue.py
@@ -8,9 +8,11 @@ from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
-from sentry.utils.redis import redis_clusters
+from sentry.utils.redis import load_redis_script, redis_clusters
 
 logger = logging.getLogger(__name__)
+
+drain_list = load_redis_script("utils/drain_list.lua")
 
 _QUEUE_TTL_SECONDS = 60 * 60 * 24
 _REDIS_CLUSTER = "default"
@@ -42,19 +44,20 @@ def try_enqueue_autofix_feedback(
     decision = feedback.source.should_queue(run_state)
 
     if decision.ok:
+        item = QueuedAutofixFeedback(
+            organization_id=organization_id,
+            group_id=group_id,
+            feedback=feedback,
+            referrer=referrer,
+            actor_user_id=actor_user_id,
+        )
+
         redis = redis_clusters.get(_REDIS_CLUSTER)
         key = _feedback_queue_key(run_id)
-        redis.rpush(
-            key,
-            QueuedAutofixFeedback(
-                organization_id=organization_id,
-                group_id=group_id,
-                feedback=feedback,
-                referrer=referrer,
-                actor_user_id=actor_user_id,
-            ).json(),
-        )
-        redis.expire(key, _QUEUE_TTL_SECONDS)
+        with redis.pipeline() as pipe:
+            pipe.rpush(key, item.json())
+            pipe.expire(key, _QUEUE_TTL_SECONDS)
+            pipe.execute()
 
     # One log name for both branches, emitted after the push so ``queued`` means
     # the feedback is actually in Redis: ``outcome`` says which way it went and
@@ -102,12 +105,7 @@ def peek_queued_autofix_feedback(run_id: int) -> list[QueuedAutofixFeedback]:
 
 
 def pop_queued_autofix_feedback(run_id: int) -> list[QueuedAutofixFeedback]:
-    redis = redis_clusters.get(_REDIS_CLUSTER)
-    key = _feedback_queue_key(run_id)
-    items: list[QueuedAutofixFeedback] = []
+    client = redis_clusters.get(_REDIS_CLUSTER)
+    raw_items = drain_list([_feedback_queue_key(run_id)], [], client)
 
-    while raw_item := redis.lpop(key):
-        if (item := _parse_queued_item(raw_item)) is not None:
-            items.append(item)
-
-    return items
+    return [item for item in (_parse_queued_item(raw) for raw in raw_items) if item is not None]

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -14,7 +14,9 @@ from sentry.seer.autofix.pr_iteration.mention import handle_issue_comment_for_au
 from sentry.seer.autofix.pr_iteration.pause import is_pr_iteration_paused
 from sentry.seer.autofix.pr_iteration.queue import (
     _parse_queued_item,
+    clear_queued_autofix_feedback,
     peek_queued_autofix_feedback,
+    pop_queued_autofix_feedback,
     try_enqueue_autofix_feedback,
 )
 from sentry.testutils.cases import TestCase
@@ -202,6 +204,25 @@ class TryEnqueueAutofixFeedbackTest(TestCase):
         assert queued[0].feedback.source._autofix_run is None
         assert "autofix_run" not in queued[0].feedback.source.dict()
         mock_resolve.assert_not_called()
+
+    def test_pop_drains_the_queue(self) -> None:
+        first = Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="first"))
+        second = Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="second"))
+        self._enqueue(run_id=4848, feedback=first)
+        self._enqueue(run_id=4848, feedback=second)
+
+        items = pop_queued_autofix_feedback(4848)
+
+        assert [item.feedback.text for item in items] == ["first", "second"]
+        assert peek_queued_autofix_feedback(4848) == []
+
+    def test_clear_empties_the_queue(self) -> None:
+        feedback = Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it"))
+        self._enqueue(run_id=4949, feedback=feedback)
+
+        clear_queued_autofix_feedback(4949)
+
+        assert peek_queued_autofix_feedback(4949) == []
 
 
 class StopCommandEndToEndTest(TestCase):


### PR DESCRIPTION
pop_queued_autofix_feedback drained the Redis queue with a while lpop()
loop, so feedback enqueued mid-drain could interleave with the pops and
be lost or only partially observed. A Lua script (LRANGE + DEL) now takes
the whole queue in one call.

The enqueue side pushes and sets its TTL in one pipeline for the same
reason.