### PR TITLE
ref(ui): Drop unused optional args in utils performance and replays

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -132,10 +132,6 @@ describe('formatRate()', () => {
     expect(formatRate(0.271, undefined, {minimumValue: 0.01})).toBe('0.271/s');
   });
 
-  it('Obeys a significant digits option', () => {
-    expect(formatRate(7.1, undefined, {significantDigits: 4})).toBe('7.100/s');
-  });
-
   it('Abbreviates large numbers using SI prefixes', () => {
     expect(formatRate(1023.142)).toBe('1.02K/s');
     expect(formatRate(1523142)).toBe('1.52M/s');
@@ -205,17 +201,6 @@ describe('formatSpanOperation', () => {
     ['resource.js', 'resource'],
   ])('formats short description for %s span operation', (operation, description) => {
     expect(formatSpanOperation(operation)).toEqual(description);
-  });
-
-  it.each([
-    ['db', 'database query'],
-    ['db.redis', 'cache query'],
-    ['task.run', 'application task'],
-    ['http.get', 'URL request'],
-    ['resource.script', 'JavaScript file'],
-    ['resource.img', 'image'],
-  ])('formats long description for %s span operation', (operation, description) => {
-    expect(formatSpanOperation(operation, 'long')).toEqual(description);
   });
 });
 

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -122,12 +122,13 @@ export function formatAbbreviatedNumberWithDynamicPrecision(
   return formatAbbreviatedNumber(value, maximumSignificantDigits, true);
 }
 
