### PR TITLE
feat(seer): Resolve embed payloads from structuredContent by reference

### DIFF
--- a/static/app/components/seer/markdown/__stories__/referencedEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/referencedEmbedStory.tsx
@@ -1,0 +1,75 @@
+import {CodeBlock} from '@sentry/scraps/code';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {SeerEmbedResolverProvider, SeerMarkdown} from 'sentry/components/seer/markdown';
+import {Demo} from 'sentry/stories';
+
+const LANE = {
+  a3f: {
+    title: 'Error volume',
+    visualization: 'line',
+    x_axis: 'time',
+    y_axis_unit: 'number',
+    series: [
+      {
+        label: 'Errors',
+        data: [
+          {x: '2026-07-30T12:00:00Z', y: 12},
+          {x: '2026-07-30T13:00:00Z', y: 31},
+          {x: '2026-07-30T14:00:00Z', y: 18},
+        ],
+      },
+    ],
+  },
+  b7c: {
+    title: 'Checkout p95',
+    visualization: 'area',
+    x_axis: 'time',
+    y_axis_unit: 'duration',
+    series: [
+      {
+        label: 'p95',
+        data: [
+          {x: '2026-07-30T12:00:00Z', y: 240},
+          {x: '2026-07-30T13:00:00Z', y: 910},
+          {x: '2026-07-30T14:00:00Z', y: 380},
+        ],
+      },
+    ],
+  },
+} as const;
+
+const RAW = [
+  'Errors climbed after the deploy, and checkout latency followed.',
+  '',
+  '{% chart ref="blk-9.chart.a3f" /%}',
+  '',
+  '{% chart ref="blk-9.chart.b7c" /%}',
+].join('\n');
+
+/**
+ * An assistant message carrying only addresses. Each payload arrived earlier on a tool result's
+ * `structuredContent`, so neither chart's data appears in the markdown the model wrote.
+ */
+export function ReferencedEmbedStory() {
+  return (
+    <Stack gap="xl">
+      <Text>
+        Two charts of one type in a single message, each resolving to its own payload.
+      </Text>
+      <CodeBlock language="markdown">{RAW}</CodeBlock>
+      <Demo>
+        <SeerEmbedResolverProvider
+          resolver={(blockId, name, key) =>
+            blockId === 'blk-9' && name === 'chart'
+              ? LANE[key as keyof typeof LANE]
+              : undefined
+          }
+        >
+          <SeerMarkdown raw={RAW} />
+        </SeerEmbedResolverProvider>
+      </Demo>
+    </Stack>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/reference.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/reference.spec.tsx
@@ -1,0 +1,115 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown, SeerEmbedResolverProvider} from 'sentry/components/seer/markdown';
+
+import {parseEmbedReference} from './reference';
+
+const CHART = {
+  title: 'Error volume',
+  visualization: 'line',
+  x_axis: 'time',
+  y_axis_unit: 'number',
+  series: [{label: 'Errors', data: [{x: '2026-07-30T12:00:00Z', y: 12}]}],
+};
+
+describe('parseEmbedReference', () => {
+  it('splits a reference into block, type and key', () => {
+    expect(parseEmbedReference('blk-9.chart.a3f')).toEqual({
+      blockId: 'blk-9',
+      name: 'chart',
+      key: 'a3f',
+    });
+  });
+
+  it('keeps dots in the block id', () => {
+    // Block ids are opaque here, so only the last two segments are structural.
+    expect(parseEmbedReference('run.1.block.2.chart.a3f')?.blockId).toBe('run.1.block.2');
+  });
+
+  it.each([
+    ['an unregistered type', 'blk-9.nonesuch.a3f'],
+    [
+      'a structured-only embed, which owns its key as a single value',
+      'b.agentWriteApproval.k',
+    ],
+    ['a missing key', 'blk-9.chart.'],
+    ['a missing block', '.chart.a3f'],
+    ['too few segments', 'chart.a3f'],
+    ['no segments', 'a3f'],
+  ])('rejects %s', (_label, ref) => {
+    expect(parseEmbedReference(ref)).toBeNull();
+  });
+});
+
+describe('referenced embeds', () => {
+  function renderWithLane(raw: string, lane: Record<string, unknown> = {a3f: CHART}) {
+    render(
+      <SeerEmbedResolverProvider
+        resolver={(blockId, name, key) =>
+          blockId === 'blk-9' && name === 'chart' ? lane[key] : undefined
+        }
+      >
+        <SeerMarkdown raw={raw} />
+      </SeerEmbedResolverProvider>
+    );
+  }
+
+  it('renders a payload the markdown only addresses', () => {
+    renderWithLane('{% chart ref="blk-9.chart.a3f" /%}');
+    expect(screen.getByText('Error volume')).toBeInTheDocument();
+  });
+
+  it('resolves two references in one document to different payloads', () => {
+    renderWithLane(
+      '{% chart ref="blk-9.chart.a3f" /%}\n\n{% chart ref="blk-9.chart.b7c" /%}',
+      {a3f: CHART, b7c: {...CHART, title: 'Latency'}}
+    );
+    expect(screen.getByText('Error volume')).toBeInTheDocument();
+    expect(screen.getByText('Latency')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the key names no entry', () => {
+    renderWithLane('{% chart ref="blk-9.chart.missing" /%}');
+    expect(screen.queryByText('Error volume')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the block names no lane', () => {
+    renderWithLane('{% chart ref="other-block.chart.a3f" /%}');
+    expect(screen.queryByText('Error volume')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the tag disagrees with the reference type', () => {
+    // Rather than handing the payload to a schema it was not produced for.
+    renderWithLane('{% issue ref="blk-9.chart.a3f" /%}');
+    expect(screen.queryByText('Error volume')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when no resolver is in scope', () => {
+    render(<SeerMarkdown raw='{% chart ref="blk-9.chart.a3f" /%}' />);
+    expect(screen.queryByText('Error volume')).not.toBeInTheDocument();
+  });
+});
+
+describe('resolution without a reference', () => {
+  it('still reads an inline body', () => {
+    render(<SeerMarkdown raw={`{% chart %}${JSON.stringify(CHART)}{% /chart %}`} />);
+    expect(screen.getByText('Error volume')).toBeInTheDocument();
+  });
+
+  it('still reads structuredContent for a bodyless tag', () => {
+    render(
+      <SeerMarkdown raw="{% chart %}{% /chart %}" structuredContent={{chart: CHART}} />
+    );
+    expect(screen.getByText('Error volume')).toBeInTheDocument();
+  });
+
+  it('prefers an inline body over structuredContent', () => {
+    render(
+      <SeerMarkdown
+        raw={`{% chart %}${JSON.stringify(CHART)}{% /chart %}`}
+        structuredContent={{chart: {...CHART, title: 'From the bus'}}}
+      />
+    );
+    expect(screen.getByText('Error volume')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/seer/markdown/embeds/reference.ts
+++ b/static/app/components/seer/markdown/embeds/reference.ts
@@ -1,0 +1,34 @@
+import {isLaneEmbedName, type SeerLaneEmbedName} from './schemas';
+
+/**
+ * An embed reference: `{blockId}.{type}.{key}`.
+ *
+ * Seer mints one when it puts a payload on `structuredContent`, so the markdown carries only the
+ * address and the payload never crosses the model.
+ */
+export interface EmbedReference {
+  blockId: string;
+  key: string;
+  name: SeerLaneEmbedName;
+}
+
+/**
+ * Parse a `ref` attribute, or null if it is not one this build can resolve.
+ *
+ * The block id is matched loosely because it is opaque here; the type segment must name a
+ * registered embed, which is what lets resolution be a table lookup rather than a conditional.
+ */
+export function parseEmbedReference(ref: string): EmbedReference | null {
+  const separator = ref.lastIndexOf('.');
+  const typeSeparator = ref.lastIndexOf('.', separator - 1);
+  if (separator <= 0 || typeSeparator <= 0) {
+    return null;
+  }
+  const blockId = ref.slice(0, typeSeparator);
+  const name = ref.slice(typeSeparator + 1, separator);
+  const key = ref.slice(separator + 1);
+  if (!blockId || !key || !isLaneEmbedName(name)) {
+    return null;
+  }
+  return {blockId, name, key};
+}

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -680,3 +680,27 @@ export function seerEmbedsToJsonSchemas(): Array<{
     };
   });
 }
+
+/**
+ * Embed names that can carry a lane. Excludes the structured-only embeds, which already own their
+ * `structuredContent` key as a single value and so cannot also hold a list.
+ */
+export type SeerLaneEmbedName = keyof typeof SEER_EMBED_SCHEMAS;
+
+export function isLaneEmbedName(value: string): value is SeerLaneEmbedName {
+  return value in SEER_EMBED_SCHEMAS;
+}
+
+/**
+ * The embed lanes a Code Mode tool result may carry on `structuredContent`.
+ *
+ * A lane is keyed by embed name — the same key that resolves the schema above and the component in
+ * the registry — so adding a schema yields a typed lane with no other change. List-valued, because
+ * one execute can render several of a type and each needs its own address.
+ */
+export type SeerEmbedLanes = {
+  [N in SeerLaneEmbedName]?: Array<{
+    data: z.input<(typeof SEER_EMBED_SCHEMAS)[N]['schema']>;
+    key: string;
+  }>;
+};

--- a/static/app/components/seer/markdown/embeds/utils.tsx
+++ b/static/app/components/seer/markdown/embeds/utils.tsx
@@ -18,6 +18,30 @@ export type EmbedOutput<N extends SeerEmbedName> = z.output<
  */
 const reportedInvalidEmbeds = new Set<string>();
 
+/**
+ * An embed whose reference resolved to nothing renders nothing, which is indistinguishable from
+ * working — so it is reported rather than skipped silently.
+ */
+export function reportUnresolvedEmbed(name: string, ref: string) {
+  if (NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(`[SeerEmbed] ${name}: unresolved reference`, ref);
+    return;
+  }
+
+  if (reportedInvalidEmbeds.has(`unresolved:${name}`)) {
+    return;
+  }
+  reportedInvalidEmbeds.add(`unresolved:${name}`);
+
+  Sentry.withScope(scope => {
+    scope.setLevel('warning');
+    scope.setTag('seer_embed.name', name);
+    scope.setFingerprint(['seer-embed-unresolved-reference', name]);
+    Sentry.captureException(new Error(`[SeerEmbed] ${name}: unresolved reference`));
+  });
+}
+
 function reportInvalidEmbed(name: string, issues: readonly z.core.$ZodIssue[]) {
   if (NODE_ENV === 'development') {
     // eslint-disable-next-line no-console

--- a/static/app/components/seer/markdown/index.tsx
+++ b/static/app/components/seer/markdown/index.tsx
@@ -8,7 +8,9 @@ import {Link} from '@sentry/scraps/link';
 import {Markdown, type MarkdownProps} from '@sentry/scraps/markdown';
 import {Heading} from '@sentry/scraps/text';
 
+import {parseEmbedReference} from './embeds/reference';
 import {STRUCTURED_SEER_EMBED_SCHEMAS} from './embeds/schemas';
+import {reportUnresolvedEmbed} from './embeds/utils';
 import {SeerEmbedRegistry} from './embeds';
 
 const ISSUE_SHORT_ID_PATTERN =
@@ -40,6 +42,31 @@ function LinkifyIssueShortIds({children}: {children: string}): ReactNode {
 
 const IsInsideLinkContext = createContext(false);
 const StructuredContentContext = createContext<Record<string, unknown> | null>(null);
+
+/**
+ * Resolves an embed reference against every tool result in the conversation.
+ *
+ * A tool result's own `structuredContent` reaches only its own renderer, but an embed generally
+ * has to appear in a later assistant message — so the payload is looked up by address instead.
+ * Kept generic over where the payloads come from: the conversation view builds the index.
+ */
+export type SeerEmbedResolver = (blockId: string, name: string, key: string) => unknown;
+
+const EmbedResolverContext = createContext<SeerEmbedResolver | null>(null);
+
+export function SeerEmbedResolverProvider({
+  resolver,
+  children,
+}: {
+  children: ReactNode;
+  resolver: SeerEmbedResolver;
+}) {
+  return (
+    <EmbedResolverContext.Provider value={resolver}>
+      {children}
+    </EmbedResolverContext.Provider>
+  );
+}
 
 function toRelativeHref(href: string): string {
   if (!/^https?:\/\//.test(href)) {
@@ -84,13 +111,38 @@ function reportUnhandledTag(
   });
 }
 
+/**
+ * The payload a `ref` addresses, or undefined when it names nothing this conversation carries.
+ *
+ * A reference whose type segment disagrees with the tag it sits on resolves to nothing rather than
+ * handing a payload to the wrong schema.
+ */
+function resolveReferencedEmbed(
+  name: string,
+  ref: string,
+  resolver: SeerEmbedResolver | null
+): unknown {
+  const parsed = parseEmbedReference(ref);
+  if (parsed?.name !== name || !resolver) {
+    reportUnresolvedEmbed(name, ref);
+    return undefined;
+  }
+  const payload = resolver(parsed.blockId, parsed.name, parsed.key);
+  if (payload === undefined) {
+    reportUnresolvedEmbed(name, ref);
+  }
+  return payload;
+}
+
 const SEER_EMBED_COMPONENTS: MarkdownProps['components'] = {
   Tag: function SeerTag({name, data, level, attrs}) {
     const structuredContent = useContext(StructuredContentContext);
+    const resolver = useContext(EmbedResolverContext);
     const Embed = SeerEmbedRegistry.get(name);
     if (Embed) {
-      const embedData =
-        name in STRUCTURED_SEER_EMBED_SCHEMAS
+      const embedData = attrs?.ref
+        ? resolveReferencedEmbed(name, attrs.ref, resolver)
+        : name in STRUCTURED_SEER_EMBED_SCHEMAS
           ? structuredContent?.[name]
           : data === undefined
             ? structuredContent?.[name]

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -10,6 +10,7 @@ import * as Storybook from 'sentry/stories';
 
 import {BasicDemo, LinkifyDemo, StreamingEmbedExamples} from './__stories__/components';
 import {EmbedStory} from './__stories__/embedStory';
+import {ReferencedEmbedStory} from './__stories__/referencedEmbedStory';
 import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
@@ -197,6 +198,20 @@ const embeds = [Timestamp, MyWidget];
 ```bash
 pnpm gen:embed-widgets
 ```
+
+## Referenced embeds
+
+A tag can address a payload instead of carrying one: `{% chart ref="{blockId}.{type}.{key}" /%}`.
+Seer mints the reference when it puts the payload on a tool result's `structuredContent`, so the
+data never passes through the model — which is what makes it deterministic rather than transcribed.
+
+Resolution is conversation-scoped, so an assistant message can render an embed produced by an
+earlier tool call. Wrap the conversation in `SeerEmbedResolverProvider`; a tag without `ref`
+resolves exactly as before.
+
+<Storybook.Demo>
+  <ReferencedEmbedStory />
+</Storybook.Demo>
 
 ## Props
 

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
+import {useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
@@ -13,6 +13,7 @@ import {
   AutofixChatProvider,
   type SendMessageOptions,
 } from 'sentry/components/seer/autofixChatContext';
+import {SeerEmbedResolverProvider} from 'sentry/components/seer/markdown';
 import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -51,6 +52,7 @@ import {UpdateSlackAlert} from 'sentry/views/seerExplorer/components/updateSlack
 import {usePendingUserInput} from 'sentry/views/seerExplorer/hooks/usePendingUserInput';
 import {useSeerExplorer} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
 import type {SeerExplorerSidebarPosition} from 'sentry/views/seerExplorer/types';
+import {useEmbedResolver} from 'sentry/views/seerExplorer/useEmbedResolver';
 import {
   getExplorerFeedbackOptions,
   getExplorerUrl,
@@ -237,6 +239,7 @@ export function SeerExplorerContent({
     }
     return null;
   }, [blocks]);
+  const embedResolver = useEmbedResolver(blocks);
   const isAwaitingUserInput = sessionData?.status === 'awaiting_user_input';
   const pendingInput = sessionData?.pending_user_input ?? null;
   const isAgentWriteApprovalPending =
@@ -624,7 +627,7 @@ export function SeerExplorerContent({
               onSuggestionClick={readOnly ? undefined : sendMessage}
             />
           ) : (
-            <Fragment>
+            <SeerEmbedResolverProvider resolver={embedResolver}>
               {groupTranscript(blocks).map(segment => {
                 const interactionPending =
                   isFileApprovalPending ||
@@ -701,7 +704,7 @@ export function SeerExplorerContent({
                   }
                 />
               )}
-            </Fragment>
+            </SeerEmbedResolverProvider>
           )}
         </BlocksContainer>
         {isTimedOut && (

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -1,6 +1,7 @@
 import {z} from 'zod';
 
 import {isFilePatch, type FilePatch} from 'sentry/components/events/autofix/types';
+import type {SeerEmbedLanes} from 'sentry/components/seer/markdown/embeds/schemas';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 
 /**
@@ -135,13 +136,15 @@ export interface ToolResult {
   // returns every surface it produces here rather than on a bespoke block field, so a renderer
   // resolves a surface from this *and* the legacy field. Keys are optional and additive — absent on
   // old seer responses, in which case only the legacy field is read.
-  structuredContent?: {
-    agentWriteApproval?: AgentWriteApproval;
-    artifacts?: Artifact[];
-    calls?: CallRecord[];
-    links?: ToolLink[];
-    todos?: TodoItem[];
-  } | null;
+  structuredContent?:
+    | (SeerEmbedLanes & {
+        agentWriteApproval?: AgentWriteApproval;
+        artifacts?: Artifact[];
+        calls?: CallRecord[];
+        links?: ToolLink[];
+        todos?: TodoItem[];
+      })
+    | null;
 }
 
 export interface ToolCall {

--- a/static/app/views/seerExplorer/useEmbedResolver.spec.tsx
+++ b/static/app/views/seerExplorer/useEmbedResolver.spec.tsx
@@ -1,0 +1,90 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import type {Block, ToolResult} from 'sentry/views/seerExplorer/types';
+import {useEmbedResolver} from 'sentry/views/seerExplorer/useEmbedResolver';
+
+const CHART = {
+  title: 'Error volume',
+  series: [{label: 'Errors', data: [{x: '2026-07-30T12:00:00Z', y: 12}]}],
+};
+const LATENCY = {...CHART, title: 'Latency'};
+
+function block(id: string, lane?: ToolResult['structuredContent']): Block {
+  return {
+    id,
+    timestamp: '2026-07-30T12:00:00Z',
+    message: {content: null, role: 'tool_use'},
+    tool_results: lane
+      ? [
+          {
+            content: '{% chart /%}',
+            tool_call_function: 'sentry_api_execute',
+            tool_call_id: `call-${id}`,
+            structuredContent: lane,
+          },
+        ]
+      : undefined,
+  };
+}
+
+describe('useEmbedResolver', () => {
+  it('resolves a payload from the block that produced it', () => {
+    const {result} = renderHook(() =>
+      useEmbedResolver([block('blk-9', {chart: [{key: 'a3f', data: CHART}]})])
+    );
+    expect(result.current('blk-9', 'chart', 'a3f')).toEqual(CHART);
+  });
+
+  it('resolves across blocks, so a later answer reaches an earlier tool result', () => {
+    const {result} = renderHook(() =>
+      useEmbedResolver([
+        block('blk-1', {chart: [{key: 'aaa', data: CHART}]}),
+        block('blk-2'),
+        block('blk-3', {chart: [{key: 'bbb', data: LATENCY}]}),
+      ])
+    );
+    expect(result.current('blk-1', 'chart', 'aaa')).toEqual(CHART);
+    expect(result.current('blk-3', 'chart', 'bbb')).toEqual(LATENCY);
+  });
+
+  it('keeps keys from different blocks apart', () => {
+    const {result} = renderHook(() =>
+      useEmbedResolver([
+        block('blk-1', {chart: [{key: 'same', data: CHART}]}),
+        block('blk-2', {chart: [{key: 'same', data: LATENCY}]}),
+      ])
+    );
+    expect(result.current('blk-1', 'chart', 'same')).toEqual(CHART);
+    expect(result.current('blk-2', 'chart', 'same')).toEqual(LATENCY);
+  });
+
+  it('indexes several tool results in one block', () => {
+    // Parallel tool calls each drain their own lane; both are addressable against the block.
+    const parallel = block('blk-9', {chart: [{key: 'aaa', data: CHART}]});
+    parallel.tool_results = [
+      ...parallel.tool_results!,
+      {
+        content: '{% chart /%}',
+        tool_call_function: 'sentry_api_execute',
+        tool_call_id: 'call-b',
+        structuredContent: {chart: [{key: 'bbb', data: LATENCY}]},
+      },
+    ];
+    const {result} = renderHook(() => useEmbedResolver([parallel]));
+    expect(result.current('blk-9', 'chart', 'aaa')).toEqual(CHART);
+    expect(result.current('blk-9', 'chart', 'bbb')).toEqual(LATENCY);
+  });
+
+  it('returns undefined for an unknown address', () => {
+    const {result} = renderHook(() => useEmbedResolver([block('blk-9')]));
+    expect(result.current('blk-9', 'chart', 'a3f')).toBeUndefined();
+  });
+
+  it('ignores non-lane structuredContent keys', () => {
+    // `todos` and `links` share the channel but are not addressable embeds.
+    const {result} = renderHook(() =>
+      useEmbedResolver([block('blk-9', {todos: [{content: 'x', status: 'pending'}]})])
+    );
+    expect(result.current('blk-9', 'todos', '0')).toBeUndefined();
+  });
+});

--- a/static/app/views/seerExplorer/useEmbedResolver.tsx
+++ b/static/app/views/seerExplorer/useEmbedResolver.tsx
@@ -1,0 +1,37 @@
+import {useMemo} from 'react';
+
+import type {SeerEmbedResolver} from 'sentry/components/seer/markdown';
+import type {Block} from 'sentry/views/seerExplorer/types';
+
+/**
+ * Resolves an embed reference against every tool result in the conversation.
+ *
+ * A tool result's `structuredContent` reaches only its own renderer, but seer addresses an embed by
+ * block so a later assistant message can render a payload an earlier tool call produced. Built as a
+ * forward index rather than a backward walk: one pass, memoized, so a tag costs a map lookup.
+ */
+export function useEmbedResolver(blocks: Block[]): SeerEmbedResolver {
+  const index = useMemo(() => {
+    const byAddress = new Map<string, unknown>();
+    for (const block of blocks) {
+      for (const result of block.tool_results ?? []) {
+        for (const [name, lane] of Object.entries(result?.structuredContent ?? {})) {
+          if (!Array.isArray(lane)) {
+            continue;
+          }
+          for (const entry of lane) {
+            if (entry && typeof entry === 'object' && 'key' in entry) {
+              byAddress.set(`${block.id}.${name}.${entry.key}`, entry.data);
+            }
+          }
+        }
+      }
+    }
+    return byAddress;
+  }, [blocks]);
+
+  return useMemo(
+    () => (blockId, name, key) => index.get(`${blockId}.${name}.${key}`),
+    [index]
+  );
+}


### PR DESCRIPTION
A Seer embed carries its payload as JSON inside the markdown the agent wrote, so a chart is thousands of tokens the model has to transcribe without altering a timestamp. Seer can now put the payload on a tool result's structuredContent and write only an address — but a tool result's bus reaches its own renderer, and an embed generally has to appear in a later assistant message.

A tag may now carry `ref="{blockId}.{type}.{key}"`, resolved against every tool result in the conversation. The type segment is the registry key, so resolution stays a table lookup and the lane type is a mapped type over the existing schemas: adding a schema yields a typed lane with no other change.

Additive. A tag without `ref` resolves exactly as before, so persisted conversations carrying inline JSON keep rendering, and a surface with no resolver in scope is unaffected.

Nothing emits a reference until the seer and declaration PRs land, in that order.

Seer side: https://github.com/getsentry/seer/pull/7969