### PR TITLE
fix(auth): Preserve rollout across organizations

### DIFF
--- a/static/app/utils/useAuthV2Rollout.spec.tsx
+++ b/static/app/utils/useAuthV2Rollout.spec.tsx
@@ -8,20 +8,36 @@ import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useAuthV2Rollout} from 'sentry/utils/useAuthV2Rollout';
 import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
 
+const AUTH_V2_ROLLOUT_ORGANIZATION = 'sentry_react_auth_rollout_organization';
+
+function getRolloutOrganization(): string | null {
+  return JSON.parse(localStorage.getItem(AUTH_V2_ROLLOUT_ORGANIZATION) ?? 'null') as
+    | string
+    | null;
+}
+
+function setRolloutOrganization(organizationSlug: string) {
+  localStorage.setItem(AUTH_V2_ROLLOUT_ORGANIZATION, JSON.stringify(organizationSlug));
+}
+
 describe('useAuthV2Rollout', () => {
   beforeEach(() => {
     OrganizationStore.init();
     Cookies.remove('sentry_react_auth', {path: '/'});
+    localStorage.removeItem(AUTH_V2_ROLLOUT_ORGANIZATION);
   });
 
   it('enables Auth V2 when a member organization has the rollout feature', async () => {
     renderHook(useAuthV2Rollout);
 
     act(() => {
-      OrganizationStore.onUpdate(OrganizationFixture({features: ['authv2-rollout']}));
+      OrganizationStore.onUpdate(
+        OrganizationFixture({slug: 'rollout-org', features: ['authv2-rollout']})
+      );
     });
 
     await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
+    expect(getRolloutOrganization()).toBe('rollout-org');
   });
 
   it('preserves an explicit opt-out while the organization has the rollout feature', async () => {
@@ -67,6 +83,7 @@ describe('useAuthV2Rollout', () => {
       OrganizationStore.onUpdate(OrganizationFixture({features: ['authv2-rollout']}));
     });
     await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
+    expect(getRolloutOrganization()).not.toBeNull();
 
     act(() => {
       override.current.setAuthV2CookieState(AuthV2CookieState.DISABLED);
@@ -74,16 +91,31 @@ describe('useAuthV2Rollout', () => {
     });
 
     await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('0'));
+    expect(getRolloutOrganization()).toBeNull();
   });
 
-  it('clears an enabled cookie outside the rollout', async () => {
+  it('preserves rollout state in a different organization', async () => {
     Cookies.set('sentry_react_auth', '1', {path: '/'});
+    setRolloutOrganization('rollout-org');
     renderHook(useAuthV2Rollout);
 
     act(() => {
-      OrganizationStore.onUpdate(OrganizationFixture());
+      OrganizationStore.onUpdate(OrganizationFixture({slug: 'other-org'}));
+    });
+
+    await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
+  });
+
+  it('clears rollout state when disabled for the enrolling organization', async () => {
+    Cookies.set('sentry_react_auth', '1', {path: '/'});
+    setRolloutOrganization('rollout-org');
+    renderHook(useAuthV2Rollout);
+
+    act(() => {
+      OrganizationStore.onUpdate(OrganizationFixture({slug: 'rollout-org'}));
     });
 
     await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBeUndefined());
+    expect(getRolloutOrganization()).toBeNull();
   });
 });

--- a/static/app/utils/useAuthV2Rollout.ts
+++ b/static/app/utils/useAuthV2Rollout.ts
@@ -10,7 +10,7 @@ import {
 
 export function useAuthV2Rollout() {
   const {loading, organization} = useLegacyStore(OrganizationStore);
-  const {setAuthV2CookieState} = useEnableAuthV2();
+  const {authV2RolloutOrganization, setAuthV2CookieState} = useEnableAuthV2();
 
   useEffect(() => {
     if (loading || !organization) {
@@ -18,16 +18,18 @@ export function useAuthV2Rollout() {
     }
 
     const authV2CookieState = getAuthV2CookieState();
-
     if (!organization.features.includes('authv2-rollout')) {
-      if (authV2CookieState === AuthV2CookieState.ENABLED) {
+      if (
+        authV2CookieState === AuthV2CookieState.ENABLED &&
+        authV2RolloutOrganization === organization.slug
+      ) {
         setAuthV2CookieState(AuthV2CookieState.UNSET);
       }
       return;
     }
 
     if (authV2CookieState === AuthV2CookieState.UNSET) {
-      setAuthV2CookieState(AuthV2CookieState.ENABLED);
+      setAuthV2CookieState(AuthV2CookieState.ENABLED, organization.slug);
     }
-  }, [loading, organization, setAuthV2CookieState]);
+  }, [authV2RolloutOrganization, loading, organization, setAuthV2CookieState]);
 }

--- a/static/app/utils/useEnableAuthV2.ts
+++ b/static/app/utils/useEnableAuthV2.ts
@@ -1,7 +1,10 @@
 import {useCallback, useState} from 'react';
 import Cookies from 'js-cookie';
 
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+
 const REACT_AUTH_COOKIE = 'sentry_react_auth';
+const AUTH_V2_ROLLOUT_ORGANIZATION = 'sentry_react_auth_rollout_organization';
 
 export enum AuthV2CookieState {
   DISABLED = 'disabled',
@@ -39,32 +42,43 @@ function getCookieDomain() {
 
 export function useEnableAuthV2() {
   const [authV2CookieState, setAuthV2CookieStateValue] = useState(getAuthV2CookieState);
+  const [authV2RolloutOrganization, setAuthV2RolloutOrganization] =
+    useSyncedLocalStorageState<string | null>(AUTH_V2_ROLLOUT_ORGANIZATION, null);
   const isAuthV2Enabled = authV2CookieState === AuthV2CookieState.ENABLED;
 
-  const setAuthV2CookieState = useCallback((state: AuthV2CookieState) => {
-    const domain = getCookieDomain();
-    const secure = window.location.protocol === 'https:';
-    const options: Cookies.CookieAttributes = {
-      path: '/',
-      sameSite: secure ? 'none' : 'lax',
-      ...(secure ? {secure: true} : {}),
-      ...(domain ? {domain} : {}),
-    };
+  const setAuthV2CookieState = useCallback(
+    (state: AuthV2CookieState, rolloutOrganization: string | null = null) => {
+      const domain = getCookieDomain();
+      const secure = window.location.protocol === 'https:';
+      const options: Cookies.CookieAttributes = {
+        path: '/',
+        sameSite: secure ? 'none' : 'lax',
+        ...(secure ? {secure: true} : {}),
+        ...(domain ? {domain} : {}),
+      };
 
-    Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});
+      Cookies.remove(REACT_AUTH_COOKIE, {...options, path: '/auth/'});
+      setAuthV2RolloutOrganization(rolloutOrganization);
 
-    if (state === AuthV2CookieState.UNSET) {
-      Cookies.remove(REACT_AUTH_COOKIE, options);
-    } else {
-      Cookies.set(
-        REACT_AUTH_COOKIE,
-        state === AuthV2CookieState.ENABLED ? '1' : '0',
-        options
-      );
-    }
+      if (state === AuthV2CookieState.UNSET) {
+        Cookies.remove(REACT_AUTH_COOKIE, options);
+      } else {
+        Cookies.set(
+          REACT_AUTH_COOKIE,
+          state === AuthV2CookieState.ENABLED ? '1' : '0',
+          options
+        );
+      }
 
-    setAuthV2CookieStateValue(state);
-  }, []);
+      setAuthV2CookieStateValue(state);
+    },
+    [setAuthV2RolloutOrganization]
+  );
 
-  return {authV2CookieState, isAuthV2Enabled, setAuthV2CookieState};
+  return {
+    authV2CookieState,
+    authV2RolloutOrganization,
+    isAuthV2Enabled,
+    setAuthV2CookieState,
+  };
 }


### PR DESCRIPTION
Tracks the organization that automatically enrolled the browser in Auth V2.

Loading a different organization without the rollout flag now preserves the login cookie. The cookie is only removed when the enrolling organization loses the flag, while explicit help-menu choices clear rollout ownership and remain authoritative.