### PR TITLE
feat(hybridcloud): Report webhook backlog depth per provider

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -1,6 +1,7 @@
 import datetime
 import enum
 import logging
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from concurrent.futures import as_completed
 from typing import Any
@@ -8,7 +9,7 @@ from typing import Any
 import orjson
 import sentry_sdk
 from django.core.cache import cache
-from django.db.models import Case, CharField, Exists, Min, Q, Subquery, Value, When
+from django.db.models import Case, CharField, Count, Exists, Min, Q, Subquery, Value, When
 from django.utils import timezone
 from requests import Response
 from requests.models import HTTPError
@@ -476,6 +477,25 @@ def _gated_mailbox_heads() -> list[dict[str, Any]]:
     return records
 
 
+def _record_backlog_depth(due_rows: Mapping[str, int], in_flight_rows: Mapping[str, int]) -> None:
+    """
+    Report the scanned backlog's depth per provider: due rows await dispatch,
+    in-flight rows are held by claims and retry backoffs.
+    """
+    for provider, rows in due_rows.items():
+        metrics.distribution(
+            "hybridcloud.schedule_webhook_delivery.due_rows",
+            rows,
+            tags={"provider": provider},
+        )
+    for provider, rows in in_flight_rows.items():
+        metrics.distribution(
+            "hybridcloud.schedule_webhook_delivery.in_flight_rows",
+            rows,
+            tags={"provider": provider},
+        )
+
+
 def _due_mailbox_heads() -> list[dict[str, Any]]:
     """
     Discovery for due-head mode: one aggregate pass finds two mailbox records:
@@ -483,21 +503,32 @@ def _due_mailbox_heads() -> list[dict[str, Any]]:
     dispatch from the oldest due record; strict providers still require the true
     head to be due (see `_gated_mailbox_heads`). Provider comes from the mailbox
     name — the aggregate never fetches rows.
+
+    The same pass counts each mailbox's due and in-flight rows for the per-provider
+    backlog metrics; it already visits every row to find the heads.
     """
     now = timezone.now()
     mailbox_heads = WebhookPayload.objects.values("mailbox_name").annotate(
         id_min=Min("id"),
         id_min_due=Min("id", filter=Q(schedule_for__lte=now)),
+        due_count=Count("id", filter=Q(schedule_for__lte=now)),
+        in_flight_count=Count("id", filter=Q(schedule_for__gt=now)),
     )
     skip_on_failure_providers = frozenset(
         options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
     )
+    due_rows: defaultdict[str, int] = defaultdict(int)
+    in_flight_rows: defaultdict[str, int] = defaultdict(int)
     heads = []
     for mailbox_head in mailbox_heads:
+        provider = _provider_from_mailbox(mailbox_head["mailbox_name"])
+        # Counted before the skips below: a mailbox that cannot dispatch is backlog
+        # too, and omitting it would shrink depth exactly when a provider stalls.
+        due_rows[provider] += mailbox_head["due_count"]
+        in_flight_rows[provider] += mailbox_head["in_flight_count"]
         if mailbox_head["id_min_due"] is None:
             # Everything is claimed or backing off.
             continue
-        provider = _provider_from_mailbox(mailbox_head["mailbox_name"])
         if (
             provider not in skip_on_failure_providers
             and mailbox_head["id_min"] != mailbox_head["id_min_due"]
@@ -519,6 +550,7 @@ def _due_mailbox_heads() -> list[dict[str, Any]]:
         len(heads),
         tags={"source": "aggregate"},
     )
