### PR TITLE
feat(api): Add auto-detected `client_kind` attribute to /events

### DIFF
--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -18,9 +18,10 @@ from rest_framework.request import Request
 from sentry import features
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import is_system_auth
+from sentry.middleware import is_frontend_request
 from sentry.models.organization import Organization
 from sentry.seer.agent_token import is_agent_auth
-from sentry.utils.http import is_mcp_request
+from sentry.utils.http import get_mcp_client_family, is_mcp_request
 
 FEATURE_FLAG = "organizations:api-client-kind-check"
 
@@ -88,15 +89,20 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
         return ClientKind.MCP
 
     if auth is None:
-        # Session cookie: the web UI, or an unauthenticated request.
-        return (
-            ClientKind.FRONTEND if getattr(user, "is_authenticated", False) else ClientKind.UNKNOWN
-        )
+        # Cookies and no token is the web UI. Share `is_frontend_request` with the
+        # `ui_request` tag on `view.response` so the two reconcile; the extra
+        # authentication check keeps anonymous cookie-bearing requests out of the bucket.
+        if is_frontend_request(request) and getattr(user, "is_authenticated", False):
+            return ClientKind.FRONTEND
+        return ClientKind.UNKNOWN
 
-    # A SentryApp installation token authenticates as the app's proxy user; an
-    # OAuth token carries the third-party application that minted it.
+    # A SentryApp installation token authenticates as the app's proxy user.
     if getattr(user, "is_sentry_app", False):
         return ClientKind.INTEGRATION
+    # A bare OAuth token is *probably* a third-party integration, but a first-party
+    # OAuth client acting for a user looks identical here -- the MCP is one, and only
+    # avoids this branch because its user agent is checked above. Separating them needs
+    # the first-party client_id allowlist this POC does not have yet.
     if isinstance(auth, AuthenticatedToken) and auth.application_id is not None:
         return ClientKind.INTEGRATION
 
@@ -111,3 +117,12 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
         return ClientKind.SCRIPT
 
     return ClientKind.UNKNOWN
+
+
+def get_client_host(request: Request) -> str | None:
+    """The agent host behind an MCP call (`claude-code`, `cursor`, ...), when it declares one.
+
+    Declared rather than derived, so untrusted -- see the doc's trust column. Only the
+    first-party MCP server sends it; every other caller yields None.
+    """
+    return get_mcp_client_family(request)

