### PR TITLE
feat(hybrid-cloud): read deletion watermarks from postgres behind a flag

### DIFF
--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -46,6 +46,9 @@ TOMBSTONE_WATERMARK = "tombstone"
 ROW_WATERMARK = "row"
 WATERMARK_PREFIXES = (TOMBSTONE_WATERMARK, ROW_WATERMARK)
 
+WRITE_WATERMARK_TO_POSTGRES_OPTION = "hybrid_cloud.write_deletion_watermark_to_postgres"
+READ_WATERMARK_FROM_POSTGRES_OPTION = "hybrid_cloud.read_deletion_watermark_from_postgres"
+
 
 @dataclass
 class WatermarkBatch:
@@ -96,7 +99,7 @@ def _write_watermark(
     )
 
     # Dual-write deletion watermarks to Redis and Postgres
-    if options.get("hybrid_cloud.write_deletion_watermark_to_postgres"):
+    if options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION):
         try:
             _watermark_model(field).objects.update_or_create(
                 prefix=prefix,
@@ -116,18 +119,52 @@ def _write_watermark(
             )
 
 
-def get_watermark(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> tuple[int, str]:
-    client = _get_redis_client()
-    key = get_watermark_key(prefix, field)
-    v = client.get(key)
+def _watermark_row_lookup(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> dict[str, str]:
+    return dict(
+        prefix=prefix,
+        table_name=field.model._meta.db_table,
+        field_name=field.name,
+    )
+
+
+def _read_redis_watermark(
+    prefix: str, field: HybridCloudForeignKey[Any, Any]
+) -> tuple[int, str] | None:
+    v = _get_redis_client().get(get_watermark_key(prefix, field))
     if v is None:
-        result = (0, uuid4().hex)
-        _write_watermark(prefix, field, *result)
-        return result
+        return None
     lower, transaction_id = json.loads(v)
     if not (isinstance(lower, int) and isinstance(transaction_id, str)):
         raise TypeError("Expected watermarks data to be a tuple of (int, str)")
     return lower, transaction_id
+
+
+def _read_postgres_watermark(
+    prefix: str, field: HybridCloudForeignKey[Any, Any]
+) -> tuple[int, str] | None:
+    row = _watermark_model(field).objects.filter(**_watermark_row_lookup(prefix, field)).first()
+    if row is None:
+        return None
+    return row.low_bound, row.transaction_id
+
+
+def _postgres_is_source_of_truth() -> bool:
+    return bool(options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION)) and bool(
+        options.get(READ_WATERMARK_FROM_POSTGRES_OPTION)
+    )
+
+
+def get_watermark(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> tuple[int, str]:
+    if _postgres_is_source_of_truth():
+        watermark = _read_postgres_watermark(prefix, field)
+    else:
+        watermark = _read_redis_watermark(prefix, field)
+
+    if watermark is None:
+        result = (0, uuid4().hex)
+        _write_watermark(prefix, field, *result)
+        return result
+    return watermark
 
 
 def set_watermark(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2530,6 +2530,11 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "hybrid_cloud.read_deletion_watermark_from_postgres",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # List of event IDs to pass through
 register(

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable, Generator
 from operator import itemgetter
 from typing import Any, ClassVar, ContextManager, NotRequired, TypedDict, cast
@@ -7,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.apps import apps
-from django.db import ProgrammingError, connections, router, transaction
+from django.db import IntegrityError, ProgrammingError, connections, router, transaction
 from django.db.models import BooleanField, Max, Min, QuerySet
 
 from sentry.backup.scopes import RelocationScope
@@ -17,13 +18,17 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.deletions.models.watermark import CellDeletionWatermark, ControlDeletionWatermark
 from sentry.deletions.tasks.hybrid_cloud import (
+    READ_WATERMARK_FROM_POSTGRES_OPTION,
     ROW_WATERMARK,
     TOMBSTONE_WATERMARK,
     WATERMARK_PREFIXES,
+    WRITE_WATERMARK_TO_POSTGRES_OPTION,
     WatermarkBatch,
     _get_redis_client,
     _process_hybrid_cloud_foreign_key_cascade,
+    _read_postgres_watermark,
     _watermark_model,
+    _write_watermark,
     get_ids_cross_db_for_row_watermark,
     get_ids_cross_db_for_tombstone_watermark,
     get_watermark,
@@ -248,7 +253,13 @@ def test_watermark_and_transaction_id(
     assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field) == (wm, new_tid1)
 
 
-DUAL_WRITE_OPTION = "hybrid_cloud.write_deletion_watermark_to_postgres"
+# The write option is the parent. The read option only takes effect while the
+# write option is also on, so the read path needs both.
+DUAL_WRITE_ON = {WRITE_WATERMARK_TO_POSTGRES_OPTION: True}
+POSTGRES_READS_ON = {
+    WRITE_WATERMARK_TO_POSTGRES_OPTION: True,
+    READ_WATERMARK_FROM_POSTGRES_OPTION: True,
+}
 
 
 def _cell_watermark_rows(
@@ -279,7 +290,7 @@ def test_dual_write_puts_the_same_value_in_both_stores(
 ) -> None:
     _cell_watermark_rows(project_bookmark_user_id_field).delete()
 
-    with override_options({DUAL_WRITE_OPTION: True}):
+    with override_options(DUAL_WRITE_ON):
         _, tid = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
         set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 7, tid)
 
@@ -297,7 +308,7 @@ def test_dual_write_updates_the_row_in_place(
 ) -> None:
     _cell_watermark_rows(project_bookmark_user_id_field).delete()
 
-    with override_options({DUAL_WRITE_OPTION: True}):
+    with override_options(DUAL_WRITE_ON):
         _, tid = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
         set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 7, tid)
         _, tid = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
@@ -314,16 +325,26 @@ def test_dual_write_failure_does_not_stop_the_cascade(
 ) -> None:
     _cell_watermark_rows(project_bookmark_user_id_field).delete()
 
+    # Both stores agree before the failure.
+    with override_options(DUAL_WRITE_ON):
+        set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 5, "abc123")
+
     broken = Mock(side_effect=ProgrammingError("relation does not exist"))
-    with override_options({DUAL_WRITE_OPTION: True}):
+    with override_options(DUAL_WRITE_ON):
         with patch.object(CellDeletionWatermark.objects, "update_or_create", broken):
             _, tid = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
             set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 13, tid)
 
     # Redis advanced and no exception escaped, so the batch task keeps working.
     assert broken.called
+
+    row = _cell_watermark_rows(project_bookmark_user_id_field).get(prefix=TOMBSTONE_WATERMARK)
+    assert row.low_bound == 5
+
+    with override_options(POSTGRES_READS_ON):
+        assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)[0] == 5
+
     assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)[0] == 13
-    assert not _cell_watermark_rows(project_bookmark_user_id_field).exists()
 
 
 @django_db_all
@@ -334,7 +355,7 @@ def test_one_cycle_fills_both_watermark_rows(
     reset_watermarks()
     _cell_watermark_rows(project_bookmark_user_id_field).delete()
 
-    with override_options({DUAL_WRITE_OPTION: True}):
+    with override_options(DUAL_WRITE_ON):
         with task_runner():
             schedule_hybrid_cloud_foreign_key_jobs()
 
@@ -366,7 +387,7 @@ def test_dual_write_uses_the_control_table_in_control_silo() -> None:
         table_name=AuthProvider._meta.db_table, field_name=field.name
     ).delete()
 
-    with override_options({DUAL_WRITE_OPTION: True}):
+    with override_options(DUAL_WRITE_ON):
         _, tid = get_watermark(TOMBSTONE_WATERMARK, field)
         set_watermark(TOMBSTONE_WATERMARK, field, 11, tid)
 
@@ -380,6 +401,155 @@ def test_dual_write_uses_the_control_table_in_control_silo() -> None:
     )
     assert row.low_bound == low_bound
     assert row.transaction_id == transaction_id
