### PR TITLE
feat(dart): Fall back to token-level remapping for compound exception types

### DIFF
--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 import orjson
 import sentry_sdk
 
+from sentry import options
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.project import Project
 from sentry.stacktraces.processing import find_stacktraces_in_data
@@ -20,6 +21,32 @@ from sentry.utils.tracing import set_span_tag, start_span
 # any values other than "<" and ">".
 # VIEW_HIERARCHY_TYPE_REGEX = re.compile(r"([^<>]+)(?:<([^<>]+)>)?")
 INSTANCE_OF_VALUE_RE = re.compile(r"Instance of '([^']+)'")
+
+# Dart identifiers: letters, digits, "_" and "$" (e.g. "aBc", "_aBc", "_$aBcImpl").
+# Everything else is a delimiter and is preserved byte-for-byte.
+IDENTIFIER_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
+
+
+def remap_exception_type(exception_type: str, symbol_map: Mapping[str, str]) -> str:
+    """
+    Deobfuscates an exception type, falling back to remapping the identifiers it
+    contains when the complete type has no mapping.
+
+    Compound types such as "Bloc aBc" (from 'Bloc ${bloc.runtimeType}') don't exist
+    in the symbol map, but the obfuscated identifier they contain does.
+    """
+    if not exception_type or not symbol_map:
+        return exception_type
+
+    # Whole-string lookup is authoritative and takes precedence over token remapping.
+    mapped_type = symbol_map.get(exception_type)
+    if mapped_type:
+        return mapped_type
+
+    return IDENTIFIER_RE.sub(
+        lambda match: symbol_map.get(match.group(0)) or match.group(0),
+        exception_type,
+    )
 
 
 def get_debug_meta_image_ids(event: dict[str, Any]) -> set[str]:
@@ -71,7 +98,9 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]) -> None:
     """
     Deobfuscates exception types and certain values in-place.
 
-    - Exception type: replaced directly via symbol map lookup
+    - Exception type: replaced via symbol map lookup of the complete type, falling
+      back to remapping the identifiers within it. The original type is kept in
+      "raw_type" whenever the type changes.
     - Exception value: deobfuscate the quoted symbol for all occurrences of the
       pattern "Instance of 'obfuscated_symbol'" in the value.
 
@@ -95,11 +124,17 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]) -> None:
         if symbol_map is None:
             return None
 
+        remap_compound_types = options.get("dart.compound-type-deobfuscation.enabled")
+
         for exception in exceptions:
             exception_type = exception.get("type")
             if isinstance(exception_type, str):
-                mapped_type = symbol_map.get(exception_type)
-                if mapped_type is not None:
+                if remap_compound_types:
+                    mapped_type = remap_exception_type(exception_type, symbol_map)
+                else:
+                    mapped_type = symbol_map.get(exception_type) or exception_type
+                if mapped_type != exception_type:
+                    exception["raw_type"] = exception_type
                     exception["type"] = mapped_type
 
             # Deobfuscate occurrences of "Instance of 'xYz'" in the exception value

--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -22,30 +22,26 @@ from sentry.utils.tracing import set_span_tag, start_span
 # VIEW_HIERARCHY_TYPE_REGEX = re.compile(r"([^<>]+)(?:<([^<>]+)>)?")
 INSTANCE_OF_VALUE_RE = re.compile(r"Instance of '([^']+)'")
 
-# Dart identifiers: letters, digits, "_" and "$" (e.g. "aBc", "_aBc", "_$aBcImpl").
-# Everything else is a delimiter and is preserved byte-for-byte.
+# Matches one complete identifier, so a key can never match inside a longer one,
+# e.g. "er" within "Error".
 IDENTIFIER_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
 
-# A symbol map covers the Flutter framework as well as the app, which is large enough
-# to exhaust the one and two character name space the obfuscator allocates from. Every
-# short word is therefore a key, and remapping one inside a compound type turns
-# "Error in aBc" into an unrelated framework class. Only the token fallback below is
-# affected: a short type on its own still deobfuscates through the complete-type lookup.
+# A map includes the Flutter framework, which exhausts the one and two character name
+# space the obfuscator allocates from, so every short word is a key and "Error in aBc"
+# would remap "in". Only the fallback is gated; a short complete type still resolves.
 MIN_REMAPPABLE_TOKEN_LENGTH = 3
 
 
 def remap_exception_type(exception_type: str, symbol_map: Mapping[str, str]) -> str:
     """
