### PR TITLE
feat(seer-infra-telemetry): Show GCP connection status on the integration settings page

### DIFF
--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -1,3 +1,5 @@
+import type {SnakeCasedProperties} from 'type-fest';
+
 import {t} from 'sentry/locale';
 import {unreachable} from 'sentry/utils/unreachable';
 
@@ -52,6 +54,8 @@ interface GcpProjectVerification extends Pick<
 > {
   errorDetail: string | null;
 }
+
+type GcpStoredProjectStatus = SnakeCasedProperties<GcpProjectVerification>;
 
 export interface GcpVerificationInput extends Pick<
   GcpVerifyConnectionResponse,
@@ -109,7 +113,7 @@ export function describeService(service: GcpServiceResult): string {
   }`;
 }
 
-export function parseGcpProjectIds(value: string): string[] {
+function parseGcpProjectIds(value: string): string[] {
   return [
     ...new Set(
       value
@@ -118,4 +122,35 @@ export function parseGcpProjectIds(value: string): string[] {
         .filter(Boolean)
     ),
   ];
+}
+
+export function buildGcpVerifyPayload(
+  configData: Record<string, unknown> | null | undefined
+): {customerSaEmail: string; gcpProjectIds: string[]} | null {
+  const customerSaEmail = configData?.customer_sa_email;
+  const projectIds = configData?.projects;
+  if (typeof customerSaEmail !== 'string' || typeof projectIds !== 'string') {
+    return null;
+  }
+
+  const gcpProjectIds = parseGcpProjectIds(projectIds);
+  if (!customerSaEmail || !gcpProjectIds.length) {
+    return null;
+  }
+
+  return {customerSaEmail, gcpProjectIds};
+}
+
+export function getConnectionErrorDetails(projectStatuses: unknown): string[] {
+  if (!Array.isArray(projectStatuses)) {
+    return [];
+  }
+
+  const details = projectStatuses
+    .map(status => (status as GcpStoredProjectStatus | null)?.error_detail)
+    .filter(
+      (detail): detail is string => typeof detail === 'string' && detail.length > 0
+    );
+
+  return [...new Set(details)];
 }

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -1,5 +1,3 @@
-import type {SnakeCasedProperties} from 'type-fest';
-
 import {t} from 'sentry/locale';
 import {unreachable} from 'sentry/utils/unreachable';
 
@@ -54,8 +52,6 @@ interface GcpProjectVerification extends Pick<
 > {
   errorDetail: string | null;
 }
-
-type GcpStoredProjectStatus = SnakeCasedProperties<GcpProjectVerification>;
 
 export interface GcpVerificationInput extends Pick<
   GcpVerifyConnectionResponse,
@@ -147,7 +143,11 @@ export function getConnectionErrorDetails(projectStatuses: unknown): string[] {
   }
 
   const details = projectStatuses
-    .map(status => (status as GcpStoredProjectStatus | null)?.error_detail)
+    .map(status =>
+      status !== null && typeof status === 'object' && 'error_detail' in status
+        ? status.error_detail
+        : null
+    )
     .filter(
       (detail): detail is string => typeof detail === 'string' && detail.length > 0
     );

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -385,7 +385,10 @@ describe('ConfigureIntegration GCP re-verification', () => {
   const integrationId = '1';
   const CUSTOMER_SA = 'gcp-sentry@my-project.iam.gserviceaccount.com';
 
-  function setup({providerKey = 'gcp'}: {providerKey?: string} = {}) {
+  function setup({
+    providerKey = 'gcp',
+    connectionStatus = 'connected',
+  }: {connectionStatus?: string; providerKey?: string} = {}) {
     const organization = OrganizationFixture({
       access: ['org:integrations', 'org:write'],
     });
@@ -415,6 +418,9 @@ describe('ConfigureIntegration GCP re-verification', () => {
       configData: {
         customer_sa_email: CUSTOMER_SA,
         projects: 'project-prod, project-staging',
+        connection_status: connectionStatus,
+        project_statuses: [],
+        last_verified_at: '2026-08-30T00:00:00+00:00',
       },
     });
 
@@ -441,7 +447,16 @@ describe('ConfigureIntegration GCP re-verification', () => {
     const verifyRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/monitoring-providers/gcp/verify-connection/`,
       method: 'POST',
