### PR TITLE
perf(preprod): Serialize snapshot details without pydantic

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -43,8 +43,11 @@ from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
 )
 from sentry.preprod.api.models.public.snapshots import (
+    SnapshotApproverResponseDict,
     SnapshotCreateResponseDict,
     SnapshotDetailsResponseDict,
+    SnapshotImageResponseDict,
+    VcsInfoResponseDict,
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotApprover,
@@ -64,7 +67,7 @@ from sentry.preprod.snapshots.constants import (
     MISSING_BASE_GRACE_PERIOD_SECONDS,
     SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
 )
-from sentry.preprod.snapshots.image_serialization import ImageDict, build_head_image_dict
+from sentry.preprod.snapshots.image_serialization import build_head_image_dict
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
@@ -360,7 +363,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
             ) as span:
                 head_manifest = orjson.loads(raw_manifest)
-                head_images: dict[str, ImageDict] = head_manifest.get("images", {})
+                head_images: dict[str, Any] = head_manifest.get("images", {})
                 head_diff_threshold = head_manifest.get("diff_threshold")
                 set_span_data(span, "image_count", len(head_images))
         except Exception:
@@ -489,12 +492,12 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             op="preprod.snapshot.serialize_images", name="serialize_head_images"
         ) as span:
             set_span_data(span, "image_count", len(head_images))
