### PR TITLE
feat(explore): show start + finish timestamp in more legible utc

### DIFF
--- a/static/app/components/unixTimestamp.spec.tsx
+++ b/static/app/components/unixTimestamp.spec.tsx
@@ -1,0 +1,30 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {UnixTimestamp} from 'sentry/components/unixTimestamp';
+
+describe('UnixTimestamp', () => {
+  it('shows the raw Unix value and reveals a human-readable card on hover', async () => {
+    render(<UnixTimestamp value={1740787200.123} />);
+
+    expect(screen.getByText('1740787200.123')).toBeInTheDocument();
+    expect(screen.queryByText('Timestamp')).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('1740787200.123'));
+
+    expect(await screen.findByText('Timestamp')).toBeInTheDocument();
+    expect(screen.getByText('UTC')).toBeInTheDocument();
+  });
+
+  it('renders the fallback when the value is not a finite number', () => {
+    render(<UnixTimestamp value="not-a-number" fallback={<span>raw</span>} />);
+
+    expect(screen.getByText('raw')).toBeInTheDocument();
+    expect(screen.queryByText('Timestamp')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the value is invalid and no fallback is provided', () => {
+    const {container} = render(<UnixTimestamp value={undefined} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/app/components/unixTimestamp.tsx
+++ b/static/app/components/unixTimestamp.tsx
@@ -1,0 +1,33 @@
+import {RELATIVE_TIME_MAX_WIDTH, RelativeTime} from '@sentry/scraps/relativeTime';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {t} from 'sentry/locale';
+
+interface UnixTimestampProps {
+  value: unknown;
+  fallback?: React.ReactNode;
+  label?: React.ReactNode;
+}
+
+/**
+ * Renders Unix timestamp with a hover card that makes it human-readable
+ */
+export function UnixTimestamp({
+  value,
+  fallback = null,
+  label = t('Timestamp'),
+}: UnixTimestampProps): React.ReactNode {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds)) {
+    return fallback;
+  }
+
+  return (
+    <Tooltip
+      maxWidth={RELATIVE_TIME_MAX_WIDTH}
+      title={<RelativeTime date={seconds * 1000} label={label} showSeconds />}
+    >
+      <span>{String(value)}</span>
+    </Tooltip>
+  );
+}

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -9,6 +9,7 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {UnixTimestamp} from 'sentry/components/unixTimestamp';
 import {t} from 'sentry/locale';
 import {getTimeStampFromTableDateField} from 'sentry/utils/dates';
 import type {EventData} from 'sentry/utils/discover/eventView';
@@ -37,10 +38,7 @@ import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SpanFields} from 'sentry/views/insights/types';
-import {
-  renderPreciseTimestamp,
-  sortAttributes,
-} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+import {sortAttributes} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
@@ -272,8 +270,9 @@ function useSpanAttributeRenderers({
       return Number.isFinite(value) ? formatDollars(+value.toFixed(10)) : basicRendered;
     };
 
-    const preciseTimestampRenderer: SpanAttributeRenderer = ({item, basicRendered}) =>
-      renderPreciseTimestamp(item.value, basicRendered);
+    const preciseTimestampRenderer: SpanAttributeRenderer = ({item, basicRendered}) => (
+      <UnixTimestamp value={item.value} fallback={basicRendered} />
+    );
 
     return {
       [FieldKey.PROFILE_ID]: profileRenderer,

--- a/static/app/views/explore/tables/spanItemDetails.tsx
+++ b/static/app/views/explore/tables/spanItemDetails.tsx
@@ -37,7 +37,10 @@ import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SpanFields} from 'sentry/views/insights/types';
-import {sortAttributes} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+import {
+  renderPreciseTimestamp,
+  sortAttributes,
+} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 
@@ -269,6 +272,9 @@ function useSpanAttributeRenderers({
       return Number.isFinite(value) ? formatDollars(+value.toFixed(10)) : basicRendered;
     };
 
+    const preciseTimestampRenderer: SpanAttributeRenderer = ({item, basicRendered}) =>
+      renderPreciseTimestamp(item.value, basicRendered);
+
     return {
       [FieldKey.PROFILE_ID]: profileRenderer,
       [SpanFields.PROFILE_ID]: profileRenderer,
@@ -293,6 +299,8 @@ function useSpanAttributeRenderers({
       [SpanFields.GEN_AI_COST_INPUT_TOKENS]: costRenderer,
       [SpanFields.GEN_AI_COST_OUTPUT_TOKENS]: costRenderer,
       [SpanFields.GEN_AI_COST_TOTAL_TOKENS]: costRenderer,
+      [SpanFields.PRECISE_START_TS]: preciseTimestampRenderer,
+      [SpanFields.PRECISE_FINISH_TS]: preciseTimestampRenderer,
     };
   }, [dateSelection, location, organization, projectSlug, spanId, timestamp]);
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.spec.tsx
@@ -41,14 +41,13 @@ describe('AttributesContent', () => {
   }
 
   it.each(['precise.start_ts', 'precise.finish_ts'])(
-    'renders %s as a human-readable UTC datetime',
+    'keeps the raw %s value visible with a human-readable card on hover',
     name => {
       // 2025-03-01T00:00:00.123Z as a Unix timestamp in seconds (float)
       renderAttributes([{name, type: 'float', value: 1740787200.123}]);
 
-      const rendered = screen.getByText(/UTC/);
-      expect(rendered).toHaveTextContent('Mar 1, 2025');
-      expect(screen.queryByText('1740787200.123')).not.toBeInTheDocument();
+      expect(screen.getByText('1740787200.123')).toBeInTheDocument();
+      expect(screen.queryByText(/UTC/)).not.toBeInTheDocument();
     }
   );
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.spec.tsx
@@ -1,0 +1,61 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {ThemeFixture} from 'sentry-fixture/theme';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
+import {makeEAPSpan} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
+
+import {AttributesContent} from './attributes';
+
+describe('AttributesContent', () => {
+  const organization = OrganizationFixture();
+  const location = LocationFixture();
+  const theme = ThemeFixture();
+  const project = ProjectFixture({id: '1', slug: 'project_slug'});
+
+  function renderAttributes(attributes: TraceItemResponseAttribute[]) {
+    const node = new EapSpanNode(
+      null,
+      makeEAPSpan({event_id: 'span-id', project_id: 1, project_slug: 'project_slug'}),
+      {organization}
+    );
+
+    return render(
+      <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+        <AttributesContent
+          node={node}
+          attributes={attributes}
+          theme={theme}
+          location={location}
+          organization={organization}
+          project={project}
+        />
+      </TraceStateProvider>
+    );
+  }
+
+  it.each(['precise.start_ts', 'precise.finish_ts'])(
+    'renders %s as a human-readable UTC datetime',
+    name => {
+      // 2025-03-01T00:00:00.123Z as a Unix timestamp in seconds (float)
+      renderAttributes([{name, type: 'float', value: 1740787200.123}]);
+
+      const rendered = screen.getByText(/UTC/);
+      expect(rendered).toHaveTextContent('Mar 1, 2025');
+      expect(screen.queryByText('1740787200.123')).not.toBeInTheDocument();
+    }
+  );
+
+  it('falls back to the raw value when the timestamp is not a number', () => {
+    renderAttributes([{name: 'precise.start_ts', type: 'str', value: 'not-a-number'}]);
+
+    expect(screen.getByText('not-a-number')).toBeInTheDocument();
+    expect(screen.queryByText(/UTC/)).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -11,6 +11,7 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SearchBar as BaseSearchBar} from 'sentry/components/searchBar';
 import {StructuredData} from 'sentry/components/structuredEventData';
+import {UnixTimestamp} from 'sentry/components/unixTimestamp';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -36,7 +37,6 @@ import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/tr
 import {
   findSpanAttributeValue,
   getTraceAttributesTreeActions,
-  renderPreciseTimestamp,
   sortAttributes,
   tryParseJsonRecursive,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
@@ -62,8 +62,9 @@ const truncatedTextRenderer = (props: CustomRenderersProps) => {
   return ellipsize(props.item.value, 100);
 };
 
-const preciseTimestampRenderer = (props: CustomRenderersProps) =>
-  renderPreciseTimestamp(props.item.value, props.basicRendered);
+const preciseTimestampRenderer = (props: CustomRenderersProps) => (
+  <UnixTimestamp value={props.item.value} fallback={props.basicRendered} />
+);
 
 interface AttributesProps {
   attributes: TraceItemResponseAttribute[];

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -36,6 +36,7 @@ import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/tr
 import {
   findSpanAttributeValue,
   getTraceAttributesTreeActions,
+  renderPreciseTimestamp,
   sortAttributes,
   tryParseJsonRecursive,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
@@ -60,6 +61,9 @@ const truncatedTextRenderer = (props: CustomRenderersProps) => {
   }
   return ellipsize(props.item.value, 100);
 };
+
+const preciseTimestampRenderer = (props: CustomRenderersProps) =>
+  renderPreciseTimestamp(props.item.value, props.basicRendered);
 
 interface AttributesProps {
   attributes: TraceItemResponseAttribute[];
@@ -196,6 +200,8 @@ export function AttributesContent({
     [SpanFields.GEN_AI_COST_TOTAL_TOKENS]: (props: CustomRenderersProps) => {
       return formatDollars(+Number(props.item.value).toFixed(10));
     },
+    [SpanFields.PRECISE_START_TS]: preciseTimestampRenderer,
+    [SpanFields.PRECISE_FINISH_TS]: preciseTimestampRenderer,
     assertion_failure_data: (props: CustomRenderersProps) => {
       if (props.item.value === null) {
         return <Text variant="muted">null</Text>;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -1,6 +1,5 @@
 import type {Location} from 'history';
 
-import {DateTime} from 'sentry/components/dateTime';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
@@ -21,17 +20,6 @@ import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTra
 import {fixJson} from 'sentry/views/explore/replays/detail/network/truncateJson/fixJson';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
-
-export function renderPreciseTimestamp(
-  value: unknown,
-  fallback: React.ReactNode
-): React.ReactNode {
-  const seconds = Number(value);
-  if (!Number.isFinite(seconds)) {
-    return fallback;
-  }
-  return <DateTime utc year seconds milliseconds date={seconds * 1000} />;
-}
 
 export function getProfileMeta(event: EventTransaction | null) {
   const profileId = event?.contexts?.profile?.profile_id;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 
+import {DateTime} from 'sentry/components/dateTime';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
@@ -20,6 +21,17 @@ import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTra
 import {fixJson} from 'sentry/views/explore/replays/detail/network/truncateJson/fixJson';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+
+export function renderPreciseTimestamp(
+  value: unknown,
+  fallback: React.ReactNode
+): React.ReactNode {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds)) {
+    return fallback;
+  }
+  return <DateTime utc year seconds milliseconds date={seconds * 1000} />;
+}
 
 export function getProfileMeta(event: EventTransaction | null) {
   const profileId = event?.contexts?.profile?.profile_id;


### PR DESCRIPTION
Making trace attributes like `precise.start_ts` and `precise.finish_ts` show up as readable UTC dates instead of raw Unix timestamps for readability, as per https://github.com/getsentry/sentry/issues/111412. Added tests to confirm the timestamps render correctly and gracefully fall back to the raw value if it isn't a valid number.

After 
<img width="556" height="180" alt="Screenshot 2026-09-01 at 1 20 28 PM" src="https://github.com/user-attachments/assets/88d775d1-8efa-4260-9518-c1fa42444ebe" />


Closes EXP-848