-    Deobfuscates an exception type, falling back to remapping the identifiers it
-    contains when the complete type has no mapping.
-
-    Compound types such as "Bloc aBc" (from 'Bloc ${bloc.runtimeType}') don't exist
-    in the symbol map, but the obfuscated identifier they contain does.
+    Deobfuscates an exception type, falling back to remapping the identifiers inside it
+    when the complete type has no mapping. Compound types such as "Bloc aBc" (from
+    'Bloc ${bloc.runtimeType}') aren't in the symbol map, but their identifier is.
     """
     if not exception_type or not symbol_map:
         return exception_type
 
-    # Whole-string lookup is authoritative and takes precedence over token remapping.
+    # Complete-type keys win, and types below the token floor resolve only here.
     mapped_type = symbol_map.get(exception_type)
     if mapped_type:
         return mapped_type
@@ -108,9 +104,8 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]) -> None:
     """
     Deobfuscates exception types and certain values in-place.
 
-    - Exception type: replaced via symbol map lookup of the complete type, falling
-      back to remapping the identifiers within it. The original type is kept in
-      "raw_type" whenever the type changes.
+    - Exception type: symbol map lookup of the complete type, falling back to remapping
+      the identifiers within it. The original is kept in "raw_type" when the type changes.
     - Exception value: deobfuscate the quoted symbol for all occurrences of the
       pattern "Instance of 'obfuscated_symbol'" in the value.
 

--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -26,6 +26,13 @@ INSTANCE_OF_VALUE_RE = re.compile(r"Instance of '([^']+)'")
 # Everything else is a delimiter and is preserved byte-for-byte.
 IDENTIFIER_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
 