--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -1,0 +1,101 @@
+"""Derive *who* called the API, as opposed to *what code path served it*.
+
+``client_kind`` is derived at the edge from the credential, the transport and the
+user agent -- never from a client-declared query param -- so it stays meaningful
+for clients that lie and for clients that never upgrade. It is deliberately not
+the same thing as ``referrer``, which names the code path that served a request.
+
+See https://linear.app/getsentry/document/how-to-track-api-usage-df929656b848
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+from rest_framework.request import Request
+
+from sentry.auth.services.auth import AuthenticatedToken
+from sentry.auth.system import is_system_auth
+from sentry.seer.agent_token import is_agent_auth
+from sentry.utils.http import is_mcp_request
+
+
+class ClientKind(StrEnum):
+    FRONTEND = "frontend"
+    SEER = "seer"
+    INTERNAL_SERVICE = "internal_service"
+    MCP = "mcp"
+    INTEGRATION = "integration"
+    CLI = "cli"
+    SDK = "sdk"
+    SCRIPT = "script"
+    UNKNOWN = "unknown"
+
+
+# `sentry-cli/2.42.1`. Checked before the SDK pattern, which it also matches.
+_CLI_USER_AGENT = re.compile(r"^sentry-cli/", re.IGNORECASE)
+
+# `sentry.python/2.19.0`, `sentry-ruby/5.22.1`, ... SDKs calling the web API,
+# which is a different thing from an SDK submitting events to ingest.
+_SDK_USER_AGENT = re.compile(r"^sentry[.-][a-z0-9_.-]+/", re.IGNORECASE)
+
+# Generic HTTP clients: someone's automation, not a Sentry-authored client. A
+# coding agent hitting the API directly lands here too -- nothing in the request
+# separates it from any other script, so we don't pretend to detect `agent`.
+_SCRIPT_USER_AGENT = re.compile(
+    r"^(?:"
+    r"curl|wget|python-requests|python-urllib|urllib3|httpx|aiohttp|requests"
+    r"|node-fetch|axios|got|undici|okhttp|go-http-client|java|libwww-perl"
+    r"|postmanruntime|insomnia|ruby|php|guzzlehttp|httparty|faraday|reqwest"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def get_client_kind(request: Request) -> ClientKind:
+    """Classify the caller of an API request. Never raises; falls back to UNKNOWN."""
+    auth = getattr(request, "auth", None)
+    user = getattr(request, "user", None)
+    user_agent = request.META.get("HTTP_USER_AGENT", "")
+
+    # First-party callers first: several of them ride on credentials that would
+    # otherwise be classified as an ordinary customer token below.
+    if is_system_auth(auth):
+        return ClientKind.INTERNAL_SERVICE
+
+    # Seer reaches us two ways: its own capability token, or by echoing back the
+    # viewer context Sentry signed for it (which leaves `request.auth` unset).
+    if is_agent_auth(auth) or request.META.get("HTTP_X_VIEWER_CONTEXT"):
+        return ClientKind.SEER
+
+    # The first-party MCP server is only identifiable by its user agent today.
+    # TODO: derive from the OAuth client_id of the MCP app instead, once MCP
+    # traffic reliably carries one -- a user agent is strippable.
+    if is_mcp_request(request):
+        return ClientKind.MCP
+
+    if auth is None:
+        # Session cookie: the web UI, or an unauthenticated request.
+        return (
+            ClientKind.FRONTEND if getattr(user, "is_authenticated", False) else ClientKind.UNKNOWN
+        )
+
+    # A SentryApp installation token authenticates as the app's proxy user; an
+    # OAuth token carries the third-party application that minted it.
+    if getattr(user, "is_sentry_app", False):
+        return ClientKind.INTEGRATION
+    if isinstance(auth, AuthenticatedToken) and auth.application_id is not None:
+        return ClientKind.INTEGRATION
+
+    # What's left is a user token, org auth token or API key. Only the user
+    # agent tells those apart, and it can be stripped or forged -- so everything
+    # below this line is a medium-confidence guess.
+    if _CLI_USER_AGENT.match(user_agent):
+        return ClientKind.CLI
+    if _SDK_USER_AGENT.match(user_agent):
+        return ClientKind.SDK
+    if _SCRIPT_USER_AGENT.match(user_agent):
+        return ClientKind.SCRIPT
+
+    return ClientKind.UNKNOWN

--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -15,10 +15,14 @@ from enum import StrEnum
 
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import is_system_auth
+from sentry.models.organization import Organization
 from sentry.seer.agent_token import is_agent_auth
 from sentry.utils.http import is_mcp_request
+
+FEATURE_FLAG = "organizations:api-client-kind-check"
 
 
 class ClientKind(StrEnum):
@@ -53,8 +57,16 @@ _SCRIPT_USER_AGENT = re.compile(
 )
 
 
-def get_client_kind(request: Request) -> ClientKind:
-    """Classify the caller of an API request. Never raises; falls back to UNKNOWN."""
+def get_client_kind(request: Request, organization: Organization) -> ClientKind | None:
+    """Classify the caller of an API request.
+
+    Returns ``None`` when the org has not opted in, so that a disabled org is
+    distinguishable from one whose traffic genuinely classifies as ``UNKNOWN``.
+    Otherwise never raises; unrecognized callers fall back to ``UNKNOWN``.
+    """
+    if not features.has(FEATURE_FLAG, organization, actor=request.user):
+        return None
+
     auth = getattr(request, "auth", None)
     user = getattr(request, "user", None)
     user_agent = request.META.get("HTTP_USER_AGENT", "")

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -14,6 +14,7 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.client_kind import get_client_kind
 from sentry.api.helpers.error_upsampling import (
     is_errors_query_for_error_upsampled_projects,
     transform_orderby_for_error_upsampling,
@@ -213,6 +214,10 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         referrer = request.GET.get("referrer")
         sentry_sdk.set_attribute("query.raw_referrer", referrer or "")
+
+        client_kind = get_client_kind(request)
+        sentry_sdk.set_tag("client_kind", client_kind.value)
+        sentry_sdk.set_attribute("client_kind", client_kind.value)
 
         try:
             snuba_params = self.get_snuba_params(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -14,7 +14,7 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.client_kind import get_client_kind
+from sentry.api.client_kind import get_client_host, get_client_kind
 from sentry.api.helpers.error_upsampling import (
     is_errors_query_for_error_upsampled_projects,
     transform_orderby_for_error_upsampling,
@@ -221,6 +221,10 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             # real `client_kind` attribute later.
             sentry_sdk.set_tag("client_kind_test", client_kind.value)
             sentry_sdk.set_attribute("client_kind_test", client_kind.value)
+            client_host = get_client_host(request)
+            if client_host is not None:
+                sentry_sdk.set_tag("client_host_test", client_host)
+                sentry_sdk.set_attribute("client_host_test", client_host)
 
         try:
             snuba_params = self.get_snuba_params(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -215,9 +215,10 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         referrer = request.GET.get("referrer")
         sentry_sdk.set_attribute("query.raw_referrer", referrer or "")
 
-        client_kind = get_client_kind(request)
-        sentry_sdk.set_tag("client_kind", client_kind.value)
-        sentry_sdk.set_attribute("client_kind", client_kind.value)
+        client_kind = get_client_kind(request, organization)
+        if client_kind is not None:
+            sentry_sdk.set_tag("client_kind", client_kind.value)
+            sentry_sdk.set_attribute("client_kind", client_kind.value)
 
         try:
             snuba_params = self.get_snuba_params(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -217,8 +217,10 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         client_kind = get_client_kind(request, organization)
         if client_kind is not None:
-            sentry_sdk.set_tag("client_kind", client_kind.value)
-            sentry_sdk.set_attribute("client_kind", client_kind.value)
+            # `_test` suffix while this is a POC, to keep it out of the way of a
+            # real `client_kind` attribute later.
+            sentry_sdk.set_tag("client_kind_test", client_kind.value)
+            sentry_sdk.set_attribute("client_kind_test", client_kind.value)
 
         try:
             snuba_params = self.get_snuba_params(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -217,6 +217,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.
     manager.add("organizations:api-fetch-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
+    # Enable derivation of the `client_kind` API-usage attribute.
+    manager.add("organizations:api-client-kind-check", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/issues/action_log/base.py
+++ b/src/sentry/issues/action_log/base.py
@@ -10,19 +10,11 @@ from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource, GroupActi
 from sentry.middleware import is_frontend_request
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-from sentry.utils.http import is_mcp_request
+from sentry.utils.http import KNOWN_MCP_CLIENT_FAMILIES, get_mcp_client_family, is_mcp_request
 
 logger = logging.getLogger(__name__)
 
-MCP_CLIENT_FAMILY_HEADER = "HTTP_X_SENTRY_MCP_CLIENT_FAMILY"
 SEER_REFERRER_HEADER = "HTTP_X_SEER_REFERRER"
-
-# Standardized client families the MCP buckets its callers into and forwards via
-# X-Sentry-MCP-Client-Family (source of truth: client-family.ts in getsentry/sentry-mcp).
-KNOWN_MCP_CLIENT_FAMILIES = frozenset(
-    {"claude-code", "cursor", "copilot", "opencode", "claude-desktop", "codex"}
-)
-MCP_CATCHALL_CLIENT_FAMILIES = frozenset({"other", "unknown"})
 
 
 def resolve_action_source(request: Request) -> str:
@@ -32,10 +24,10 @@ def resolve_action_source(request: Request) -> str:
     user_agent = request.META.get("HTTP_USER_AGENT", "")
 
     if is_mcp_request(request):
-        family = request.META.get(MCP_CLIENT_FAMILY_HEADER, "").strip().lower()
+        family = get_mcp_client_family(request)
         if family in KNOWN_MCP_CLIENT_FAMILIES:
             return f"{ActionSource.MCP}:{family}"
-        if family and family not in MCP_CATCHALL_CLIENT_FAMILIES:
+        if family:
             # Values outside this set are logged so we know to add new ones
             logger.warning(
                 "group.action_log.unrecognized_mcp_client_family",

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -20,6 +20,15 @@ from ipaddress import ip_address, ip_interface, ip_network
 # getsentry/sentry-mcp). Used to attribute requests originating from the MCP.
 MCP_USER_AGENT_PREFIX = "sentry-mcp/"
 
+MCP_CLIENT_FAMILY_HEADER = "HTTP_X_SENTRY_MCP_CLIENT_FAMILY"
+
+# Standardized client families the MCP buckets its callers into and forwards via
+# X-Sentry-MCP-Client-Family (source of truth: client-family.ts in getsentry/sentry-mcp).
+KNOWN_MCP_CLIENT_FAMILIES = frozenset(
+    {"claude-code", "cursor", "copilot", "opencode", "claude-desktop", "codex"}
+)
+MCP_CATCHALL_CLIENT_FAMILIES = frozenset({"other", "unknown"})
+
 
 class ParsedUriMatch(NamedTuple):
     scheme: str
@@ -225,6 +234,21 @@ def is_mcp_request(request: HttpRequest | Request) -> bool:
     by its `sentry-mcp/` user-agent prefix.
     """
     return request.META.get("HTTP_USER_AGENT", "").startswith(MCP_USER_AGENT_PREFIX)