+const FORMAT_RATE_SIGNIFICANT_DIGITS = 3;
+
 export function formatRate(
   value: number,
   unit: RateUnit = RateUnit.PER_SECOND,
   options: {
     minimumValue?: number;
-    significantDigits?: number;
   } = {}
 ) {
   // NOTE: `Intl` doesn't support unitless-per-unit formats (i.e.,
@@ -140,7 +141,7 @@ export function formatRate(
   }
 
   const minimumValue = options.minimumValue ?? 0;
-  const significantDigits = options.significantDigits ?? 3;
+  const significantDigits = FORMAT_RATE_SIGNIFICANT_DIGITS;
 
   const numberFormatOptions: ConstructorParameters<typeof Intl.NumberFormat>[1] = {
     notation: 'compact',
@@ -158,62 +159,7 @@ export function formatRate(
   }`;
 }
 
-export function formatSpanOperation(
-  operation?: string,
-  length: 'short' | 'long' = 'short'
-) {
-  if (length === 'long') {
-    return getLongSpanOperationDescription(operation);
-  }
-
-  return getShortSpanOperationDescription(operation);
-}
-
-function getLongSpanOperationDescription(operation?: string) {
-  if (operation?.startsWith('http')) {
-    return t('URL request');
-  }
-
-  if (operation === 'db.redis') {
-    return t('cache query');
-  }
-
-  if (operation?.startsWith('db')) {
-    return t('database query');
-  }
-
-  if (operation?.startsWith('task')) {
-    return t('application task');
-  }
-
-  if (operation?.startsWith('serialize')) {
-    return t('serializer');
-  }
-
-  if (operation?.startsWith('middleware')) {
-    return t('middleware');
-  }
-
-  if (operation === 'resource') {
-    return t('resource');
-  }
-
-  if (operation === 'resource.script') {
-    return t('JavaScript file');
-  }
-
-  if (operation === 'resource.css') {
-    return t('stylesheet');
-  }
-
-  if (operation === 'resource.img') {
-    return t('image');
-  }
-
-  return t('span');
-}
-
-function getShortSpanOperationDescription(operation?: string) {
+export function formatSpanOperation(operation?: string) {
   if (operation?.startsWith('http')) {
     return t('request');
   }

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -270,19 +270,16 @@ export const getIntegrationSourceUrl = (
   }
 };
 
-export function getCodeOwnerIcon(
-  provider: CodeOwner['provider'],
-  iconSize: SVGIconProps['size'] = 'md'
-) {
+export function getCodeOwnerIcon(provider: CodeOwner['provider']) {
   switch (provider ?? '') {
     case 'github':
-      return <IconGithub size={iconSize} />;
+      return <IconGithub size="md" />;
     case 'gitlab':
-      return <IconGitlab size={iconSize} />;
+      return <IconGitlab size="md" />;
     case 'perforce':
-      return <IconPerforce size={iconSize} />;
+      return <IconPerforce size="md" />;
     default:
-      return <IconSentry size={iconSize} />;
+      return <IconSentry size="md" />;
   }
 }
 /**

--- a/static/app/utils/replays/getReplayEvent.spec.tsx
+++ b/static/app/utils/replays/getReplayEvent.spec.tsx
@@ -162,15 +162,4 @@ describe('getPrevReplayFrame', () => {
 
     expect(result).toEqual(frames[0]);
   });
-
-  it('should return the same frame if timestamps exactly match and allowExact is enabled', () => {
-    const exactTime = frames[1]!.offsetMs;
-    const result = getPrevReplayFrame({
-      frames,
-      targetOffsetMs: exactTime,
-      allowExact: true,
-    });
-
-    expect(result).toEqual(frames[1]);
-  });
 });

--- a/static/app/utils/replays/getReplayEvent.tsx
+++ b/static/app/utils/replays/getReplayEvent.tsx
@@ -3,24 +3,15 @@ import type {ReplayFrame} from 'sentry/utils/replays/types';
 export function getPrevReplayFrame({
   frames,
   targetOffsetMs,
-  allowExact = false,
 }: {
   frames: ReplayFrame[];
   targetOffsetMs: number;
-  allowExact?: boolean;
 }) {
   return frames.reduce<ReplayFrame | undefined>((found, item) => {
-    if (
-      item.offsetMs > targetOffsetMs ||
-      (!allowExact && item.offsetMs === targetOffsetMs)
-    ) {
+    if (item.offsetMs >= targetOffsetMs) {
       return found;
     }
-    if (
-      (allowExact && item.offsetMs === targetOffsetMs) ||
-      !found ||
-      item.offsetMs > found.offsetMs
-    ) {
+    if (!found || item.offsetMs > found.offsetMs) {
       return item;
     }
     return found;

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -260,29 +260,22 @@ describe('useReplayData', () => {
       url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
       body: {data: mockReplayResponse},
     });
-    const mockedSegmentsCall1 = MockApiClient.addMockResponse({
+    const mockedSegmentsCall = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/recording-segments/`,
-      body: mockSegmentResponse1,
+      body: [...mockSegmentResponse1, ...mockSegmentResponse2],
       match: [(_url, options) => options.query?.cursor === '0:0:0'],
-    });
-    const mockedSegmentsCall2 = MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${project.slug}/replays/${mockReplayResponse.id}/recording-segments/`,
-      body: mockSegmentResponse2,
-      match: [(_url, options) => options.query?.cursor === '0:1:0'],
     });
 
     const {result} = renderHookWithProviders(useReplayData, {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
-        segmentsPerPage: 1,
       },
     });
 
     await act(() => jest.advanceTimersByTimeAsync(0));
 
-    await waitFor(() => expect(mockedSegmentsCall1).toHaveBeenCalledTimes(1));
-    expect(mockedSegmentsCall2).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedSegmentsCall).toHaveBeenCalledTimes(1));
 
     await waitFor(() => {
       expect(result.current).toStrictEqual(
@@ -348,7 +341,6 @@ describe('useReplayData', () => {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
-        errorsPerPage: 1,
       },
     });
 
@@ -483,7 +475,6 @@ describe('useReplayData', () => {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
-        errorsPerPage: 1,
       },
     });
 

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -86,19 +86,10 @@ type Options = {
    * The replayId
    */
   replayId: string | undefined;
-
-  /**
-   * Default: 50
-   * You can override this for testing
-   */
-  errorsPerPage?: number;
-
-  /**
-   * Default: 100
-   * You can override this for testing
-   */
-  segmentsPerPage?: number;
 };
+
+const ERRORS_PER_PAGE = 50;
+const SEGMENTS_PER_PAGE = 100;
 
 const REPLAY_ERROR_FIELDS = [
   'error.type',
@@ -151,12 +142,7 @@ interface Result {
  * @param {orgSlug, replayId} Where to find the root replay event
  * @returns An object representing a unified result of the network requests. Either a single `ReplayReader` data object or fetch errors.
  */
-export function useReplayData({
-  replayId,
-  orgSlug,
-  errorsPerPage = 50,
-  segmentsPerPage = 100,
-}: Options): Result {
+export function useReplayData({replayId, orgSlug}: Options): Result {
   const queryClient = useQueryClient();
 
   // Fetch every field of the replay. The TS type definition lists every field
@@ -197,8 +183,8 @@ export function useReplayData({
     Boolean(replayRecord);
 
   const attachmentCursors = Array.from(
-    {length: Math.ceil((replayRecord?.count_segments ?? 0) / segmentsPerPage)},
-    (_, i) => `0:${segmentsPerPage * i}:0`
+    {length: Math.ceil((replayRecord?.count_segments ?? 0) / SEGMENTS_PER_PAGE)},
+    (_, i) => `0:${SEGMENTS_PER_PAGE * i}:0`
   );
 
   const {
@@ -208,7 +194,7 @@ export function useReplayData({
   } = useQueries({
     queries: enableAttachments
       ? attachmentCursors.map(cursor =>
-          getAttachmentsQueryOptions({cursor, per_page: segmentsPerPage})
+          getAttachmentsQueryOptions({cursor, per_page: SEGMENTS_PER_PAGE})
         )
       : [],
     combine: results => ({
@@ -253,8 +239,8 @@ export function useReplayData({
   );
 
   const errorCursors = Array.from(
-    {length: Math.ceil((replayRecord?.count_errors ?? 0) / errorsPerPage)},
-    (_, i) => `0:${errorsPerPage * i}:0`
+    {length: Math.ceil((replayRecord?.count_errors ?? 0) / ERRORS_PER_PAGE)},
+    (_, i) => `0:${ERRORS_PER_PAGE * i}:0`
   );
 
   const enableErrors = Boolean(replayRecord) && Boolean(projectSlug);
@@ -268,7 +254,7 @@ export function useReplayData({
           queryOptions({
             ...getErrorsQueryOptions({
               cursor,
-              per_page: errorsPerPage,
+              per_page: ERRORS_PER_PAGE,
             }),
             select: selectJsonWithHeaders,
           })
@@ -305,7 +291,7 @@ export function useReplayData({
           end: replayEnd,
           project: ALL_ACCESS_PROJECTS,
           query: `replayId:[${replayRecord?.id}]`,
-          per_page: errorsPerPage,
+          per_page: ERRORS_PER_PAGE,
           cursor: lastLinkHeader.next?.cursor ?? '0:0:0',
         },
         staleTime: Infinity,
@@ -330,7 +316,7 @@ export function useReplayData({
           end: replayEnd,
           project: ALL_ACCESS_PROJECTS,
           query: `replayId:[${replayRecord?.id}]`,
-          per_page: errorsPerPage,
+          per_page: ERRORS_PER_PAGE,
           cursor: '0:0:0',
         },
         staleTime: Infinity,

--- a/static/app/utils/useEventWaiter.spec.tsx
+++ b/static/app/utils/useEventWaiter.spec.tsx
@@ -12,6 +12,8 @@ describe('useEventWaiter', () => {
   });
 
   it('waits for the first project event and resolves the matching issue', async () => {
+    jest.useFakeTimers();
+
     const org = OrganizationFixture();
     const project = ProjectFixture({firstEvent: null});
 
@@ -28,12 +30,17 @@ describe('useEventWaiter', () => {
           eventType: 'error',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );
 
     // Initially null
+    expect(result.current).toBeNull();
+
+    // Flush the initial fetch before the first event exists
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1);
+    });
     expect(result.current).toBeNull();
 
     // Simulate first event arriving on subsequent poll
@@ -54,13 +61,19 @@ describe('useEventWaiter', () => {
       body: events,
     });
 
-    // Wait for the hook to resolve the first issue
-    await waitFor(() => {
-      expect(result.current).toEqual(events[0]);
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(5000);
     });
+    // Flush the issues query that starts once the first event is detected
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1);
+    });
+
+    expect(result.current).toEqual(events[0]);
 
     // Verify polling stops after resolution
     projectApiMock.mockClear();
+    jest.useRealTimers();
   });
 
   it('returns true when first event has expired (no matching issue)', async () => {
@@ -86,7 +99,6 @@ describe('useEventWaiter', () => {
           eventType: 'error',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );
@@ -112,7 +124,6 @@ describe('useEventWaiter', () => {
           eventType: 'transaction',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );
@@ -139,7 +150,6 @@ describe('useEventWaiter', () => {
           organization: org,
           project,
           disabled: true,
-          pollInterval: 100,
         }),
       {organization: org}
     );
@@ -167,7 +177,6 @@ describe('useEventWaiter', () => {
           eventType: 'transaction',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );
@@ -221,7 +230,6 @@ describe('useEventWaiter', () => {
             eventType,
             organization: org,
             project,
-            pollInterval: 100,
           }),
         {organization: org}
       );
@@ -265,7 +273,6 @@ describe('useEventWaiter', () => {
           eventType: 'error',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );
@@ -302,7 +309,6 @@ describe('useEventWaiter', () => {
           eventType: 'transaction',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );
@@ -337,7 +343,6 @@ describe('useEventWaiter', () => {
           eventType: 'transaction',
           organization: org,
           project,
-          pollInterval: 100,
         }),
       {organization: org}
     );

--- a/static/app/utils/useEventWaiter.tsx
+++ b/static/app/utils/useEventWaiter.tsx
@@ -38,7 +38,6 @@ interface UseEventWaiterOptions {
   organization: Organization;
   project: Project;
   disabled?: boolean;
-  pollInterval?: number;
 }
 
 function getProjectEventValue(eventType: EventType, project: Project): ProjectEventValue {
@@ -72,7 +71,6 @@ export function useEventWaiter({
   organization,
   project,
   disabled,
-  pollInterval = DEFAULT_POLL_INTERVAL,
 }: UseEventWaiterOptions): EventWaiterResult {
   const shouldPoll = !disabled && !!organization && !!project;
 
@@ -101,7 +99,7 @@ export function useEventWaiter({
       if (projectData && getProjectEventValue(eventType, projectData)) {
         return false;
       }
-      return pollInterval;
+      return DEFAULT_POLL_INTERVAL;
     },
     enabled: shouldPoll,
     staleTime: 0,


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~200 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/utils`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/utils/formatters.spec.tsx`
- `static/app/utils/formatters.tsx`
- `static/app/utils/integrationUtil.tsx`
- `static/app/utils/replays/getReplayEvent.spec.tsx`
- `static/app/utils/replays/getReplayEvent.tsx`
- `static/app/utils/replays/hooks/useReplayData.spec.tsx`
- `static/app/utils/replays/hooks/useReplayData.tsx`
- `static/app/utils/useEventWaiter.spec.tsx`
- `static/app/utils/useEventWaiter.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/utils`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

