### PR TITLE
ref(ui): Drop unused optional args in organization stats

### DIFF
--- a/static/app/views/organizationStats/usageChart/utils.spec.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.spec.tsx
@@ -52,15 +52,16 @@ describe('getDateFromMoment', () => {
   });
 
   it('shows the date and time in 24 hour format if 24 hour format is enabled', () => {
-    expect(getDateFromMoment(start, '6h', false, true)).toBe(
-      'Jul 8 20:00 - 02:00 (-04:00)'
-    );
-    expect(getDateFromMoment(start, '1h', false, true)).toBe(
-      'Jul 8 20:00 - 21:00 (-04:00)'
-    );
-    expect(getDateFromMoment(start, '5m', false, true)).toBe(
-      'Jul 8 20:00 - 20:05 (-04:00)'
-    );
+    ConfigStore.set('user', {
+      ...ConfigStore.get('user'),
+      options: {
+        ...ConfigStore.get('user')?.options,
+        clock24Hours: true,
+      },
+    });
+    expect(getDateFromMoment(start, '6h', false)).toBe('Jul 8 20:00 - 02:00 (-04:00)');
+    expect(getDateFromMoment(start, '1h', false)).toBe('Jul 8 20:00 - 21:00 (-04:00)');
+    expect(getDateFromMoment(start, '5m', false)).toBe('Jul 8 20:00 - 20:05 (-04:00)');
   });
 });
 
