### PR TITLE
ref(ui): Drop unused optional args in utils analytics and formatters

### DIFF
--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -24,7 +24,6 @@ type Options = Parameters<Overrides['analytics:raw-track-event']>[1];
  * Generates functions used to track an event for analytics.
  * Each function can only handle the event types specified by the
  * generic for EventParameters and the events in eventKeyToNameMap.
- * Can specifcy default options with the defaultOptions argument as well.
  * Can make orgnization required with the second generic.
  */
 export function makeAnalyticsFunction<
@@ -32,10 +31,7 @@ export function makeAnalyticsFunction<
   // This is used to provide a nice curried type for consumers.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   OrgRequirement extends OptionalOrg = OptionalOrg,
->(
-  eventKeyToNameMap: Record<keyof EventParameters, string | null>,
-  defaultOptions?: Options
-) {
+>(eventKeyToNameMap: Record<keyof EventParameters, string | null>) {
   /**
    * Function used for analytics of specifc types determined from factory function
    * Uses the current session ID or generates a new one if startSession == true.
@@ -60,8 +56,7 @@ export function makeAnalyticsFunction<
     }
 
     // only apply options if required to make mock assertions easier
-    if (options || defaultOptions) {
-      options = {...defaultOptions, ...options};
+    if (options) {
       rawTrackAnalyticsEvent(params, options);
     } else {
       rawTrackAnalyticsEvent(params);

--- a/static/app/utils/demoMode/demoTours.spec.tsx
+++ b/static/app/utils/demoMode/demoTours.spec.tsx
@@ -135,7 +135,7 @@ describe('DemoTours', () => {
       const tour = result.current;
 
       act(() => {
-        tour?.startTour(DemoTourStep.RELEASES_LIST);
+        tour?.startTour();
       });
 
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
@@ -178,14 +178,14 @@ describe('DemoTours', () => {
       const issuesTour = issuesResult.current;
 
       act(() => {
-        sidebarTour?.startTour(DemoTourStep.RELEASES_LIST);
+        sidebarTour?.startTour();
       });
 
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
       expect(mockState[DemoTour.ISSUES].currentStepId).toBeNull();
 
       act(() => {
-        issuesTour?.startTour(DemoTourStep.ISSUES_STREAM);
+        issuesTour?.startTour();
       });
 
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
@@ -220,7 +220,7 @@ describe('DemoTours', () => {
       const sidebarTour = result.current;
 
       act(() => {
-        sidebarTour?.startTour(DemoTourStep.RELEASES_LIST);
+        sidebarTour?.startTour();
       });
       expect(mockState[DemoTour.RELEASES].currentStepId).toBe(DemoTourStep.RELEASES_LIST);
 

--- a/static/app/utils/members/useMembers.tsx
+++ b/static/app/utils/members/useMembers.tsx
@@ -8,10 +8,9 @@ import {memberUsersQueryOptions, normalizeMemberValues} from './shared';
 interface UseMembersOptions {
   enabled?: boolean;
   ids?: string[];
-  limit?: number;
 }
 
-export function useMembers({enabled = true, ids, limit}: UseMembersOptions = {}) {
+export function useMembers({enabled = true, ids}: UseMembersOptions = {}) {
   const organization = useOrganization();
   const normalizedIds = useMemo(() => normalizeMemberValues(ids), [ids]);
   const hasIdFilter = ids !== undefined;
@@ -21,7 +20,6 @@ export function useMembers({enabled = true, ids, limit}: UseMembersOptions = {})
     ...memberUsersQueryOptions({
       orgSlug: organization.slug,
       ids: hasIdFilter ? normalizedIds : undefined,
-      limit,
     }),
     enabled: enabled && (!hasIdFilter || hasIds),
   });

--- a/static/app/utils/number/formatPercentage.spec.tsx
+++ b/static/app/utils/number/formatPercentage.spec.tsx
@@ -27,11 +27,4 @@ describe('formatPercentage()', () => {
     // @ts-expect-error we are testing invalid inputs
     expect(formatPercentage(undefined)).toBe('0%');
   });
-
-  it('handles null and undefined inputs with a custom null value', () => {
-    // @ts-expect-error we are testing invalid inputs
-    expect(formatPercentage(null, 0, {nullValue: 'N/A'})).toBe('N/A');
-    // @ts-expect-error we are testing invalid inputs
-    expect(formatPercentage(undefined, 0, {nullValue: '-'})).toBe('-');
-  });
 });

--- a/static/app/utils/number/formatPercentage.tsx
+++ b/static/app/utils/number/formatPercentage.tsx
@@ -9,7 +9,6 @@ export function formatPercentage(
   places = 2,
   options: {
     minimumValue?: number;
-    nullValue?: string;
   } = {}
 ) {
   if (value === 0) {
@@ -17,7 +16,7 @@ export function formatPercentage(
   }
 
   if (value === undefined || value === null) {
-    return options.nullValue ?? '0%';
+    return '0%';
   }
 
   const minimumValue = options.minimumValue ?? 0;

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -266,11 +266,7 @@ export function VisuallyCompleteWithData({
  * @param max - The approximate maximum value for the tag, A bucket between max and Infinity is also captured so it's fine if it's not precise, the data won't be entirely lost.
  * @param n - The value to be grouped, should represent `n` entities.
  */
-export const setGroupedEntityTag = (
-  tagName: string,
-  max: number,
-  n: number
-) => {
+export const setGroupedEntityTag = (tagName: string, max: number, n: number) => {
   Sentry.setExtra(tagName, n);
   let groups = [0];
   loop: for (let m = 1, mag = 0; m <= max; m *= 10, mag++) {

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -265,18 +265,16 @@ export function VisuallyCompleteWithData({
  * @param tagName - Name for the tag, will create `<tagName>` in data and `<tagname>.grouped` as a tag
  * @param max - The approximate maximum value for the tag, A bucket between max and Infinity is also captured so it's fine if it's not precise, the data won't be entirely lost.
  * @param n - The value to be grouped, should represent `n` entities.
- * @param [buckets=[1,2,5]] - An optional param to specify the bucket progression. Default is 1,2,5 (10,20,50 etc).
  */
 export const setGroupedEntityTag = (
   tagName: string,
   max: number,
-  n: number,
-  buckets = [1, 2, 5]
+  n: number
 ) => {
   Sentry.setExtra(tagName, n);
   let groups = [0];
   loop: for (let m = 1, mag = 0; m <= max; m *= 10, mag++) {
-    for (const i of buckets) {
+    for (const i of [1, 2, 5]) {
       const group = i * 10 ** mag;
       if (group > max) {
         break loop;

--- a/static/app/utils/repositories/repoQueryOptions.ts
+++ b/static/app/utils/repositories/repoQueryOptions.ts
@@ -53,7 +53,6 @@ export function organizationRepositoriesInfiniteOptions({
 export function organizationRepositoriesWithSettingsInfiniteOptions({
   organization,
   query,
-  staleTime,
 }: {
   organization: Organization;
   query?: {
@@ -64,7 +63,6 @@ export function organizationRepositoriesWithSettingsInfiniteOptions({
     sort?: Sort;
     status?: 'active' | 'deleted';
   };
-  staleTime?: number;
 }) {
   const sortQuery = query?.sort ? encodeSort(query.sort) : undefined;
   return apiOptions.asInfinite<RepositoryWithSettings[]>()(
@@ -72,7 +70,7 @@ export function organizationRepositoriesWithSettingsInfiniteOptions({
     {
       path: {organizationIdOrSlug: organization.slug},
       query: {expand: 'settings', per_page: 100, ...query, sort: sortQuery},
-      staleTime: staleTime ?? 0,
+      staleTime: 0,
     }
   );
 }

--- a/static/app/utils/string/trimCommonAffixes.spec.tsx
+++ b/static/app/utils/string/trimCommonAffixes.spec.tsx
@@ -54,14 +54,8 @@ describe('trimCommonAffixes', () => {
     expect(trimCommonAffixes(['abcdef', 'abcdef'])).toEqual(['…', '…']);
   });
 
-  it('respects custom minAffixLength', () => {
-    // With default (3), 'abc' prefix wouldn't be trimmed
+  it('does not trim affixes at or below the minimum length', () => {
     expect(trimCommonAffixes(['abcfoo', 'abcbar'])).toEqual(['abcfoo', 'abcbar']);
-    // With minAffixLength 0, it should be trimmed
-    expect(trimCommonAffixes(['abcfoo', 'abcbar'], {minAffixLength: 0})).toEqual([
-      '…foo',
-      '…bar',
-    ]);
   });
 
   it('returns values unchanged when an empty string is in the array', () => {
@@ -250,9 +244,10 @@ describe('trimCommonAffixes', () => {
     it('does not trim when only the separator itself is common', () => {
       // Common prefix '/' (1 char). Snap: '/' at index 0 → snappedPrefix = 0.
       // 0 is not > anything, so no trim — there's nothing before the separator.
-      expect(
-        trimCommonAffixes(['/xxxx', '/yyyy'], {minAffixLength: 0, separator: '/'})
-      ).toEqual(['/xxxx', '/yyyy']);
+      expect(trimCommonAffixes(['/xxxx', '/yyyy'], {separator: '/'})).toEqual([
+        '/xxxx',
+        '/yyyy',
+      ]);
     });
 
     it('handles consecutive separators in paths', () => {

--- a/static/app/utils/string/trimCommonAffixes.tsx
+++ b/static/app/utils/string/trimCommonAffixes.tsx
@@ -134,7 +134,7 @@ function snapAffixToSeparator(
 /**
  * Computes the common prefix and suffix of the given strings, then strips
  * them from each value, replacing each with `…`. Only trims affixes longer
- * than `minAffixLength` (default 3).
+ * than 3 characters.
  *
  * When `separator` is provided, affix boundaries snap to the nearest
  * separator so trimming never cuts mid-segment.
@@ -143,7 +143,7 @@ function snapAffixToSeparator(
  *
  *   1. Compute raw character-level affix lengths
  *   2. (Optional) Snap affix boundaries to the nearest separator
- *   3. Drop any affix that's ≤ minAffixLength (too short to be worth trimming)
+ *   3. Drop any affix that's ≤ MIN_AFFIX_LENGTH (too short to be worth trimming)
  *   4. For each string, replace the prefix/suffix regions with `…`
  *
  * Step 2 happens before step 3 intentionally: snapping can reduce an affix
@@ -153,9 +153,9 @@ function snapAffixToSeparator(
  */
 export function trimCommonAffixes(
   strings: string[],
-  options: {minAffixLength?: number; separator?: string} = {}
+  options: {separator?: string} = {}
 ): string[] {
-  const {minAffixLength = MIN_AFFIX_LENGTH, separator} = options;
+  const {separator} = options;
 
   if (strings.length <= 1) {
     return strings;
@@ -174,8 +174,8 @@ export function trimCommonAffixes(
   }
 
   // Step 3: drop affixes that are too short to justify an ellipsis
-  const prefixLen = rawPrefixLen > minAffixLength ? rawPrefixLen : 0;
-  const suffixLen = rawSuffixLen > minAffixLength ? rawSuffixLen : 0;
+  const prefixLen = rawPrefixLen > MIN_AFFIX_LENGTH ? rawPrefixLen : 0;
+  const suffixLen = rawSuffixLen > MIN_AFFIX_LENGTH ? rawSuffixLen : 0;
 
   if (prefixLen === 0 && suffixLen === 0) {
     return strings;

--- a/static/app/utils/timeSeries/determineSeriesConfidence.tsx
+++ b/static/app/utils/timeSeries/determineSeriesConfidence.tsx
@@ -4,10 +4,7 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 // Timeseries with more than this ratio of low confidence intervals will be considered low confidence
 const LOW_CONFIDENCE_THRESHOLD = 0.25;
 
-export function determineTimeSeriesConfidence(
-  timeSeries: TimeSeries,
-  threshold = LOW_CONFIDENCE_THRESHOLD
-): Confidence {
+export function determineTimeSeriesConfidence(timeSeries: TimeSeries): Confidence {
   const {lowConfidence, highConfidence, nullConfidence} = timeSeries.values.reduce(
     (acc, item) => {
       if (item.confidence === 'low') {
@@ -22,7 +19,12 @@ export function determineTimeSeriesConfidence(
     {lowConfidence: 0, highConfidence: 0, nullConfidence: 0}
   );
 
-  return finalConfidence(lowConfidence, highConfidence, nullConfidence, threshold);
+  return finalConfidence(
+    lowConfidence,
+    highConfidence,
+    nullConfidence,
+    LOW_CONFIDENCE_THRESHOLD
+  );
 }
 
 function finalConfidence(

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -374,7 +374,7 @@ export class MutableSearch {
    * Adds the filter values separated by OR operators. This is in contrast to
    * addFilterValues, which implicitly separates each filter value with an AND operator.
    */
-  addDisjunctionFilterValues(key: string, values: string[], shouldEscape = true) {
+  addDisjunctionFilterValues(key: string, values: string[]) {
     if (values.length === 0) {
       return this;
     }
@@ -384,7 +384,7 @@ export class MutableSearch {
       if (i > 0) {
         this.addOp('OR');
       }
-      this.addFilterValue(key, values[i]!, shouldEscape);
+      this.addFilterValue(key, values[i]!);
     }
     this.addOp(')');
     return this;

--- a/static/app/utils/useCommitters.tsx
+++ b/static/app/utils/useCommitters.tsx
@@ -2,7 +2,6 @@ import type {Group} from 'sentry/types/group';
 import type {Committer} from 'sentry/types/integrations';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {usePrevious} from 'sentry/utils/usePrevious';
 
@@ -35,10 +34,7 @@ const makeCommittersQueryKey = (
   ),
 ];
 
-export function useCommitters(
-  {eventId, projectSlug, group}: UseCommittersProps,
-  options: Partial<UseApiQueryOptions<CommittersResponse>> = {}
-) {
+export function useCommitters({eventId, projectSlug, group}: UseCommittersProps) {
   const org = useOrganization();
   const previousGroupId = usePrevious(group.id);
   return useApiQuery<CommittersResponse>(
@@ -50,7 +46,6 @@ export function useCommitters(
       placeholderData: previousData => {
         return group.id === previousGroupId ? previousData : undefined;
       },
-      ...options,
     }
   );
 }

--- a/static/app/utils/useDispatchingReducer.spec.tsx
+++ b/static/app/utils/useDispatchingReducer.spec.tsx
@@ -25,15 +25,6 @@ describe('useDispatchingReducer', () => {
 
     expect(result.current[0]).toBe(initialState);
   });
-  it('initializes state with fn initializer arg', () => {
-    const reducer = jest.fn().mockImplementation(s => s);
-    const initialState = {type: 'initial'};
-    const {result} = renderHook(() =>
-      useDispatchingReducer(reducer, undefined, () => initialState)
-    );
-
-    expect(result.current[0]).toBe(initialState);
-  });
   describe('action dispatching', () => {
     const reducer = jest.fn().mockImplementation((_s, action: string) => {
       switch (action) {

--- a/static/app/utils/useDispatchingReducer.tsx
+++ b/static/app/utils/useDispatchingReducer.tsx
@@ -9,7 +9,6 @@ import type {ReducerAction} from 'sentry/types/reducerAction';
  *
  * @param reducer The reducer function that updates the state.
  * @param initialState The initial state of the reducer.
- * @param initializer An optional function that can be used to initialize the state.
  */
 
 export interface DispatchingReducerMiddleware<R extends React.Reducer<any, any>> {
@@ -95,11 +94,10 @@ function update<R extends React.Reducer<any, any>>(
 
 export function useDispatchingReducer<R extends React.Reducer<any, any>>(
   reducer: R,
-  initialState: ReducerState<R>,
-  initializer?: (arg: ReducerState<R>) => ReducerState<R>
+  initialState: ReducerState<R>
 ): [ReducerState<R>, React.Dispatch<ReducerAction<R>>, DispatchingReducerEmitter<R>] {
   const emitter = useMemo(() => new DispatchingReducerEmitter<R>(), []);
-  const [state, setState] = useState(initialState ?? initializer?.(initialState)!);
+  const [state, setState] = useState(initialState);
 
   const stateRef = useRef(state);
   stateRef.current = state;

--- a/static/app/utils/useIssueEventOwners.tsx
+++ b/static/app/utils/useIssueEventOwners.tsx
@@ -1,6 +1,5 @@
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {EventOwners} from 'sentry/views/issueDetails/header/getOwnerList';
@@ -24,10 +23,7 @@ const makeCommittersQueryKey = (
   }),
 ];
 
-export function useIssueEventOwners(
-  {eventId, projectSlug}: UseIssueEventOwnersProps,
-  options: Partial<UseApiQueryOptions<EventOwners>> = {}
-) {
+export function useIssueEventOwners({eventId, projectSlug}: UseIssueEventOwnersProps) {
   const org = useOrganization();
   return useApiQuery<EventOwners>(
     makeCommittersQueryKey(org.slug, projectSlug, eventId),
@@ -35,7 +31,6 @@ export function useIssueEventOwners(
       staleTime: Infinity,
       retry: false,
       enabled: !!eventId,
-      ...options,
     }
   );
 }

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -3,10 +3,7 @@ import {useEffect, useState} from 'react';
 /**
  * Hook to detect when a specific key is being pressed
  */
-export const useKeyPress = (
-  targetKey: string,
-  target?: HTMLElement | null
-) => {
+export const useKeyPress = (targetKey: string, target?: HTMLElement | null) => {
   const [keyPressed, setKeyPressed] = useState(false);
   const current = target ?? document.body;
 

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -5,8 +5,7 @@ import {useEffect, useState} from 'react';
  */
 export const useKeyPress = (
   targetKey: string,
-  target?: HTMLElement | null,
-  captureAndStop = false
+  target?: HTMLElement | null
 ) => {
   const [keyPressed, setKeyPressed] = useState(false);
   const current = target ?? document.body;
@@ -15,31 +14,23 @@ export const useKeyPress = (
     const downHandler = (event: KeyboardEvent) => {
       if (event.key === targetKey) {
         setKeyPressed(true);
-        if (captureAndStop) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
       }
     };
 
     const upHandler = (event: KeyboardEvent) => {
       if (event.key === targetKey) {
         setKeyPressed(false);
-        if (captureAndStop) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
       }
     };
 
-    current.addEventListener('keydown', downHandler, captureAndStop);
-    current.addEventListener('keyup', upHandler, captureAndStop);
+    current.addEventListener('keydown', downHandler);
+    current.addEventListener('keyup', upHandler);
 
     return () => {
-      current.removeEventListener('keydown', downHandler, captureAndStop);
-      current.removeEventListener('keyup', upHandler, captureAndStop);
+      current.removeEventListener('keydown', downHandler);
+      current.removeEventListener('keyup', upHandler);
     };
-  }, [targetKey, current, captureAndStop]);
+  }, [targetKey, current]);
 
   return keyPressed;
 };

--- a/static/app/utils/useReleaseStats.tsx
+++ b/static/app/utils/useReleaseStats.tsx
@@ -14,12 +14,6 @@ interface UseReleaseStatsParams {
   datetime: Parameters<typeof normalizeDateTimeParams>[0];
   environments: readonly string[];
   projects: readonly number[];
-
-  /**
-   * Max number of pages to fetch. Default is 10 pages, which should be
-   * sufficient to fetch "all" releases.
-   */
-  maxPages?: number;
 }
 
 /**
@@ -27,7 +21,7 @@ interface UseReleaseStatsParams {
  * 10 pages (of 1000 results) to be slightly cautious.
  */
 export function useReleaseStats(
-  {datetime, environments, projects, maxPages = 10}: UseReleaseStatsParams,
+  {datetime, environments, projects}: UseReleaseStatsParams,
   queryOptions?: {enabled?: boolean; staleTime?: number}
 ) {
   const organization = useOrganization();
@@ -54,7 +48,7 @@ export function useReleaseStats(
   const currentNumberPages = data?.pages.length ?? 0;
 
   // Auto-fetch each page, one at a time
-  useFetchAllPages({result, enabled: currentNumberPages + 1 < maxPages});
+  useFetchAllPages({result, enabled: currentNumberPages + 1 < 10});
 
   return {
     isLoading,

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -33,11 +33,6 @@ interface UseResizableOptions {
    * Triggered when the user finishes dragging the resize handle.
    */
   onResizeEnd?: (newWidth: number) => void;
-
-  /**
-   * Triggered when the user starts dragging the resize handle.
-   */
-  onResizeStart?: () => void;
 }
 
 /**
@@ -51,7 +46,6 @@ export const useResizable = ({
   maxWidth = RESIZABLE_MAX_WIDTH,
   minWidth = RESIZABLE_MIN_WIDTH,
   onResizeEnd,
-  onResizeStart,
 }: UseResizableOptions): {
   /**
    * Whether the drag handle is held.
@@ -99,9 +93,8 @@ export const useResizable = ({
 
       document.body.style.cursor = 'ew-resize';
       document.body.style.userSelect = 'none';
-      onResizeStart?.();
     },
-    [ref, onResizeStart]
+    [ref]
   );
 
   const handleMouseMove = useCallback(

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -16,6 +16,11 @@ export interface UseResizableDrawerOptions {
    */
   min: number;
   /**
+   * The maximum size the container may be dragged to. Optional — defaults
+   * to no upper bound. Only enforced during drag, mirroring `min`.
+   */
+  max?: number;
+  /**
    * Triggered while dragging
    */
   onResize?: (
@@ -23,11 +28,6 @@ export interface UseResizableDrawerOptions {
     maybeOldSize: number | undefined,
     userEvent: boolean
   ) => void;
-  /**
-   * The maximum size the container may be dragged to. Optional — defaults
-   * to no upper bound. Only enforced during drag, mirroring `min`.
-   */
-  max?: number;
   /**
    * Fires once when a drag completes (on mouseUp). Receives the size at
    * the start and end of the drag.

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -18,7 +18,7 @@ export interface UseResizableDrawerOptions {
   /**
    * Triggered while dragging
    */
-  onResize: (
+  onResize?: (
     newSize: number,
     maybeOldSize: number | undefined,
     userEvent: boolean
@@ -99,7 +99,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
   const updateSize = useCallback((newSize: number, userEvent = false) => {
     sizeRef.current = newSize;
     setSize(newSize);
-    optionsRef.current.onResize(newSize, undefined, userEvent);
+    optionsRef.current.onResize?.(newSize, undefined, userEvent);
     if (optionsRef.current.sizeStorageKey) {
       localStorage.setItem(optionsRef.current.sizeStorageKey, newSize.toString());
     }
@@ -110,7 +110,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
   // invoke the onResize callback with the previously stored dimensions.
   useLayoutEffect(() => {
     const clamped = clampSize(options.initialSize ?? 0, options.min, options.max);
-    options.onResize(clamped, size, false);
+    options.onResize?.(clamped, size, false);
     setSize(clamped);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.direction]);

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -85,7 +85,6 @@ type Options = {
 
 type FetchTeamOptions = {
   cursor?: State['nextCursor'];
-  ids?: string[];
   lastSearch?: State['lastSearch'];
   limit?: Options['limit'];
   search?: State['lastSearch'];
@@ -99,7 +98,7 @@ type FetchTeamOptions = {
 async function fetchTeams(
   api: Client,
   orgId: string,
-  {slugs, ids, search, limit, lastSearch, cursor}: FetchTeamOptions = {}
+  {slugs, search, limit, lastSearch, cursor}: FetchTeamOptions = {}
 ) {
   const query: {
     cursor?: typeof cursor;
@@ -109,10 +108,6 @@ async function fetchTeams(
 
   if (slugs !== undefined && slugs.length > 0) {
     query.query = slugs.map(slug => `slug:${slug}`).join(' ');
-  }
-
-  if (ids !== undefined && ids.length > 0) {
-    query.query = ids.map(id => `id:${id}`).join(' ');
   }
 
   if (search) {

--- a/static/app/utils/window/useFullscreen.tsx
+++ b/static/app/utils/window/useFullscreen.tsx
@@ -18,7 +18,7 @@ interface Return {
    *
    * FullscreenOptions: https://developer.mozilla.org/en-US/docs/web/api/element/requestfullscreen#options_2
    */
-  enter: (options?: FullscreenOptions) => void;
+  enter: () => void;
 
   /**
    * Bring the browser out of fullscreen, regardless of which DOM element is
@@ -39,14 +39,11 @@ interface Return {
 export function useFullscreen<Element extends HTMLElement>({
   elementRef,
 }: Props<Element>): Return {
-  const enter = useCallback(
-    async (opts: FullscreenOptions = {navigationUI: 'auto'}) => {
-      if (screenfull.isEnabled && elementRef.current) {
-        await screenfull.request(elementRef.current, opts);
-      }
-    },
-    [elementRef]
-  );
+  const enter = useCallback(async () => {
+    if (screenfull.isEnabled && elementRef.current) {
+      await screenfull.request(elementRef.current, {navigationUI: 'auto'});
+    }
+  }, [elementRef]);
 
   const exit = useCallback(async () => {
     if (screenfull.isEnabled) {

--- a/static/app/utils/withApi.tsx
+++ b/static/app/utils/withApi.tsx
@@ -18,11 +18,10 @@ type WrappedProps<P> = Omit<P, keyof InjectedApiProps> & Partial<InjectedApiProp
  * through.
  */
 export const withApi = <P extends InjectedApiProps>(
-  WrappedComponent: React.ComponentType<P>,
-  options: Parameters<typeof useApi>[0] = {}
+  WrappedComponent: React.ComponentType<P>
 ) => {
   function WithApi({api: propsApi, ...props}: WrappedProps<P>) {
-    const api = useApi({api: propsApi, ...options});
+    const api = useApi({api: propsApi});
 
     // TODO(any): HoC prop types not working w/ emotion https://github.com/emotion-js/emotion/issues/3261
     return <WrappedComponent {...(props as any)} api={api} />;


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~186 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/utils`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/utils/analytics/makeAnalyticsFunction.tsx`
- `static/app/utils/demoMode/demoTours.spec.tsx`
- `static/app/utils/members/useMembers.tsx`
- `static/app/utils/number/formatPercentage.spec.tsx`
- `static/app/utils/number/formatPercentage.tsx`
- `static/app/utils/performanceForSentry/index.tsx`
- `static/app/utils/repositories/repoQueryOptions.ts`
- `static/app/utils/string/trimCommonAffixes.spec.tsx`
- `static/app/utils/string/trimCommonAffixes.tsx`
- `static/app/utils/timeSeries/determineSeriesConfidence.tsx`
- `static/app/utils/tokenizeSearch.tsx`
- `static/app/utils/useCommitters.tsx`
- `static/app/utils/useDispatchingReducer.spec.tsx`
- `static/app/utils/useDispatchingReducer.tsx`
- `static/app/utils/useIssueEventOwners.tsx`
- `static/app/utils/useKeyPress.tsx`
- `static/app/utils/useReleaseStats.tsx`
- `static/app/utils/useResizable.tsx`
- `static/app/utils/useResizableDrawer.tsx`
- `static/app/utils/useTeams.tsx`
- `static/app/utils/window/useFullscreen.tsx`
- `static/app/utils/withApi.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/utils`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

