### PR TITLE
ref(ui): Drop unused optional args in arithmeticInput and searchSyntax

### DIFF
--- a/static/app/components/arithmeticInput/parser.spec.tsx
+++ b/static/app/components/arithmeticInput/parser.spec.tsx
@@ -1,5 +1,15 @@
 import {Operation, parseArithmetic} from 'sentry/components/arithmeticInput/parser';
 
+function operation(
+  operator: Operation['operator'],
+  lhs: Operation['lhs'],
+  rhs: Operation['rhs']
+) {
+  const result = new Operation({operator, rhs: rhs!});
+  result.lhs = lhs;
+  return result;
+}
+
 describe('arithmeticInput/parser', () => {
   it('errors on too many operators', () => {
     expect(parseArithmetic('1+1+1+1+1+1+1+1+1+1+1+1').error).toBe(
@@ -16,120 +26,52 @@ describe('arithmeticInput/parser', () => {
   });
 
   it('handles some addition', () => {
-    expect(parseArithmetic('1 + 2').result).toStrictEqual(
-      new Operation({
-        operator: 'plus',
-        lhs: '1',
-        rhs: '2',
-      })
-    );
+    expect(parseArithmetic('1 + 2').result).toStrictEqual(operation('plus', '1', '2'));
   });
 
   it('handles three term addition', () => {
     expect(parseArithmetic('1 + 2 + 3').result).toStrictEqual(
-      new Operation({
-        operator: 'plus',
-        lhs: new Operation({
-          operator: 'plus',
-          lhs: '1',
-          rhs: '2',
-        }),
-        rhs: '3',
-      })
+      operation('plus', operation('plus', '1', '2'), '3')
     );
   });
 
   it('handles some multiplication', () => {
-    expect(parseArithmetic('1 * 2').result).toStrictEqual(
-      new Operation({
-        operator: 'multiply',
-        lhs: '1',
-        rhs: '2',
-      })
-    );
+    expect(parseArithmetic('1 * 2').result).toStrictEqual(operation('multiply', '1', '2'));
   });
 
   it('handles three term multiplication', () => {
     expect(parseArithmetic('1 * 2 * 3').result).toStrictEqual(
-      new Operation({
-        operator: 'multiply',
-        lhs: new Operation({
-          operator: 'multiply',
-          lhs: '1',
-          rhs: '2',
-        }),
-        rhs: '3',
-      })
+      operation('multiply', operation('multiply', '1', '2'), '3')
     );
   });
 
   it('handles brackets', () => {
     expect(parseArithmetic('1 * (2 + 3)').result).toStrictEqual(
-      new Operation({
-        operator: 'multiply',
-        lhs: '1',
-        rhs: new Operation({
-          operator: 'plus',
-          lhs: '2',
-          rhs: '3',
-        }),
-      })
+      operation('multiply', '1', operation('plus', '2', '3'))
     );
 
     expect(parseArithmetic('(1 + 2) / 3').result).toStrictEqual(
-      new Operation({
-        operator: 'divide',
-        lhs: new Operation({
-          operator: 'plus',
-          lhs: '1',
-          rhs: '2',
-        }),
-        rhs: '3',
-      })
+      operation('divide', operation('plus', '1', '2'), '3')
     );
   });
 
   it('handles order of operations', () => {
     expect(parseArithmetic('1 + 2 * 3').result).toStrictEqual(
-      new Operation({
-        operator: 'plus',
-        lhs: '1',
-        rhs: new Operation({
-          operator: 'multiply',
-          lhs: '2',
-          rhs: '3',
-        }),
-      })
+      operation('plus', '1', operation('multiply', '2', '3'))
     );
 
     expect(parseArithmetic('1 / 2 - 3').result).toStrictEqual(
-      new Operation({
-        operator: 'minus',
-        lhs: new Operation({
-          operator: 'divide',
-          lhs: '1',
-          rhs: '2',
-        }),
-        rhs: '3',
-      })
+      operation('minus', operation('divide', '1', '2'), '3')
     );
   });
 
   it('handles fields and functions', () => {
     expect(parseArithmetic('spans.db + measurements.lcp').result).toStrictEqual(
-      new Operation({
-        operator: 'plus',
-        lhs: 'spans.db',
-        rhs: 'measurements.lcp',
-      })
+      operation('plus', 'spans.db', 'measurements.lcp')
     );
 
     expect(parseArithmetic('failure_count() + count_unique(user)').result).toStrictEqual(
-      new Operation({
-        operator: 'plus',
-        lhs: 'failure_count()',
-        rhs: 'count_unique(user)',
-      })
+      operation('plus', 'failure_count()', 'count_unique(user)')
     );
   });
 });

--- a/static/app/components/arithmeticInput/parser.spec.tsx
+++ b/static/app/components/arithmeticInput/parser.spec.tsx
@@ -36,7 +36,9 @@ describe('arithmeticInput/parser', () => {
   });
 
   it('handles some multiplication', () => {
-    expect(parseArithmetic('1 * 2').result).toStrictEqual(operation('multiply', '1', '2'));
+    expect(parseArithmetic('1 * 2').result).toStrictEqual(
+      operation('multiply', '1', '2')
+    );
   });
 
   it('handles three term multiplication', () => {

--- a/static/app/components/arithmeticInput/parser.tsx
+++ b/static/app/components/arithmeticInput/parser.tsx
@@ -11,7 +11,6 @@ const MAX_OPERATOR_MESSAGE = t('Maximum operators exceeded');
 type OperationOpts = {
   operator: Operator;
   rhs: Expression;
-  lhs?: Expression;
 };
 
 type Operator = 'plus' | 'minus' | 'multiply' | 'divide';
@@ -22,9 +21,9 @@ export class Operation {
   lhs?: Expression;
   rhs: Expression;
 
-  constructor({operator, lhs = null, rhs}: OperationOpts) {
+  constructor({operator, rhs}: OperationOpts) {
     this.operator = operator;
-    this.lhs = lhs;
+    this.lhs = null;
     this.rhs = rhs;
   }
 }


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~103 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/components/arithmeticInput`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/components/arithmeticInput/parser.spec.tsx`
- `static/app/components/arithmeticInput/parser.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/components/arithmeticInput`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

