### PR TITLE
ref(ui): Drop unused optional args in insights

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -40,7 +40,6 @@ type Props = {
   ringSegmentColors: readonly string[];
   text: React.ReactNode;
   autoSize?: boolean;
-  barWidth?: number;
   height?: number;
   inPerformanceWidget?: boolean;
   labelHeightPadding?: number;
@@ -114,7 +113,6 @@ export function PerformanceScoreRingWithTooltips({
   autoSize = false,
   width = 220,
   height = 200,
-  barWidth = 16,
   inPerformanceWidget = false,
   size = 140,
   y: yProp,
@@ -165,7 +163,7 @@ export function PerformanceScoreRingWithTooltips({
     size,
     x,
     y,
-    barWidth,
+    16,
     weights,
     labelHeightPadding,
     radiusPadding
@@ -259,7 +257,7 @@ export function PerformanceScoreRingWithTooltips({
           ]}
           text={text}
           size={size}
-          barWidth={barWidth}
+          barWidth={16}
           textCss={() => css`
             font-size: 32px;
             font-weight: ${theme.font.weight.sans.medium};

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -29,7 +29,6 @@ export function useSpanSamplesWebVitalsQuery({
   limit,
   enabled,
   filter = SPANS_FILTER,
-  sortName,
   browserTypes,
   subregions,
   webVital = 'inp',
@@ -38,7 +37,6 @@ export function useSpanSamplesWebVitalsQuery({
   browserTypes?: BrowserType[];
   enabled?: boolean;
   filter?: string;
-  sortName?: string;
   subregions?: SubregionCode[];
   transaction?: string;
   webVital?: WebVitals;
@@ -48,7 +46,6 @@ export function useSpanSamplesWebVitalsQuery({
     ...SORTABLE_INDEXED_INTERACTION_FIELDS,
   ];
   const sort = useWebVitalsSort({
-    sortName,
     defaultSort: DEFAULT_INDEXED_SPANS_SORT,
     sortableFields: filteredSortableFields,
   });

--- a/static/app/views/insights/crons/components/monitorForm.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.spec.tsx
@@ -96,7 +96,6 @@ describe('MonitorForm', () => {
         apiMethod="POST"
         apiEndpoint={apiEndpont}
         onSubmitSuccess={mockHandleSubmitSuccess}
-        submitLabel="Add Cron Monitor"
       />,
       {
         organization,
@@ -151,7 +150,7 @@ describe('MonitorForm', () => {
       method: 'POST',
     });
 
-    await userEvent.click(screen.getByRole('button', {name: 'Add Cron Monitor'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
 
     const config = {
       checkinMargin: '5',
@@ -199,7 +198,6 @@ describe('MonitorForm', () => {
         apiMethod="POST"
         apiEndpoint={apiEndpont}
         onSubmitSuccess={jest.fn()}
-        submitLabel="Edit Monitor"
       />,
       {
         organization,
@@ -257,7 +255,7 @@ describe('MonitorForm', () => {
     });
 
     // Monitor form is not submitable until something is changed
-    const submitButton = screen.getByRole('button', {name: 'Edit Monitor'});
+    const submitButton = screen.getByRole('button', {name: 'Save Changes'});
     expect(submitButton).toBeDisabled();
 
     // Change Failure Tolerance

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -67,7 +67,6 @@ type Props = {
   apiMethod: FormProps['apiMethod'];
   onSubmitSuccess: FormProps['onSubmitSuccess'];
   monitor?: Monitor;
-  submitLabel?: string;
 };
 
 interface TransformedData extends Partial<Omit<Monitor, 'config' | 'alertRule'>> {
@@ -168,13 +167,7 @@ function mapMonitorFormErrors(responseJson?: any) {
   return {...responseRest, ...configErrors};
 }
 
-export function MonitorForm({
-  monitor,
-  submitLabel,
-  apiEndpoint,
-  apiMethod,
-  onSubmitSuccess,
-}: Props) {
+export function MonitorForm({monitor, apiEndpoint, apiMethod, onSubmitSuccess}: Props) {
   const theme = useTheme();
   const organization = useOrganization();
   const form = useRef(
@@ -255,7 +248,6 @@ export function MonitorForm({
             }
       }
       onSubmitSuccess={onSubmitSuccess}
-      submitLabel={submitLabel}
       mapFormErrors={mapMonitorFormErrors}
     >
       <StyledList symbol="colored-numeric">

--- a/static/app/views/insights/crons/components/useCronsUpsertGuideState.tsx
+++ b/static/app/views/insights/crons/components/useCronsUpsertGuideState.tsx
@@ -24,17 +24,6 @@ const guideParser = parseAsStringEnum<GuideKey | 'manual'>([
   'manual',
 ]);
 
-interface Options {
-  /**
-   * Default guide to use if not present in URL.
-   */
-  defaultGuide?: GuideKey | 'manual';
-  /**
-   * Default platform to use if not present in URL.
-   */
-  defaultPlatform?: SupportedPlatform;
-}
-
 interface PlatformGuideState {
   /**
    * The selected Crons platform guide
@@ -71,15 +60,11 @@ interface PlatformGuideState {
 /**
  * Custom hook to manage platform and guide query parameters using nuqs.
  */
-export function useCronsUpsertGuideState(options?: Options): PlatformGuideState {
+export function useCronsUpsertGuideState(): PlatformGuideState {
   const [{platform: platformKey, guide: guideKey}, setQueryParams] = useQueryStates(
     {
-      platform: options?.defaultPlatform
-        ? platformParser.withDefault(options.defaultPlatform)
-        : platformParser,
-      guide: options?.defaultGuide
-        ? guideParser.withDefault(options.defaultGuide)
-        : guideParser,
+      platform: platformParser,
+      guide: guideParser,
     },
     {
       history: 'replace',

--- a/static/app/views/insights/crons/utils/useMonitorStats.tsx
+++ b/static/app/views/insights/crons/utils/useMonitorStats.tsx
@@ -1,6 +1,6 @@
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {MonitorBucket} from 'sentry/views/insights/crons/types';
@@ -14,10 +14,6 @@ interface Options {
    * The window configuration object
    */
   timeWindowConfig: TimeWindowConfig;
-  /**
-   * Do not query stats when set to false
-   */
-  enabled?: boolean;
 }
 
 type Result = Record<string, MonitorBucket[]>;
@@ -25,10 +21,7 @@ type Result = Record<string, MonitorBucket[]>;
 /**
  * Fetches Monitor stats
  */
-export function useMonitorStats(
-  {monitors, timeWindowConfig, enabled = true}: Options,
-  options: Partial<UseApiQueryOptions<Result>> = {}
-) {
+export function useMonitorStats({monitors, timeWindowConfig}: Options) {
   const {start, end, rollupConfig} = timeWindowConfig;
 
   const selectionQuery = {
@@ -61,9 +54,8 @@ export function useMonitorStats(
     ],
     {
       staleTime: 0,
-      enabled: enabled && rollupConfig.totalBuckets > 0,
+      enabled: rollupConfig.totalBuckets > 0,
       retry: false,
-      ...options,
     }
   );
 }

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
@@ -34,7 +34,6 @@ type Tab = {
   content: () => React.ReactNode;
   key: TabKey;
   label: string;
-  feature?: string;
   featureBadge?: FeatureBadgeProps['type'];
 };
 
@@ -88,10 +87,8 @@ function ScreenDetailsPage() {
   const tabList = (
     <TabList>
       {tabs.map(tab => {
-        const visible =
-          tab.feature === undefined || organization.features.includes(tab.feature);
         return (
-          <TabList.Item key={tab.key} hidden={!visible} textValue={tab.label}>
+          <TabList.Item key={tab.key} textValue={tab.label}>
             {tab.label}
             {tab.featureBadge && <FeatureBadge type={tab.featureBadge} />}
           </TabList.Item>

--- a/static/app/views/insights/pages/agents/components/modelName.spec.tsx
+++ b/static/app/views/insights/pages/agents/components/modelName.spec.tsx
@@ -27,11 +27,4 @@ describe('getModelPlatform Function', () => {
     expect(getModelPlatform('Qwen 2.5')).toBeNull();
     expect(getModelPlatform('random-ai-model')).toBeNull();
   });
-
-  it('returns provider when provider is explicitly provided', () => {
-    expect(getModelPlatform('some-model', 'openai')).toBe('openai');
-    expect(getModelPlatform('some-model', 'google')).toBe('google');
-    expect(getModelPlatform('some-model', 'anthropic')).toBe('anthropic');
-    expect(getModelPlatform('some-model', 'unknown-provider')).toBe('unknown-provider');
-  });
 });

--- a/static/app/views/insights/pages/agents/components/modelName.tsx
+++ b/static/app/views/insights/pages/agents/components/modelName.tsx
@@ -40,11 +40,7 @@ const NameWrapper = styled('div')`
   min-width: 0;
 `;
 
-export function getModelPlatform(modelId: string | null, provider?: string) {
-  if (provider) {
-    return provider;
-  }
-
+export function getModelPlatform(modelId: string | null) {
   if (!modelId) {
     return null;
   }

--- a/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
@@ -42,7 +42,7 @@ const AI_TRACE_BASE_ATTRIBUTES = [
   'gen_ai.tool.output',
 ];
 
-export function useAITrace(traceSlug: string, timestamp?: number): UseAITraceResult {
+export function useAITrace(traceSlug: string): UseAITraceResult {
   const [nodes, setNodes] = useState<AITraceSpanNode[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -52,7 +52,6 @@ export function useAITrace(traceSlug: string, timestamp?: number): UseAITraceRes
 
   const trace = useTrace({
     traceSlug,
-    timestamp,
     additionalAttributes: AI_TRACE_BASE_ATTRIBUTES,
   });
 

--- a/static/app/views/insights/pages/domainViewHeader.spec.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.spec.tsx
@@ -91,23 +91,6 @@ describe('DomainViewHeader', () => {
     expect(screen.queryByRole('tab', {name: 'Network Requests'})).not.toBeInTheDocument();
   });
 
-  it('does not show overview tab with hasOverviewPage=false', () => {
-    render(
-      <DomainViewHeader
-        domainBaseUrl="domainBaseUrl"
-        domainTitle="domainTitle"
-        modules={[ModuleName.HTTP]}
-        selectedModule={undefined}
-        hasOverviewPage={false}
-      />,
-      {organization, initialRouterConfig: baseRouterConfig}
-    );
-
-    expect(screen.getByText('domainTitle')).toBeInTheDocument();
-    expect(screen.queryByRole('tab', {name: 'Overview'})).not.toBeInTheDocument();
-    expect(screen.getByRole('tab', {name: 'Network Requests'})).toBeInTheDocument();
-  });
-
   it('renders a new badge only for mobile vitals', () => {
     render(
       <DomainViewHeader
@@ -115,7 +98,6 @@ describe('DomainViewHeader', () => {
         domainTitle="domainTitle"
         modules={[ModuleName.HTTP, ModuleName.MOBILE_VITALS]}
         selectedModule={undefined}
-        hasOverviewPage={false}
       />,
       {organization, initialRouterConfig: baseRouterConfig}
     );

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -38,8 +38,6 @@ export type Props = {
   selectedModule: ModuleName | undefined;
   additionalBreadCrumbs?: Crumb[];
   additonalHeaderActions?: React.ReactNode;
-  // TODO - hasOverviewPage could be improved, the overview page could just be a "module", but that has a lot of other implications that have to be considered
-  hasOverviewPage?: boolean;
   headerTitle?: React.ReactNode;
   hideDefaultTabs?: boolean;
   tabs?: {onTabChange: (key: string) => void; tabList: React.ReactNode; value: string};
@@ -47,7 +45,6 @@ export type Props = {
 
 export function DomainViewHeader({
   modules,
-  hasOverviewPage = true,
   headerTitle,
   domainTitle,
   selectedModule,
@@ -86,15 +83,11 @@ export function DomainViewHeader({
   };
 
   const tabList: TabListItemProps[] = [
-    ...(hasOverviewPage
-      ? [
-          {
-            key: OVERVIEW_PAGE_TITLE,
-            children: OVERVIEW_PAGE_TITLE,
-            to: {pathname: domainBaseUrl, query: globalQuery},
-          },
-        ]
-      : []),
+    {
+      key: OVERVIEW_PAGE_TITLE,
+      children: OVERVIEW_PAGE_TITLE,
+      to: {pathname: domainBaseUrl, query: globalQuery},
+    },
     ...modules
       .filter(moduleName => isModuleVisible(moduleName, organization))
       .map(moduleName => ({

--- a/static/app/views/insights/pages/platform/laravel/utils.tsx
+++ b/static/app/views/insights/pages/platform/laravel/utils.tsx
@@ -1,19 +1,12 @@
 import {useMemo} from 'react';
 
-import {getInterval, type Fidelity} from 'sentry/components/charts/utils';
+import {getInterval} from 'sentry/components/charts/utils';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import type {PageFilters} from 'sentry/types/core';
 
-export function usePageFilterChartParams({
-  granularity = 'spans',
-  pageFilters,
-}: {
-  granularity?: Fidelity;
-  pageFilters?: PageFilters;
-} = {}) {
+export function usePageFilterChartParams() {
   const pageFilterContext = usePageFilters();
-  const selection = pageFilters || pageFilterContext.selection;
+  const selection = pageFilterContext.selection;
 
   const normalizedDateTime = useMemo(
     () => normalizeDateTimeParams(selection.datetime),
@@ -22,7 +15,7 @@ export function usePageFilterChartParams({
 
   return {
     ...normalizedDateTime,
-    interval: getInterval(selection.datetime, granularity),
+    interval: getInterval(selection.datetime, 'spans'),
     project: selection.projects,
     environment: selection.environments,
   };

--- a/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
@@ -1,34 +1,21 @@
 import {useTheme} from '@emotion/react';
-import type {LocationDescriptor} from 'history';
 
 import {Flex} from '@sentry/scraps/layout';
-import {Link} from '@sentry/scraps/link';
 
 import {defined} from 'sentry/utils/defined';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {ThresholdCell} from 'sentry/views/insights/pages/platform/shared/table/ThresholdCell';
 
-export function ErrorRateCell({
-  errorRate,
-  issuesLink,
-  total,
-}: {
-  errorRate: number;
-  total: number;
-  issuesLink?: LocationDescriptor;
-}) {
+export function ErrorRateCell({errorRate, total}: {errorRate: number; total: number}) {
   const theme = useTheme();
   const errorCount = Math.floor(errorRate * total);
 
-  const errorCountElement =
-    issuesLink && errorCount > 0 ? (
-      <Link to={issuesLink}>({formatAbbreviatedNumber(errorCount)})</Link>
-    ) : (
-      <span style={{color: theme.tokens.content.secondary}}>
-        ({formatAbbreviatedNumber(errorCount)})
-      </span>
-    );
+  const errorCountElement = (
+    <span style={{color: theme.tokens.content.secondary}}>
+      ({formatAbbreviatedNumber(errorCount)})
+    </span>
+  );
 
   return (
     <ThresholdCell value={errorRate}>

--- a/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx
@@ -1,6 +1,6 @@
 import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {CheckStatusBucket} from 'sentry/views/detectors/components/uptime/types';
 
@@ -21,10 +21,7 @@ type Result = Record<string, CheckStatusBucket[]>;
 /**
  * Fetches Uptime Monitor stats
  */
-export function useUptimeMonitorStats(
-  {detectorIds, timeWindowConfig}: Options,
-  options: Partial<UseApiQueryOptions<Result>> = {}
-) {
+export function useUptimeMonitorStats({detectorIds, timeWindowConfig}: Options) {
   const {start, end, rollupConfig} = timeWindowConfig;
 
   const selectionQuery = {
@@ -50,7 +47,6 @@ export function useUptimeMonitorStats(
     {
       staleTime: 0,
       enabled: rollupConfig.totalBuckets > 0,
-      ...options,
     }
   );
 }

--- a/static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx
@@ -1,4 +1,3 @@
-import type {TimeWindowConfig} from 'sentry/components/checkInTimeline/types';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -10,24 +9,12 @@ interface Options {
    * IDs of the UptimeRule id's
    */
   detectorIds: string[];
-  /**
-   * The window configuration object, if supplied the `start` and `end` will be
-   * calculated using the timewindow start end time.
-   */
-  timeWindowConfig?: TimeWindowConfig;
 }
 
 /**
  * Fetches Uptime Monitor summaries
  */
-export function useUptimeMonitorSummaries({detectorIds, timeWindowConfig}: Options) {
-  const selectionQuery: Record<string, any> = {};
-
-  if (timeWindowConfig) {
-    selectionQuery.start = Math.floor(timeWindowConfig.start.getTime() / 1000);
-    selectionQuery.end = Math.floor(timeWindowConfig.end.getTime() / 1000);
-  }
-
+export function useUptimeMonitorSummaries({detectorIds}: Options) {
   const organization = useOrganization();
 
   return useApiQuery<Record<string, UptimeSummary>>(
@@ -38,13 +25,11 @@ export function useUptimeMonitorSummaries({detectorIds, timeWindowConfig}: Optio
       {
         query: {
           uptimeDetectorId: detectorIds,
-          ...selectionQuery,
         },
       },
     ],
     {
       staleTime: 0,
-      enabled: !timeWindowConfig || timeWindowConfig.rollupConfig.totalBuckets > 0,
     }
   );
 }

--- a/static/app/views/insights/uptime/utils/useUptimeRule.tsx
+++ b/static/app/views/insights/uptime/utils/useUptimeRule.tsx
@@ -1,6 +1,6 @@
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery, type UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {UptimeRule} from 'sentry/views/detectors/components/uptime/types';
 
@@ -9,10 +9,7 @@ interface UseUptimeRuleOptions {
   projectSlug: string;
 }
 
-export function useUptimeRule(
-  {projectSlug, detectorId}: UseUptimeRuleOptions,
-  options: Partial<UseApiQueryOptions<UptimeRule>> = {}
-) {
+export function useUptimeRule({projectSlug, detectorId}: UseUptimeRuleOptions) {
   const organization = useOrganization();
 
   const queryKey: ApiQueryKey = [
@@ -27,5 +24,5 @@ export function useUptimeRule(
       }
     ),
   ];
-  return useApiQuery<UptimeRule>(queryKey, {staleTime: 0, ...options});
+  return useApiQuery<UptimeRule>(queryKey, {staleTime: 0});
 }


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~190 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views/insights`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/insights/browser/webVitals/components/performanceScoreRingWithTooltips.tsx`
- `static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx`
- `static/app/views/insights/crons/components/monitorForm.spec.tsx`
- `static/app/views/insights/crons/components/monitorForm.tsx`
- `static/app/views/insights/crons/components/useCronsUpsertGuideState.tsx`
- `static/app/views/insights/crons/utils/useMonitorStats.tsx`
- `static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx`
- `static/app/views/insights/pages/agents/components/modelName.spec.tsx`
- `static/app/views/insights/pages/agents/components/modelName.tsx`
- `static/app/views/insights/pages/agents/hooks/useAITrace.tsx`
- `static/app/views/insights/pages/domainViewHeader.spec.tsx`
- `static/app/views/insights/pages/domainViewHeader.tsx`
- `static/app/views/insights/pages/platform/laravel/utils.tsx`
- `static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx`
- `static/app/views/insights/uptime/utils/useUptimeMonitorStats.tsx`
- `static/app/views/insights/uptime/utils/useUptimeMonitorSummary.tsx`
- `static/app/views/insights/uptime/utils/useUptimeRule.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views/insights`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

