### PR TITLE
ref(ui): Drop unused optional args in trace details

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts
@@ -108,16 +108,12 @@ const DETECTORS: readonly ContentDetector[] = [htmlDetector, jsonDetector];
  * Returns `text` with any detected HTML/JSON runs wrapped in fenced code
  * blocks. Content already inside fenced or inline code is left untouched.
  */
-export function fenceContent(
-  text: string,
-  detectors: readonly ContentDetector[] = DETECTORS
-): string {
+export function fenceContent(text: string): string {
   const protectedRanges = getProtectedRanges(text);
   const overlapsProtected = (start: number, end: number) =>
     protectedRanges.some(r => start < r.end && end > r.start);
 
-  const candidates = detectors
-    .flatMap(detector => detector.detect(text))
+  const candidates = DETECTORS.flatMap(detector => detector.detect(text))
     .filter(block => !overlapsProtected(block.start, block.end))
     // Earliest first; on a tie prefer the longer block.
     .sort((a, b) => a.start - b.start || b.end - a.end);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -105,7 +105,6 @@ interface AIContentRendererProps {
    * defaults to clipped and JSON defaults to flowing (matching prior behavior).
    */
   clip?: boolean;
-  collapsibleXmlTags?: boolean;
   inline?: boolean;
   maxJsonDepth?: number;
 }
@@ -213,7 +212,6 @@ export function AIContentRenderer({
   inline = false,
   maxJsonDepth = 2,
   autoCollapseLimit,
-  collapsibleXmlTags = true,
   clip,
 }: AIContentRendererProps) {
   const detection = useMemo(() => detectAIContentType(text), [text]);
@@ -238,18 +236,13 @@ export function AIContentRenderer({
 
     case 'markdown-with-xml':
       if (inline) {
-        return (
-          <MarkdownWithXmlRenderer text={text} collapsibleXmlTags={collapsibleXmlTags} />
-        );
+        return <MarkdownWithXmlRenderer text={text} collapsibleXmlTags />;
       }
       return (
         <TraceDrawerComponents.MultilineText
           clip={clipText}
           renderFormatted={rawText => (
-            <MarkdownWithXmlRenderer
-              text={rawText}
-              collapsibleXmlTags={collapsibleXmlTags}
-            />
+            <MarkdownWithXmlRenderer text={rawText} collapsibleXmlTags />
           )}
         >
           {text}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -338,7 +338,6 @@ function TableRow({
           <StyledPre>
             <span className="val-string">{children}</span>
           </StyledPre>
-          <TableRowButtonContainer>{null}</TableRowButtonContainer>
         </TableValueRow>
       </ValueTd>
     </tr>
@@ -724,10 +723,6 @@ const TableValueRow = styled('div')`
 const StyledPre = styled('pre')`
   margin: 0 !important;
   background-color: transparent !important;
-`;
-
-const TableRowButtonContainer = styled('div')`
-  padding: 8px 10px;
 `;
 
 const ValueTd = styled('td')`
@@ -1345,7 +1340,6 @@ export const TraceDrawerComponents = {
   Duration,
   TableRow,
   LAZY_RENDER_PROPS,
-  TableRowButtonContainer,
   TableValueRow,
   IssuesLink,
   SectionCard,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo, useState, type PropsWithChildren} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
-import type {LocationDescriptor} from 'history';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -320,38 +319,26 @@ function Duration(props: DurationProps) {
 
 function TableRow({
   title,
-  keep,
   children,
-  prefix,
-  extra = null,
-  toolTipText,
 }: {
   children: React.ReactNode;
   title: React.JSX.Element | string | null;
-  extra?: React.ReactNode;
-  keep?: boolean;
-  prefix?: React.JSX.Element;
-  toolTipText?: string;
 }) {
-  if (!keep && !children) {
+  if (!children) {
     return null;
   }
 
   return (
     <tr>
       <td className="key">
-        <Flex align="center">
-          {prefix}
-          {title}
-          {toolTipText ? <StyledQuestionTooltip size="xs" title={toolTipText} /> : null}
-        </Flex>
+        <Flex align="center">{title}</Flex>
       </td>
       <ValueTd className="value">
         <TableValueRow>
           <StyledPre>
             <span className="val-string">{children}</span>
           </StyledPre>
-          <TableRowButtonContainer>{extra}</TableRowButtonContainer>
+          <TableRowButtonContainer>{null}</TableRowButtonContainer>
         </TableValueRow>
       </ValueTd>
     </tr>
@@ -734,10 +721,6 @@ const TableValueRow = styled('div')`
   margin: 2px;
 `;
 
-const StyledQuestionTooltip = styled(QuestionTooltip)`
-  margin-left: ${p => p.theme.space.xs};
-`;
-
 const StyledPre = styled('pre')`
   margin: 0 !important;
   background-color: transparent !important;
@@ -1038,16 +1021,16 @@ function EventTags({projectSlug, event}: {event: Event; projectSlug: string}) {
 
 export type SectionCardKeyValueList = KeyValueListData;
 
+const SECTION_CARD_TRUNCATE_LENGTH = 5;
+
 function SectionCard({
   items,
   title,
-  disableTruncate,
   sortAlphabetically = false,
   itemProps = {},
 }: {
   items: SectionCardKeyValueList;
   title: React.ReactNode;
-  disableTruncate?: boolean;
   itemProps?: Partial<KeyValueDataContentProps>;
   sortAlphabetically?: boolean;
 }) {
@@ -1059,7 +1042,7 @@ function SectionCard({
         title={title}
         contentItems={contentItems}
         sortAlphabetically={sortAlphabetically}
-        truncateLength={disableTruncate ? Infinity : 5}
+        truncateLength={SECTION_CARD_TRUNCATE_LENGTH}
       />
     </CardWrapper>
   );
@@ -1090,17 +1073,7 @@ function SectionCardGroup({children}: {children: React.ReactNode}) {
   return <KeyValueData.Container>{children}</KeyValueData.Container>;
 }
 
-function CopyableCardValueWithLink({
-  value,
-  linkTarget,
-  linkText,
-  onClick,
-}: {
-  value: React.ReactNode;
-  linkTarget?: LocationDescriptor;
-  linkText?: string;
-  onClick?: () => void;
-}) {
+function CopyableCardValueWithLink({value}: {value: React.ReactNode}) {
   return (
     <CardValueContainer>
       <CardValueText>
@@ -1114,11 +1087,6 @@ function CopyableCardValueWithLink({
           />
         ) : null}
       </CardValueText>
-      {linkTarget && linkTarget ? (
-        <Link to={linkTarget} onClick={onClick}>
-          {linkText}
-        </Link>
-      ) : null}
     </CardValueContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import {Stack} from '@sentry/scraps/layout';
 
 import ReplayClipPreview from 'sentry/components/events/eventReplay/replayClipPreview';
@@ -26,17 +24,14 @@ function ReplaySection({
   eventTimestampMs,
   organization,
   analyticsParams,
-  showTitle = false,
 }: {
   eventTimestampMs: number;
   organization: Organization;
   replayId: string;
   analyticsParams?: Record<string, unknown>;
-  showTitle?: boolean;
 }) {
   return (
     <Stack>
-      {showTitle ? <ReplaySectionTitle>{t('Session Replay')}</ReplaySectionTitle> : null}
       <ReplayClipPreview
         analyticsContext="trace-view"
         replaySlug={replayId}
@@ -87,9 +82,3 @@ export function ReplayPreview({
     </ReplayAccess>
   );
 }
-
-const ReplaySectionTitle = styled('div')`
-  font-size: ${p => p.theme.font.size.md};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  margin-bottom: ${p => p.theme.space.xl};
-`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
@@ -1,4 +1,4 @@
-import type {Location, LocationDescriptor} from 'history';
+import type {LocationDescriptor} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
 import {getDateFromTimestamp} from 'sentry/utils/dates';
@@ -13,8 +13,7 @@ export function makeTransactionProfilingLink(
   options: {
     organization: Organization;
     projectSlug: string;
-  },
-  query: Location['query'] = {}
+  }
 ): LocationDescriptor | null {
   if (!options.projectSlug || !options.organization) {
     return null;
@@ -23,7 +22,7 @@ export function makeTransactionProfilingLink(
     organization: options.organization,
     projectSlug: options.projectSlug,
     profileId,
-    query,
+    query: {},
   });
 }
 
@@ -38,8 +37,7 @@ export function makeTraceContinuousProfilingLink(
     projectSlug: string;
     threadId: string | undefined;
     traceId: string;
-  },
-  query: Location['query'] = {}
+  }
 ): LocationDescriptor | null {
   if (!options.projectSlug || !options.organization) {
     return null;
@@ -82,7 +80,6 @@ export function makeTraceContinuousProfilingLink(
   }
 
   const queryWithEventData: Record<string, string> = {
-    ...query,
     eventId: transactionId,
     traceId: options.traceId,
   };

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts
@@ -22,7 +22,6 @@ export function makeTransactionProfilingLink(
     organization: options.organization,
     projectSlug: options.projectSlug,
     profileId,
-    query: {},
   });
 }
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
@@ -27,10 +27,7 @@ export function PlaceHolder({
     <TraceHeaderComponents.HeaderLayout>
       <TraceHeaderComponents.HeaderContent>
         <Flex justify="between" align="center" gap="md">
-          <TraceBreadcrumbs
-            organization={organization}
-            traceSlug={traceSlug}
-          />
+          <TraceBreadcrumbs organization={organization} traceSlug={traceSlug} />
           <Grid flow="column" align="center" gap="md">
             <TopBar.Slot name="feedback">
               <FeedbackButton

--- a/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx
@@ -3,7 +3,6 @@ import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
 import {TraceHeaderComponents} from './styles';
@@ -19,12 +18,10 @@ const traceViewFeedbackOptions = {
 
 export function PlaceHolder({
   organization,
-  project,
   traceSlug,
 }: {
   organization: Organization;
   traceSlug: string;
-  project?: Project;
 }) {
   return (
     <TraceHeaderComponents.HeaderLayout>
@@ -33,7 +30,6 @@ export function PlaceHolder({
           <TraceBreadcrumbs
             organization={organization}
             traceSlug={traceSlug}
-            project={project}
           />
           <Grid flow="column" align="center" gap="md">
             <TopBar.Slot name="feedback">

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx
@@ -161,14 +161,11 @@ export function makeTracePerformanceIssue(
   } as TraceTree.TracePerformanceIssue;
 }
 
-export function makeEventTransaction(
-  overrides: Partial<Event> = {},
-  spans: TraceTree.Span[] = []
-): EventTransaction {
+export function makeEventTransaction(overrides: Partial<Event> = {}): EventTransaction {
   return {
     contexts: {},
     tags: [],
-    entries: [{type: EntryType.SPANS, data: spans}],
+    entries: [{type: EntryType.SPANS, data: []}],
     ...overrides,
   } as EventTransaction;
 }

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -694,7 +694,6 @@ export class VirtualizedViewManager {
   onZoomIntoSpace(
     space: [number, number],
     options: {
-      onComplete?: () => void;
       padding?: boolean;
     } = {}
   ) {
@@ -753,7 +752,6 @@ export class VirtualizedViewManager {
           x: final_x,
           width: final_width,
         });
-        options.onComplete?.();
       }
     };
 

--- a/static/app/views/performance/newTraceDetails/useTraceEventView.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceEventView.tsx
@@ -1,15 +1,13 @@
 import {useMemo} from 'react';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
-import type {NewQuery} from 'sentry/types/organization';
 import {EventView} from 'sentry/utils/discover/eventView';
 
 import type {TraceViewQueryParams} from './useTraceQueryParams';
 
 export function useTraceEventView(
   traceSlug: string,
-  params: TraceViewQueryParams,
-  partialSavedQuery?: Partial<NewQuery>
+  params: TraceViewQueryParams
 ): EventView {
   return useMemo(() => {
     let startTimeStamp = params.start;
@@ -36,7 +34,6 @@ export function useTraceEventView(
       start: startTimeStamp,
       end: endTimeStamp,
       range: startTimeStamp || endTimeStamp ? undefined : params.statsPeriod,
-      ...partialSavedQuery,
     });
-  }, [params, traceSlug, partialSavedQuery]);
+  }, [params, traceSlug]);
 }


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~107 LOC).

## Summary
- Remove unused optional arguments and fields under `static/app/views/performance/newTraceDetails`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentFencing.ts`
- `static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx`
- `static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx`
- `static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx`
- `static/app/views/performance/newTraceDetails/traceDrawer/traceProfilingLink.ts`
- `static/app/views/performance/newTraceDetails/traceHeader/placeholder.tsx`
- `static/app/views/performance/newTraceDetails/traceModels/traceTreeTestUtils.tsx`
- `static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx`
- `static/app/views/performance/newTraceDetails/useTraceEventView.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/app/views/performance/newTraceDetails`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

