### PR TITLE
ref(ui): Drop unused optional args in dashboards dataset config

### DIFF
--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -174,81 +174,6 @@ describe('Dashboards > Dashboard', () => {
     expect(tagsMock).toHaveBeenCalled();
   });
 
-  it('dashboard adds new widget if component is mounted with newWidget prop', async () => {
-    const mockHandleAddCustomWidget = jest.fn();
-    const mockCallbackToUnsetNewWidget = jest.fn();
-    render(
-      <Dashboard
-        dashboard={mockDashboard}
-        isEditingDashboard={false}
-        onUpdate={() => {}}
-        handleUpdateWidgetList={() => {}}
-        handleAddCustomWidget={mockHandleAddCustomWidget}
-        newWidget={newWidget}
-        widgetLimitReached={false}
-        onSetNewWidget={mockCallbackToUnsetNewWidget}
-        widgetLegendState={widgetLegendState}
-      />
-    );
-    await waitFor(() => expect(mockHandleAddCustomWidget).toHaveBeenCalled());
-    expect(mockCallbackToUnsetNewWidget).toHaveBeenCalled();
-  });
-
-  it('dashboard adds new widget if component updated with newWidget prop', async () => {
-    const mockHandleAddCustomWidget = jest.fn();
-    const mockCallbackToUnsetNewWidget = jest.fn();
-    const {rerender} = render(
-      <Dashboard
-        dashboard={mockDashboard}
-        isEditingDashboard={false}
-        onUpdate={() => {}}
-        handleUpdateWidgetList={() => {}}
-        handleAddCustomWidget={mockHandleAddCustomWidget}
-        widgetLimitReached={false}
-        onSetNewWidget={mockCallbackToUnsetNewWidget}
-        widgetLegendState={widgetLegendState}
-      />
-    );
-    expect(mockHandleAddCustomWidget).not.toHaveBeenCalled();
-    expect(mockCallbackToUnsetNewWidget).not.toHaveBeenCalled();
-
-    // Re-render with newWidget prop
-    rerender(
-      <Dashboard
-        dashboard={mockDashboard}
-        isEditingDashboard={false}
-        onUpdate={() => {}}
-        handleUpdateWidgetList={() => {}}
-        handleAddCustomWidget={mockHandleAddCustomWidget}
-        widgetLimitReached={false}
-        onSetNewWidget={mockCallbackToUnsetNewWidget}
-        newWidget={newWidget}
-        widgetLegendState={widgetLegendState}
-      />
-    );
-    await waitFor(() => expect(mockHandleAddCustomWidget).toHaveBeenCalled());
-    expect(mockCallbackToUnsetNewWidget).toHaveBeenCalled();
-  });
-
-  it('dashboard does not try to add new widget if no newWidget', () => {
-    const mockHandleAddCustomWidget = jest.fn();
-    const mockCallbackToUnsetNewWidget = jest.fn();
-    render(
-      <Dashboard
-        dashboard={mockDashboard}
-        isEditingDashboard={false}
-        onUpdate={() => {}}
-        handleUpdateWidgetList={() => {}}
-        handleAddCustomWidget={mockHandleAddCustomWidget}
-        widgetLimitReached={false}
-        onSetNewWidget={mockCallbackToUnsetNewWidget}
-        widgetLegendState={widgetLegendState}
-      />
-    );
-    expect(mockHandleAddCustomWidget).not.toHaveBeenCalled();
-    expect(mockCallbackToUnsetNewWidget).not.toHaveBeenCalled();
-  });
-
   it('handles duplicate widget in view mode', async () => {
     const mockOnUpdate = jest.fn();
     const mockHandleUpdateWidgetList = jest.fn();
@@ -278,7 +203,6 @@ describe('Dashboards > Dashboard', () => {
           handleUpdateWidgetList={mockHandleUpdateWidgetList}
           handleAddCustomWidget={() => {}}
           widgetLimitReached={false}
-          onSetNewWidget={() => {}}
           widgetLegendState={widgetLegendState}
         />
       </MEPSettingProvider>,

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -12,8 +12,6 @@ import debounce from 'lodash/debounce';
 
 import {Button} from '@sentry/scraps/button';
 
-import {validateWidget} from 'sentry/actionCreators/dashboards';
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconResize} from 'sentry/icons';
@@ -90,12 +88,10 @@ type Props = {
   widgetLimitReached: boolean;
   isEmbedded?: boolean;
   isPreview?: boolean;
-  newWidget?: Widget;
   newlyAddedWidget?: Widget;
   onAddWidget?: (dataset: DataSet, openWidgetTemplates?: boolean) => void;
   onEditWidget?: (widget: Widget) => void;
   onNewWidgetScrollComplete?: () => void;
-  onSetNewWidget?: () => void;
   widgetInterval?: string;
 };
 
@@ -106,7 +102,6 @@ interface LayoutState extends Record<string, Layout[]> {
 
 function DashboardInner({
   dashboard,
-  handleAddCustomWidget,
   handleUpdateWidgetList,
   isEditingDashboard,
   onUpdate,
@@ -114,12 +109,10 @@ function DashboardInner({
   widgetLimitReached,
   isEmbedded,
   isPreview,
-  newWidget,
   newlyAddedWidget,
   onAddWidget,
   onEditWidget,
   onNewWidgetScrollComplete,
-  onSetNewWidget,
   widgetInterval,
 }: Props) {
   const theme = useTheme();
@@ -175,19 +168,6 @@ function DashboardInner({
     []
   );
 
-  const addNewWidget = useCallback(async () => {
-    if (newWidget) {
-      try {
-        await validateWidget(api, organization.slug, newWidget);
-        handleAddCustomWidget(newWidget);
-        onSetNewWidget?.();
-      } catch (error: any) {
-        // Don't do anything, widget isn't valid
-        addErrorMessage(error);
-      }
-    }
-  }, [newWidget, handleAddCustomWidget, onSetNewWidget, api, organization.slug]);
-
   useEffect(() => {
     // Always load organization tags on dashboards
     loadOrganizationTags(api, organization.slug, selection, addAlert);
@@ -216,13 +196,6 @@ function DashboardInner({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Handle newWidget parsed from Add to Dashboard flows
-  useEffect(() => {
-    if (newWidget) {
-      addNewWidget();
-    }
-  }, [newWidget, addNewWidget]);
 
   const handleDeleteWidget = useCallback(
     (widgetToDelete: Widget) => () => {

--- a/static/app/views/dashboards/datasetConfig/formatTraceMetricsFunction.tsx
+++ b/static/app/views/dashboards/datasetConfig/formatTraceMetricsFunction.tsx
@@ -1,11 +1,6 @@
-import {type ReactNode} from 'react';
-
 import {parseFunction} from 'sentry/utils/discover/fields';
 
-export function formatTraceMetricsFunction(
-  valueToParse: string | string[],
-  defaultValue?: string | ReactNode
-) {
+export function formatTraceMetricsFunction(valueToParse: string | string[]) {
   if (Array.isArray(valueToParse)) {
     const parsedFunctions = valueToParse.map(v => parseFunction(v));
     const functionNames = parsedFunctions.map(f => f?.name).join(', ');
@@ -17,5 +12,5 @@ export function formatTraceMetricsFunction(
   if (parsedFunction) {
     return `${parsedFunction.name}(${parsedFunction.arguments[1] ?? '…'})`;
   }
-  return defaultValue ?? valueToParse;
+  return valueToParse;
 }

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -299,16 +299,8 @@ function filterYAxisOptions() {
   };
 }
 
-function getGroupByFieldOptions(
-  organization: Organization,
-  tags?: TagCollection,
-  customMeasurements?: CustomMeasurementCollection
-) {
-  const primaryFieldOptions = getPrimaryFieldOptions(
-    organization,
-    tags,
-    customMeasurements
-  );
+function getGroupByFieldOptions(organization: Organization, tags?: TagCollection) {
+  const primaryFieldOptions = getPrimaryFieldOptions(organization, tags);
   const yAxisFilter = filterYAxisOptions();
   const filterGroupByOptions = (option: FieldValueOption) => !yAxisFilter(option);
 

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -391,16 +391,8 @@ function filterYAxisOptions() {
   };
 }
 
-function getGroupByFieldOptions(
-  organization: Organization,
-  tags?: TagCollection,
-  customMeasurements?: CustomMeasurementCollection
-) {
-  const primaryFieldOptions = getPrimaryFieldOptions(
-    organization,
-    tags,
-    customMeasurements
-  );
+function getGroupByFieldOptions(organization: Organization, tags?: TagCollection) {
+  const primaryFieldOptions = getPrimaryFieldOptions(organization, tags);
   const yAxisFilter = filterYAxisOptions();
 
   const filterGroupByOptions = (option: FieldValueOption) => !yAxisFilter(option);

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
@@ -64,11 +64,7 @@ describe('TraceMetricsConfig', () => {
       );
     });
 
-    it('returns default value for unparseable string input', () => {
-      expect(formatTraceMetricsFunction('not-a-function', 'fallback')).toBe('fallback');
-    });
-
-    it('returns the raw value for unparseable string input when default is not provided', () => {
+    it('returns the raw value for unparseable string input', () => {
       expect(formatTraceMetricsFunction('not-a-function')).toBe('not-a-function');
     });
 

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -402,16 +402,8 @@ function filterYAxisOptions() {
   };
 }
 
-function getGroupByFieldOptions(
-  organization: Organization,
-  tags?: TagCollection,
-  customMeasurements?: CustomMeasurementCollection
-) {
-  const primaryFieldOptions = getPrimaryFieldOptions(
-    organization,
-    tags,
-    customMeasurements
-  );
+function getGroupByFieldOptions(organization: Organization, tags?: TagCollection) {
+  const primaryFieldOptions = getPrimaryFieldOptions(organization, tags);
   const yAxisFilter = filterYAxisOptions();
   const filterGroupByOptions = (option: FieldValueOption) => !yAxisFilter(option);
 

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -358,9 +358,7 @@ export const TraceMetricsConfig: DatasetConfig<
   getFieldHeaderMap: widgetQuery => {
     return (
       widgetQuery?.aggregates.reduce<Record<string, string>>((acc, aggregate) => {
-        acc[aggregate] = stripEquationPrefix(
-          formatTraceMetricsFunction(aggregate) as string
-        );
+        acc[aggregate] = stripEquationPrefix(formatTraceMetricsFunction(aggregate));
         return acc;
       }, {}) ?? {}
     );

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -1,3 +1,4 @@
+import type {ResponseMeta} from 'sentry/types/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import {getDynamicText} from 'sentry/utils/getDynamicText';
@@ -39,8 +40,8 @@ export function IssueWidgetQueries({
 }: Props) {
   const config = IssuesConfig;
 
-  const afterFetchTableData = (_rawResult: Group[]) => {
-    return {totalIssuesCount: undefined};
+  const afterFetchTableData = (_rawResult: Group[], response?: ResponseMeta) => {
+    return {totalIssuesCount: response?.getResponseHeader('X-Hits') ?? undefined};
   };
 
   const {loading, ...rest} = useGenericWidgetQueries<IssuesSeriesResponse, Group[]>({

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx
@@ -1,4 +1,3 @@
-import type {ResponseMeta} from 'sentry/types/api';
 import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import {getDynamicText} from 'sentry/utils/getDynamicText';
@@ -40,8 +39,8 @@ export function IssueWidgetQueries({
 }: Props) {
   const config = IssuesConfig;
 
-  const afterFetchTableData = (_rawResult: Group[], response?: ResponseMeta) => {
-    return {totalIssuesCount: response?.getResponseHeader('X-Hits') ?? undefined};
+  const afterFetchTableData = (_rawResult: Group[]) => {
+    return {totalIssuesCount: undefined};
   };
 
   const {loading, ...rest} = useGenericWidgetQueries<IssuesSeriesResponse, Group[]>({

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -75,9 +75,7 @@ export function transformWidgetSeriesToTimeSeries(
   const yAxis =
     aggregates.find(aggregate => {
       if (widget.widgetType === WidgetType.TRACEMETRICS) {
-        return splitUnprefixedName.includes(
-          formatTraceMetricsFunction(aggregate) as string
-        );
+        return splitUnprefixedName.includes(formatTraceMetricsFunction(aggregate));
       }
       return splitUnprefixedName.includes(aggregate);
     }) ??

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -109,7 +109,7 @@ export function WidgetQueries({
   let setIsMetricsData: undefined | ((value?: boolean) => void);
   let setIsMetricsExtractedData:
     | undefined
-    | ((mapKey: MetricsResultsMetaMapKey, value?: boolean) => void);
+    | ((mapKey: MetricsResultsMetaMapKey, value: boolean) => void);
 
   if (context) {
     setIsMetricsData = context.setIsMetricsData;

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -229,46 +229,10 @@ export class WidgetLegendSelectionState {
   }
 
   // when a widget has been changed/added/deleted update legend to incorporate that
-  setMultipleWidgetSelectionStateURL(newDashboard: DashboardDetails, newWidget?: Widget) {
+  setMultipleWidgetSelectionStateURL(newDashboard: DashboardDetails) {
     const location = this.location;
     if (!location.query.unselectedSeries) {
       return location.query.unselectedSeries;
-    }
-
-    // if widget was updated it returns updated widget to default selection state
-    if (newWidget && newDashboard.widgets.includes(newWidget)) {
-      const formattedDefaultQuery = this.formatLegendDefaultQuery(newWidget);
-
-      const newQuery = Array.isArray(location.query.unselectedSeries)
-        ? location.query.unselectedSeries
-            .map(legend => {
-              if (legend.includes(newWidget.id!)) {
-                return this.formatLegendDefaultQuery(newWidget);
-              }
-              return legend;
-            })
-            .filter(Boolean)
-        : location.query.unselectedSeries.includes(newWidget.id!)
-          ? formattedDefaultQuery
-          : [location.query.unselectedSeries, formattedDefaultQuery].filter(Boolean);
-
-      return newQuery;
-    }
-
-    // if widget was deleted it removes it from the selection query (clean up the url)
-    if (newWidget) {
-      return Array.isArray(location.query.unselectedSeries)
-        ? location.query.unselectedSeries
-            .map(legend => {
-              if (legend.includes(newWidget.id!)) {
-                return;
-              }
-              return legend;
-            })
-            .filter(Boolean)
-        : location.query.unselectedSeries.includes(newWidget.id!)
-          ? []
-          : location.query.unselectedSeries;
     }
 
     // widget added (since added widgets don't have an id until submitted), it sets selection state based on all widgets

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabelForWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabelForWidgetQuery.tsx
@@ -47,7 +47,7 @@ export function formatTimeSeriesLabelForWidgetQuery(
   if (aggregates.length > 1 && columns.length > 0) {
     labelParts.push(
       widget.widgetType === WidgetType.TRACEMETRICS
-        ? (formatTraceMetricsFunction(yAxis) as string)
+        ? formatTraceMetricsFunction(yAxis)
         : yAxis
     );
   }

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -185,13 +185,11 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
           ...metricQueries.map((metricQuery, index) => {
             const visualize = metricQuery.queryParams.visualizes[0]!;
             const label = isVisualizeFunction(visualize)
-              ? `${metricQuery.label ?? getVisualizeLabel(index, isVisualizeEquation(visualize))}: ${
-                  formatTraceMetricsFunction(
-                    metricQuery.queryParams.aggregateFields
-                      .filter(isVisualize)
-                      .map(v => v.yAxis)
-                  ) as string
-                }`
+              ? `${metricQuery.label ?? getVisualizeLabel(index, isVisualizeEquation(visualize))}: ${formatTraceMetricsFunction(
+                  metricQuery.queryParams.aggregateFields
+                    .filter(isVisualize)
+                    .map(v => v.yAxis)
+                )}`
               : (metricQuery.label ?? '');
             return {
               key: `add-to-dashboard-${index}`,


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~199 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views/dashboards`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/dashboards/dashboard.spec.tsx`
- `static/app/views/dashboards/dashboard.tsx`
- `static/app/views/dashboards/datasetConfig/formatTraceMetricsFunction.tsx`
- `static/app/views/dashboards/datasetConfig/logs.tsx`
- `static/app/views/dashboards/datasetConfig/spans.tsx`
- `static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx`
- `static/app/views/dashboards/datasetConfig/traceMetrics.tsx`
- `static/app/views/dashboards/widgetCard/issueWidgetQueries.tsx`
- `static/app/views/dashboards/widgetCard/widgetQueries.tsx`
- `static/app/views/dashboards/widgetLegendSelectionState.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views/dashboards`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

