### PR TITLE
feat(seer-infra-telemetry): Re-verify GCP connection after configuration changes from frontend

### DIFF
--- a/static/app/components/pipeline/integrationGcp/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.spec.tsx
@@ -169,6 +169,7 @@ describe('GcpVerificationStep', () => {
       {
         gcpProjectId: 'my-project-prod',
         connectionStatus: 'permission_denied',
+        errorDetail: 'Cloud Trace: IAM roles not granted',
         services: [
           {service: 'logging', status: 'connected'},
           {
@@ -301,7 +302,6 @@ describe('GcpVerificationStep', () => {
 
     await userEvent.click(await screen.findByRole('button', {name: 'Continue Anyway'}));
 
-    // Seer reports the actionable message per service, not per project.
     expect(advance).toHaveBeenCalledWith({
       connectionStatus: 'permission_denied',
       projects: [
@@ -314,49 +314,7 @@ describe('GcpVerificationStep', () => {
     });
   });
 
-  it('rolls several failing services into one detail', async () => {
-    MockApiClient.addMockResponse({
-      url: VERIFY_URL,
-      method: 'POST',
-      body: {
-        connectionStatus: 'error',
-        projects: [
-          {
-            gcpProjectId: 'my-project-prod',
-            connectionStatus: 'error',
-            services: [
-              {service: 'logging', status: 'connected'},
-              {
-                service: 'monitoring',
-                status: 'api_disabled',
-                errorDetail: 'Cloud Monitoring API is disabled',
-              },
-              {service: 'cloudtrace', status: 'project_not_found'},
-            ],
-          },
-        ],
-      },
-    });
-    const advance = jest.fn();
-
-    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
-
-    await userEvent.click(await screen.findByRole('button', {name: 'Continue Anyway'}));
-
-    expect(advance).toHaveBeenCalledWith({
-      connectionStatus: 'error',
-      projects: [
-        {
-          gcpProjectId: 'my-project-prod',
-          connectionStatus: 'error',
-          errorDetail:
-            'Cloud Monitoring: Cloud Monitoring API is disabled; Cloud Trace: Project not found',
-        },
-      ],
-    });
-  });
-
-  it('keeps the project-level detail when the impersonation chain fails', async () => {
+  it('forwards a project detail with no failing services of its own', async () => {
     MockApiClient.addMockResponse({
       url: VERIFY_URL,
       method: 'POST',

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -30,7 +30,6 @@ import type {
 import {
   describeService,
   getFailedServices,
-  getProjectErrorDetail,
   getStatusLabel,
   getStatusVariant,
 } from 'sentry/utils/seer/gcpConnection';
@@ -285,7 +284,7 @@ function GcpVerificationStep({
         projects: result.projects.map(project => ({
           gcpProjectId: project.gcpProjectId,
           connectionStatus: project.connectionStatus,
-          errorDetail: getProjectErrorDetail(project),
+          errorDetail: project.errorDetail ?? null,
         })),
       });
       return;

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -10,11 +10,12 @@ import {unreachable} from 'sentry/utils/unreachable';
  */
 const GCP_STATUS_VARIANTS = {
   connected: 'success',
+  unverified: 'muted',
   permission_denied: 'danger',
   api_disabled: 'warning',
   project_not_found: 'danger',
   error: 'danger',
-} as const satisfies Record<string, 'success' | 'warning' | 'danger'>;
+} as const satisfies Record<string, 'success' | 'muted' | 'warning' | 'danger'>;
 
 type GcpConnectionStatus = keyof typeof GCP_STATUS_VARIANTS;
 
@@ -70,6 +71,8 @@ export function getStatusLabel(status: string): string {
   switch (status) {
     case 'connected':
       return t('Connected');
+    case 'unverified':
+      return t('Not verified');
     case 'permission_denied':
       return t('Permission denied');
     case 'api_disabled':
@@ -106,13 +109,13 @@ export function describeService(service: GcpServiceResult): string {
   }`;
 }
 
-export function getProjectErrorDetail(project: GcpProjectResult): string | null {
-  if (project.errorDetail) {
-    return project.errorDetail;
-  }
-  const failed = getFailedServices(project);
-  if (failed.length === 0) {
-    return null;
-  }
-  return failed.map(describeService).join('; ');
+export function parseGcpProjectIds(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map(id => id.trim())
+        .filter(Boolean)
+    ),
+  ];
 }

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -380,3 +380,108 @@ describe('ConfigureIntegration mapping removals', () => {
     );
   });
 });
+
+describe('ConfigureIntegration GCP re-verification', () => {
+  const integrationId = '1';
+  const CUSTOMER_SA = 'gcp-sentry@my-project.iam.gserviceaccount.com';
+
+  function setup({providerKey = 'gcp'}: {providerKey?: string} = {}) {
+    const organization = OrganizationFixture({
+      access: ['org:integrations', 'org:write'],
+    });
+    const provider = GitHubIntegrationProviderFixture({
+      key: providerKey,
+      slug: providerKey,
+      name: 'Google Cloud Platform',
+      features: [],
+    });
+    const integration = OrganizationIntegrationsFixture({
+      id: integrationId,
+      provider: {
+        ...OrganizationIntegrationsFixture().provider,
+        key: providerKey,
+        slug: providerKey,
+        name: provider.name,
+        features: [],
+      },
+      configOrganization: [
+        {
+          name: 'customer_sa_email',
+          type: 'string' as const,
+          label: 'Customer Service Account',
+          required: true,
+        },
+      ],
+      configData: {
+        customer_sa_email: CUSTOMER_SA,
+        projects: 'project-prod, project-staging',
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      body: {providers: [provider]},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/`,
+      body: integration,
+    });
+    const saveRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${integrationId}/`,
+      method: 'POST',
+      body: {},
+    });
+    const verifyRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/monitoring-providers/gcp/verify-connection/`,
+      method: 'POST',
+      body: {connectionStatus: 'connected', projects: []},
+    });
+
+    render(<ConfigureIntegration />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organization.slug}/integrations/${providerKey}/${integrationId}/`,
+          query: {},
+        },
+        route: '/settings/:orgId/integrations/:providerKey/:integrationId/',
+      },
+    });
+
+    return {saveRequest, verifyRequest};
+  }
+
+  async function saveNewSaEmail(value: string) {
+    const field = await screen.findByRole('textbox', {name: 'Customer Service Account'});
+    await userEvent.clear(field);
+    await userEvent.type(field, value);
+    await userEvent.tab();
+  }
+
+  it('re-runs verification with the saved settings', async () => {
+    const {verifyRequest} = setup();
+
+    await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
+
+    await waitFor(() =>
+      expect(verifyRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            customerSaEmail: 'new-sa@my-project.iam.gserviceaccount.com',
+            gcpProjectIds: ['project-prod', 'project-staging'],
+          },
+        })
+      )
+    );
+  });
+
+  it('does not re-run verification for other providers', async () => {
+    const {saveRequest, verifyRequest} = setup({providerKey: 'github'});
+
+    await saveNewSaEmail('someone@example.com');
+
+    await waitFor(() => expect(saveRequest).toHaveBeenCalled());
+    expect(verifyRequest).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -418,18 +418,25 @@ describe('ConfigureIntegration GCP re-verification', () => {
       },
     });
 
+    // Stand in for the stored config, so a save is visible to the refetch that
+    // follows it — which is what the verification payload is built from.
+    let storedConfig: Record<string, unknown> = {...integration.configData};
+
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/config/integrations/`,
       body: {providers: [provider]},
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${integrationId}/`,
-      body: integration,
+      body: () => ({...integration, configData: storedConfig}),
     });
     const saveRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${integrationId}/`,
       method: 'POST',
-      body: {},
+      body: (_url: string, options: {data?: Record<string, unknown>}) => {
+        storedConfig = {...storedConfig, ...options.data};
+        return {};
+      },
     });
     const verifyRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/monitoring-providers/gcp/verify-connection/`,
@@ -448,7 +455,13 @@ describe('ConfigureIntegration GCP re-verification', () => {
       },
     });
 
-    return {saveRequest, verifyRequest};
+    return {
+      saveRequest,
+      verifyRequest,
+      setStoredConfig: (next: Record<string, unknown>) => {
+        storedConfig = {...storedConfig, ...next};
+      },
+    };
   }
 
   async function saveNewSaEmail(value: string) {
@@ -470,6 +483,27 @@ describe('ConfigureIntegration GCP re-verification', () => {
           data: {
             customerSaEmail: 'new-sa@my-project.iam.gserviceaccount.com',
             gcpProjectIds: ['project-prod', 'project-staging'],
+          },
+        })
+      )
+    );
+  });
+
+  it('builds the payload from the refetched config, not the local one', async () => {
+    const {verifyRequest, setStoredConfig} = setup();
+
+    // A sibling field was saved elsewhere, so what this render closed over is stale.
+    setStoredConfig({projects: 'project-prod, project-staging, project-new'});
+
+    await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
+
+    await waitFor(() =>
+      expect(verifyRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            customerSaEmail: 'new-sa@my-project.iam.gserviceaccount.com',
+            gcpProjectIds: ['project-prod', 'project-staging', 'project-new'],
           },
         })
       )

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import {mutationOptions, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -34,6 +35,7 @@ import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {parseGcpProjectIds} from 'sentry/utils/seer/gcpConnection';
 import {unreachable} from 'sentry/utils/unreachable';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -354,6 +356,30 @@ function ConfigureIntegration() {
       '/organizations/$organizationIdOrSlug/integrations/$integrationId/',
       {path: {organizationIdOrSlug: organization.slug, integrationId: integration.id}}
     );
+
+    const verifyGcpConnection = async (saved: Record<string, unknown>) => {
+      const savedConfig = {...integration.configData, ...saved};
+      const customerSaEmail = savedConfig.customer_sa_email;
+      const projectIds = savedConfig.projects;
+      if (typeof customerSaEmail !== 'string' || typeof projectIds !== 'string') {
+        return;
+      }
+
+      const gcpProjectIds = parseGcpProjectIds(projectIds);
+      if (!customerSaEmail || !gcpProjectIds.length) {
+        return;
+      }
+
+      await fetchMutation({
+        method: 'POST',
+        url: getApiUrl(
+          '/organizations/$organizationIdOrSlug/monitoring-providers/gcp/verify-connection/',
+          {path: {organizationIdOrSlug: organization.slug}}
+        ),
+        data: {customerSaEmail, gcpProjectIds},
+      });
+    };
+
     const integrationMutationOptions = mutationOptions({
       mutationFn: (data: Record<string, unknown>) => {
         let requestData = data;
@@ -370,7 +396,17 @@ function ConfigureIntegration() {
           data: requestData,
         });
       },
-      onSuccess: () => {
+      onSuccess: async (_data, variables) => {
+        if (provider.key === 'gcp') {
+          try {
+            await verifyGcpConnection(variables);
+          } catch (error) {
+            // The save itself succeeded; the connection stays recorded as unverified
+            // and the customer can re-test, so don't report this as a failed save.
+            Sentry.captureException(error);
+          }
+        }
+
         // it's important that we keep the mutation pending while the refetch is happening by returning it.
         // Otherwise, clicking toggles again while the invalidation is running won't do anything because they still see old defaultValues.
         // this makes the mutations seem to run longer than before. We could do optimistic updates here too, but I'm not sure it's worth the added complexity.

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -357,10 +357,16 @@ function ConfigureIntegration() {
       {path: {organizationIdOrSlug: organization.slug, integrationId: integration.id}}
     );
 
-    const verifyGcpConnection = async (saved: Record<string, unknown>) => {
-      const savedConfig = {...integration.configData, ...saved};
-      const customerSaEmail = savedConfig.customer_sa_email;
-      const projectIds = savedConfig.projects;
+    const integrationQueryOptions = organizationIntegrationApiOptions({
+      organizationSlug: organization.slug,
+      integrationId,
+    });
+
+    const verifyGcpConnection = async () => {
+      const savedConfig = queryClient.getQueryData(integrationQueryOptions.queryKey)?.json
+        .configData;
+      const customerSaEmail = savedConfig?.customer_sa_email;
+      const projectIds = savedConfig?.projects;
       if (typeof customerSaEmail !== 'string' || typeof projectIds !== 'string') {
         return;
       }
@@ -396,26 +402,21 @@ function ConfigureIntegration() {
           data: requestData,
         });
       },
-      onSuccess: async (_data, variables) => {
+      onSuccess: async () => {
+        // it's important that we keep the mutation pending while the refetch is happening by awaiting it.
+        // Otherwise, clicking toggles again while the invalidation is running won't do anything because they still see old defaultValues.
+        // this makes the mutations seem to run longer than before. We could do optimistic updates here too, but I'm not sure it's worth the added complexity.
+        await queryClient.invalidateQueries(integrationQueryOptions);
+
         if (provider.key === 'gcp') {
           try {
-            await verifyGcpConnection(variables);
+            await verifyGcpConnection();
           } catch (error) {
             // The save itself succeeded; the connection stays recorded as unverified
             // and the customer can re-test, so don't report this as a failed save.
             Sentry.captureException(error);
           }
         }
-
-        // it's important that we keep the mutation pending while the refetch is happening by returning it.
-        // Otherwise, clicking toggles again while the invalidation is running won't do anything because they still see old defaultValues.
-        // this makes the mutations seem to run longer than before. We could do optimistic updates here too, but I'm not sure it's worth the added complexity.
-        return queryClient.invalidateQueries(
-          organizationIntegrationApiOptions({
-            organizationSlug: organization.slug,
-            integrationId,
-          })
-        );
       },
     });
 


### PR DESCRIPTION
PR 2 for https://linear.app/getsentry/issue/CW-1981/make-gcp-integration-settings-fields-writable-and-re-verify-on-change.

Saving a change to the GCP integration configuration now re-posts to `verify-connection`, which records the result itself. Also drops `getProjectErrorDetail` now that the endpoint resolves the project-level detail server-side, and adds the `unverified` status to the shared status table.