### PR TITLE
fix(auth-v2): switch cookie settings based on protocol

### DIFF
--- a/static/app/utils/useEnableAuthV2.ts
+++ b/static/app/utils/useEnableAuthV2.ts
@@ -44,11 +44,11 @@ export function useEnableAuthV2() {
   const setAuthV2CookieState = useCallback((state: AuthV2CookieState) => {
     const domain = getCookieDomain();
     const secure = window.location.protocol === 'https:';
-    const secureOptions: Cookies.CookieAttributes = {sameSite: 'none', secure: true};
-    const laxOptions: Cookies.CookieAttributes = {sameSite: 'lax', domain};
     const options: Cookies.CookieAttributes = {
       path: '/',
-      ...(secure ? secureOptions : laxOptions),
+      sameSite: secure ? 'none' : 'lax',
+      ...(secure ? {secure: true} : {}),
+      ...(domain ? {domain} : {}),
     };
 
     Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});

--- a/static/app/utils/useEnableAuthV2.ts
+++ b/static/app/utils/useEnableAuthV2.ts
@@ -43,11 +43,12 @@ export function useEnableAuthV2() {
 
   const setAuthV2CookieState = useCallback((state: AuthV2CookieState) => {
     const domain = getCookieDomain();
-    const options = {
+    const secure = window.location.protocol === 'https:';
+    const secureOptions: Cookies.CookieAttributes = {sameSite: 'none', secure: true};
+    const laxOptions: Cookies.CookieAttributes = {sameSite: 'lax', domain};
+    const options: Cookies.CookieAttributes = {
       path: '/',
-      sameSite: 'none' as const,
-      secure: true,
-      ...(domain ? {domain} : {}),
+      ...(secure ? secureOptions : laxOptions),
     };
 
     Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});


### PR DESCRIPTION
fixes frontend test failures

**The problem:** jsdom couldn't write cookies because the host defaults to `about:blank`, but we were passing `SameSite=None; Secure`

**The solution:** Switch the settings based on `http/s` protocol. Local dev / jsdom (where `getCookieDomain()` returns `undefined`) can use `SameSite=Lax` without Secure (matching previous behavior), `SameSite=None; Secure` is only needed for cross-site SAML callbacks on recognized Sentry domains