+# A symbol map covers the Flutter framework as well as the app, which is large enough
+# to exhaust the one and two character name space the obfuscator allocates from. Every
+# short word is therefore a key, and remapping one inside a compound type turns
+# "Error in aBc" into an unrelated framework class. Only the token fallback below is
+# affected: a short type on its own still deobfuscates through the complete-type lookup.
+MIN_REMAPPABLE_TOKEN_LENGTH = 3
+
 
 def remap_exception_type(exception_type: str, symbol_map: Mapping[str, str]) -> str:
     """
@@ -43,10 +50,13 @@ def remap_exception_type(exception_type: str, symbol_map: Mapping[str, str]) -> 
     if mapped_type:
         return mapped_type
 
-    return IDENTIFIER_RE.sub(
-        lambda match: symbol_map.get(match.group(0)) or match.group(0),
-        exception_type,
-    )
+    def remap_token(match: re.Match[str]) -> str:
+        token = match.group(0)
+        if len(token) < MIN_REMAPPABLE_TOKEN_LENGTH:
+            return token
+        return symbol_map.get(token) or token
+
+    return IDENTIFIER_RE.sub(remap_token, exception_type)
 
 
 def get_debug_meta_image_ids(event: dict[str, Any]) -> set[str]:

--- a/src/sentry/lang/dart/utils.py
+++ b/src/sentry/lang/dart/utils.py
@@ -149,7 +149,7 @@ def deobfuscate_exception_type(data: MutableMapping[str, Any]) -> None:
                 def replace_symbol(match: re.Match[str]) -> str:
                     symbol = match.group(1)
                     deobfuscated_symbol = symbol_map.get(symbol)
-                    if deobfuscated_symbol is None:
+                    if not deobfuscated_symbol:
                         return match.group(0)
                     return f"Instance of '{deobfuscated_symbol}'"
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4323,6 +4323,14 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Killswitch for token-level remapping of compound Dart exception types.
+register(
+    "dart.compound-type-deobfuscation.enabled",
+    default=True,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Selectively allow issue detectors to run (via the create-a-fake-transaction-event shim) during
 # segment processing. Enabled detectors should be specified by their corresponding `DetectorType`
 # value. To run all possible detectors, set the value to `["*"]`.

--- a/tests/sentry/lang/dart/test_utils.py
+++ b/tests/sentry/lang/dart/test_utils.py
@@ -23,8 +23,8 @@ MOCK_DEBUG_MAP = {
     "_YMa": "_entry",
 }
 
-# Includes the junk entries real dart symbol maps contain: an empty pair, an
-# identity mapping and a symbol mapping to an empty string.
+# Includes the junk real dart symbol maps carry: an empty pair, an identity mapping
+# and a symbol mapping to an empty string.
 MOCK_SYMBOL_MAP = {
     "": "",
     "a": "A",
@@ -656,12 +656,12 @@ def test_deobfuscate_exception_type_compound() -> None:
 
     exceptions = data["exception"]["values"]
 
-    # Compound type: the obfuscated token is remapped, the readable prefix is kept
+    # Compound type: only the obfuscated token changes
     assert exceptions[0]["type"] == "Bloc CheckoutBloc"
     assert exceptions[0]["raw_type"] == "Bloc aBc"
     assert exceptions[0]["value"] == "Instance of 'CheckoutBloc'"
 
-    # Exact match still works and now records the original type
+    # Exact match still works and now records the original
     assert exceptions[1]["type"] == "CheckoutBloc"
     assert exceptions[1]["raw_type"] == "aBc"
 

--- a/tests/sentry/lang/dart/test_utils.py
+++ b/tests/sentry/lang/dart/test_utils.py
@@ -576,10 +576,12 @@ def test_deobfuscate_exception_value_without_type() -> None:
         pytest.param("aBc<xYz>", "CheckoutBloc<Foo>", id="generic"),
         pytest.param("aBc<xYz, qWe>", "CheckoutBloc<Foo, Bar>", id="multi argument generic"),
         pytest.param("aBc<aBc<xYz>>", "CheckoutBloc<CheckoutBloc<Foo>>", id="nested generic"),
-        pytest.param("a.er.aBc", "A.SemanticsAction.CheckoutBloc", id="dotted segments"),
+        pytest.param("a.er.aBc", "a.er.CheckoutBloc", id="dotted segments"),
         pytest.param("_aBc", "_CheckoutBloc", id="leading underscore"),
         pytest.param("_$aBcImpl", "_$CheckoutBlocImpl", id="generated identifier"),
-        pytest.param("a er area", "A SemanticsAction area", id="short whole tokens"),
+        pytest.param("a er area", "a er area", id="short tokens are left alone"),
+        pytest.param("Error in aBc", "Error in CheckoutBloc", id="short word not remapped"),
+        pytest.param("er", "SemanticsAction", id="short type still matches as a whole"),
         pytest.param("Error", "Error", id="no substring match inside longer token"),
         pytest.param("aBcaBc", "aBcaBc", id="no partial match"),
         pytest.param("nope", "nope", id="missing key"),
@@ -634,6 +636,7 @@ def test_deobfuscate_exception_type_compound() -> None:
                 {"type": "aBc", "value": "boom"},
                 {"type": "_NativeInteger", "value": "boom"},
                 {"type": "Bloc nope", "value": "boom"},
+                {"type": "Bloc er", "value": "Instance of 'er'"},
                 {"type": 12345, "value": "boom"},
             ]
         },
@@ -670,9 +673,14 @@ def test_deobfuscate_exception_type_compound() -> None:
     assert exceptions[3]["type"] == "Bloc nope"
     assert "raw_type" not in exceptions[3]
 
-    # Non-string types are ignored
-    assert exceptions[4]["type"] == 12345
+    # Short tokens are too ambiguous to remap, but the value pattern is still exact
+    assert exceptions[4]["type"] == "Bloc er"
     assert "raw_type" not in exceptions[4]
+    assert exceptions[4]["value"] == "Instance of 'SemanticsAction'"
+
+    # Non-string types are ignored
+    assert exceptions[5]["type"] == 12345
+    assert "raw_type" not in exceptions[5]
 
 
 def test_deobfuscate_exception_type_compound_killswitch() -> None:

--- a/tests/sentry/lang/dart/test_utils.py
+++ b/tests/sentry/lang/dart/test_utils.py
@@ -2,12 +2,17 @@ import tempfile
 from typing import Any
 from unittest import mock
 
+import pytest
+
 from sentry.lang.dart.utils import (
     deobfuscate_exception_type,
     generate_dart_symbols_map,
     get_debug_meta_image_ids,
+    remap_exception_type,
 )
 from sentry.models.project import Project
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 
 MOCK_DEBUG_FILE = b'["","","_NativeInteger","_NativeInteger","SemanticsAction","er","ButtonTheme","mD","_entry","_YMa"]'
 MOCK_DEBUG_MAP = {
@@ -16,6 +21,21 @@ MOCK_DEBUG_MAP = {
     "er": "SemanticsAction",
     "mD": "ButtonTheme",
     "_YMa": "_entry",
+}
+
+# Includes the junk entries real dart symbol maps contain: an empty pair, an
+# identity mapping and a symbol mapping to an empty string.
+MOCK_SYMBOL_MAP = {
+    "": "",
+    "a": "A",
+    "aBc": "CheckoutBloc",
+    "eMp": "",
+    "er": "SemanticsAction",
+    "qWe": "Bar",
+    "xYz": "Foo",
+    "_aBc": "_CheckoutBloc",
+    "_$aBcImpl": "_$CheckoutBlocImpl",
+    "_NativeInteger": "_NativeInteger",
 }
 
 
@@ -144,6 +164,7 @@ def test_get_debug_meta_image_ids_no_debug_meta() -> None:
     assert debug_ids == set()
 
 
+@django_db_all
 def test_deobfuscate_exception_type() -> None:
     """Test deobfuscation of exception types."""
     mock_project = mock.Mock(id=123)
@@ -239,6 +260,7 @@ def test_deobfuscate_exception_type_no_exceptions() -> None:
         deobfuscate_exception_type(data)
 
 
+@django_db_all
 def test_deobfuscate_exception_type_missing_value() -> None:
     """Test deobfuscation when exception value is missing."""
     mock_project = mock.Mock(id=123)
@@ -309,6 +331,7 @@ def test_deobfuscate_exception_type_no_mapping_file() -> None:
         assert data["exception"]["values"][0]["type"] == original_type
 
 
+@django_db_all
 def test_deobfuscate_exception_type_non_string_value() -> None:
     """Test that non-string exception values don't cause AttributeError."""
     mock_project = mock.Mock(id=123)
