### PR TITLE
ref(ui): Drop unused optional args in detector uptime components

### DIFF
--- a/static/app/views/detectors/components/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx
+++ b/static/app/views/detectors/components/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx
@@ -19,7 +19,11 @@ describe('AssertionFailureTree', () => {
     const assertion: UptimeAssertion = {
       root: makeAndOp({
         children: [
-          makeStatusCodeOp({operator: {cmp: UptimeComparisonType.EQUALS}, value: 500}),
+          {
+            ...makeStatusCodeOp(),
+            operator: {cmp: UptimeComparisonType.EQUALS},
+            value: 500,
+          },
         ],
       }),
     };
@@ -41,19 +45,22 @@ describe('AssertionFailureTree', () => {
     const assertion: UptimeAssertion = {
       root: makeAndOp({
         children: [
-          makeOrOp({
+          {
+            ...makeOrOp(),
             children: [
-              makeJsonPathOp({
+              {
+                ...makeJsonPathOp(),
                 value: '$.status',
                 operator: {cmp: UptimeComparisonType.EQUALS},
                 operand: {jsonpath_op: 'literal', value: 'ok'},
-              }),
-              makeHeaderCheckOp({
+              },
+              {
+                ...makeHeaderCheckOp(),
                 key_operand: {header_op: 'literal', value: 'content-type'},
                 value_operand: {header_op: 'literal', value: 'application/json'},
-              }),
+              },
             ],
-          }),
+          },
         ],
       }),
     };

--- a/static/app/views/detectors/components/uptime/assertions/assertionFailure/models/tree.spec.tsx
+++ b/static/app/views/detectors/components/uptime/assertions/assertionFailure/models/tree.spec.tsx
@@ -16,18 +16,16 @@ describe('Assertion Failure Tree model', () => {
       root: makeAndOp({
         id: 'op-1',
         children: [
-          makeStatusCodeOp({id: 'op-2', value: 200}),
-          makeOrOp({
-            id: 'op-3',
-            children: [makeJsonPathOp({id: 'op-4'})],
-          }),
-          makeNotOp({
+          {...makeStatusCodeOp(), id: 'op-2', value: 200},
+          {...makeOrOp(), id: 'op-3', children: [{...makeJsonPathOp(), id: 'op-4'}]},
+          {
+            ...makeNotOp(),
             id: 'op-5',
             operand: makeAndOp({
               id: 'op-6',
-              children: [makeHeaderCheckOp({id: 'op-7'})],
+              children: [{...makeHeaderCheckOp(), id: 'op-7'}],
             }),
-          }),
+          },
         ],
       }),
     };
@@ -42,13 +40,15 @@ describe('Assertion Failure Tree model', () => {
       root: makeAndOp({
         id: 'op-1',
         children: [
-          makeNotOp({
+          {
+            ...makeNotOp(),
             id: 'op-2',
-            operand: makeOrOp({
+            operand: {
+              ...makeOrOp(),
               id: 'op-3',
-              children: [makeStatusCodeOp({id: 'op-4', value: 200})],
-            }),
-          }),
+              children: [{...makeStatusCodeOp(), id: 'op-4', value: 200}],
+            },
+          },
         ],
       }),
     };
@@ -62,16 +62,17 @@ describe('Assertion Failure Tree model', () => {
       root: makeAndOp({
         id: 'op-1',
         children: [
-          makeNotOp({
+          {
+            ...makeNotOp(),
             id: 'op-2',
             operand: makeAndOp({
               id: 'op-3',
               children: [
-                makeStatusCodeOp({id: 'op-4', value: 200}),
-                makeJsonPathOp({id: 'op-5'}),
+                {...makeStatusCodeOp(), id: 'op-4', value: 200},
+                {...makeJsonPathOp(), id: 'op-5'},
               ],
             }),
-          }),
+          },
         ],
       }),
     };

--- a/static/app/views/detectors/components/uptime/assertions/assertionFailure/models/treeNode.spec.tsx
+++ b/static/app/views/detectors/components/uptime/assertions/assertionFailure/models/treeNode.spec.tsx
@@ -27,8 +27,8 @@ describe('Assertion Failure TreeNode model', () => {
   describe('constructor', () => {
     it('pushes node into parent.children when parent is provided', () => {
       const root = new MockTreeNode(makeAndOp({id: 'op-1'}), null);
-      const child1 = new MockTreeNode(makeStatusCodeOp({id: 'op-2'}), root);
-      const child2 = new MockTreeNode(makeStatusCodeOp({id: 'op-3'}), root);
+      const child1 = new MockTreeNode({...makeStatusCodeOp(), id: 'op-2'}, root);
+      const child2 = new MockTreeNode({...makeStatusCodeOp(), id: 'op-3'}, root);
 
       expect(root.children.map(n => n.value.id)).toEqual(['op-2', 'op-3']);
       expect(child1.value.id).toBe('op-2');
@@ -39,8 +39,8 @@ describe('Assertion Failure TreeNode model', () => {
   describe('depth', () => {
     it('increments per ancestor', () => {
       const root = new MockTreeNode(makeAndOp({id: 'op-1'}), null);
-      const parent = new MockTreeNode(makeStatusCodeOp({id: 'op-2'}), root);
-      const child = new MockTreeNode(makeJsonPathOp({id: 'op-3'}), parent);
+      const parent = new MockTreeNode({...makeStatusCodeOp(), id: 'op-2'}, root);
+      const child = new MockTreeNode({...makeJsonPathOp(), id: 'op-3'}, parent);
 
       expect(parent.depth).toBe(1);
       expect(child.depth).toBe(2);
@@ -55,8 +55,8 @@ describe('Assertion Failure TreeNode model', () => {
 
     it('reflects ordering within parent.children', () => {
       const root = new MockTreeNode(makeAndOp({id: 'op-1'}), null);
-      const firstChild = new MockTreeNode(makeStatusCodeOp({id: 'op-2'}), root);
-      const lastChild = new MockTreeNode(makeStatusCodeOp({id: 'op-3'}), root);
+      const firstChild = new MockTreeNode({...makeStatusCodeOp(), id: 'op-2'}, root);
+      const lastChild = new MockTreeNode({...makeStatusCodeOp(), id: 'op-3'}, root);
 
       expect(firstChild.isLastChild).toBe(false);
       expect(lastChild.isLastChild).toBe(true);
@@ -65,7 +65,7 @@ describe('Assertion Failure TreeNode model', () => {
 
   describe('nextOps', () => {
     it('returns children when value has children', () => {
-      const leaf1 = makeStatusCodeOp({id: 'op-2'});
+      const leaf1 = {...makeStatusCodeOp(), id: 'op-2'};
 
       const node = new MockTreeNode(makeAndOp({id: 'op-1', children: [leaf1]}), null);
 
@@ -87,7 +87,7 @@ describe('Assertion Failure TreeNode model', () => {
 
       const grandchild = new MockTreeNode(makeAndOp({id: 'op-4'}), firstChild);
       const greatGrandchild = new MockTreeNode(
-        makeStatusCodeOp({id: 'op-5'}),
+        {...makeStatusCodeOp(), id: 'op-5'},
         grandchild
       );
 
@@ -103,7 +103,7 @@ describe('Assertion Failure TreeNode model', () => {
 
   describe('renderRow', () => {
     it('returns a ReactNode for the mock', () => {
-      const node = new MockTreeNode(makeStatusCodeOp({id: 'op-1'}), null);
+      const node = new MockTreeNode({...makeStatusCodeOp(), id: 'op-1'}, null);
 
       render(<div>{node.renderRow()}</div>);
 

--- a/static/app/views/detectors/components/uptime/formErrors.spec.tsx
+++ b/static/app/views/detectors/components/uptime/formErrors.spec.tsx
@@ -120,19 +120,21 @@ describe('mapPreviewCheckErrorToMessage', () => {
 
 describe('resolveErroredAssertionOp', () => {
   it('resolves errored op from assertion_failure_data by matching value', () => {
-    const target = makeStatusCodeOp({
+    const target = {
+      ...makeStatusCodeOp(),
       value: 404,
       operator: {cmp: UptimeComparisonType.EQUALS},
-    });
-    const other = makeStatusCodeOp({
+    };
+    const other = {
+      ...makeStatusCodeOp(),
       value: 200,
       operator: {cmp: UptimeComparisonType.EQUALS},
-    });
+    };
     const rootOp = makeAndOp({children: [other, target]});
 
     const failureRoot = makeAndOp({
       children: [
-        makeStatusCodeOp({value: 404, operator: {cmp: UptimeComparisonType.EQUALS}}),
+        {...makeStatusCodeOp(), value: 404, operator: {cmp: UptimeComparisonType.EQUALS}},
       ],
     });
     const data = {check_result: {assertion_failure_data: {root: failureRoot}}};

--- a/static/app/views/detectors/components/uptime/testUptimeMonitorButton.spec.tsx
+++ b/static/app/views/detectors/components/uptime/testUptimeMonitorButton.spec.tsx
@@ -144,77 +144,7 @@ describe('TestUptimeMonitorButton', () => {
     });
   });
 
-  it('calls onValidationError with response JSON on validation failure', async () => {
-    const responseBody = {
-      assertion: {error: 'compilation_error', details: 'Invalid expression'},
-    };
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/uptime-preview-check/`,
-      method: 'POST',
-      statusCode: 400,
-      body: responseBody,
-    });
-
-    const onValidationError = jest.fn();
-
-    render(
-      <TestUptimeMonitorButton
-        getFormData={() => ({
-          url: 'https://example.com',
-          method: 'GET',
-          headers: [],
-          body: null,
-          timeoutMs: 5000,
-          assertion: null,
-        })}
-        onValidationError={onValidationError}
-      />,
-      {organization}
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Test Monitor'}));
-
-    await waitFor(() => {
-      expect(onValidationError).toHaveBeenCalledWith(responseBody);
-    });
-    expect(indicators.addErrorMessage).not.toHaveBeenCalled();
-  });
-
-  it('shows error toast for server errors even when onValidationError is provided', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/uptime-preview-check/`,
-      method: 'POST',
-      statusCode: 500,
-      body: {detail: 'Internal server error'},
-    });
-
-    const onValidationError = jest.fn();
-
-    render(
-      <TestUptimeMonitorButton
-        getFormData={() => ({
-          url: 'https://example.com',
-          method: 'GET',
-          headers: [],
-          body: null,
-          timeoutMs: 5000,
-          assertion: null,
-        })}
-        onValidationError={onValidationError}
-      />,
-      {organization}
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Test Monitor'}));
-
-    await waitFor(() => {
-      expect(indicators.addErrorMessage).toHaveBeenCalledWith('Uptime check failed');
-    });
-    expect(onValidationError).not.toHaveBeenCalled();
-  });
-
-  it('falls back to error toast when onValidationError is not provided', async () => {
+  it('shows error toast on validation failure', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/uptime-preview-check/`,
       method: 'POST',

--- a/static/app/views/detectors/components/uptime/testUptimeMonitorButton.tsx
+++ b/static/app/views/detectors/components/uptime/testUptimeMonitorButton.tsx
@@ -40,12 +40,6 @@ interface TestUptimeMonitorButtonProps {
    */
   label?: string;
   /**
-   * Called when the preview check returns a validation error (e.g. assertion
-   * compilation errors). Receives the parsed response JSON so callers can
-   * surface the errors on form fields.
-   */
-  onValidationError?: (responseJson: any) => void;
-  /**
    * Button size
    */
   size?: ButtonProps['size'];
@@ -54,7 +48,6 @@ interface TestUptimeMonitorButtonProps {
 export function TestUptimeMonitorButton({
   getFormData,
   label,
-  onValidationError,
   size,
 }: TestUptimeMonitorButtonProps) {
   const organization = useOrganization();
@@ -88,14 +81,10 @@ export function TestUptimeMonitorButton({
       const extractedError = extractPreviewCheckError(error.responseJSON);
       previewCheckResult?.setPreviewCheckError(extractedError);
 
-      if (onValidationError && error.status === 400 && error.responseJSON) {
-        onValidationError(error.responseJSON);
-      } else {
-        const trailingMessage = mapPreviewCheckErrorToMessage(extractedError);
-        addErrorMessage(
-          t('Uptime check failed%s', trailingMessage ? ` (${trailingMessage})` : '')
-        );
-      }
+      const trailingMessage = mapPreviewCheckErrorToMessage(extractedError);
+      addErrorMessage(
+        t('Uptime check failed%s', trailingMessage ? ` (${trailingMessage})` : '')
+      );
     },
   });
 


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~177 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views/detectors/components/uptime`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/detectors/components/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx`
- `static/app/views/detectors/components/uptime/assertions/assertionFailure/models/tree.spec.tsx`
- `static/app/views/detectors/components/uptime/assertions/assertionFailure/models/treeNode.spec.tsx`
- `static/app/views/detectors/components/uptime/formErrors.spec.tsx`
- `static/app/views/detectors/components/uptime/testUptimeMonitorButton.spec.tsx`
- `static/app/views/detectors/components/uptime/testUptimeMonitorButton.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views/detectors/components/uptime`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

