### PR TITLE
feat(seer-infra-telemetry): Expose GCP connection status in integration config data

### DIFF
--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -262,6 +262,9 @@ class GcpIntegration(IntegrationInstallation):
             "sentry_sa_email": config.get("sentry_sa_email", ""),
             "customer_sa_email": config.get("customer_sa_email", ""),
             "projects": ", ".join(config.get("projects", [])),
+            "connection_status": config.get("connection_status", GCP_STATUS_UNVERIFIED),
+            "project_statuses": config.get("project_statuses", []),
+            "last_verified_at": config.get("last_verified_at"),
         }
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -699,6 +699,39 @@ class GcpIntegrationTest(TestCase):
         assert data["customer_sa_email"] == _CUSTOMER_SA
         assert data["projects"] == "project-a, project-b, project-c"
 
+    def test_get_config_data_exposes_the_connection_status(self) -> None:
+        installation = self._create_installed_integration()
+        data = installation.get_config_data()
+
+        assert data["connection_status"] == "connected"
+        assert data["last_verified_at"] == "2026-08-01T00:00:00+00:00"
+        assert data["project_statuses"] == [
+            {
+                "gcp_project_id": "my-gcp-project",
+                "connection_status": "connected",
+                "error_detail": None,
+            }
+        ]
+
+    def test_get_config_data_defaults_to_unverified(self) -> None:
+        self._create_installed_integration()
+        oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)
+        oi.update(
+            config={
+                "sentry_sa_email": _SA_EMAIL,
+                "customer_sa_email": _CUSTOMER_SA,
+                "projects": ["my-gcp-project"],
+            }
+        )
+
+        installation = oi.integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, GcpIntegration)
+        data = installation.get_config_data()
+
+        assert data["connection_status"] == GCP_STATUS_UNVERIFIED
+        assert data["project_statuses"] == []
+        assert data["last_verified_at"] is None
+
     def test_get_config_data_empty_without_config(self) -> None:
         self._create_installed_integration()
         oi = OrganizationIntegration.objects.get(organization_id=self.organization.id)


### PR DESCRIPTION
PR 1 for https://linear.app/getsentry/issue/CW-1668/build-gcp-mcp-connected-state-error-state-ui.

`get_config_data` returns only the SA emails and project IDs, so the connection status recorded on the integration is invisible to the frontend. Add `connection_status`, `project_statuses`, and `last_verified_at` so the settings page can render it.

Each of these fields falls back rather than assuming the key exists: `unverified`, `[]`, and `None` respectively.