### PR TITLE
ref(ui): Drop unused optional args in detectors, automations, and discover views

### DIFF
--- a/static/app/views/app/globalAlerts.tsx
+++ b/static/app/views/app/globalAlerts.tsx
@@ -103,10 +103,10 @@ export function GlobalAlertProvider({children}: Props) {
   const timersRef = useRef(new Map<string, number>());
 
   const closeAlert = useCallback(
-    (alert: StoredGlobalAlert, muteDurationSeconds = DEFAULT_MUTE_DURATION_SECONDS) => {
+    (alert: StoredGlobalAlert) => {
       if (alert.id !== undefined) {
         const muted = readMutedAlerts();
-        muted[alert.id] = Math.floor(Date.now() / 1000) + muteDurationSeconds;
+        muted[alert.id] = Math.floor(Date.now() / 1000) + DEFAULT_MUTE_DURATION_SECONDS;
         writeMutedAlerts(muted);
       }
 

--- a/static/app/views/app/globalAlerts.tsx
+++ b/static/app/views/app/globalAlerts.tsx
@@ -102,24 +102,21 @@ export function GlobalAlertProvider({children}: Props) {
   const [alerts, setAlerts] = useState<readonly StoredGlobalAlert[]>([]);
   const timersRef = useRef(new Map<string, number>());
 
-  const closeAlert = useCallback(
-    (alert: StoredGlobalAlert) => {
-      if (alert.id !== undefined) {
-        const muted = readMutedAlerts();
-        muted[alert.id] = Math.floor(Date.now() / 1000) + DEFAULT_MUTE_DURATION_SECONDS;
-        writeMutedAlerts(muted);
-      }
+  const closeAlert = useCallback((alert: StoredGlobalAlert) => {
+    if (alert.id !== undefined) {
+      const muted = readMutedAlerts();
+      muted[alert.id] = Math.floor(Date.now() / 1000) + DEFAULT_MUTE_DURATION_SECONDS;
+      writeMutedAlerts(muted);
+    }
 
-      const timer = timersRef.current.get(alert.key);
-      if (timer !== undefined) {
-        window.clearTimeout(timer);
-        timersRef.current.delete(alert.key);
-      }
+    const timer = timersRef.current.get(alert.key);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      timersRef.current.delete(alert.key);
+    }
 
-      setAlerts(prev => prev.filter(a => a.key !== alert.key));
-    },
-    []
-  );
+    setAlerts(prev => prev.filter(a => a.key !== alert.key));
+  }, []);
 
   const addAlert = useCallback(
     (alert: GlobalAlert) => {

--- a/static/app/views/app/globalAlerts.tsx
+++ b/static/app/views/app/globalAlerts.tsx
@@ -63,7 +63,7 @@ export type AddAlert = (alert: GlobalAlert) => void;
 interface GlobalAlertContextValue {
   addAlert: AddAlert;
   alerts: readonly StoredGlobalAlert[];
-  closeAlert: (alert: StoredGlobalAlert, muteDurationSeconds?: number) => void;
+  closeAlert: (alert: StoredGlobalAlert) => void;
 }
 
 const MUTED_STORAGE_KEY = 'alerts:muted';

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -35,7 +35,6 @@ export const automationsApiOptions = (
     detector?: string[];
     ids?: string[];
     limit?: number;
-    priorityDetector?: string;
     projects?: number[];
     query?: string;
     sortBy?: string;
@@ -45,7 +44,6 @@ export const automationsApiOptions = (
     ? {
         query: options.query,
         sortBy: options.sortBy,
-        priorityDetector: options.priorityDetector,
         id: options.ids,
         per_page: options.limit,
         cursor: options.cursor,

--- a/static/app/views/automations/pathnames.tsx
+++ b/static/app/views/automations/pathnames.tsx
@@ -1,20 +1,11 @@
-import * as qs from 'query-string';
-
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 
 export const makeAutomationBasePathname = (orgSlug: string) => {
   return normalizeUrl(`/organizations/${orgSlug}/monitors/alerts/`);
 };
 
-export const makeAutomationCreatePathname = (
-  orgSlug: string,
-  query: {
-    connectedIds?: string[];
-  } = {}
-) => {
-  return normalizeUrl(
-    `${makeAutomationBasePathname(orgSlug)}new/?${qs.stringify(query)}`
-  );
+export const makeAutomationCreatePathname = (orgSlug: string) => {
+  return normalizeUrl(`${makeAutomationBasePathname(orgSlug)}new/`);
 };
 
 export const makeAutomationDetailsPathname = (orgSlug: string, automationId: string) => {

--- a/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx
@@ -6,7 +6,6 @@ import {getWorkflowEngineResponseErrorMessage} from 'sentry/components/workflowE
 import {t} from 'sentry/locale';
 import type {
   BaseDetectorUpdatePayload,
-  Detector,
   DetectorType,
 } from 'sentry/types/workflowEngine/detectors';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -26,8 +25,6 @@ interface UseCreateDetectorFormSubmitOptions<TFormData, TUpdatePayload> {
    * Function to transform form data to API payload
    */
   formDataToEndpointPayload: (formData: TFormData) => TUpdatePayload;
-  onError?: (error: unknown) => void;
-  onSuccess?: (detector: Detector) => void;
 }
 
 export function useCreateDetectorFormSubmit<
@@ -36,8 +33,6 @@ export function useCreateDetectorFormSubmit<
 >({
   detectorType,
   formDataToEndpointPayload,
-  onError,
-  onSuccess,
 }: UseCreateDetectorFormSubmitOptions<TFormData, TUpdatePayload>): OnSubmitCallback {
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -74,11 +69,7 @@ export function useCreateDetectorFormSubmit<
 
         addSuccessMessage(t('Monitor created'));
 
-        if (onSuccess) {
-          onSuccess(resultDetector);
-        } else {
-          navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
-        }
+        navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
 
         onSubmitSuccess?.(resultDetector);
       } catch (error: unknown) {
@@ -94,21 +85,9 @@ export function useCreateDetectorFormSubmit<
             : null) ?? t('Unable to create monitor')
         );
 
-        if (onError) {
-          onError(error);
-        }
-
         onSubmitError?.(error);
       }
     },
-    [
-      detectorType,
-      formDataToEndpointPayload,
-      createDetector,
-      organization,
-      navigate,
-      onSuccess,
-      onError,
-    ]
+    [detectorType, formDataToEndpointPayload, createDetector, organization, navigate]
   );
 }

--- a/static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx
@@ -22,8 +22,6 @@ interface UseEditDetectorFormSubmitOptions<TDetector, TFormData> {
    * Function to transform form data to API payload
    */
   formDataToEndpointPayload: (formData: TFormData) => BaseDetectorUpdatePayload;
-  onError?: (error: unknown) => void;
-  onSuccess?: (detector: TDetector) => void;
 }
 
 export function useEditDetectorFormSubmit<
@@ -32,8 +30,6 @@ export function useEditDetectorFormSubmit<
 >({
   detector,
   formDataToEndpointPayload,
-  onSuccess,
-  onError,
 }: UseEditDetectorFormSubmitOptions<TDetector, TFormData>): OnSubmitCallback {
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -69,11 +65,7 @@ export function useEditDetectorFormSubmit<
 
         addSuccessMessage(t('Monitor updated'));
 
-        if (onSuccess) {
-          onSuccess(resultDetector as TDetector);
-        } else {
-          navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
-        }
+        navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
 
         onSubmitSuccess?.(resultDetector);
       } catch (error) {
@@ -83,21 +75,9 @@ export function useEditDetectorFormSubmit<
             : null) ?? t('Unable to update monitor')
         );
 
-        if (onError) {
-          onError(error);
-        }
-
         onSubmitError?.(error);
       }
     },
-    [
-      detector,
-      formDataToEndpointPayload,
-      updateDetector,
-      organization,
-      navigate,
-      onSuccess,
-      onError,
-    ]
+    [detector, formDataToEndpointPayload, updateDetector, organization, navigate]
   );
 }

--- a/static/app/views/detectors/hooks/useSubmitEditDetector.tsx
+++ b/static/app/views/detectors/hooks/useSubmitEditDetector.tsx
@@ -3,10 +3,7 @@ import {useCallback} from 'react';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {getWorkflowEngineResponseErrorMessage} from 'sentry/components/workflowEngine/getWorkflowEngineResponseErrorMessage';
 import {t} from 'sentry/locale';
-import type {
-  BaseDetectorUpdatePayload,
-  Detector,
-} from 'sentry/types/workflowEngine/detectors';
+import type {BaseDetectorUpdatePayload} from 'sentry/types/workflowEngine/detectors';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -17,20 +14,12 @@ import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 type UpdatePayload = {detectorId: string} & Partial<BaseDetectorUpdatePayload>;
 
-interface UseSubmitEditDetectorOptions<TDetector extends Detector> {
-  onError?: (error: unknown) => void;
-  onSuccess?: (detector: TDetector) => void;
-}
-
 /**
  * Handles the common submission logic for edit detector forms:
  * submitting the payload, tracking analytics, showing indicators,
  * and navigating to the detector details page.
  */
-export function useSubmitEditDetector<TDetector extends Detector>({
-  onSuccess,
-  onError,
-}: UseSubmitEditDetectorOptions<TDetector> = {}) {
+export function useSubmitEditDetector() {
   const organization = useOrganization();
   const navigate = useNavigate();
   const {mutateAsync: updateDetector} = useUpdateDetector();
@@ -47,11 +36,7 @@ export function useSubmitEditDetector<TDetector extends Detector>({
 
         addSuccessMessage(t('Monitor updated'));
 
-        if (onSuccess) {
-          onSuccess(resultDetector as TDetector);
-        } else {
-          navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
-        }
+        navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
 
         return resultDetector;
       } catch (error) {
@@ -60,10 +45,9 @@ export function useSubmitEditDetector<TDetector extends Detector>({
             ? getWorkflowEngineResponseErrorMessage(error.responseJSON)
             : null) ?? t('Unable to update monitor')
         );
-        onError?.(error);
         return;
       }
     },
-    [updateDetector, organization, navigate, onSuccess, onError]
+    [updateDetector, organization, navigate]
   );
 }

--- a/static/app/views/discover/results/tags.tsx
+++ b/static/app/views/discover/results/tags.tsx
@@ -42,7 +42,6 @@ type State = {
   tags: Tag[];
   totalValues: null | number;
   nextCursor?: string;
-  tagLinks?: string;
 };
 
 class Tags extends Component<Props, State> {

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -412,12 +412,10 @@ function ColumnEditCollection({
       canDrag = true,
       isGhost = false,
       gridColumns,
-      disabled = false,
     }: {
       gridColumns: number;
       canDelete?: boolean;
       canDrag?: boolean;
-      disabled?: boolean;
       isGhost?: boolean;
     }
   ) => {
@@ -466,7 +464,6 @@ function ColumnEditCollection({
             takeFocus={i === columns.length - 1}
             otherColumns={columns}
             shouldRenderTag
-            disabled={disabled}
             filterPrimaryOptions={filterPrimaryOptions}
             filterAggregateParameters={filterAggregateParameters}
           />

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -41,7 +41,6 @@ import {
 } from 'sentry/utils/discover/fields';
 import {DisplayModes, SavedQueryDatasets, TOP_N} from 'sentry/utils/discover/types';
 import {downloadFromHref} from 'sentry/utils/downloadFromHref';
-import {getTitle} from 'sentry/utils/events';
 import {DISCOVER_FIELDS, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {
@@ -146,13 +145,11 @@ export function decodeColumnOrder(
 
 export function generateTitle({
   eventView,
-  event,
   isHomepage,
   organization,
 }: {
   eventView: EventView;
   organization: Organization;
-  event?: Event;
   isHomepage?: boolean;
 }) {
   const titles = [getDiscoverDeprecation(organization) ? t('Errors') : t('Discover')];
@@ -164,12 +161,6 @@ export function generateTitle({
   const eventViewName = eventView.name;
   if (typeof eventViewName === 'string' && String(eventViewName).trim().length > 0) {
     titles.push(String(eventViewName).trim());
-  }
-
-  const eventTitle = event ? getTitle(event).title : undefined;
-
-  if (eventTitle) {
-    titles.push(eventTitle);
   }
 
   titles.reverse();

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -490,7 +490,7 @@ export function useUpdateInvestigationBlockPromptMutation(
     investigationId
   );
 
-  return useMutation({
+  return useMutation<InvestigationBlock, Error, UpdateBlockPromptVariables>({
     mutationFn: ({block, investigationVersion, prompt}) =>
       fetchMutation<InvestigationBlock>({
         url: getApiUrl(
@@ -510,7 +510,7 @@ export function useUpdateInvestigationBlockPromptMutation(
           generationPrompt: prompt,
         },
       }),
-    onSuccess: async (updatedBlock, variables) => {
+    onSuccess: (updatedBlock, variables) => {
       queryClient.setQueryData(detailOptions.queryKey, current =>
         current
           ? {

--- a/static/app/views/investigations/api.ts
+++ b/static/app/views/investigations/api.ts
@@ -482,8 +482,7 @@ export function useRunInvestigationBlockMutation(
 
 export function useUpdateInvestigationBlockPromptMutation(
   organizationSlug: string,
-  investigationId: string,
-  options?: MutationOptions<InvestigationBlock, UpdateBlockPromptVariables>
+  investigationId: string
 ) {
   const queryClient = useQueryClient();
   const detailOptions = getInvestigationDetailQueryOptions(
@@ -492,7 +491,6 @@ export function useUpdateInvestigationBlockPromptMutation(
   );
 
   return useMutation({
-    ...options,
     mutationFn: ({block, investigationVersion, prompt}) =>
       fetchMutation<InvestigationBlock>({
         url: getApiUrl(
@@ -512,7 +510,7 @@ export function useUpdateInvestigationBlockPromptMutation(
           generationPrompt: prompt,
         },
       }),
-    onSuccess: async (updatedBlock, variables, onMutateResult, context) => {
+    onSuccess: async (updatedBlock, variables) => {
       queryClient.setQueryData(detailOptions.queryKey, current =>
         current
           ? {
@@ -529,11 +527,9 @@ export function useUpdateInvestigationBlockPromptMutation(
             }
           : current
       );
-      await options?.onSuccess?.(updatedBlock, variables, onMutateResult, context);
     },
-    onError: async (error, variables, onMutateResult, context) => {
+    onError: async () => {
       await queryClient.invalidateQueries({queryKey: detailOptions.queryKey});
-      await options?.onError?.(error, variables, onMutateResult, context);
     },
   });
 }


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~115 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/app/globalAlerts.tsx`
- `static/app/views/automations/hooks/index.tsx`
- `static/app/views/automations/pathnames.tsx`
- `static/app/views/detectors/hooks/useCreateDetectorFormSubmit.tsx`
- `static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx`
- `static/app/views/detectors/hooks/useSubmitEditDetector.tsx`
- `static/app/views/discover/results/tags.tsx`
- `static/app/views/discover/table/columnEditCollection.tsx`
- `static/app/views/discover/utils.tsx`
- `static/app/views/investigations/api.ts`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

