### PR TITLE
fix(seer): allow collapsing ThinkingBlock while thinking is active

### DIFF
--- a/static/app/components/core/chat/thinkingBlock.spec.tsx
+++ b/static/app/components/core/chat/thinkingBlock.spec.tsx
@@ -55,6 +55,48 @@ describe('ThinkingBlock', () => {
     expect(screen.getByText('inner content')).not.toBeVisible();
   });
 
+  it('can be manually collapsed while thinking is active', async () => {
+    jest.useRealTimers();
+    const start = new Date();
+
+    render(
+      <ThinkingBlock title="Thinking" startTime={start}>
+        <div>inner content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('inner content')).toBeVisible();
+
+    await userEvent.click(screen.getByText('Thinking'));
+    expect(screen.getByText('inner content')).not.toBeVisible();
+  });
+
+  it('auto-collapses when thinking completes even if user re-expanded', async () => {
+    jest.useRealTimers();
+    const start = new Date();
+
+    const {rerender} = render(
+      <ThinkingBlock title="Thinking" startTime={start}>
+        <div>inner content</div>
+      </ThinkingBlock>
+    );
+
+    // collapse then re-expand while still active
+    await userEvent.click(screen.getByText('Thinking'));
+    expect(screen.getByText('inner content')).not.toBeVisible();
+    await userEvent.click(screen.getByText('Thinking'));
+    expect(screen.getByText('inner content')).toBeVisible();
+
+    // thinking completes → auto-collapse
+    rerender(
+      <ThinkingBlock title="Thinking" startTime={start} endTime={new Date()}>
+        <div>inner content</div>
+      </ThinkingBlock>
+    );
+
+    expect(screen.getByText('inner content')).not.toBeVisible();
+  });
+
   it('can be manually toggled after collapsing', async () => {
     jest.useRealTimers();
     const start = new Date();

--- a/static/app/components/core/chat/thinkingBlock.tsx
+++ b/static/app/components/core/chat/thinkingBlock.tsx
@@ -76,19 +76,26 @@ export function ThinkingBlock({title, startTime, endTime, children}: ThinkingBlo
   const {t} = useTranslation();
   const elapsed = useElapsedTime(startTime, endTime);
   const isActive = !endTime;
-  const [userExpanded, setUserExpanded] = useState(false);
+  // ponytail: null = no user interaction, falls through to isActive default
+  const [override, setOverride] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!isActive) {
+      setOverride(null);
+    }
+  }, [isActive]);
 
   const titleRef = useRef<HTMLSpanElement>(null);
   const baseTitle = title.replace(/[.…\s]+$/u, '');
   useTextDecodeAnimation(titleRef, baseTitle);
 
-  const isExpanded = isActive || userExpanded;
+  const isExpanded = override ?? isActive;
   const summaryTitle = t('See thinking and tool calls');
 
   return (
     <Disclosure
       expanded={isExpanded}
-      onExpandedChange={setUserExpanded}
+      onExpandedChange={setOverride}
       size="sm"
       variant="outline"
       flex={1}


### PR DESCRIPTION
Currently, `ThinkingBlock` forces the disclosure open while `isActive` is true (`isExpanded = isActive || userExpanded`), so users can't collapse it mid-thought.

In this PR, we replace the `boolean` with a nullable override — `null` means no user interaction and falls through to `isActive` as the default. When thinking completes, an effect resets the override to `null` so it auto-collapses.

**Before**

https://github.com/user-attachments/assets/ac55beb8-882b-4da7-9d82-ea755ec65720

**After**

https://github.com/user-attachments/assets/83b80639-73aa-450f-9285-a0e5d9a5e3a6

