### PR TITLE
feat(onboarding): Track agentic checklist refocuses

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -1,4 +1,17 @@
+import type {
+  AgenticProgressRunStatus,
+  AgenticProgressStage,
+  AgenticProgressStageStatus,
+} from 'sentry/views/onboarding/agenticProgress/types';
+
 export type OnboardingEventParameters = {
+  'onboarding.agentic_progress_refocused': {
+    duration_seconds: number;
+    run_id: string;
+    run_status: AgenticProgressRunStatus;
+    stage: AgenticProgressStage | null;
+    stage_status: AgenticProgressStageStatus | null;
+  };
   'onboarding.ai_prompt_copied': {
     platform: string;
     product: 'logs' | 'traces' | 'conversations' | 'agents';
@@ -165,6 +178,7 @@ export type OnboardingEventParameters = {
 };
 
 export const onboardingEventMap: Record<keyof OnboardingEventParameters, string> = {
+  'onboarding.agentic_progress_refocused': 'Onboarding: Agentic Progress Refocused',
   'onboarding.ai_prompt_copied': 'Onboarding: AI Prompt Copied',
   'onboarding.js_loader_optional_configuration_shown':
     'Onboarding: JS Loader Optional Configuration Expanded',

--- a/static/app/views/onboarding/agenticProgress/types.ts
+++ b/static/app/views/onboarding/agenticProgress/types.ts
@@ -1,4 +1,4 @@
-type AgenticProgressStage =
+export type AgenticProgressStage =
   | 'connect_mcp'
   | 'analyze_project'
   | 'create_project'
@@ -9,7 +9,7 @@ type AgenticProgressStage =
   | 'prepare_production'
   | 'check_stack_trace_quality';
 
-type AgenticProgressStageStatus =
+export type AgenticProgressStageStatus =
   | 'active'
   | 'waiting'
   | 'completed'
@@ -17,7 +17,7 @@ type AgenticProgressStageStatus =
   | 'bypassed'
   | 'failed';
 
-type AgenticProgressRunStatus = 'active' | 'completed' | 'failed' | 'cancelled';
+export type AgenticProgressRunStatus = 'active' | 'completed' | 'failed' | 'cancelled';
 
 type Stage<
   Key extends AgenticProgressStage,

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressRefocusAnalytics.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressRefocusAnalytics.spec.tsx
@@ -1,0 +1,84 @@
+import {AgenticProgressRunFixture} from 'sentry-fixture/agenticProgressRun';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+import type {AgenticProgressRun} from './types';
+import {useAgenticProgressRefocusAnalytics} from './useAgenticProgressRefocusAnalytics';
+
+jest.mock('sentry/utils/analytics');
+
+describe('useAgenticProgressRefocusAnalytics', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records the current progress when the browser is refocused', () => {
+    const organization = OrganizationFixture();
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const run = AgenticProgressRunFixture({
+      runId: '019c4dfe-a5fa-79b1-b880-3ff127a87766',
+      runStatus: 'active',
+      stages: [
+        {
+          stage: 'instrument_app',
+          status: 'waiting',
+          eventNote: null,
+          extra: null,
+        },
+      ],
+    });
+
+    renderHookWithProviders(() => useAgenticProgressRefocusAnalytics(run), {
+      organization,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+      now.mockReturnValue(6_000);
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(trackAnalytics).toHaveBeenCalledWith('onboarding.agentic_progress_refocused', {
+      organization,
+      duration_seconds: 5,
+      run_id: run.runId,
+      run_status: 'active',
+      stage: 'instrument_app',
+      stage_status: 'waiting',
+    });
+  });
+
+  it('records a blur that occurs before progress is available', () => {
+    const organization = OrganizationFixture();
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const run = AgenticProgressRunFixture();
+    const {rerender} = renderHookWithProviders(
+      (currentRun: AgenticProgressRun | undefined) =>
+        useAgenticProgressRefocusAnalytics(currentRun),
+      {initialProps: undefined, organization}
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+    });
+
+    rerender(run);
+
+    act(() => {
+      now.mockReturnValue(6_000);
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(trackAnalytics).toHaveBeenCalledWith('onboarding.agentic_progress_refocused', {
+      organization,
+      duration_seconds: 5,
+      run_id: run.runId,
+      run_status: run.runStatus,
+      stage: 'connect_mcp',
+      stage_status: null,
+    });
+  });
+});

--- a/static/app/views/onboarding/agenticProgress/useAgenticProgressRefocusAnalytics.tsx
+++ b/static/app/views/onboarding/agenticProgress/useAgenticProgressRefocusAnalytics.tsx
@@ -1,0 +1,55 @@
+import {useEffect, useRef} from 'react';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import type {AgenticProgressRun} from './types';
+
+type AgenticProgressStage = AgenticProgressRun['stages'][number];
+
+function getCurrentStage(stages: AgenticProgressStage[]) {
+  return (
+    stages.find(stage => ['active', 'waiting', 'failed'].includes(stage.status ?? '')) ??
+    stages.findLast(stage => stage.status !== null) ??
+    stages[0]
+  );
+}
+
+export function useAgenticProgressRefocusAnalytics(run: AgenticProgressRun | undefined) {
+  const organization = useOrganization();
+  const blurredAtRef = useRef<number | null>(null);
+  const currentStage = run ? getCurrentStage(run.stages) : undefined;
+  const runId = run?.runId;
+  const runStatus = run?.runStatus;
+
+  useEffect(() => {
+    function handleBlur() {
+      blurredAtRef.current = Date.now();
+    }
+
+    function handleFocus() {
+      const blurredAt = blurredAtRef.current;
+      if (blurredAt === null || !runId || !runStatus) {
+        return;
+      }
+
+      blurredAtRef.current = null;
+      trackAnalytics('onboarding.agentic_progress_refocused', {
+        organization,
+        duration_seconds: (Date.now() - blurredAt) / 1_000,
+        run_id: runId,
+        run_status: runStatus,
+        stage: currentStage?.stage ?? null,
+        stage_status: currentStage?.status ?? null,
+      });
+    }
+
+    window.addEventListener('blur', handleBlur);
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      window.removeEventListener('blur', handleBlur);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [currentStage?.stage, currentStage?.status, organization, runId, runStatus]);
+}

--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -8,6 +8,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {AgenticProgress} from 'sentry/views/onboarding/agenticProgress/agenticProgressList';
 import {useAgenticProgress} from 'sentry/views/onboarding/agenticProgress/useAgenticProgress';
 import {useAgenticProgressInit} from 'sentry/views/onboarding/agenticProgress/useAgenticProgressInit';
+import {useAgenticProgressRefocusAnalytics} from 'sentry/views/onboarding/agenticProgress/useAgenticProgressRefocusAnalytics';
 import {
   AgentSetupCard,
   type AgentSetupCopySource,
@@ -35,6 +36,8 @@ export function WelcomeAgentSetup({
   const initialization = useAgenticProgressInit({enabled: true});
   const progress = useAgenticProgress({runId: initialization.data?.runId ?? null});
   const run = progress.data ?? initialization.data;
+  useAgenticProgressRefocusAnalytics(run);
+
   const connectionStatus = run?.stages.find(
     stage => stage.stage === 'connect_mcp'
   )?.status;


### PR DESCRIPTION
The agentic onboarding checklist sends users to work in the terminal while their setup progresses. Record when they return so we can understand where they re-engage and how long they spend away.

The new refocus event includes the current stage and stage status, overall run status, elapsed unfocused time in seconds, and the backend run ID for correlation with stage-completion events.

Tests cover the focus lifecycle and analytics payload.