### PR TITLE
feat(seer-infra-telemetry): Make GCP integration settings editable and re-verify on change

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import logging
+from typing import Any
+
+from django.utils import timezone
 from rest_framework.fields import CharField, ListField
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,10 +22,15 @@ from sentry.api.serializers.rest_framework.base import (
     convert_dict_key_case,
     snake_to_camel_case,
 )
-from sentry.integrations.gcp.client import verify_gcp_connection
+from sentry.constants import ObjectStatus
+from sentry.integrations.gcp.client import GcpVerifyConnectionResult, verify_gcp_connection
+from sentry.integrations.gcp.utils import resolve_project_error_detail
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import IntegrationError
+
+logger = logging.getLogger(__name__)
 
 
 class GcpVerifyConnectionSerializer(CamelSnakeSerializer["GcpVerifyConnectionSerializer"]):
@@ -48,6 +57,51 @@ class GcpVerifyConnectionResponseSerializer(Serializer[dict[str, object]]):
     connection_status = CharField()
     projects = GcpVerifyConnectionProjectResultSerializer(many=True)
     error_detail = CharField(required=False, allow_null=True)
+
+
+def _record_verification_result(
+    organization: Organization,
+    verified: dict[str, Any],
+    result: GcpVerifyConnectionResult,
+) -> None:
+    ctx = integration_service.organization_context(
+        organization_id=organization.id,
+        provider=IntegrationProviderSlug.GCP.value,
+    )
+    integration = ctx.integration
+    org_integration = ctx.organization_integration
+    if (
+        integration is None
+        or org_integration is None
+        or integration.status != ObjectStatus.ACTIVE
+        or org_integration.status != ObjectStatus.ACTIVE
+    ):
+        return
+
+    # Only record a result that describes what is currently stored, so a stale caller
+    # cannot overwrite the status with results for settings that have since changed.
+    config = org_integration.config or {}
+    if config.get("customer_sa_email") != verified["customer_sa_email"]:
+        return
+    if set(config.get("projects", [])) != set(verified["gcp_project_ids"]):
+        return
+
+    integration_service.update_organization_integration(
+        org_integration_id=org_integration.id,
+        config={
+            **config,
+            "connection_status": result["connection_status"],
+            "project_statuses": [
+                {
+                    "gcp_project_id": project["gcp_project_id"],
+                    "connection_status": project["connection_status"],
+                    "error_detail": project.get("error_detail"),
+                }
+                for project in result["projects"]
+            ],
+            "last_verified_at": timezone.now().isoformat(),
+        },
+    )
 
 
 @cell_silo_endpoint
@@ -85,6 +139,17 @@ class OrganizationMonitoringProviderVerifyConnectionEndpoint(OrganizationEndpoin
             )
         except IntegrationError as exc:
             return Response({"detail": str(exc)}, status=502)
+
+        for project in result["projects"]:
+            project["error_detail"] = resolve_project_error_detail(project)
+
+        try:
+            _record_verification_result(organization, data, result)
+        except Exception:
+            logger.exception(
+                "gcp.verify_connection_record_failed",
+                extra={"organization_id": organization.id},
+            )
 
         response_serializer = GcpVerifyConnectionResponseSerializer(data=result)
         if not response_serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from django.utils import timezone
@@ -23,7 +24,7 @@ from sentry.api.serializers.rest_framework.base import (
     snake_to_camel_case,
 )
 from sentry.constants import ObjectStatus
