### PR TITLE
ref(ui): Drop unused optional args in performance landing

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -228,8 +228,7 @@ export function generateGenericPerformanceEventView(
 
 export function generateBackendPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
-  useEap = false
+  withStaticFilters: boolean
 ): EventView {
   const {query} = location;
 
@@ -253,7 +252,7 @@ export function generateBackendPerformanceEventView(
   const savedQuery: NewQuery = {
     id: undefined,
     name: t('Performance'),
-    query: useEap ? 'is_transaction:true' : 'event.type:transaction',
+    query: 'event.type:transaction',
     projects: [],
     fields,
     version: 2,
@@ -277,11 +276,7 @@ export function generateBackendPerformanceEventView(
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 
-  if (useEap) {
-    eventView.additionalConditions.addFilterValues('is_transaction', ['true']);
-  } else {
-    eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
-  }
+  eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
 
   return eventView;
 }
@@ -359,8 +354,7 @@ export function generateMobilePerformanceEventView(
 
 export function generateFrontendOtherPerformanceEventView(
   location: Location,
-  withStaticFilters: boolean,
-  useEap = false
+  withStaticFilters: boolean
 ): EventView {
   const {query} = location;
 
@@ -382,7 +376,7 @@ export function generateFrontendOtherPerformanceEventView(
   const savedQuery: NewQuery = {
     id: undefined,
     name: t('Performance'),
-    query: useEap ? 'is_transaction:true' : 'event.type:transaction',
+    query: 'event.type:transaction',
     projects: [],
     fields,
     version: 2,
@@ -405,11 +399,7 @@ export function generateFrontendOtherPerformanceEventView(
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
 
-  if (useEap) {
-    eventView.additionalConditions.addFilterValues('is_transaction', ['true']);
-  } else {
-    eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
-  }
+  eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
 
   return eventView;
 }

--- a/static/app/views/performance/landing/queryBatcher.spec.tsx
+++ b/static/app/views/performance/landing/queryBatcher.spec.tsx
@@ -40,7 +40,6 @@ function WrappedComponent({data, ...rest}: any) {
               PerformanceWidgetSetting.USER_MISERY_AREA,
             ]}
             rowChartSettings={[]}
-            forceDefaultChartSetting
             {...data}
             {...rest}
           />

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -3,6 +3,7 @@ import {initializeData as _initializeData} from 'sentry-test/performance/initial
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ConfigStore} from 'sentry/stores/configStore';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {OrganizationContext} from 'sentry/utils/organizationContext';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -53,7 +54,6 @@ function WrappedComponent({data, withStaticFilters = false, ...rest}: any) {
               allowedCharts={allowedCharts}
               rowChartSettings={[]}
               withStaticFilters={withStaticFilters}
-              forceDefaultChartSetting
               {...data}
               {...rest}
             />
@@ -77,6 +77,7 @@ describe('Performance > Widgets > WidgetContainer', () => {
   let issuesListMock: jest.Mock;
 
   beforeEach(() => {
+    localStorageWrapper.removeItem('landing-chart-container');
     ConfigStore.init();
     eventStatsMock = MockApiClient.addMockResponse({
       method: 'GET',

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -56,7 +56,6 @@ interface Props extends ChartRowProps {
   rowChartSettings: PerformanceWidgetSetting[];
   setRowChartSettings: (settings: PerformanceWidgetSetting[]) => void;
   withStaticFilters: boolean;
-  forceDefaultChartSetting?: boolean;
 }
 
 function trackChartSettingChange(
@@ -82,8 +81,7 @@ export function WidgetContainer(props: Props) {
     index,
     chartHeight,
     performanceType,
-    rest.defaultChartSetting,
-    rest.forceDefaultChartSetting
+    rest.defaultChartSetting
   );
   const mepSetting = useMEPSettingContext();
   const allowedCharts = filterAllowedChartsMetrics(
@@ -99,9 +97,7 @@ export function WidgetContainer(props: Props) {
   const [chartSetting, setChartSettingState] = useState(_chartSetting);
 
   const setChartSetting = (setting: PerformanceWidgetSetting) => {
-    if (!props.forceDefaultChartSetting) {
-      _setChartSetting(index, chartHeight, performanceType, setting);
-    }
+    _setChartSetting(index, chartHeight, performanceType, setting);
     setChartSettingState(setting);
     const newSettings = [...rowChartSettings];
     newSettings[index] = setting;

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -35,21 +35,15 @@ function setWidgetStorageObject(localObject: Record<string, string>) {
 
 const mepQueryParamBase: Record<string, string> = {};
 
-export function getMEPQueryParams(
-  mepContext: MetricsEnhancedSettingContext,
-  forceAuto?: boolean
-) {
+export function getMEPQueryParams(mepContext: MetricsEnhancedSettingContext) {
   let queryParams: Record<string, string> = {};
   const base = mepQueryParamBase;
-  if (mepContext.shouldQueryProvideMEPAutoParams || forceAuto) {
+  if (mepContext.shouldQueryProvideMEPAutoParams) {
     queryParams = {
       ...queryParams,
       ...base,
       dataset: 'metricsEnhanced',
     };
-    if (forceAuto) {
-      return queryParams;
-    }
   }
   if (mepContext.shouldQueryProvideMEPTransactionParams) {
     queryParams = {...queryParams, ...base, dataset: 'discover'};
@@ -98,12 +92,8 @@ export const getChartSetting = (
   index: number,
   height: number,
   performanceType: ProjectPerformanceType,
-  defaultType: PerformanceWidgetSetting,
-  forceDefaultChartSetting?: boolean // Used for testing.
+  defaultType: PerformanceWidgetSetting
 ): PerformanceWidgetSetting => {
-  if (forceDefaultChartSetting) {
-    return defaultType;
-  }
   const key = getContainerKey(index, performanceType, height);
   const localObject = getWidgetStorageObject();
   const value = localObject?.[key];

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
@@ -36,22 +36,12 @@ type EventsDisplayFilter = {
 
 type EventsFilterOptions = Record<EventsDisplayFilterName, EventsDisplayFilter>;
 
-type EventsFilterPercentileValues = Record<
-  Exclude<EventsDisplayFilterName, EventsDisplayFilterName.P100>,
-  number
->;
-
 export function getEventsFilterOptions(
-  spanOperationBreakdownFilter: SpanOperationBreakdownFilter,
-  percentileValues?: EventsFilterPercentileValues
+  spanOperationBreakdownFilter: SpanOperationBreakdownFilter
 ): EventsFilterOptions {
-  const {p99, p95, p75, p50} = percentileValues
-    ? percentileValues
-    : {p99: 0, p95: 0, p75: 0, p50: 0};
   return {
     [EventsDisplayFilterName.P50]: {
       name: EventsDisplayFilterName.P50,
-      query: p50 ? [['transaction.duration', `<=${p50.toFixed(0)}`]] : undefined,
       sort: {
         kind: 'desc',
         field: filterToField(spanOperationBreakdownFilter) || 'transaction.duration',
@@ -60,7 +50,6 @@ export function getEventsFilterOptions(
     },
     [EventsDisplayFilterName.P75]: {
       name: EventsDisplayFilterName.P75,
-      query: p75 ? [['transaction.duration', `<=${p75.toFixed(0)}`]] : undefined,
       sort: {
         kind: 'desc',
         field: filterToField(spanOperationBreakdownFilter) || 'transaction.duration',
@@ -69,7 +58,6 @@ export function getEventsFilterOptions(
     },
     [EventsDisplayFilterName.P95]: {
       name: EventsDisplayFilterName.P95,
-      query: p95 ? [['transaction.duration', `<=${p95.toFixed(0)}`]] : undefined,
       sort: {
         kind: 'desc',
         field: filterToField(spanOperationBreakdownFilter) || 'transaction.duration',
@@ -78,7 +66,6 @@ export function getEventsFilterOptions(
     },
     [EventsDisplayFilterName.P99]: {
       name: EventsDisplayFilterName.P99,
-      query: p99 ? [['transaction.duration', `<=${p99.toFixed(0)}`]] : undefined,
       sort: {
         kind: 'desc',
         field: filterToField(spanOperationBreakdownFilter) || 'transaction.duration',

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -124,7 +124,7 @@ function ReplaysContent({
     events,
   });
 
-  const {allMobileProj} = useAllMobileProj({});
+  const {allMobileProj} = useAllMobileProj();
 
   return (
     <Layout.Main width="full">

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -124,7 +124,7 @@ function ReplaysContent({
     events,
   });
 
-  const {allMobileProj} = useAllMobileProj();
+  const {allMobileProj} = useAllMobileProj({});
 
   return (
     <Layout.Main width="full">

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -75,11 +75,8 @@ export function transactionSummaryRouteWithQuery({
   transaction,
   projectID,
   query,
-  unselectedSeries = ['p100()', 'avg()'],
   display,
   trendFunction,
-  trendColumn,
-  showTransactions,
   additionalQuery,
   subPath,
   view,
@@ -90,11 +87,8 @@ export function transactionSummaryRouteWithQuery({
   additionalQuery?: Record<string, string | undefined>;
   display?: DisplayModes;
   projectID?: string | string[];
-  showTransactions?: TransactionFilterOptions;
   subPath?: string;
-  trendColumn?: string;
   trendFunction?: string;
-  unselectedSeries?: string | string[];
   view?: DomainView;
 }) {
   const pathname = generateTransactionSummaryRoute({
@@ -120,18 +114,16 @@ export function transactionSummaryRouteWithQuery({
       start: query.start,
       end: query.end,
       query: searchFilter,
-      unselectedSeries,
-      showTransactions,
+      unselectedSeries: ['p100()', 'avg()'],
       display,
       trendFunction,
-      trendColumn,
       referrer: 'performance-transaction-summary',
       ...additionalQuery,
     },
   };
 }
 
-export function generateTraceLink(dateSelection: any, view?: DomainView) {
+export function generateTraceLink(dateSelection: any) {
   return (
     organization: Organization,
     tableRow: TableDataRow,
@@ -149,7 +141,6 @@ export function generateTraceLink(dateSelection: any, view?: DomainView) {
       timestamp: tableRow.timestamp,
       location,
       source: TraceViewSources.PERFORMANCE_TRANSACTION_SUMMARY,
-      view,
     });
   };
 }

--- a/static/app/views/performance/trends/utils/index.tsx
+++ b/static/app/views/performance/trends/utils/index.tsx
@@ -212,8 +212,10 @@ export function getUnselectedSeries(trendChangeType: TrendChangeType) {
   return trendUnselectedSeries[trendChangeType];
 }
 
-const smoothTrend = (data: Array<[number, number]>, resolution = 100) => {
-  return ASAP(data, resolution);
+const SMOOTH_TREND_RESOLUTION = 100;
+
+const smoothTrend = (data: Array<[number, number]>) => {
+  return ASAP(data, SMOOTH_TREND_RESOLUTION);
 };
 
 export function transformEventStatsSmoothed(data?: Series[], seriesName?: string) {

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -196,11 +196,8 @@ export function isSummaryViewFrontend(eventView: EventView, projects: Project[])
   );
 }
 
-function getPerformanceTrendsUrl(
-  organization: OrganizationSummary,
-  view?: DomainView
-): string {
-  return `${getPerformanceBaseUrl(organization.slug, view)}/trends/`;
+function getPerformanceTrendsUrl(organization: OrganizationSummary): string {
+  return `${getPerformanceBaseUrl(organization.slug)}/trends/`;
 }
 
 export function getTransactionSearchQuery(location: Location, query = '') {
@@ -212,13 +209,11 @@ export function trendsTargetRoute({
   organization,
   initialConditions,
   additionalQuery,
-  view,
 }: {
   location: Location;
   organization: Organization;
   additionalQuery?: Record<string, string>;
   initialConditions?: MutableSearch;
-  view?: DomainView;
 }) {
   const newQuery = {
     ...location.query,
@@ -228,23 +223,12 @@ export function trendsTargetRoute({
   const modifiedConditions = initialConditions ?? new MutableSearch([]);
   newQuery.query = modifiedConditions.formatString();
 
-  return {pathname: getPerformanceTrendsUrl(organization, view), query: {...newQuery}};
+  return {pathname: getPerformanceTrendsUrl(organization), query: {...newQuery}};
 }
 
-export function removeTracingKeysFromSearch(
-  currentFilter: MutableSearch,
-  options: {excludeTagKeys: Set<string>} = {
-    excludeTagKeys: new Set([
-      // event type can be "transaction" but we're searching for issues
-      'event.type',
-      // the project is already determined by the transaction,
-      // and issue search does not support the project filter
-      'project',
-    ]),
-  }
-) {
+export function removeTracingKeysFromSearch(currentFilter: MutableSearch) {
   currentFilter.getFilterKeys().forEach(tagKey => {
-    if (shouldExcludeTracingKeys(tagKey, options)) {
+    if (shouldExcludeTracingKeys(tagKey)) {
       currentFilter.removeFilter(tagKey);
     }
   });
@@ -252,29 +236,16 @@ export function removeTracingKeysFromSearch(
   return currentFilter;
 }
 
-export function shouldExcludeTracingKeys(
-  tagKey: string,
-  options: {excludeTagKeys: Set<string>} = {
-    excludeTagKeys: new Set([
-      // event type can be "transaction" but we're searching for issues
-      'event.type',
-      // the project is already determined by the transaction,
-      // and issue search does not support the project filter
-      'project',
-    ]),
-  }
-): boolean {
+export function shouldExcludeTracingKeys(tagKey: string): boolean {
   // Remove aggregates and transaction event fields
   const searchKey = tagKey.startsWith('!') ? tagKey.substring(1) : tagKey;
 
-  // aggregates
-  const condAggregates = searchKey.match(/\w+\(.*\)/) !== null;
-  // transaction event fields
-  const condTransactionEventFields = TRACING_FIELDS.includes(searchKey);
-  // tags that we don't want to pass to pass to issue search
-  const condExcludeTagKeys = options.excludeTagKeys.has(searchKey);
-
-  return condAggregates || condTransactionEventFields || condExcludeTagKeys;
+  return (
+    searchKey.match(/\w+\(.*\)/) !== null ||
+    TRACING_FIELDS.includes(searchKey) ||
+    searchKey === 'event.type' ||
+    searchKey === 'project'
+  );
 }
 
 export function addRoutePerformanceContext(selection: PageFilters) {


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~139 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views/performance`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/performance/data.tsx`
- `static/app/views/performance/landing/queryBatcher.spec.tsx`
- `static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx`
- `static/app/views/performance/landing/widgets/components/widgetContainer.tsx`
- `static/app/views/performance/landing/widgets/utils.tsx`
- `static/app/views/performance/transactionSummary/transactionEvents/utils.tsx`
- `static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx`
- `static/app/views/performance/transactionSummary/utils.tsx`
- `static/app/views/performance/trends/utils/index.tsx`
- `static/app/views/performance/utils/index.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views/performance`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

