### PR TITLE
ref(ui): Drop unused optional args in acl and group list

### DIFF
--- a/static/app/components/aiPrivacyTooltip.tsx
+++ b/static/app/components/aiPrivacyTooltip.tsx
@@ -1,18 +1,9 @@
-import type {ComponentProps, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 
 import {ExternalLink} from '@sentry/scraps/link';
-import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {tct} from 'sentry/locale';
-
-interface AiPrivacyNoticeProps {
-  linkProps?: Partial<ComponentProps<typeof ExternalLink>>;
-}
-
-interface AiPrivacyTooltipProps
-  extends Omit<TooltipProps, 'title' | 'children'>, AiPrivacyNoticeProps {
-  children: ReactNode;
-}
 
 const AI_PRIVACY_NOTICE_LINK =
   'https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/';
@@ -20,11 +11,11 @@ const AI_PRIVACY_NOTICE_LINK =
 /**
  * This notice should be presented along with any AI-powered feature.
  */
-export function AiPrivacyNotice({linkProps = {}}: AiPrivacyNoticeProps) {
+export function AiPrivacyNotice() {
   return tct(
     'Powered by generative AI. Learn more about our [link:AI privacy principles].',
     {
-      link: <ExternalLink href={AI_PRIVACY_NOTICE_LINK} {...linkProps} />,
+      link: <ExternalLink href={AI_PRIVACY_NOTICE_LINK} />,
     }
   );
 }
@@ -32,26 +23,18 @@ export function AiPrivacyNotice({linkProps = {}}: AiPrivacyNoticeProps) {
 /**
  * A shortened version of the privacy noice, useful for tooltips or places where space is limited.
  */
-function AiPrivacyNoticeShort({linkProps = {}}: AiPrivacyNoticeProps) {
+function AiPrivacyNoticeShort() {
   return tct('Powered by genAI. [link:Learn more.]', {
-    link: <ExternalLink href={AI_PRIVACY_NOTICE_LINK} {...linkProps} />,
+    link: <ExternalLink href={AI_PRIVACY_NOTICE_LINK} />,
   });
 }
 
 /**
  * A tooltip wrapper for the privacy notice.
  */
-export function AiPrivacyTooltip({
-  children,
-  linkProps,
-  ...tooltipProps
-}: AiPrivacyTooltipProps) {
+export function AiPrivacyTooltip({children}: {children: ReactNode}) {
   return (
-    <Tooltip
-      isHoverable
-      title={<AiPrivacyNoticeShort linkProps={linkProps} />}
-      {...tooltipProps}
-    >
+    <Tooltip isHoverable title={<AiPrivacyNoticeShort />}>
       {children}
     </Tooltip>
   );

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -11,28 +11,17 @@ import {
   type SuggestedAssignee,
 } from 'sentry/components/assigneeSelectorDropdown';
 import {t} from 'sentry/locale';
-import type {Actor} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {selectUsersFromMembers} from 'sentry/utils/members/shared';
-import {
-  useAssignIssueMutation,
-  type AssignedBy,
-} from 'sentry/views/issueDetails/useAssignIssueMutation';
-
-type HandleAssignOptions = {
-  assignedBy?: AssignedBy;
-};
+import {useAssignIssueMutation} from 'sentry/views/issueDetails/useAssignIssueMutation';
 
 interface AssigneeSelectorProps {
   assigneeLoading: boolean;
   group: AssigneeGroup;
-  handleAssigneeChange: (
-    assignedActor: AssignableEntity | null,
-    options?: HandleAssignOptions
-  ) => void;
+  handleAssigneeChange: (assignedActor: AssignableEntity | null) => void;
   additionalMenuFooterItems?: React.ReactNode;
   assignmentDetails?: AssignmentDetails;
   memberList?: User[];
@@ -41,51 +30,28 @@ interface AssigneeSelectorProps {
   useOwnerAssignmentDetails?: boolean;
 }
 
-type OnAssignCallback = (
-  type: Actor['type'],
-  assignee: User | Actor,
-  suggestedAssignee?: SuggestedAssignee
-) => void;
-
 export function useHandleAssigneeChange({
   organization,
   group,
-  onAssign,
   onSuccess,
-  onError,
 }: {
   group: AssigneeGroup;
   organization: Organization;
-  onAssign?: OnAssignCallback;
-  onError?: (error: Error) => void;
   onSuccess?: (assignedTo: Group['assignedTo']) => void;
 }) {
   const {mutate: assignMutate, isPending: assigneeLoading} = useAssignIssueMutation();
 
-  const handleAssigneeChange = (
-    newAssignee: AssignableEntity | null,
-    {assignedBy = 'assignee_selector'}: HandleAssignOptions = {}
-  ) => {
+  const handleAssigneeChange = (newAssignee: AssignableEntity | null) => {
     assignMutate(
       {
         groupId: group.id,
         orgSlug: organization.slug,
         actor: newAssignee ? {id: newAssignee.id, type: newAssignee.type} : null,
-        assignedBy,
+        assignedBy: 'assignee_selector',
       },
       {
         onSuccess: updatedGroup => {
-          if (onAssign && newAssignee) {
-            onAssign(
-              newAssignee.type,
-              newAssignee.assignee,
-              newAssignee.suggestedAssignee
-            );
-          }
           onSuccess?.(updatedGroup.assignedTo);
-        },
-        onError: error => {
-          onError?.(error);
         },
       }
     );

--- a/static/app/components/issues/groupList.spec.tsx
+++ b/static/app/components/issues/groupList.spec.tsx
@@ -10,7 +10,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {GroupStore} from 'sentry/stores/groupStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 
-import {GroupList, RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from './groupList';
+import {GroupList} from './groupList';
 
 describe('GroupList', () => {
   const organization = OrganizationFixture();
@@ -80,8 +80,7 @@ describe('GroupList', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders custom error when query has boolean logic', async () => {
-    const renderErrorMessage = jest.fn(() => <div>custom error</div>);
+  it('renders error when query has boolean logic', async () => {
     const issuesRequest = MockApiClient.addMockResponse({
       url: issuesUrl,
       method: 'GET',
@@ -92,7 +91,6 @@ describe('GroupList', () => {
       <GroupList
         numPlaceholderRows={1}
         queryParams={{...defaultQueryParams, query: 'foo OR bar'}}
-        renderErrorMessage={renderErrorMessage}
       />,
       {
         organization,
@@ -106,11 +104,7 @@ describe('GroupList', () => {
       }
     );
 
-    expect(await screen.findByText('custom error')).toBeInTheDocument();
-    expect(renderErrorMessage).toHaveBeenCalledWith(
-      {detail: RELATED_ISSUES_BOOLEAN_QUERY_ERROR},
-      expect.any(Function)
-    );
+    expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
     expect(issuesRequest).not.toHaveBeenCalled();
   });
 

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -21,15 +21,11 @@ import type {Group, PriorityLevel} from 'sentry/types/group';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {indexMembersByProject} from 'sentry/utils/members/shared';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {GroupListHeader} from './groupListHeader';
-
-export const RELATED_ISSUES_BOOLEAN_QUERY_ERROR =
-  'Error parsing search query: Boolean statements containing "OR" or "AND" are not supported in this search';
 
 export type GroupListColumn =
   | 'graph'
@@ -75,7 +71,6 @@ type Props = {
   query?: string;
   queryFilterDescription?: string;
   renderEmptyMessage?: () => React.ReactNode;
-  renderErrorMessage?: (props: {detail: string}, retry: () => void) => React.ReactNode;
   // where the group list is rendered
   source?: string;
   staleTime?: number;
@@ -110,7 +105,6 @@ export function GroupList({
   endpoint = {path: '/organizations/$organizationIdOrSlug/issues/'},
   onFetchSuccess,
   renderEmptyMessage,
-  renderErrorMessage,
   queryFilterDescription,
   source,
   staleTime = 0,
@@ -215,7 +209,6 @@ export function GroupList({
     isPending,
     isError: isQueryError,
     isSuccess: isQuerySuccess,
-    error: queryError,
     refetch,
   } = useQuery({
     ...issuesQueryOptions,
@@ -273,19 +266,6 @@ export function GroupList({
 
   const pageLinks = data?.headers.Link ?? null;
   const groups = groupsData ?? [];
-  const errorDetail = hasLogicBoolean
-    ? RELATED_ISSUES_BOOLEAN_QUERY_ERROR
-    : (() => {
-        const detail = (queryError as RequestError | undefined)?.responseJSON?.detail;
-        if (typeof detail === 'string') {
-          return detail;
-        }
-        if (detail?.message) {
-          return detail.message;
-        }
-        return (queryError as RequestError | undefined)?.message ?? null;
-      })();
-  const errorData = errorDetail ? {detail: errorDetail} : null;
   const hasError = hasLogicBoolean || isQueryError;
   const loading = !hasLogicBoolean && isPending;
 
@@ -317,10 +297,6 @@ export function GroupList({
   const columns = withColumns;
 
   if (hasError) {
-    if (typeof renderErrorMessage === 'function' && errorData) {
-      return renderErrorMessage(errorData, refetch);
-    }
-
     return <LoadingError onRetry={refetch} />;
   }
 

--- a/static/app/components/pipeline/usePipeline.spec.tsx
+++ b/static/app/components/pipeline/usePipeline.spec.tsx
@@ -396,36 +396,6 @@ describe('usePipeline', () => {
     expect(onComplete).toHaveBeenCalledWith({result: 'Pipeline finished successfully'});
   });
 
-  it('does not initialize when enabled is false', async () => {
-    const initRequest = MockApiClient.addMockResponse({
-      url: API_URL,
-      method: 'POST',
-      body: {
-        step: 'step_one',
-        stepIndex: 0,
-        totalSteps: 2,
-        provider: 'dummy',
-        data: {message: 'Hello!'},
-      },
-    });
-
-    function DisabledHarness() {
-      const pipeline = usePipeline('integration', 'dummy', {enabled: false});
-      return (
-        <div>
-          <div data-test-id="is-initializing">{String(pipeline.isInitializing)}</div>
-          <div data-test-id="step">{pipeline.stepDefinition?.stepId ?? 'none'}</div>
-        </div>
-      );
-    }
-
-    render(<DisabledHarness />, {organization});
-
-    // Give it a tick to potentially fire
-    expect(await screen.findByText('none')).toBeInTheDocument();
-    expect(initRequest).not.toHaveBeenCalled();
-  });
-
   it('includes initialData in the initialize request', async () => {
     const initRequest = MockApiClient.addMockResponse({
       url: API_URL,

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -70,7 +70,6 @@ interface UsePipelineOptions<
    * Copy override forwarded to step components that render descriptive intro text.
    */
   description?: string;
-  enabled?: boolean;
   /**
    * Data that will be passed through to the initialization call.
    */
@@ -111,7 +110,7 @@ interface UsePipelineOptions<
  *
  * ## How this hook works
  *
- * On mount (when `enabled`), the hook initializes the pipeline and enters
+ * On mount, the hook initializes the pipeline and enters
  * the `active` state with the first step's data. It looks up the matching
  * step component from the frontend pipeline definition (registered in
  * `registry.tsx`) and renders it via the returned `view` property.
@@ -139,7 +138,7 @@ export function usePipeline<
   onCompleteRef.current = options.onComplete;
   const generationRef = useRef(0);
 
-  const {enabled = true, initialData, description} = options;
+  const {initialData, description} = options;
 
   const pipelineName = getBackendPipelineType(type);
   const apiUrl = getApiUrl(
@@ -279,13 +278,13 @@ export function usePipeline<
     initializeMutate();
   }, [initializeMutate, resetAdvance]);
 
-  // Initialize the pipeline on mount when enabled
+  // Initialize the pipeline on mount
   useEffect(() => {
-    if (enabled && !initializedRef.current) {
+    if (!initializedRef.current) {
       initializedRef.current = true;
       restart();
     }
-  }, [enabled, restart]);
+  }, [restart]);
 
   const stepDefinition = useMemo(() => {
     if (state.status === 'active') {

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -56,7 +56,6 @@ interface PlatformPickerProps {
   noAutoFilter?: boolean;
   organization?: Organization;
   platform?: string | null;
-  showOther?: boolean;
   source?: string;
   /**
    * For project-creation picker events, `source` identifies the flow and `variant`
@@ -79,7 +78,6 @@ export function PlatformPicker({
   variant,
   visibleSelection = true,
   loading = false,
-  showOther = true,
 }: PlatformPickerProps) {
   const {isSelfHosted} = useLegacyStore(ConfigStore);
 
@@ -120,7 +118,7 @@ export function PlatformPicker({
     // 'other' is not part of the createablePlatforms list, therefore it won't be included in the filtered list
     const filtered = availablePlatforms.filter(filter ? subsetMatch : categoryMatch);
 
-    if (showOther && filter.toLowerCase() === 'other') {
+    if (filter.toLowerCase() === 'other') {
       // We only show 'Other' if users click on the 'Other' suggestion rendered in the not found state or type this word in the search bar
       return [otherPlatform];
     }
@@ -135,7 +133,7 @@ export function PlatformPicker({
 
     // We only want to sort the platforms alphabetically if users are not viewing the 'popular' tab category
     return filtered.sort((a, b) => comparePlatformNames(a.name, b.name));
-  }, [filter, category, availablePlatforms, showOther]);
+  }, [filter, category, availablePlatforms]);
 
   const latestValuesRef = useRef({
     filter,

--- a/static/app/components/tours/tourContext.spec.tsx
+++ b/static/app/components/tours/tourContext.spec.tsx
@@ -46,7 +46,7 @@ describe('useTourReducer', () => {
     expect(result.current.currentStepId).toBeNull();
     act(() => result.current.startTour());
     expect(result.current.currentStepId).toBe(TestTour.NAME);
-    act(() => result.current.startTour(TestTour.EMAIL));
+    act(() => result.current.setStep(TestTour.EMAIL));
     expect(result.current.currentStepId).toBe(TestTour.EMAIL);
     act(() => result.current.endTour());
     expect(result.current.currentStepId).toBeNull();
@@ -72,7 +72,8 @@ describe('useTourReducer', () => {
     expect(result.current.currentStepId).toBeNull();
     act(() => result.current.previousStep());
     expect(result.current.currentStepId).toBeNull();
-    act(() => result.current.startTour(TestTour.PASSWORD));
+    act(() => result.current.startTour());
+    act(() => result.current.setStep(TestTour.PASSWORD));
     expect(result.current.currentStepId).toBe(TestTour.PASSWORD);
     act(() => result.current.previousStep());
     expect(result.current.currentStepId).toBe(TestTour.EMAIL);

--- a/static/app/components/tours/tourContext.tsx
+++ b/static/app/components/tours/tourContext.tsx
@@ -74,14 +74,7 @@ type TourOptions<T extends TourEnumType> = Partial<{
   requireAllStepsRegistered: boolean;
 }>;
 
-function computeStartTourStep<T extends TourEnumType>(
-  state: TourState<T>,
-  stepId?: T
-): T | null {
-  if (stepId && state.orderedStepIds.includes(stepId)) {
-    return stepId;
-  }
-
+function computeStartTourStep<T extends TourEnumType>(state: TourState<T>): T | null {
   return state.orderedStepIds[0] ?? null;
 }
 
@@ -198,22 +191,19 @@ export function useTourReducer<T extends TourEnumType>(
     [orderedStepIds, options?.requireAllStepsRegistered]
   );
 
-  const startTour = useCallback(
-    (incomingStepId?: T) => {
-      if (options?.requireAllStepsRegistered !== false && !state.isRegistered) {
-        return;
-      }
+  const startTour = useCallback(() => {
+    if (options?.requireAllStepsRegistered !== false && !state.isRegistered) {
+      return;
+    }
 
-      const stepId = computeStartTourStep(state, incomingStepId);
+    const stepId = computeStartTourStep(state);
 
-      if (stepId) {
-        dispatch({type: 'START_TOUR', stepId});
-        options?.onStartTour?.(stepId);
-        options?.onStepChange?.(stepId);
-      }
-    },
-    [options, state]
-  );
+    if (stepId) {
+      dispatch({type: 'START_TOUR', stepId});
+      options?.onStartTour?.(stepId);
+      options?.onStepChange?.(stepId);
+    }
+  }, [options, state]);
 
   const endTour = useCallback(() => {
     dispatch({type: 'END_TOUR'});
@@ -286,5 +276,5 @@ export interface TourContextType<T extends TourEnumType> extends TourState<T> {
   nextStep: () => void;
   previousStep: () => void;
   setStep: (stepId: T) => void;
-  startTour: (stepId?: T) => void;
+  startTour: () => void;
 }

--- a/static/app/components/tours/useAssistant.tsx
+++ b/static/app/components/tours/useAssistant.tsx
@@ -29,7 +29,6 @@ export function useAssistant(
 interface MutateAssistantData {
   guide: string;
   status: 'viewed' | 'dismissed' | 'restart';
-  useful?: boolean;
 }
 
 // Matching the logic from src/sentry/api/endpoints/assistant.py

--- a/static/app/utils/demoMode/demoTours.spec.tsx
+++ b/static/app/utils/demoMode/demoTours.spec.tsx
@@ -135,7 +135,7 @@ describe('DemoTours', () => {
       const tour = result.current;
 
       act(() => {
-        tour?.startTour(DemoTourStep.RELEASES_LIST);
+        tour?.startTour();
       });
 
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
@@ -178,14 +178,14 @@ describe('DemoTours', () => {
       const issuesTour = issuesResult.current;
 
       act(() => {
-        sidebarTour?.startTour(DemoTourStep.RELEASES_LIST);
+        sidebarTour?.startTour();
       });
 
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
       expect(mockState[DemoTour.ISSUES].currentStepId).toBeNull();
 
       act(() => {
-        issuesTour?.startTour(DemoTourStep.ISSUES_STREAM);
+        issuesTour?.startTour();
       });
 
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
@@ -220,7 +220,7 @@ describe('DemoTours', () => {
       const sidebarTour = result.current;
 
       act(() => {
-        sidebarTour?.startTour(DemoTourStep.RELEASES_LIST);
+        sidebarTour?.startTour();
       });
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
 

--- a/static/app/views/issueDetails/useAssignIssueMutation.ts
+++ b/static/app/views/issueDetails/useAssignIssueMutation.ts
@@ -18,7 +18,7 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {groupQueryKey} from 'sentry/views/issueDetails/useGroup';
 
-export type AssignedBy = 'suggested_assignee' | 'assignee_selector';
+type AssignedBy = 'suggested_assignee' | 'assignee_selector';
 
 type AssignIssueVariables = {
   actor: Pick<Actor, 'id' | 'type'> | null;


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~200 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/components`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/components/aiPrivacyTooltip.tsx`
- `static/app/components/group/assigneeSelector.tsx`
- `static/app/components/issues/groupList.spec.tsx`
- `static/app/components/issues/groupList.tsx`
- `static/app/components/pipeline/usePipeline.spec.tsx`
- `static/app/components/pipeline/usePipeline.tsx`
- `static/app/components/platformPicker.tsx`
- `static/app/components/tours/tourContext.spec.tsx`
- `static/app/components/tours/tourContext.tsx`
- `static/app/components/tours/useAssistant.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/components`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

