### PR TITLE
ref(ui): Drop unused optional args in search query builder and tours

### DIFF
--- a/static/app/components/banner.spec.tsx
+++ b/static/app/components/banner.spec.tsx
@@ -12,9 +12,4 @@ describe('Banner', () => {
     expect(screen.queryByText('test')).not.toBeInTheDocument();
     expect(localStorage.getItem('test-banner-dismissed')).toBe('true');
   });
-
-  it('is not dismissable', () => {
-    render(<Banner isDismissable={false} />);
-    expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
-  });
 });

--- a/static/app/components/banner.tsx
+++ b/static/app/components/banner.tsx
@@ -35,7 +35,6 @@ type Props = BannerWrapperProps & {
   children?: React.ReactNode;
   className?: string;
   dismissKey?: string;
-  isDismissable?: boolean;
   subtitle?: string;
   title?: string;
 };
@@ -43,7 +42,6 @@ type Props = BannerWrapperProps & {
 export function Banner({
   title,
   subtitle,
-  isDismissable = true,
   dismissKey = 'generic-banner',
   className,
   backgroundImg,
@@ -59,16 +57,14 @@ export function Banner({
   return (
     <BannerWrapper backgroundImg={backgroundImg} className={className}>
       {backgroundComponent}
-      {isDismissable ? (
-        <CloseButton
-          type="button"
-          size="xs"
-          variant="link"
-          icon={<IconClose />}
-          onClick={dismiss}
-          aria-label={t('Close')}
-        />
-      ) : null}
+      <CloseButton
+        type="button"
+        size="xs"
+        variant="link"
+        icon={<IconClose />}
+        onClick={dismiss}
+        aria-label={t('Close')}
+      />
       <BannerContent>
         <BannerTitle>{title}</BannerTitle>
         <BannerSubtitle>{subtitle}</BannerSubtitle>

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -111,7 +111,6 @@ interface UseChartZoomOptions {
    * inside dataZoom model for synced charts.
    */
   disabled?: boolean;
-  onZoom?: (period: FormattedPeriod) => void;
   /**
    * Use either `saveOnZoom` or `usePageDate` not both
    * Will persist zoom state to page filters
@@ -123,7 +122,6 @@ interface UseChartZoomOptions {
    * Sets the start, end, and statsPeriod query params.
    */
   usePageDate?: boolean;
-  xAxisIndex?: number | number[];
 }
 
 /**
@@ -215,10 +213,8 @@ function useChartZoomCancel(disabled?: boolean) {
  */
 export function useChartZoom({
   disabled,
-  onZoom,
   usePageDate,
   saveOnZoom,
-  xAxisIndex,
 }: UseChartZoomOptions): ZoomRenderProps {
   const {handleChartReady} = useChartZoomCancel(disabled);
   const location = useLocation();
@@ -244,14 +240,9 @@ export function useChartZoom({
 
   const setPeriod = useCallback(
     (newPeriod: DateTimeUpdate) => {
-      const formattedPeriod = getFormattedPeriod(newPeriod);
-
-      // Callback to let parent component know zoom has changed.
-      onZoom?.(formattedPeriod);
-
-      commitZoomPeriod(formattedPeriod);
+      commitZoomPeriod(getFormattedPeriod(newPeriod));
     },
-    [commitZoomPeriod, onZoom]
+    [commitZoomPeriod]
   );
 
   const handleDataZoom = useCallback<EChartDataZoomHandler>(
@@ -306,10 +297,9 @@ export function useChartZoom({
     // still receive x-range changes without this hook writing URL state.
     const zoomInside = DataZoomInside({
       id: 'useChartZoom-inside',
-      xAxisIndex,
     });
     return zoomInside;
-  }, [xAxisIndex]);
+  }, []);
 
   const toolBox = useMemo<ToolboxComponentOption>(() => {
     if (disabled) {
@@ -322,7 +312,6 @@ export function useChartZoom({
       {id: 'useChartZoom-toolbox'},
       {
         dataZoom: {
-          xAxisIndex,
           title: {
             zoom: '',
             back: '',
@@ -335,7 +324,7 @@ export function useChartZoom({
         },
       }
     );
-  }, [disabled, xAxisIndex]);
+  }, [disabled]);
 
   const renderProps = useMemo<ZoomRenderProps>(
     () => ({

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -268,14 +268,11 @@ export function canIncludePreviousPeriod(
 }
 
 export function shouldFetchPreviousPeriod({
-  includePrevious = true,
   period,
   start,
   end,
-}: {
-  includePrevious?: boolean;
-} & Pick<DateTimeObject, 'start' | 'end' | 'period'>) {
-  return !start && !end && canIncludePreviousPeriod(includePrevious, period);
+}: Pick<DateTimeObject, 'start' | 'end' | 'period'>) {
+  return !start && !end && canIncludePreviousPeriod(true, period);
 }
 
 /**

--- a/static/app/components/container/accordion.tsx
+++ b/static/app/components/container/accordion.tsx
@@ -16,7 +16,6 @@ interface Props {
   items: AccordionItemContent[];
   setExpandedIndex: (index: number) => void;
   collapsedChevronDirection?: SVGIconDirection;
-  collapsible?: boolean;
   expandedChevronDirection?: SVGIconDirection;
 }
 
@@ -26,7 +25,6 @@ export function Accordion({
   expandedChevronDirection = 'up',
   setExpandedIndex,
   items,
-  collapsible = true,
 }: Props) {
   return (
     <AccordionContainer>
@@ -45,14 +43,14 @@ export function Accordion({
                     }
                   />
                 }
-                aria-label={collapsible && isExpanded ? t('Collapse') : t('Expand')}
+                aria-label={isExpanded ? t('Collapse') : t('Expand')}
                 aria-expanded={isExpanded}
                 size="zero"
                 variant="transparent"
-                onClick={() => setExpandedIndex(collapsible && isExpanded ? -1 : index)}
+                onClick={() => setExpandedIndex(isExpanded ? -1 : index)}
               />
               <LineItemWrapper
-                onClick={() => setExpandedIndex(isExpanded && collapsible ? -1 : index)}
+                onClick={() => setExpandedIndex(isExpanded ? -1 : index)}
               >
                 {item.header}
               </LineItemWrapper>

--- a/static/app/components/container/accordion.tsx
+++ b/static/app/components/container/accordion.tsx
@@ -49,9 +49,7 @@ export function Accordion({
                 variant="transparent"
                 onClick={() => setExpandedIndex(isExpanded ? -1 : index)}
               />
-              <LineItemWrapper
-                onClick={() => setExpandedIndex(isExpanded ? -1 : index)}
-              >
+              <LineItemWrapper onClick={() => setExpandedIndex(isExpanded ? -1 : index)}>
                 {item.header}
               </LineItemWrapper>
             </AccordionHeader>

--- a/static/app/components/frontendVersionContext.spec.tsx
+++ b/static/app/components/frontendVersionContext.spec.tsx
@@ -111,18 +111,6 @@ describe('FrontendVersionProvider', () => {
     expect(await screen.findByTestId('running-version')).toHaveTextContent(commitSha);
   });
 
-  it('provides forced state when force prop is set', async () => {
-    render(
-      <FrontendVersionProvider releaseVersion="frontend@abc123" force="stale">
-        <TestComponent />
-      </FrontendVersionProvider>
-    );
-
-    expect(await screen.findByTestId('state')).toHaveTextContent('stale');
-    expect(await screen.findByTestId('deployed-version')).toHaveTextContent('null');
-    expect(await screen.findByTestId('running-version')).toHaveTextContent('abc123');
-  });
-
   it('provides state="disabled" when sentryMode is not SAAS', async () => {
     MockApiClient.addMockResponse({
       url: '/internal/frontend-version/',

--- a/static/app/components/frontendVersionContext.tsx
+++ b/static/app/components/frontendVersionContext.tsx
@@ -63,11 +63,6 @@ interface Props {
    * constant. Should be in the format `package@<commit-sha>`.
    */
   releaseVersion: string | null;
-  /**
-   * Force the status for testing purposes. When enabled, disables the API
-   * query and sets the forced state.
-   */
-  force?: State;
 }
 
 const FrontendVersionContext = createContext<VersionStatus>({
@@ -80,12 +75,12 @@ const FrontendVersionContext = createContext<VersionStatus>({
  * Context provider that polls the frontend version endpoint every 5 minutes
  * and on tab focus to detect if the frontend version has changed.
  */
-export function FrontendVersionProvider({children, force, releaseVersion}: Props) {
+export function FrontendVersionProvider({children, releaseVersion}: Props) {
   const {sentryMode} = useLegacyStore(ConfigStore);
 
   // Version checking only applies to production SAAS builds
   const isSaas = sentryMode === 'SAAS';
-  const canCheckVersion = !force && IS_PRODUCTION_BUILD && isSaas;
+  const canCheckVersion = IS_PRODUCTION_BUILD && isSaas;
 
   const [delayElapsed, setDelayElapsed] = useState(false);
 
@@ -118,9 +113,6 @@ export function FrontendVersionProvider({children, force, releaseVersion}: Props
   const deployedVersion = frontendVersionData?.version ?? null;
 
   function getState(): State {
-    if (force) {
-      return force;
-    }
     if (!enabled) {
       return 'disabled';
     }

--- a/static/app/components/groupMetaRow.spec.tsx
+++ b/static/app/components/groupMetaRow.spec.tsx
@@ -82,31 +82,6 @@ describe('GroupMetaRow', () => {
     expect(screen.getByRole('link', {name: 'annotation1'})).toBeInTheDocument();
   });
 
-  it('renders assignee when enabled', () => {
-    render(
-      <GroupMetaRow
-        data={GroupFixture({
-          project: ProjectFixture({id: 'projectId'}),
-          id: 'groupId',
-          lastSeen: '2017-07-25T22:56:12Z',
-          firstSeen: '2017-07-01T02:06:02Z',
-          numComments: 14,
-          shortId: 'shortId',
-          logger: 'javascript logger',
-          annotations: [
-            {url: 'http://example.com', displayName: 'annotation1'},
-            {url: 'http://example.com', displayName: 'annotation2'},
-          ],
-          assignedTo: ActorFixture({name: 'Assignee Name'}),
-          status: GroupStatus.RESOLVED,
-        })}
-        showAssignee
-      />
-    );
-
-    expect(screen.getByText('Assigned to Assignee Name')).toBeInTheDocument();
-  });
-
   it('should only make one replay-count API request', async () => {
     const organization = OrganizationFixture({
       features: ['session-replay'],

--- a/static/app/components/groupMetaRow.tsx
+++ b/static/app/components/groupMetaRow.tsx
@@ -15,7 +15,6 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconChat} from 'sentry/icons';
-import {tct} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import {getTitle} from 'sentry/utils/events';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
@@ -24,7 +23,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 type Props = {
   data: Group;
-  showAssignee?: boolean;
   showLifetime?: boolean;
 };
 
@@ -49,7 +47,7 @@ function Lifetime({
   );
 }
 
-export function GroupMetaRow({data, showAssignee, showLifetime = true}: Props) {
+export function GroupMetaRow({data, showLifetime = true}: Props) {
   const {
     id,
     lastSeen,
@@ -57,7 +55,6 @@ export function GroupMetaRow({data, showAssignee, showLifetime = true}: Props) {
     subscriptionDetails,
     numComments,
     logger,
-    assignedTo,
     annotations,
     shortId,
     project,
@@ -135,9 +132,6 @@ export function GroupMetaRow({data, showAssignee, showLifetime = true}: Props) {
           <ExternalLink href={annotation.url}>{annotation.displayName}</ExternalLink>
         </Annotation>
       ))}
-      {showAssignee && assignedTo ? (
-        <div>{tct('Assigned to [name]', {name: assignedTo.name})}</div>
-      ) : null}
     </GroupExtra>
   );
 }

--- a/static/app/components/performance/layouts.tsx
+++ b/static/app/components/performance/layouts.tsx
@@ -6,17 +6,13 @@ import {Grid, type GridProps} from '@sentry/scraps/layout';
 
 type PerformanceLayoutBodyRowProps = Omit<GridProps, 'columns'> & {
   minSize: number;
-  columns?: number;
 };
 
 export function PerformanceLayoutBodyRow({
   minSize,
-  columns,
   ...props
 }: PerformanceLayoutBodyRowProps) {
-  const largeColumns = columns
-    ? `repeat(${columns}, 1fr)`
-    : `repeat(auto-fit, minmax(${minSize}px, 1fr))`;
+  const largeColumns = `repeat(auto-fit, minmax(${minSize}px, 1fr))`;
 
   return (
     <Grid

--- a/static/app/components/performance/searchBar.spec.tsx
+++ b/static/app/components/performance/searchBar.spec.tsx
@@ -7,7 +7,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import type {SearchBarProps} from 'sentry/components/performance/searchBar';
 import {SearchBar} from 'sentry/components/performance/searchBar';
 import {EventView} from 'sentry/utils/discover/eventView';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 describe('SearchBar', () => {
   let eventsMock: any;
@@ -180,12 +179,7 @@ describe('SearchBar', () => {
       },
     });
 
-    render(
-      <SearchBar
-        {...testProps}
-        additionalConditions={new MutableSearch(['transaction.op:ui.load'])}
-      />
-    );
+    render(<SearchBar {...testProps} />);
 
     await userEvent.click(screen.getByRole('textbox'));
     await userEvent.paste('proje');
@@ -196,7 +190,7 @@ describe('SearchBar', () => {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: 'transaction.op:ui.load transaction:*proje* event.type:transaction',
+          query: 'transaction:*proje* event.type:transaction',
         }),
       })
     );

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -27,9 +27,7 @@ export type SearchBarProps = {
   onSearch: (query: string) => void;
   organization: Organization;
   query: string;
-  additionalConditions?: MutableSearch;
   className?: string;
-  placeholder?: string;
 };
 
 export function SearchBar(props: SearchBarProps) {
@@ -39,8 +37,6 @@ export function SearchBar(props: SearchBarProps) {
     onSearch,
     query: searchQuery,
     className,
-    placeholder,
-    additionalConditions,
   } = props;
 
   const navigate = useNavigate();
@@ -184,7 +180,7 @@ export function SearchBar(props: SearchBarProps) {
         async query => {
           try {
             setLoading(true);
-            const conditions = additionalConditions?.copy() ?? new MutableSearch('');
+            const conditions = new MutableSearch('');
             conditions.addFilterValues(
               'transaction',
               [wrapQueryInWildcards(query)],
@@ -247,7 +243,7 @@ export function SearchBar(props: SearchBarProps) {
         DEFAULT_DEBOUNCE_DURATION,
         {leading: true}
       ),
-    [api, url, eventView.statsPeriod, eventView.project, additionalConditions]
+    [api, url, eventView.statsPeriod, eventView.project]
   );
 
   const handleSearchChange = useCallback(
@@ -286,7 +282,7 @@ export function SearchBar(props: SearchBarProps) {
       ref={containerRef}
     >
       <BaseSearchBar
-        placeholder={placeholder ?? t('Search Transactions')}
+        placeholder={t('Search Transactions')}
         onChange={handleSearchChange}
         onKeyDown={handleKeyDown}
         query={searchString}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -58,11 +58,10 @@ const makeInitialAskSeerData = <
   session: null,
 });
 
-interface UseAskSeerPollingOptions<T extends QueryTokensProps> {
+interface UseAskSeerPollingOptions {
   projectIds: number[];
   strategy: string;
   onError?: (error: Error) => void;
-  onSuccess?: (result: T) => void;
   options?: Record<string, unknown>;
 }
 
@@ -75,7 +74,7 @@ interface UseAskSeerPollingOptions<T extends QueryTokensProps> {
  * 3. Stop polling when status is completed or error
  */
 export function useAskSeerPolling<T extends QueryTokensProps>(
-  options: UseAskSeerPollingOptions<T>
+  options: UseAskSeerPollingOptions
 ) {
   const api = useApi();
   const queryClient = useQueryClient();
@@ -175,12 +174,9 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
         sessionData.status === 'processing' || !!sessionData.current_step;
       if (!isStillProcessing) {
         setWaitingForResponse(false);
-        if (sessionData.status === 'completed' && sessionData.final_response) {
-          options.onSuccess?.(sessionData.final_response);
-        }
       }
     }
-  }, [waitingForResponse, sessionData, options]);
+  }, [waitingForResponse, sessionData]);
 
   // Reset function
   const reset = useCallback(() => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.tsx
@@ -1,7 +1,6 @@
 import {parse} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/grammar.pegjs';
 import {
   TokenConverter,
-  type SearchConfig,
   type Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
@@ -14,11 +13,10 @@ import {
  * - Does not disallow spaces or parens outside of quoted values
  */
 export function parseMultiSelectFilterValue(
-  value: string,
-  config?: Partial<SearchConfig>
+  value: string
 ): TokenResult<Token.VALUE_TEXT_LIST> | null {
   try {
-    return parse(value, {TokenConverter, config, startRule: 'text_in_list'});
+    return parse(value, {TokenConverter, startRule: 'text_in_list'});
   } catch (e) {
     return null;
   }

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -123,16 +123,13 @@ interface EscapeTagValueOptions {
   allowArrayValue?: boolean;
 }
 
-export function escapeTagValue(
-  value: string,
-  options: EscapeTagValueOptions = {}
-): string {
+export function escapeTagValue(value: string): string {
   if (!value) {
     return '';
   }
 
   // Wrap in quotes if there is a space or parens
-  const shouldEscape = shouldEscapeTagValue(value, options);
+  const shouldEscape = shouldEscapeTagValue(value);
   return shouldEscape ? `"${escapeDoubleQuotes(value)}"` : value;
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -119,13 +119,12 @@ function replaceFocusedWordWithFilter(
   value: string,
   cursorPosition: number,
   key: string,
-  getFieldDefinition: FieldDefinitionGetter,
-  operator?: TermOperator
+  getFieldDefinition: FieldDefinitionGetter
 ) {
   return replaceFocusedWord(
     value,
     cursorPosition,
-    getInitialFilterText(key, getFieldDefinition(key), operator)
+    getInitialFilterText(key, getFieldDefinition(key))
   );
 }
 


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~200 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/components`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/components/banner.spec.tsx`
- `static/app/components/banner.tsx`
- `static/app/components/brandPageLayout/index.tsx`
- `static/app/components/charts/useChartZoom.tsx`
- `static/app/components/charts/utils.tsx`
- `static/app/components/container/accordion.tsx`
- `static/app/components/frontendVersionContext.spec.tsx`
- `static/app/components/frontendVersionContext.tsx`
- `static/app/components/groupMetaRow.spec.tsx`
- `static/app/components/groupMetaRow.tsx`
- `static/app/components/performance/layouts.tsx`
- `static/app/components/performance/searchBar.spec.tsx`
- `static/app/components/performance/searchBar.tsx`
- `static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx`
- `static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.tsx`
- `static/app/components/searchQueryBuilder/tokens/filter/utils.tsx`
- `static/app/components/searchQueryBuilder/tokens/freeText.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/components`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