+
+
+def get_mcp_client_family(request: HttpRequest | Request) -> str | None:
+    """The client family (`claude-code`, `cursor`, ...) the MCP server declares for its caller.
+
+    Returns None when the header is absent or the MCP bucketed the caller into a catch-all.
+    A value outside `KNOWN_MCP_CLIENT_FAMILIES` is still returned: this set can lag
+    client-family.ts upstream, so callers decide whether to log the unrecognized value.
+
+    Declared by the client, so untrusted -- unlike `is_mcp_request`, which is derived.
+    """
+    family = request.META.get(MCP_CLIENT_FAMILY_HEADER, "").strip().lower()
+    if not family or family in MCP_CATCHALL_CLIENT_FAMILIES:
+        return None
+    return family
 
 
 def percent_encode(val: str) -> str:

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from rest_framework.request import Request
 
-from sentry.api.client_kind import FEATURE_FLAG, ClientKind, get_client_kind
+from sentry.api.client_kind import FEATURE_FLAG, ClientKind, get_client_host, get_client_kind
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
@@ -18,10 +18,13 @@ def make_request(
     user: Any = None,
     user_agent: str | None = None,
     headers: dict[str, str] | None = None,
+    cookies: bool = True,
 ) -> Request:
     request = Request(RequestFactory().get("/", headers=headers or {}))
     if user_agent is not None:
         request.META["HTTP_USER_AGENT"] = user_agent
