### PR TITLE
fix(auth): Canonicalize customer domain login URLs

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -117,6 +117,10 @@ class AuthLoginView(BaseView, ReactMixin):
         return super().handle(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, **kwargs) -> HttpResponseBase:
+        customer_domain_redirect = self.get_customer_domain_login_redirect(request)
+        if customer_domain_redirect is not None:
+            return customer_domain_redirect
+
         if should_render_react_auth(request):
             return self.handle_react(request)
 
@@ -189,6 +193,23 @@ class AuthLoginView(BaseView, ReactMixin):
             and self.org_exists(request=request)
             and request.path_info not in non_sso_urls
         )
+
+    def get_customer_domain_login_redirect(
+        self, request: HttpRequest
+    ) -> HttpResponseRedirect | None:
+        if (
+            not features.has("system:multi-region")
+            or request.user.is_authenticated
+            or not request.subdomain
+            or not self.org_exists(request)
+        ):
+            return None
+
+        path = construct_link_with_query(
+            path=reverse("sentry-auth-organization", args=[request.subdomain]),
+            query_params=request.GET,
+        )
+        return HttpResponseRedirect(absolute_uri(path))
 
     def get_org_auth_login_redirect(self, request: HttpRequest) -> HttpResponseBase:
         """

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -59,6 +59,11 @@ class AuthOrganizationLoginView(AuthLoginView):
 
     @method_decorator(never_cache)
     def handle(self, request: HttpRequest, organization_slug) -> HttpResponseBase:
+        if request.method == "GET":
+            customer_domain_redirect = self.get_customer_domain_login_redirect(request)
+            if customer_domain_redirect is not None:
+                return customer_domain_redirect
+
         if should_render_react_auth(request):
             return self.handle_react(request)
 

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -33,6 +33,13 @@ NON_CUSTOMER_DOMAIN_URL_NAMES = [
     "sentry-account-*",
 ]
 
+# Organization subdomains also host auth flows outside multi-region, so these routes are
+# primary-domain-only when customer domains are enabled.
+MULTI_REGION_NON_CUSTOMER_DOMAIN_URL_NAMES = [
+    "sentry-login",
+    "sentry-auth-organization",
+]
+
 
 def resolve_redirect_url(request: HttpRequest, org_slug: str, user_id=None):
     org_context = organization_service.get_organization_by_slug(
@@ -118,6 +125,10 @@ class ReactMixin:
         url_is_non_customer_domain = (
             any(fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES) if url_name else False
         )
+        if url_name and features.has("system:multi-region"):
+            url_is_non_customer_domain = url_is_non_customer_domain or any(
+                fnmatch(url_name, pattern) for pattern in MULTI_REGION_NON_CUSTOMER_DOMAIN_URL_NAMES
+            )
 
         # If a customer domain is being used, and if a non-customer domain url_name is
         # encountered, we redirect the user to sentryUrl.

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -59,6 +59,38 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         self.assertTemplateUsed(resp, "sentry/base-react.html")
         self.assertTemplateNotUsed(resp, "sentry/login.html")
 
+    @with_feature("system:multi-region")
+    def test_customer_domain_login_redirects_to_primary_domain(self) -> None:
+        organization = self.create_organization(slug="customer-domain-org")
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        response = self.client.get(
+            f"{self.path}?next=%2Fsettings%2Faccount%2F",
+            HTTP_HOST=f"{organization.slug}.testserver",
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert response.redirect_chain == [
+            (
+                f"http://testserver/auth/login/{organization.slug}/?next=%2Fsettings%2Faccount%2F",
+                302,
+            )
+        ]
+        self.assertTemplateUsed(response, "sentry/base-react.html")
+
+    def test_customer_domain_login_does_not_redirect_without_multi_region(self) -> None:
+        organization = self.create_organization(slug="customer-domain-org")
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        response = self.client.get(
+            self.path,
+            HTTP_HOST=f"{organization.slug}.testserver",
+        )
+
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "sentry/base-react.html")
+
     def test_cannot_request_access(self) -> None:
         resp = self.client.get(self.path)
 
@@ -241,9 +273,10 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         redirect_url = getattr(resp, "url", None)
         assert redirect_url == reverse("sentry-auth-organization", args=[org.slug])
 
-        # get redirect
+        # Canonicalize the customer-domain login URL onto the primary domain.
         resp = self.client.get(redirect_url, HTTP_HOST=f"{org.slug}.testserver")
-        assert resp.status_code == 200
+        assert resp.status_code == 302
+        assert resp["Location"] == f"http://testserver/auth/login/{org.slug}/"
 
     def test_registration_disabled(self) -> None:
         with self.feature({"auth:register": False}), self.allow_registration():

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -59,6 +59,20 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(response, "sentry/base-react.html")
         self.assertTemplateNotUsed(response, "sentry/organization-login.html")
 
+    @with_feature("system:multi-region")
+    def test_customer_domain_login_redirects_to_primary_domain(self) -> None:
+        self.client.cookies["sentry_react_auth"] = "1"
+
+        response = self.client.get(
+            f"{self.path}?next=%2Fsettings%2Faccount%2F",
+            HTTP_HOST=f"{self.organization.slug}.testserver",
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == (
+            f"http://testserver/auth/login/{self.organization.slug}/?next=%2Fsettings%2Faccount%2F"
+        )
+
     def test_cannot_get_request_join_link_with_setting_disabled(self) -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             OrganizationOption.objects.create(


### PR DESCRIPTION
Auth login requests on an organization customer domain can render React before reaching the primary-domain organization login route. The generic React domain redirect can then send the organization-scoped auth route back to the customer domain, producing unnecessary redirects or a loop.

Canonicalize customer-domain auth login requests on the backend before rendering React, preserving the query string, and classify the Auth V2 login routes as primary-domain-only. Tests follow the redirect and verify it terminates at the React login page on the primary host.