### PR TITLE
feat(aci): Move dedupe abstract function to stateful detector class

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -395,9 +395,6 @@ class PreprodSizeAnalysisDetectorHandler(
 
         return occurrence, event_data
 
-    def extract_dedupe_value(self, data_packet: SizeAnalysisDataPacket) -> int:
-        raise NotImplementedError
-
 
 class PreprodSizeAnalysisDetectorValidator(BaseDetectorTypeValidator):
     data_source_required = False

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -190,13 +190,3 @@ class DetectorHandler(
         This value is used to determine if the data condition group is in a triggered state.
         """
         pass
-
-    @abc.abstractmethod
-    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
-        """
-        Extracts the de-duplication value from a passed data packet. This duplication
-        value is used to determine if we've already processed data to this point or not.
-
-        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
-        """
-        pass

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -341,6 +341,16 @@ class StatefulDetectorHandler(
         """
         return {}
 
+    @abc.abstractmethod
+    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
+        """
+        Extracts the de-duplication value from a passed data packet. This duplication
+        value is used to determine if we've already processed data to this point or not.
+
+        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
+        """
+        pass
+
     def build_issue_fingerprint(self, group_key: DetectorGroupKey = None) -> list[str]:
         """
         A hook that allows for additional fingerprinting to be added to the detectors issue occurrences.

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -69,9 +69,6 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             def extract_value(self, data_packet: DataPacket[dict[Never, Never]]) -> bool:
                 return True
 
-            def extract_dedupe_value(self, data_packet: DataPacket[dict[Never, Never]]) -> int:
-                return 1
-
             def create_occurrence(
                 self,
                 evaluation_result: DataConditionGroupEvaluation,

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -141,9 +141,6 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
                 value = self.extract_value(data_packet)
                 return build_mock_occurrence_and_event(self, value, PriorityLevel(priority))
 
-            def extract_dedupe_value(self, data_packet: DataPacket[dict[str, Any]]) -> int:
-                return data_packet.packet.get("dedupe", 0)
-
         class MockDetectorWithUpdateHandler(DetectorHandler[dict[str, Any], int]):
             def evaluate(
                 self, data_packet: DataPacket[dict[str, Any]]
@@ -182,9 +179,6 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
             def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> int:
                 return data_packet.packet.get("value", 0)
-
-            def extract_dedupe_value(self, data_packet: DataPacket[dict[str, Any]]) -> int:
-                return data_packet.packet.get("dedupe", 0)
 
         class HandlerGroupType(GroupType):
             type_id = 2


### PR DESCRIPTION
The dedupe function is only used for stateful detectors

Fixes ID-1800