@@ -364,6 +387,7 @@ def test_deobfuscate_exception_type_non_string_value() -> None:
         assert data["exception"]["values"][2]["value"] == ["list", "of", "errors"]  # Unchanged
 
 
+@django_db_all
 def test_deobfuscate_exception_type_instance_of_pattern() -> None:
     """Test that 'Instance of' patterns are properly deobfuscated."""
     mock_project = mock.Mock(id=123)
@@ -438,6 +462,7 @@ def test_deobfuscate_exception_type_instance_of_pattern() -> None:
         )
 
 
+@django_db_all
 def test_deobfuscate_exception_type_special_regex_chars() -> None:
     """Test that symbols containing regex special characters are handled correctly in Instance of patterns."""
     mock_project = mock.Mock(id=123)
@@ -495,6 +520,7 @@ def test_deobfuscate_exception_type_special_regex_chars() -> None:
         )
 
 
+@django_db_all
 def test_deobfuscate_exception_value_without_type() -> None:
     """Values should be deobfuscated even if the exception type is missing or None."""
     mock_project = mock.Mock(id=123)
@@ -539,3 +565,148 @@ def test_deobfuscate_exception_value_without_type() -> None:
         # Third: no pattern; unchanged
         assert data["exception"]["values"][2]["type"] is None
         assert data["exception"]["values"][2]["value"] == "No pattern here"
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "expected"),
+    (
+        pytest.param("aBc", "CheckoutBloc", id="exact match"),
+        pytest.param("Bloc aBc", "Bloc CheckoutBloc", id="compound with unknown token"),
+        pytest.param("aBc xYz", "CheckoutBloc Foo", id="multiple mapped tokens"),
+        pytest.param("aBc<xYz>", "CheckoutBloc<Foo>", id="generic"),
+        pytest.param("aBc<xYz, qWe>", "CheckoutBloc<Foo, Bar>", id="multi argument generic"),
+        pytest.param("aBc<aBc<xYz>>", "CheckoutBloc<CheckoutBloc<Foo>>", id="nested generic"),
+        pytest.param("a.er.aBc", "A.SemanticsAction.CheckoutBloc", id="dotted segments"),
+        pytest.param("_aBc", "_CheckoutBloc", id="leading underscore"),
+        pytest.param("_$aBcImpl", "_$CheckoutBlocImpl", id="generated identifier"),
+        pytest.param("a er area", "A SemanticsAction area", id="short whole tokens"),
+        pytest.param("Error", "Error", id="no substring match inside longer token"),
+        pytest.param("aBcaBc", "aBcaBc", id="no partial match"),
+        pytest.param("nope", "nope", id="missing key"),
+        pytest.param("", "", id="empty type"),
+        pytest.param("_NativeInteger", "_NativeInteger", id="identity mapping"),
+        pytest.param("eMp", "eMp", id="empty mapping value on exact match"),
+        pytest.param("Bloc eMp", "Bloc eMp", id="empty mapping value on token"),
+        pytest.param("  Bloc  aBc ", "  Bloc  CheckoutBloc ", id="whitespace preserved"),
+        pytest.param("(aBc) [xYz]: qWe", "(CheckoutBloc) [Foo]: Bar", id="delimiters preserved"),
+    ),
+)
+def test_remap_exception_type(exception_type: str, expected: str) -> None:
+    assert remap_exception_type(exception_type, MOCK_SYMBOL_MAP) == expected
+
+
+def test_remap_exception_type_empty_map() -> None:
+    """An empty symbol map leaves the type untouched."""
+    assert remap_exception_type("Bloc aBc", {}) == "Bloc aBc"
+
+
+def test_remap_exception_type_whole_string_takes_precedence() -> None:
+    """A mapping for the complete type wins over the mappings of its tokens."""
+    symbol_map = {
+        "Bloc aBc": "CheckoutBlocFailure",
+        "aBc": "CheckoutBloc",
+    }
+
+    assert remap_exception_type("Bloc aBc", symbol_map) == "CheckoutBlocFailure"
+
+
+def test_remap_exception_type_whole_string_mapped_to_empty() -> None:
+    """An empty whole-string mapping falls through to token remapping."""
+    symbol_map = {
+        "Bloc aBc": "",
+        "aBc": "CheckoutBloc",
+    }
+
+    assert remap_exception_type("Bloc aBc", symbol_map) == "Bloc CheckoutBloc"
+
+
+@django_db_all
+def test_deobfuscate_exception_type_compound() -> None:
+    """Compound types are remapped token by token and keep their original in raw_type."""
+    mock_project = mock.Mock(id=123)
+
+    data: dict[str, Any] = {
+        "project": 123,
+        "debug_meta": {"images": [{"debug_id": "test-debug-id"}]},
+        "exception": {
+            "values": [
+                {"type": "Bloc aBc", "value": "Instance of 'aBc'"},
+                {"type": "aBc", "value": "boom"},
+                {"type": "_NativeInteger", "value": "boom"},
+                {"type": "Bloc nope", "value": "boom"},
+                {"type": 12345, "value": "boom"},
+            ]
+        },
+    }
+
+    with (
+        mock.patch(
+            "sentry.models.Project.objects.get_from_cache",
+            return_value=mock_project,
+        ),
+        mock.patch(
+            "sentry.lang.dart.utils.generate_dart_symbols_map",
+            return_value=MOCK_SYMBOL_MAP,
+        ),
+    ):
+        deobfuscate_exception_type(data)
+
+    exceptions = data["exception"]["values"]
+
+    # Compound type: the obfuscated token is remapped, the readable prefix is kept
+    assert exceptions[0]["type"] == "Bloc CheckoutBloc"
+    assert exceptions[0]["raw_type"] == "Bloc aBc"
+    assert exceptions[0]["value"] == "Instance of 'CheckoutBloc'"
+
+    # Exact match still works and now records the original type
+    assert exceptions[1]["type"] == "CheckoutBloc"
+    assert exceptions[1]["raw_type"] == "aBc"
+
+    # Identity mapping is not a change, so no raw_type
+    assert exceptions[2]["type"] == "_NativeInteger"
+    assert "raw_type" not in exceptions[2]
+
+    # Nothing maps, so no raw_type
+    assert exceptions[3]["type"] == "Bloc nope"
+    assert "raw_type" not in exceptions[3]
+
+    # Non-string types are ignored
+    assert exceptions[4]["type"] == 12345
+    assert "raw_type" not in exceptions[4]
+
+
+def test_deobfuscate_exception_type_compound_killswitch() -> None:
+    """With the killswitch off, only complete types are remapped."""
+    mock_project = mock.Mock(id=123)
+
+    data: dict[str, Any] = {
+        "project": 123,
+        "debug_meta": {"images": [{"debug_id": "test-debug-id"}]},
+        "exception": {
+            "values": [
+                {"type": "Bloc aBc", "value": "boom"},
+                {"type": "aBc", "value": "boom"},
+            ]
+        },
+    }
+
+    with (
+        mock.patch(
+            "sentry.models.Project.objects.get_from_cache",
+            return_value=mock_project,
+        ),
+        mock.patch(
+            "sentry.lang.dart.utils.generate_dart_symbols_map",
+            return_value=MOCK_SYMBOL_MAP,
+        ),
+        override_options({"dart.compound-type-deobfuscation.enabled": False}),
+    ):
+        deobfuscate_exception_type(data)
+
+    exceptions = data["exception"]["values"]
+
+    assert exceptions[0]["type"] == "Bloc aBc"
+    assert "raw_type" not in exceptions[0]
+
+    assert exceptions[1]["type"] == "CheckoutBloc"
+    assert exceptions[1]["raw_type"] == "aBc"

