### PR TITLE
ref(workflow_engine): Delete all-project issue_stream detectors

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -43,4 +43,4 @@ tempest: 0001_squashed_0003_use_encrypted_char_field
 
 uptime: 0001_squashed_0055_backfill_2xx_status_assertion
 
-workflow_engine: 0118_repair_latest_adopted_release_environments
+workflow_engine: 0119_delete_all_project_detectors

--- a/src/sentry/workflow_engine/migrations/0119_delete_all_project_detectors.py
+++ b/src/sentry/workflow_engine/migrations/0119_delete_all_project_detectors.py
@@ -1,0 +1,66 @@
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+
+# Detectors are deleted in batches so that each cascade stays small and no single
+# statement holds locks on the related tables for a long time.
+BATCH_SIZE = 100
+
+
+def delete_all_project_detectors(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """
+    Reverses 0117_backfill_all_project_detectors by removing every project-less
+    `issue_stream` detector.
+
+    There is no index on (project_id, type), so a filtered keyset scan would have
+    to read many rows per page. Instead we page over the primary key alone -- each
+    page is a plain index range scan -- and apply the filter in memory.
+    """
+    Detector = apps.get_model("workflow_engine", "Detector")
+
+    batch: list[int] = []
+    for detector_id, project_id, detector_type in RangeQuerySetWrapperWithProgressBar(
+        Detector.objects.all().values_list("id", "project_id", "type"),
+        result_value_getter=lambda item: item[0],
+    ):
+        if project_id is not None or detector_type != "issue_stream":
+            continue
+
+        batch.append(detector_id)
+        if len(batch) >= BATCH_SIZE:
+            Detector.objects.filter(id__in=batch).delete()
+            batch = []
+
+    if batch:
+        Detector.objects.filter(id__in=batch).delete()
+
+
+class Migration(CheckedMigration):
+    # This flag is used to mark that a migration shouldn't be automatically run in production.
+    # This should only be used for operations where it's safe to run the migration after your
+    # code has deployed. So this should not be used for most operations that alter the schema
+    # of a table.
+    # Here are some things that make sense to mark as post deployment:
+    # - Large data migrations. Typically we want these to be run manually so that they can be
+    #   monitored and not block the deploy for a long period of time while they run.
+    # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
+    #   run this outside deployments so that we don't block them. Note that while adding an index
+    #   is a schema change, it's completely safe to run the operation after the code has deployed.
+    # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
+
+    is_post_deployment = True
+
+    dependencies = [
+        ("workflow_engine", "0118_repair_latest_adopted_release_environments"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_all_project_detectors,
+            reverse_code=migrations.RunPython.noop,
+            hints={"tables": ["workflow_engine_detector"]},
+        ),
+    ]

--- a/tests/sentry/migrations/test_0119_delete_all_project_detectors.py
+++ b/tests/sentry/migrations/test_0119_delete_all_project_detectors.py
@@ -1,0 +1,53 @@
+from sentry.silo.safety import unguarded_write
+from sentry.testutils.cases import TestMigrations
+
+
+class DeleteAllProjectDetectorsTest(TestMigrations):
+    app = "workflow_engine"
+    migrate_from = "0118_repair_latest_adopted_release_environments"
+    migrate_to = "0119_delete_all_project_detectors"
+
+    def setup_before_migration(self, apps):
+        Organization = apps.get_model("sentry", "Organization")
+        Project = apps.get_model("sentry", "Project")
+        Detector = apps.get_model("workflow_engine", "Detector")
+
+        with unguarded_write(using="default"):
+            org = Organization.objects.create(slug="delete-detectors", name="Delete Detectors")
+            project = Project.objects.create(
+                organization_id=org.id, slug="a-project", name="A Project"
+            )
+
+        # Deleted: project-less `issue_stream` detectors.
+        self.all_projects_detector = Detector.objects.create(
+            type="issue_stream",
+            project=None,
+            config={"organization_id": org.id},
+            name="Issue Stream: All Projects",
+            enabled=True,
+        )
+
+        # Kept: an `issue_stream` detector that has a project.
+        self.project_detector = Detector.objects.create(
+            type="issue_stream",
+            project=project,
+            config={},
+            name="Issue Stream",
+            enabled=True,
+        )
+
+        # Kept: a project-less detector of a different type.
+        self.other_type_detector = Detector.objects.create(
+            type="metric_issue",
+            project=None,
+            config={"organization_id": org.id},
+            name="Other Type",
+            enabled=True,
+        )
+
+    def test(self):
+        Detector = self.apps.get_model("workflow_engine", "Detector")
+
+        assert not Detector.objects.filter(project__isnull=True, type="issue_stream").exists()
+        assert Detector.objects.filter(id=self.project_detector.id).exists()
+        assert Detector.objects.filter(id=self.other_type_detector.id).exists()


### PR DESCRIPTION
Reverses [migration 0117](https://github.com/getsentry/sentry/blob/master/src/sentry/workflow_engine/migrations/0117_backfill_all_project_detectors.py), which created one project-less `issue_stream` detector per organization. This migration deletes every `Detector` with `project_id IS NULL` and `type = 'issue_stream'`.

### Why the scan is unfiltered

There is no index on `(project_id, type)`, so a filtered keyset scan would have to read many rows per page to fill it. Instead the migration pages over the primary key alone — each page is a plain index range scan — and applies the filter in memory. `values_list("id", "project_id", "type")` keeps the pages narrow and avoids reading the `config` JSONB column.

### Deletion

Deletes run in batches of 100 so each cascade stays small and no single statement holds locks for long. The cascade removes `DetectorWorkflow`, `DetectorState`, `DataSourceDetector` and `AlertRuleDetector` rows, and sets `detector_id` to `NULL` on `DetectorGroup` and `WorkflowFireHistory`. Both `SET NULL` columns are indexed.

Marked `is_post_deployment = True`, with a noop reverse — same as 0117.

### Scope note

This removes **all** project-less `issue_stream` detectors, not only the ones 0117 created. 0117 skipped organizations that already had one, so any rows that predate it are deleted too. That is intended.

### Testing

`tests/sentry/migrations/test_0119_delete_all_project_detectors.py` seeds three detectors and confirms only the project-less `issue_stream` one is removed; a project-scoped `issue_stream` detector and a project-less `metric_issue` detector survive.

https://claude.ai/code/session_01PVufJZYHMoQQ3er3mCUfhf