### PR TITLE
fix(data_export): strip UI preview truncation limits from exported query_info (#122767)

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -143,6 +143,10 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
             del query_info["statsPeriodStart"]
         if "statsPeriodEnd" in query_info:
             del query_info["statsPeriodEnd"]
+        if "truncate" in query_info:
+            del query_info["truncate"]
+        if "max_string_length" in query_info:
+            del query_info["max_string_length"]
         query_info["start"] = start.isoformat()
         query_info["end"] = end.isoformat()
 

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -184,6 +184,21 @@ class DataExportTest(APITestCase):
         # rather than a list of strings
         assert data_export.query_info["field"] == ["id"]
 
+    def test_export_strips_truncation_limits(self) -> None:
+        """
+        Ensures UI table preview limits like `truncate` and `max_string_length` are stripped
+        from data export query_info so exported rows contain full field values (#122767).
+        """
+        payload = self.make_payload(
+            "discover",
+            {"field": ["id"], "truncate": "256", "max_string_length": 256},
+        )
+        with self.feature("organizations:discover-query"):
+            response = self.get_success_response(self.org.slug, status_code=201, **payload)
+        data_export = ExportedData.objects.get(id=response.data["id"])
+        assert "truncate" not in data_export.query_info
+        assert "max_string_length" not in data_export.query_info
+
     def test_export_too_many_fields(self) -> None:
         """
         Ensures that if too many fields are requested, returns a 400 status code with the


### PR DESCRIPTION
Closes #122767

### What Problem This Solves
When users export dataset rows via CSV or JSONL (Selected Columns) from Explore / Discover, long field values (such as log messages > 256 characters) were being silently truncated at 256 characters with `...` appended.

### Why This Change Was Made
`DataExportQuerySerializer` validates and sanitizes `query_info` when constructing an export payload. When an export request was triggered from a UI table view, UI preview parameters (`truncate` / `max_string_length`) were retained in `query_info`, causing downstream Snuba dataset query processing to apply preview truncation to the exported file.

We updated `DataExportQuerySerializer._validate_query_info` in `src/sentry/data_export/endpoints/data_export.py` to strip `truncate` and `max_string_length` from `query_info`, ensuring exports always deliver full, untruncated values.

### User Impact
Exported CSV and JSONL (Selected Columns) files now contain complete, untruncated log messages and attribute values matching the database payload.

### Testing & Verification
Added `test_export_strips_truncation_limits` in `tests/sentry/data_export/endpoints/test_data_export.py` asserting that `truncate` and `max_string_length` are stripped from `query_info` when creating a data export.