--- a/tests/sentry/lang/dart/test_utils.py
+++ b/tests/sentry/lang/dart/test_utils.py
@@ -413,11 +413,16 @@ def test_deobfuscate_exception_type_instance_of_pattern() -> None:
                     "type": "ghi",
                     "value": "Instance of 'xyz' and Instance of 'ghi' both occurred",
                 },
+                {
+                    "type": "jkl",
+                    "value": "Instance of 'jkl'",
+                },
             ]
         },
     }
 
     mock_map = {
+        "jkl": "",
         "xyz": "NetworkException",
         "abc": "DatabaseException",
         "def": "FileException",
@@ -460,6 +465,10 @@ def test_deobfuscate_exception_type_instance_of_pattern() -> None:
             data["exception"]["values"][3]["value"]
             == "Instance of 'NetworkException' and Instance of 'IOException' both occurred"
         )
+
+        # An empty mapping is not a deobfuscation; keep the obfuscated symbol
+        assert data["exception"]["values"][4]["type"] == "jkl"
+        assert data["exception"]["values"][4]["value"] == "Instance of 'jkl'"
 
 
 @django_db_all


### PR DESCRIPTION
Obfuscated Flutter apps often build an exception type out of a label plus a runtime type, like `'Bloc ${bloc.runtimeType}'`. That arrives as `Bloc aBc`, and since the symbol map only contains `aBc`, the lookup on the full string missed and issue titles stayed half-obfuscated.

Deobfuscation now falls back to remapping the identifiers *inside* the type when the full string has no match, so `Bloc aBc` becomes `Bloc CheckoutBloc`. The full-string lookup still runs first and wins. Punctuation, generics and whitespace are preserved exactly, exception values keep their current behavior, and the original type is saved to `raw_type` — already exposed by the API as `rawType`, the same way Java ProGuard does it, so there is no frontend change.

Identifiers under three characters are skipped. A symbol map includes the Flutter framework, which is large enough to use up every one- and two-character name, so short words are always keys: without a floor, `Error in aBc` would rewrite `in` into an unrelated framework class. Short types on their own still resolve, because they match on the full string.

**Review note:** `exception.type` always feeds the grouping hash, so events whose types start resolving will split into new issues once after deploy. `dart.compound-type-deobfuscation.enabled` (on by default) turns off the fallback if that or anything else misbehaves.

Refs [sentry-dart#3902](https://github.com/getsentry/sentry-dart/issues/3902)