+    _record_backlog_depth(due_rows, in_flight_rows)
     return [
         {"id": head_id, "mailbox_name": mailbox_name}
         for _, head_id, mailbox_name in heads[:BATCH_SELECT_LIMIT]

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -15,12 +15,14 @@ from sentry import options
 from sentry.hybridcloud.models.webhookpayload import MAX_ATTEMPTS, WebhookPayload
 from sentry.hybridcloud.tasks import deliver_webhooks
 from sentry.hybridcloud.tasks.deliver_webhooks import (
+    BATCH_SCHEDULE_OFFSET,
     DRAIN_LOCK_TTL,
     MAX_MAILBOX_DRAIN,
     PARALLEL_DRAIN_THRESHOLD,
     SLOW_DELIVERY_THRESHOLD,
     Dispatcher,
     _claim_and_dispatch,
+    _due_mailbox_heads,
     drain_mailbox,
     drain_mailbox_parallel,
     maybe_trigger_drain,
@@ -45,6 +47,8 @@ DISPATCH_METRIC = "hybridcloud.deliver_webhooks.dispatch"
 DISPATCH_CLAIMED_METRIC = "hybridcloud.deliver_webhooks.dispatch.claimed"
 PUSH_TRIGGER_ERROR_METRIC = "hybridcloud.deliver_webhooks.push_trigger.error"
 SCHEDULER_SKIPPED_METRIC = "hybridcloud.deliver_webhooks.scheduler.skipped"
+DUE_ROWS_METRIC = "hybridcloud.schedule_webhook_delivery.due_rows"
+IN_FLIGHT_ROWS_METRIC = "hybridcloud.schedule_webhook_delivery.in_flight_rows"
 CYCLE_METRIC = "hybridcloud.schedule_webhook_delivery.cycle"
 CARRYOVER_METRIC = "hybridcloud.schedule_webhook_delivery.carryover"
 CARRYOVER_ERROR_METRIC = "hybridcloud.schedule_webhook_delivery.carryover.error"
@@ -812,6 +816,86 @@ class ScheduleCarryoverFloorTest(CarryoverTestBase):
 
         assert self.carryover() is None
         assert self.tags_for(mock_metrics, CARRYOVER_DROPPED_METRIC) == [{}]
+
+
+@control_silo_test
+class DueHeadDepthTest(MetricCallsMixin, TestCase):
+    """
+    Discovery reports what sits in each mailbox, not just which are due: a mailbox
+    count cannot tell one record per mailbox from a thousand.
+    """
+
+    def rows_by_provider(self, mock_metrics: MagicMock, metric: str) -> dict[str, float]:
+        """The value recorded per provider, keyed so emission order doesn't matter."""
+        return {
+            tags["provider"]: value for value, tags in self.distribution_calls(mock_metrics, metric)
+        }
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_claimed_and_backing_off_rows_are_both_in_flight(self, mock_metrics: MagicMock) -> None:
+        due = create_payloads(2, "github:123", provider="github")
+        claimed = create_payloads(3, "github:123", provider="github")
+        WebhookPayload.objects.filter(id__in=[record.id for record in claimed]).update(
+            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET
+        )
+        self.create_webhook_payload(
+            mailbox_name="github:123",
+            cell_name="us",
+            provider="github",
+            schedule_for=timezone.now() + timedelta(minutes=1),
+        )
+
+        heads = _due_mailbox_heads()
+
+        # The head is the oldest due record, not the mailbox's true head.
+        assert heads == [{"id": due[0].id, "mailbox_name": "github:123"}]
+        # Claimed rows and the backing-off row are both in flight: neither is
+        # available to this cycle's dispatch.
+        assert self.rows_by_provider(mock_metrics, DUE_ROWS_METRIC) == {"github": 2}
+        assert self.rows_by_provider(mock_metrics, IN_FLIGHT_ROWS_METRIC) == {"github": 4}
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_depth_summed_per_provider(self, mock_metrics: MagicMock) -> None:
+        create_payloads(2, "github:123", provider="github")
+        create_payloads(1, "github:456", provider="github")
+        jira = create_payloads(3, "jira:123", provider="jira")
+        WebhookPayload.objects.filter(id=jira[-1].id).update(
+            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET
+        )
+
+        _due_mailbox_heads()
+
+        assert self.rows_by_provider(mock_metrics, DUE_ROWS_METRIC) == {"github": 3, "jira": 2}
+        assert self.rows_by_provider(mock_metrics, IN_FLIGHT_ROWS_METRIC) == {
+            "github": 0,
+            "jira": 1,
+        }
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_depth_counts_mailboxes_that_cannot_dispatch(self, mock_metrics: MagicMock) -> None:
+        # An undispatchable mailbox is still backlog worth seeing.
+        self.create_webhook_payload(
+            mailbox_name="github:123",
+            cell_name="us",
+            provider="github",
+            schedule_for=timezone.now() + timedelta(minutes=1),
+        )
+        # jira is strict-ordering: a claimed head gates the due rows behind it.
+        self.create_webhook_payload(
+            mailbox_name="jira:123",
+            cell_name="us",
+            provider="jira",
+            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET,
+        )
+        create_payloads(2, "jira:123", provider="jira")
+
+        assert _due_mailbox_heads() == []
+
+        assert self.rows_by_provider(mock_metrics, DUE_ROWS_METRIC) == {"github": 0, "jira": 2}
+        assert self.rows_by_provider(mock_metrics, IN_FLIGHT_ROWS_METRIC) == {
+            "github": 1,
+            "jira": 1,
+        }
 
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:


### PR DESCRIPTION
## Problem

Discovery reports how many mailboxes are waiting, which says nothing about how much is in them: a provider holding a single record per mailbox is indistinguishable from one holding hundreds. That gap matters during an incident, when the question is which provider is actually backing up.

## Change

The due-head aggregate already groups every row by mailbox to find the heads, so counting each mailbox's due and in-flight rows is the same scan with two more aggregates and no extra round trip. The counts are summed per provider into two new distributions:

- `hybridcloud.schedule_webhook_delivery.due_rows` — rows awaiting dispatch
- `hybridcloud.schedule_webhook_delivery.in_flight_rows` — rows held by claims and retry backoffs

Mailboxes this cycle cannot dispatch are counted before the skips, not after: a stalled provider is precisely the depth worth seeing, and omitting it would make depth shrink exactly when a provider backs up.

No dispatch behavior changes, and the gated discovery path is untouched.

## Note on tags

Both distributions carry a `provider` tag. Per the Datadog tag configuration, a newly emitted tag is not queryable until it is allowlisted, and that is not retroactive — worth confirming before relying on the per-provider split in a dashboard.

## Tests

Depth is summed per provider across mailboxes; claimed rows and backing-off rows both count as in-flight; mailboxes that cannot dispatch this cycle still contribute.
