### PR TITLE
feat(auth): Clear active organization context

### DIFF
--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -5,6 +5,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.urls import reverse
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -22,6 +23,7 @@ from sentry.http import get_server_hostname
 from sentry.models.organization import Organization
 from sentry.users.models.authenticator import Authenticator
 from sentry.utils.auth import (
+    clear_active_org,
     get_org_redirect_url,
     get_pending_2fa_user,
     has_user_registration,
@@ -45,10 +47,23 @@ class AuthConfigResponse(TypedDict):
 
 
 @control_silo_endpoint
+class AuthConfigClearOrganizationEndpoint(Endpoint):
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.FOUNDATIONS
+    permission_classes = ()
+
+    @extend_schema(
+        operation_id="Clear active organization from auth session",
+        responses={204: None},
+    )
+    def post(self, request: Request) -> Response:
+        clear_active_org(request)
+        return Response(status=204)
+
+
+@control_silo_endpoint
 class AuthConfigEndpoint(Endpoint, OrganizationMixin):
-    publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
-    }
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
     owner = ApiOwner.FOUNDATIONS
     # Disable authentication and permission requirements.
     permission_classes = ()

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -730,7 +730,7 @@ from .endpoints.artifact_bundles import ArtifactBundlesEndpoint
 from .endpoints.artifact_lookup import ProjectArtifactLookupEndpoint
 from .endpoints.assistant import AssistantEndpoint
 from .endpoints.auth_2fa import AuthTwoFactorChallengeEndpoint, AuthTwoFactorEndpoint
-from .endpoints.auth_config import AuthConfigEndpoint
+from .endpoints.auth_config import AuthConfigClearOrganizationEndpoint, AuthConfigEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.auth_login import AuthLoginEndpoint
 from .endpoints.auth_organization_config import AuthOrganizationConfigEndpoint
@@ -1082,6 +1082,11 @@ AUTH_URLS = [
         r"^config/$",
         AuthConfigEndpoint.as_view(),
         name="sentry-api-0-auth-config",
+    ),
+    re_path(
+        r"^config/clear-organization/$",
+        AuthConfigClearOrganizationEndpoint.as_view(),
+        name="sentry-api-0-auth-config-clear-organization",
     ),
     re_path(
         r"^login/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -27,6 +27,7 @@ export type KnownSentryApiUrls =
   | '/auth/2fa/'
   | '/auth/2fa/challenge/'
   | '/auth/config/'
+  | '/auth/config/clear-organization/'
   | '/auth/login/'
   | '/auth/organizations/$organizationIdOrSlug/config/'
   | '/auth/recovery/'

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -15,6 +15,21 @@ from sentry.web.frontend.auth_login import additional_context
 
 
 @control_silo_test
+class AuthConfigClearOrganizationEndpointTest(APITestCase):
+    path = "/api/0/auth/config/clear-organization/"
+
+    def test_clear_active_organization(self) -> None:
+        session = self.client.session
+        session["activeorg"] = "previous-org"
+        session.save()
+
+        response = self.client.post(self.path)
+
+        assert response.status_code == 204
+        assert "activeorg" not in self.client.session
+
+
+@control_silo_test
 class AuthConfigEndpointTest(APITestCase):
     path = "/api/0/auth/config/"
 


### PR DESCRIPTION
Adds a private `POST /api/0/auth/config/clear-organization/` action that clears the session's active organization.

This lets Auth V2 remove the server-side post-login fallback when a user clears the organization context from the login page.
