### PR TITLE
feat(pr-iter): grey out the iteration form on a paused run

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -211,6 +211,7 @@ export interface ExplorerAutofixState {
     id: string;
     input_type: 'file_change_approval' | 'ask_user_question';
   } | null;
+  pr_iteration_paused?: boolean;
   queued_feedback?: RawFeedback[];
   repo_pr_states?: Record<string, RepoPRState>;
   sentry_run_id?: string | null;
@@ -517,6 +518,10 @@ export function isCodingAgentsSection(section: AutofixSection): boolean {
 
 export function isRunValidForPrIteration(organization: Organization): boolean {
   return organization.features.includes('autofix-pr-iteration-manual');
+}
+
+export function isPrIterationPaused(runState: ExplorerAutofixState | null): boolean {
+  return runState?.pr_iteration_paused === true;
 }
 
 export function isLastStepPrIteration(runState: ExplorerAutofixState | null): boolean {

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -67,6 +67,34 @@ describe('PrIterationFeedbackForm', () => {
     expect(screen.getByRole('button', {name: 'Submit'})).toBeInTheDocument();
   });
 
+  it('keeps the form rendered but inert when PR iteration is paused', async () => {
+    const autofix = makeAutofix({
+      runState: {run_id: 1, blocks: [], pr_iteration_paused: true} as any,
+    });
+    render(<PrIterationFeedbackForm autofix={autofix} groupId="1" runId={1} />);
+
+    // The ticket asks for the form to stay visible, just greyed out.
+    expect(screen.getByRole('textbox')).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Submit'})).toBeDisabled();
+
+    await userEvent.hover(screen.getByRole('img', {name: 'Disabled'}));
+    expect(await screen.findByText(/paused for this run/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
+    expect(autofix.startStep).not.toHaveBeenCalled();
+  });
+
+  it('leaves the form usable when PR iteration is not paused', async () => {
+    const autofix = makeAutofix();
+    render(<PrIterationFeedbackForm autofix={autofix} groupId="1" runId={1} />);
+
+    expect(screen.getByRole('textbox')).toBeEnabled();
+    expect(screen.queryByRole('img', {name: 'Disabled'})).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByRole('textbox'), 'make it blue');
+    expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();
+  });
+
   it('keeps the feedback and surfaces an error when submit fails', async () => {
     const autofix = makeAutofix({
       startStep: jest.fn().mockRejectedValue(new Error('boom')),

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -77,8 +77,10 @@ describe('PrIterationFeedbackForm', () => {
     expect(screen.getByRole('textbox')).toBeDisabled();
     expect(screen.getByRole('button', {name: 'Submit'})).toBeDisabled();
 
-    await userEvent.hover(screen.getByRole('img', {name: 'Disabled'}));
-    expect(await screen.findByText(/paused for this run/)).toBeInTheDocument();
+    await userEvent.hover(screen.getByRole('button', {name: 'Submit'}));
+    expect(
+      await screen.findByText('PR iteration has been stopped for this Autofix Run')
+    ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
     expect(autofix.startStep).not.toHaveBeenCalled();
@@ -89,7 +91,11 @@ describe('PrIterationFeedbackForm', () => {
     render(<PrIterationFeedbackForm autofix={autofix} groupId="1" runId={1} />);
 
     expect(screen.getByRole('textbox')).toBeEnabled();
-    expect(screen.queryByRole('img', {name: 'Disabled'})).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Submit'}));
+    expect(
+      screen.queryByText('PR iteration has been stopped for this Autofix Run')
+    ).not.toBeInTheDocument();
 
     await userEvent.type(screen.getByRole('textbox'), 'make it blue');
     expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -79,7 +79,7 @@ describe('PrIterationFeedbackForm', () => {
 
     await userEvent.hover(screen.getByRole('button', {name: 'Submit'}));
     expect(
-      await screen.findByText('PR iteration has been stopped for this Autofix Run')
+      await screen.findByText('PR iteration has been stopped for this Autofix run')
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
@@ -94,7 +94,7 @@ describe('PrIterationFeedbackForm', () => {
 
     await userEvent.hover(screen.getByRole('button', {name: 'Submit'}));
     expect(
-      screen.queryByText('PR iteration has been stopped for this Autofix Run')
+      screen.queryByText('PR iteration has been stopped for this Autofix run')
     ).not.toBeInTheDocument();
 
     await userEvent.type(screen.getByRole('textbox'), 'make it blue');

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -2,10 +2,10 @@ import {useRef, useState} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {DisabledTip} from '@sentry/scraps/info';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {
@@ -43,6 +43,9 @@ export function PrIterationFeedbackForm({
   const submitButtonRef = useRef<HTMLButtonElement>(null);
 
   const prompt = t('Anything else you want to see on your PR?');
+  // A disabled control fires no pointer events, so the tooltip hangs off the
+  // wrapper element rather than the control itself.
+  const pausedTooltip = t('PR iteration has been stopped for this Autofix Run');
 
   const handleSubmit = async () => {
     // Also guards the Enter hotkey, which clicks the button directly.
@@ -80,51 +83,48 @@ export function PrIterationFeedbackForm({
         <Text>{prompt}</Text>
         <FeatureBadge type="alpha" />
       </Flex>
-      <InputGroup>
-        <InputGroup.TextArea
-          autosize
-          rows={2}
-          placeholder={t(
-            'Give Seer additional context to improve your pull request and make changes to your code. Hit ENTER to submit.'
-          )}
-          value={feedback}
-          disabled={isSubmitting || isPaused}
-          onChange={event => setFeedback(event.target.value)}
-          onKeyDown={event => {
-            if (event.nativeEvent.isComposing) {
-              return;
-            }
-            if (event.key === 'Enter' && !event.shiftKey) {
-              event.preventDefault();
-              // Simulate a real click on the submit button (matching the Ask Seer
-              // hotkey behavior) so the press goes through the button itself.
-              submitButtonRef.current?.click();
-            }
-          }}
-        />
-        <InputGroup.TrailingItems style={{alignItems: 'flex-start', top: 12}}>
-          <IconReturn variant="muted" />
-        </InputGroup.TrailingItems>
-      </InputGroup>
-      <Flex gap="md" align="center">
+      <Tooltip title={pausedTooltip} disabled={!isPaused} containerDisplayMode="block">
+        <InputGroup>
+          <InputGroup.TextArea
+            autosize
+            rows={2}
+            placeholder={t(
+              'Give Seer additional context to improve your pull request and make changes to your code. Hit ENTER to submit.'
+            )}
+            value={feedback}
+            disabled={isSubmitting || isPaused}
+            onChange={event => setFeedback(event.target.value)}
+            onKeyDown={event => {
+              if (event.nativeEvent.isComposing) {
+                return;
+              }
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                // Simulate a real click on the submit button (matching the Ask Seer
+                // hotkey behavior) so the press goes through the button itself.
+                submitButtonRef.current?.click();
+              }
+            }}
+          />
+          <InputGroup.TrailingItems style={{alignItems: 'flex-start', top: 12}}>
+            <IconReturn variant="muted" />
+          </InputGroup.TrailingItems>
+        </InputGroup>
+      </Tooltip>
+      <Flex gap="md">
         {onClose && (
           <Button aria-label={t('Close')} icon={<IconClose />} onClick={onClose} />
         )}
-        <Button
-          ref={submitButtonRef}
-          icon={isSubmitting ? undefined : <IconArrow size="md" direction="right" />}
-          disabled={isSubmitting || isPaused || !feedback.trim()}
-          onClick={handleSubmit}
-        >
-          {isSubmitting ? t('Submitting feedback') : t('Submit')}
-        </Button>
-        {/* The disabled controls fire no pointer events of their own, so the
-            explanation hangs off a glyph that stays interactive. */}
-        {isPaused && (
-          <DisabledTip
-            title={t("PR iteration is paused for this run and can't be resumed.")}
-          />
-        )}
+        <Tooltip title={pausedTooltip} disabled={!isPaused}>
+          <Button
+            ref={submitButtonRef}
+            icon={isSubmitting ? undefined : <IconArrow size="md" direction="right" />}
+            disabled={isSubmitting || isPaused || !feedback.trim()}
+            onClick={handleSubmit}
+          >
+            {isSubmitting ? t('Submitting feedback') : t('Submit')}
+          </Button>
+        </Tooltip>
       </Flex>
     </Stack>
   );

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -45,7 +45,7 @@ export function PrIterationFeedbackForm({
   const prompt = t('Anything else you want to see on your PR?');
   // A disabled control fires no pointer events, so the tooltip hangs off the
   // wrapper element rather than the control itself.
-  const pausedTooltip = t('PR iteration has been stopped for this Autofix Run');
+  const pausedTooltip = t('PR iteration has been stopped for this Autofix run');
 
   const handleSubmit = async () => {
     // Also guards the Enter hotkey, which clicks the button directly.
@@ -78,7 +78,7 @@ export function PrIterationFeedbackForm({
   };
 
   return (
-    <Stack gap="lg">
+    <Stack gap="xl">
       <Flex gap="xs" align="center">
         <Text>{prompt}</Text>
         <FeatureBadge type="alpha" />
@@ -111,7 +111,7 @@ export function PrIterationFeedbackForm({
           </InputGroup.TrailingItems>
         </InputGroup>
       </Tooltip>
-      <Flex gap="md">
+      <Flex gap="md" align="center">
         {onClose && (
           <Button aria-label={t('Close')} icon={<IconClose />} onClick={onClose} />
         )}

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -2,12 +2,16 @@ import {useRef, useState} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
+import {DisabledTip} from '@sentry/scraps/info';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {type useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {
+  isPrIterationPaused,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {IconArrow} from 'sentry/icons/iconArrow';
 import {IconClose} from 'sentry/icons/iconClose';
 import {IconReturn} from 'sentry/icons/iconReturn';
@@ -33,6 +37,7 @@ export function PrIterationFeedbackForm({
 }: PrIterationFeedbackFormProps) {
   const organization = useOrganization();
   const {startStep} = autofix;
+  const isPaused = isPrIterationPaused(autofix.runState);
   const [feedback, setFeedback] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submitButtonRef = useRef<HTMLButtonElement>(null);
@@ -40,7 +45,8 @@ export function PrIterationFeedbackForm({
   const prompt = t('Anything else you want to see on your PR?');
 
   const handleSubmit = async () => {
-    if (!feedback.trim()) {
+    // Also guards the Enter hotkey, which clicks the button directly.
+    if (isPaused || !feedback.trim()) {
       return;
     }
     // Briefly show the loader while the request is in flight to guard against a
@@ -82,7 +88,7 @@ export function PrIterationFeedbackForm({
             'Give Seer additional context to improve your pull request and make changes to your code. Hit ENTER to submit.'
           )}
           value={feedback}
-          disabled={isSubmitting}
+          disabled={isSubmitting || isPaused}
           onChange={event => setFeedback(event.target.value)}
           onKeyDown={event => {
             if (event.nativeEvent.isComposing) {
@@ -100,18 +106,25 @@ export function PrIterationFeedbackForm({
           <IconReturn variant="muted" />
         </InputGroup.TrailingItems>
       </InputGroup>
-      <Flex gap="md">
+      <Flex gap="md" align="center">
         {onClose && (
           <Button aria-label={t('Close')} icon={<IconClose />} onClick={onClose} />
         )}
         <Button
           ref={submitButtonRef}
           icon={isSubmitting ? undefined : <IconArrow size="md" direction="right" />}
-          disabled={isSubmitting || !feedback.trim()}
+          disabled={isSubmitting || isPaused || !feedback.trim()}
           onClick={handleSubmit}
         >
           {isSubmitting ? t('Submitting feedback') : t('Submit')}
         </Button>
+        {/* The disabled controls fire no pointer events of their own, so the
+            explanation hangs off a glyph that stays interactive. */}
+        {isPaused && (
+          <DisabledTip
+            title={t("PR iteration is paused for this run and can't be resumed.")}
+          />
+        )}
       </Flex>
     </Stack>
   );


### PR DESCRIPTION
after stopping the iteration the user will see this in the UI

<img width="1111" height="895" alt="image" src="https://github.com/user-attachments/assets/4d290eb7-36d7-4550-b6ca-64051c6c4e01" />


all textboxes + submit buttons are greyed out and has a tooltip saying "PR iteration has been paused for this Autofix run"