### PR TITLE
fix(issues): Store an event for segment-detected occurrences

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -110,51 +110,6 @@ def lookup_event(project_id: int, event_id: str) -> Event:
 
 
 @trace
-def create_event(project_id: int, event_id: str, event_data: dict[str, Any]) -> Event:
-    return Event(
-        event_id=event_id,
-        project_id=project_id,
-        # `snuba_data` only backs the `Event` property accessors. The eventstream serializes
-        # `event.data`, where the `generic-events` schema requires `received`.
-        data={"received": event_data["received"]},
-        snuba_data={
-            "event_id": event_data["event_id"],
-            "project_id": event_data["project_id"],
-            "timestamp": event_data["timestamp"],
-            "release": event_data.get("release"),
-            "environment": event_data.get("environment"),
-            "platform": event_data.get("platform"),
-            "tags.key": [tag[0] for tag in event_data.get("tags") or []],
-            "tags.value": [tag[1] for tag in event_data.get("tags") or []],
-        },
-    )
-
-
-@trace
-def create_event_and_issue_occurrence(
-    occurrence_data: IssueOccurrenceData, event_data: dict[str, Any]
-) -> tuple[IssueOccurrence, GroupInfo | None]:
-    """With standalone span ingestion, we won't be storing events in
-    nodestore, so instead we create a light-weight event with a small
-    set of fields that lets us create occurrences.
-    """
-    project_id = occurrence_data["project_id"]
-    event_id = occurrence_data["event_id"]
-    if occurrence_data["event_id"] != event_data["event_id"]:
-        raise ValueError(
-            f"event_id in occurrence({occurrence_data['event_id']}) is different from event_id in event_data({event_data['event_id']})"
-        )
-
-    event = create_event(project_id, event_id, event_data)
-
-    with metrics.timer(
-        "occurrence_consumer._process_message.save_issue_occurrence",
-        tags={"method": "create_event_and_issue_occurrence"},
-    ):
-        return save_issue_occurrence(occurrence_data, event)
-
-
-@trace
 def process_event_and_issue_occurrence(
     occurrence_data: IssueOccurrenceData, event_data: dict[str, Any]
 ) -> tuple[IssueOccurrence, GroupInfo | None]:
@@ -278,6 +233,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "request",
                     "sdk",
                     "server_name",
+                    "spans",
                     "stacktrace",
                     "trace_id",
                     "transaction",
@@ -335,11 +291,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                     "title": occurrence_data["issue_title"],
                 }
 
