### PR TITLE
ref(ui): Drop unused optional args in contextPickerModal

### DIFF
--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -1,8 +1,6 @@
-import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
-import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
@@ -10,13 +8,10 @@ import {selectEvent} from 'sentry-test/selectEvent';
 import {makeCloseButton, ModalBody, ModalFooter} from '@sentry/scraps/modal';
 
 import {ContextPickerModalContainer as ContextPickerModal} from 'sentry/components/contextPickerModal';
-import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 
 describe('ContextPickerModal', () => {
   let project!: Project;
@@ -240,133 +235,6 @@ describe('ContextPickerModal', () => {
     expect(fetchProjectsForOrg2).toHaveBeenCalled();
     expect(await screen.findByText('org2-project')).toBeInTheDocument();
     expect(screen.queryByText('org1-project')).not.toBeInTheDocument();
-  });
-
-  it('isSuperUser and selects an integrationConfig and calls `onFinish` with URL to that configuration', async () => {
-    OrganizationsStore.load([org]);
-    OrganizationStore.onUpdate(org);
-    ConfigStore.set('user', UserFixture({isSuperuser: true}));
-
-    const provider = {slug: 'github'};
-    const configQueryKey = [
-      getApiUrl('/organizations/$organizationIdOrSlug/integrations/', {
-        path: {organizationIdOrSlug: org.slug},
-      }),
-      {query: {provider_key: provider.slug, includeConfig: 0}},
-    ] satisfies ApiQueryKey;
-    const integration = GitHubIntegrationFixture();
-    const fetchGithubConfigs = MockApiClient.addMockResponse({
-      url: configQueryKey[0],
-      body: [integration],
-      match: [MockApiClient.matchQuery(configQueryKey[1].query)],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/projects/`,
-      body: [],
-    });
-
-    render(
-      getComponent({
-        needOrg: false,
-        needProject: false,
-        nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
-        configQueryKey,
-      })
-    );
-
-    await waitFor(() => {
-      expect(fetchGithubConfigs).toHaveBeenCalled();
-    });
-
-    if (integration.domainName === null) {
-      throw new Error('Integration domainName is null');
-    }
-
-    await selectEvent.select(await screen.findByRole('textbox'), integration.domainName);
-    expect(onFinish).toHaveBeenCalledWith(
-      `/settings/${org.slug}/integrations/github/${integration.id}/`
-    );
-  });
-
-  it('not superUser and cannot select an integrationConfig and calls `onFinish` with URL to integration overview page', async () => {
-    OrganizationsStore.load([org]);
-    OrganizationStore.onUpdate(org);
-    ConfigStore.set('user', UserFixture({isSuperuser: false}));
-
-    const provider = {slug: 'github'};
-    const configQueryKey = [
-      getApiUrl('/organizations/$organizationIdOrSlug/integrations/', {
-        path: {organizationIdOrSlug: org.slug},
-      }),
-      {query: {provider_key: provider.slug, includeConfig: 0}},
-    ] satisfies ApiQueryKey;
-
-    const fetchGithubConfigs = MockApiClient.addMockResponse({
-      url: configQueryKey[0],
-      body: [GitHubIntegrationFixture()],
-      match: [MockApiClient.matchQuery(configQueryKey[1].query)],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/projects/`,
-      body: [],
-    });
-
-    render(
-      getComponent({
-        needOrg: false,
-        needProject: false,
-        nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
-        configQueryKey,
-      })
-    );
-
-    await waitFor(() => {
-      expect(fetchGithubConfigs).toHaveBeenCalled();
-    });
-  });
-
-  it('is superUser and no integration configurations and calls `onFinish` with URL to integration overview page', async () => {
-    OrganizationsStore.load([org]);
-    OrganizationStore.onUpdate(org);
-    ConfigStore.set('user', UserFixture({isSuperuser: false}));
-
-    const provider = {slug: 'github'};
-    const configQueryKey = [
-      getApiUrl('/organizations/$organizationIdOrSlug/integrations/', {
-        path: {organizationIdOrSlug: org.slug},
-      }),
-      {query: {provider_key: provider.slug, includeConfig: 0}},
-    ] satisfies ApiQueryKey;
-
-    const fetchGithubConfigs = MockApiClient.addMockResponse({
-      url: configQueryKey[0],
-      body: [],
-      match: [MockApiClient.matchQuery(configQueryKey[1].query)],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/projects/`,
-      body: [],
-    });
-
-    render(
-      getComponent({
-        needOrg: false,
-        needProject: false,
-        nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
-        configQueryKey,
-      })
-    );
-
-    await waitFor(() => {
-      expect(fetchGithubConfigs).toHaveBeenCalled();
-    });
-
-    await waitFor(() => {
-      expect(onFinish).toHaveBeenCalledWith(`/settings/${org.slug}/integrations/github/`);
-    });
   });
 
   it('preserves path object query parameters', async () => {

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,26 +1,40 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 import type {Query} from 'history';
 
 import {ProjectAvatar, TeamAvatar} from '@sentry/scraps/avatar';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import type {StylesConfig} from '@sentry/scraps/select';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {Integration} from 'sentry/types/integrations';
 import type {OrganizationSummary, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
+import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
 
 type SharedProps = ModalRenderProps & {
   /**
@@ -61,6 +75,8 @@ type ContentProps = SharedProps & {
 };
 
 type ContainerProps = SharedProps & {
+  configQueryKey?: ApiQueryKey;
+
   /**
    * List of slugs we want to be able to choose from
    */
@@ -446,13 +462,171 @@ function TeamSelector({
   );
 }
 
+function ConfigUrlContainer(
+  props: SharedProps & {
+    configQueryKey: ApiQueryKey;
+    organizations: OrganizationSummary[];
+    selectedOrgSlug: string | undefined;
+    setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
+  }
+) {
+  const {
+    configQueryKey,
+    organizations,
+    selectedOrgSlug,
+    setSelectedOrgSlug,
+    ...sharedProps
+  } = props;
+
+  const {data, isError, isPending, refetch} = useApiQuery<Integration[]>(configQueryKey, {
+    staleTime: Infinity,
+  });
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
+  }
+  if (!data.length) {
+    sharedProps.onFinish(sharedProps.nextPath);
+  }
+
+  return (
+    <ConfigPickerContent
+      {...sharedProps}
+      organizations={organizations}
+      selectedOrgSlug={selectedOrgSlug}
+      setSelectedOrgSlug={setSelectedOrgSlug}
+      integrationConfigs={data}
+    />
+  );
+}
+
+function ConfigPickerContent({
+  organizations,
+  selectedOrgSlug,
+  setSelectedOrgSlug,
+  integrationConfigs,
+  needOrg,
+  nextPath,
+  onFinish,
+  Header,
+  Body,
+}: SharedProps & {
+  integrationConfigs: Integration[];
+  organizations: OrganizationSummary[];
+  selectedOrgSlug: string | undefined;
+  setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
+}) {
+  const {isSuperuser} = ConfigStore.get('user') || {};
+  const shouldShowConfigSelector = integrationConfigs.length > 0 && isSuperuser;
+
+  function handleSelectOrganization({value}: {value: string}) {
+    setSelectedOrgSlug(value);
+  }
+
+  function handleSelectConfiguration({value}: {value: string}) {
+    if (!value) {
+      return;
+    }
+    const newPath =
+      typeof nextPath === 'string'
+        ? `${nextPath}${value}/`
+        : {
+            ...nextPath,
+            pathname: `${nextPath.pathname}${value}/`,
+          };
+    onFinish(newPath);
+  }
+
+  const orgChoices = organizations
+    .filter(({status}) => status.id !== 'pending_deletion')
+    .map(({slug}) => ({label: slug, value: slug}));
+
+  if (!needOrg && !shouldShowConfigSelector) {
+    return null;
+  }
+
+  const headerText = shouldShowConfigSelector
+    ? t('Select a configuration to continue')
+    : t('Select an organization to continue');
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h5">{headerText}</Heading>
+      </Header>
+      <Body>
+        <Stack gap="md">
+          {needOrg && (
+            <Select
+              ref={shouldShowConfigSelector ? undefined : autoFocusReactSelect}
+              placeholder={t('Select an Organization')}
+              name="organization"
+              options={orgChoices}
+              value={selectedOrgSlug}
+              onChange={handleSelectOrganization}
+              components={{DropdownIndicator: null}}
+              styles={selectStyles}
+              menuIsOpen
+            />
+          )}
+
+          {shouldShowConfigSelector && (
+            <Select
+              ref={autoFocusReactSelect}
+              placeholder={t('Select a configuration to continue')}
+              name="configurations"
+              options={[
+                {
+                  label: tct('[providerName] Configurations', {
+                    providerName: integrationConfigs[0]!.provider.name,
+                  }),
+                  options: integrationConfigs.map(config => ({
+                    value: config.id,
+                    label: (
+                      <Grid columns="32px auto" rows="1fr">
+                        <IntegrationIcon size={22} integration={config} />
+                        <span>{config.domainName}</span>
+                      </Grid>
+                    ),
+                    disabled: !isSuperuser,
+                  })),
+                },
+              ]}
+              onChange={handleSelectConfiguration}
+              components={{DropdownIndicator: null}}
+              styles={selectStyles}
+              menuIsOpen
+            />
+          )}
+        </Stack>
+      </Body>
+    </Fragment>
+  );
+}
+
 export function ContextPickerModalContainer({
+  configQueryKey,
   projectSlugs,
   ...sharedProps
 }: ContainerProps) {
   const {organizations} = useLegacyStore(OrganizationsStore);
   const {organization} = useLegacyStore(OrganizationStore);
   const [selectedOrgSlug, setSelectedOrgSlug] = useState(organization?.slug);
+
+  if (configQueryKey) {
+    return (
+      <ConfigUrlContainer
+        configQueryKey={configQueryKey}
+        organizations={organizations}
+        selectedOrgSlug={selectedOrgSlug}
+        setSelectedOrgSlug={setSelectedOrgSlug}
+        {...sharedProps}
+      />
+    );
+  }
 
   return (
     <ContextPickerContent

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,40 +1,26 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 import type {Query} from 'history';
 
 import {ProjectAvatar, TeamAvatar} from '@sentry/scraps/avatar';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import type {StylesConfig} from '@sentry/scraps/select';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {Integration} from 'sentry/types/integrations';
 import type {OrganizationSummary, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
-import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
 
 type SharedProps = ModalRenderProps & {
   /**
@@ -75,8 +61,6 @@ type ContentProps = SharedProps & {
 };
 
 type ContainerProps = SharedProps & {
-  configQueryKey?: ApiQueryKey;
-
   /**
    * List of slugs we want to be able to choose from
    */
@@ -462,171 +446,13 @@ function TeamSelector({
   );
 }
 
-function ConfigUrlContainer(
-  props: SharedProps & {
-    configQueryKey: ApiQueryKey;
-    organizations: OrganizationSummary[];
-    selectedOrgSlug: string | undefined;
-    setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
-  }
-) {
-  const {
-    configQueryKey,
-    organizations,
-    selectedOrgSlug,
-    setSelectedOrgSlug,
-    ...sharedProps
-  } = props;
-
-  const {data, isError, isPending, refetch} = useApiQuery<Integration[]>(configQueryKey, {
-    staleTime: Infinity,
-  });
-
-  if (isPending) {
-    return <LoadingIndicator />;
-  }
-  if (isError) {
-    return <LoadingError onRetry={refetch} />;
-  }
-  if (!data.length) {
-    sharedProps.onFinish(sharedProps.nextPath);
-  }
-
-  return (
-    <ConfigPickerContent
-      {...sharedProps}
-      organizations={organizations}
-      selectedOrgSlug={selectedOrgSlug}
-      setSelectedOrgSlug={setSelectedOrgSlug}
-      integrationConfigs={data}
-    />
-  );
-}
-
-function ConfigPickerContent({
-  organizations,
-  selectedOrgSlug,
-  setSelectedOrgSlug,
-  integrationConfigs,
-  needOrg,
-  nextPath,
-  onFinish,
-  Header,
-  Body,
-}: SharedProps & {
-  integrationConfigs: Integration[];
-  organizations: OrganizationSummary[];
-  selectedOrgSlug: string | undefined;
-  setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
-}) {
-  const {isSuperuser} = ConfigStore.get('user') || {};
-  const shouldShowConfigSelector = integrationConfigs.length > 0 && isSuperuser;
-
-  function handleSelectOrganization({value}: {value: string}) {
-    setSelectedOrgSlug(value);
-  }
-
-  function handleSelectConfiguration({value}: {value: string}) {
-    if (!value) {
-      return;
-    }
-    const newPath =
-      typeof nextPath === 'string'
-        ? `${nextPath}${value}/`
-        : {
-            ...nextPath,
-            pathname: `${nextPath.pathname}${value}/`,
-          };
-    onFinish(newPath);
-  }
-
-  const orgChoices = organizations
-    .filter(({status}) => status.id !== 'pending_deletion')
-    .map(({slug}) => ({label: slug, value: slug}));
-
-  if (!needOrg && !shouldShowConfigSelector) {
-    return null;
-  }
-
-  const headerText = shouldShowConfigSelector
-    ? t('Select a configuration to continue')
-    : t('Select an organization to continue');
-
-  return (
-    <Fragment>
-      <Header closeButton>
-        <Heading as="h5">{headerText}</Heading>
-      </Header>
-      <Body>
-        <Stack gap="md">
-          {needOrg && (
-            <Select
-              ref={shouldShowConfigSelector ? undefined : autoFocusReactSelect}
-              placeholder={t('Select an Organization')}
-              name="organization"
-              options={orgChoices}
-              value={selectedOrgSlug}
-              onChange={handleSelectOrganization}
-              components={{DropdownIndicator: null}}
-              styles={selectStyles}
-              menuIsOpen
-            />
-          )}
-
-          {shouldShowConfigSelector && (
-            <Select
-              ref={autoFocusReactSelect}
-              placeholder={t('Select a configuration to continue')}
-              name="configurations"
-              options={[
-                {
-                  label: tct('[providerName] Configurations', {
-                    providerName: integrationConfigs[0]!.provider.name,
-                  }),
-                  options: integrationConfigs.map(config => ({
-                    value: config.id,
-                    label: (
-                      <Grid columns="32px auto" rows="1fr">
-                        <IntegrationIcon size={22} integration={config} />
-                        <span>{config.domainName}</span>
-                      </Grid>
-                    ),
-                    disabled: !isSuperuser,
-                  })),
-                },
-              ]}
-              onChange={handleSelectConfiguration}
-              components={{DropdownIndicator: null}}
-              styles={selectStyles}
-              menuIsOpen
-            />
-          )}
-        </Stack>
-      </Body>
-    </Fragment>
-  );
-}
-
 export function ContextPickerModalContainer({
-  configQueryKey,
   projectSlugs,
   ...sharedProps
 }: ContainerProps) {
   const {organizations} = useLegacyStore(OrganizationsStore);
   const {organization} = useLegacyStore(OrganizationStore);
   const [selectedOrgSlug, setSelectedOrgSlug] = useState(organization?.slug);
-
-  if (configQueryKey) {
-    return (
-      <ConfigUrlContainer
-        configQueryKey={configQueryKey}
-        organizations={organizations}
-        selectedOrgSlug={selectedOrgSlug}
-        setSelectedOrgSlug={setSelectedOrgSlug}
-        {...sharedProps}
-      />
-    );
-  }
 
   return (
     <ContextPickerContent


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~310 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/components`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/components/contextPickerModal.spec.tsx`
- `static/app/components/contextPickerModal.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/components`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

