### PR TITLE
chore(hybridcloud): remove dead externalactor replication option

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -129,13 +129,6 @@ register(
 )
 
 register(
-    "outbox_replication.sentry_externalactor.replication_version",
-    type=Int,
-    default=0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
     "outbox_replication.sentry_projectkey.replication_version",
     type=Int,
     default=0,


### PR DESCRIPTION
3 of 3 changes to tear out the unused option.

Removes registration for `outbox_replication.sentry_externalactor.replication_version`. ExternalActor stopped producing outboxes in #119525, so the option doesn't do anything.

Refs [INFRENG-567](https://linear.app/getsentry/issue/INFRENG-567/cleanup-remove-outbox-replicationsentry-externalactorreplication)
