### PR TITLE
ref(ui): Drop unused optional args in gsApp checkout and subscription views

### DIFF
--- a/static/gsApp/views/amCheckout/components/cart.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.tsx
@@ -156,13 +156,11 @@ function ItemWithPrice({
   price,
   shouldBoldItem,
   isVariableCost,
-  isCredit,
 }: {
   item: React.ReactNode;
   price: React.ReactNode;
   shouldBoldItem: boolean;
   'data-test-id'?: string;
-  isCredit?: boolean;
   isVariableCost?: boolean;
 }) {
   return (
@@ -170,10 +168,7 @@ function ItemWithPrice({
       <Text bold={shouldBoldItem} variant={isVariableCost ? 'muted' : 'primary'}>
         {item}
       </Text>
-      <Text
-        align="right"
-        variant={isVariableCost ? 'muted' : isCredit ? 'success' : 'primary'}
-      >
+      <Text align="right" variant={isVariableCost ? 'muted' : 'primary'}>
         {price}
       </Text>
     </ItemFlex>

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -29,7 +29,6 @@ export function getProductCheckoutDescription({
 }: {
   product: AddOnCategory;
   withPunctuation: boolean;
-  includedBudget?: string;
 }) {
   if (product === AddOnCategory.LEGACY_SEER) {
     return tct('Detect and fix issues faster with our AI agent[punctuation]', {

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -282,7 +282,7 @@ function recordAnalytics(
   data: CheckoutAPIData,
   isMigratingPartnerAccount: boolean
 ) {
-  trackMarketingEvent('Upgrade', {plan: data.plan});
+  trackMarketingEvent('Upgrade');
   const currentData: CheckoutData = {
     plan: data.plan,
   };

--- a/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
@@ -274,7 +274,7 @@ function ProjectsWithoutRepos({
   );
 
   const handleUpdateProjectState = useCallback(
-    (projectId: string, preference: any, codeMappingRepos?: SeerRepoDefinition[]) => {
+    (projectId: string, preference: any) => {
       setProjectStates(prev => {
         const existingState = prev[projectId];
         return {
@@ -288,7 +288,7 @@ function ProjectsWithoutRepos({
       });
       const project = projects.find(p => p.id === projectId);
       if (project) {
-        onProjectStateUpdate(project, preference, false, codeMappingRepos);
+        onProjectStateUpdate(project, preference, false);
       }
     },
     [projects, onProjectStateUpdate]

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -51,6 +51,8 @@ type Props = {
   subscription: Subscription;
 };
 
+const DEFAULT_SPEND_ALLOCATION_PERIODS = 1;
+
 export function SpendAllocationsRoot({subscription}: Props) {
   const organization = useOrganization();
   const {openModal} = useModal();
@@ -131,69 +133,62 @@ export function SpendAllocationsRoot({subscription}: Props) {
     return root;
   }, [currentRootAllocations, selectedMetric]);
 
-  const fetchSpendAllocations = useCallback(
-    // Target timestamp allows us to specify a period
-    // Periods allows us to specify how many periods we want to fetch
-    async (targetTimestamp?: number, periods = 1) => {
-      try {
-        setIsLoading(true);
-        // NOTE: we cannot just use the subscription period start since newly created allocations could start after the period start
-        // we cannot use the middle of the subscription period since it's possible to have a current allocation that ends before mid period
-        if (!targetTimestamp) {
-          targetTimestamp = Math.max(Date.now() / 1000, period[0]!.getTime() / 1000);
-        }
-        const SPEND_ALLOCATIONS_PATH = `/organizations/${organization.slug}/spend-allocations/`;
+  const fetchSpendAllocations = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      // NOTE: we cannot just use the subscription period start since newly created allocations could start after the period start
+      // we cannot use the middle of the subscription period since it's possible to have a current allocation that ends before mid period
+      const targetTimestamp = Math.max(Date.now() / 1000, period[0]!.getTime() / 1000);
+      const periods = DEFAULT_SPEND_ALLOCATION_PERIODS;
+      const SPEND_ALLOCATIONS_PATH = `/organizations/${organization.slug}/spend-allocations/`;
 
-        // there should only be one root allocation per billing metric, so we don't need to pass the cursor
-        const rootAllocationsResp = await api.requestPromise(SPEND_ALLOCATIONS_PATH, {
+      // there should only be one root allocation per billing metric, so we don't need to pass the cursor
+      const rootAllocationsResp = await api.requestPromise(SPEND_ALLOCATIONS_PATH, {
+        method: 'GET',
+        query: {
+          timestamp: targetTimestamp,
+          periods,
+          target_id: organization.id,
+          target_type: 'Organization',
+        },
+      });
+      setRootAllocations(rootAllocationsResp);
+
+      const [projectAllocations, _, resp] = await api.requestPromise(
+        SPEND_ALLOCATIONS_PATH,
+        {
           method: 'GET',
+          includeAllArgs: true,
           query: {
             timestamp: targetTimestamp,
             periods,
-            target_id: organization.id,
-            target_type: 'Organization',
+            target_type: 'Project',
+            cursor: currentCursor,
+            billing_metric: getCategoryInfoFromPlural(selectedMetric)?.name, // TODO: we should update the endpoint to use camelCase api name
           },
-        });
-        setRootAllocations(rootAllocationsResp);
-
-        const [projectAllocations, _, resp] = await api.requestPromise(
-          SPEND_ALLOCATIONS_PATH,
-          {
-            method: 'GET',
-            includeAllArgs: true,
-            query: {
-              timestamp: targetTimestamp,
-              periods,
-              target_type: 'Project',
-              cursor: currentCursor,
-              billing_metric: getCategoryInfoFromPlural(selectedMetric)?.name, // TODO: we should update the endpoint to use camelCase api name
-            },
-          }
-        );
-        setOrgEnabledFlag(true);
-        setSpendAllocations(projectAllocations);
-        setErrors(null);
-
-        const links =
-          (resp?.getResponseHeader('Link') || resp?.getResponseHeader('link')) ??
-          undefined;
-        setPageLinks(links);
-      } catch (err: any) {
-        if (err.status === 404) {
-          setErrors('Error fetching spend allocations');
-        } else if (err.status === 403) {
-          // NOTE: If spend allocations are not enabled, API will return a 403 not found
-          // So capture this case and set enabled to false
-          setOrgEnabledFlag(false);
-        } else {
-          setErrors(err.statusText);
         }
+      );
+      setOrgEnabledFlag(true);
+      setSpendAllocations(projectAllocations);
+      setErrors(null);
+
+      const links =
+        (resp?.getResponseHeader('Link') || resp?.getResponseHeader('link')) ?? undefined;
+      setPageLinks(links);
+    } catch (err: any) {
+      if (err.status === 404) {
+        setErrors('Error fetching spend allocations');
+      } else if (err.status === 403) {
+        // NOTE: If spend allocations are not enabled, API will return a 403 not found
+        // So capture this case and set enabled to false
+        setOrgEnabledFlag(false);
+      } else {
+        setErrors(err.statusText);
       }
-      setIsLoading(false);
-      setShouldRetry(true);
-    },
-    [api, currentCursor, organization.id, organization.slug, period, selectedMetric]
-  );
+    }
+    setIsLoading(false);
+    setShouldRetry(true);
+  }, [api, currentCursor, organization.id, organization.slug, period, selectedMetric]);
 
   const deleteSpendAllocation =
     (

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -76,8 +76,7 @@ function calculateCategoryPrepaidUsage(
   subscription: Subscription,
   prepaid: number,
   accepted?: number | null,
-  reservedCpe?: number | null,
-  reservedSpend?: number | null
+  reservedCpe?: number | null
 ): {
   onDemandUsage: number;
   prepaidPercentUsed: number;
@@ -91,16 +90,12 @@ function calculateCategoryPrepaidUsage(
   const categoryInfo = subscription.categories[category];
   const usage = accepted ?? categoryInfo?.usage ?? 0;
 
-  // If reservedCpe or reservedSpend aren't provided but category is part of a reserved budget,
-  // try to extract them from subscription.reservedBudgets
+  // If reservedCpe isn't provided but category is part of a reserved budget,
+  // extract reservedCpe / reservedSpend from subscription.reservedBudgets.
   let effectiveReservedCpe = reservedCpe ?? undefined;
-  let effectiveReservedSpend = reservedSpend ?? undefined;
+  let effectiveReservedSpend: number | undefined;
 
-  if (
-    (effectiveReservedCpe === undefined || effectiveReservedSpend === undefined) &&
-    isPartOfReservedBudget(category, subscription.reservedBudgets ?? [])
-  ) {
-    // Look for the category in reservedBudgets
+  if (isPartOfReservedBudget(category, subscription.reservedBudgets ?? [])) {
     for (const budget of subscription.reservedBudgets || []) {
       if (category in budget.categories) {
         const categoryBudget = budget.categories[category];
@@ -108,9 +103,7 @@ function calculateCategoryPrepaidUsage(
           if (effectiveReservedCpe === undefined) {
             effectiveReservedCpe = categoryBudget.reservedCpe;
           }
-          if (effectiveReservedSpend === undefined) {
-            effectiveReservedSpend = categoryBudget.reservedSpend;
-          }
+          effectiveReservedSpend = categoryBudget.reservedSpend;
           break;
         }
       }

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -96,18 +96,17 @@ function Cta({
 
 function FindOutMoreButton({
   href,
-  to,
   selectedProduct,
 }: {
+  href: string;
   selectedProduct: DataCategory | AddOnCategory;
-} & ({href: string; to?: never} | {to: string; href?: never})) {
+}) {
   return (
     <LinkButton
       icon={<IconOpen />}
       variant="link"
       size="sm"
       href={href}
-      to={to ?? ''}
       analyticsEventName="Subscription Settings: Find Out More Button Clicked"
       analyticsEventKey="subscription_settings.find_out_more_button_clicked"
       analyticsParams={{product: selectedProduct}}


### PR DESCRIPTION
Split out of #122373 and #122624 so this folder can be reviewed on its own (~143 LOC).

## Summary
- Remove unused optional arguments and fields under `static/gsApp/views`.
- Same approach as the original PRs: drop args/fields nothing passes, keep public hook/component options, inline previous defaults.

## Files
- `static/gsApp/views/amCheckout/components/cart.tsx`
- `static/gsApp/views/amCheckout/steps/productSelect.tsx`
- `static/gsApp/views/amCheckout/utils.tsx`
- `static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx`
- `static/gsApp/views/spendAllocations/index.tsx`
- `static/gsApp/views/subscriptionPage/reservedUsageChart.tsx`
- `static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites in `static/gsApp/views`.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