+    if cookies:
+        request._request.COOKIES["sentrysid"] = "x"
     # Assigning both short-circuits the lazy authentication the getters would
     # otherwise run, so the request arrives pre-authenticated.
     request.user = user if user is not None else AnonymousUser()
@@ -97,3 +100,21 @@ class GetClientKindTest(TestCase):
             with self.subTest(user_agent=user_agent):
                 request = make_request(auth=api_token(), user_agent=user_agent)
                 assert self.classify(request) == expected
+
+    def test_frontend_requires_a_session_cookie(self) -> None:
+        # Shares `is_frontend_request` with the `ui_request` tag on `view.response`.
+        request = make_request(user=session_user(), cookies=False)
+        assert self.classify(request) == ClientKind.UNKNOWN
+
+
+class GetClientHostTest(TestCase):
+    def test_mcp_client_family(self) -> None:
+        request = make_request(headers={"X-Sentry-MCP-Client-Family": "Claude-Code"})
+        assert get_client_host(request) == "claude-code"
+
+    def test_catchall_family_is_none(self) -> None:
+        request = make_request(headers={"X-Sentry-MCP-Client-Family": "unknown"})
+        assert get_client_host(request) is None
+
+    def test_absent_header_is_none(self) -> None:
+        assert get_client_host(make_request()) is None

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -1,15 +1,15 @@
 from types import SimpleNamespace
 from typing import Any
 
-import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from rest_framework.request import Request
 
