### PR TITLE
chore(event formatter): split the formatter rollout for API clients

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -347,6 +347,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-search-merged-generic-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
     # Enables the shared issue/event formatter module (markdown/xml output for LLMs)
     manager.add("organizations:issue-standardized-markdown-for-llm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Same formatter, rolled out separately for API clients (the MCP) -- they share the
+    # endpoints with the UI but not its content needs, so the two ramp independently
+    manager.add("organizations:issue-standardized-markdown-for-llm-api", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Batch latest-event attachment lookups in the issue stream
     manager.add("organizations:issue-stream-batched-latest-event-attachments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -31,9 +31,29 @@ else:
 logger = logging.getLogger(__name__)
 
 FORMATTER_FEATURE = "organizations:issue-standardized-markdown-for-llm"
+# API clients ramp separately from the UI. They share these endpoints and the same query param
+# but not the same content needs: the UI wants breadcrumbs inlined, while the MCP deliberately
+# leaves them to its own tool. The MCP is the only API consumer of ``?llmFormat`` today.
+FORMATTER_FEATURE_API = "organizations:issue-standardized-markdown-for-llm-api"
 # not "format": DRF reserves that query param for renderer content-negotiation
 QUERY_PARAM = "llmFormat"
 VALID_FORMATS: tuple[Format, ...] = get_args(Format)
+
+
+def formatter_feature_for(request: Request) -> str:
+    """Pick the rollout feature for this caller.
+
+    ``auth`` is unset for the Sentry UI (session cookies) and for viewer-context callers, which
+    null it on purpose to borrow session semantics; a token or key means an API client. An
+    unrecognised caller lands on the API feature deliberately -- it is the narrower rollout, so
+    a new consumer can't inherit the UI's wider one just by not being recognised.
+
+    Auth type is a proxy for the caller, not the caller itself: an agent-token request would be
+    classified as an API client even though Seer belongs with the UI. That costs nothing today
+    because Seer reads the formatter over RPC rather than through this mixin, but a Seer caller
+    arriving here would need naming explicitly rather than inferring from auth.
+    """
+    return FORMATTER_FEATURE if request.auth is None else FORMATTER_FEATURE_API
 
 
 class FormattableResponseMixin(_Base):
@@ -52,7 +72,7 @@ class FormattableResponseMixin(_Base):
             adapter is None
             or fmt not in VALID_FORMATS
             or organization is None
-            or not features.has(FORMATTER_FEATURE, organization, actor=request.user)
+            or not features.has(formatter_feature_for(request), organization, actor=request.user)
         ):
             return response
         if response.status_code != 200 or not isinstance(response.data, dict):

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -31,9 +31,7 @@ else:
 logger = logging.getLogger(__name__)
 
 FORMATTER_FEATURE = "organizations:issue-standardized-markdown-for-llm"
-# API clients ramp separately from the UI. They share these endpoints and the same query param
-# but not the same content needs: the UI wants breadcrumbs inlined, while the MCP deliberately
-# leaves them to its own tool. The MCP is the only API consumer of ``?llmFormat`` today.
+# API clients (just the MCP today) ramp separately from the UI
 FORMATTER_FEATURE_API = "organizations:issue-standardized-markdown-for-llm-api"
 # not "format": DRF reserves that query param for renderer content-negotiation
 QUERY_PARAM = "llmFormat"
@@ -41,17 +39,9 @@ VALID_FORMATS: tuple[Format, ...] = get_args(Format)
 
 
 def formatter_feature_for(request: Request) -> str:
-    """Pick the rollout feature for this caller.
+    """Session and viewer-context callers are the UI; a token or key is an API client.
 
-    ``auth`` is unset for the Sentry UI (session cookies) and for viewer-context callers, which
-    null it on purpose to borrow session semantics; a token or key means an API client. An
-    unrecognised caller lands on the API feature deliberately -- it is the narrower rollout, so
-    a new consumer can't inherit the UI's wider one just by not being recognised.
-
-    Auth type is a proxy for the caller, not the caller itself: an agent-token request would be
-    classified as an API client even though Seer belongs with the UI. That costs nothing today
-    because Seer reads the formatter over RPC rather than through this mixin, but a Seer caller
-    arriving here would need naming explicitly rather than inferring from auth.
+    An unrecognised caller lands on the API feature deliberately: it is the narrower rollout.
     """
     return FORMATTER_FEATURE if request.auth is None else FORMATTER_FEATURE_API
 

--- a/tests/sentry/issues/formatting/test_mixin.py
+++ b/tests/sentry/issues/formatting/test_mixin.py
@@ -40,22 +40,10 @@ def test_rest_output_opts_into_user_identifiers() -> None:
 
 
 class _FakeRequest:
-    """Only ``auth`` is read, so a stub keeps these tests off the auth stack."""
-
     def __init__(self, auth: object) -> None:
         self.auth = auth
 
 
-def test_session_auth_uses_the_ui_feature() -> None:
-    # the Sentry UI hits these endpoints with a session, not a token
+def test_ui_and_api_callers_check_different_features() -> None:
     assert formatter_feature_for(cast(Request, _FakeRequest(None))) == FORMATTER_FEATURE
-
-
-def test_token_auth_uses_the_api_feature() -> None:
-    # the MCP calls through the API with a token, and ramps separately from the UI
     assert formatter_feature_for(cast(Request, _FakeRequest(object()))) == FORMATTER_FEATURE_API
-
-
-def test_the_two_rollouts_are_distinct_features() -> None:
-    # a single feature would mean widening the UI rollout also widens every API client's
-    assert FORMATTER_FEATURE != FORMATTER_FEATURE_API

--- a/tests/sentry/issues/formatting/test_mixin.py
+++ b/tests/sentry/issues/formatting/test_mixin.py
@@ -1,6 +1,13 @@
-from typing import Any
+from typing import Any, cast
 
-from sentry.issues.formatting.mixin import format_event_response
+from rest_framework.request import Request
+
+from sentry.issues.formatting.mixin import (
+    FORMATTER_FEATURE,
+    FORMATTER_FEATURE_API,
+    format_event_response,
+    formatter_feature_for,
+)
 
 
 def _event_with_request_body(body_chars: int) -> dict[str, Any]:
@@ -30,3 +37,25 @@ def test_rest_output_opts_into_user_identifiers() -> None:
     out = format_event_response(data, "markdown")
     assert "someone@example.com" in out
     assert "203.0.113.7" in out
+
+
+class _FakeRequest:
+    """Only ``auth`` is read, so a stub keeps these tests off the auth stack."""
+
+    def __init__(self, auth: object) -> None:
+        self.auth = auth
+
+
+def test_session_auth_uses_the_ui_feature() -> None:
+    # the Sentry UI hits these endpoints with a session, not a token
+    assert formatter_feature_for(cast(Request, _FakeRequest(None))) == FORMATTER_FEATURE
+
+
+def test_token_auth_uses_the_api_feature() -> None:
+    # the MCP calls through the API with a token, and ramps separately from the UI
+    assert formatter_feature_for(cast(Request, _FakeRequest(object()))) == FORMATTER_FEATURE_API
+
+
+def test_the_two_rollouts_are_distinct_features() -> None:
+    # a single feature would mean widening the UI rollout also widens every API client's
+    assert FORMATTER_FEATURE != FORMATTER_FEATURE_API


### PR DESCRIPTION
Splits the shared formatter's rollout so the UI and the MCP can ramp independently.

Today both hit the same endpoints with `?llmFormat` and share one feature, so widening the UI's rollout necessarily widens the MCP's. The UI's output is at parity and ready to go to EA; the MCP's has known gaps against its own formatter, so it needs to stay put. One flag can't be in both positions.

Adds `organizations:issue-standardized-markdown-for-llm-api` and picks between
the two features on auth type:

    - session auth (the UI) → existing flag
    - token auth (API clients, currently just the MCP) → new flag

Gating server-side rather than in the MCP because flagpole is the only per-org rollout mechanism available. the MCP has no equivalent