-from sentry.integrations.gcp.client import GcpVerifyConnectionResult, verify_gcp_connection
+from sentry.integrations.gcp.client import verify_gcp_connection
 from sentry.integrations.gcp.utils import resolve_project_error_detail
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
@@ -62,7 +63,7 @@ class GcpVerifyConnectionResponseSerializer(Serializer[dict[str, object]]):
 def _record_verification_result(
     organization: Organization,
     verified: dict[str, Any],
-    result: GcpVerifyConnectionResult,
+    result: Mapping[str, Any],
 ) -> None:
     ctx = integration_service.organization_context(
         organization_id=organization.id,
@@ -140,17 +141,6 @@ class OrganizationMonitoringProviderVerifyConnectionEndpoint(OrganizationEndpoin
         except IntegrationError as exc:
             return Response({"detail": str(exc)}, status=502)
 
-        for project in result["projects"]:
-            project["error_detail"] = resolve_project_error_detail(project)
-
-        try:
-            _record_verification_result(organization, data, result)
-        except Exception:
-            logger.exception(
-                "gcp.verify_connection_record_failed",
-                extra={"organization_id": organization.id},
-            )
-
         response_serializer = GcpVerifyConnectionResponseSerializer(data=result)
         if not response_serializer.is_valid():
             return Response(
@@ -158,6 +148,16 @@ class OrganizationMonitoringProviderVerifyConnectionEndpoint(OrganizationEndpoin
                 status=502,
             )
 
-        return Response(
-            convert_dict_key_case(response_serializer.validated_data, snake_to_camel_case)
-        )
+        verified_result = response_serializer.validated_data
+        for project in verified_result["projects"]:
+            project["error_detail"] = resolve_project_error_detail(project)
+
+        try:
+            _record_verification_result(organization, data, verified_result)
+        except Exception:
+            logger.exception(
+                "gcp.verify_connection_record_failed",
+                extra={"organization_id": organization.id},
+            )
+
+        return Response(convert_dict_key_case(verified_result, snake_to_camel_case))

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -266,7 +266,7 @@ class GcpIntegration(IntegrationInstallation):
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         config = self.gcp_config
-        if config is None:
+        if config is None or not config.get("projects"):
             raise IntegrationConfigurationError("GCP integration is not configured.")
 
         new_config: GcpConfig = cast(GcpConfig, dict(config))

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -280,7 +280,7 @@ class GcpIntegration(IntegrationInstallation):
 
         if "projects" in data:
             projects = parse_gcp_project_ids(data["projects"])
-            if projects != config.get("projects"):
+            if set(projects) != set(config.get("projects", [])):
                 new_config["projects"] = projects
                 changed = True
 

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -22,7 +22,13 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.gcp.client import delete_sentry_sa, generate_sentry_sa
-from sentry.integrations.gcp.utils import GCP_MCP_URLS, validate_gcp_project_id
+from sentry.integrations.gcp.utils import (
+    GCP_MCP_URLS,
+    GCP_STATUS_UNVERIFIED,
+    parse_customer_sa_email,
+    parse_gcp_project_ids,
+    validate_gcp_project_id,
+)
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
@@ -222,8 +228,8 @@ class GcpIntegration(IntegrationInstallation):
                 "type": "string",
                 "label": _("Sentry Service Account"),
                 "help": _(
-                    "Auto-generated service account in the sentry-connectors project. "
-                    "Your customer SA must grant this account the "
+                    "A service account that Sentry has auto-generated for you. "
+                    "Your service account must grant this account the "
                     "roles/iam.serviceAccountTokenCreator role."
                 ),
                 "disabled": True,
@@ -234,19 +240,17 @@ class GcpIntegration(IntegrationInstallation):
                 "type": "string",
                 "label": _("Customer Service Account"),
                 "help": _(
-                    "Your GCP service account that the Sentry SA impersonates. "
-                    "It must have viewer roles on the configured projects."
+                    "Your GCP service account that the Sentry service account impersonates. "
+                    "It must have viewer roles on the connected projects."
                 ),
-                "disabled": True,
-                "disabledReason": _("To update, uninstall and re-install the integration."),
+                "required": True,
             },
             {
                 "name": "projects",
                 "type": "string",
                 "label": _("GCP Project IDs"),
-                "help": _("Comma-separated list of GCP project IDs."),
-                "disabled": True,
-                "disabledReason": _("To update, uninstall and re-install the integration."),
+                "help": _("Comma-separated list of IDs for connected GCP projects."),
+                "required": True,
             },
         ]
 
@@ -261,7 +265,43 @@ class GcpIntegration(IntegrationInstallation):
         }
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
-        pass
+        config = self.gcp_config
+        if config is None:
+            raise IntegrationConfigurationError("GCP integration is not configured.")
+
+        new_config: GcpConfig = cast(GcpConfig, dict(config))
+        changed = False
+
+        if "customer_sa_email" in data:
+            customer_sa_email = parse_customer_sa_email(data["customer_sa_email"])
+            if customer_sa_email != config.get("customer_sa_email"):
+                new_config["customer_sa_email"] = customer_sa_email
+                changed = True
+
+        if "projects" in data:
+            projects = parse_gcp_project_ids(data["projects"])
+            if projects != config.get("projects"):
+                new_config["projects"] = projects
+                changed = True
+
+        if not changed:
+            return
+
+        new_config["connection_status"] = GCP_STATUS_UNVERIFIED
+        new_config["project_statuses"] = [
+            {
+                "gcp_project_id": project_id,
+                "connection_status": GCP_STATUS_UNVERIFIED,
+                "error_detail": None,
+            }
+            for project_id in new_config["projects"]
+        ]
+        new_config["last_verified_at"] = None
+
+        integration_service.update_organization_integration(
+            org_integration_id=self.org_integration.id,
+            config=dict(new_config),
+        )
 
     def get_client(self) -> Any:
         raise NotImplementedError

