### PR TITLE
fix(api): Reject invalid organization stats parameters

### DIFF
--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -1,3 +1,4 @@
+from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -61,7 +62,13 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 project_list.extend(Project.objects.filter(teams__in=team_list, id__in=project_ids))
             keys = list({p.id for p in project_list})
         else:
-            raise ValueError("Invalid group: %s" % group)
+            raise ParseError(
+                detail=(
+                    f"group={group} is not supported. Use group=organization for "
+                    "organization-wide statistics or group=project for statistics separated "
+                    "by project."
+                )
+            )
 
         if "id" in request.GET:
             id_filter_set = frozenset(map(int, request.GET.getlist("id")))
@@ -97,7 +104,13 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, StatsMixin):
                     raise ResourceDoesNotExist
 
         if stat_model is None:
-            raise ValueError(f"Invalid group: {group}, stat: {stat}")
+            raise ParseError(
+                detail=(
+                    f"stat={stat} is not supported with group={group}. Use stat=received, "
+                    "stat=rejected, or stat=blacklisted. stat=generated is only supported "
+                    "with group=project."
+                )
+            )
         data: dict[int, list[tuple[int, int]]] | list[tuple[int, int]]
         data = tsdb.backend.get_range(
             model=stat_model,

--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -10,6 +10,31 @@ from sentry.utils.outcomes import Outcome
 
 @freeze_time(before_now(days=1).replace(hour=1, minute=10))
 class OrganizationStatsTest(APITestCase, OutcomesSnubaTest):
+    def test_rejects_unsupported_group(self) -> None:
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-stats", args=[self.organization.slug])
+
+        response = self.client.get(url, {"group": "category"})
+
+        assert response.status_code == 400
+        assert response.data["detail"] == (
+            "group=category is not supported. Use group=organization for organization-wide "
+            "statistics or group=project for statistics separated by project."
+        )
+
+    def test_rejects_unsupported_stat_for_group(self) -> None:
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-stats", args=[self.organization.slug])
+
+        response = self.client.get(url, {"stat": "generated"})
+
+        assert response.status_code == 400
+        assert response.data["detail"] == (
+            "stat=generated is not supported with group=organization. Use stat=received, "
+            "stat=rejected, or stat=blacklisted. stat=generated is only supported with "
+            "group=project."
+        )
+
     def test_simple(self) -> None:
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Return 400 responses for unsupported group and stat values instead of letting ValueError escape as an internal error.

Fixes SENTRY-5QY9

Fixes SENTRY-5TW7