### PR TITLE
fix(features): Honor registered handlers in batch checks

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -375,7 +375,8 @@ class FeatureManager(RegisteredFeatureManager):
     ) -> dict[str, dict[str, bool | None]] | None:
         """
         Determine if multiple features are enabled. Unhandled flags will not be in
-        the results if they cannot be handled.
+        the results if they cannot be handled. Feature-specific handlers take
+        precedence over the entity handler.
 
         Will only accept one type of feature, either all ProjectFeatures or all
         OrganizationFeatures.
@@ -386,14 +387,109 @@ class FeatureManager(RegisteredFeatureManager):
         """
         try:
             if self._entity_handler:
-                with metrics.timer("features.entity_batch_has", sample_rate=0.01):
-                    return self._entity_handler.batch_has(
-                        feature_names,
-                        actor,
-                        projects=projects,
-                        organization=organization,
-                        skip_experiment_exposure=skip_experiment_exposure,
-                    )
+                if not any(self._handler_registry.get(name) for name in feature_names):
+                    with metrics.timer("features.entity_batch_has", sample_rate=0.01):
+                        return self._entity_handler.batch_has(
+                            feature_names,
+                            actor,
+                            projects=projects,
+                            organization=organization,
+                            skip_experiment_exposure=skip_experiment_exposure,
+                        )
+
+                if projects is not None:
+                    entity_keys = [f"project:{project.id}" for project in projects]
+                else:
+                    entity_keys = [
+                        "unscoped" if organization is None else f"organization:{organization.id}"
+                    ]
+
+                batch_results: dict[str, dict[str, bool | None]] = {
+                    entity_key: {} for entity_key in entity_keys
+                }
+                unresolved_features: list[str] = []
+
+                # Evaluate feature-specific handlers first. Features without a complete
+                # project or organization decision fall through to the entity handler.
+                for feature_name in feature_names:
+                    if not self._handler_registry.get(feature_name):
+                        unresolved_features.append(feature_name)
+                        continue
+
+                    if projects is not None:
+                        if not projects:
+                            unresolved_features.append(feature_name)
+                            continue
+                        # Use the same logic as `has_for_batch` to evaluate the feature
+                        # for each project in the batch.
+                        evaluation = self._evaluate_handlers_for_projects(
+                            feature_name,
+                            projects[0].organization,
+                            projects,
+                            actor,
+                        )
+                        for project, project_value in evaluation.decisions.items():
+                            project_key = f"project:{project.id}"
+                            batch_results[project_key][feature_name] = project_value
+
+                        if evaluation.failed:
+                            for project in evaluation.unresolved_projects:
+                                project_key = f"project:{project.id}"
+                                batch_results[project_key][feature_name] = False
+                        elif evaluation.unresolved_projects:
+                            # The entity handler must evaluate a feature if any project
+                            # is unresolved.
+                            unresolved_features.append(feature_name)
+                    else:
+                        try:
+                            if organization is None:
+                                feature = self.get(feature_name)
+                            else:
+                                feature = self.get(feature_name, organization)
+                            handler_value = self._get_handler(feature, actor)
+                        except Exception as e:
+                            if in_random_rollout("features.error.capture_rate"):
+                                sentry_sdk.capture_exception(e)
+                            handler_value = False
+
+                        if handler_value is None:
+                            unresolved_features.append(feature_name)
+                        else:
+                            batch_results[entity_keys[0]][feature_name] = handler_value
+
+                # Evaluate unresolved features together with the entity handler.
+                if unresolved_features:
+                    with metrics.timer("features.entity_batch_has", sample_rate=0.01):
+                        entity_results = self._entity_handler.batch_has(
+                            unresolved_features,
+                            actor,
+                            projects=projects,
+                            organization=organization,
+                            skip_experiment_exposure=skip_experiment_exposure,
+                        )
+
+                    if entity_results:
+                        # Preserve feature-specific decisions when merging entity results.
+                        for entity_key, entity_feature_results in entity_results.items():
+                            feature_results = batch_results.setdefault(entity_key, {})
+                            for feature_name, value in entity_feature_results.items():
+                                feature_results.setdefault(feature_name, value)
+
+                # Callers treat a feature as fully batch-evaluated once any entity has a
+                # result. For features with feature-specific handlers, complete missing
+                # entity results with the same final fallback as `has()`.
+                for feature_name in feature_names:
+                    if not self._handler_registry.get(feature_name):
+                        continue
+                    default_value = settings.SENTRY_FEATURES.get(feature_name, False)
+                    if default_value is None:
+                        default_value = False
+                    for entity_key in entity_keys:
+                        feature_results = batch_results[entity_key]
+                        if feature_results.get(feature_name) is None:
+                            feature_results[feature_name] = default_value
+
+                return batch_results or None
             else:
                 # Fall back to default handler if no entity handler available.
                 project_features = [name for name in feature_names if name.startswith("projects:")]

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -320,6 +320,123 @@ class FeatureManagerTest(TestCase):
         assert ret is not None
         assert ret[f"project:{self.project.id}"]["projects:feature"]
 
