### PR TITLE
fix(auth): Redirect SSO directly to organization

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -54,6 +54,7 @@ from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.locks import locks
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
+from sentry.models.organization import Organization
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import (
     RpcOrganization,
@@ -248,7 +249,9 @@ class AuthIdentityHandler:
         try:
             self._login(user)
         except self._NotCompletedSecurityChecks:
-            return HttpResponseRedirect(self._get_login_redirect(subdomain))
+            return HttpResponseRedirect(
+                self._get_login_redirect(subdomain, default_to_organization=False)
+            )
 
         state.clear()
 
@@ -257,10 +260,20 @@ class AuthIdentityHandler:
             auth.set_active_org(self.request, self.organization.slug)
         return HttpResponseRedirect(self._get_login_redirect(subdomain))
 
-    def _get_login_redirect(self, subdomain: str | None) -> str:
+    def _get_login_redirect(
+        self, subdomain: str | None, *, default_to_organization: bool = True
+    ) -> str:
         # TODO(domains) Passing this method the organization should let us consolidate and simplify subdomain
         # state tracking.
-        login_redirect_url = auth.get_login_redirect(self.request)
+        if default_to_organization:
+            default_redirect_url = (
+                reverse("issues")
+                if subdomain is not None
+                else Organization.get_url(self.organization.slug)
+            )
+            login_redirect_url = auth.get_login_redirect(self.request, default=default_redirect_url)
+        else:
+            login_redirect_url = auth.get_login_redirect(self.request)
         if subdomain is not None:
             url_prefix = generate_organization_url(subdomain)
             login_redirect_url = absolute_uri(login_redirect_url, url_prefix=url_prefix)

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -314,7 +314,9 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
         redirect = self.handler.handle_existing_identity(self.state, auth_identity)
 
         assert redirect.url == mock_auth.get_login_redirect.return_value
-        mock_auth.get_login_redirect.assert_called_with(self.request)
+        mock_auth.get_login_redirect.assert_called_with(
+            self.request, default=f"/organizations/{self.organization.slug}/issues/"
+        )
 
         persisted_identity = AuthIdentity.objects.get(ident=auth_identity.ident)
         assert persisted_identity.data == self.identity["data"]
@@ -341,7 +343,9 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest, HybridCloudTestMixin):
             redirect = self.handler.handle_existing_identity(self.state, auth_identity)
 
             assert redirect.url == mock_auth.get_login_redirect.return_value
-            mock_auth.get_login_redirect.assert_called_with(self.request)
+            mock_auth.get_login_redirect.assert_called_with(
+                self.request, default=f"/organizations/{self.organization.slug}/issues/"
+            )
 
             persisted_identity = AuthIdentity.objects.get(ident=auth_identity.ident)
             assert persisted_identity.data == self.identity["data"]

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -129,10 +129,13 @@ class AuthOAuth2Test(AuthProviderTestCase):
                     resp = self.client.get(resp["Location"])
 
             assert resp.status_code == 302
-            assert resp["Location"] == f"{customer_domain}/auth/login/"
+            expected_location = (
+                f"{customer_domain}/issues/" if customer_domain else "/organizations/baz/issues/"
+            )
+            assert resp["Location"] == expected_location
             resp = self.client.get(resp["Location"], follow=True)
             assert resp.status_code == 200
-            assert resp.redirect_chain == [("/organizations/baz/issues/", 302)]
+            assert resp.redirect_chain == []
             assert resp.context["user"].id == self.user.id
 
             assert urlopen.called

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -243,10 +243,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse("sentry-auth-sso")
         resp = self.client.post(path, {"email": "foo@example.com"}, follow=True)
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
 
     def test_org_redirects_to_relative_next_url(self) -> None:
         user = self.create_user("bar@example.com")
@@ -307,10 +304,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse("sentry-auth-sso")
         resp = self.client.post(path, {"email": "foo@example.com"}, follow=True)
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
 
     def test_flow_as_unauthenticated_existing_matched_user_no_merge(self) -> None:
         auth_provider = AuthProvider.objects.create(
@@ -809,10 +803,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(
             path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}, follow=True
         )
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
 
         # Ensure the ident was migrated from the legacy identity
         updated_ident = AuthIdentity.objects.get(id=user_ident.id)
@@ -947,10 +938,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         path = reverse("sentry-auth-sso")
         resp = self.client.post(path, {"email": "foo@example.com"}, follow=True)
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            (f"/organizations/{org1.slug}/issues/", 302),
-        ]
+        assert resp.redirect_chain == [(f"/organizations/{org1.slug}/issues/", 302)]
 
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
     @with_feature({"organizations:create": False})

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -134,10 +134,19 @@ class AuthSAML2Test(AuthProviderTestCase):
         resp = self.accept_auth(follow=True)
 
         assert resp.status_code == 200
-        assert resp.redirect_chain == [
-            ("/auth/login/", 302),
-            ("/organizations/saml2-org/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/saml2-org/issues/", 302)]
+
+    def test_auth_sp_initiated_login_with_react_auth_skips_login_page(self) -> None:
+        AuthIdentity.objects.create(
+            user_id=self.user.id, auth_provider=self.auth_provider_inst, ident="1234"
+        )
+        self.client.cookies["sentry_react_auth"] = "1"
+        self.client.post(self.login_path, {"init": True})
+
+        response = self.accept_auth(follow=True)
+
+        assert response.status_code == 200
+        assert response.redirect_chain == [("/organizations/saml2-org/issues/", 302)]
 
     def test_auth_sp_initiated_customer_domain(self) -> None:
         # setup an existing identity so we can complete login
@@ -149,10 +158,7 @@ class AuthSAML2Test(AuthProviderTestCase):
         resp = self.accept_auth(follow=True)
 
         assert resp.status_code == 200
-        assert resp.redirect_chain == [
-            ("http://saml2-org.testserver/auth/login/", 302),
-            ("http://saml2-org.testserver/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("http://saml2-org.testserver/issues/", 302)]
 
     @with_feature("system:multi-region")
     def test_auth_sp_initiated_login_customer_domain_feature(self) -> None:
@@ -165,10 +171,7 @@ class AuthSAML2Test(AuthProviderTestCase):
         resp = self.accept_auth(follow=True)
 
         assert resp.status_code == 200
-        assert resp.redirect_chain == [
-            ("http://saml2-org.testserver/auth/login/", 302),
-            ("http://saml2-org.testserver/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("http://saml2-org.testserver/issues/", 302)]
 
     def test_auth_idp_initiated(self) -> None:
         auth = self.accept_auth()


### PR DESCRIPTION
Successful SAML and social identity authentication currently returns through `/auth/login/`, requiring the login config request to discover that authentication is complete and issue another redirect.

Resolve the shared authentication pipeline's next URL directly so successful SSO proceeds to the intended organization without revisiting the login page. The acceptance coverage asserts the complete redirect chain and ensures `/auth/login/` is never an intermediate redirect.

## Rollout order

1. Merge [getsentry/getsentry#21731](https://github.com/getsentry/getsentry/pull/21731), which temporarily accepts both redirect chains across the independently deployed repositories.
2. Merge this PR to enable the direct organization redirect.
3. Merge the prepared getsentry cleanup to require only the direct redirect chain.