-                return {
-                    "occurrence_data": occurrence_data,
-                    "event_data": event_data,
-                    "is_buffered_spans": payload.get("is_buffered_spans") is True,
-                }
+                return {"occurrence_data": occurrence_data, "event_data": event_data}
             else:
                 if not payload.get("event_id"):
                     raise InvalidEventPayloadError(
@@ -363,8 +315,6 @@ def process_occurrence_message(
         kwargs = _get_kwargs(message)
     occurrence_data = kwargs["occurrence_data"]
     metric_tags = {"occurrence_type": occurrence_data["type"]}
-    is_buffered_spans = kwargs.get("is_buffered_spans", False)
-
     metrics.incr(
         "occurrence_ingest.messages",
         sample_rate=1.0,
@@ -399,9 +349,7 @@ def process_occurrence_message(
         set_span_tag(span, "result", "dropped_rate_limited")
         return None
 
-    if "event_data" in kwargs and is_buffered_spans:
-        return create_event_and_issue_occurrence(kwargs["occurrence_data"], kwargs["event_data"])
-    elif "event_data" in kwargs:
+    if "event_data" in kwargs:
         set_span_tag(span, "result", "success")
         with metrics.timer(
             "occurrence_consumer._process_message.process_event_and_issue_occurrence",

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -55,10 +55,9 @@ def produce_occurrence_to_kafka(
     occurrence: IssueOccurrence | None = None,
     status_change: StatusChangeMessage | None = None,
     event_data: dict[str, Any] | None = None,
-    is_buffered_spans: bool | None = False,
 ) -> None:
     if payload_type == PayloadType.OCCURRENCE:
-        payload_data = _prepare_occurrence_message(occurrence, event_data, is_buffered_spans)
+        payload_data = _prepare_occurrence_message(occurrence, event_data)
     elif payload_type == PayloadType.STATUS_CHANGE:
         payload_data = _prepare_status_change_message(status_change)
     else:
@@ -96,7 +95,6 @@ def produce_occurrence_to_kafka(
 def _prepare_occurrence_message(
     occurrence: IssueOccurrence | None,
     event_data: dict[str, Any] | None,
-    is_buffered_spans: bool | None = False,
 ) -> MutableMapping[str, Any] | None:
     if not occurrence:
         raise ValueError("occurrence must be provided")
@@ -130,9 +128,6 @@ def _prepare_occurrence_message(
             )
 
         payload_data["event"] = event_data
-
-    if is_buffered_spans:
-        payload_data["is_buffered_spans"] = True
 
     return payload_data
 

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -62,6 +62,21 @@ logger = logging.getLogger(__name__)
 
 outcome_aggregator = OutcomeAggregator()
 
+MAX_EVIDENCE_SPANS = 100  # Bound the evidence data included in occurrences.
+MAX_SPAN_VALUE_LENGTH = 500
+EVIDENCE_SPAN_DATA_KEYS = frozenset(  # Used in issue details
+    (
+        "code.filepath",
+        "code.function",
+        "code.lineno",
+        "http.query",
+        "http.request.request_start",
+        "http.request.response_start",
+        "http.response_content_length",
+        "url",
+    )
+)
+
 
 @metrics.wraps("spans.consumers.process_segments.process_segment")
 def process_segment(
@@ -422,24 +437,33 @@ def _run_legacy_detectors(
     ):
         return detected_problems
 
-    # Prepare a slimmer event payload for the occurrence consumer. This event will be persisted
-    # by the consumer. Once issue detectors can run on standalone spans, we should directly
-    # build a minimal occurrence event payload here, instead.
-    event_data["spans"] = []
-    event_data["timestamp"] = event_data["datetime"]
+    spans_by_id = {span["span_id"]: span for span in event_data["spans"]}
 
     for problem in detected_problems:
+        evidence_data = _evidence_data(problem, spans_by_id)
+        span_ids = (
+            *evidence_data["parent_span_ids"],
+            *evidence_data["cause_span_ids"],
+            *evidence_data["offender_span_ids"],
+        )
+        occurrence_id = uuid.uuid4().hex
+        occurrence_event_data = {  # dict.fromkeys is order preserving
+            **event_data,
+            "event_id": occurrence_id,
+            "spans": [_evidence_span(spans_by_id[id]) for id in dict.fromkeys(span_ids)],
+        }
+
         occurrence = IssueOccurrence(
-            id=uuid.uuid4().hex,
+            id=occurrence_id,
             resource_id=None,
             project_id=project.id,
-            event_id=event_data["event_id"],
+            event_id=occurrence_id,
             fingerprint=[problem.fingerprint],
             type=problem.type,
             issue_title=problem.title,
             subtitle=problem.desc,
             culprit=event_data["transaction"],
-            evidence_data=problem.evidence_data or {},
+            evidence_data=evidence_data,
             evidence_display=problem.evidence_display,
             detection_time=to_datetime(segment_span["end_timestamp"]),
             level="info",
@@ -448,11 +472,44 @@ def _run_legacy_detectors(
         produce_occurrence_to_kafka(
             payload_type=PayloadType.OCCURRENCE,
             occurrence=occurrence,
-            event_data=event_data,
-            is_buffered_spans=True,
+            event_data=occurrence_event_data,
         )
 
     return detected_problems
+
+
+def _evidence_data(problem: PerformanceProblem, spans_by_id: Mapping[str, Any]) -> dict[str, Any]:
+    # Only the top MAX_EVIDENCE_SPANS to ensure the occurrence isn't too large.
+    ids = (*problem.parent_span_ids, *problem.cause_span_ids, *problem.offender_span_ids)
+    kept = [id for id in ids if id in spans_by_id][:MAX_EVIDENCE_SPANS]
+    return {
+        **(problem.evidence_data or {}),
+        "parent_span_ids": [id for id in problem.parent_span_ids if id in kept],
+        "cause_span_ids": [id for id in problem.cause_span_ids if id in kept],
+        "offender_span_ids": [id for id in problem.offender_span_ids if id in kept],
+    }
+
+
+def _evidence_span(span: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "span_id": span["span_id"],
+        "op": span.get("op"),
+        "description": _truncate(span.get("description")),
+        "start_timestamp": span.get("start_timestamp"),
+        "timestamp": span.get("timestamp"),
+        "exclusive_time": span.get("exclusive_time"),
+        "hash": span.get("hash"),
+        "data": {
+            k: _truncate(v)
+            for k, v in (span.get("data") or {}).items()
+            if k in EVIDENCE_SPAN_DATA_KEYS
+        },
+    }
+
+
+def _truncate(value: Any) -> Any:
+    # Span attribute values aren't bounded, limit their size in span evidence.
+    return value[:MAX_SPAN_VALUE_LENGTH] if isinstance(value, str) else value
 
 
 def _maybe_run_span_first_detector_parity_check(

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -24,7 +24,6 @@ from sentry.issues.occurrence_consumer import (
 )
 from sentry.issues.producer import _prepare_status_change_message
 from sentry.issues.status_change_message import StatusChangeMessage
-from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.ratelimits.sliding_windows import Quota
@@ -308,51 +307,6 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert rate_limit_quota.window_seconds == 3600
         assert rate_limit_quota.granularity_seconds == 60
         assert rate_limit_quota.limit == 1000
-
-
-class IssueOccurrenceBufferedSpansTest(IssueOccurrenceTestBase):
-    """Occurrences from the span segment processor never get saved to nodestore, so the eventstream
-    payload has to be built entirely from the event data on the message.
-    """
-
-    def setUp(self) -> None:
-        super().setUp()
-        # Nothing on this path saves an event, so the default environment is never created for us
-        Environment.get_or_create(self.project, None)
-
-    def run_buffered_spans_message(self, **event_overrides: Any) -> dict[str, Any]:
-        message = get_test_message(self.project.id, is_buffered_spans=True)
-        message["event"].update(event_overrides)
-
-        with mock.patch("sentry.issues.ingest.eventstream.backend.insert") as mock_insert:
-            with self.feature("organizations:profile-file-io-main-thread-ingest"):
-                result = _process_message(message)
-
-        assert result is not None
-        assert mock_insert.call_count == 1
-        group_event = mock_insert.call_args.kwargs["event"]
-        return dict(group_event.get_raw_data(for_stream=True))
-
-    @django_db_all
-    def test_received_reaches_the_eventstream(self) -> None:
-        received = before_now(minutes=1)
-        stream_data = self.run_buffered_spans_message(received=received.isoformat())
-
-        assert stream_data["received"] == pytest.approx(received.timestamp())
-
-    @django_db_all
-    def test_received_reaches_the_eventstream_when_sent_as_a_timestamp(self) -> None:
-        received = before_now(minutes=1).timestamp()
-        stream_data = self.run_buffered_spans_message(received=received)
-
-        assert stream_data["received"] == pytest.approx(received)
-
-    @django_db_all
-    @freeze_time()
-    def test_null_received_falls_back_to_now(self) -> None:
-        stream_data = self.run_buffered_spans_message(received=None)
-
-        assert stream_data["received"] == pytest.approx(datetime.datetime.now().timestamp())
 
 
 class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
+from sentry import nodestore
 from sentry.issue_detection.detectors.n_plus_one_db_span_detector import NPlusOneDBSpanDetector
 from sentry.issue_detection.detectors.span_first.run_detectors import run_span_first_detectors
 from sentry.issue_detection.detectors.span_first.span_first_utils import (
@@ -23,6 +24,7 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
+from sentry.services.eventstore.models import Event
 from sentry.spans.consumers.process_segments import message as message_module
 from sentry.spans.consumers.process_segments.message import (
     _bump_release_last_seen,
@@ -266,6 +268,23 @@ class TestSpansTask(TestCase):
             ).hexdigest()
         ]
         assert performance_problem.type == PerformanceNPlusOneGroupType
+
+        # Ensure the spans are present so the issue can render evidence.
+        event = mock_eventstream.call_args[0][0]
+        assert event.get_event_type() == "generic"
+
+        stored = nodestore.backend.get(Event.generate_node_id(self.project.id, event.event_id))
+        assert stored is not None
+
+        evidence = performance_problem.evidence_data
+        referenced = {
+            *evidence["parent_span_ids"],
+            *evidence["cause_span_ids"],
+            *evidence["offender_span_ids"],
+        }
+        assert {span["span_id"] for span in stored["spans"]} == referenced
+        assert len(referenced) < len(spans)
+        assert "attributes" not in stored["spans"][0]
 
     @override_options({DETECTORS_ENABLED_OPTION: ["*"]})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")


### PR DESCRIPTION
Occurrences from the span segment pipeline set `is_buffered_spans`, which built an Event backed only by `snuba_data` and never wrote to nodestore. The eventstream payload was therefore just `{"received": ...}`, so occurrences reached Snuba and showed up in the issue feed while issue details was broken and the event JSON endpoint returned "Event not found".

Drop the special case and send these through the same path as every other occurrence producer. Each detected problem now carries its own event holding only the spans its evidence points at, projected down to the fields issue details and Seer actually read, and capped so the message stays under the producer's limit.