@@ -78,13 +79,13 @@ describe('getXAxisDates', () => {
   it('calculates 4h intervals in UTC', () => {
     const dates = getXAxisDates(TS_START, TS_END, true, '4h');
     expect(dates).toEqual([
-      'Jul 9 12:00 AM - 4:00 AM (+00:00)',
-      'Jul 9 4:00 AM - 8:00 AM (+00:00)',
-      'Jul 9 8:00 AM - 12:00 PM (+00:00)',
-      'Jul 9 12:00 PM - 4:00 PM (+00:00)',
-      'Jul 9 4:00 PM - 8:00 PM (+00:00)',
-      'Jul 9 8:00 PM - 12:00 AM (+00:00)',
-      'Jul 10 12:00 AM - 4:00 AM (+00:00)',
+      'Jul 9 00:00 - 04:00 (+00:00)',
+      'Jul 9 04:00 - 08:00 (+00:00)',
+      'Jul 9 08:00 - 12:00 (+00:00)',
+      'Jul 9 12:00 - 16:00 (+00:00)',
+      'Jul 9 16:00 - 20:00 (+00:00)',
+      'Jul 9 20:00 - 00:00 (+00:00)',
+      'Jul 10 00:00 - 04:00 (+00:00)',
     ]);
   });
 
@@ -92,13 +93,13 @@ describe('getXAxisDates', () => {
   it('calculates 4h intervals', () => {
     const dates = getXAxisDates(TS_START, TS_END, false, '4h');
     expect(dates).toEqual([
-      'Jul 8 8:00 PM - 12:00 AM (-04:00)',
-      'Jul 9 12:00 AM - 4:00 AM (-04:00)',
-      'Jul 9 4:00 AM - 8:00 AM (-04:00)',
-      'Jul 9 8:00 AM - 12:00 PM (-04:00)',
-      'Jul 9 12:00 PM - 4:00 PM (-04:00)',
-      'Jul 9 4:00 PM - 8:00 PM (-04:00)',
-      'Jul 9 8:00 PM - 12:00 AM (-04:00)',
+      'Jul 8 20:00 - 00:00 (-04:00)',
+      'Jul 9 00:00 - 04:00 (-04:00)',
+      'Jul 9 04:00 - 08:00 (-04:00)',
+      'Jul 9 08:00 - 12:00 (-04:00)',
+      'Jul 9 12:00 - 16:00 (-04:00)',
+      'Jul 9 16:00 - 20:00 (-04:00)',
+      'Jul 9 20:00 - 00:00 (-04:00)',
     ]);
   });
 
@@ -106,31 +107,31 @@ describe('getXAxisDates', () => {
   it('calculates 1h intervals', () => {
     const dates = getXAxisDates(TS_START, TS_END, false, '1h');
     expect(dates).toEqual([
-      'Jul 8 8:00 PM - 9:00 PM (-04:00)',
-      'Jul 8 9:00 PM - 10:00 PM (-04:00)',
-      'Jul 8 10:00 PM - 11:00 PM (-04:00)',
-      'Jul 8 11:00 PM - 12:00 AM (-04:00)',
-      'Jul 9 12:00 AM - 1:00 AM (-04:00)',
-      'Jul 9 1:00 AM - 2:00 AM (-04:00)',
-      'Jul 9 2:00 AM - 3:00 AM (-04:00)',
-      'Jul 9 3:00 AM - 4:00 AM (-04:00)',
-      'Jul 9 4:00 AM - 5:00 AM (-04:00)',
-      'Jul 9 5:00 AM - 6:00 AM (-04:00)',
-      'Jul 9 6:00 AM - 7:00 AM (-04:00)',
-      'Jul 9 7:00 AM - 8:00 AM (-04:00)',
-      'Jul 9 8:00 AM - 9:00 AM (-04:00)',
-      'Jul 9 9:00 AM - 10:00 AM (-04:00)',
-      'Jul 9 10:00 AM - 11:00 AM (-04:00)',
-      'Jul 9 11:00 AM - 12:00 PM (-04:00)',
-      'Jul 9 12:00 PM - 1:00 PM (-04:00)',
-      'Jul 9 1:00 PM - 2:00 PM (-04:00)',
-      'Jul 9 2:00 PM - 3:00 PM (-04:00)',
-      'Jul 9 3:00 PM - 4:00 PM (-04:00)',
-      'Jul 9 4:00 PM - 5:00 PM (-04:00)',
-      'Jul 9 5:00 PM - 6:00 PM (-04:00)',
-      'Jul 9 6:00 PM - 7:00 PM (-04:00)',
-      'Jul 9 7:00 PM - 8:00 PM (-04:00)',
-      'Jul 9 8:00 PM - 9:00 PM (-04:00)',
+      'Jul 8 20:00 - 21:00 (-04:00)',
+      'Jul 8 21:00 - 22:00 (-04:00)',
+      'Jul 8 22:00 - 23:00 (-04:00)',
+      'Jul 8 23:00 - 00:00 (-04:00)',
+      'Jul 9 00:00 - 01:00 (-04:00)',
+      'Jul 9 01:00 - 02:00 (-04:00)',
+      'Jul 9 02:00 - 03:00 (-04:00)',
+      'Jul 9 03:00 - 04:00 (-04:00)',
+      'Jul 9 04:00 - 05:00 (-04:00)',
+      'Jul 9 05:00 - 06:00 (-04:00)',
+      'Jul 9 06:00 - 07:00 (-04:00)',
+      'Jul 9 07:00 - 08:00 (-04:00)',
+      'Jul 9 08:00 - 09:00 (-04:00)',
+      'Jul 9 09:00 - 10:00 (-04:00)',
+      'Jul 9 10:00 - 11:00 (-04:00)',
+      'Jul 9 11:00 - 12:00 (-04:00)',
+      'Jul 9 12:00 - 13:00 (-04:00)',
+      'Jul 9 13:00 - 14:00 (-04:00)',
+      'Jul 9 14:00 - 15:00 (-04:00)',
+      'Jul 9 15:00 - 16:00 (-04:00)',
+      'Jul 9 16:00 - 17:00 (-04:00)',
+      'Jul 9 17:00 - 18:00 (-04:00)',
+      'Jul 9 18:00 - 19:00 (-04:00)',
+      'Jul 9 19:00 - 20:00 (-04:00)',
+      'Jul 9 20:00 - 21:00 (-04:00)',
     ]);
   });
 

--- a/static/app/views/organizationStats/usageChart/utils.spec.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.spec.tsx
@@ -59,9 +59,9 @@ describe('getDateFromMoment', () => {
         clock24Hours: true,
       },
     });
-    expect(getDateFromMoment(start, '6h', false)).toBe('Jul 8 20:00 - 02:00 (-04:00)');
-    expect(getDateFromMoment(start, '1h', false)).toBe('Jul 8 20:00 - 21:00 (-04:00)');
-    expect(getDateFromMoment(start, '5m', false)).toBe('Jul 8 20:00 - 20:05 (-04:00)');
+    expect(getDateFromMoment(start, '6h')).toBe('Jul 8 20:00 - 02:00 (-04:00)');
+    expect(getDateFromMoment(start, '1h')).toBe('Jul 8 20:00 - 21:00 (-04:00)');
+    expect(getDateFromMoment(start, '5m')).toBe('Jul 8 20:00 - 20:05 (-04:00)');
   });
 });
 

--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -25,8 +25,7 @@ export const FORMAT_DATETIME_HOURLY_24H = 'MMM D HH:mm';
 export function getDateFromMoment(
   m: moment.Moment,
   interval: IntervalPeriod = '1d',
-  useUtc = false,
-  use24Hours = shouldUse24Hours()
+  useUtc = false
 ) {
   // Convert interval to days
   const days = parsePeriodToHours(interval) / 24;
@@ -43,6 +42,7 @@ export function getDateFromMoment(
     ? moment(m).utc()
     : moment(m).tz(getUserTimezone() ?? moment.tz.guess());
 
+  const use24Hours = shouldUse24Hours();
   const intervalFormat = use24Hours ? FORMAT_DATETIME_HOURLY_24H : FORMAT_DATETIME_HOURLY;
 
   return parsedInterval

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -125,7 +125,6 @@ export function getEndpointQuery({
 }
 
 export function getChartProps({
-  dataError,
   chartData,
   dataCategory,
   clientDiscard,
@@ -166,22 +165,15 @@ export function getChartProps({
   ) => void;
   loading: boolean;
   clientDiscard?: boolean;
-  dataError?: Error;
 }): UsageChartProps & {
   footer: React.ReactNode;
   title: React.ReactNode;
 } {
-  const errors =
-    error || dataError
-      ? {
-          ...(error ? {error} : {}),
-          ...(dataError ? {data: dataError} : {}),
-        }
-      : undefined;
+  const errors = error ? {error} : undefined;
 
   return {
     isLoading: loading,
-    isError: Boolean(error || !!dataError),
+    isError: Boolean(error),
     errors,
     title: (
       <Fragment>


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~113 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views/organizationStats`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/organizationStats/usageChart/utils.spec.tsx`
- `static/app/views/organizationStats/usageChart/utils.tsx`
- `static/app/views/organizationStats/usageStatsOrg.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views/organizationStats`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