--- a/src/sentry/integrations/gcp/utils.py
+++ b/src/sentry/integrations/gcp/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
+from typing import Any
 
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
@@ -12,6 +14,12 @@ GCP_MCP_URLS: tuple[str, ...] = (
     "https://cloudtrace.googleapis.com/mcp",
 )
 
+GCP_SERVICE_LABELS: Mapping[str, str] = {
+    "logging": "Cloud Logging",
+    "monitoring": "Cloud Monitoring",
+    "cloudtrace": "Cloud Trace",
+}
+
 # Connection statuses returned by Seer's GCP verification endpoint. Mirrors
 # ConnectionStatus in seer/automation/agent/mcp/gcp_verification.py.
 GCP_CONNECTION_STATUSES: tuple[str, ...] = (
@@ -22,6 +30,10 @@ GCP_CONNECTION_STATUSES: tuple[str, ...] = (
     "error",
 )
 
+GCP_STATUS_UNVERIFIED = "unverified"
+
+MAX_CUSTOMER_SA_EMAIL_LENGTH = 255
+
 
 def validate_gcp_project_id(project_id: str) -> None:
     if not GCP_PROJECT_ID_RE.match(project_id):
@@ -29,3 +41,54 @@ def validate_gcp_project_id(project_id: str) -> None:
             "Invalid GCP project ID. Must be 6-30 characters: lowercase letters, "
             "digits, and hyphens. Must start with a letter and cannot end with a hyphen."
         )
+
+
+def parse_gcp_project_ids(value: Any) -> list[str]:
+    if isinstance(value, str):
+        raw: list[Any] = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        raw = list(value)
+    else:
+        raise IntegrationConfigurationError(
+            "GCP project IDs must be a comma-separated list of project IDs."
+        )
+
+    project_ids = list(dict.fromkeys(str(item).strip() for item in raw if str(item).strip()))
+    if not project_ids:
+        raise IntegrationConfigurationError("At least one GCP project ID is required.")
+
+    for project_id in project_ids:
+        validate_gcp_project_id(project_id)
+
+    return project_ids
+
+
+def parse_customer_sa_email(value: Any) -> str:
+    email = str(value or "").strip()
+    if not email:
+        raise IntegrationConfigurationError("A service account email is required.")
+    if len(email) > MAX_CUSTOMER_SA_EMAIL_LENGTH:
+        raise IntegrationConfigurationError(
+            f"Service account email must be at most {MAX_CUSTOMER_SA_EMAIL_LENGTH} characters."
+        )
+    return email
+
+
+def resolve_project_error_detail(project: Mapping[str, Any]) -> str | None:
+    existing = project.get("error_detail")
+    if existing:
+        return str(existing)
+
+    failed = [
+        service for service in project.get("services", []) if service.get("status") != "connected"
+    ]
+    if not failed:
+        return None
+
+    return "; ".join(
+        "{label}: {detail}".format(
+            label=GCP_SERVICE_LABELS.get(service.get("service", ""), service.get("service", "")),
+            detail=service.get("error_detail") or "Unknown error",
+        )
+        for service in failed
+    )

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
@@ -1,16 +1,43 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode_of
 
 _PATCH_VERIFY = (
     "sentry.api.endpoints.organization_monitoring_provider_verify_connection.verify_gcp_connection"
 )
 _PATCH_SA_EMAIL = "sentry.api.endpoints.organization_monitoring_provider_verify_connection.integration_service.get_gcp_service_account_email"
 