-from sentry.api.client_kind import ClientKind, get_client_kind
+from sentry.api.client_kind import FEATURE_FLAG, ClientKind, get_client_kind
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
+from sentry.testutils.cases import TestCase
 
 
 def make_request(
@@ -37,58 +37,59 @@ def api_token(*, application_id: int | None = None) -> AuthenticatedToken:
     return AuthenticatedToken(kind="api_token", user_id=1, application_id=application_id)
 
 
-def test_session_auth_is_frontend() -> None:
-    assert get_client_kind(make_request(user=session_user())) == ClientKind.FRONTEND
+class GetClientKindTest(TestCase):
+    def classify(self, request: Request) -> ClientKind | None:
+        with self.feature(FEATURE_FLAG):
+            return get_client_kind(request, self.organization)
 
+    def test_returns_none_when_feature_is_disabled(self) -> None:
+        # A disabled org has to stay distinguishable from one that classifies as UNKNOWN.
+        with self.feature({FEATURE_FLAG: False}):
+            assert get_client_kind(make_request(), self.organization) is None
 
-def test_anonymous_is_unknown() -> None:
-    assert get_client_kind(make_request()) == ClientKind.UNKNOWN
+    def test_session_auth_is_frontend(self) -> None:
+        assert self.classify(make_request(user=session_user())) == ClientKind.FRONTEND
 
+    def test_anonymous_is_unknown(self) -> None:
+        assert self.classify(make_request()) == ClientKind.UNKNOWN
 
-def test_system_auth_is_internal_service() -> None:
-    auth = AuthenticatedToken.from_token(SystemToken())
-    assert get_client_kind(make_request(auth=auth)) == ClientKind.INTERNAL_SERVICE
+    def test_system_auth_is_internal_service(self) -> None:
+        auth = AuthenticatedToken.from_token(SystemToken())
+        assert self.classify(make_request(auth=auth)) == ClientKind.INTERNAL_SERVICE
 
+    def test_agent_token_is_seer(self) -> None:
+        auth = AuthenticatedToken(kind=AGENT_TOKEN_KIND, user_id=1, organization_id=1)
+        assert self.classify(make_request(auth=auth)) == ClientKind.SEER
 
-def test_agent_token_is_seer() -> None:
-    auth = AuthenticatedToken(kind=AGENT_TOKEN_KIND, user_id=1, organization_id=1)
-    assert get_client_kind(make_request(auth=auth)) == ClientKind.SEER
+    def test_viewer_context_header_is_seer(self) -> None:
+        # Seer echoes back the viewer context Sentry signed, which leaves auth unset.
+        request = make_request(user=session_user(), headers={"X-Viewer-Context": "a.b.c"})
+        assert self.classify(request) == ClientKind.SEER
 
+    def test_mcp_user_agent_wins_over_the_token_it_carries(self) -> None:
+        request = make_request(auth=api_token(), user_agent="sentry-mcp/0.19.0")
+        assert self.classify(request) == ClientKind.MCP
 
-def test_viewer_context_header_is_seer() -> None:
-    # Seer echoes back the viewer context Sentry signed, which leaves auth unset.
-    request = make_request(user=session_user(), headers={"X-Viewer-Context": "a.b.c"})
-    assert get_client_kind(request) == ClientKind.SEER
+    def test_sentry_app_token_is_integration(self) -> None:
+        request = make_request(auth=api_token(), user=session_user(is_sentry_app=True))
+        assert self.classify(request) == ClientKind.INTEGRATION
 
+    def test_oauth_token_is_integration(self) -> None:
+        request = make_request(auth=api_token(application_id=42))
+        assert self.classify(request) == ClientKind.INTEGRATION
 
-def test_mcp_user_agent_wins_over_the_token_it_carries() -> None:
-    request = make_request(auth=api_token(), user_agent="sentry-mcp/0.19.0")
-    assert get_client_kind(request) == ClientKind.MCP
-
-
-def test_sentry_app_token_is_integration() -> None:
-    user = session_user(is_sentry_app=True)
-    assert get_client_kind(make_request(auth=api_token(), user=user)) == ClientKind.INTEGRATION
-
-
-def test_oauth_token_is_integration() -> None:
-    request = make_request(auth=api_token(application_id=42))
-    assert get_client_kind(request) == ClientKind.INTEGRATION
-
-
-@pytest.mark.parametrize(
-    ("user_agent", "expected"),
-    [
-        ("sentry-cli/2.42.1", ClientKind.CLI),
-        ("sentry.python/2.19.0", ClientKind.SDK),
-        ("sentry-ruby/5.22.1", ClientKind.SDK),
-        ("python-requests/2.31.0", ClientKind.SCRIPT),
-        ("curl/8.7.1", ClientKind.SCRIPT),
-        ("node-fetch/1.0", ClientKind.SCRIPT),
-        ("", ClientKind.UNKNOWN),
-        ("something-bespoke/1.0", ClientKind.UNKNOWN),
-    ],
-)
-def test_token_auth_falls_back_to_user_agent(user_agent: str, expected: ClientKind) -> None:
-    request = make_request(auth=api_token(), user_agent=user_agent)
-    assert get_client_kind(request) == expected
+    def test_token_auth_falls_back_to_user_agent(self) -> None:
+        cases = [
+            ("sentry-cli/2.42.1", ClientKind.CLI),
+            ("sentry.python/2.19.0", ClientKind.SDK),
+            ("sentry-ruby/5.22.1", ClientKind.SDK),
+            ("python-requests/2.31.0", ClientKind.SCRIPT),
+            ("curl/8.7.1", ClientKind.SCRIPT),
+            ("node-fetch/1.0", ClientKind.SCRIPT),
+            ("", ClientKind.UNKNOWN),
+            ("something-bespoke/1.0", ClientKind.UNKNOWN),
+        ]
+        for user_agent, expected in cases:
+            with self.subTest(user_agent=user_agent):
+                request = make_request(auth=api_token(), user_agent=user_agent)
+                assert self.classify(request) == expected

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+from rest_framework.request import Request
+
+from sentry.api.client_kind import ClientKind, get_client_kind
+from sentry.auth.services.auth import AuthenticatedToken
+from sentry.auth.system import SystemToken
+from sentry.seer.agent_token import AGENT_TOKEN_KIND
+
+
+def make_request(*, auth=None, user=None, user_agent=None, headers=None) -> Request:
+    request = Request(RequestFactory().get("/", headers=headers or {}))
+    if user_agent is not None:
+        request.META["HTTP_USER_AGENT"] = user_agent
+    request._authenticator = None
+    request._auth = auth
+    request._user = user if user is not None else AnonymousUser()
+    return request
+
+
+def session_user(*, is_sentry_app: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(is_authenticated=True, is_sentry_app=is_sentry_app)
+
+
+def api_token(**kwargs) -> AuthenticatedToken:
+    return AuthenticatedToken(kind="api_token", user_id=1, **kwargs)
+
+
+def test_session_auth_is_frontend() -> None:
+    assert get_client_kind(make_request(user=session_user())) == ClientKind.FRONTEND
+
+
+def test_anonymous_is_unknown() -> None:
+    assert get_client_kind(make_request()) == ClientKind.UNKNOWN
+
+
+def test_system_auth_is_internal_service() -> None:
+    auth = AuthenticatedToken.from_token(SystemToken())
+    assert get_client_kind(make_request(auth=auth)) == ClientKind.INTERNAL_SERVICE
+
+
+def test_agent_token_is_seer() -> None:
+    auth = AuthenticatedToken(kind=AGENT_TOKEN_KIND, user_id=1, organization_id=1)
+    assert get_client_kind(make_request(auth=auth)) == ClientKind.SEER
+
+
+def test_viewer_context_header_is_seer() -> None:
+    # Seer echoes back the viewer context Sentry signed, which leaves auth unset.
+    request = make_request(user=session_user(), headers={"X-Viewer-Context": "a.b.c"})
+    assert get_client_kind(request) == ClientKind.SEER
+
+
+def test_mcp_user_agent_wins_over_the_token_it_carries() -> None:
+    request = make_request(auth=api_token(), user_agent="sentry-mcp/0.19.0")
+    assert get_client_kind(request) == ClientKind.MCP
+
+
+def test_sentry_app_token_is_integration() -> None:
+    user = session_user(is_sentry_app=True)
+    assert get_client_kind(make_request(auth=api_token(), user=user)) == ClientKind.INTEGRATION
+
+
+def test_oauth_token_is_integration() -> None:
+    assert (
+        get_client_kind(make_request(auth=api_token(application_id=42))) == ClientKind.INTEGRATION
+    )
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        ("sentry-cli/2.42.1", ClientKind.CLI),
+        ("sentry.python/2.19.0", ClientKind.SDK),
+        ("sentry-ruby/5.22.1", ClientKind.SDK),
+        ("python-requests/2.31.0", ClientKind.SCRIPT),
+        ("curl/8.7.1", ClientKind.SCRIPT),
+        ("node-fetch/1.0", ClientKind.SCRIPT),
+        ("", ClientKind.UNKNOWN),
+        ("something-bespoke/1.0", ClientKind.UNKNOWN),
+    ],
+)
+def test_token_auth_falls_back_to_user_agent(user_agent: str, expected: ClientKind) -> None:
+    request = make_request(auth=api_token(), user_agent=user_agent)
+    assert get_client_kind(request) == expected

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -11,13 +12,20 @@ from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
 
 
-def make_request(*, auth=None, user=None, user_agent=None, headers=None) -> Request:
+def make_request(
+    *,
+    auth: Any = None,
+    user: Any = None,
+    user_agent: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> Request:
     request = Request(RequestFactory().get("/", headers=headers or {}))
     if user_agent is not None:
         request.META["HTTP_USER_AGENT"] = user_agent
-    request._authenticator = None
-    request._auth = auth
-    request._user = user if user is not None else AnonymousUser()
+    # Assigning both short-circuits the lazy authentication the getters would
+    # otherwise run, so the request arrives pre-authenticated.
+    request.user = user if user is not None else AnonymousUser()
+    request.auth = auth
     return request
 
 
@@ -25,8 +33,8 @@ def session_user(*, is_sentry_app: bool = False) -> SimpleNamespace:
     return SimpleNamespace(is_authenticated=True, is_sentry_app=is_sentry_app)
 
 
-def api_token(**kwargs) -> AuthenticatedToken:
-    return AuthenticatedToken(kind="api_token", user_id=1, **kwargs)
+def api_token(*, application_id: int | None = None) -> AuthenticatedToken:
+    return AuthenticatedToken(kind="api_token", user_id=1, application_id=application_id)
 
 
 def test_session_auth_is_frontend() -> None:
@@ -64,9 +72,8 @@ def test_sentry_app_token_is_integration() -> None:
 
 
 def test_oauth_token_is_integration() -> None:
-    assert (
-        get_client_kind(make_request(auth=api_token(application_id=42))) == ClientKind.INTEGRATION
-    )
+    request = make_request(auth=api_token(application_id=42))
+    assert get_client_kind(request) == ClientKind.INTEGRATION
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -66,8 +66,12 @@ class GetClientKindTest(TestCase):
         request = make_request(user=session_user(), headers={"X-Viewer-Context": "a.b.c"})
         assert self.classify(request) == ClientKind.SEER
 
-    def test_mcp_user_agent_wins_over_the_token_it_carries(self) -> None:
-        request = make_request(auth=api_token(), user_agent="sentry-mcp/0.19.0")
+    def test_mcp_user_agent_wins_over_the_oauth_token_it_carries(self) -> None:
+        # MCP authenticates via OAuth, so its token would otherwise read as INTEGRATION.
+        request = make_request(
+            auth=api_token(application_id=42),
+            user_agent="sentry-mcp/0.35.0 (https://mcp.sentry.dev)",
+        )
         assert self.classify(request) == ClientKind.MCP
 
     def test_sentry_app_token_is_integration(self) -> None:


### PR DESCRIPTION
Quick POC for the `client_kind` attribute described in [How to track api usage](https://linear.app/getsentry/document/how-to-track-api-usage-df929656b848). Adds a `get_client_kind(request)` classifier that derives *who* called the API at the edge from the credential, transport and user agent — never from a client-declared param — and sets it as a tag/span attribute on `/events` only. This is all under a flag and just for testing

Only the auto-detectable values are implemented: `frontend`, `seer`, `internal_service`, `mcp`, `integration`, `cli`, `sdk`, `script`, `unknown`. `ingest` never reaches this endpoint, and `agent` is indistinguishable from `script` with the signals available, so neither is guessed at. MCP detection currently rides on the `sentry-mcp/` user agent; there's a TODO to move it to the first-party OAuth `client_id`.

Not wired into any other endpoint or exported anywhere downstream yet — this is just to see whether the classification holds up on real traffic.
