### PR TITLE
ref(ui): Drop unused optional args in charts, duration, and seer menus

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -629,7 +629,7 @@ describe('AssigneeSelectorDropdown', () => {
     expect(await screen.findByText('Suggested based on')).toBeInTheDocument();
   });
 
-  it('shows the suggested assignee even if they would be cut off by the size limit', async () => {
+  it('shows the suggested assignee at the top of the menu', async () => {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_3);
 
     render(
@@ -638,7 +638,6 @@ describe('AssigneeSelectorDropdown', () => {
         loading={false}
         memberList={[USER_1, USER_2, USER_3, USER_4]}
         onAssign={newAssignee => updateGroup(GROUP_3, newAssignee)}
-        sizeLimit={2}
       />
     );
 
@@ -646,10 +645,7 @@ describe('AssigneeSelectorDropdown', () => {
     expect(await screen.findByText('GH')).toBeInTheDocument();
 
     await openMenu();
-    // User 4, Git Hub, would have normally been cut off by the size limit since it is
-    // alphabetically last, but it should still be shown because it is a suggested assignee
     const options = await screen.findAllByRole('option');
-    expect(options).toHaveLength(2);
     expect(options[0]).toHaveTextContent('GH');
   });
 

--- a/static/app/components/carousel.spec.tsx
+++ b/static/app/components/carousel.spec.tsx
@@ -109,7 +109,7 @@ describe('Carousel', () => {
 
   it('skips an element when it is past the visibleRatio', async () => {
     render(
-      <Carousel visibleRatio={0.9}>
+      <Carousel>
         <div data-test-id="child-1" />
         <div data-test-id="child-2" />
         <div data-test-id="child-3" />

--- a/static/app/components/carousel.tsx
+++ b/static/app/components/carousel.tsx
@@ -10,26 +10,16 @@ import {useRefChildrenVisibility} from 'sentry/utils/useRefChildrenVisibility';
 
 interface CarouselProps {
   children?: React.ReactNode;
-  /**
-   * This number determines what percentage of an element must be within the
-   * visible scroll region for it to be considered 'visible'. If it is visible
-   * but slightly off screen it will be skipped when scrolling
-   *
-   * For example, if set to 0.8, and 10% of the element is out of the scroll
-   * area to the right, pressing the right arrow will skip over scrolling to
-   * this element, and will scroll to the next invisible one.
-   *
-   * @default 0.8
-   */
-  visibleRatio?: number;
 }
 
-export function Carousel({children, visibleRatio = 0.8}: CarouselProps) {
+const VISIBLE_RATIO = 0.8;
+
+export function Carousel({children}: CarouselProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const {visibility, childrenEls} = useRefChildrenVisibility({
     children,
     scrollContainerRef,
-    visibleRatio,
+    visibleRatio: VISIBLE_RATIO,
   });
 
   const isAtStart = visibility[0];

--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -46,11 +46,6 @@ const baseCommit: Commit = {
 
 // static/app/components/hovercard.tsx
 describe('commitRow', () => {
-  it('renders custom avatar', () => {
-    render(<CommitRow commit={baseCommit} customAvatar="Custom Avatar" />);
-    expect(screen.getByText(/Custom Avatar/)).toBeInTheDocument();
-  });
-
   it('renders invite flow for non associated users', async () => {
     const commit = {
       ...baseCommit,

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -32,19 +32,12 @@ export function formatCommitMessage(message: string | null) {
 
 export interface CommitRowProps {
   commit: Commit;
-  customAvatar?: React.ReactNode;
   onCommitClick?: (commit: Commit) => void;
   onPullRequestClick?: () => void;
   project?: AvatarProject;
 }
 
-function CommitRow({
-  commit,
-  customAvatar,
-  onPullRequestClick,
-  onCommitClick,
-  project,
-}: CommitRowProps) {
+function CommitRow({commit, onPullRequestClick, onCommitClick, project}: CommitRowProps) {
   const user = useUser();
   const organization = useOrganization();
   const handleInviteClick = useCallback(() => {
@@ -87,11 +80,7 @@ function CommitRow({
         <Message>{formatCommitMessage(commit.message)}</Message>
       )}
       <MetaWrapper>
-        {customAvatar ? (
-          customAvatar
-        ) : commit.author ? (
-          <UserAvatar size={16} user={commit.author} />
-        ) : null}
+        {commit.author ? <UserAvatar size={16} user={commit.author} /> : null}
         <Meta>
           <Tooltip
             title={tct(

--- a/static/app/components/duration/duration.spec.tsx
+++ b/static/app/components/duration/duration.spec.tsx
@@ -10,13 +10,6 @@ describe('Duration', () => {
     expect(time).toBeInTheDocument();
   });
 
-  it('should render the duration in the specified format', () => {
-    render(<Duration duration={[83_456, 'ms']} precision="ms" format="h:mm:ss.sss" />);
-
-    const time = screen.getByText('1:23.456');
-    expect(time).toBeInTheDocument();
-  });
-
   it('should include `dateTime` & `title` attributes for accessibility', () => {
     // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 

--- a/static/app/components/duration/duration.tsx
+++ b/static/app/components/duration/duration.tsx
@@ -1,8 +1,11 @@
 import type {HTMLAttributes} from 'react';
 import styled from '@emotion/styled';
 
-import {formatDuration, type Format} from 'sentry/utils/duration/formatDuration';
+import {formatDuration} from 'sentry/utils/duration/formatDuration';
 import type {Duration as TDuration, Unit} from 'sentry/utils/duration/types';
+
+const DURATION_MS_FORMAT = 'hh:mm:ss.sss';
+const DURATION_FORMAT = 'hh:mm:ss';
 
 interface Props extends HTMLAttributes<HTMLTimeElement> {
   /**
@@ -15,19 +18,12 @@ interface Props extends HTMLAttributes<HTMLTimeElement> {
    * that has `ms` precision but only show the total number of seconds.
    */
   precision: Unit;
-
-  /**
-   * The style/format to render into.
-   *
-   * Default is `hh:mm:ss.sss` if the precision is `ms`
-   */
-  format?: Format;
 }
 
-export const Duration = styled(({duration, format, precision, ...props}: Props) => {
+export const Duration = styled(({duration, precision, ...props}: Props) => {
   // Style and precision should match, otherwise style will pad out missing or
   // truncated values which we don't want in this component.
-  const style = format ?? (precision === 'ms' ? 'hh:mm:ss.sss' : 'hh:mm:ss');
+  const style = precision === 'ms' ? DURATION_MS_FORMAT : DURATION_FORMAT;
 
   return (
     <time

--- a/static/app/components/highlight.spec.tsx
+++ b/static/app/components/highlight.spec.tsx
@@ -59,16 +59,6 @@ describe('MultiHighlight', () => {
     );
   });
 
-  it('renders plain text when disabled', () => {
-    render(
-      <MultiHighlight disabled terms={['error']}>
-        error occurred
-      </MultiHighlight>
-    );
-
-    expect(screen.getByText('error occurred').tagName.toLowerCase()).not.toBe('span');
-  });
-
   it('highlights the longest term when a shorter term overlaps it', () => {
     render(
       <MultiHighlight terms={['work', 'workflow']}>workflow then work</MultiHighlight>

--- a/static/app/components/highlight.tsx
+++ b/static/app/components/highlight.tsx
@@ -14,17 +14,12 @@ interface MultiHighlightProps {
    */
   caseSensitive?: boolean;
   className?: string;
-  /**
-   * Should highlighting be disabled?
-   */
-  disabled?: boolean;
 }
 
 export function MultiHighlight({
   caseSensitive,
   className,
   children,
-  disabled,
   terms,
 }: MultiHighlightProps) {
   const {validTerms, pattern} = useMemo(() => {
@@ -40,7 +35,7 @@ export function MultiHighlight({
     };
   }, [terms, caseSensitive]);
 
-  if (disabled || !pattern || typeof children !== 'string') {
+  if (!pattern || typeof children !== 'string') {
     return children;
   }
 

--- a/static/app/components/list/utils.tsx
+++ b/static/app/components/list/utils.tsx
@@ -10,15 +10,10 @@ const bulletStyle = (theme: Theme) => css`
 `;
 
 type Options = {
-  // setting initialCounterValue to 0 means the first visible step is 1
-  initialCounterValue?: number;
   isSolid?: boolean;
 };
 
-const numericStyle = (
-  theme: Theme,
-  {isSolid = false, initialCounterValue = 0}: Options
-) => css`
+const numericStyle = (theme: Theme, {isSolid = false}: Options) => css`
   & > li {
     padding-left: ${theme.space['3xl']};
     :before {
@@ -53,7 +48,7 @@ const numericStyle = (
       }
     }
   }
-  counter-reset: numberedList ${initialCounterValue};
+  counter-reset: numberedList 0;
 `;
 
 export const listSymbol = {
@@ -62,16 +57,12 @@ export const listSymbol = {
   bullet: 'bullet',
 };
 
-export function getListSymbolStyle(
-  theme: Theme,
-  symbol: keyof typeof listSymbol,
-  initialCounterValue?: number
-) {
+export function getListSymbolStyle(theme: Theme, symbol: keyof typeof listSymbol) {
   switch (symbol) {
     case 'numeric':
-      return numericStyle(theme, {initialCounterValue});
+      return numericStyle(theme, {});
     case 'colored-numeric':
-      return numericStyle(theme, {isSolid: true, initialCounterValue});
+      return numericStyle(theme, {isSolid: true});
     default:
       return bulletStyle(theme);
   }

--- a/static/app/components/messagingIntegrations/setupMessagingIntegrationButton.spec.tsx
+++ b/static/app/components/messagingIntegrations/setupMessagingIntegrationButton.spec.tsx
@@ -24,7 +24,6 @@ describe('SetupAlertIntegrationButton', () => {
 
   const getComponent = () => (
     <SetupMessagingIntegrationButton
-      refetchConfigs={jest.fn()}
       analyticsView={MessagingIntegrationAnalyticsView.ALERT_RULE_CREATION}
     />
   );

--- a/static/app/components/messagingIntegrations/setupMessagingIntegrationButton.tsx
+++ b/static/app/components/messagingIntegrations/setupMessagingIntegrationButton.tsx
@@ -24,26 +24,18 @@ export enum MessagingIntegrationAnalyticsView {
 
 type Props = {
   analyticsView: MessagingIntegrationAnalyticsView;
-  refetchConfigs?: () => void;
   // `analyticsView` identifies the flow; `variant` identifies the SCM or legacy
   // project-creation experience. Alert-rule creation leaves `variant` undefined.
   variant?: 'scm' | 'legacy';
 };
 
-export function SetupMessagingIntegrationButton({
-  refetchConfigs,
-  analyticsView,
-  variant,
-}: Props) {
+export function SetupMessagingIntegrationButton({analyticsView, variant}: Props) {
   const {openModal} = useModal();
 
   const organization = useOrganization();
 
   const onAddIntegration = () => {
     messagingIntegrationsQuery.refetch();
-    if (refetchConfigs) {
-      refetchConfigs();
-    }
   };
 
   const messagingIntegrationsQuery = useQuery(

--- a/static/app/components/notAvailable.spec.tsx
+++ b/static/app/components/notAvailable.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {NotAvailable} from 'sentry/components/notAvailable';
 
@@ -6,15 +6,5 @@ describe('NotAvailable', () => {
   it('renders', () => {
     render(<NotAvailable />);
     expect(screen.getByText('\u2014')).toBeInTheDocument();
-  });
-
-  it('renders with tooltip', async () => {
-    render(<NotAvailable tooltip="Tooltip text" />);
-    expect(screen.getByText('\u2014')).toBeInTheDocument();
-    expect(screen.queryByText('Tooltip text')).not.toBeInTheDocument();
-
-    await userEvent.hover(screen.getByText('\u2014'));
-
-    expect(await screen.findByText('Tooltip text')).toBeInTheDocument();
   });
 });

--- a/static/app/components/notAvailable.tsx
+++ b/static/app/components/notAvailable.tsx
@@ -1,18 +1,11 @@
 import styled from '@emotion/styled';
 
-import {Tooltip} from '@sentry/scraps/tooltip';
-
 type Props = {
   className?: string;
-  tooltip?: React.ReactNode;
 };
 
-export function NotAvailable({tooltip, className}: Props) {
-  return (
-    <Tooltip title={tooltip} skipWrapper disabled={tooltip === undefined}>
-      <Wrapper className={className}>{'\u2014'}</Wrapper>
-    </Tooltip>
-  );
+export function NotAvailable({className}: Props) {
+  return <Wrapper className={className}>{'\u2014'}</Wrapper>;
 }
 
 const Wrapper = styled('div')`

--- a/static/app/components/notificationActions/notificationActionManager.spec.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.spec.tsx
@@ -78,7 +78,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={notificationActions}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -96,7 +95,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[0]!]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -117,7 +115,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -169,7 +166,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[0]!]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -194,7 +190,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -243,7 +238,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[1]!]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -281,7 +275,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[1]!]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -329,7 +322,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -392,7 +384,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[2]!]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -434,7 +425,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -497,7 +487,6 @@ describe('Adds, deletes, and updates notification actions', () => {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[3]!]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -35,10 +35,6 @@ type NotificationActionManagerProps = {
    * Optional list of roles to display as recipients of Sentry notifications
    */
   recipientRoles?: string[];
-  /**
-   * Updates the notification alert count for this project
-   */
-  updateAlertCount?: (projectId: number, alertCount: number) => void;
 };
 
 export function NotificationActionManager({

--- a/static/app/components/scoreBar.spec.tsx
+++ b/static/app/components/scoreBar.spec.tsx
@@ -8,23 +8,23 @@ describe('ScoreBar', () => {
   afterEach(() => {});
 
   it('renders', () => {
-    render(<ScoreBar size={60} thickness={2} score={3} />);
+    render(<ScoreBar size={60} score={3} />);
   });
 
   it('renders vertically', () => {
-    render(<ScoreBar size={60} thickness={2} vertical score={2} />);
+    render(<ScoreBar size={60} vertical score={2} />);
   });
 
   it('renders with score = 0', () => {
-    render(<ScoreBar size={60} thickness={2} score={0} />);
+    render(<ScoreBar size={60} score={0} />);
   });
 
   it('renders with score > max score', () => {
-    render(<ScoreBar size={60} thickness={2} score={10} />);
+    render(<ScoreBar size={60} score={10} />);
   });
 
   it('renders with < 0 score', () => {
-    render(<ScoreBar size={60} thickness={2} score={-2} />);
+    render(<ScoreBar size={60} score={-2} />);
   });
 
   it('has custom palette', () => {
@@ -32,7 +32,6 @@ describe('ScoreBar', () => {
       <ScoreBar
         vertical
         size={60}
-        thickness={2}
         score={7}
         palette={['white', 'red', 'red', 'pink', 'pink', 'purple', 'purple', 'black']}
       />

--- a/static/app/components/scoreBar.tsx
+++ b/static/app/components/scoreBar.tsx
@@ -3,13 +3,14 @@ import styled from '@emotion/styled';
 
 import {SIMILARITY_SCORE_COLORS} from './similarScoreCard';
 
+const DEFAULT_THICKNESS = 4;
+
 type Props = {
   score: number;
   className?: string;
   palette?: readonly string[];
   radius?: number;
   size?: number;
-  thickness?: number;
   vertical?: boolean;
 };
 
@@ -18,7 +19,6 @@ function BaseScoreBar({
   className,
   vertical,
   size = 40,
-  thickness = 4,
   radius = 3,
   palette = SIMILARITY_SCORE_COLORS,
   ...props
@@ -33,7 +33,7 @@ function BaseScoreBar({
   // Size of bar, depends on orientation, although we could just apply a transformation via css
   const barProps = {
     vertical,
-    thickness,
+    thickness: DEFAULT_THICKNESS,
     size,
     radius,
   };

--- a/static/app/components/seer/preferredAgentDropdownMenu.tsx
+++ b/static/app/components/seer/preferredAgentDropdownMenu.tsx
@@ -2,7 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 
 import {Link} from '@sentry/scraps/link';
 
-import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {t} from 'sentry/locale';
 import {seerAgentIntegrationsSelectQueryOptions} from 'sentry/utils/seer/preferredAgent';
@@ -11,12 +11,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function PreferredAgentDropdownMenu({
   isDisabled,
-  size = 'xs',
   onChange,
 }: {
   isDisabled: boolean;
   onChange: (value: AutofixAgentSelectOption) => void;
-  size?: DropdownMenuProps['size'];
 }) {
   const organization = useOrganization();
   const {data: agentOptions = []} = useQuery(
@@ -26,7 +24,7 @@ export function PreferredAgentDropdownMenu({
   return (
     <DropdownMenu
       isDisabled={isDisabled}
-      size={size}
+      size="xs"
       triggerLabel={t('Agent')}
       items={
         agentOptions.map(({value, label}) => ({

--- a/static/app/components/seer/stoppingPointDropdownMenu.tsx
+++ b/static/app/components/seer/stoppingPointDropdownMenu.tsx
@@ -1,7 +1,7 @@
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {IconOpen} from 'sentry/icons/iconOpen';
 import {t} from 'sentry/locale';
@@ -10,18 +10,16 @@ import type {SeerAutofixStoppingPoint} from 'sentry/utils/seer/types';
 
 export function StoppingPointDropdownMenu({
   isDisabled,
-  size = 'xs',
   onChange,
 }: {
   isDisabled: boolean;
   onChange: (value: SeerAutofixStoppingPoint) => void;
-  size?: DropdownMenuProps['size'];
 }) {
   const stoppingPointOptions = useStoppingPointSelectOptions();
   return (
     <DropdownMenu
       isDisabled={isDisabled}
-      size={size}
+      size="xs"
       triggerLabel={t('Automation Steps')}
       items={stoppingPointOptions.map(option => ({
         key: option.value,

--- a/static/app/utils/duration/formatDuration.tsx
+++ b/static/app/utils/duration/formatDuration.tsx
@@ -1,7 +1,7 @@
 import {formatSecondsToClock} from 'sentry/utils/duration/formatSecondsToClock';
 import type {Duration, Unit} from 'sentry/utils/duration/types';
 
-export type Format =
+type Format =
   // example: `3,600`
   | 'count-locale'
   // example: `86400`


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~200 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/components`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/components/assigneeSelectorDropdown.spec.tsx`
- `static/app/components/assigneeSelectorDropdown.tsx`
- `static/app/components/carousel.spec.tsx`
- `static/app/components/carousel.tsx`
- `static/app/components/commitRow.spec.tsx`
- `static/app/components/commitRow.tsx`
- `static/app/components/duration/duration.spec.tsx`
- `static/app/components/duration/duration.tsx`
- `static/app/components/highlight.spec.tsx`
- `static/app/components/highlight.tsx`
- `static/app/components/list/utils.tsx`
- `static/app/components/messagingIntegrations/setupMessagingIntegrationButton.spec.tsx`
- `static/app/components/messagingIntegrations/setupMessagingIntegrationButton.tsx`
- `static/app/components/notAvailable.spec.tsx`
- `static/app/components/notAvailable.tsx`
- `static/app/components/notificationActions/notificationActionManager.spec.tsx`
- `static/app/components/notificationActions/notificationActionManager.tsx`
- `static/app/components/scoreBar.spec.tsx`
- `static/app/components/scoreBar.tsx`
- `static/app/components/seer/preferredAgentDropdownMenu.tsx`
- `static/app/components/seer/stoppingPointDropdownMenu.tsx`
- `static/app/components/tables/gridEditable/useQueryBasedColumnResize.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/components`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