-      body: {connectionStatus: 'connected', projects: []},
+      body: () => {
+        // The endpoint records its result on the integration.
+        storedConfig = {
+          ...storedConfig,
+          connection_status: 'connected',
+          project_statuses: [],
+          last_verified_at: '2026-08-31T00:00:00+00:00',
+        };
+        return {connectionStatus: 'connected', projects: []};
+      },
     });
 
     render(<ConfigureIntegration />, {
@@ -470,6 +485,22 @@ describe('ConfigureIntegration GCP re-verification', () => {
     await userEvent.type(field, value);
     await userEvent.tab();
   }
+
+  it('shows the connection status for a GCP integration', async () => {
+    setup();
+
+    expect(await screen.findByText('Connection Status')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeInTheDocument();
+  });
+
+  it('does not show the connection status for other providers', async () => {
+    setup({providerKey: 'github'});
+
+    expect(
+      await screen.findByRole('textbox', {name: 'Customer Service Account'})
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Connection Status')).not.toBeInTheDocument();
+  });
 
   it('re-runs verification with the saved settings', async () => {
     const {verifyRequest} = setup();
@@ -508,6 +539,17 @@ describe('ConfigureIntegration GCP re-verification', () => {
         })
       )
     );
+  });
+
+  it('shows the newly recorded status after a save', async () => {
+    setup({connectionStatus: 'unverified'});
+
+    expect(await screen.findByText('Not verified')).toBeInTheDocument();
+
+    await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
+
+    // The check runs after the save, so the page has to refresh again to show it.
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
   });
 
   it('does not re-run verification for other providers', async () => {

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -35,7 +35,7 @@ import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
-import {parseGcpProjectIds} from 'sentry/utils/seer/gcpConnection';
+import {buildGcpVerifyPayload} from 'sentry/utils/seer/gcpConnection';
 import {unreachable} from 'sentry/utils/unreachable';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -47,6 +47,7 @@ import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcru
 import {Divider} from 'sentry/views/settings/components/settingsBreadcrumb/divider';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
+import {GcpConnectionStatus} from './gcpConnectionStatus';
 import {IntegrationAlertRules} from './integrationAlertRules';
 import {IntegrationCodeMappings} from './integrationCodeMappings';
 import {IntegrationExternalTeamMappings} from './integrationExternalTeamMappings';
@@ -365,14 +366,8 @@ function ConfigureIntegration() {
     const verifyGcpConnection = async () => {
       const savedConfig = queryClient.getQueryData(integrationQueryOptions.queryKey)?.json
         .configData;
-      const customerSaEmail = savedConfig?.customer_sa_email;
-      const projectIds = savedConfig?.projects;
-      if (typeof customerSaEmail !== 'string' || typeof projectIds !== 'string') {
-        return;
-      }
-
-      const gcpProjectIds = parseGcpProjectIds(projectIds);
-      if (!customerSaEmail || !gcpProjectIds.length) {
+      const payload = buildGcpVerifyPayload(savedConfig);
+      if (!payload) {
         return;
       }
 
@@ -382,7 +377,7 @@ function ConfigureIntegration() {
           '/organizations/$organizationIdOrSlug/monitoring-providers/gcp/verify-connection/',
           {path: {organizationIdOrSlug: organization.slug}}
         ),
-        data: {customerSaEmail, gcpProjectIds},
+        data: payload,
       });
     };
 
@@ -411,6 +406,7 @@ function ConfigureIntegration() {
         if (provider.key === 'gcp') {
           try {
             await verifyGcpConnection();
+            await queryClient.invalidateQueries(integrationQueryOptions);
           } catch (error) {
             // The save itself succeeded; the connection stays recorded as unverified
             // and the customer can re-test, so don't report this as a failed save.
@@ -422,6 +418,14 @@ function ConfigureIntegration() {
 
     return (
       <Fragment>
+        {provider.key === 'gcp' && (
+          <GcpConnectionStatus
+            configData={integration.configData}
+            organization={organization}
+            onRetested={() => queryClient.invalidateQueries(integrationQueryOptions)}
+          />
+        )}
+
         {(integration.configOrganization?.length ?? 0) > 0 && (
           <FieldGroup
             title={

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -54,6 +54,7 @@ describe('GcpConnectionStatus', () => {
     });
 
     expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getByText(/Last checked/)).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled();
   });
 

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -1,0 +1,192 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {GcpConnectionStatus} from 'sentry/views/settings/organizationIntegrations/gcpConnectionStatus';
+
+describe('GcpConnectionStatus', () => {
+  const organization = OrganizationFixture();
+  const VERIFY_URL = `/organizations/${organization.slug}/monitoring-providers/gcp/verify-connection/`;
+
+  const baseConfig = {
+    sentry_sa_email: 'sentry-abc@sentry-connectors.iam.gserviceaccount.com',
+    customer_sa_email: 'gcp-sentry@my-project.iam.gserviceaccount.com',
+    projects: 'project-prod, project-staging',
+  };
+
+  function renderStatus({
+    configData,
+    onRetested = jest.fn(),
+  }: {
+    configData: OrganizationIntegration['configData'];
+    onRetested?: jest.Mock;
+  }) {
+    render(
+      <GcpConnectionStatus
+        configData={configData}
+        organization={organization}
+        onRetested={onRetested}
+      />,
+      {organization}
+    );
+    return onRetested;
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows a connected integration with no remediation', () => {
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'connected',
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'connected',
+            error_detail: null,
+          },
+        ],
+        last_verified_at: '2026-08-30T00:00:00+00:00',
+      },
+    });
+
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled();
+  });
+
+  it('shows the failure message alongside the status', () => {
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'permission_denied',
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'permission_denied',
+            error_detail:
+              'IAM roles not granted — verify your service account has viewer roles on this project',
+          },
+        ],
+        last_verified_at: '2026-08-30T00:00:00+00:00',
+      },
+    });
+
+    expect(screen.getByText('Permission denied')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'IAM roles not granted — verify your service account has viewer roles on this project'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('collapses the same failure reported by several projects', () => {
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'permission_denied',
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'permission_denied',
+            error_detail: 'IAM roles not granted',
+          },
+          {
+            gcp_project_id: 'project-staging',
+            connection_status: 'permission_denied',
+            error_detail: 'IAM roles not granted',
+          },
+        ],
+        last_verified_at: '2026-08-30T00:00:00+00:00',
+      },
+    });
+
+    expect(screen.getAllByText('IAM roles not granted')).toHaveLength(1);
+  });
+
+  it('reports an integration whose settings changed but was never re-checked', () => {
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'unverified',
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'unverified',
+            error_detail: null,
+          },
+        ],
+        last_verified_at: null,
+      },
+    });
+
+    expect(screen.getByText('Not verified')).toBeInTheDocument();
+    expect(screen.getByText('Never checked')).toBeInTheDocument();
+  });
+
+  it('re-tests the connection and refreshes the integration', async () => {
+    const verifyRequest = MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: {connectionStatus: 'connected', projects: []},
+    });
+    const onRetested = renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'unverified',
+        project_statuses: [],
+        last_verified_at: null,
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+
+    await waitFor(() =>
+      expect(verifyRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            customerSaEmail: baseConfig.customer_sa_email,
+            gcpProjectIds: ['project-prod', 'project-staging'],
+          },
+        })
+      )
+    );
+    await waitFor(() => expect(onRetested).toHaveBeenCalled());
+  });
+
+  it('still refreshes when the re-test request fails', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      statusCode: 502,
+    });
+    const onRetested = renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'unverified',
+        project_statuses: [],
+        last_verified_at: null,
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+
+    await waitFor(() => expect(onRetested).toHaveBeenCalled());
+  });
+
+  it('cannot be re-tested when the config is incomplete', () => {
+    renderStatus({
+      configData: {
+        sentry_sa_email: baseConfig.sentry_sa_email,
+        connection_status: 'unverified',
+        project_statuses: [],
+        last_verified_at: null,
+      },
+    });
+
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
+  });
+});

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
@@ -1,0 +1,104 @@
+import {useMutation} from '@tanstack/react-query';
+
+import {Button} from '@sentry/scraps/button';
+import {FieldGroup} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {StatusIndicator} from '@sentry/scraps/statusIndicator';
+import {Text} from '@sentry/scraps/text';
+
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconRefresh} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {OrganizationIntegration} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {
+  buildGcpVerifyPayload,
+  getConnectionErrorDetails,
+  getStatusLabel,
+  getStatusVariant,
+} from 'sentry/utils/seer/gcpConnection';
+
+interface GcpConnectionStatusProps {
+  configData: OrganizationIntegration['configData'];
+  onRetested: () => void | Promise<void>;
+  organization: Organization;
+}
+
+export function GcpConnectionStatus({
+  configData,
+  onRetested,
+  organization,
+}: GcpConnectionStatusProps) {
+  const status =
+    typeof configData?.connection_status === 'string'
+      ? configData.connection_status
+      : 'unverified';
+  const lastVerifiedAt = configData?.last_verified_at;
+  const isConnected = status === 'connected';
+  const errorDetails = isConnected
+    ? []
+    : getConnectionErrorDetails(configData?.project_statuses);
+
+  const payload = buildGcpVerifyPayload(configData);
+
+  const {mutate: retest, isPending} = useMutation({
+    mutationFn: () =>
+      fetchMutation({
+        method: 'POST',
+        url: getApiUrl(
+          '/organizations/$organizationIdOrSlug/monitoring-providers/gcp/verify-connection/',
+          {path: {organizationIdOrSlug: organization.slug}}
+        ),
+        data: payload ?? undefined,
+      }),
+    onSuccess: () => onRetested(),
+    onError: () => onRetested(),
+  });
+
+  return (
+    <FieldGroup title={t('Connection Status')}>
+      <Stack gap="md" padding="xl">
+        <Flex gap="sm" align="center">
+          {isPending ? (
+            <StatusIndicator variant="muted" />
+          ) : (
+            <StatusIndicator
+              variant={getStatusVariant(status)}
+              animationIterationCount={1}
+            />
+          )}
+          <Text bold>
+            {isPending ? t('Checking connection...') : getStatusLabel(status)}
+          </Text>
+        </Flex>
+
+        {errorDetails.map(detail => (
+          <Text key={detail} variant="muted" size="sm">
+            {detail}
+          </Text>
+        ))}
+
+        <Flex gap="md" align="center" justify="between">
+          <Text variant="muted" size="sm">
+            {typeof lastVerifiedAt === 'string' ? (
+              <TimeSince date={lastVerifiedAt} prefix={t('Last checked')} />
+            ) : (
+              t('Never checked')
+            )}
+          </Text>
+          <Button
+            size="sm"
+            icon={<IconRefresh size="xs" />}
+            onClick={() => retest()}
+            busy={isPending}
+            disabled={isPending || !payload}
+          >
+            {t('Re-test')}
+          </Button>
+        </Flex>
+      </Stack>
+    </FieldGroup>
+  );
+}

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
@@ -8,7 +8,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconRefresh} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -82,11 +82,9 @@ export function GcpConnectionStatus({
 
         <Flex gap="md" align="center" justify="between">
           <Text variant="muted" size="sm">
-            {typeof lastVerifiedAt === 'string' ? (
-              <TimeSince date={lastVerifiedAt} prefix={t('Last checked')} />
-            ) : (
-              t('Never checked')
-            )}
+            {typeof lastVerifiedAt === 'string'
+              ? tct('Last checked [when]', {when: <TimeSince date={lastVerifiedAt} />})
+              : t('Never checked')}
           </Text>
           <Button
             size="sm"


### PR DESCRIPTION
PR 2 for https://linear.app/getsentry/issue/CW-1668/build-gcp-mcp-connected-state-error-state-ui.

Adds a connection status block to the GCP integration settings page: the current status, the failure message and remediation when it isn't connected, when it was last checked, and a Re-test button.

Re-test posts to `verify-connection` and refreshes. The endpoint records its own result on the organization integration config, so nothing else is needed.

Initial verification UI looks like this (this will be improved):

<img width="637" height="525" alt="image" src="https://github.com/user-attachments/assets/7a2b808a-0540-4242-8fde-d7a3b2e41fbe" />

Configuration page (added in this PR):

<img width="3181" height="526" alt="image" src="https://github.com/user-attachments/assets/aacab39a-7bbf-49e8-b59d-56cff7d67756" />