### PR TITLE
ref(ui): Drop unused optional args in gsApp billing helpers

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -77,16 +77,15 @@ function toDollars(cents: number | null | undefined, decimals = 0) {
  */
 function toAnnualDollars(
   cents: number | null | undefined,
-  billingInterval: string | null | undefined,
-  decimals = 0
+  billingInterval: string | null | undefined
 ) {
   if (typeof cents !== 'number') {
     return cents;
   }
   if (billingInterval === 'monthly') {
-    return toDollars(cents * 12, decimals);
+    return toDollars(cents * 12);
   }
-  return toDollars(cents, decimals);
+  return toDollars(cents);
 }
 
 /**
@@ -101,11 +100,11 @@ function toCpeCents(dollars: number | null | undefined) {
   return parseInt(((dollars * 100) / CPE_MULTIPLIER_TO_CENTS).toFixed(0), 10);
 }
 
-function toCents(dollars: number | null | undefined, decimals = 0) {
+function toCents(dollars: number | null | undefined) {
   if (typeof dollars !== 'number') {
     return dollars;
   }
-  return parseFloat((dollars * 100).toFixed(decimals));
+  return parseFloat((dollars * 100).toFixed(0));
 }
 
 /**

--- a/static/gsApp/actionCreators/upsell.tsx
+++ b/static/gsApp/actionCreators/upsell.tsx
@@ -24,7 +24,6 @@ export async function sendReplayOnboardRequest({
 }: {
   api: Client;
   currentPlan: 'am2-beta' | 'am2-non-beta' | 'am1-beta' | 'am1-non-beta';
-  data?: Record<string, any>;
   onError?: () => void;
   onSuccess?: () => void;
   orgSlug?: Organization['slug'];
@@ -61,7 +60,6 @@ export function sendUpgradeRequest({
 }: {
   api: Client;
   organization: Organization;
-  data?: Record<string, any>;
   handleSuccess?: () => void;
   type?: string;
 }) {
@@ -105,7 +103,6 @@ export function sendAddEventsRequest({
   api: Client;
   organization: Organization;
   eventTypes?: EventType[];
-  handleSuccess?: () => void;
   notificationType?: string;
 }) {
   const endpoint = `/organizations/${organization.slug}/event-limit-increase-request/`;

--- a/static/gsApp/components/billingDetails/form.spec.tsx
+++ b/static/gsApp/components/billingDetails/form.spec.tsx
@@ -38,22 +38,10 @@ describe('BillingDetailsForm', () => {
     });
   });
 
-  it('shows billing email field when isDetailed is true', async () => {
-    render(<BillingDetailsForm {...defaultProps} isDetailed />);
+  it('shows billing email field', async () => {
+    render(<BillingDetailsForm {...defaultProps} />);
 
     await screen.findByRole('textbox', {name: 'Billing email'});
-  });
-
-  it('hides billing email field when isDetailed is false', async () => {
-    render(<BillingDetailsForm {...defaultProps} isDetailed={false} />);
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-    });
-
-    expect(
-      screen.queryByRole('textbox', {name: 'Billing email'})
-    ).not.toBeInTheDocument();
   });
 
   it('shows warning when Stripe hooks return null', async () => {
@@ -95,17 +83,9 @@ describe('BillingDetailsForm', () => {
       taxNumber: '123456789',
     });
 
-    render(
-      <BillingDetailsForm {...defaultProps} initialData={detailsWithTax} isDetailed />
-    );
+    render(<BillingDetailsForm {...defaultProps} initialData={detailsWithTax} />);
 
     await screen.findByRole('textbox', {name: /VAT Number/i});
-  });
-
-  it('renders custom submit label when provided', async () => {
-    render(<BillingDetailsForm {...defaultProps} submitLabel="Update Address" />);
-
-    await screen.findByRole('button', {name: 'Update Address'});
   });
 
   it('renders extra button when provided', async () => {

--- a/static/gsApp/components/billingDetails/form.tsx
+++ b/static/gsApp/components/billingDetails/form.tsx
@@ -49,15 +49,7 @@ type Props = {
    * Initial form data.
    */
   initialData?: BillingDetails;
-  /**
-   * Display detailed view for subscription settings.
-   */
-  isDetailed?: boolean;
   onSubmitError?: (error: any) => void;
-  /**
-   * Form submit button label.
-   */
-  submitLabel?: string;
 };
 
 type State = {
@@ -70,7 +62,6 @@ const GOOGLE_MAPS_API_KEY = ConfigStore.get('getsentry.googleMapsApiKey');
 
 function BillingDetailsFormFields({
   form,
-  isDetailed,
   initialData,
   handleStripeFormChange,
   state,
@@ -79,7 +70,6 @@ function BillingDetailsFormFields({
 }: {
   form: FormModel;
   handleStripeFormChange: (data: StripeAddressElementChangeEvent) => void;
-  isDetailed: boolean;
   onSubmitDisabled: (disabled: boolean) => void;
   state: State;
   initialData?: BillingDetails;
@@ -124,7 +114,7 @@ function BillingDetailsFormFields({
         </Alert>
       ) : (
         <Fragment>
-          {isDetailed && !stripeIsLoading && (
+          {!stripeIsLoading && (
             <CustomBillingDetailsFormField
               inputName="billingEmail"
               label={t('Billing email')}
@@ -231,8 +221,6 @@ export function BillingDetailsForm({
   onSubmitError,
   onSubmitSuccess,
   organization,
-  submitLabel,
-  isDetailed = true,
   extraButton,
   analyticsEvent,
 }: Props) {
@@ -327,7 +315,6 @@ export function BillingDetailsForm({
         model={form}
         submitDisabled={submitDisabled}
         apiEndpoint={`/customers/${organization.slug}/billing-details/`}
-        submitLabel={submitLabel}
         onSubmitSuccess={handleSubmit}
         onSubmitError={err => onSubmitError?.(err)}
         initialData={transformedInitialData}
@@ -335,7 +322,6 @@ export function BillingDetailsForm({
       >
         <BillingDetailsFormFields
           form={form}
-          isDetailed={isDetailed}
           initialData={initialData}
           handleStripeFormChange={handleStripeFormChange}
           state={state}

--- a/static/gsApp/hooks/useProductBillingMetadata.tsx
+++ b/static/gsApp/hooks/useProductBillingMetadata.tsx
@@ -73,8 +73,7 @@ const EMPTY_PRODUCT_BILLING_METADATA: ProductBillingMetadata = {
 export function useProductBillingMetadata(
   subscription: Subscription | null,
   product: DataCategory | AddOnCategory,
-  parentProduct?: DataCategory | AddOnCategory,
-  excludeProductTrials?: boolean
+  parentProduct?: DataCategory | AddOnCategory
 ): ProductBillingMetadata {
   const organization = useOrganization();
   const isAddOn = checkIsAddOn(parentProduct ?? product);
@@ -121,12 +120,14 @@ export function useProductBillingMetadata(
     isEnabled: productIsEnabled(subscription, parentProduct ?? product),
     addOnInfo,
     usageExceeded: subscription.categories[billedCategory]?.usageExceeded ?? false,
-    activeProductTrial: excludeProductTrials
-      ? null
-      : getActiveProductTrial(subscription.productTrials ?? null, billedCategory),
-    potentialProductTrial: excludeProductTrials
-      ? null
-      : getPotentialProductTrial(subscription.productTrials ?? null, billedCategory),
+    activeProductTrial: getActiveProductTrial(
+      subscription.productTrials ?? null,
+      billedCategory
+    ),
+    potentialProductTrial: getPotentialProductTrial(
+      subscription.productTrials ?? null,
+      billedCategory
+    ),
     productLink:
       organization && billedCategoryInfo
         ? billedCategoryInfo.getProductLink?.(organization)

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -215,14 +215,6 @@ describe('formatReservedWithUnits', () => {
     ).toBe('1K');
   });
 
-  it('returns correct string for reserved budget', () => {
-    expect(formatReservedWithUnits(1000, DataCategory.SPANS, {}, true)).toBe('$10.00');
-    expect(formatReservedWithUnits(1500_00, DataCategory.SPANS, {}, true)).toBe(
-      '$1,500.00'
-    );
-    expect(formatReservedWithUnits(0, DataCategory.SPANS, {}, true)).toBe('$0.00');
-  });
-
   it('returns correct string for logs', () => {
     expect(formatReservedWithUnits(0, DataCategory.LOG_BYTE)).toBe('0 GB');
     expect(formatReservedWithUnits(0.1, DataCategory.LOG_BYTE)).toBe('0.1 GB');

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1,6 +1,5 @@
 import type {PromptData} from 'sentry/actionCreators/prompts';
 import {IconBuilding, IconGroup, IconSeer, IconUser} from 'sentry/icons';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
@@ -132,7 +131,6 @@ type FormatOptions = {
  * quantities for the data categories that we sell.
  *
  * Note: reservedQuantity for Attachments should be in GIGABYTES
- * If isReservedBudget is true, the reservedQuantity is in cents
  */
 export function formatReservedWithUnits(
   reservedQuantity: number | null,
@@ -141,13 +139,8 @@ export function formatReservedWithUnits(
     isAbbreviated: false,
     useUnitScaling: false,
     isGifted: false,
-  },
-  isReservedBudget = false
-): string {
-  if (isReservedBudget) {
-    return displayPriceWithCents({cents: reservedQuantity ?? 0});
   }
-
+): string {
   const categoryInfo = getCategoryInfoFromPlural(dataCategory);
   const unitType = categoryInfo?.formatting.unitType ?? 'count';
 
@@ -530,9 +523,9 @@ export function getPlanIcon(plan: Plan) {
   return <IconUser />;
 }
 
-export function getProductIcon(product: AddOnCategory, size?: SVGIconProps['size']) {
+export function getProductIcon(product: AddOnCategory) {
   if ([AddOnCategory.LEGACY_SEER, AddOnCategory.SEER].includes(product)) {
-    return <IconSeer size={size} />;
+    return <IconSeer />;
   }
   return null;
 }

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -321,7 +321,6 @@ export function formatCategoryQuantityWithDisplayName({
   quantity,
   formattedQuantity,
   subscription,
-  planOverride,
   options,
 }: {
   dataCategory: DataCategory;
@@ -329,12 +328,11 @@ export function formatCategoryQuantityWithDisplayName({
   options: Omit<CategoryNameProps, 'category'>;
   quantity: number;
   subscription: Subscription;
-  planOverride?: Plan;
 }) {
   if (isContinuousProfiling(dataCategory)) {
     return formatWithHours(quantity, formattedQuantity, options);
   }
-  const plan = planOverride ?? subscription.planDetails;
+  const plan = subscription.planDetails;
   if (quantity === 1) {
     const displayName = getSingularCategoryName({
       plan,

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
@@ -367,8 +367,7 @@ describe('rawTrackAnalyticsEvent', () => {
     );
 
     expect(trackMarketingEvent).toHaveBeenCalledWith(
-      'Growth: Onboarding Clicked Need Help',
-      {plan: 'am1_f'}
+      'Growth: Onboarding Clicked Need Help'
     );
   });
   it('sets previous_referrer', () => {

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -250,7 +250,7 @@ export function rawTrackAnalyticsEvent(
     }
     // using the eventName for marketing event names
     if (eventName && MARKETING_EVENT_NAMES.has(eventName)) {
-      trackMarketingEvent(eventName, {plan: subscription?.plan});
+      trackMarketingEvent(eventName);
     }
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/static/gsApp/utils/trackMarketingEvent.tsx
+++ b/static/gsApp/utils/trackMarketingEvent.tsx
@@ -2,7 +2,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 
 export function trackMarketingEvent(
   event_type: string,
-  options?: {event_label?: string; plan?: string}
+  options?: {event_label?: string}
 ) {
   // quit early if analytics is disabled
   if (!ConfigStore.get('enableAnalytics')) {

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -282,7 +282,7 @@ function recordAnalytics(
   data: CheckoutAPIData,
   isMigratingPartnerAccount: boolean
 ) {
-  trackMarketingEvent('Upgrade', {plan: data.plan});
+  trackMarketingEvent('Upgrade');
   const currentData: CheckoutData = {
     plan: data.plan,
   };


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~102 LOC).

## Summary
- Remove unused optional arguments and fields under `static`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/gsAdmin/components/provisionSubscriptionAction.tsx`
- `static/gsApp/actionCreators/upsell.tsx`
- `static/gsApp/components/billingDetails/form.spec.tsx`
- `static/gsApp/components/billingDetails/form.tsx`
- `static/gsApp/hooks/useProductBillingMetadata.tsx`
- `static/gsApp/utils/billing.spec.tsx`
- `static/gsApp/utils/billing.tsx`
- `static/gsApp/utils/dataCategory.tsx`
- `static/gsApp/utils/rawTrackAnalyticsEvent.tsx`
- `static/gsApp/utils/trackMarketingEvent.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