+
+
+@django_db_all
+def test_read_starts_fresh_when_no_store_holds_the_watermark(
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    _cell_watermark_rows(project_bookmark_user_id_field).delete()
+    _get_redis_client().delete(
+        get_watermark_key(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
+    )
+
+    with override_options(POSTGRES_READS_ON):
+        low_bound, transaction_id = get_watermark(
+            TOMBSTONE_WATERMARK, project_bookmark_user_id_field
+        )
+
+    assert low_bound == 0
+    assert transaction_id
+
+    row = _cell_watermark_rows(project_bookmark_user_id_field).get(prefix=TOMBSTONE_WATERMARK)
+    assert (row.low_bound, row.transaction_id) == (0, transaction_id)
+
+
+@django_db_all
+def test_read_prefers_the_postgres_row_over_redis(
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    _cell_watermark_rows(project_bookmark_user_id_field).delete()
+
+    with override_options(DUAL_WRITE_ON):
+        set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 55, "abc123")
+
+    # Move Redis on its own, so a Redis read would give a different answer.
+    _write_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 99, "stale-redis-tid")
+    row = _cell_watermark_rows(project_bookmark_user_id_field).get(prefix=TOMBSTONE_WATERMARK)
+
+    recording_client = Mock(wraps=_get_redis_client())
+    with override_options(POSTGRES_READS_ON):
+        with patch(
+            "sentry.deletions.tasks.hybrid_cloud._get_redis_client", return_value=recording_client
+        ):
+            watermark = get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)
+
+    assert watermark == (55, row.transaction_id)
+    assert recording_client.get.call_count == 0
+
+
+@django_db_all
+def test_read_with_the_options_off_still_uses_redis(
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    _cell_watermark_rows(project_bookmark_user_id_field).delete()
+
+    with override_options(DUAL_WRITE_ON):
+        set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 55, "abc123")
+
+    # Move Redis on its own. With the options off the Redis value is the answer.
+    _write_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 99, "stale-redis-tid")
+
+    assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field) == (
+        99,
+        "stale-redis-tid",
+    )
+
+
+@django_db_all
+@pytest.mark.parametrize(
+    "half_on",
+    [
+        pytest.param({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}, id="write-only"),
+        pytest.param({READ_WATERMARK_FROM_POSTGRES_OPTION: True}, id="read-only"),
+    ],
+)
+def test_read_needs_both_options_to_use_postgres(
+    half_on: dict[str, bool],
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    _cell_watermark_rows(project_bookmark_user_id_field).delete()
+
+    with override_options(DUAL_WRITE_ON):
+        set_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 55, "abc123")
+
+    # Move Redis on its own, so a Postgres read would give a different answer.
+    _write_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field, 99, "stale-redis-tid")
+
+    with override_options(half_on):
+        assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field) == (
+            99,
+            "stale-redis-tid",
+        )
+
+
+@django_db_all(transaction=True)
+def test_two_concurrent_reads_create_one_row(
+    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
+) -> None:
+    field = project_bookmark_user_id_field
+    _cell_watermark_rows(field).delete()
+    _get_redis_client().delete(get_watermark_key(TOMBSTONE_WATERMARK, field))
+
+    looked_up = threading.Barrier(2, timeout=10)
+    ready_to_insert = threading.Barrier(2, timeout=10)
+    # The concrete queryset class is a silo limited subclass, so patch that one.
+    watermark_queryset = type(CellDeletionWatermark.objects.get_queryset())
+    real_create = watermark_queryset.create
+    results: list[tuple[int, str]] = []
+    errors: list[BaseException] = []
+    conflicts: list[IntegrityError] = []
+
+    def read_row_then_wait(
+        prefix: str, hcfk: HybridCloudForeignKey[Any, Any]
+    ) -> tuple[int, str] | None:
+        watermark = _read_postgres_watermark(prefix, hcfk)
+        looked_up.wait()
+        return watermark
+
+    def insert_alongside_the_other_reader(self: Any, **kwargs: Any) -> Any:
+        ready_to_insert.wait()
+        try:
+            return real_create(self, **kwargs)
+        except IntegrityError as err:
+            conflicts.append(err)
+            raise
+
+    def read_watermark() -> None:
+        try:
+            results.append(get_watermark(TOMBSTONE_WATERMARK, field))
+        except BaseException as err:
+            errors.append(err)
+        finally:
+            for connection in connections.all():
+                connection.close()
+
+    with (
+        override_options(POSTGRES_READS_ON),
+        patch("sentry.deletions.tasks.hybrid_cloud._read_postgres_watermark", read_row_then_wait),
+        patch.object(watermark_queryset, "create", insert_alongside_the_other_reader),
+    ):
+        readers = [threading.Thread(target=read_watermark) for _ in range(2)]
+        for reader in readers:
+            reader.start()
+        for reader in readers:
+            reader.join(timeout=30)
+
+    assert errors == []
+    assert len(conflicts) == 1
+    assert _cell_watermark_rows(field).filter(prefix=TOMBSTONE_WATERMARK).count() == 1
+
+    assert [low_bound for low_bound, _ in results] == [0, 0]
 
 
 @django_db_all


### PR DESCRIPTION
This PR prepares for the cutover to Postgres as the source of truth for deletion watermarks. In addition to the option which gates the dual-write, I'm introducing a second option which gates the cutover to actually read from Postgres. That way if we need to switch back to Redis as the source of truth, we can do that without also disabling the dual-write path. That option is off by default for now.

Refs INFRENG-561