### PR TITLE
ref(ui): Drop unused optional args in gettingStartedDocs and app chrome

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -706,7 +706,7 @@ export const replayFrontendPlatforms: readonly PlatformKey[] = [
 ];
 
 // These are the mobile platforms that can set up replay.
-export const replayMobilePlatforms: PlatformKey[] = [
+const replayMobilePlatforms: PlatformKey[] = [
   'android',
   'apple-ios',
   'react-native',

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -706,7 +706,7 @@ export const replayFrontendPlatforms: readonly PlatformKey[] = [
 ];
 
 // These are the mobile platforms that can set up replay.
-const replayMobilePlatforms: PlatformKey[] = [
+export const replayMobilePlatforms: PlatformKey[] = [
   'android',
   'apple-ios',
   'react-native',

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -366,10 +366,8 @@ export function agentMonitoring({
   packageName = '@sentry/browser',
   clientConfigFileName,
   serverConfigFileName,
-  minVersion = MIN_REQUIRED_VERSION,
 }: {
   clientConfigFileName?: string;
-  minVersion?: string;
   packageName?: `@sentry/${string}`;
   serverConfigFileName?: string;
 } = {}): OnboardingConfig {
@@ -377,14 +375,14 @@ export function agentMonitoring({
     introduction: params => (
       <SdkUpdateAlert
         projectId={params.project.id}
-        minVersion={getMinRequiredVersion(params, minVersion)}
+        minVersion={getMinRequiredVersion(params, MIN_REQUIRED_VERSION)}
         packageName={packageName}
       />
     ),
     install: params =>
       getInstallStep(params, {
         packageName,
-        minVersion,
+        minVersion: MIN_REQUIRED_VERSION,
       }),
     configure: params => {
       const selected = getAgentIntegration(params);

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -1194,23 +1194,21 @@ const text = lastMessage.content;`,
 export const agentMonitoring = ({
   packageName = '@sentry/node',
   configFileName,
-  minVersion = MIN_REQUIRED_VERSION,
 }: {
   configFileName?: string;
-  minVersion?: string;
   packageName?: `@sentry/${string}`;
 } = {}): OnboardingConfig => ({
   introduction: params => (
     <SdkUpdateAlert
       projectId={params.project.id}
-      minVersion={getMinRequiredVersion(params, minVersion)}
+      minVersion={getMinRequiredVersion(params, MIN_REQUIRED_VERSION)}
       packageName={packageName}
     />
   ),
   install: params =>
     getInstallStep(params, {
       packageName,
-      minVersion,
+      minVersion: MIN_REQUIRED_VERSION,
     }),
   configure: params => {
     const selected = getAgentIntegration(params);

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -111,11 +111,8 @@ function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
 /**
  * Import Snippet for the Node and Serverless SDKs without other packages (like profiling).
  */
-export function getSentryImportSnippet(
-  packageName: `@sentry/${string}`,
-  defaultMode?: 'esm' | 'cjs'
-): string {
-  return getImport(packageName, defaultMode).join('\n');
+export function getSentryImportSnippet(packageName: `@sentry/${string}`): string {
+  return getImport(packageName).join('\n');
 }
 
 export function getImportInstrumentSnippet(

--- a/static/app/gettingStartedDocs/python/logs.tsx
+++ b/static/app/gettingStartedDocs/python/logs.tsx
@@ -50,11 +50,7 @@ logger.error('Something went wrong')`,
   ],
 });
 
-export const logs = ({
-  packageName = 'sentry-sdk',
-}: {
-  packageName?: string;
-} = {}): OnboardingConfig => ({
+export const logs = (): OnboardingConfig => ({
   install: () => [
     {
       type: StepType.INSTALL,
@@ -69,7 +65,7 @@ export const logs = ({
           ),
         },
         getPythonInstallCodeBlock({
-          packageName,
+          packageName: 'sentry-sdk',
           minimumVersion: '2.35.0',
         }),
       ],

--- a/static/app/gettingStartedDocs/python/logs.tsx
+++ b/static/app/gettingStartedDocs/python/logs.tsx
@@ -65,7 +65,6 @@ export const logs = (): OnboardingConfig => ({
           ),
         },
         getPythonInstallCodeBlock({
-          packageName: 'sentry-sdk',
           minimumVersion: '2.35.0',
         }),
       ],

--- a/static/app/gettingStartedDocs/python/metrics.spec.tsx
+++ b/static/app/gettingStartedDocs/python/metrics.spec.tsx
@@ -29,11 +29,8 @@ describe('metrics', () => {
     expect(codeSnippet).toContain('metrics.count');
   });
 
-  it('generates metrics onboarding config with custom parameters', () => {
-    const result = metrics({
-      packageName: 'custom-sentry-sdk',
-      minimumVersion: '3.0.0',
-    });
+  it('generates metrics onboarding config install steps', () => {
+    const result = metrics();
 
     const installSteps = result.install();
     expect(installSteps[0].content).toHaveLength(2);

--- a/static/app/gettingStartedDocs/python/metrics.tsx
+++ b/static/app/gettingStartedDocs/python/metrics.tsx
@@ -10,6 +10,8 @@ import {t, tct} from 'sentry/locale';
 
 import {getPythonInstallCodeBlock} from './utils';
 
+const METRICS_PACKAGE_NAME = 'sentry-sdk';
+
 export const metricsVerify = (params: DocsParams): ContentBlock => ({
   type: 'conditional',
   condition: params.isMetricsSelected,
@@ -33,11 +35,7 @@ metrics.distribution("cart.amount_usd", 187.5)`,
   ],
 });
 
-export const metrics = ({
-  packageName = 'sentry-sdk',
-}: {
-  packageName?: string;
-} = {}): OnboardingConfig => ({
+export const metrics = (): OnboardingConfig => ({
   install: () => [
     {
       type: StepType.INSTALL,
@@ -52,7 +50,7 @@ export const metrics = ({
           ),
         },
         getPythonInstallCodeBlock({
-          packageName,
+          packageName: METRICS_PACKAGE_NAME,
           minimumVersion: '2.44.0',
         }),
       ],

--- a/static/app/gettingStartedDocs/python/profiling.tsx
+++ b/static/app/gettingStartedDocs/python/profiling.tsx
@@ -96,10 +96,8 @@ export const alternativeProfiling = (params: DocsParams): ContentBlock => ({
 });
 
 export const profiling = ({
-  basePackage = 'sentry-sdk',
   traceLifecycle = 'trace',
 }: {
-  basePackage?: string;
   traceLifecycle?: 'manual' | 'trace';
 } = {}): OnboardingConfig => ({
   install: () => [
@@ -116,7 +114,7 @@ export const profiling = ({
           ),
         },
         getPythonInstallCodeBlock({
-          packageName: basePackage,
+          packageName: 'sentry-sdk',
           minimumVersion: '2.24.1',
         }),
       ],

--- a/static/app/gettingStartedDocs/python/profiling.tsx
+++ b/static/app/gettingStartedDocs/python/profiling.tsx
@@ -114,7 +114,6 @@ export const profiling = ({
           ),
         },
         getPythonInstallCodeBlock({
-          packageName: 'sentry-sdk',
           minimumVersion: '2.24.1',
         }),
       ],

--- a/static/app/gettingStartedDocs/python/utils.tsx
+++ b/static/app/gettingStartedDocs/python/utils.tsx
@@ -64,22 +64,16 @@ export function getPythonInstallCodeBlock({
   };
 }
 
-export function getPythonAiocontextvarsCodeBlocks({
-  description,
-}: {
-  description?: React.ReactNode;
-} = {}): ContentBlock[] {
-  const defaultDescription = tct(
-    "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
-    {
-      code: <code />,
-    }
-  );
-
+export function getPythonAiocontextvarsCodeBlocks(): ContentBlock[] {
   return [
     {
       type: 'text',
-      text: description ?? defaultDescription,
+      text: tct(
+        "If you're on Python 3.6, you also need the [code:aiocontextvars] package:",
+        {
+          code: <code />,
+        }
+      ),
     },
     getPythonInstallCodeBlock({
       packageName: 'aiocontextvars',

--- a/static/app/gettingStartedDocs/rust/logs.tsx
+++ b/static/app/gettingStartedDocs/rust/logs.tsx
@@ -10,8 +10,8 @@ import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersi
 
 type Params = DocsParams;
 
-const getInstallSnippet = (params: Params, defaultVersion = '0.42.0') => {
-  const version = getPackageVersion(params, 'sentry.rust', defaultVersion);
+const getInstallSnippet = (params: Params) => {
+  const version = getPackageVersion(params, 'sentry.rust', '0.42.0');
   return params.isLogsSelected
     ? `
 [dependencies]

--- a/static/app/gettingStartedDocs/rust/onboarding.tsx
+++ b/static/app/gettingStartedDocs/rust/onboarding.tsx
@@ -8,8 +8,8 @@ import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersi
 
 type Params = DocsParams;
 
-const getInstallSnippet = (params: Params, defaultVersion = '0.42.0') => {
-  const version = getPackageVersion(params, 'sentry.rust', defaultVersion);
+const getInstallSnippet = (params: Params) => {
+  const version = getPackageVersion(params, 'sentry.rust', '0.42.0');
   return params.isLogsSelected
     ? `
 [dependencies]

--- a/static/app/router/routeMapTestUtils.spec.tsx
+++ b/static/app/router/routeMapTestUtils.spec.tsx
@@ -173,12 +173,6 @@ describe('toCustomerDomainForm', () => {
 });
 
 describe('dedupeRoutes', () => {
-  // Inject a simple org-prefix stripper so the dedup logic is tested in
-  // isolation from normalizeUrl.
-  const toCD = (url: string) =>
-    url.startsWith('/organizations/:orgId')
-      ? url.slice('/organizations/:orgId'.length) || '/'
-      : url;
   const slug = (url: string, component: string) => ({
     url,
     params: extractParams(url),
@@ -199,8 +193,7 @@ describe('dedupeRoutes', () => {
         // The customer-domain run re-emits both forms.
         domain('/organizations/:orgId/issues/', 'sentry/views/issues'),
         domain('/issues/', 'sentry/views/issues'),
-      ],
-      toCD
+      ]
     );
 
     expect(routes).toHaveLength(1);
@@ -214,8 +207,7 @@ describe('dedupeRoutes', () => {
   it('keeps the slugless form as url for routes seen only in the domain run', () => {
     const routes = dedupeRoutes(
       [],
-      [domain('/onboarding/:step/', 'sentry/views/onboarding')],
-      toCD
+      [domain('/onboarding/:step/', 'sentry/views/onboarding')]
     );
 
     expect(routes).toHaveLength(1);
@@ -225,14 +217,13 @@ describe('dedupeRoutes', () => {
   it('drops layout shells (null component)', () => {
     const routes = dedupeRoutes(
       [{url: '/settings/', params: [], component: null, customerDomain: false}],
-      [],
-      toCD
+      []
     );
     expect(routes).toHaveLength(0);
   });
 
   it('produces a stable order independent of input order', () => {
-    const forward = dedupeRoutes([slug('/b/', 'b'), slug('/a/', 'a')], [], toCD).map(
+    const forward = dedupeRoutes([slug('/b/', 'b'), slug('/a/', 'a')], []).map(
       r => r.url
     );
     expect(forward).toEqual(['/a/', '/b/']);

--- a/static/app/router/routeMapTestUtils.tsx
+++ b/static/app/router/routeMapTestUtils.tsx
@@ -271,8 +271,7 @@ export function toCustomerDomainForm(url: string): string {
  */
 export function dedupeRoutes(
   slugRecords: RouteRecord[],
-  domainRecords: RouteRecord[],
-  toCustomerDomain: (url: string) => string = toCustomerDomainForm
+  domainRecords: RouteRecord[]
 ): LogicalRoute[] {
   const byKey = new Map<string, LogicalRoute>();
 
@@ -280,7 +279,7 @@ export function dedupeRoutes(
     if (!record.component) {
       return;
     }
-    const urlCustomerDomain = toCustomerDomain(record.url);
+    const urlCustomerDomain = toCustomerDomainForm(record.url);
     const key = `${urlCustomerDomain} ${record.component}`;
     if (byKey.has(key)) {
       return;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -93,7 +93,7 @@ interface GuideStoreDefinition extends StrictStoreDefinition<GuideStoreState> {
   setForceHide(forceHide: boolean): void;
   teardown(): void;
   unregisterAnchor(target: string): void;
-  updateCurrentGuide(): void;
+  updateCurrentGuide(dismissed?: boolean): void;
   updatePrevGuide(nextGuide: Guide | null): void;
 }
 
@@ -194,7 +194,7 @@ const storeConfig: GuideStoreDefinition = {
       return guide;
     });
     this.state = {...this.state, guides: newGuides, forceShow: false};
-    this.updateCurrentGuide();
+    this.updateCurrentGuide(dismissed);
   },
 
   nextStep() {
@@ -249,7 +249,7 @@ const storeConfig: GuideStoreDefinition = {
    *  - If the user has already seen the guide, don't show the guide
    *  - Otherwise show the guide
    */
-  updateCurrentGuide() {
+  updateCurrentGuide(dismissed?: boolean) {
     const {anchors, guides, forceShow} = this.state;
 
     let guideOptions = guides
@@ -298,7 +298,7 @@ const storeConfig: GuideStoreDefinition = {
     this.state = {...this.state, currentGuide: nextGuide, currentStep};
 
     this.trigger(this.state);
-    getOverride('callback:on-guide-update')?.(nextGuide, {dismissed: undefined});
+    getOverride('callback:on-guide-update')?.(nextGuide, {dismissed});
   },
 };
 

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -93,7 +93,7 @@ interface GuideStoreDefinition extends StrictStoreDefinition<GuideStoreState> {
   setForceHide(forceHide: boolean): void;
   teardown(): void;
   unregisterAnchor(target: string): void;
-  updateCurrentGuide(dismissed?: boolean): void;
+  updateCurrentGuide(): void;
   updatePrevGuide(nextGuide: Guide | null): void;
 }
 
@@ -249,7 +249,7 @@ const storeConfig: GuideStoreDefinition = {
    *  - If the user has already seen the guide, don't show the guide
    *  - Otherwise show the guide
    */
-  updateCurrentGuide(dismissed?: boolean) {
+  updateCurrentGuide() {
     const {anchors, guides, forceShow} = this.state;
 
     let guideOptions = guides
@@ -298,7 +298,7 @@ const storeConfig: GuideStoreDefinition = {
     this.state = {...this.state, currentGuide: nextGuide, currentStep};
 
     this.trigger(this.state);
-    getOverride('callback:on-guide-update')?.(nextGuide, {dismissed});
+    getOverride('callback:on-guide-update')?.(nextGuide, {dismissed: undefined});
   },
 };
 

--- a/static/app/stores/onboardingDrawerStore.tsx
+++ b/static/app/stores/onboardingDrawerStore.tsx
@@ -5,7 +5,7 @@ import type {StrictStoreDefinition} from './types';
 type ActivePanelType = Readonly<OnboardingDrawerKey | ''>;
 
 interface OnboardingDrawerStoreDefinition extends StrictStoreDefinition<ActivePanelType> {
-  close(hash?: string): void;
+  close(): void;
 
   open(panel: OnboardingDrawerKey): void;
   toggle(panel: OnboardingDrawerKey): void;
@@ -43,13 +43,8 @@ const storeConfig: OnboardingDrawerStoreDefinition = {
     }
   },
 
-  close(hash?: string) {
+  close() {
     this.state = '';
-
-    if (hash) {
-      window.location.hash = window.location.hash.replace(`#${hash}`, '');
-    }
-
     this.trigger(this.state);
   },
 

--- a/static/app/styles/animations.tsx
+++ b/static/app/styles/animations.tsx
@@ -41,13 +41,15 @@ export const pulse = (size: number) => keyframes`
   }
 `;
 
+const SHAKE_DISTANCE_PX = 3;
+
 export const makeShake = () => keyframes`
 ${Array.from({length: 50})
   .fill(0)
   .map(
     (_, i) => `${i * 2}% {
-  transform: translate(${Math.round(Math.random() * 3)}px, ${Math.round(
-    Math.random() * 3
+  transform: translate(${Math.round(Math.random() * SHAKE_DISTANCE_PX)}px, ${Math.round(
+    Math.random() * SHAKE_DISTANCE_PX
   )}px);
 }`
   )

--- a/static/app/styles/animations.tsx
+++ b/static/app/styles/animations.tsx
@@ -41,13 +41,13 @@ export const pulse = (size: number) => keyframes`
   }
 `;
 
-export const makeShake = (distance = 3) => keyframes`
+export const makeShake = () => keyframes`
 ${Array.from({length: 50})
   .fill(0)
   .map(
     (_, i) => `${i * 2}% {
-  transform: translate(${Math.round(Math.random() * distance)}px, ${Math.round(
-    Math.random() * distance
+  transform: translate(${Math.round(Math.random() * 3)}px, ${Math.round(
+    Math.random() * 3
   )}px);
 }`
   )


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~121 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/data/platformCategories.tsx`
- `static/app/gettingStartedDocs/javascript/agentMonitoring.tsx`
- `static/app/gettingStartedDocs/node/agentMonitoring.tsx`
- `static/app/gettingStartedDocs/node/utils.tsx`
- `static/app/gettingStartedDocs/python/logs.tsx`
- `static/app/gettingStartedDocs/python/metrics.spec.tsx`
- `static/app/gettingStartedDocs/python/metrics.tsx`
- `static/app/gettingStartedDocs/python/profiling.tsx`
- `static/app/gettingStartedDocs/python/utils.tsx`
- `static/app/gettingStartedDocs/rust/logs.tsx`
- `static/app/gettingStartedDocs/rust/onboarding.tsx`
- `static/app/router/routeMapTestUtils.spec.tsx`
- `static/app/router/routeMapTestUtils.tsx`
- `static/app/stores/guideStore.tsx`
- `static/app/stores/onboardingDrawerStore.tsx`
- `static/app/styles/animations.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