-_SA_EMAIL = "sa@sentry-connectors.iam.gserviceaccount.com"
+_SENTRY_SA = "sa@sentry-connectors.iam.gserviceaccount.com"
+_CUSTOMER_SA = "cust@customer.iam.gserviceaccount.com"
+
+
+def _denied_result(project_id: str = "proj-a") -> dict[str, Any]:
+    return {
+        "connection_status": "permission_denied",
+        "projects": [
+            {
+                "gcp_project_id": project_id,
+                "connection_status": "permission_denied",
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                    {
+                        "service": "cloudtrace",
+                        "status": "permission_denied",
+                        "error_detail": "IAM roles not granted",
+                    },
+                ],
+                "error_detail": None,
+            }
+        ],
+        "error_detail": None,
+    }
 
 
 class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
@@ -21,6 +48,41 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         super().setUp()
         self.login_as(self.user)
 
+    def _install(
+        self, *, projects: list[str] | None = None, customer_sa: str = _CUSTOMER_SA
+    ) -> Integration:
+        project_ids = projects or ["proj-a"]
+        return self.create_integration(
+            organization=self.organization,
+            provider="gcp",
+            external_id=str(self.organization.id),
+            name="Google Cloud Platform",
+            metadata={},
+            oi_params={
+                "config": {
+                    "sentry_sa_email": _SENTRY_SA,
+                    "customer_sa_email": customer_sa,
+                    "projects": project_ids,
+                    "connection_status": "unverified",
+                    "project_statuses": [
+                        {
+                            "gcp_project_id": project_id,
+                            "connection_status": "unverified",
+                            "error_detail": None,
+                        }
+                        for project_id in project_ids
+                    ],
+                    "last_verified_at": None,
+                }
+            },
+        )
+
+    def _config(self) -> dict[str, Any]:
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
+        assert isinstance(oi.config, dict)
+        return oi.config
+
     def test_requires_feature_flag(self) -> None:
         response = self.get_response(
             self.organization.slug,
@@ -29,7 +91,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         )
         assert response.status_code == 404
 
