### PR TITLE
test(auth): Expect disabled Auth V2 cookie

### DIFF
--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -291,9 +291,10 @@ describe('AuthLogin', () => {
         screen.getByRole('button', {name: 'Return to the old login experience'})
       );
 
-      expect(Cookies.get('sentry_react_auth')).toBeUndefined();
+      expect(Cookies.get('sentry_react_auth')).toBe('0');
       expect(testableWindowLocation.reload).toHaveBeenCalled();
     } finally {
+      Cookies.remove('sentry_react_auth', {domain: '.sentry.io', path: '/'});
       Cookies.remove('sentry_react_auth', {domain: '.sentry.io', path: '/auth/'});
       setWindowLocation(originalLocation);
     }


### PR DESCRIPTION
The legacy login test now expects the explicit `sentry_react_auth=0` opt-out
written by the current runtime behavior. Its cleanup also removes the root-path
cookie so the test cannot leak state.