+    def test_batch_has_uses_feature_handler_precedence(self) -> None:
+        feature_name = "organizations:handled"
+
+        manager = features.FeatureManager()
+        manager.add(feature_name, OrganizationFeature)
+
+        feature_handler = mock.Mock(spec=features.FeatureHandler)
+        feature_handler.features = {feature_name}
+        feature_handler.return_value = False
+        manager.add_handler(feature_handler)
+
+        entity_handler = mock.Mock(spec=features.FeatureHandler)
+        manager.add_entity_handler(entity_handler)
+
+        result = manager.batch_has([feature_name], actor=self.user, organization=self.organization)
+
+        assert result == {f"organization:{self.organization.id}": {feature_name: False}}
+        entity_handler.batch_has.assert_not_called()
+
+    def test_batch_has_completes_partial_project_handler_results(self) -> None:
+        feature_name = "feature-without-scope-prefix"
+        other_project = self.create_project(organization=self.organization)
+
+        manager = features.FeatureManager()
+        manager.add(feature_name, ProjectFeature, default=True)
+
+        feature_handler = mock.Mock(spec=features.FeatureHandler)
+        feature_handler.features = {feature_name}
+        feature_handler.has_for_batch.return_value = {
+            self.project: True,
+            other_project: None,
+        }
+        manager.add_handler(feature_handler)
+
+        entity_handler = mock.Mock(spec=features.FeatureHandler)
+        entity_handler.batch_has.return_value = {
+            f"project:{self.project.id}": {feature_name: False},
+        }
+        manager.add_entity_handler(entity_handler)
+
+        result = manager.batch_has(
+            [feature_name], actor=self.user, projects=[self.project, other_project]
+        )
+
+        assert result == {
+            f"project:{self.project.id}": {feature_name: True},
+            f"project:{other_project.id}": {feature_name: True},
+        }
+        feature_handler.has_for_batch.assert_called_once()
+        entity_handler.batch_has.assert_called_once()
+
+    def test_batch_has_isolates_feature_handler_error(self) -> None:
+        failed_feature = "organizations:failed"
+        entity_feature = "organizations:feature"
+
+        manager = features.FeatureManager()
+        manager.add(failed_feature, OrganizationFeature)
+        manager.add(entity_feature, OrganizationFeature)
+
+        feature_handler = mock.Mock(spec=features.FeatureHandler)
+        feature_handler.features = {failed_feature}
+        feature_handler.side_effect = Exception("something bad")
+        manager.add_handler(feature_handler)
+        manager.add_entity_handler(MockBatchHandler())
+
+        result = manager.batch_has(
+            [failed_feature, entity_feature],
+            actor=self.user,
+            organization=self.organization,
+        )
+
+        assert result == {
+            f"organization:{self.organization.id}": {
+                failed_feature: False,
+                entity_feature: True,
+            }
+        }
+
+    def test_batch_has_isolates_project_feature_handler_error(self) -> None:
+        failed_feature = "projects:failed"
+        entity_feature = "projects:feature"
+        other_project = self.create_project(organization=self.organization)
+        projects = [self.project, other_project]
+
+        manager = features.FeatureManager()
+        manager.add(failed_feature, ProjectFeature)
+        manager.add(entity_feature, ProjectFeature)
+
+        partial_handler = mock.Mock(spec=features.FeatureHandler)
+        partial_handler.features = {failed_feature}
+        partial_handler.has_for_batch.return_value = {
+            self.project: True,
+            other_project: None,
+        }
+        manager.add_handler(partial_handler)
+
+        failing_handler = mock.Mock(spec=features.FeatureHandler)
+        failing_handler.features = {failed_feature}
+        failing_handler.has_for_batch.side_effect = Exception("something bad")
+        manager.add_handler(failing_handler)
+        manager.add_entity_handler(MockBatchHandler())
+
+        result = manager.batch_has(
+            [failed_feature, entity_feature], actor=self.user, projects=projects
+        )
+
+        assert result == {
+            f"project:{self.project.id}": {
+                failed_feature: True,
+                entity_feature: True,
+            },
+            f"project:{other_project.id}": {
+                failed_feature: False,
+                entity_feature: True,
+            },
+        }
+
     def test_batch_has_error(self) -> None:
         manager = features.FeatureManager()
         manager.add("organizations:feature", OrganizationFeature)


### PR DESCRIPTION
Right now, `batch_has` only will check flagpole, rather than checking both registered flag handler in getsentry and then flagpole, like `has` does. This makes it problematic to actually use getsentry and flagpole together — e.g. the org serializer won't check getsentry, which means that flags with `api_expose=True` will not go through getsentry handlers. 

Change this so that for each feature flag called in `batch_has`, we check whether it has a registered handler first, then batch evaluate everything else.