-    @patch(_PATCH_SA_EMAIL, return_value=_SA_EMAIL)
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY)
     def test_successful_verification(
         self, mock_verify: MagicMock, mock_sa_email: MagicMock
@@ -66,12 +128,12 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert "internalDetail" not in response.data
         mock_sa_email.assert_called_once_with(organization_id=self.organization.id)
         mock_verify.assert_called_once_with(
-            sentry_sa_email=_SA_EMAIL,
+            sentry_sa_email=_SENTRY_SA,
             customer_sa_email="cust@customer.iam.gserviceaccount.com",
             gcp_project_ids=["proj-a"],
         )
 
-    @patch(_PATCH_SA_EMAIL, return_value=_SA_EMAIL)
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(
         _PATCH_VERIFY,
         return_value={
@@ -107,7 +169,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert response.data["projects"][0]["connectionStatus"] == "new_status"
         assert response.data["projects"][0]["services"][0]["status"] == "new_status"
 
-    @patch(_PATCH_SA_EMAIL, return_value=_SA_EMAIL)
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY, side_effect=IntegrationError("Failed to verify GCP connection."))
     def test_seer_error_returns_502(self, mock_verify: MagicMock, mock_sa_email: MagicMock) -> None:
         with self.feature("organizations:seer-infra-telemetry"):
@@ -120,7 +182,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert response.status_code == 502
         assert "Failed to verify GCP connection" in response.data["detail"]
 
-    @patch(_PATCH_SA_EMAIL, return_value=_SA_EMAIL)
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(
         _PATCH_VERIFY,
         return_value={
@@ -149,7 +211,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert "customerSaEmail" in response.data
         assert "gcpProjectIds" in response.data
 
-    @patch(_PATCH_SA_EMAIL, return_value=_SA_EMAIL)
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     def test_empty_project_ids_rejected(self, mock_sa_email: MagicMock) -> None:
         with self.feature("organizations:seer-infra-telemetry"):
             response = self.get_response(
@@ -172,7 +234,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert response.status_code == 404
         assert "No GCP service account" in response.data["detail"]
 
-    @patch(_PATCH_SA_EMAIL, return_value=_SA_EMAIL)
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY)
     def test_ignores_sentry_sa_email_from_request_body(
         self, mock_verify: MagicMock, mock_sa_email: MagicMock
@@ -192,7 +254,68 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
             )
 
         mock_verify.assert_called_once_with(
-            sentry_sa_email=_SA_EMAIL,
+            sentry_sa_email=_SENTRY_SA,
             customer_sa_email="cust@customer.iam.gserviceaccount.com",
             gcp_project_ids=["proj-a"],
         )
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(_PATCH_VERIFY, return_value=_denied_result())
+    def test_records_result_on_the_installed_integration(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install()
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            response = self.get_success_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a"],
+            )
+
+        assert response.data["projects"][0]["errorDetail"] == ("Cloud Trace: IAM roles not granted")
+
+        config = self._config()
+        assert config["connection_status"] == "permission_denied"
+        assert config["project_statuses"] == [
+            {
+                "gcp_project_id": "proj-a",
+                "connection_status": "permission_denied",
+                "error_detail": "Cloud Trace: IAM roles not granted",
+            }
+        ]
+        assert config["last_verified_at"] is not None
+        assert config["customer_sa_email"] == _CUSTOMER_SA
+        assert config["sentry_sa_email"] == _SENTRY_SA
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(_PATCH_VERIFY, return_value=_denied_result())
+    def test_skips_recording_when_the_sa_email_is_stale(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install(customer_sa="current@customer.iam.gserviceaccount.com")
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            self.get_success_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a"],
+            )
+
+        assert self._config()["connection_status"] == "unverified"
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(_PATCH_VERIFY, return_value=_denied_result())
+    def test_skips_recording_when_the_project_set_is_stale(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install(projects=["proj-a", "proj-b"])
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            self.get_success_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a"],
+            )
+
+        assert self._config()["connection_status"] == "unverified"

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
@@ -289,6 +289,52 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         assert config["sentry_sa_email"] == _SENTRY_SA
 
     @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(
+        _PATCH_VERIFY,
+        return_value={
+            "connection_status": "connected",
+            "projects": [
+                {
+                    "gcp_project_id": "proj-a",
+                    "connection_status": "connected",
+                    "services": [
+                        {"service": "logging", "status": "connected", "error_detail": None},
+                        {"service": "monitoring", "status": "connected", "error_detail": None},
+                        {"service": "cloudtrace", "status": "connected", "error_detail": None},
+                    ],
+                    "error_detail": None,
+                }
+            ],
+            "error_detail": None,
+        },
+    )
+    def test_records_a_connected_result(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install()
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            response = self.get_success_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a"],
+            )
+
+        assert response.data["connectionStatus"] == "connected"
+        assert response.data["projects"][0]["errorDetail"] is None
+
+        config = self._config()
+        assert config["connection_status"] == "connected"
+        assert config["project_statuses"] == [
+            {
+                "gcp_project_id": "proj-a",
+                "connection_status": "connected",
+                "error_detail": None,
+            }
+        ]
+        assert config["last_verified_at"] is not None
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY, return_value=_denied_result())
     def test_skips_recording_when_the_sa_email_is_stale(
         self, mock_verify: MagicMock, mock_sa_email: MagicMock

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -604,6 +604,29 @@ class GcpIntegrationTest(TestCase):
         ]
         assert config["connection_status"] == GCP_STATUS_UNVERIFIED
 
+    def test_update_config_reordering_projects_is_not_a_change(self) -> None:
+        installation = self._create_installed_integration(
+            projects=["project-prod", "project-staging"]
+        )
+
+        installation.update_organization_config({"projects": "project-staging, project-prod"})
+
+        config = self._stored_config()
+        assert config["projects"] == ["project-prod", "project-staging"]
+        assert config["connection_status"] == "connected"
+        assert config["last_verified_at"] == "2026-08-01T00:00:00+00:00"
+
+    def test_update_config_changing_the_project_set_marks_unverified(self) -> None:
+        installation = self._create_installed_integration(
+            projects=["project-prod", "project-staging"]
+        )
+
+        installation.update_organization_config({"projects": "project-staging, project-new"})
+
+        config = self._stored_config()
+        assert config["connection_status"] == GCP_STATUS_UNVERIFIED
+        assert config["last_verified_at"] is None
+
     def test_update_config_rejects_invalid_project_id(self) -> None:
         installation = self._create_installed_integration()
 

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -16,7 +16,13 @@ from sentry.integrations.gcp.integration import (
     GcpVerificationApiStep,
     GcpVerificationInputSerializer,
 )
-from sentry.integrations.gcp.utils import validate_gcp_project_id
+from sentry.integrations.gcp.utils import (
+    GCP_STATUS_UNVERIFIED,
+    parse_customer_sa_email,
+    parse_gcp_project_ids,
+    resolve_project_error_detail,
+    validate_gcp_project_id,
+)
 from sentry.integrations.models.gcp_service_account import GcpServiceAccount
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.pipeline.types import PipelineStepAction, PipelineStepResult
@@ -69,12 +75,27 @@ class GcpIntegrationTest(TestCase):
         }
 
     def _create_installed_integration(
-        self, *, sa_email: str = _SA_EMAIL, projects: list[str] | None = None
+        self,
+        *,
+        sa_email: str = _SA_EMAIL,
+        projects: list[str] | None = None,
+        connection_status: str = "connected",
     ) -> GcpIntegration:
+        project_ids = projects or ["my-gcp-project"]
         gcp_config = {
             "sentry_sa_email": sa_email,
             "customer_sa_email": _CUSTOMER_SA,
-            "projects": projects or ["my-gcp-project"],
+            "projects": project_ids,
+            "connection_status": connection_status,
+            "project_statuses": [
+                {
+                    "gcp_project_id": project_id,
+                    "connection_status": connection_status,
+                    "error_detail": None,
+                }
+                for project_id in project_ids
+            ],
+            "last_verified_at": "2026-08-01T00:00:00+00:00",
         }
         integration = self.create_integration(
             organization=self.organization,
@@ -543,27 +564,107 @@ class GcpIntegrationTest(TestCase):
         assert isinstance(installation, GcpIntegration)
         assert installation.gcp_config is None
 
-    # -- Config immutability --
+    # -- Editing integration configuration --
 
-    def test_update_organization_config_is_noop(self) -> None:
-        installation = self._create_installed_integration()
-
-        installation.update_organization_config({"sentry_sa_email": "evil@attacker.com"})
-
+    def _stored_config(self) -> dict[str, Any]:
         oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
-        assert oi.config["sentry_sa_email"] == _SA_EMAIL
-        assert oi.config["customer_sa_email"] == _CUSTOMER_SA
-        assert oi.config["projects"] == ["my-gcp-project"]
+        assert isinstance(oi.config, dict)
+        return oi.config
 
-    def test_get_organization_config_returns_disabled_fields(self) -> None:
+    def test_update_config_changes_customer_sa_email_and_marks_unverified(self) -> None:
         installation = self._create_installed_integration()
-        fields = installation.get_organization_config()
 
-        assert len(fields) == 3
-        names = [f["name"] for f in fields]
-        assert names == ["sentry_sa_email", "customer_sa_email", "projects"]
-        for field in fields:
-            assert field["disabled"] is True
+        installation.update_organization_config({"customer_sa_email": "new@customer.com"})
+
+        config = self._stored_config()
+        assert config["customer_sa_email"] == "new@customer.com"
+        assert config["sentry_sa_email"] == _SA_EMAIL
+        assert config["connection_status"] == GCP_STATUS_UNVERIFIED
+        assert config["last_verified_at"] is None
+        assert config["project_statuses"] == [
+            {
+                "gcp_project_id": "my-gcp-project",
+                "connection_status": GCP_STATUS_UNVERIFIED,
+                "error_detail": None,
+            }
+        ]
+
+    def test_update_config_parses_dedupes_and_trims_projects(self) -> None:
+        installation = self._create_installed_integration()
+
+        installation.update_organization_config(
+            {"projects": " project-prod , project-staging ,project-prod"}
+        )
+
+        config = self._stored_config()
+        assert config["projects"] == ["project-prod", "project-staging"]
+        assert [p["gcp_project_id"] for p in config["project_statuses"]] == [
+            "project-prod",
+            "project-staging",
+        ]
+        assert config["connection_status"] == GCP_STATUS_UNVERIFIED
+
+    def test_update_config_rejects_invalid_project_id(self) -> None:
+        installation = self._create_installed_integration()
+
+        with pytest.raises(IntegrationConfigurationError, match="Invalid GCP project ID"):
+            installation.update_organization_config({"projects": "INVALID"})
+
+        assert self._stored_config()["projects"] == ["my-gcp-project"]
+
+    def test_update_config_rejects_empty_projects(self) -> None:
+        installation = self._create_installed_integration()
+
+        with pytest.raises(IntegrationConfigurationError, match="At least one GCP project ID"):
+            installation.update_organization_config({"projects": "  ,  "})
+
+    def test_update_config_rejects_empty_customer_sa_email(self) -> None:
+        installation = self._create_installed_integration()
+
+        with pytest.raises(IntegrationConfigurationError, match="is required"):
+            installation.update_organization_config({"customer_sa_email": "   "})
+
+        assert self._stored_config()["customer_sa_email"] == _CUSTOMER_SA
+
+    def test_update_config_ignores_sentry_sa_email(self) -> None:
+        installation = self._create_installed_integration()
+        installation.update_organization_config(
+            {
+                "sentry_sa_email": "evil@attacker.iam.gserviceaccount.com",
+                "customer_sa_email": "new@customer.com",
+            }
+        )
+        assert self._stored_config()["sentry_sa_email"] == _SA_EMAIL
+
+    def test_update_config_noop_when_nothing_changed(self) -> None:
+        installation = self._create_installed_integration()
+        installation.update_organization_config(
+            {"customer_sa_email": _CUSTOMER_SA, "projects": "my-gcp-project"}
+        )
+
+        config = self._stored_config()
+        assert config["connection_status"] == "connected"
+        assert config["last_verified_at"] == "2026-08-01T00:00:00+00:00"
+
+    def test_update_config_requires_existing_config(self) -> None:
+        self._create_installed_integration()
+        oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
+        oi.update(config={})
+
+        installation = oi.integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, GcpIntegration)
+
+        with pytest.raises(IntegrationConfigurationError, match="not configured"):
+            installation.update_organization_config({"customer_sa_email": "new@customer.com"})
+
+    def test_get_organization_config_only_locks_the_sentry_sa(self) -> None:
+        installation = self._create_installed_integration()
+        fields = {f["name"]: f for f in installation.get_organization_config()}
+
+        assert list(fields) == ["sentry_sa_email", "customer_sa_email", "projects"]
+        assert fields["sentry_sa_email"]["disabled"] is True
+        assert "disabled" not in fields["customer_sa_email"]
+        assert "disabled" not in fields["projects"]
 
     def test_get_config_data_flattens_projects(self) -> None:
         installation = self._create_installed_integration(
@@ -659,6 +760,82 @@ class GcpIntegrationTest(TestCase):
             "my-cool-project-name-here-12",
         ]:
             validate_gcp_project_id(project_id)
+
+    def test_parse_gcp_project_ids_accepts_a_list(self) -> None:
+        assert parse_gcp_project_ids(["project-a", "project-b"]) == ["project-a", "project-b"]
+
+    def test_parse_gcp_project_ids_rejects_unusable_input(self) -> None:
+        with pytest.raises(IntegrationConfigurationError, match="comma-separated list"):
+            parse_gcp_project_ids(42)
+
+    def test_parse_customer_sa_email_trims(self) -> None:
+        assert parse_customer_sa_email("  cust@customer.com  ") == "cust@customer.com"
+
+    def test_parse_customer_sa_email_requires_a_value(self) -> None:
+        with pytest.raises(IntegrationConfigurationError, match="is required"):
+            parse_customer_sa_email("   ")
+
+    def test_parse_customer_sa_email_rejects_overlong_values(self) -> None:
+        with pytest.raises(IntegrationConfigurationError, match="at most"):
+            parse_customer_sa_email("a" * 250 + "@customer.com")
+
+    def test_resolve_project_error_detail_prefers_the_project_level_message(self) -> None:
+        detail = resolve_project_error_detail(
+            {
+                "gcp_project_id": "project-a",
+                "connection_status": "permission_denied",
+                "error_detail": "SA impersonation chain failed",
+                "services": [
+                    {"service": "logging", "status": "permission_denied", "error_detail": "nope"}
+                ],
+            }
+        )
+        assert detail == "SA impersonation chain failed"
+
+    def test_resolve_project_error_detail_rolls_up_failing_services(self) -> None:
+        detail = resolve_project_error_detail(
+            {
+                "gcp_project_id": "project-a",
+                "connection_status": "error",
+                "error_detail": None,
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                    {
+                        "service": "monitoring",
+                        "status": "api_disabled",
+                        "error_detail": "API is disabled",
+                    },
+                    {
+                        "service": "cloudtrace",
+                        "status": "project_not_found",
+                        "error_detail": "Project not found",
+                    },
+                ],
+            }
+        )
+        assert detail == ("Cloud Monitoring: API is disabled; Cloud Trace: Project not found")
+
+    def test_resolve_project_error_detail_handles_unknown_service(self) -> None:
+        detail = resolve_project_error_detail(
+            {
+                "gcp_project_id": "project-a",
+                "connection_status": "error",
+                "error_detail": None,
+                "services": [{"service": "brand-new", "status": "error", "error_detail": None}],
+            }
+        )
+        assert detail == "brand-new: Unknown error"
+
+    def test_resolve_project_error_detail_is_none_when_connected(self) -> None:
+        detail = resolve_project_error_detail(
+            {
+                "gcp_project_id": "project-a",
+                "connection_status": "connected",
+                "error_detail": None,
+                "services": [{"service": "logging", "status": "connected", "error_detail": None}],
+            }
+        )
+        assert detail is None
 
     def test_validate_gcp_project_id_rejects_invalid_ids(self) -> None:
         for project_id in [


### PR DESCRIPTION
PR 1 for https://linear.app/getsentry/issue/CW-1981/make-gcp-integration-settings-fields-writable-and-re-verify-on-change.

Changing the customer service account email or connected project IDs previously required uninstalling and reinstalling the integration. Now that verification runs during setup, those two fields are editable. `sentry_sa_email` stays read-only since Sentry auto-generates and manages this.

The cell-side `verify-connection` endpoint now records its result on the integration.

The follow-up frontend PR will add the post-save trigger and render the integration status.