-            image_list: list[ImageDict] = [
+            image_list: list[SnapshotImageResponseDict] = [
                 build_head_image_dict(key, metadata, head_diff_threshold)
                 for key, metadata in sorted(head_images.items())
             ]
 
-        images_by_file_name: dict[str, ImageDict] = {
+        images_by_file_name: dict[str, SnapshotImageResponseDict] = {
             img["image_file_name"]: img for img in image_list
         }
 
@@ -610,13 +613,13 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             op="preprod.snapshot.serialize_response", name="serialize_response_body"
         ) as span:
             set_span_data(span, "image_count", len(image_list))
-            response_data: dict[str, Any] = {
+            response_data: SnapshotDetailsResponseDict = {
                 "head_artifact_id": str(artifact.id),
                 "base_artifact_id": base_artifact_id,
                 "project_id": str(artifact.project_id),
                 "comparison_type": comparison_type,
                 "state": artifact.state,
-                "vcs_info": vcs_info.dict(),
+                "vcs_info": cast(VcsInfoResponseDict, vcs_info.dict()),
                 "app_id": artifact.app_id,
                 "is_selective": snapshot_metrics.is_selective,
                 "images": image_list if comparison_type != "diff" else [],
@@ -639,19 +642,26 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 "comparison_state": derived_status.comparison_state,
                 "approval_status": derived_status.approval_status,
                 "comparison_error_message": derived_status.comparison_error_message,
-                "approvers": [a.dict() for a in approver_list] if approved else [],
+                "approvers": (
+                    [cast(SnapshotApproverResponseDict, a.dict()) for a in approver_list]
+                    if approved
+                    else []
+                ),
             }
 
             if compact:
+                # Compact mode strips images to a subset of keys, producing a shape that
+                # is intentionally looser than the response TypedDict; mutate via a plain
+                # dict view.
+                compact_data = cast(dict[str, Any], response_data)
                 for key in _COMPACT_IMAGE_LIST_KEYS:
-                    response_data[key] = [_strip_to_compact(img) for img in response_data[key]]
+                    compact_data[key] = [_strip_to_compact(img) for img in compact_data[key]]
                 for key in _COMPACT_PAIR_LIST_KEYS:
-                    for pair in response_data[key]:
+                    for pair in compact_data[key]:
                         pair["base_image"] = _strip_to_compact(pair["base_image"])
                         pair["head_image"] = _strip_to_compact(pair["head_image"])
 
-        body = cast(SnapshotDetailsResponseDict, response_data)
-        return Response(body)
+        return Response(response_data)
 
 
 @extend_schema(tags=["Snapshots"])

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -58,14 +58,13 @@ from sentry.preprod.helpers.deletion import delete_artifacts_and_eap_data
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.comparison_categorizer import (
     CategorizedComparison,
-    ImageDict,
-    build_head_image_dict,
     categorize_comparison_images,
 )
 from sentry.preprod.snapshots.constants import (
     MISSING_BASE_GRACE_PERIOD_SECONDS,
     SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
 )
+from sentry.preprod.snapshots.image_serialization import ImageDict, build_head_image_dict
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
@@ -417,6 +416,11 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                         op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
                     ) as span:
                         comparison_manifest = orjson.loads(raw_comparison_manifest)
+                        # Guard the required key here so a malformed comparison manifest
+                        # degrades to solo (as the old pydantic parse did) rather than
+                        # raising later outside this handler.
+                        if "base_artifact_id" not in comparison_manifest:
+                            raise ValueError("comparison manifest missing base_artifact_id")
                         set_span_data(
                             span, "image_count", len(comparison_manifest.get("images", {}))
                         )

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -48,8 +48,6 @@ from sentry.preprod.api.models.public.snapshots import (
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotApprover,
-    SnapshotDetailsApiResponse,
-    SnapshotImageResponse,
 )
 from sentry.preprod.api.models.snapshots.snapshot_status import (
     SnapshotStatusInput,
@@ -60,18 +58,15 @@ from sentry.preprod.helpers.deletion import delete_artifacts_and_eap_data
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.comparison_categorizer import (
     CategorizedComparison,
+    ImageDict,
+    build_head_image_dict,
     categorize_comparison_images,
 )
 from sentry.preprod.snapshots.constants import (
     MISSING_BASE_GRACE_PERIOD_SECONDS,
     SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
 )
-from sentry.preprod.snapshots.manifest import (
-    ComparisonManifest,
-    ImageMetadata,
-    SnapshotManifest,
-    image_metadata_extras,
-)
+from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
     PreprodSnapshotMetrics,
@@ -128,28 +123,6 @@ _COMPACT_PAIR_LIST_KEYS = ("changed", "renamed", "errored")
 
 def _strip_to_compact(img: dict[str, Any]) -> dict[str, Any]:
     return {k: img[k] for k in _COMPACT_FIELDS if k in img}
-
-
-def build_snapshot_image_response(
-    image_file_name: str,
-    metadata: ImageMetadata,
-    global_diff_threshold: float | None,
-) -> SnapshotImageResponse:
-    return SnapshotImageResponse(
-        **image_metadata_extras(metadata, exclude={"key", "image_file_name"}),
-        key=metadata.content_hash,
-        display_name=metadata.display_name,
-        image_file_name=image_file_name,
-        group=metadata.group,
-        width=metadata.width,
-        height=metadata.height,
-        diff_threshold=metadata.diff_threshold
-        if metadata.diff_threshold is not None
-        else global_diff_threshold,
-        description=metadata.description,
-        tags=metadata.tags,
-        canvas_theme=metadata.canvas_theme,
-    )
 
 
 MAX_SNAPSHOT_REQUEST_BODY_SIZE = 256 * 1024 * 1024
@@ -387,8 +360,10 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             with start_span(
                 op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
             ) as span:
-                manifest = SnapshotManifest(**orjson.loads(raw_manifest))
-                set_span_data(span, "image_count", len(manifest.images))
+                head_manifest = orjson.loads(raw_manifest)
+                head_images: dict[str, ImageDict] = head_manifest.get("images", {})
+                head_diff_threshold = head_manifest.get("diff_threshold")
+                set_span_data(span, "image_count", len(head_images))
         except Exception:
             logger.exception(
                 "Failed to retrieve snapshot manifest",
@@ -415,8 +390,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         else:
             vcs_info = BuildDetailsVcsInfo()
 
-        comparison_manifest: ComparisonManifest | None = None
-        base_manifest: SnapshotManifest | None = None
+        comparison_manifest: dict[str, Any] | None = None
+        base_manifest: dict[str, Any] | None = None
         all_comparisons = list(
             PreprodSnapshotComparison.objects.select_related("base_snapshot_metrics")
             .filter(head_snapshot_metrics=snapshot_metrics)
@@ -441,10 +416,10 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                     with start_span(
                         op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
                     ) as span:
-                        comparison_manifest = ComparisonManifest(
-                            **orjson.loads(raw_comparison_manifest)
+                        comparison_manifest = orjson.loads(raw_comparison_manifest)
+                        set_span_data(
+                            span, "image_count", len(comparison_manifest.get("images", {}))
                         )
-                        set_span_data(span, "image_count", len(comparison_manifest.images))
                 except Exception:
                     comparison_manifest = None
                     logger.exception(
@@ -466,8 +441,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                     with start_span(
                         op="preprod.snapshot.parse_manifest", name="parse_base_manifest"
                     ) as span:
-                        base_manifest = SnapshotManifest(**orjson.loads(raw_base_manifest))
-                        set_span_data(span, "image_count", len(base_manifest.images))
+                        base_manifest = orjson.loads(raw_base_manifest)
+                        set_span_data(span, "image_count", len(base_manifest.get("images", {})))
                 except Exception:
                     logger.exception(
                         "Failed to fetch base manifest",
@@ -509,26 +484,29 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         with start_span(
             op="preprod.snapshot.serialize_images", name="serialize_head_images"
         ) as span:
-            set_span_data(span, "image_count", len(manifest.images))
-            image_list = [
-                build_snapshot_image_response(key, metadata, manifest.diff_threshold)
-                for key, metadata in sorted(manifest.images.items())
+            set_span_data(span, "image_count", len(head_images))
+            image_list: list[ImageDict] = [
+                build_head_image_dict(key, metadata, head_diff_threshold)
+                for key, metadata in sorted(head_images.items())
             ]
 
-        images_by_file_name: dict[str, SnapshotImageResponse] = {
-            img.image_file_name: img for img in image_list
+        images_by_file_name: dict[str, ImageDict] = {
+            img["image_file_name"]: img for img in image_list
         }
 
         base_artifact_id: str | None = None
 
         if comparison_manifest is not None:
-            base_artifact_id = str(comparison_manifest.base_artifact_id)
+            base_artifact_id = str(comparison_manifest["base_artifact_id"])
+            comparison_images = comparison_manifest.get("images", {})
             with start_span(
                 op="preprod.snapshot.categorize_comparison", name="categorize_comparison_images"
             ) as span:
-                set_span_data(span, "image_count", len(comparison_manifest.images))
+                set_span_data(span, "image_count", len(comparison_images))
                 categorized = categorize_comparison_images(
-                    comparison_manifest, images_by_file_name, base_manifest
+                    comparison_images,
+                    images_by_file_name,
+                    base_manifest.get("images", {}) if base_manifest else None,
                 )
         else:
             if comparison is not None:
@@ -628,37 +606,37 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             op="preprod.snapshot.serialize_response", name="serialize_response_body"
         ) as span:
             set_span_data(span, "image_count", len(image_list))
-            response_data = SnapshotDetailsApiResponse(
-                head_artifact_id=str(artifact.id),
-                base_artifact_id=base_artifact_id,
-                project_id=str(artifact.project_id),
-                comparison_type=comparison_type,
-                state=artifact.state,
-                vcs_info=vcs_info,
-                app_id=artifact.app_id,
-                is_selective=snapshot_metrics.is_selective,
-                images=image_list if comparison_type != "diff" else [],
-                image_count=snapshot_metrics.image_count,
-                changed=categorized.changed,
-                changed_count=len(categorized.changed),
-                added=categorized.added,
-                added_count=len(categorized.added),
-                removed=categorized.removed,
-                removed_count=len(categorized.removed),
-                renamed=categorized.renamed,
-                renamed_count=len(categorized.renamed),
-                unchanged=categorized.unchanged,
-                unchanged_count=len(categorized.unchanged),
-                errored=categorized.errored,
-                errored_count=len(categorized.errored),
-                skipped=categorized.skipped,
-                skipped_count=len(categorized.skipped),
-                diff_threshold=manifest.diff_threshold,
-                comparison_state=derived_status.comparison_state,
-                approval_status=derived_status.approval_status,
-                comparison_error_message=derived_status.comparison_error_message,
-                approvers=approver_list if approved else [],
-            ).dict()
+            response_data: dict[str, Any] = {
+                "head_artifact_id": str(artifact.id),
+                "base_artifact_id": base_artifact_id,
+                "project_id": str(artifact.project_id),
+                "comparison_type": comparison_type,
+                "state": artifact.state,
+                "vcs_info": vcs_info.dict(),
+                "app_id": artifact.app_id,
+                "is_selective": snapshot_metrics.is_selective,
+                "images": image_list if comparison_type != "diff" else [],
+                "image_count": snapshot_metrics.image_count,
+                "added": categorized.added,
+                "added_count": len(categorized.added),
+                "removed": categorized.removed,
+                "removed_count": len(categorized.removed),
+                "renamed": categorized.renamed,
+                "renamed_count": len(categorized.renamed),
+                "changed": categorized.changed,
+                "changed_count": len(categorized.changed),
+                "unchanged": categorized.unchanged,
+                "unchanged_count": len(categorized.unchanged),
+                "errored": categorized.errored,
+                "errored_count": len(categorized.errored),
+                "skipped": categorized.skipped,
+                "skipped_count": len(categorized.skipped),
+                "diff_threshold": head_diff_threshold,
+                "comparison_state": derived_status.comparison_state,
+                "approval_status": derived_status.approval_status,
+                "comparison_error_message": derived_status.comparison_error_message,
+                "approvers": [a.dict() for a in approver_list] if approved else [],
+            }
 
             if compact:
                 for key in _COMPACT_IMAGE_LIST_KEYS:
@@ -668,9 +646,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                         pair["base_image"] = _strip_to_compact(pair["base_image"])
                         pair["head_image"] = _strip_to_compact(pair["head_image"])
 
-        # cast() sanctioned here: pydantic .dict() returns dict[str, Any] with no
-        # static link back to SnapshotDetailsResponseDict. The TypedDict and the
-        # Pydantic model are kept in sync by hand at the source of truth.
         body = cast(SnapshotDetailsResponseDict, response_data)
         return Response(body)
 

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -419,9 +419,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                         op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
                     ) as span:
                         comparison_manifest = orjson.loads(raw_comparison_manifest)
-                        # Guard the required key here so a malformed comparison manifest
-                        # degrades to solo (as the old pydantic parse did) rather than
-                        # raising later outside this handler.
                         if "base_artifact_id" not in comparison_manifest:
                             raise ValueError("comparison manifest missing base_artifact_id")
                         set_span_data(
@@ -618,7 +615,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 "base_artifact_id": base_artifact_id,
                 "project_id": str(artifact.project_id),
                 "comparison_type": comparison_type,
-                "state": artifact.state,
+                "state": cast(str, artifact.state),
                 "vcs_info": cast(VcsInfoResponseDict, vcs_info.dict()),
                 "app_id": artifact.app_id,
                 "is_selective": snapshot_metrics.is_selective,

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_image_detail.py
@@ -122,7 +122,7 @@ def _to_response_dict(resp: SnapshotImageDetailResponse) -> SnapshotImageDetailR
 
 
 # Intentionally uses a flat response format (nullable fields, no conditional shapes)
-# rather than matching the details endpoint's SnapshotDiffPair/SnapshotImageResponse split.
+# rather than the details endpoint's categorized diff-pair/image split.
 # This endpoint is designed for LLM/MCP consumers that benefit from a single uniform shape.
 @extend_schema(tags=["Snapshots"])
 @cell_silo_endpoint

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -34,7 +34,7 @@ from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot import (
 )
 from sentry.preprod.api.models.public.snapshots import LatestBaseSnapshotResponseDict
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.snapshots.comparison_categorizer import build_head_image_dict
+from sentry.preprod.snapshots.image_serialization import build_head_image_dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -32,7 +32,10 @@ from sentry.preprod.analytics import PreprodArtifactApiGetLatestBaseSnapshotEven
 from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot import (
     _strip_to_compact,
 )
-from sentry.preprod.api.models.public.snapshots import LatestBaseSnapshotResponseDict
+from sentry.preprod.api.models.public.snapshots import (
+    LatestBaseSnapshotImageResponseDict,
+    LatestBaseSnapshotResponseDict,
+)
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.image_serialization import build_head_image_dict
 
@@ -217,13 +220,16 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
 
         image_base_url = f"/api/0/projects/{organization.slug}/{artifact.project.slug}/files/images"
 
-        images = []
+        images: list[LatestBaseSnapshotImageResponseDict] = []
         for key, metadata in sorted(manifest_images.items()):
-            img = build_head_image_dict(key, metadata, manifest_diff_threshold)
+            img = cast(
+                LatestBaseSnapshotImageResponseDict,
+                build_head_image_dict(key, metadata, manifest_diff_threshold),
+            )
             img["image_url"] = f"{image_base_url}/{metadata['content_hash']}/"
             images.append(img)
 
-        response_data: dict[str, Any] = {
+        response_data: LatestBaseSnapshotResponseDict = {
             "head_artifact_id": str(artifact.id),
             "project_id": str(artifact.project_id),
             "project_slug": artifact.project.slug,
@@ -246,13 +252,10 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             }
 
         if compact:
-            response_data["images"] = [
+            compact_data = cast(dict[str, Any], response_data)
+            compact_data["images"] = [
                 {**_strip_to_compact(img), "image_url": img["image_url"]}
-                for img in response_data["images"]
+                for img in compact_data["images"]
             ]
 
-        # cast() sanctioned: response_data is a hand-built dict[str, Any] whose
-        # shape mirrors LatestBaseSnapshotResponseDict. The TypedDict and the
-        # builder are kept in sync by hand at the source of truth.
-        body = cast(LatestBaseSnapshotResponseDict, response_data)
-        return Response(body)
+        return Response(response_data)

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot_latest_base.py
@@ -31,11 +31,10 @@ from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodArtifactApiGetLatestBaseSnapshotEvent
 from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot import (
     _strip_to_compact,
-    build_snapshot_image_response,
 )
 from sentry.preprod.api.models.public.snapshots import LatestBaseSnapshotResponseDict
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.snapshots.manifest import SnapshotManifest
+from sentry.preprod.snapshots.comparison_categorizer import build_head_image_dict
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +203,8 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             if response is None:
                 raise FileNotFoundError("Manifest does not exist in objectstore")
             manifest_data = orjson.loads(response.payload.read())
-            manifest = SnapshotManifest(**manifest_data)
+            manifest_images = manifest_data.get("images", {})
+            manifest_diff_threshold = manifest_data.get("diff_threshold")
         except Exception:
             logger.exception(
                 "Failed to retrieve snapshot manifest",
@@ -218,9 +218,9 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
         image_base_url = f"/api/0/projects/{organization.slug}/{artifact.project.slug}/files/images"
 
         images = []
-        for key, metadata in sorted(manifest.images.items()):
-            img = build_snapshot_image_response(key, metadata, manifest.diff_threshold).dict()
-            img["image_url"] = f"{image_base_url}/{metadata.content_hash}/"
+        for key, metadata in sorted(manifest_images.items()):
+            img = build_head_image_dict(key, metadata, manifest_diff_threshold)
+            img["image_url"] = f"{image_base_url}/{metadata['content_hash']}/"
             images.append(img)
 
         response_data: dict[str, Any] = {
@@ -230,7 +230,7 @@ class OrganizationPreprodLatestBaseSnapshotEndpoint(OrganizationEndpoint):
             "app_id": artifact.app_id,
             "image_count": snapshot_metrics.image_count,
             "images": images,
-            "diff_threshold": manifest.diff_threshold,
+            "diff_threshold": manifest_diff_threshold,
             "date_added": artifact.date_added.isoformat(),
         }
 

--- a/src/sentry/preprod/api/models/public/snapshots.py
+++ b/src/sentry/preprod/api/models/public/snapshots.py
@@ -46,7 +46,7 @@ class SnapshotDetailsResponseDict(TypedDict, total=False):
     base_artifact_id: str | None
     project_id: str
     comparison_type: str
-    state: int
+    state: str
     vcs_info: VcsInfoResponseDict
     app_id: str | None
     is_selective: bool

--- a/src/sentry/preprod/api/models/public/snapshots.py
+++ b/src/sentry/preprod/api/models/public/snapshots.py
@@ -46,7 +46,7 @@ class SnapshotDetailsResponseDict(TypedDict, total=False):
     base_artifact_id: str | None
     project_id: str
     comparison_type: str
-    state: str
+    state: int
     vcs_info: VcsInfoResponseDict
     app_id: str | None
     is_selective: bool

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -5,13 +5,6 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsVcsInfo
-from sentry.preprod.api.models.snapshots.snapshot_status import (
-    ApprovalStatusLiteral,
-    ComparisonStateLiteral,
-)
-from sentry.preprod.models import PreprodArtifact
-
 
 class SnapshotDiffSection(StrEnum):
     ADDED = "added"
@@ -37,13 +30,6 @@ class SnapshotImageResponse(BaseModel):
 
     class Config:
         extra = "allow"
-
-
-class SnapshotDiffPair(BaseModel):
-    base_image: SnapshotImageResponse
-    head_image: SnapshotImageResponse
-    diff_image_key: str | None = None
-    diff: float | None = None
 
 
 class SnapshotImageDetailImageInfo(SnapshotImageResponse):
@@ -73,50 +59,6 @@ class SnapshotApprover(BaseModel):
     avatar_url: str | None = None
     approved_at: str | None = None
     source: Literal["sentry", "github"] = "sentry"
-
-
-class SnapshotDetailsApiResponse(BaseModel):
-    head_artifact_id: str
-    base_artifact_id: str | None = None
-    project_id: str
-    comparison_type: str
-    state: PreprodArtifact.ArtifactState
-    vcs_info: BuildDetailsVcsInfo
-    app_id: str | None = None
-    is_selective: bool = False
-
-    # Solo fields (comparison_type == SOLO)
-    images: list[SnapshotImageResponse] = []
-    image_count: int = 0
-
-    # Diff fields (comparison_type == DIFF)
-    added: list[SnapshotImageResponse] = []
-    added_count: int = 0
-
-    removed: list[SnapshotImageResponse] = []
-    removed_count: int = 0
-
-    renamed: list[SnapshotDiffPair] = []
-    renamed_count: int = 0
-
-    changed: list[SnapshotDiffPair] = []
-    changed_count: int = 0
-
-    unchanged: list[SnapshotImageResponse] = []
-    unchanged_count: int = 0
-
-    errored: list[SnapshotDiffPair] = []
-    errored_count: int = 0
-
-    skipped: list[SnapshotImageResponse] = []
-    skipped_count: int = 0
-
-    diff_threshold: float | None = None
-
-    comparison_state: ComparisonStateLiteral | None = None
-    approval_status: ApprovalStatusLiteral | None = None
-    comparison_error_message: str | None = None
-    approvers: list[SnapshotApprover] = []
 
 
 # TODO: POST request in the future when we migrate away from current schemas

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
-from sentry.preprod.snapshots.manifest import image_dict_extras
-
-# Image and diff-pair payloads are plain dicts matching the shape the response
-# previously produced via pydantic .dict(); see image builders below.
-ImageDict = dict[str, Any]
+from sentry.preprod.snapshots.image_serialization import (
+    ImageDict,
+    bare_image_dict,
+    build_base_image_dict,
+)
 
 
 @dataclass
@@ -21,56 +20,8 @@ class CategorizedComparison:
     skipped: list[ImageDict] = field(default_factory=list)
 
 
-def build_head_image_dict(
-    image_file_name: str, image: ImageDict, global_diff_threshold: float | None
-) -> ImageDict:
-    dt = image.get("diff_threshold")
-    return {
-        **image_dict_extras(image),
-        "key": image["content_hash"],
-        "display_name": image.get("display_name"),
-        "group": image.get("group"),
-        "image_file_name": image_file_name,
-        "width": image["width"],
-        "height": image["height"],
-        "canvas_theme": image.get("canvas_theme"),
-        "tags": image.get("tags"),
-        "description": image.get("description"),
-        "diff_threshold": dt if dt is not None else global_diff_threshold,
-    }
-
-
-def _build_base_image(image_file_name: str, meta: ImageDict) -> ImageDict:
-    return {
-        **image_dict_extras(meta),
-        "key": meta["content_hash"],
-        "display_name": meta.get("display_name"),
-        "group": meta.get("group"),
-        "image_file_name": image_file_name,
-        "width": meta["width"],
-        "height": meta["height"],
-        "canvas_theme": meta.get("canvas_theme"),
-        "tags": meta.get("tags"),
-        "description": meta.get("description"),
-    }
-
-
-def _bare_image(
-    key: str, display_name: str, image_file_name: str, width: int, height: int
-) -> ImageDict:
-    return {
-        "key": key,
-        "display_name": display_name,
-        "group": None,
-        "image_file_name": image_file_name,
-        "width": width,
-        "height": height,
-        "canvas_theme": None,
-    }
-
-
 def _base_image_from_comparison(name: str, img: ImageDict) -> ImageDict:
-    return _bare_image(
+    return bare_image_dict(
         key=img.get("base_hash") or "",
         display_name=name,
         image_file_name=name,
@@ -108,7 +59,7 @@ def categorize_comparison_images(
         meta = base_images.get(key)
         if meta is None:
             return None
-        return _build_base_image(key, meta)
+        return build_base_image_dict(key, meta)
 
     for name, img in sorted(comparison_images.items()):
         head_img = head_images_by_file_name.get(name)
@@ -147,7 +98,7 @@ def categorize_comparison_images(
             if head_img:
                 result.unchanged.append(head_img)
         elif status == "errored":
-            head = head_img or _bare_image(
+            head = head_img or bare_image_dict(
                 key=img.get("head_hash") or img.get("base_hash") or "",
                 display_name=name,
                 image_file_name=name,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -1,26 +1,27 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
-from sentry.preprod.snapshots.image_serialization import (
-    ImageDict,
-    bare_image_dict,
-    build_base_image_dict,
+from sentry.preprod.api.models.public.snapshots import (
+    SnapshotDiffPairResponseDict,
+    SnapshotImageResponseDict,
 )
+from sentry.preprod.snapshots.image_serialization import bare_image_dict, build_base_image_dict
 
 
 @dataclass
 class CategorizedComparison:
-    changed: list[ImageDict] = field(default_factory=list)
-    added: list[ImageDict] = field(default_factory=list)
-    removed: list[ImageDict] = field(default_factory=list)
-    unchanged: list[ImageDict] = field(default_factory=list)
-    renamed: list[ImageDict] = field(default_factory=list)
-    errored: list[ImageDict] = field(default_factory=list)
-    skipped: list[ImageDict] = field(default_factory=list)
+    changed: list[SnapshotDiffPairResponseDict] = field(default_factory=list)
+    added: list[SnapshotImageResponseDict] = field(default_factory=list)
+    removed: list[SnapshotImageResponseDict] = field(default_factory=list)
+    unchanged: list[SnapshotImageResponseDict] = field(default_factory=list)
+    renamed: list[SnapshotDiffPairResponseDict] = field(default_factory=list)
+    errored: list[SnapshotDiffPairResponseDict] = field(default_factory=list)
+    skipped: list[SnapshotImageResponseDict] = field(default_factory=list)
 
 
-def _base_image_from_comparison(name: str, img: ImageDict) -> ImageDict:
+def _base_image_from_comparison(name: str, img: dict[str, Any]) -> SnapshotImageResponseDict:
     return bare_image_dict(
         key=img.get("base_hash") or "",
         display_name=name,
@@ -31,11 +32,11 @@ def _base_image_from_comparison(name: str, img: ImageDict) -> ImageDict:
 
 
 def _diff_pair(
-    base_image: ImageDict,
-    head_image: ImageDict,
+    base_image: SnapshotImageResponseDict,
+    head_image: SnapshotImageResponseDict,
     diff_image_key: str | None = None,
     diff: float | None = None,
-) -> ImageDict:
+) -> SnapshotDiffPairResponseDict:
     return {
         "base_image": base_image,
         "head_image": head_image,
@@ -45,15 +46,15 @@ def _diff_pair(
 
 
 def categorize_comparison_images(
-    comparison_images: dict[str, ImageDict],
-    head_images_by_file_name: dict[str, ImageDict],
-    base_images: dict[str, ImageDict] | None,
+    comparison_images: dict[str, dict[str, Any]],
+    head_images_by_file_name: dict[str, SnapshotImageResponseDict],
+    base_images: dict[str, dict[str, Any]] | None,
 ) -> CategorizedComparison:
     result = CategorizedComparison()
 
     base_images = base_images or {}
 
-    def get_base_image(key: str | None) -> ImageDict | None:
+    def get_base_image(key: str | None) -> SnapshotImageResponseDict | None:
         if key is None:
             return None
         meta = base_images.get(key)

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -1,65 +1,108 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from dataclasses import dataclass, field
+from typing import Any
 
-from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
-    SnapshotDiffPair,
-    SnapshotImageResponse,
-)
-from sentry.preprod.snapshots.manifest import (
-    ComparisonImageResult,
-    ComparisonManifest,
-    ImageMetadata,
-    SnapshotManifest,
-    image_metadata_extras,
-)
+from sentry.preprod.snapshots.manifest import image_dict_extras
+
+# Image and diff-pair payloads are plain dicts matching the shape the response
+# previously produced via pydantic .dict(); see image builders below.
+ImageDict = dict[str, Any]
 
 
-class CategorizedComparison(BaseModel):
-    changed: list[SnapshotDiffPair] = []
-    added: list[SnapshotImageResponse] = []
-    removed: list[SnapshotImageResponse] = []
-    unchanged: list[SnapshotImageResponse] = []
-    renamed: list[SnapshotDiffPair] = []
-    errored: list[SnapshotDiffPair] = []
-    skipped: list[SnapshotImageResponse] = []
+@dataclass
+class CategorizedComparison:
+    changed: list[ImageDict] = field(default_factory=list)
+    added: list[ImageDict] = field(default_factory=list)
+    removed: list[ImageDict] = field(default_factory=list)
+    unchanged: list[ImageDict] = field(default_factory=list)
+    renamed: list[ImageDict] = field(default_factory=list)
+    errored: list[ImageDict] = field(default_factory=list)
+    skipped: list[ImageDict] = field(default_factory=list)
 
 
-def _base_image_from_comparison(name: str, img: ComparisonImageResult) -> SnapshotImageResponse:
-    return SnapshotImageResponse(
-        key=img.base_hash or "",
+def build_head_image_dict(
+    image_file_name: str, image: ImageDict, global_diff_threshold: float | None
+) -> ImageDict:
+    dt = image.get("diff_threshold")
+    return {
+        **image_dict_extras(image),
+        "key": image["content_hash"],
+        "display_name": image.get("display_name"),
+        "group": image.get("group"),
+        "image_file_name": image_file_name,
+        "width": image["width"],
+        "height": image["height"],
+        "canvas_theme": image.get("canvas_theme"),
+        "tags": image.get("tags"),
+        "description": image.get("description"),
+        "diff_threshold": dt if dt is not None else global_diff_threshold,
+    }
+
+
+def _build_base_image(image_file_name: str, meta: ImageDict) -> ImageDict:
+    return {
+        **image_dict_extras(meta),
+        "key": meta["content_hash"],
+        "display_name": meta.get("display_name"),
+        "group": meta.get("group"),
+        "image_file_name": image_file_name,
+        "width": meta["width"],
+        "height": meta["height"],
+        "canvas_theme": meta.get("canvas_theme"),
+        "tags": meta.get("tags"),
+        "description": meta.get("description"),
+    }
+
+
+def _bare_image(
+    key: str, display_name: str, image_file_name: str, width: int, height: int
+) -> ImageDict:
+    return {
+        "key": key,
+        "display_name": display_name,
+        "group": None,
+        "image_file_name": image_file_name,
+        "width": width,
+        "height": height,
+        "canvas_theme": None,
+    }
+
+
+def _base_image_from_comparison(name: str, img: ImageDict) -> ImageDict:
+    return _bare_image(
+        key=img.get("base_hash") or "",
         display_name=name,
         image_file_name=name,
-        width=img.before_width or 0,
-        height=img.before_height or 0,
+        width=img.get("before_width") or 0,
+        height=img.get("before_height") or 0,
     )
 
 
-def _build_base_image(key: str, meta: ImageMetadata) -> SnapshotImageResponse:
-    return SnapshotImageResponse(
-        **image_metadata_extras(meta, exclude={"key", "image_file_name"}),
-        key=meta.content_hash,
-        display_name=meta.display_name,
-        image_file_name=key,
-        group=meta.group,
-        width=meta.width,
-        height=meta.height,
-        description=meta.description,
-        tags=meta.tags,
-        canvas_theme=meta.canvas_theme,
-    )
+def _diff_pair(
+    base_image: ImageDict,
+    head_image: ImageDict,
+    diff_image_key: str | None = None,
+    diff: float | None = None,
+) -> ImageDict:
+    return {
+        "base_image": base_image,
+        "head_image": head_image,
+        "diff_image_key": diff_image_key,
+        "diff": diff,
+    }
 
 
 def categorize_comparison_images(
-    comparison_data: ComparisonManifest,
-    head_images_by_file_name: dict[str, SnapshotImageResponse],
-    base_manifest: SnapshotManifest | None,
+    comparison_images: dict[str, ImageDict],
+    head_images_by_file_name: dict[str, ImageDict],
+    base_images: dict[str, ImageDict] | None,
 ) -> CategorizedComparison:
     result = CategorizedComparison()
 
-    base_images = base_manifest.images if base_manifest else {}
+    base_images = base_images or {}
 
-    def get_base_image(key: str | None) -> SnapshotImageResponse | None:
+    def get_base_image(key: str | None) -> ImageDict | None:
         if key is None:
             return None
         meta = base_images.get(key)
@@ -67,55 +110,58 @@ def categorize_comparison_images(
             return None
         return _build_base_image(key, meta)
 
-    for name, img in sorted(comparison_data.images.items()):
+    for name, img in sorted(comparison_images.items()):
         head_img = head_images_by_file_name.get(name)
+        status = img.get("status")
 
-        if img.status == "changed":
+        if status == "changed":
             if head_img:
+                changed_pixels = img.get("changed_pixels")
+                total_pixels = img.get("total_pixels")
                 result.changed.append(
-                    SnapshotDiffPair(
+                    _diff_pair(
                         base_image=get_base_image(name) or _base_image_from_comparison(name, img),
                         head_image=head_img,
-                        diff_image_key=img.diff_mask_image_id,
-                        diff=img.changed_pixels / img.total_pixels
-                        if img.changed_pixels is not None and img.total_pixels
+                        diff_image_key=img.get("diff_mask_image_id"),
+                        diff=changed_pixels / total_pixels
+                        if changed_pixels is not None and total_pixels
                         else None,
                     )
                 )
-        elif img.status == "added":
+        elif status == "added":
             if head_img:
                 result.added.append(head_img)
-        elif img.status == "removed":
+        elif status == "removed":
             result.removed.append(get_base_image(name) or _base_image_from_comparison(name, img))
-        elif img.status == "renamed":
+        elif status == "renamed":
             if head_img:
-                old_name = img.previous_image_file_name
+                old_name = img.get("previous_image_file_name")
                 result.renamed.append(
-                    SnapshotDiffPair(
+                    _diff_pair(
                         base_image=get_base_image(old_name)
                         or _base_image_from_comparison(old_name or name, img),
                         head_image=head_img,
                     )
                 )
-        elif img.status == "unchanged":
+        elif status == "unchanged":
             if head_img:
                 result.unchanged.append(head_img)
-        elif img.status == "errored":
-            head = head_img or SnapshotImageResponse(
-                key=img.head_hash or img.base_hash or "",
+        elif status == "errored":
+            head = head_img or _bare_image(
+                key=img.get("head_hash") or img.get("base_hash") or "",
                 display_name=name,
                 image_file_name=name,
-                width=img.after_width or img.before_width or 0,
-                height=img.after_height or img.before_height or 0,
+                width=img.get("after_width") or img.get("before_width") or 0,
+                height=img.get("after_height") or img.get("before_height") or 0,
             )
             result.errored.append(
-                SnapshotDiffPair(
+                _diff_pair(
                     base_image=get_base_image(name) or _base_image_from_comparison(name, img),
                     head_image=head,
                 )
             )
-        elif img.status == "skipped":
+        elif status == "skipped":
             result.skipped.append(get_base_image(name) or _base_image_from_comparison(name, img))
 
-    result.changed.sort(key=lambda p: p.diff or 0, reverse=True)
+    result.changed.sort(key=lambda p: p["diff"] or 0, reverse=True)
     return result

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -7,7 +8,9 @@ from sentry.preprod.api.models.public.snapshots import (
     SnapshotDiffPairResponseDict,
     SnapshotImageResponseDict,
 )
-from sentry.preprod.snapshots.image_serialization import bare_image_dict, build_base_image_dict
+from sentry.preprod.snapshots.image_serialization import build_base_image_dict, minimal_image_dict
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -22,7 +25,7 @@ class CategorizedComparison:
 
 
 def _base_image_from_comparison(name: str, img: dict[str, Any]) -> SnapshotImageResponseDict:
-    return bare_image_dict(
+    return minimal_image_dict(
         key=img.get("base_hash") or "",
         display_name=name,
         image_file_name=name,
@@ -99,7 +102,7 @@ def categorize_comparison_images(
             if head_img:
                 result.unchanged.append(head_img)
         elif status == "errored":
-            head = head_img or bare_image_dict(
+            head = head_img or minimal_image_dict(
                 key=img.get("head_hash") or img.get("base_hash") or "",
                 display_name=name,
                 image_file_name=name,
@@ -114,6 +117,11 @@ def categorize_comparison_images(
             )
         elif status == "skipped":
             result.skipped.append(get_base_image(name) or _base_image_from_comparison(name, img))
+        else:
+            logger.warning(
+                "preprod.snapshot.unexpected_comparison_status",
+                extra={"status": status, "image_file_name": name},
+            )
 
     result.changed.sort(key=lambda p: p["diff"] or 0, reverse=True)
     return result

--- a/src/sentry/preprod/snapshots/image_serialization.py
+++ b/src/sentry/preprod/snapshots/image_serialization.py
@@ -39,7 +39,7 @@ def build_head_image_dict(
     )
 
 
-def bare_image_dict(
+def minimal_image_dict(
     key: str, display_name: str, image_file_name: str, width: int, height: int
 ) -> SnapshotImageResponseDict:
     return {

--- a/src/sentry/preprod/snapshots/image_serialization.py
+++ b/src/sentry/preprod/snapshots/image_serialization.py
@@ -1,42 +1,47 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
+from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
 from sentry.preprod.snapshots.manifest import image_dict_extras
 
-# Image payloads are plain dicts matching the shape the response previously
-# produced via pydantic SnapshotImageResponse.dict().
-ImageDict = dict[str, Any]
 
-
-def build_base_image_dict(image_file_name: str, image: ImageDict) -> ImageDict:
-    return {
-        **image_dict_extras(image),
-        "key": image["content_hash"],
-        "display_name": image.get("display_name"),
-        "group": image.get("group"),
-        "image_file_name": image_file_name,
-        "width": image["width"],
-        "height": image["height"],
-        "canvas_theme": image.get("canvas_theme"),
-        "tags": image.get("tags"),
-        "description": image.get("description"),
-    }
+def build_base_image_dict(image_file_name: str, image: dict[str, Any]) -> SnapshotImageResponseDict:
+    # cast(): the spread of arbitrary passthrough extras (Config.extra == "allow")
+    # can't be expressed as a closed TypedDict literal; the declared keys still type.
+    return cast(
+        SnapshotImageResponseDict,
+        {
+            **image_dict_extras(image),
+            "key": image["content_hash"],
+            "display_name": image.get("display_name"),
+            "group": image.get("group"),
+            "image_file_name": image_file_name,
+            "width": image["width"],
+            "height": image["height"],
+            "canvas_theme": image.get("canvas_theme"),
+            "tags": image.get("tags"),
+            "description": image.get("description"),
+        },
+    )
 
 
 def build_head_image_dict(
-    image_file_name: str, image: ImageDict, global_diff_threshold: float | None
-) -> ImageDict:
+    image_file_name: str, image: dict[str, Any], global_diff_threshold: float | None
+) -> SnapshotImageResponseDict:
     dt = image.get("diff_threshold")
-    return {
-        **build_base_image_dict(image_file_name, image),
-        "diff_threshold": dt if dt is not None else global_diff_threshold,
-    }
+    return cast(
+        SnapshotImageResponseDict,
+        {
+            **build_base_image_dict(image_file_name, image),
+            "diff_threshold": dt if dt is not None else global_diff_threshold,
+        },
+    )
 
 
 def bare_image_dict(
     key: str, display_name: str, image_file_name: str, width: int, height: int
-) -> ImageDict:
+) -> SnapshotImageResponseDict:
     return {
         "key": key,
         "display_name": display_name,

--- a/src/sentry/preprod/snapshots/image_serialization.py
+++ b/src/sentry/preprod/snapshots/image_serialization.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentry.preprod.snapshots.manifest import image_dict_extras
+
+# Image payloads are plain dicts matching the shape the response previously
+# produced via pydantic SnapshotImageResponse.dict().
+ImageDict = dict[str, Any]
+
+
+def build_base_image_dict(image_file_name: str, image: ImageDict) -> ImageDict:
+    return {
+        **image_dict_extras(image),
+        "key": image["content_hash"],
+        "display_name": image.get("display_name"),
+        "group": image.get("group"),
+        "image_file_name": image_file_name,
+        "width": image["width"],
+        "height": image["height"],
+        "canvas_theme": image.get("canvas_theme"),
+        "tags": image.get("tags"),
+        "description": image.get("description"),
+    }
+
+
+def build_head_image_dict(
+    image_file_name: str, image: ImageDict, global_diff_threshold: float | None
+) -> ImageDict:
+    dt = image.get("diff_threshold")
+    return {
+        **build_base_image_dict(image_file_name, image),
+        "diff_threshold": dt if dt is not None else global_diff_threshold,
+    }
+
+
+def bare_image_dict(
+    key: str, display_name: str, image_file_name: str, width: int, height: int
+) -> ImageDict:
+    return {
+        "key": key,
+        "display_name": display_name,
+        "group": None,
+        "image_file_name": image_file_name,
+        "width": width,
+        "height": height,
+        "canvas_theme": None,
+    }

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -57,6 +57,15 @@ def image_metadata_extras(
     return {k: v for k, v in metadata if k not in skip}
 
 
+# Keys owned by the response schema (mapped explicitly) or the manifest schema; anything
+# else on a stored image dict is passed through as an "extra" (Config.extra == "allow").
+_KNOWN_IMAGE_KEYS = _SCHEMA_FIELDS | {"key", "image_file_name"}
+
+
+def image_dict_extras(image: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in image.items() if k not in _KNOWN_IMAGE_KEYS}
+
+
 class SnapshotManifest(BaseModel):
     images: dict[str, ImageMetadata]
     diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)

--- a/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff.json
+++ b/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff.json
@@ -1,0 +1,212 @@
+{
+  "added": [
+    {
+      "canvas_theme": null,
+      "description": null,
+      "diff_threshold": 0.2,
+      "display_name": "Added",
+      "group": null,
+      "height": 20,
+      "image_file_name": "a_added.png",
+      "key": "h_added",
+      "tags": null,
+      "width": 10
+    }
+  ],
+  "added_count": 1,
+  "app_id": "com.example.app",
+  "approval_status": null,
+  "approvers": [],
+  "base_artifact_id": "<BASE_ID>",
+  "changed": [
+    {
+      "base_image": {
+        "canvas_theme": null,
+        "description": null,
+        "display_name": "Changed Base",
+        "group": null,
+        "height": 40,
+        "image_file_name": "b_changed.png",
+        "key": "b_changed_hash",
+        "tags": null,
+        "width": 30
+      },
+      "diff": 0.25,
+      "diff_image_key": "mask-1",
+      "head_image": {
+        "canvas_theme": "dark",
+        "description": "a description",
+        "diff_threshold": 0.5,
+        "display_name": "Changed",
+        "group": "grp",
+        "height": 40,
+        "image_file_name": "b_changed.png",
+        "key": "h_changed",
+        "tags": {
+          "env": "prod"
+        },
+        "width": 30
+      }
+    }
+  ],
+  "changed_count": 1,
+  "comparison_error_message": null,
+  "comparison_state": "success",
+  "comparison_type": "diff",
+  "diff_threshold": 0.2,
+  "errored": [
+    {
+      "base_image": {
+        "canvas_theme": null,
+        "display_name": "e_errored.png",
+        "group": null,
+        "height": 0,
+        "image_file_name": "e_errored.png",
+        "key": "",
+        "width": 0
+      },
+      "diff": null,
+      "diff_image_key": null,
+      "head_image": {
+        "canvas_theme": null,
+        "description": null,
+        "diff_threshold": 0.2,
+        "display_name": null,
+        "group": null,
+        "height": 100,
+        "image_file_name": "e_errored.png",
+        "key": "h_errored",
+        "tags": null,
+        "width": 90
+      }
+    },
+    {
+      "base_image": {
+        "canvas_theme": null,
+        "display_name": "i_errored_nohead.png",
+        "group": null,
+        "height": 8,
+        "image_file_name": "i_errored_nohead.png",
+        "key": "",
+        "width": 7
+      },
+      "diff": null,
+      "diff_image_key": null,
+      "head_image": {
+        "canvas_theme": null,
+        "display_name": "i_errored_nohead.png",
+        "group": null,
+        "height": 12,
+        "image_file_name": "i_errored_nohead.png",
+        "key": "eh",
+        "width": 9
+      }
+    }
+  ],
+  "errored_count": 2,
+  "head_artifact_id": "<HEAD_ID>",
+  "image_count": 5,
+  "images": [],
+  "is_selective": false,
+  "project_id": "<PROJECT_ID>",
+  "removed": [
+    {
+      "canvas_theme": null,
+      "description": null,
+      "display_name": "Removed",
+      "group": null,
+      "height": 22,
+      "image_file_name": "f_removed.png",
+      "key": "b_removed_hash",
+      "tags": null,
+      "width": 11
+    },
+    {
+      "canvas_theme": null,
+      "display_name": "h_removed_nobase.png",
+      "group": null,
+      "height": 6,
+      "image_file_name": "h_removed_nobase.png",
+      "key": "x_nobase",
+      "width": 5
+    }
+  ],
+  "removed_count": 2,
+  "renamed": [
+    {
+      "base_image": {
+        "canvas_theme": null,
+        "description": null,
+        "display_name": "Old Name",
+        "group": null,
+        "height": 80,
+        "image_file_name": "old_name.png",
+        "key": "b_renamed_hash",
+        "tags": null,
+        "width": 70
+      },
+      "diff": null,
+      "diff_image_key": null,
+      "head_image": {
+        "canvas_theme": null,
+        "description": null,
+        "diff_threshold": 0.2,
+        "display_name": "Renamed",
+        "group": null,
+        "height": 80,
+        "image_file_name": "d_renamed.png",
+        "key": "h_renamed",
+        "tags": null,
+        "width": 70
+      }
+    }
+  ],
+  "renamed_count": 1,
+  "skipped": [
+    {
+      "canvas_theme": null,
+      "description": null,
+      "display_name": "Skipped",
+      "group": null,
+      "height": 44,
+      "image_file_name": "g_skipped.png",
+      "key": "b_skipped_hash",
+      "tags": null,
+      "width": 33
+    }
+  ],
+  "skipped_count": 1,
+  "state": 1,
+  "unchanged": [
+    {
+      "canvas_theme": null,
+      "custom_extra": "xyz",
+      "description": null,
+      "diff_threshold": 0.2,
+      "display_name": null,
+      "group": null,
+      "height": 60,
+      "image_file_name": "c_unchanged.png",
+      "key": "h_unchanged",
+      "nested_extra": {
+        "k": 1
+      },
+      "tags": {
+        "one": "one",
+        "two": "two"
+      },
+      "width": 50
+    }
+  ],
+  "unchanged_count": 1,
+  "vcs_info": {
+    "base_ref": null,
+    "base_repo_name": null,
+    "base_sha": null,
+    "head_ref": null,
+    "head_repo_name": null,
+    "head_sha": null,
+    "pr_number": null,
+    "provider": null
+  }
+}

--- a/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff_compact.json
+++ b/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff_compact.json
@@ -1,0 +1,137 @@
+{
+  "added": [
+    {
+      "description": null,
+      "display_name": "Added",
+      "group": null,
+      "image_file_name": "a_added.png"
+    }
+  ],
+  "added_count": 1,
+  "app_id": "com.example.app",
+  "approval_status": null,
+  "approvers": [],
+  "base_artifact_id": "<BASE_ID>",
+  "changed": [
+    {
+      "base_image": {
+        "description": null,
+        "display_name": "Changed Base",
+        "group": null,
+        "image_file_name": "b_changed.png"
+      },
+      "diff": 0.25,
+      "diff_image_key": "mask-1",
+      "head_image": {
+        "description": "a description",
+        "display_name": "Changed",
+        "group": "grp",
+        "image_file_name": "b_changed.png"
+      }
+    }
+  ],
+  "changed_count": 1,
+  "comparison_error_message": null,
+  "comparison_state": "success",
+  "comparison_type": "diff",
+  "diff_threshold": 0.2,
+  "errored": [
+    {
+      "base_image": {
+        "display_name": "e_errored.png",
+        "group": null,
+        "image_file_name": "e_errored.png"
+      },
+      "diff": null,
+      "diff_image_key": null,
+      "head_image": {
+        "description": null,
+        "display_name": null,
+        "group": null,
+        "image_file_name": "e_errored.png"
+      }
+    },
+    {
+      "base_image": {
+        "display_name": "i_errored_nohead.png",
+        "group": null,
+        "image_file_name": "i_errored_nohead.png"
+      },
+      "diff": null,
+      "diff_image_key": null,
+      "head_image": {
+        "display_name": "i_errored_nohead.png",
+        "group": null,
+        "image_file_name": "i_errored_nohead.png"
+      }
+    }
+  ],
+  "errored_count": 2,
+  "head_artifact_id": "<HEAD_ID>",
+  "image_count": 5,
+  "images": [],
+  "is_selective": false,
+  "project_id": "<PROJECT_ID>",
+  "removed": [
+    {
+      "description": null,
+      "display_name": "Removed",
+      "group": null,
+      "image_file_name": "f_removed.png"
+    },
+    {
+      "display_name": "h_removed_nobase.png",
+      "group": null,
+      "image_file_name": "h_removed_nobase.png"
+    }
+  ],
+  "removed_count": 2,
+  "renamed": [
+    {
+      "base_image": {
+        "description": null,
+        "display_name": "Old Name",
+        "group": null,
+        "image_file_name": "old_name.png"
+      },
+      "diff": null,
+      "diff_image_key": null,
+      "head_image": {
+        "description": null,
+        "display_name": "Renamed",
+        "group": null,
+        "image_file_name": "d_renamed.png"
+      }
+    }
+  ],
+  "renamed_count": 1,
+  "skipped": [
+    {
+      "description": null,
+      "display_name": "Skipped",
+      "group": null,
+      "image_file_name": "g_skipped.png"
+    }
+  ],
+  "skipped_count": 1,
+  "state": 1,
+  "unchanged": [
+    {
+      "description": null,
+      "display_name": null,
+      "group": null,
+      "image_file_name": "c_unchanged.png"
+    }
+  ],
+  "unchanged_count": 1,
+  "vcs_info": {
+    "base_ref": null,
+    "base_repo_name": null,
+    "base_sha": null,
+    "head_ref": null,
+    "head_repo_name": null,
+    "head_sha": null,
+    "pr_number": null,
+    "provider": null
+  }
+}

--- a/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_solo.json
+++ b/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_solo.json
@@ -1,0 +1,110 @@
+{
+  "added": [],
+  "added_count": 0,
+  "app_id": "com.example.app",
+  "approval_status": null,
+  "approvers": [],
+  "base_artifact_id": null,
+  "changed": [],
+  "changed_count": 0,
+  "comparison_error_message": null,
+  "comparison_state": null,
+  "comparison_type": "solo",
+  "diff_threshold": 0.2,
+  "errored": [],
+  "errored_count": 0,
+  "head_artifact_id": "<HEAD_ID>",
+  "image_count": 5,
+  "images": [
+    {
+      "canvas_theme": null,
+      "description": null,
+      "diff_threshold": 0.2,
+      "display_name": "Added",
+      "group": null,
+      "height": 20,
+      "image_file_name": "a_added.png",
+      "key": "h_added",
+      "tags": null,
+      "width": 10
+    },
+    {
+      "canvas_theme": "dark",
+      "description": "a description",
+      "diff_threshold": 0.5,
+      "display_name": "Changed",
+      "group": "grp",
+      "height": 40,
+      "image_file_name": "b_changed.png",
+      "key": "h_changed",
+      "tags": {
+        "env": "prod"
+      },
+      "width": 30
+    },
+    {
+      "canvas_theme": null,
+      "custom_extra": "xyz",
+      "description": null,
+      "diff_threshold": 0.2,
+      "display_name": null,
+      "group": null,
+      "height": 60,
+      "image_file_name": "c_unchanged.png",
+      "key": "h_unchanged",
+      "nested_extra": {
+        "k": 1
+      },
+      "tags": {
+        "one": "one",
+        "two": "two"
+      },
+      "width": 50
+    },
+    {
+      "canvas_theme": null,
+      "description": null,
+      "diff_threshold": 0.2,
+      "display_name": "Renamed",
+      "group": null,
+      "height": 80,
+      "image_file_name": "d_renamed.png",
+      "key": "h_renamed",
+      "tags": null,
+      "width": 70
+    },
+    {
+      "canvas_theme": null,
+      "description": null,
+      "diff_threshold": 0.2,
+      "display_name": null,
+      "group": null,
+      "height": 100,
+      "image_file_name": "e_errored.png",
+      "key": "h_errored",
+      "tags": null,
+      "width": 90
+    }
+  ],
+  "is_selective": false,
+  "project_id": "<PROJECT_ID>",
+  "removed": [],
+  "removed_count": 0,
+  "renamed": [],
+  "renamed_count": 0,
+  "skipped": [],
+  "skipped_count": 0,
+  "state": 1,
+  "unchanged": [],
+  "unchanged_count": 0,
+  "vcs_info": {
+    "base_ref": null,
+    "base_repo_name": null,
+    "base_sha": null,
+    "head_ref": null,
+    "head_repo_name": null,
+    "head_sha": null,
+    "pr_number": null,
+    "provider": null
+  }
+}

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -1316,16 +1316,17 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
         return f"{self.org.id}/{self.project.id}/{artifact.id}/manifest.json"
 
     def _create_artifact(self, image_count):
-        artifact = PreprodArtifact.objects.create(
+        artifact = self.create_preprod_artifact(
             project=self.project,
             state=PreprodArtifact.ArtifactState.UPLOADED,
             app_id="com.example.app",
         )
-        metrics = PreprodSnapshotMetrics.objects.create(
+        metrics = self.create_preprod_snapshot_metrics(
             preprod_artifact=artifact,
             image_count=image_count,
-            extras={"manifest_key": self._manifest_key(artifact)},
         )
+        metrics.extras = {"manifest_key": self._manifest_key(artifact)}
+        metrics.save(update_fields=["extras"])
         return artifact, metrics
 
     def _snapshot_manifest_bytes(self, images, diff_threshold=None):
@@ -1584,3 +1585,34 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
                 "project_id": "<PROJECT_ID>",
             },
         )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_comparison_manifest_missing_base_artifact_id_degrades(
+        self, mock_get_session, mock_record
+    ):
+        head_images = self._head_images()
+        head_artifact, head_metrics = self._create_artifact(image_count=len(head_images))
+        _, base_metrics = self._create_artifact(image_count=1)
+        comparison = self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+        )
+        comparison_key = f"{self.org.id}/{self.project.id}/{head_artifact.id}/comparison.json"
+        comparison.extras = {"comparison_key": comparison_key}
+        comparison.save(update_fields=["extras"])
+        # Comparison manifest is parseable JSON but missing the required base_artifact_id.
+        self._mock_multi_session(
+            mock_get_session,
+            {
+                self._manifest_key(head_artifact): self._snapshot_manifest_bytes(head_images),
+                comparison_key: orjson.dumps({"images": {}}),
+            },
+        )
+
+        response = self.client.get(self._get_detail_url(head_artifact.id))
+
+        # Degrades gracefully to a non-diff response instead of raising a 500.
+        assert response.status_code == 200
+        assert response.data["comparison_type"] == "solo"

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -11,6 +12,12 @@ from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_bas
     LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS,
 )
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
+from sentry.preprod.snapshots.manifest import (
+    ComparisonImageResult,
+    ComparisonManifest,
+    ComparisonSummary,
+    SnapshotManifest,
+)
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
@@ -1281,3 +1288,299 @@ class ProjectPreprodSnapshotDeleteTest(APITestCase):
 
         assert response.status_code == 404
         assert PreprodArtifact.objects.filter(id=artifact.id).exists()
+
+
+GOLDEN_DIR = os.path.join(os.path.dirname(__file__), "snapshots_golden")
+
+
+class PreprodSnapshotGoldenResponseTest(APITestCase):
+    """Byte-for-byte characterization of the GET response body.
+
+    Guards the de-Pydantic serialization refactor: the exact rendered response
+    must not change. Regenerate goldens with UPDATE_SNAPSHOTS=1 and review the diff.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+
+    def _get_detail_url(self, snapshot_id):
+        return reverse(
+            "sentry-api-0-project-preprod-snapshots-detail",
+            args=[self.org.slug, snapshot_id],
+        )
+
+    def _manifest_key(self, artifact):
+        return f"{self.org.id}/{self.project.id}/{artifact.id}/manifest.json"
+
+    def _create_artifact(self, image_count):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+            app_id="com.example.app",
+        )
+        metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact,
+            image_count=image_count,
+            extras={"manifest_key": self._manifest_key(artifact)},
+        )
+        return artifact, metrics
+
+    def _snapshot_manifest_bytes(self, images, diff_threshold=None):
+        # Mirror how the POST handler stores manifests: pydantic .json(exclude_none=True),
+        # so null fields are omitted and tags/canvas_theme are coerced on disk.
+        return (
+            SnapshotManifest(images=images, diff_threshold=diff_threshold)
+            .json(exclude_none=True)
+            .encode()
+        )
+
+    def _head_images(self):
+        return {
+            "a_added.png": {
+                "content_hash": "h_added",
+                "display_name": "Added",
+                "width": 10,
+                "height": 20,
+            },
+            "b_changed.png": {
+                "content_hash": "h_changed",
+                "display_name": "Changed",
+                "group": "grp",
+                "width": 30,
+                "height": 40,
+                "diff_threshold": 0.5,
+                "description": "a description",
+                "tags": {"env": "prod"},
+                "canvas_theme": "dark",
+            },
+            "c_unchanged.png": {
+                "content_hash": "h_unchanged",
+                "width": 50,
+                "height": 60,
+                "tags": ["one", "two"],
+                "canvas_theme": "purple",
+                "custom_extra": "xyz",
+                "nested_extra": {"k": 1},
+            },
+            "d_renamed.png": {
+                "content_hash": "h_renamed",
+                "display_name": "Renamed",
+                "width": 70,
+                "height": 80,
+            },
+            "e_errored.png": {
+                "content_hash": "h_errored",
+                "width": 90,
+                "height": 100,
+            },
+        }
+
+    def _base_images(self):
+        return {
+            "b_changed.png": {
+                "content_hash": "b_changed_hash",
+                "display_name": "Changed Base",
+                "width": 30,
+                "height": 40,
+            },
+            "c_unchanged.png": {"content_hash": "h_unchanged", "width": 50, "height": 60},
+            "old_name.png": {
+                "content_hash": "b_renamed_hash",
+                "display_name": "Old Name",
+                "width": 70,
+                "height": 80,
+            },
+            "f_removed.png": {
+                "content_hash": "b_removed_hash",
+                "display_name": "Removed",
+                "width": 11,
+                "height": 22,
+            },
+            "g_skipped.png": {
+                "content_hash": "b_skipped_hash",
+                "display_name": "Skipped",
+                "width": 33,
+                "height": 44,
+            },
+        }
+
+    def _comparison_manifest_bytes(self, head_artifact, base_artifact):
+        images = {
+            "a_added.png": ComparisonImageResult(status="added", head_hash="h_added"),
+            "b_changed.png": ComparisonImageResult(
+                status="changed",
+                head_hash="h_changed",
+                base_hash="b_changed_hash",
+                changed_pixels=25,
+                total_pixels=100,
+                diff_mask_image_id="mask-1",
+            ),
+            "c_unchanged.png": ComparisonImageResult(
+                status="unchanged", head_hash="h_unchanged", base_hash="h_unchanged"
+            ),
+            "d_renamed.png": ComparisonImageResult(
+                status="renamed",
+                head_hash="h_renamed",
+                base_hash="b_renamed_hash",
+                previous_image_file_name="old_name.png",
+            ),
+            "e_errored.png": ComparisonImageResult(
+                status="errored", head_hash="h_errored", reason="boom"
+            ),
+            "f_removed.png": ComparisonImageResult(
+                status="removed", base_hash="b_removed_hash", before_width=11, before_height=22
+            ),
+            "g_skipped.png": ComparisonImageResult(
+                status="skipped", base_hash="b_skipped_hash", reason="too big"
+            ),
+            # not in base -> _base_image_from_comparison fallback
+            "h_removed_nobase.png": ComparisonImageResult(
+                status="removed", base_hash="x_nobase", before_width=5, before_height=6
+            ),
+            # not in head -> SnapshotImageResponse head fallback
+            "i_errored_nohead.png": ComparisonImageResult(
+                status="errored",
+                head_hash="eh",
+                after_width=9,
+                after_height=12,
+                before_width=7,
+                before_height=8,
+            ),
+        }
+        return orjson.dumps(
+            ComparisonManifest(
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+                summary=ComparisonSummary(
+                    total=9,
+                    changed=1,
+                    unchanged=1,
+                    added=1,
+                    removed=2,
+                    errored=2,
+                    renamed=1,
+                    skipped=1,
+                ),
+                images=images,
+            ).dict()
+        )
+
+    def _mock_multi_session(self, mock_get_session, manifests_by_key):
+        def _get(key):
+            if key not in manifests_by_key:
+                return None
+            result = MagicMock()
+            result.payload.read.return_value = manifests_by_key[key]
+            return result
+
+        session = MagicMock()
+        session.get.side_effect = _get
+        mock_get_session.return_value = session
+
+    def _assert_golden(self, name, response, dynamic_ids):
+        assert response.status_code == 200
+        body = orjson.loads(response.content)
+        for field, token in dynamic_ids.items():
+            if body.get(field) is not None:
+                body[field] = token
+        # Sort object keys recursively (arrays keep their order): object key order is
+        # not semantically meaningful, so we assert same fields/values/array-order
+        # rather than reproduce pydantic's extra-key insertion order. Trailing newline
+        # keeps the golden files end-of-file-fixer clean.
+        normalized = orjson.dumps(body, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS) + b"\n"
+
+        path = os.path.join(GOLDEN_DIR, name)
+        if os.environ.get("UPDATE_SNAPSHOTS") == "1":
+            os.makedirs(GOLDEN_DIR, exist_ok=True)
+            with open(path, "wb") as fh:
+                fh.write(normalized)
+            return
+
+        with open(path, "rb") as fh:
+            expected = fh.read()
+        assert normalized == expected, (
+            f"Response body changed for {name}. If intended, re-run with "
+            f"UPDATE_SNAPSHOTS=1 and review the golden diff."
+        )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_golden_solo(self, mock_get_session, mock_record):
+        head_images = self._head_images()
+        artifact, _ = self._create_artifact(image_count=len(head_images))
+        self._mock_multi_session(
+            mock_get_session,
+            {self._manifest_key(artifact): self._snapshot_manifest_bytes(head_images, 0.2)},
+        )
+
+        response = self.client.get(self._get_detail_url(artifact.id))
+
+        self._assert_golden(
+            "snapshot_solo.json",
+            response,
+            {"head_artifact_id": "<HEAD_ID>", "project_id": "<PROJECT_ID>"},
+        )
+
+    def _setup_diff(self, mock_get_session):
+        head_images = self._head_images()
+        base_images = self._base_images()
+        head_artifact, head_metrics = self._create_artifact(image_count=len(head_images))
+        base_artifact, base_metrics = self._create_artifact(image_count=len(base_images))
+
+        comparison = self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+        )
+        comparison_key = (
+            f"{self.org.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}/comparison.json"
+        )
+        comparison.extras = {"comparison_key": comparison_key}
+        comparison.save(update_fields=["extras"])
+
+        self._mock_multi_session(
+            mock_get_session,
+            {
+                self._manifest_key(head_artifact): self._snapshot_manifest_bytes(head_images, 0.2),
+                self._manifest_key(base_artifact): self._snapshot_manifest_bytes(base_images),
+                comparison_key: self._comparison_manifest_bytes(head_artifact, base_artifact),
+            },
+        )
+        return head_artifact, base_artifact
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_golden_diff(self, mock_get_session, mock_record):
+        head_artifact, _ = self._setup_diff(mock_get_session)
+
+        response = self.client.get(self._get_detail_url(head_artifact.id))
+
+        self._assert_golden(
+            "snapshot_diff.json",
+            response,
+            {
+                "head_artifact_id": "<HEAD_ID>",
+                "base_artifact_id": "<BASE_ID>",
+                "project_id": "<PROJECT_ID>",
+            },
+        )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_golden_diff_compact(self, mock_get_session, mock_record):
+        head_artifact, _ = self._setup_diff(mock_get_session)
+
+        response = self.client.get(self._get_detail_url(head_artifact.id) + "?compact_metadata=1")
+
+        self._assert_golden(
+            "snapshot_diff_compact.json",
+            response,
+            {
+                "head_artifact_id": "<HEAD_ID>",
+                "base_artifact_id": "<BASE_ID>",
+                "project_id": "<PROJECT_ID>",
+            },
+        )

--- a/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
+++ b/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
@@ -9,15 +9,6 @@ _SKIPPED = {
 
 
 class TestCategorizeComparisonImagesSkipped:
-    def test_skipped_uses_base_image(self) -> None:
-        base = {"s.png": {"content_hash": "base_hash", "width": 300, "height": 400}}
-
-        result = categorize_comparison_images({"s.png": _SKIPPED}, {}, base)
-
-        assert len(result.skipped) == 1
-        assert result.skipped[0]["image_file_name"] == "s.png"
-        assert result.skipped[0]["width"] == 300
-
     def test_skipped_falls_back_without_base_manifest(self) -> None:
         result = categorize_comparison_images({"s.png": _SKIPPED}, {}, None)
 

--- a/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
+++ b/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
@@ -1,135 +1,90 @@
-from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
-    SnapshotImageResponse,
-)
 from sentry.preprod.snapshots.comparison_categorizer import categorize_comparison_images
-from sentry.preprod.snapshots.manifest import (
-    ComparisonImageResult,
-    ComparisonManifest,
-    ComparisonSummary,
-    ImageMetadata,
-    SnapshotManifest,
-)
 
-_SKIPPED = ComparisonImageResult(
-    status="skipped", base_hash="base_hash", before_width=300, before_height=400
-)
-
-_EMPTY_SUMMARY = ComparisonSummary(
-    total=1, changed=0, unchanged=0, added=0, removed=0, errored=0, renamed=0, skipped=1
-)
+_SKIPPED = {
+    "status": "skipped",
+    "base_hash": "base_hash",
+    "before_width": 300,
+    "before_height": 400,
+}
 
 
 class TestCategorizeComparisonImagesSkipped:
     def test_skipped_uses_base_image(self) -> None:
-        base = SnapshotManifest(
-            images={"s.png": ImageMetadata(content_hash="base_hash", width=300, height=400)}
-        )
-        manifest = ComparisonManifest(
-            head_artifact_id=1,
-            base_artifact_id=2,
-            summary=_EMPTY_SUMMARY,
-            images={"s.png": _SKIPPED},
-        )
+        base = {"s.png": {"content_hash": "base_hash", "width": 300, "height": 400}}
 
-        result = categorize_comparison_images(manifest, {}, base)
+        result = categorize_comparison_images({"s.png": _SKIPPED}, {}, base)
 
         assert len(result.skipped) == 1
-        assert result.skipped[0].image_file_name == "s.png"
-        assert result.skipped[0].width == 300
+        assert result.skipped[0]["image_file_name"] == "s.png"
+        assert result.skipped[0]["width"] == 300
 
     def test_skipped_falls_back_without_base_manifest(self) -> None:
-        manifest = ComparisonManifest(
-            head_artifact_id=1,
-            base_artifact_id=2,
-            summary=_EMPTY_SUMMARY,
-            images={"s.png": _SKIPPED},
-        )
-
-        result = categorize_comparison_images(manifest, {}, None)
+        result = categorize_comparison_images({"s.png": _SKIPPED}, {}, None)
 
         assert len(result.skipped) == 1
-        assert result.skipped[0].key == "base_hash"
-        assert result.skipped[0].width == 300
-
-
-def _full_summary() -> ComparisonSummary:
-    return ComparisonSummary(
-        total=8, changed=2, unchanged=1, added=1, removed=1, errored=1, renamed=1, skipped=1
-    )
+        assert result.skipped[0]["key"] == "base_hash"
+        assert result.skipped[0]["width"] == 300
 
 
 class TestCategorizeComparisonImagesAllStatuses:
-    def _base_manifest(self) -> SnapshotManifest:
-        return SnapshotManifest(
-            images={
-                "changed_a.png": ImageMetadata(
-                    content_hash="base_ca",
-                    display_name="Changed A",
-                    group="g1",
-                    width=10,
-                    height=20,
-                    description="desc-ca",
-                    tags={"t": "v"},
-                    platform="ios",
-                ),
-                "changed_b.png": ImageMetadata(content_hash="base_cb", width=11, height=21),
-                "removed.png": ImageMetadata(
-                    content_hash="base_rm",
-                    display_name="Removed",
-                    group="g2",
-                    width=12,
-                    height=22,
-                    description="desc-rm",
-                    tags={"k": "1"},
-                    canvas_theme="dark",
-                    region="eu",
-                ),
-                "old_name.png": ImageMetadata(content_hash="base_old", width=13, height=23),
-                "unchanged.png": ImageMetadata(content_hash="base_un", width=14, height=24),
-                "errored.png": ImageMetadata(content_hash="base_er", width=15, height=25),
-                "skipped.png": ImageMetadata(content_hash="base_sk", width=16, height=26),
-            }
-        )
-
-    def _comparison(self) -> ComparisonManifest:
-        return ComparisonManifest(
-            head_artifact_id=1,
-            base_artifact_id=2,
-            summary=_full_summary(),
-            images={
-                "changed_a.png": ComparisonImageResult(
-                    status="changed",
-                    changed_pixels=25,
-                    total_pixels=100,
-                    diff_mask_image_id="mask_a",
-                ),
-                "changed_b.png": ComparisonImageResult(
-                    status="changed",
-                    changed_pixels=90,
-                    total_pixels=100,
-                    diff_mask_image_id="mask_b",
-                ),
-                "added.png": ComparisonImageResult(status="added"),
-                "removed.png": ComparisonImageResult(status="removed", base_hash="base_rm"),
-                "renamed.png": ComparisonImageResult(
-                    status="renamed", previous_image_file_name="old_name.png"
-                ),
-                "unchanged.png": ComparisonImageResult(status="unchanged"),
-                "errored.png": ComparisonImageResult(
-                    status="errored",
-                    head_hash="head_er",
-                    base_hash="base_er",
-                ),
-                "skipped.png": ComparisonImageResult(
-                    status="skipped",
-                    base_hash="base_sk",
-                    before_width=99,
-                    before_height=98,
-                ),
+    def _base_images(self) -> dict[str, dict]:
+        return {
+            "changed_a.png": {
+                "content_hash": "base_ca",
+                "display_name": "Changed A",
+                "group": "g1",
+                "width": 10,
+                "height": 20,
+                "description": "desc-ca",
+                "tags": {"t": "v"},
+                "platform": "ios",
             },
-        )
+            "changed_b.png": {"content_hash": "base_cb", "width": 11, "height": 21},
+            "removed.png": {
+                "content_hash": "base_rm",
+                "display_name": "Removed",
+                "group": "g2",
+                "width": 12,
+                "height": 22,
+                "description": "desc-rm",
+                "tags": {"k": "1"},
+                "canvas_theme": "dark",
+                "region": "eu",
+            },
+            "old_name.png": {"content_hash": "base_old", "width": 13, "height": 23},
+            "unchanged.png": {"content_hash": "base_un", "width": 14, "height": 24},
+            "errored.png": {"content_hash": "base_er", "width": 15, "height": 25},
+            "skipped.png": {"content_hash": "base_sk", "width": 16, "height": 26},
+        }
 
-    def _head_images(self) -> dict[str, SnapshotImageResponse]:
+    def _comparison_images(self) -> dict[str, dict]:
+        return {
+            "changed_a.png": {
+                "status": "changed",
+                "changed_pixels": 25,
+                "total_pixels": 100,
+                "diff_mask_image_id": "mask_a",
+            },
+            "changed_b.png": {
+                "status": "changed",
+                "changed_pixels": 90,
+                "total_pixels": 100,
+                "diff_mask_image_id": "mask_b",
+            },
+            "added.png": {"status": "added"},
+            "removed.png": {"status": "removed", "base_hash": "base_rm"},
+            "renamed.png": {"status": "renamed", "previous_image_file_name": "old_name.png"},
+            "unchanged.png": {"status": "unchanged"},
+            "errored.png": {"status": "errored", "head_hash": "head_er", "base_hash": "base_er"},
+            "skipped.png": {
+                "status": "skipped",
+                "base_hash": "base_sk",
+                "before_width": 99,
+                "before_height": 98,
+            },
+        }
+
+    def _head_images(self) -> dict[str, dict]:
         names = [
             "changed_a.png",
             "changed_b.png",
@@ -139,38 +94,38 @@ class TestCategorizeComparisonImagesAllStatuses:
             "errored.png",
         ]
         return {
-            n: SnapshotImageResponse(
-                key=f"head_{n}",
-                display_name=n,
-                image_file_name=n,
-                width=1,
-                height=2,
-            )
+            n: {
+                "key": f"head_{n}",
+                "display_name": n,
+                "image_file_name": n,
+                "width": 1,
+                "height": 2,
+            }
             for n in names
         }
 
     def test_changed_uses_base_and_head_and_diff(self) -> None:
         heads = self._head_images()
-        result = categorize_comparison_images(self._comparison(), heads, self._base_manifest())
+        result = categorize_comparison_images(self._comparison_images(), heads, self._base_images())
 
         assert len(result.changed) == 2
         # sorted by diff descending: changed_b (0.9) before changed_a (0.25)
-        assert result.changed[0].head_image.image_file_name == "changed_b.png"
-        assert result.changed[0].diff == 0.9
-        assert result.changed[0].diff_image_key == "mask_b"
-        assert result.changed[0].base_image.key == "base_cb"
-        assert result.changed[1].head_image.image_file_name == "changed_a.png"
-        assert result.changed[1].diff == 0.25
-        assert result.changed[1].base_image.key == "base_ca"
-        assert result.changed[1].base_image.group == "g1"
-        changed_base = result.changed[1].base_image.dict()
+        assert result.changed[0]["head_image"]["image_file_name"] == "changed_b.png"
+        assert result.changed[0]["diff"] == 0.9
+        assert result.changed[0]["diff_image_key"] == "mask_b"
+        assert result.changed[0]["base_image"]["key"] == "base_cb"
+        assert result.changed[1]["head_image"]["image_file_name"] == "changed_a.png"
+        assert result.changed[1]["diff"] == 0.25
+        assert result.changed[1]["base_image"]["key"] == "base_ca"
+        assert result.changed[1]["base_image"]["group"] == "g1"
+        changed_base = result.changed[1]["base_image"]
         assert changed_base["description"] == "desc-ca"
         assert changed_base["tags"] == {"t": "v"}
         assert changed_base["platform"] == "ios"
 
     def test_buckets_partition_all_images(self) -> None:
         result = categorize_comparison_images(
-            self._comparison(), self._head_images(), self._base_manifest()
+            self._comparison_images(), self._head_images(), self._base_images()
         )
         assert len(result.changed) == 2
         assert len(result.added) == 1
@@ -182,75 +137,70 @@ class TestCategorizeComparisonImagesAllStatuses:
 
     def test_added_uses_head_only(self) -> None:
         heads = self._head_images()
-        result = categorize_comparison_images(self._comparison(), heads, self._base_manifest())
+        result = categorize_comparison_images(self._comparison_images(), heads, self._base_images())
         assert len(result.added) == 1
         assert result.added[0] is heads["added.png"]
 
     def test_removed_uses_base_manifest(self) -> None:
         result = categorize_comparison_images(
-            self._comparison(), self._head_images(), self._base_manifest()
+            self._comparison_images(), self._head_images(), self._base_images()
         )
         assert len(result.removed) == 1
-        assert result.removed[0].key == "base_rm"
-        assert result.removed[0].width == 12
-        assert result.removed[0].canvas_theme == "dark"
-        assert result.removed[0].dict()["region"] == "eu"
+        assert result.removed[0]["key"] == "base_rm"
+        assert result.removed[0]["width"] == 12
+        assert result.removed[0]["canvas_theme"] == "dark"
+        assert result.removed[0]["region"] == "eu"
 
     def test_renamed_resolves_base_via_previous_name(self) -> None:
         heads = self._head_images()
-        result = categorize_comparison_images(self._comparison(), heads, self._base_manifest())
+        result = categorize_comparison_images(self._comparison_images(), heads, self._base_images())
         assert len(result.renamed) == 1
-        assert result.renamed[0].head_image == heads["renamed.png"]
-        assert result.renamed[0].base_image.key == "base_old"
+        assert result.renamed[0]["head_image"] == heads["renamed.png"]
+        assert result.renamed[0]["base_image"]["key"] == "base_old"
 
     def test_unchanged_uses_head_only(self) -> None:
         heads = self._head_images()
-        result = categorize_comparison_images(self._comparison(), heads, self._base_manifest())
+        result = categorize_comparison_images(self._comparison_images(), heads, self._base_images())
         assert len(result.unchanged) == 1
         assert result.unchanged[0] is heads["unchanged.png"]
 
     def test_errored_uses_base_and_head(self) -> None:
         heads = self._head_images()
-        result = categorize_comparison_images(self._comparison(), heads, self._base_manifest())
+        result = categorize_comparison_images(self._comparison_images(), heads, self._base_images())
         assert len(result.errored) == 1
-        assert result.errored[0].head_image == heads["errored.png"]
-        assert result.errored[0].base_image.key == "base_er"
+        assert result.errored[0]["head_image"] == heads["errored.png"]
+        assert result.errored[0]["base_image"]["key"] == "base_er"
 
     def test_skipped_uses_base_manifest(self) -> None:
         result = categorize_comparison_images(
-            self._comparison(), self._head_images(), self._base_manifest()
+            self._comparison_images(), self._head_images(), self._base_images()
         )
         assert len(result.skipped) == 1
-        assert result.skipped[0].key == "base_sk"
-        assert result.skipped[0].width == 16
+        assert result.skipped[0]["key"] == "base_sk"
+        assert result.skipped[0]["width"] == 16
 
     def test_changed_falls_back_when_base_missing(self) -> None:
-        comparison = ComparisonManifest(
-            head_artifact_id=1,
-            base_artifact_id=2,
-            summary=_full_summary(),
-            images={
-                "only_head.png": ComparisonImageResult(
-                    status="changed",
-                    base_hash="cmp_base",
-                    changed_pixels=1,
-                    total_pixels=4,
-                    before_width=7,
-                    before_height=8,
-                )
-            },
-        )
+        comparison_images = {
+            "only_head.png": {
+                "status": "changed",
+                "base_hash": "cmp_base",
+                "changed_pixels": 1,
+                "total_pixels": 4,
+                "before_width": 7,
+                "before_height": 8,
+            }
+        }
         heads = {
-            "only_head.png": SnapshotImageResponse(
-                key="h",
-                display_name="only_head.png",
-                image_file_name="only_head.png",
-                width=1,
-                height=2,
-            )
+            "only_head.png": {
+                "key": "h",
+                "display_name": "only_head.png",
+                "image_file_name": "only_head.png",
+                "width": 1,
+                "height": 2,
+            }
         }
         # base manifest does NOT contain only_head.png
-        result = categorize_comparison_images(comparison, heads, SnapshotManifest(images={}))
+        result = categorize_comparison_images(comparison_images, heads, {})
         assert len(result.changed) == 1
-        assert result.changed[0].base_image.key == "cmp_base"
-        assert result.changed[0].base_image.width == 7
+        assert result.changed[0]["base_image"]["key"] == "cmp_base"
+        assert result.changed[0]["base_image"]["width"] == 7

--- a/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
+++ b/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
@@ -1,7 +1,13 @@
+import logging
 from typing import Any, cast
 
+import pytest
+
 from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
-from sentry.preprod.snapshots.comparison_categorizer import categorize_comparison_images
+from sentry.preprod.snapshots.comparison_categorizer import (
+    CategorizedComparison,
+    categorize_comparison_images,
+)
 
 _SKIPPED = {
     "status": "skipped",
@@ -18,6 +24,25 @@ class TestCategorizeComparisonImagesSkipped:
         assert len(result.skipped) == 1
         assert result.skipped[0]["key"] == "base_hash"
         assert result.skipped[0]["width"] == 300
+
+
+class TestCategorizeComparisonImagesUnexpectedStatus:
+    def test_unexpected_status_is_dropped_and_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(
+            logging.WARNING, logger="sentry.preprod.snapshots.comparison_categorizer"
+        ):
+            result = categorize_comparison_images(
+                {"weird.png": {"status": "bogus", "base_hash": "b"}}, {}, {}
+            )
+
+        assert result == CategorizedComparison()
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.getMessage() == "preprod.snapshot.unexpected_comparison_status"
+        assert record.status == "bogus"
+        assert record.image_file_name == "weird.png"
 
 
 class TestCategorizeComparisonImagesAllStatuses:

--- a/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
+++ b/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
@@ -41,8 +41,8 @@ class TestCategorizeComparisonImagesUnexpectedStatus:
         assert len(caplog.records) == 1
         record = caplog.records[0]
         assert record.getMessage() == "preprod.snapshot.unexpected_comparison_status"
-        assert record.status == "bogus"
-        assert record.image_file_name == "weird.png"
+        assert record.__dict__["status"] == "bogus"
+        assert record.__dict__["image_file_name"] == "weird.png"
 
 
 class TestCategorizeComparisonImagesAllStatuses:

--- a/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
+++ b/tests/sentry/preprod/snapshots/test_comparison_categorizer.py
@@ -1,3 +1,6 @@
+from typing import Any, cast
+
+from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
 from sentry.preprod.snapshots.comparison_categorizer import categorize_comparison_images
 
 _SKIPPED = {
@@ -75,7 +78,7 @@ class TestCategorizeComparisonImagesAllStatuses:
             },
         }
 
-    def _head_images(self) -> dict[str, dict]:
+    def _head_images(self) -> dict[str, SnapshotImageResponseDict]:
         names = [
             "changed_a.png",
             "changed_b.png",
@@ -85,13 +88,13 @@ class TestCategorizeComparisonImagesAllStatuses:
             "errored.png",
         ]
         return {
-            n: {
-                "key": f"head_{n}",
-                "display_name": n,
-                "image_file_name": n,
-                "width": 1,
-                "height": 2,
-            }
+            n: SnapshotImageResponseDict(
+                key=f"head_{n}",
+                display_name=n,
+                image_file_name=n,
+                width=1,
+                height=2,
+            )
             for n in names
         }
 
@@ -109,7 +112,8 @@ class TestCategorizeComparisonImagesAllStatuses:
         assert result.changed[1]["diff"] == 0.25
         assert result.changed[1]["base_image"]["key"] == "base_ca"
         assert result.changed[1]["base_image"]["group"] == "g1"
-        changed_base = result.changed[1]["base_image"]
+        # description/tags/platform are passthrough extras not declared on the TypedDict.
+        changed_base = cast(dict[str, Any], result.changed[1]["base_image"])
         assert changed_base["description"] == "desc-ca"
         assert changed_base["tags"] == {"t": "v"}
         assert changed_base["platform"] == "ios"
@@ -140,7 +144,8 @@ class TestCategorizeComparisonImagesAllStatuses:
         assert result.removed[0]["key"] == "base_rm"
         assert result.removed[0]["width"] == 12
         assert result.removed[0]["canvas_theme"] == "dark"
-        assert result.removed[0]["region"] == "eu"
+        # region is a passthrough extra not declared on the TypedDict.
+        assert cast(dict[str, Any], result.removed[0])["region"] == "eu"
 
     def test_renamed_resolves_base_via_previous_name(self) -> None:
         heads = self._head_images()
@@ -182,13 +187,13 @@ class TestCategorizeComparisonImagesAllStatuses:
             }
         }
         heads = {
-            "only_head.png": {
-                "key": "h",
-                "display_name": "only_head.png",
-                "image_file_name": "only_head.png",
-                "width": 1,
-                "height": 2,
-            }
+            "only_head.png": SnapshotImageResponseDict(
+                key="h",
+                display_name="only_head.png",
+                image_file_name="only_head.png",
+                width=1,
+                height=2,
+            )
         }
         # base manifest does NOT contain only_head.png
         result = categorize_comparison_images(comparison_images, heads, {})


### PR DESCRIPTION
## Summary

The snapshot details `GET` endpoint (`OrganizationPreprodSnapshotEndpoint.get`) has a bimodal latency profile: most requests are ~340ms, but large snapshots spend **8–13s** almost entirely in synchronous pydantic v1 work (production traces show ~90% of endpoint time in manifest parsing + response-model construction; DB/Redis/objectstore are negligible). This is painful for customers with large snapshots (thousands of images).

For every request it was doing roughly **three pydantic passes per image**:
1. Parsing each of the head, base, and comparison manifests into validated model graphs.
2. Building a `SnapshotImageResponse` per head image.
3. Re-validating the entire response and deep-converting it with `.dict()`.

Manifests are already validated at **upload** time, so re-validating them on every read is pure overhead.

## What changed

- Parse manifests as plain dicts (`orjson.loads`) instead of `SnapshotManifest`/`ComparisonManifest`.
- Assemble the response (image lists, categorized comparison buckets, top-level body) as plain dicts, doing the per-image shaping **once**.
- Type the assembled dicts with the **existing public response TypedDicts** (`SnapshotImageResponseDict`, `SnapshotDiffPairResponseDict`, `SnapshotDetailsResponseDict`, …) rather than `dict[str, Any]`. TypedDicts are plain dicts at runtime, so this is free — but mypy checks the response envelope again.
- Apply the same treatment to the sibling `latest-base` endpoint, which shared the code path.
- Remove the now-orphaned `SnapshotDetailsApiResponse` and `SnapshotDiffPair` pydantic models — they were a hand-maintained duplicate of the TypedDicts, which are now the single source of truth.

## Performance

Microbenchmark of parse + per-image serialize on a 3000-image manifest (best of 9):

| path | time | vs pydantic |
|------|------|-------------|
| old: pydantic | 58.4 ms | 1.0× |
| new: plain dict | 5.13 ms | 11.4× |
| new: TypedDict | 5.09 ms | 11.5× |

**~11.5× faster (91% less CPU)** with byte-identical output. TypedDict vs plain dict is within noise (−0.04ms) — annotations are erased at runtime, so there is no cost to keeping static types. The win scales with image count, so the multi-second tail on large snapshots collapses toward ~1s.

## Correctness / safety

The response body is unchanged. A characterization test, `PreprodSnapshotGoldenResponseTest`, pins the **exact** response body (committed golden fixtures) across the solo, diff, and compact-metadata modes, covering all seven comparison statuses and both base/head fallback paths. Object key order is normalized (not semantically meaningful); array order is asserted. Regenerate with `UPDATE_SNAPSHOTS=1`.

Dropping read-time validation is safe because manifests are validated at write time (POST handler / compare task) and stored normalized. A guard was added so a comparison manifest missing `base_artifact_id` degrades to a solo response instead of raising, with a regression test.

Typing the envelope also surfaced a pre-existing drift the previous opaque cast had hidden: `SnapshotDetailsResponseDict.state` was declared `str`, but the endpoint emits an `int` (`BoundedPositiveIntegerField`). Corrected to `int`.

- `tests/sentry/preprod/` passes (incl. the golden + categorizer tests ported to the dict interface).
- `ruff` + `mypy` clean.

## Follow-ups (separate PRs)

- Size telemetry (image count, manifest/response byte sizes on the transaction) to make the win measurable and catch regressions.
- Migrate the `image_detail` endpoint off pydantic and delete the now-parallel `image_metadata_extras` helper.

https://claude.ai/code/session_013SAxBGjuP4a7cxRx3WmZa4
