### PR TITLE
feat(seer): Let the explorer declare that it resolves embed references

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -280,6 +280,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-thinking-blocks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer to generate rich component embeds from an adjusted prompt
     manager.add("organizations:seer-explorer-embeds", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Let the agent address embed payloads on structuredContent instead of inlining them in markdown
+    manager.add("organizations:seer-explorer-embed-references", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Agent autofix embed widget + run_autofix tool (name kept in
     # sync with the frontend embed schema's featureFlag in seer/markdown/embeds/schemas.ts)
     manager.add("organizations:seer-agent-autofix", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -326,6 +326,7 @@ class SeerAgentClient:
         code_review_enabled: bool = False,
         max_iterations: int | None = None,
         enable_embeds: bool = True,
+        enable_embed_references: bool = False,
         enable_streaming: bool | None = None,
     ):
         self.organization = organization
@@ -346,6 +347,7 @@ class SeerAgentClient:
         self.code_review_enabled = code_review_enabled
         self.max_iterations = max_iterations
         self.enable_embeds = enable_embeds
+        self.enable_embed_references = enable_embed_references
         self.enable_streaming = enable_streaming
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
@@ -628,6 +630,20 @@ class SeerAgentClient:
             "organizations:seer-explorer-embeds", self.organization, actor=self.user
         )
 
+    def _embed_references_enabled(self) -> bool:
+        """Whether the agent may address embed payloads instead of inlining them.
+
+        Only for surfaces that resolve a reference — rendering Markdoc is not enough, since an
+        unresolved reference renders nothing where an inline body would have rendered a widget.
+        Opt-in per caller, unlike ``enable_embeds``, and flagged so it can be turned off without
+        a revert.
+        """
+        if not self.enable_embed_references:
+            return False
+        return features.has(
+            "organizations:seer-explorer-embed-references", self.organization, actor=self.user
+        )
+
     def _build_agent_run_options(
         self,
         *,
@@ -678,6 +694,8 @@ class SeerAgentClient:
 
         if self._embed_widgets_enabled():
             opts["embed_widgets"] = get_embed_widgets(self.organization, self.user)
+            if self._embed_references_enabled():
+                opts["embed_references"] = True
 
         if self.enable_streaming is True or (
             self.enable_streaming is None

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -115,6 +115,7 @@ class AgentRunOptions(TypedDict):
     enable_coding: NotRequired[bool]
     enable_tool_summary: NotRequired[bool]
     embed_widgets: NotRequired[list[dict[str, Any]] | None]
+    embed_references: NotRequired[bool]
     enable_streaming: NotRequired[bool]
     is_agentic_triage_sort: NotRequired[bool]
 

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -332,6 +332,9 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 enable_bash_tools=override_bash_mode_enabled,
                 enable_coding=enable_coding,
                 enable_code_mode_tools=enable_code_mode_tools,
+                # The explorer wraps its transcript in a resolver, so it can take embed payloads
+                # off structuredContent instead of having the agent transcribe them.
+                enable_embed_references=True,
                 reasoning_effort="medium",
             )
             if resolved is not None:

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -330,6 +330,91 @@ class TestSeerAgentClient(TestCase):
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
+    @with_feature("organizations:seer-explorer-embed-references")
+    def test_embed_references_need_the_caller_to_opt_in(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        """Rendering Markdoc is not enough: an unresolved reference renders nothing where an
+        inline body would have rendered a widget, so the caller has to say it resolves them."""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user, enable_code_mode_tools="only")
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_references" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    @with_feature("organizations:seer-explorer-embed-references")
+    def test_embed_references_declared_when_opted_in(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(
+            self.organization,
+            self.user,
+            enable_code_mode_tools="only",
+            enable_embed_references=True,
+        )
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert body["agent_run_options"]["embed_references"] is True
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    def test_embed_references_need_the_flag(self, mock_collect_context, mock_post, mock_access):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(
+            self.organization,
+            self.user,
+            enable_code_mode_tools="only",
+            enable_embed_references=True,
+        )
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_references" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    @with_feature("organizations:seer-explorer-embed-references")
+    def test_embed_references_never_ship_without_widgets(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        """A reference is still an embed tag, so a surface that cannot render one must not be
+        told it may address a payload."""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(
+            self.organization,
+            self.user,
+            enable_code_mode_tools="only",
+            enable_embeds=False,
+            enable_embed_references=True,
+        )
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_references" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
     def test_code_mode_grants_embed_widgets_without_the_embeds_flag(
         self, mock_collect_context, mock_post, mock_access
     ):

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -181,6 +181,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             enable_bash_tools=False,
             enable_coding=False,
             enable_code_mode_tools="off",
+            enable_embed_references=True,
             reasoning_effort="medium",
         )
         mock_client.start_run.assert_called_once_with(
@@ -272,6 +273,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
                 enable_bash_tools=False,
                 enable_coding=feature_enabled and option_enabled,
                 enable_code_mode_tools="off",
+                enable_embed_references=True,
                 reasoning_effort="medium",
             )
 
@@ -299,6 +301,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             enable_bash_tools=False,
             enable_coding=False,
             enable_code_mode_tools="off",
+            enable_embed_references=True,
             reasoning_effort="medium",
         )
         mock_client.continue_run.assert_called_once_with(
@@ -498,6 +501,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
                 enable_bash_tools=False,
                 enable_coding=feature_enabled and option_enabled,
                 enable_code_mode_tools="off",
+                enable_embed_references=True,
                 reasoning_effort="medium",
             )
 


### PR DESCRIPTION
Seer can address an embed payload on structuredContent instead of inlining it in markdown, which keeps a chart's data out of the model entirely. It only does so when the caller says it resolves references, because an unresolved one renders nothing where an inline body would have rendered a widget.

Opt-in per caller rather than defaulted like `enable_embeds`: rendering Markdoc is not enough, the surface has to wrap its transcript in a resolver. Today that is the explorer chat. Flagged so it can be turned off without a revert.

Stacked on https://github.com/getsentry/sentry/pull/123153 — frontend/backend cannot ship in one PR, and this has to land second so the resolver exists before anything emits a reference.

Seer side: https://github.com/getsentry/seer/pull/7969