### PR TITLE
ref(ui): Drop unused optional args in events and spans

### DIFF
--- a/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
+++ b/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
@@ -31,8 +31,6 @@ interface AgentConfig {
   pluginId: string;
   provider: string;
   target: SeerAutomationHandoffConfiguration['target'];
-  // If unset, the CTA renders without a feature flag gate.
-  featureFlag?: string;
   headingName?: string;
 }
 
@@ -44,15 +42,10 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
     const user = useUser();
     const queryClient = useQueryClient();
 
-    const hasFeatureFlag =
-      !config.featureFlag || organization.features.includes(config.featureFlag);
-    const {data: projectDetails, isPending: isLoadingProject} = useDetailedProject(
-      {
-        orgSlug: organization.slug,
-        projectSlug: project.slug,
-      },
-      {enabled: hasFeatureFlag}
-    );
+    const {data: projectDetails, isPending: isLoadingProject} = useDetailedProject({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+    });
     const {data: knownAgents, isLoading: isLoadingIntegrations} = useQuery(
       knownAgentIntegrationsQueryOptions({organization})
     );
@@ -122,10 +115,6 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
         autoCreatePr: false,
       });
     };
-
-    if (!hasFeatureFlag) {
-      return null;
-    }
 
     if (
       isLoadingProject ||

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -527,10 +527,12 @@ function extractFileName(filePath: string): string | undefined {
   return filePath.split('/').pop();
 }
 
-function truncateText(text: string, maxLength = 16): string {
+const TRUNCATE_TEXT_MAX_LENGTH = 16;
+
+function truncateText(text: string): string {
   const length = text.length;
-  if (length <= maxLength) {
+  if (length <= TRUNCATE_TEXT_MAX_LENGTH) {
     return text;
   }
-  return `${text.substring(0, maxLength / 2)}\u2026${text.substring(length - maxLength / 2, length)}`;
+  return `${text.substring(0, TRUNCATE_TEXT_MAX_LENGTH / 2)}\u2026${text.substring(length - TRUNCATE_TEXT_MAX_LENGTH / 2, length)}`;
 }

--- a/static/app/components/events/contexts/platformContext/spring.tsx
+++ b/static/app/components/events/contexts/platformContext/spring.tsx
@@ -12,13 +12,7 @@ export interface SpringContext {
   [SpringContextKeys.ACTIVE_PROFILES]?: string[];
 }
 
-export function getSpringContextData({
-  data,
-  meta,
-}: {
-  data: SpringContext;
-  meta?: Record<keyof SpringContext, any>;
-}): KeyValueListData {
+export function getSpringContextData({data}: {data: SpringContext}): KeyValueListData {
   return getContextKeys({data}).map(ctxKey => {
     switch (ctxKey) {
       case SpringContextKeys.ACTIVE_PROFILES:
@@ -32,7 +26,6 @@ export function getSpringContextData({
           key: ctxKey,
           subject: ctxKey,
           value: data[ctxKey],
-          meta: meta?.[ctxKey]?.[''],
         };
     }
   });

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -108,8 +108,7 @@ export function generateIconName(
 
 export function getRelativeTimeFromEventDateCreated(
   eventDateCreated: string | undefined,
-  timestamp?: string,
-  showTimestamp = true
+  timestamp?: string
 ) {
   if (!defined(timestamp)) {
     return timestamp;
@@ -131,10 +130,6 @@ export function getRelativeTimeFromEventDateCreated(
   const relativeTime = `(${dateTime.from(referenceDate, true)} ${t(
     'before this event'
   )})`;
-
-  if (!showTimestamp) {
-    return <RelativeTime>{relativeTime}</RelativeTime>;
-  }
 
   return (
     <Fragment>

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -14,7 +14,7 @@ import {
 import {Panel} from 'sentry/components/panels/panel';
 import type {Event, Frame} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/platform';
-import type {StackTraceMechanism, StacktraceType} from 'sentry/types/stacktrace';
+import type {StacktraceType} from 'sentry/types/stacktrace';
 
 import {OmittedFrames} from './omittedFrames';
 
@@ -31,9 +31,7 @@ type Props = {
   className?: string;
   frameSourceMapDebuggerData?: FrameSourceMapDebuggerData[];
   hideSourceMapDebugger?: boolean;
-  isHoverPreviewed?: boolean;
   lockAddress?: string;
-  mechanism?: StackTraceMechanism | null;
   meta?: Record<any, any>;
   threadId?: number;
 } & Partial<DefaultProps>;
@@ -46,7 +44,6 @@ export function Content({
   expandFirstFrame = true,
   platform,
   includeSystemFrames = true,
-  isHoverPreviewed = false,
   meta,
   threadId,
   lockAddress,
@@ -151,7 +148,7 @@ export function Content({
           },
           isSubFrame: hiddenFrameIndices.includes(frameIndex),
           isShowFramesToggleExpanded: toggleFrameMap[frameIndex],
-          isHoverPreviewed,
+          isHoverPreviewed: false,
           frameMeta: meta?.frames?.[frameIndex],
           registersMeta: meta?.registers,
           isANR,

--- a/static/app/components/events/interfaces/frame/utils.tsx
+++ b/static/app/components/events/interfaces/frame/utils.tsx
@@ -56,18 +56,16 @@ export function isExpandable({
   registers,
   emptySourceNotation,
   platform,
-  isOnlyFrame,
   hasScmSourceContext,
 }: {
   frame: Frame;
   registers: StacktraceType['registers'];
   emptySourceNotation?: boolean;
   hasScmSourceContext?: boolean;
-  isOnlyFrame?: boolean;
   platform?: string;
 }) {
   return !!(
-    (!isOnlyFrame && emptySourceNotation) ||
+    emptySourceNotation ||
     hasContextSource(frame) ||
     hasContextVars(frame) ||
     hasContextRegisters(registers) ||

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -15,7 +15,6 @@ import type {
   SpanChildrenLookupType,
   SpanType,
   TraceBound,
-  TraceInfo,
   TreeDepthType,
 } from './types';
 import type {SpanBoundsType, SpanGeneratedBoundsType} from './utils';
@@ -54,19 +53,15 @@ export class SpanTreeModel {
   // An entry in this set indicates that all siblings with the op and description should be left ungrouped
   expandedSiblingGroups = new Set<string>();
 
-  traceInfo: TraceInfo | undefined = undefined;
-
   constructor(
     parentSpan: SpanType,
     childSpans: SpanChildrenLookupType,
     api: Client,
-    isRoot = false,
-    traceInfo?: TraceInfo
+    isRoot = false
   ) {
     this.api = api;
     this.span = parentSpan;
     this.isRoot = isRoot;
-    this.traceInfo = traceInfo;
     const spanID = getSpanID(parentSpan);
     const spanChildren = childSpans?.[spanID] ?? [];
 
@@ -78,7 +73,7 @@ export class SpanTreeModel {
     delete childSpans[spanID];
 
     this.children = spanChildren.map(span => {
-      return new SpanTreeModel(span, childSpans, api, false, this.traceInfo);
+      return new SpanTreeModel(span, childSpans, api);
     });
 
     makeObservable(this, {
@@ -781,10 +776,9 @@ export class SpanTreeModel {
                 SpanSubTimingMark.HTTP_RESPONSE_START
               ); // Response start is a better approximation
 
-              const spanTimeOffset =
-                responseStart && !this.traceInfo
-                  ? responseStart - parsedTrace.traceEndTimestamp
-                  : this.span.start_timestamp - parsedTrace.traceStartTimestamp;
+              const spanTimeOffset = responseStart
+                ? responseStart - parsedTrace.traceEndTimestamp
+                : this.span.start_timestamp - parsedTrace.traceStartTimestamp;
 
               parsedTrace.traceStartTimestamp += spanTimeOffset;
               parsedTrace.traceEndTimestamp += spanTimeOffset;
@@ -801,9 +795,7 @@ export class SpanTreeModel {
             const parsedRootSpan = new SpanTreeModel(
               rootSpan,
               parsedTrace.childSpans,
-              this.api,
-              false,
-              this.traceInfo
+              this.api
             );
             this.embeddedChildren.push(parsedRootSpan);
             this.fetchEmbeddedChildrenState = 'idle';
@@ -838,12 +830,8 @@ export class SpanTreeModel {
   generateTraceBounds = (): TraceBound => {
     return {
       spanId: this.span.span_id,
-      traceStartTimestamp: this.traceInfo
-        ? this.traceInfo.startTimestamp
-        : this.span.start_timestamp,
-      traceEndTimestamp: this.traceInfo
-        ? this.traceInfo.endTimestamp
-        : this.span.timestamp,
+      traceStartTimestamp: this.span.start_timestamp,
+      traceEndTimestamp: this.span.timestamp,
     };
   };
 }

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -256,39 +256,3 @@ export type DescendantGroup = {
   group: SpanTreeModel[];
   occurrence?: number;
 };
-
-export type TraceInfo = {
-  /**
-   * The very latest end timestamp in the trace.
-   */
-  endTimestamp: number;
-  /**
-   * The errors in the trace.
-   */
-  errors: Set<string>;
-  /**
-   * The maximum generation in the trace.
-   */
-  maxGeneration: number;
-  /**
-   * The performance Issues on the trace
-   */
-  performanceIssues: Set<string>;
-  /**
-   * The projects in the trace
-   */
-  projects: Set<string>;
-  /**
-   * The very earliest start timestamp in the trace.
-   */
-  startTimestamp: number;
-  /**
-   * The number of events that are not transactions,
-   * appearing as its own row in the trace view
-   */
-  trailingOrphansCount: number;
-  /**
-   * The transactions in the trace.
-   */
-  transactions: Set<string>;
-};

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -151,9 +151,9 @@ export function isOrphanSpan(span: ProcessedSpanType): span is OrphanSpanType {
   return false;
 }
 
-export function getSpanID(span: ProcessedSpanType, defaultSpanID = ''): string {
+export function getSpanID(span: ProcessedSpanType): string {
   if (isGapSpan(span)) {
-    return defaultSpanID;
+    return '';
   }
 
   return span.span_id;


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~174 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/components/events`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/components/events/autofix/codingAgentIntegrationCta.tsx`
- `static/app/components/events/autofix/v3/autofixEvidence.tsx`
- `static/app/components/events/contexts/platformContext/spring.tsx`
- `static/app/components/events/contexts/utils.tsx`
- `static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx`
- `static/app/components/events/interfaces/crashContent/stackTrace/content.tsx`
- `static/app/components/events/interfaces/frame/utils.tsx`
- `static/app/components/events/interfaces/spans/spanTreeModel.tsx`
- `static/app/components/events/interfaces/spans/types.tsx`
- `static/app/components/events/interfaces/spans/utils.tsx`
- `static/app/components/events/interfaces/spans/waterfallModel.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/components/events`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

