### PR TITLE
feat(aci): Add generic default evaluation flow for stateless detectors

### DIFF
--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -36,6 +36,9 @@ class ErrorDetectorHandler(BaseDetectorHandler[object, object, DataConditionGrou
     def extract_value(self, data_packet: DataPacket[object]) -> object:
         return None
 
+    def evaluate_extracted_value(self, extracted_value: object) -> DataConditionGroupEvaluation:
+        return DataConditionGroupEvaluation(result=False, data={})
+
     def create_occurrence(
         self,
         evaluation: DataConditionGroupEvaluation,

--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -31,15 +31,15 @@ class ErrorDetectorHandler(BaseDetectorHandler[object, object, DataConditionGrou
         return {}
 
     def evaluate(self, data_packet: DataPacket[object]) -> GroupedDetectorEvaluationResult:
-        return GroupedDetectorEvaluationResult(result={}, tainted=False)
+        raise NotImplementedError
 
     def extract_value(self, data_packet: DataPacket[object]) -> object:
-        return None
+        raise NotImplementedError
 
-    def evaluate_extracted_value(self, extracted_value: object) -> DataConditionGroupEvaluation:
-        return DataConditionGroupEvaluation(
-            result=False, data={"condition_evaluations": [], "logic_type": "and"}, triggered=False
-        )
+    def evaluate_extracted_value(
+        self, extracted_value: object
+    ) -> tuple[DataConditionGroupEvaluation | None, DetectorPriorityLevel]:
+        raise NotImplementedError
 
     def create_occurrence(
         self,

--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -37,7 +37,9 @@ class ErrorDetectorHandler(BaseDetectorHandler[object, object, DataConditionGrou
         return None
 
     def evaluate_extracted_value(self, extracted_value: object) -> DataConditionGroupEvaluation:
-        return DataConditionGroupEvaluation(result=False, data={})
+        return DataConditionGroupEvaluation(
+            result=False, data={"condition_evaluations": [], "logic_type": "and"}, triggered=False
+        )
 
     def create_occurrence(
         self,

--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -22,7 +22,7 @@ from sentry.workflow_engine.types import (
 )
 
 
-class ErrorDetectorHandler(BaseDetectorHandler[object, object]):
+class ErrorDetectorHandler(BaseDetectorHandler[object, object, DataConditionGroupEvaluation]):
     """Placeholder handler for error group types."""
 
     def _evaluate(

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone as dt_timezone
-from typing import TYPE_CHECKING, Any, NotRequired, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypeAlias, TypedDict, override
 from uuid import uuid4
 
 from sentry.exceptions import InvalidSearchQuery
@@ -216,6 +216,7 @@ class PreprodSizeAnalysisDetectorHandler(
             )
             return False
 
+    @override
     def evaluate(self, data_packet: SizeAnalysisDataPacket) -> GroupedDetectorEvaluationResult:
         if not self._matches_query(data_packet):
             return GroupedDetectorEvaluationResult(result={}, tainted=False)

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "DataPacketEvaluationResultType",
     "DataPacketEvaluationType",
     "DataPacketType",
+    "DetectorHandler",
     "DetectorOccurrence",
     "DetectorStateData",
     "GroupedDetectorEvaluationResult",
@@ -16,6 +17,7 @@ from .base import (
     DataPacketEvaluationResultType,
     DataPacketEvaluationType,
     DataPacketType,
+    DetectorHandler,
     DetectorOccurrence,
     GroupedDetectorEvaluationResult,
 )

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "BaseDetectorHandler",
     "ConditionDetectorHandler",
+    "DataPacketEvaluationResultType",
     "DataPacketEvaluationType",
     "DataPacketType",
     "DetectorOccurrence",
@@ -12,6 +13,7 @@ __all__ = [
 from .base import (
     BaseDetectorHandler,
     ConditionDetectorHandler,
+    DataPacketEvaluationResultType,
     DataPacketEvaluationType,
     DataPacketType,
     DetectorOccurrence,

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -217,7 +217,7 @@ class DetectorHandler(
 
         if self._is_detector_group_value(extracted_value):
             logger.warning(
-                "The default implementation of evaluate_data_packet expects a single value, but a dictionary of values was returned. To support grouping, please override the evaluate_data_packet method"
+                "The default implementation of evaluate expects a single value, but a dictionary of values was returned from extract_value. To support grouping, please override the evaluate method"
             )
 
             return GroupedDetectorEvaluationResult(result={}, tainted=False)
@@ -311,14 +311,13 @@ class ConditionDetectorHandler(
     DetectorHandler[DataPacketType, DataPacketEvaluationType, DataConditionGroupEvaluation]
 ):
     """
-    Base implementation class providing shared infrastructure for detector handlers.
+    Implementation class providing shared infrastructure for detector handlers.
     Includes metrics tracking and condition group loading around the `evaluate` template method.
-
-    TODO - Implement a standard DetectorHandler with this base class -- a-la StatefulDetectorHandler
     """
 
     def __init__(self, detector: Detector):
         super().__init__(detector)
+
         if detector.workflow_condition_group_id is not None:
             try:
                 # Check if workflow_condition_group is already prefetched

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -137,6 +137,16 @@ class BaseDetectorHandler(
         pass
 
     @abc.abstractmethod
+    def evaluate_extracted_value(
+        self,
+        extracted_value: DataPacketEvaluationType,
+    ) -> DataPacketEvaluationResultType:
+        """
+        Once the value has been extracted from the data packet, evaluate data condition groups (if present) or your own custom check
+        """
+        pass
+
+    @abc.abstractmethod
     def create_occurrence(
         self,
         evaluation: DataPacketEvaluationResultType,
@@ -154,8 +164,44 @@ class BaseDetectorHandler(
         pass
 
 
+class DetectorHandler(
+    BaseDetectorHandler[DataPacketType, DataPacketEvaluationType, DataPacketEvaluationResultType]
+):
+    """
+    Base implementation class for detectors that make decisions without data condition groups
+
+    The class provides a default "evaluate" flow, so a subclass only has to provide the "extract_value", "evaluate_extracted_value", and "create_occurrence" methods.
+    """
+
+    def __init__(self, detector: Detector):
+        super().__init__(detector)
+
+    def _evaluate(
+        self, data_packet: DataPacket[DataPacketType]
+    ) -> dict[DetectorGroupKey, DetectorEvaluation]:
+        tags = {
+            "detector_type": self.detector.type,
+            "result": "unknown",
+        }
+
+        try:
+            value = self.evaluate(data_packet)
+
+            tags["result"] = "tainted" if value.tainted else "success"
+
+            metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
+
+            return value.result
+        except Exception:
+            tags["result"] = "failure"
+
+            metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
+
+            raise
+
+
 class ConditionDetectorHandler(
-    BaseDetectorHandler[DataPacketType, DataPacketEvaluationType, DataConditionGroupEvaluation]
+    DetectorHandler[DataPacketType, DataPacketEvaluationType, DataConditionGroupEvaluation]
 ):
     """
     Base implementation class providing shared infrastructure for detector handlers.
@@ -187,25 +233,10 @@ class ConditionDetectorHandler(
         else:
             self.condition_group = None
 
-    def _evaluate(
-        self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluation]:
-        tags = {
-            "detector_type": self.detector.type,
-            "result": "unknown",
-        }
-
-        try:
-            value = self.evaluate(data_packet)
-
-            tags["result"] = "tainted" if value.tainted else "success"
-
-            metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
-
-            return value.result
-        except Exception:
-            tags["result"] = "failure"
-
-            metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
-
-            raise
+    def evaluate_extracted_value(
+        self,
+        extracted_value: DataPacketEvaluationType,
+    ) -> DataConditionGroupEvaluation:
+        return DataConditionGroupEvaluation(
+            result=False, data={"condition_evaluations": [], "logic_type": "and"}, triggered=False
+        )

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -4,7 +4,8 @@ import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
+from uuid import uuid4
 
 from django.utils import timezone
 
@@ -18,6 +19,8 @@ from sentry.workflow_engine.processors import (
     DataConditionGroupEvaluation,
     DetectorEvaluation,
 )
+from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
+from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
 from sentry.workflow_engine.types import (
     DetectorGroupKey,
     DetectorId,
@@ -140,7 +143,7 @@ class BaseDetectorHandler(
     def evaluate_extracted_value(
         self,
         extracted_value: DataPacketEvaluationType,
-    ) -> DataPacketEvaluationResultType:
+    ) -> tuple[DataPacketEvaluationResultType | None, DetectorPriorityLevel]:
         """
         Once the value has been extracted from the data packet, evaluate data condition groups (if present) or your own custom check
         """
@@ -199,6 +202,110 @@ class DetectorHandler(
 
             raise
 
+    def evaluate(self, data_packet: DataPacket[DataPacketType]) -> GroupedDetectorEvaluationResult:
+        """
+        A default, stateless evaluation
+
+        Extracts the value from the packet, decides whether to trigger the detector or not, and creates an occurrence if it does
+
+        Override "evaluate_extracted_value" to implement the custom evaluation logic (using data condition groups or something else)
+        Override "get_issue_fingerprint" and "get_occurrence_id" to modify the defaults
+
+        Override the "evaluate" method entirely to implement a custom evaluation flow
+        """
+        extracted_value = self.extract_value(data_packet)
+
+        if self._is_detector_group_value(extracted_value):
+            logger.warning(
+                "The default implementation of evaluate_data_packet expects a single value, but a dictionary of values was returned. To support grouping, please override the evaluate_data_packet method"
+            )
+
+            return GroupedDetectorEvaluationResult(result={}, tainted=False)
+
+        value = cast(DataPacketEvaluationType, extracted_value)
+
+        evaluation, priority = self.evaluate_extracted_value(value)
+
+        if evaluation is None:
+            return GroupedDetectorEvaluationResult(result={}, tainted=False)
+
+        if priority == DetectorPriorityLevel.OK:
+            return GroupedDetectorEvaluationResult(result={}, tainted=evaluation.is_tainted())
+
+        detector_occurrence, event_data = self.create_occurrence(evaluation, data_packet, priority)
+
+        occurrence_id = self.get_occurrence_id(event_data)
+
+        issue_fingerprint = self.get_issue_fingerprint()
+
+        issue_occurrence = detector_occurrence.to_issue_occurrence(
+            occurrence_id=occurrence_id,
+            project_id=self.detector.project_id,
+            status=priority,
+            additional_evidence_data={},
+            fingerprint=issue_fingerprint,
+        )
+
+        event_data = self._build_event_data(event_data, issue_occurrence)
+
+        detector_evaluation = DetectorEvaluation(
+            result=issue_occurrence,
+            data=DetectorEvaluationData(
+                group_key=None,
+                trigger_group_evaluation=evaluation,
+                event_data=event_data,
+            ),
+            triggered=True,
+            priority=priority,
+        )
+
+        return GroupedDetectorEvaluationResult(
+            result={None: detector_evaluation}, tainted=evaluation.is_tainted()
+        )
+
+    def get_occurrence_id(self, event_data: EventData) -> str:
+        id_in_event_data = event_data.get("event_id")
+
+        if id_in_event_data:
+            return id_in_event_data
+
+        return str(uuid4())
+
+    def get_issue_fingerprint(self) -> list[str]:
+        return [f"detector:{self.detector.id}"]
+
+    def _build_event_data(
+        self, event_data: EventData, issue_occurrence: IssueOccurrence
+    ) -> EventData:
+        event_data["event_id"] = issue_occurrence.event_id
+
+        event_data["project_id"] = issue_occurrence.project_id
+
+        event_data["timestamp"] = issue_occurrence.detection_time
+
+        event_data.setdefault("environment", self.detector.config.get("environment"))
+
+        event_data.setdefault("platform", "python")
+
+        event_data.setdefault("received", issue_occurrence.detection_time)
+
+        event_data.setdefault("tags", {})
+
+        return event_data
+
+    def _is_detector_group_value(self, value: Any) -> bool:
+        """
+        Check if value is dict[DetectorGroupKey, DataPacketEvaluationType]
+        """
+        if not isinstance(value, dict):
+            return False
+
+        if not value:  # Empty dict case
+            return False
+
+        # Check if all keys are DetectorGroupKey instances
+        return all(isinstance(key, DetectorGroupKey) for key in value.keys())
+
 
 class ConditionDetectorHandler(
     DetectorHandler[DataPacketType, DataPacketEvaluationType, DataConditionGroupEvaluation]
@@ -236,7 +343,35 @@ class ConditionDetectorHandler(
     def evaluate_extracted_value(
         self,
         extracted_value: DataPacketEvaluationType,
-    ) -> DataConditionGroupEvaluation:
-        return DataConditionGroupEvaluation(
-            result=False, data={"condition_evaluations": [], "logic_type": "and"}, triggered=False
+    ) -> tuple[DataConditionGroupEvaluation | None, DetectorPriorityLevel]:
+        if self.condition_group is None:
+            metrics.incr("workflow_engine.detector.skipping_invalid_condition_group")
+            return None, DetectorPriorityLevel.OK
+
+        group_evaluation, remaining_slow_conditions = process_data_condition_group(
+            self.condition_group, extracted_value
         )
+
+        if remaining_slow_conditions:
+            logger.warning(
+                "Slow conditions present for detector",
+                extra={
+                    "detector_id": self.detector.id,
+                    "condition_group_id": self.condition_group.id,
+                },
+            )
+
+        if not group_evaluation.triggered:
+            return group_evaluation, DetectorPriorityLevel.OK
+
+        triggered_priorities: list[DetectorPriorityLevel] = [
+            condition_evaluation.result
+            for condition_evaluation in group_evaluation.data["condition_evaluations"]
+            if condition_evaluation.triggered
+            and isinstance(condition_evaluation.result, DetectorPriorityLevel)
+        ]
+
+        if not triggered_priorities:
+            return group_evaluation, DetectorPriorityLevel.OK
+
+        return group_evaluation, max(triggered_priorities)

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -166,6 +166,7 @@ class ConditionDetectorHandler(BaseDetectorHandler[DataPacketType, DataPacketEva
                     "Failed to find the data condition group for detector",
                     extra={"detector_id": detector.id},
                 )
+
                 self.condition_group = None
         else:
             self.condition_group = None
@@ -177,12 +178,18 @@ class ConditionDetectorHandler(BaseDetectorHandler[DataPacketType, DataPacketEva
             "detector_type": self.detector.type,
             "result": "unknown",
         }
+
         try:
             value = self.evaluate(data_packet)
+
             tags["result"] = "tainted" if value.tainted else "success"
+
             metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
+
             return value.result
         except Exception:
             tags["result"] = "failure"
+
             metrics.incr("workflow_engine_detector.evaluation", tags=tags, sample_rate=1.0)
+
             raise

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -13,7 +13,11 @@ from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.types.actor import Actor
 from sentry.utils import metrics
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
+from sentry.workflow_engine.processors import (
+    CustomDetectorEvaluation,
+    DataConditionGroupEvaluation,
+    DetectorEvaluation,
+)
 from sentry.workflow_engine.types import (
     DetectorGroupKey,
     DetectorId,
@@ -24,6 +28,9 @@ logger = logging.getLogger(__name__)
 
 DataPacketType = TypeVar("DataPacketType")
 DataPacketEvaluationType = TypeVar("DataPacketEvaluationType")
+DataPacketEvaluationResultType = TypeVar(
+    "DataPacketEvaluationResultType", bound=DataConditionGroupEvaluation | CustomDetectorEvaluation
+)
 
 EventData = dict[str, Any]
 
@@ -86,13 +93,20 @@ class GroupedDetectorEvaluationResult:
     tainted: bool
 
 
-class BaseDetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
+class BaseDetectorHandler(
+    abc.ABC,
+    Generic[DataPacketType, DataPacketEvaluationType, DataPacketEvaluationResultType],
+):
     """
     Abstract base class defining the public interface for detector handlers.
 
     DataPacketType is what we've embedded within the data packet.
+
     DataPacketEvaluationType is the type of the value to be extracted from the data packet and
     used to evaluate the conditions on the detector.
+
+    DataPacketEvaluationResultType is the type of the evaluation that explains why the detector
+    triggered.
     """
 
     def __init__(self, detector: Detector):
@@ -125,7 +139,7 @@ class BaseDetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationT
     @abc.abstractmethod
     def create_occurrence(
         self,
-        evaluation: DataConditionGroupEvaluation,
+        evaluation: DataPacketEvaluationResultType,
         data_packet: DataPacket[DataPacketType],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, EventData]:
@@ -140,7 +154,9 @@ class BaseDetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationT
         pass
 
 
-class ConditionDetectorHandler(BaseDetectorHandler[DataPacketType, DataPacketEvaluationType]):
+class ConditionDetectorHandler(
+    BaseDetectorHandler[DataPacketType, DataPacketEvaluationType, DataConditionGroupEvaluation]
+):
     """
     Base implementation class providing shared infrastructure for detector handlers.
     Includes metrics tracking and condition group loading around the `evaluate` template method.

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -2,7 +2,7 @@ import abc
 import dataclasses
 import logging
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 from uuid import uuid4
 
 from django.conf import settings
@@ -420,6 +420,7 @@ class StatefulDetectorHandler(
 
         return base
 
+    @override
     def evaluate(self, data_packet: DataPacket[DataPacketType]) -> GroupedDetectorEvaluationResult:
         dedupe_value = self.extract_dedupe_value(data_packet)
         group_data_values = self._extract_value_from_packet(data_packet)
@@ -605,19 +606,6 @@ class StatefulDetectorHandler(
             triggered=new_priority != DetectorPriorityLevel.OK,
             priority=new_priority,
         )
-
-    def _is_detector_group_value(self, value: Any) -> bool:
-        """
-        Check if value is dict[DetectorGroupKey, DataPacketEvaluationType]
-        """
-        if not isinstance(value, dict):
-            return False
-
-        if not value:  # Empty dict case
-            return False
-
-        # Check if all keys are DetectorGroupKey instances
-        return all(isinstance(key, DetectorGroupKey) for key in value.keys())
 
     def _get_configured_detector_levels(self) -> list[DetectorPriorityLevel]:
         conditions = self.detector.get_conditions()

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -178,7 +178,7 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return group_type
 
     @property
-    def detector_handler(self) -> BaseDetectorHandler[Any, Any] | None:
+    def detector_handler(self) -> BaseDetectorHandler[Any, Any, Any] | None:
         group_type = self.group_type
 
         if self.settings.handler is None:

--- a/src/sentry/workflow_engine/processors/__init__.py
+++ b/src/sentry/workflow_engine/processors/__init__.py
@@ -1,4 +1,6 @@
 __all__ = [
+    "BaseWorkflowEngineEvaluation",
+    "CustomDetectorEvaluation",
     "DataConditionEvaluation",
     "DataConditionGroupEvaluation",
     "DetectorEvaluation",
@@ -6,6 +8,8 @@ __all__ = [
 ]
 
 from .evaluations import (
+    BaseWorkflowEngineEvaluation,
+    CustomDetectorEvaluation,
     DataConditionEvaluation,
     DataConditionGroupEvaluation,
     DetectorEvaluation,

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -1,4 +1,6 @@
 __all__ = [
+    "BaseWorkflowEngineEvaluation",
+    "CustomDetectorEvaluation",
     "DataConditionEvaluation",
     "DataConditionEvaluationException",
     "DataConditionGroupEvaluation",
@@ -15,10 +17,11 @@ __all__ = [
     "WorkflowEvaluationOutcome",
 ]
 
-from .base import EvaluationPhase, EvaluationType
+from .base import BaseWorkflowEngineEvaluation, EvaluationPhase, EvaluationType
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
 from .detector import (
+    CustomDetectorEvaluation,
     DetectorEvaluation,
     DetectorEvaluationData,
     DetectorEvaluationOutcome,

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -17,14 +17,14 @@ from .condition_group import DataConditionGroupEvaluation, DataConditionGroupEva
 
 @dataclass(frozen=True)
 class CustomDetectorEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
-    result: int
+    result: bool
     data: dict[str, Any]
 
 
 @dataclass(frozen=True, kw_only=True)
 class CustomDetectorEvaluation(
     BaseWorkflowEngineEvaluation[
-        DetectorPriorityLevel,
+        bool,
         dict[str, Any],
         CustomDetectorEvaluationArtifact,
     ]
@@ -33,7 +33,7 @@ class CustomDetectorEvaluation(
     The trigger decision of a detector that does not use a DataConditionGroup.
 
     Inherited properties
-    - result: DetectorPriorityLevel - The priority the detector decided on.
+    - result: bool - Whether the detector decided to trigger.
     - data: dict - Whatever the handler wants to record about how it decided.
     - error: ConditionError - Set when something went wrong while deciding.
     - triggered: bool - Whether the decision should move the detector off `OK`.
@@ -45,7 +45,7 @@ class CustomDetectorEvaluation(
         return CustomDetectorEvaluationArtifact(
             triggered=triggered,
             error=error,
-            result=self.result.value,
+            result=self.result,
             data=self.data,
         )
 

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -15,9 +15,26 @@ from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArti
 from .condition_group import DataConditionGroupEvaluation, DataConditionGroupEvaluationArtifact
 
 
+@dataclass(frozen=True, kw_only=True)
+class CustomDetectorEvaluation(BaseWorkflowEngineEvaluation[DetectorPriorityLevel, dict[str, Any]]):
+    """
+    The trigger decision of a detector that does not use a DataConditionGroup.
+
+    Inherited properties
+    - result: DetectorPriorityLevel - The priority the detector decided on.
+    - data: dict - Whatever the handler wants to record about how it decided.
+    - error: ConditionError - Set when something went wrong while deciding.
+    - triggered: bool - Whether the decision should move the detector off `OK`.
+    """
+
+    @property
+    def artifact_fields(self) -> dict[str, Any]:
+        return {"result": self.result.value, "data": self.data}
+
+
 class DetectorEvaluationData(TypedDict):
     group_key: DetectorGroupKey
-    trigger_group_evaluation: DataConditionGroupEvaluation
+    trigger_group_evaluation: DataConditionGroupEvaluation | CustomDetectorEvaluation
     event_data: dict[str, Any] | None  # TODO - improve this typing, for now migrating
 
 

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -15,8 +15,20 @@ from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArti
 from .condition_group import DataConditionGroupEvaluation, DataConditionGroupEvaluationArtifact
 
 
+@dataclass(frozen=True)
+class CustomDetectorEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
+    result: int
+    data: dict[str, Any]
+
+
 @dataclass(frozen=True, kw_only=True)
-class CustomDetectorEvaluation(BaseWorkflowEngineEvaluation[DetectorPriorityLevel, dict[str, Any]]):
+class CustomDetectorEvaluation(
+    BaseWorkflowEngineEvaluation[
+        DetectorPriorityLevel,
+        dict[str, Any],
+        CustomDetectorEvaluationArtifact,
+    ]
+):
     """
     The trigger decision of a detector that does not use a DataConditionGroup.
 
@@ -27,9 +39,15 @@ class CustomDetectorEvaluation(BaseWorkflowEngineEvaluation[DetectorPriorityLeve
     - triggered: bool - Whether the decision should move the detector off `OK`.
     """
 
-    @property
-    def artifact_fields(self) -> dict[str, Any]:
-        return {"result": self.result.value, "data": self.data}
+    def _build_artifact(
+        self, *, triggered: bool, error: str | None
+    ) -> CustomDetectorEvaluationArtifact:
+        return CustomDetectorEvaluationArtifact(
+            triggered=triggered,
+            error=error,
+            result=self.result.value,
+            data=self.data,
+        )
 
 
 class DetectorEvaluationData(TypedDict):
@@ -52,7 +70,7 @@ class DetectorEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
     event_id: str | None
     group_key: DetectorGroupKey
     priority: int
-    trigger_evaluation: DataConditionGroupEvaluationArtifact
+    trigger_evaluation: DataConditionGroupEvaluationArtifact | CustomDetectorEvaluationArtifact
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -287,7 +287,7 @@ class SnubaQueryDataSourceType(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class DetectorSettings:
-    handler: type[BaseDetectorHandler[Any, Any]] | None = None
+    handler: type[BaseDetectorHandler[Any, Any, Any]] | None = None
     validator: type[BaseDetectorTypeValidator] | None = None
     config_schema: dict[str, Any] = field(default_factory=dict)
     filter: Q | None = None

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -1,12 +1,9 @@
 from typing import Any
 from unittest import mock
-from uuid import UUID
-
-import pytest
 
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.producer import PayloadType, _prepare_occurrence_message
+from sentry.issues.producer import _prepare_occurrence_message
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.testutils.abstract import Abstract
 from sentry.types.group import PriorityLevel
@@ -19,19 +16,15 @@ from sentry.workflow_engine.handlers.detector import (
     GroupedDetectorEvaluationResult,
     StatefulDetectorHandler,
 )
-from sentry.workflow_engine.handlers.detector.base import EventData
 from sentry.workflow_engine.handlers.detector.stateful import DetectorCounters
-from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
+from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors import (
     CustomDetectorEvaluation,
-    DataConditionEvaluation,
     DataConditionGroupEvaluation,
     DetectorEvaluation,
 )
-from sentry.workflow_engine.processors.detector import process_detectors
 from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
-from sentry.workflow_engine.processors.evaluations.detector import CustomDetectorEvaluationArtifact
 from sentry.workflow_engine.types import (
     ConditionError,
     DetectorGroupKey,
@@ -118,60 +111,11 @@ class MockDefaultConditionDetectorHandler(ConditionDetectorHandler[dict[str, Any
         return build_mock_occurrence_and_event(self, value, PriorityLevel(priority))
 
 
-class MockFingerprintedConditionDetectorHandler(MockDefaultConditionDetectorHandler):
-    """Replaces the fingerprint the default `evaluate` would build."""
-
-    def get_issue_fingerprint(self) -> list[str]:
-        return ["mock-fingerprint"]
-
-
-class MockEventIdConditionDetectorHandler(MockDefaultConditionDetectorHandler):
-    """Supplies its own event id from `create_occurrence`, as preprod size analysis does."""
-
-    event_id = "0123456789abcdef0123456789abcdef"
-
-    def create_occurrence(
-        self,
-        evaluation: DataConditionGroupEvaluation,
-        data_packet: DataPacket[dict[str, Any]],
-        priority: DetectorPriorityLevel,
-    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
-        detector_occurrence, event_data = super().create_occurrence(
-            evaluation, data_packet, priority
-        )
-        event_data["event_id"] = self.event_id
-        return detector_occurrence, event_data
-
-
-class MockOccurrenceIdConditionDetectorHandler(MockDefaultConditionDetectorHandler):
-    """Supplies the occurrence id through the hook rather than through event data."""
-
-    occurrence_id = "11111111111111111111111111111111"
-
-    def get_occurrence_id(self, event_data: EventData) -> str:
-        return self.occurrence_id
-
-
-class MockGroupedConditionDetectorHandler(ConditionDetectorHandler[dict[str, Any], int]):
-    """Returns grouped values, which the default `evaluate` does not support."""
-
-    def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> dict[DetectorGroupKey, int]:
-        return {"group-one": data_packet.packet["value"]}
-
-    def create_occurrence(
-        self,
-        evaluation: DataConditionGroupEvaluation,
-        data_packet: DataPacket[dict[str, Any]],
-        priority: DetectorPriorityLevel,
-    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
-        raise AssertionError("grouped values must bail before create_occurrence")
-
-
 class MockDetectorHandler(DetectorHandler[dict[str, Any], int, CustomDetectorEvaluation]):
     """
     Decides without a data condition group, and relies on the default `evaluate`.
 
-    Any value above zero triggers; the detector it runs on has no condition group at all.
+    Any value above zero triggers.
     """
 
     def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> int:
@@ -225,13 +169,6 @@ class MockTaintedDetectorHandler(MockDetectorHandler):
             ),
             DetectorPriorityLevel.HIGH,
         )
-
-
-class MockFingerprintedDetectorHandler(MockDetectorHandler):
-    """Replaces the fingerprint the default `evaluate` would build."""
-
-    def get_issue_fingerprint(self) -> list[str]:
-        return ["mock-detector-fingerprint"]
 
 
 class MockGroupedDetectorHandler(DetectorHandler[dict[str, Any], int, CustomDetectorEvaluation]):
@@ -497,26 +434,143 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         return issue_occurrence, event_data
 
 
-class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
+class TestDetectorHandlerEvaluate(BaseGroupTypeTest):
     """
-    Covers the default stateless `evaluate` flow, with ConditionDetectorHandler supplying
-    `evaluate_extracted_value` from the detector's condition group.
+    Covers the default `evaluate` flow that DetectorHandler provides.
 
-    MockDefaultConditionDetectorHandler implements only `extract_value` and
-    `create_occurrence`, so every assertion here is about the inherited orchestration.
+    The detector under test has no `workflow_condition_group`, so everything asserted here
+    is orchestration the handler inherits rather than condition evaluation.
     """
 
     def setUp(self) -> None:
         super().setUp()
 
-        class DefaultConditionGroupType(GroupType):
+        class ConditionFreeGroupType(GroupType):
             type_id = 5
+            slug = "condition_free_handler"
+            description = "condition free handler"
+            category = GroupCategory.METRIC.value
+            detector_settings = DetectorSettings(handler=MockDetectorHandler)
+
+        self.group_type = ConditionFreeGroupType
+
+        self.detector = self.create_detector(project=self.project, type=self.group_type.slug)
+
+        self.handler = MockDetectorHandler(self.detector)
+
+    def packet(self, value: int) -> DataPacket[dict[str, Any]]:
+        return DataPacket(source_id=str(self.detector.id), packet={"value": value})
+
+    def evaluate_triggered(self) -> DetectorEvaluation:
+        result = self.handler.evaluate(self.packet(1))
+
+        assert list(result.result.keys()) == [None]
+
+        return result.result[None]
+
+    def test_evaluate__creates_occurrence_when_triggered(self) -> None:
+        result = self.handler.evaluate(self.packet(1))
+
+        assert result.tainted is False
+        assert list(result.result.keys()) == [None]
+
+        evaluation = result.result[None]
+
+        assert isinstance(evaluation.result, IssueOccurrence)
+        assert evaluation.triggered is True
+        assert evaluation.priority == DetectorPriorityLevel.HIGH
+        assert evaluation.data["group_key"] is None
+
+    def test_evaluate__carries_the_trigger_evaluation(self) -> None:
+        trigger_evaluation = self.evaluate_triggered().data["trigger_group_evaluation"]
+
+        assert isinstance(trigger_evaluation, CustomDetectorEvaluation)
+        assert trigger_evaluation.triggered is True
+        assert trigger_evaluation.data == {"value": 1}
+
+    def test_evaluate__default_fingerprint(self) -> None:
+        occurrence = self.evaluate_triggered().result
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
+
+    def test_evaluate__event_data_matches_occurrence(self) -> None:
+        evaluation = self.evaluate_triggered()
+        occurrence = evaluation.result
+        event_data = evaluation.data["event_data"]
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert event_data is not None
+        assert event_data["event_id"] == occurrence.event_id
+        assert event_data["project_id"] == self.detector.project_id
+        assert event_data["timestamp"] == occurrence.detection_time
+        assert event_data["received"] == occurrence.detection_time
+        assert event_data["environment"] is None
+        assert event_data["platform"] == "python"
+        assert event_data["tags"] == {}
+
+    def test_evaluate__produces_valid_issue_platform_payload(self) -> None:
+        evaluation = self.evaluate_triggered()
+        occurrence = evaluation.result
+
+        assert isinstance(occurrence, IssueOccurrence)
+
+        # Raises when the occurrence and the event data disagree on the event id.
+        payload = _prepare_occurrence_message(occurrence, evaluation.data["event_data"])
+
+        assert payload is not None
+        assert payload["event"]["event_id"] == occurrence.event_id
+
+    def test_evaluate__no_result_when_not_triggered(self) -> None:
+        result = self.handler.evaluate(self.packet(0))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+    def test_evaluate__no_result_when_undecided(self) -> None:
+        handler = MockUndecidedDetectorHandler(self.detector)
+
+        result = handler.evaluate(self.packet(1))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+    def test_evaluate__no_result_for_grouped_values(self) -> None:
+        handler = MockGroupedDetectorHandler(self.detector)
+
+        result = handler.evaluate(self.packet(1))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+    def test_evaluate__propagates_taint(self) -> None:
+        handler = MockTaintedDetectorHandler(self.detector)
+
+        result = handler.evaluate(self.packet(1))
+
+        assert result.tainted is True
+        assert result.result[None].priority == DetectorPriorityLevel.HIGH
+
+
+class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
+    """
+    Covers what ConditionDetectorHandler adds to the default `evaluate` flow: reaching the
+    decision from the detector's DataConditionGroup.
+
+    The orchestration around that decision is covered by TestDetectorHandlerEvaluate.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        class ConditionGroupType(GroupType):
+            type_id = 6
             slug = "default_condition_handler"
             description = "default condition handler"
             category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(handler=MockDefaultConditionDetectorHandler)
 
-        self.group_type = DefaultConditionGroupType
+        self.group_type = ConditionGroupType
 
         self.detector = self.create_detector_with_condition(
             comparison=5,
@@ -525,11 +579,7 @@ class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
 
         self.handler = MockDefaultConditionDetectorHandler(self.detector)
 
-    def create_detector_with_condition(
-        self,
-        comparison: int,
-        condition_result: Any,
-    ) -> Detector:
+    def create_detector_with_condition(self, comparison: int, condition_result: Any) -> Detector:
         detector = self.create_detector(
             project=self.project,
             workflow_condition_group=self.create_data_condition_group(),
@@ -548,14 +598,7 @@ class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
     def packet(self, value: int) -> DataPacket[dict[str, Any]]:
         return DataPacket(source_id=str(self.detector.id), packet={"value": value})
 
-    def evaluate_triggered(self, value: int = 10) -> DetectorEvaluation:
-        result = self.handler.evaluate(self.packet(value))
-
-        assert list(result.result.keys()) == [None]
-
-        return result.result[None]
-
-    def test_evaluate__creates_occurrence_when_triggered(self) -> None:
+    def test_evaluate__creates_occurrence_when_condition_triggers(self) -> None:
         result = self.handler.evaluate(self.packet(10))
 
         assert result.tainted is False
@@ -567,7 +610,7 @@ class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
         assert evaluation.triggered is True
         assert evaluation.priority == DetectorPriorityLevel.HIGH
 
-    def test_evaluate__no_result_when_not_triggered(self) -> None:
+    def test_evaluate__no_result_when_condition_does_not_trigger(self) -> None:
         result = self.handler.evaluate(self.packet(1))
 
         assert result.result == {}
@@ -575,6 +618,7 @@ class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
 
     def test_evaluate__no_result_without_condition_group(self) -> None:
         detector = self.create_detector(project=self.project, type=self.group_type.slug)
+
         handler = MockDefaultConditionDetectorHandler(detector)
 
         assert handler.evaluate(self.packet(10)).result == {}
@@ -587,487 +631,13 @@ class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
             condition_group=self.detector.workflow_condition_group,
         )
 
-        assert self.evaluate_triggered().priority == DetectorPriorityLevel.HIGH
+        evaluation = self.handler.evaluate(self.packet(10)).result[None]
+
+        assert evaluation.priority == DetectorPriorityLevel.HIGH
 
     def test_evaluate__no_result_when_conditions_carry_no_priority(self) -> None:
         detector = self.create_detector_with_condition(comparison=5, condition_result=True)
+
         handler = MockDefaultConditionDetectorHandler(detector)
 
         assert handler.evaluate(self.packet(10)).result == {}
-
-    def test_evaluate__group_key_is_none(self) -> None:
-        assert self.evaluate_triggered().data["group_key"] is None
-
-    def test_evaluate__default_fingerprint(self) -> None:
-        occurrence = self.evaluate_triggered().result
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
-
-    def test_evaluate__custom_fingerprint(self) -> None:
-        handler = MockFingerprintedConditionDetectorHandler(self.detector)
-
-        evaluation = handler.evaluate(self.packet(10)).result[None]
-        occurrence = evaluation.result
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert occurrence.fingerprint == ["mock-fingerprint"]
-
-    def test_evaluate__event_data_matches_occurrence(self) -> None:
-        evaluation = self.evaluate_triggered()
-        occurrence = evaluation.result
-        event_data = evaluation.data["event_data"]
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert event_data is not None
-        assert event_data["event_id"] == occurrence.event_id
-        assert event_data["project_id"] == self.detector.project_id
-        assert event_data["timestamp"] == occurrence.detection_time
-        assert event_data["received"] == occurrence.detection_time
-        assert event_data["environment"] is None
-        assert event_data["platform"] == "python"
-        assert event_data["tags"] == {}
-
-    def test_evaluate__preserves_event_id_from_create_occurrence(self) -> None:
-        handler = MockEventIdConditionDetectorHandler(self.detector)
-
-        evaluation = handler.evaluate(self.packet(10)).result[None]
-        occurrence = evaluation.result
-        event_data = evaluation.data["event_data"]
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert event_data is not None
-        assert occurrence.event_id == MockEventIdConditionDetectorHandler.event_id
-        assert event_data["event_id"] == MockEventIdConditionDetectorHandler.event_id
-
-    def test_evaluate__produces_valid_issue_platform_payload(self) -> None:
-        evaluation = self.evaluate_triggered()
-        occurrence = evaluation.result
-
-        assert isinstance(occurrence, IssueOccurrence)
-
-        # Raises when the occurrence and event data disagree on the event id.
-        payload = _prepare_occurrence_message(occurrence, evaluation.data["event_data"])
-
-        assert payload is not None
-        assert payload["event"]["event_id"] == occurrence.event_id
-
-    def test_evaluate__propagates_taint(self) -> None:
-        condition = self.detector.get_conditions()[0]
-        tainted_evaluation = DataConditionGroupEvaluation(
-            result=True,
-            triggered=True,
-            error=ConditionError(msg="condition blew up"),
-            data={
-                "condition_evaluations": [
-                    DataConditionEvaluation(
-                        result=DetectorPriorityLevel.HIGH,
-                        data=10,
-                        triggered=True,
-                        condition=condition,
-                    )
-                ],
-                "logic_type": DataConditionGroup.Type.ANY,
-            },
-        )
-
-        with mock.patch(
-            "sentry.workflow_engine.handlers.detector.base.process_data_condition_group",
-            return_value=(tainted_evaluation, []),
-        ):
-            result = self.handler.evaluate(self.packet(10))
-
-        assert result.tainted is True
-        assert result.result[None].priority == DetectorPriorityLevel.HIGH
-
-    def test_evaluate__generates_occurrence_id_when_absent(self) -> None:
-        first = self.evaluate_triggered().result
-        second = self.evaluate_triggered().result
-
-        assert isinstance(first, IssueOccurrence)
-        assert isinstance(second, IssueOccurrence)
-
-        # create_occurrence supplies no event id, so the hook mints a fresh one each time.
-        assert UUID(first.event_id) != UUID(second.event_id)
-
-    def test_evaluate__uses_occurrence_id_hook(self) -> None:
-        handler = MockOccurrenceIdConditionDetectorHandler(self.detector)
-
-        evaluation = handler.evaluate(self.packet(10)).result[None]
-        occurrence = evaluation.result
-        event_data = evaluation.data["event_data"]
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert event_data is not None
-        assert occurrence.event_id == MockOccurrenceIdConditionDetectorHandler.occurrence_id
-        assert event_data["event_id"] == MockOccurrenceIdConditionDetectorHandler.occurrence_id
-
-    def test_evaluate__warns_when_extract_value_returns_grouped_values(self) -> None:
-        handler = MockGroupedConditionDetectorHandler(self.detector)
-
-        with mock.patch("sentry.workflow_engine.handlers.detector.base.logger") as mock_logger:
-            result = handler.evaluate(self.packet(10))
-
-        assert result.result == {}
-        assert result.tainted is False
-
-        assert mock_logger.warning.call_count == 1
-        assert "override the evaluate method" in mock_logger.warning.call_args[0][0]
-
-    def test_evaluate__warns_when_slow_conditions_remain(self) -> None:
-        self.create_data_condition(
-            type=Condition.EVENT_FREQUENCY_COUNT,
-            comparison={"interval": "1d", "value": 7},
-            condition_result=DetectorPriorityLevel.HIGH,
-            condition_group=self.detector.workflow_condition_group,
-        )
-
-        with mock.patch("sentry.workflow_engine.handlers.detector.base.logger") as mock_logger:
-            result = self.handler.evaluate(self.packet(1))
-
-        assert result.result == {}
-
-        mock_logger.warning.assert_called_once_with(
-            "Slow conditions present for detector",
-            extra={
-                "detector_id": self.detector.id,
-                "condition_group_id": self.detector.workflow_condition_group_id,
-            },
-        )
-
-    def test__evaluate__returns_the_evaluation_map(self) -> None:
-        result = self.handler._evaluate(self.packet(10))
-
-        assert list(result.keys()) == [None]
-        assert isinstance(result[None].result, IssueOccurrence)
-
-
-class TestDetectorHandlerEvaluate(BaseGroupTypeTest):
-    """
-    Covers the default `evaluate` flow as it runs on DetectorHandler, which reaches its
-    decision without any DataConditionGroup.
-
-    The detector under test deliberately has no `workflow_condition_group`, so anything
-    that passes here is orchestration that never touched conditions.
-    """
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        class ConditionFreeGroupType(GroupType):
-            type_id = 6
-            slug = "condition_free_handler"
-            description = "condition free handler"
-            category = GroupCategory.METRIC.value
-            detector_settings = DetectorSettings(handler=MockDetectorHandler)
-
-        self.group_type = ConditionFreeGroupType
-
-        self.detector = self.create_detector(project=self.project, type=self.group_type.slug)
-
-        self.handler = MockDetectorHandler(self.detector)
-
-    def packet(self, value: int) -> DataPacket[dict[str, Any]]:
-        return DataPacket(source_id=str(self.detector.id), packet={"value": value})
-
-    def evaluate_triggered(self, value: int = 1) -> DetectorEvaluation:
-        result = self.handler.evaluate(self.packet(value))
-
-        assert list(result.result.keys()) == [None]
-
-        return result.result[None]
-
-    def test_detector_has_no_condition_group(self) -> None:
-        assert self.detector.workflow_condition_group is None
-        assert not hasattr(self.handler, "condition_group")
-
-    def test_evaluate__creates_occurrence_when_triggered(self) -> None:
-        result = self.handler.evaluate(self.packet(1))
-
-        assert result.tainted is False
-        assert list(result.result.keys()) == [None]
-
-        evaluation = result.result[None]
-
-        assert isinstance(evaluation.result, IssueOccurrence)
-        assert evaluation.triggered is True
-        assert evaluation.priority == DetectorPriorityLevel.HIGH
-
-    def test_evaluate__no_result_when_not_triggered(self) -> None:
-        result = self.handler.evaluate(self.packet(0))
-
-        assert result.result == {}
-        assert result.tainted is False
-
-    def test_evaluate__no_result_when_undecided(self) -> None:
-        handler = MockUndecidedDetectorHandler(self.detector)
-
-        result = handler.evaluate(self.packet(1))
-
-        assert result.result == {}
-        assert result.tainted is False
-
-    def test_evaluate__group_key_is_none(self) -> None:
-        assert self.evaluate_triggered().data["group_key"] is None
-
-    def test_evaluate__carries_the_trigger_evaluation(self) -> None:
-        trigger_evaluation = self.evaluate_triggered().data["trigger_group_evaluation"]
-
-        assert isinstance(trigger_evaluation, CustomDetectorEvaluation)
-        assert trigger_evaluation.result is True
-        assert trigger_evaluation.data == {"value": 1}
-
-    def test_evaluate__trigger_evaluation_is_loggable(self) -> None:
-        artifact = self.evaluate_triggered().to_artifact()
-
-        assert artifact.trigger_evaluation == CustomDetectorEvaluationArtifact(
-            triggered=True,
-            error=None,
-            result=True,
-            data={"value": 1},
-        )
-
-    def test_evaluate__default_fingerprint(self) -> None:
-        occurrence = self.evaluate_triggered().result
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
-
-    def test_evaluate__custom_fingerprint(self) -> None:
-        handler = MockFingerprintedDetectorHandler(self.detector)
-
-        occurrence = handler.evaluate(self.packet(1)).result[None].result
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert occurrence.fingerprint == ["mock-detector-fingerprint"]
-
-    def test_evaluate__event_data_matches_occurrence(self) -> None:
-        evaluation = self.evaluate_triggered()
-        occurrence = evaluation.result
-        event_data = evaluation.data["event_data"]
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert event_data is not None
-        assert event_data["event_id"] == occurrence.event_id
-        assert event_data["project_id"] == self.detector.project_id
-        assert event_data["timestamp"] == occurrence.detection_time
-        assert event_data["received"] == occurrence.detection_time
-        assert event_data["environment"] is None
-        assert event_data["platform"] == "python"
-        assert event_data["tags"] == {}
-
-    def test_evaluate__produces_valid_issue_platform_payload(self) -> None:
-        evaluation = self.evaluate_triggered()
-        occurrence = evaluation.result
-
-        assert isinstance(occurrence, IssueOccurrence)
-
-        # Raises when the occurrence and event data disagree on the event id.
-        payload = _prepare_occurrence_message(occurrence, evaluation.data["event_data"])
-
-        assert payload is not None
-        assert payload["event"]["event_id"] == occurrence.event_id
-
-    def test_evaluate__generates_occurrence_id_when_absent(self) -> None:
-        first = self.evaluate_triggered().result
-        second = self.evaluate_triggered().result
-
-        assert isinstance(first, IssueOccurrence)
-        assert isinstance(second, IssueOccurrence)
-
-        assert UUID(first.event_id) != UUID(second.event_id)
-
-    def test_evaluate__propagates_taint(self) -> None:
-        handler = MockTaintedDetectorHandler(self.detector)
-
-        result = handler.evaluate(self.packet(1))
-
-        assert result.tainted is True
-        assert result.result[None].priority == DetectorPriorityLevel.HIGH
-
-    def test_evaluate__warns_when_extract_value_returns_grouped_values(self) -> None:
-        handler = MockGroupedDetectorHandler(self.detector)
-
-        with mock.patch("sentry.workflow_engine.handlers.detector.base.logger") as mock_logger:
-            result = handler.evaluate(self.packet(1))
-
-        assert result.result == {}
-        assert result.tainted is False
-
-        assert mock_logger.warning.call_count == 1
-        assert "override the evaluate method" in mock_logger.warning.call_args[0][0]
-
-    def test__evaluate__returns_the_evaluation_map(self) -> None:
-        result = self.handler._evaluate(self.packet(1))
-
-        assert list(result.keys()) == [None]
-        assert isinstance(result[None].result, IssueOccurrence)
-
-    def test__evaluate__records_the_evaluation_metric(self) -> None:
-        with mock.patch("sentry.workflow_engine.handlers.detector.base.metrics.incr") as mock_incr:
-            self.handler._evaluate(self.packet(1))
-
-        mock_incr.assert_called_once_with(
-            "workflow_engine_detector.evaluation",
-            tags={"detector_type": self.group_type.slug, "result": "success"},
-            sample_rate=1.0,
-        )
-
-    def test__evaluate__records_a_failure_metric(self) -> None:
-        with mock.patch.object(
-            MockDetectorHandler, "extract_value", side_effect=ValueError("boom")
-        ):
-            with mock.patch(
-                "sentry.workflow_engine.handlers.detector.base.metrics.incr"
-            ) as mock_incr:
-                with pytest.raises(ValueError):
-                    self.handler._evaluate(self.packet(1))
-
-        assert mock_incr.call_args.kwargs["tags"]["result"] == "failure"
-
-    def test_handler_resolves_from_the_group_type_registry(self) -> None:
-        assert isinstance(self.detector.detector_handler, MockDetectorHandler)
-
-
-class MockIntDetectorHandler(DetectorHandler[int, int, CustomDetectorEvaluation]):
-    """
-    Triggers on any data packet carrying an integer above the threshold.
-
-    The threshold lives on the handler rather than in a DataConditionGroup, so this
-    detector reaches its decision without touching the database.
-    """
-
-    threshold = 10
-
-    def extract_value(self, data_packet: DataPacket[int]) -> int:
-        return data_packet.packet
-
-    def evaluate_extracted_value(
-        self, extracted_value: int
-    ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
-        priority = (
-            DetectorPriorityLevel.HIGH
-            if extracted_value > self.threshold
-            else DetectorPriorityLevel.OK
-        )
-
-        return (
-            CustomDetectorEvaluation(
-                result=priority != DetectorPriorityLevel.OK,
-                data={"value": extracted_value, "threshold": self.threshold},
-                triggered=priority != DetectorPriorityLevel.OK,
-            ),
-            priority,
-        )
-
-    def create_occurrence(
-        self,
-        evaluation: CustomDetectorEvaluation,
-        data_packet: DataPacket[int],
-        priority: DetectorPriorityLevel,
-    ) -> tuple[DetectorOccurrence, EventData]:
-        assert self.detector.group_type is not None
-
-        return (
-            DetectorOccurrence(
-                issue_title="Value above threshold",
-                subtitle=f"{evaluation.data['value']} is above {evaluation.data['threshold']}",
-                type=self.detector.group_type,
-                level="error",
-                culprit="",
-            ),
-            {},
-        )
-
-
-class TestMockIntDetectorHandler(BaseGroupTypeTest):
-    """
-    End to end proof that a condition-free DetectorHandler works: a detector with no
-    condition group, driven by integer data packets, reaching the issue platform.
-    """
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        class IntThresholdGroupType(GroupType):
-            type_id = 7
-            slug = "int_threshold"
-            description = "int threshold"
-            category = GroupCategory.METRIC.value
-            detector_settings = DetectorSettings(handler=MockIntDetectorHandler)
-
-        self.group_type = IntThresholdGroupType
-
-        self.detector = self.create_detector(project=self.project, type=self.group_type.slug)
-
-        self.handler = MockIntDetectorHandler(self.detector)
-
-    def packet(self, value: int) -> DataPacket[int]:
-        return DataPacket(source_id=str(self.detector.id), packet=value)
-
-    def test_evaluate__triggers_above_the_threshold(self) -> None:
-        result = self.handler.evaluate(self.packet(11))
-
-        evaluation = result.result[None]
-
-        assert isinstance(evaluation.result, IssueOccurrence)
-        assert evaluation.triggered is True
-        assert evaluation.priority == DetectorPriorityLevel.HIGH
-
-    def test_evaluate__does_nothing_at_the_threshold(self) -> None:
-        assert self.handler.evaluate(self.packet(10)).result == {}
-
-    def test_evaluate__does_nothing_below_the_threshold(self) -> None:
-        assert self.handler.evaluate(self.packet(0)).result == {}
-
-    def test_evaluate__does_nothing_for_negative_values(self) -> None:
-        assert self.handler.evaluate(self.packet(-100)).result == {}
-
-    def test_evaluate__occurrence_describes_the_value(self) -> None:
-        occurrence = self.handler.evaluate(self.packet(42)).result[None].result
-
-        assert isinstance(occurrence, IssueOccurrence)
-        assert occurrence.issue_title == "Value above threshold"
-        assert occurrence.subtitle == "42 is above 10"
-        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
-
-    def test_evaluate__records_the_decision_for_logging(self) -> None:
-        evaluation = self.handler.evaluate(self.packet(42)).result[None]
-
-        assert evaluation.to_artifact().trigger_evaluation == CustomDetectorEvaluationArtifact(
-            triggered=True,
-            error=None,
-            result=True,
-            data={"value": 42, "threshold": 10},
-        )
-
-    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
-    def test_process_detectors__sends_the_occurrence_to_the_issue_platform(
-        self, mock_produce_occurrence_to_kafka: mock.MagicMock
-    ) -> None:
-        results = process_detectors(self.packet(11), [self.detector])
-
-        assert len(results) == 1
-
-        detector, evaluations = results[0]
-
-        assert detector == self.detector
-
-        occurrence = evaluations[None].result
-
-        assert isinstance(occurrence, IssueOccurrence)
-
-        mock_produce_occurrence_to_kafka.assert_called_once_with(
-            payload_type=PayloadType.OCCURRENCE,
-            occurrence=occurrence,
-            status_change=None,
-            event_data=evaluations[None].data["event_data"],
-        )
-
-    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
-    def test_process_detectors__sends_nothing_below_the_threshold(
-        self, mock_produce_occurrence_to_kafka: mock.MagicMock
-    ) -> None:
-        assert process_detectors(self.packet(3), [self.detector]) == []
-
-        assert mock_produce_occurrence_to_kafka.call_count == 0

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -184,7 +184,7 @@ class MockDetectorHandler(DetectorHandler[dict[str, Any], int, CustomDetectorEva
 
         return (
             CustomDetectorEvaluation(
-                result=priority,
+                result=priority != DetectorPriorityLevel.OK,
                 data={"value": extracted_value},
                 triggered=priority != DetectorPriorityLevel.OK,
             ),
@@ -218,7 +218,7 @@ class MockTaintedDetectorHandler(MockDetectorHandler):
     ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
         return (
             CustomDetectorEvaluation(
-                result=DetectorPriorityLevel.HIGH,
+                result=True,
                 data={"value": extracted_value},
                 triggered=True,
                 error=ConditionError(msg="decision blew up"),
@@ -814,7 +814,7 @@ class TestDetectorHandlerEvaluate(BaseGroupTypeTest):
         trigger_evaluation = self.evaluate_triggered().data["trigger_group_evaluation"]
 
         assert isinstance(trigger_evaluation, CustomDetectorEvaluation)
-        assert trigger_evaluation.result == DetectorPriorityLevel.HIGH
+        assert trigger_evaluation.result is True
         assert trigger_evaluation.data == {"value": 1}
 
     def test_evaluate__trigger_evaluation_is_loggable(self) -> None:
@@ -823,7 +823,7 @@ class TestDetectorHandlerEvaluate(BaseGroupTypeTest):
         assert artifact.trigger_evaluation == CustomDetectorEvaluationArtifact(
             triggered=True,
             error=None,
-            result=DetectorPriorityLevel.HIGH.value,
+            result=True,
             data={"value": 1},
         )
 
@@ -953,7 +953,7 @@ class MockIntDetectorHandler(DetectorHandler[int, int, CustomDetectorEvaluation]
 
         return (
             CustomDetectorEvaluation(
-                result=priority,
+                result=priority != DetectorPriorityLevel.OK,
                 data={"value": extracted_value, "threshold": self.threshold},
                 triggered=priority != DetectorPriorityLevel.OK,
             ),
@@ -1037,7 +1037,7 @@ class TestMockIntDetectorHandler(BaseGroupTypeTest):
         assert evaluation.to_artifact().trigger_evaluation == CustomDetectorEvaluationArtifact(
             triggered=True,
             error=None,
-            result=DetectorPriorityLevel.HIGH.value,
+            result=True,
             data={"value": 42, "threshold": 10},
         )
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -1,8 +1,12 @@
 from typing import Any
 from unittest import mock
+from uuid import UUID
+
+import pytest
 
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.issues.producer import PayloadType, _prepare_occurrence_message
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.testutils.abstract import Abstract
 from sentry.types.group import PriorityLevel
@@ -10,16 +14,26 @@ from sentry.workflow_engine.handlers.detector import (
     BaseDetectorHandler,
     ConditionDetectorHandler,
     DataPacketEvaluationType,
+    DetectorHandler,
     DetectorOccurrence,
     GroupedDetectorEvaluationResult,
     StatefulDetectorHandler,
 )
+from sentry.workflow_engine.handlers.detector.base import EventData
 from sentry.workflow_engine.handlers.detector.stateful import DetectorCounters
-from sentry.workflow_engine.models import DataPacket, Detector
+from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
+from sentry.workflow_engine.processors import (
+    CustomDetectorEvaluation,
+    DataConditionEvaluation,
+    DataConditionGroupEvaluation,
+    DetectorEvaluation,
+)
+from sentry.workflow_engine.processors.detector import process_detectors
 from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
+from sentry.workflow_engine.processors.evaluations.detector import CustomDetectorEvaluationArtifact
 from sentry.workflow_engine.types import (
+    ConditionError,
     DetectorGroupKey,
     DetectorPriorityLevel,
     DetectorResult,
@@ -80,12 +94,164 @@ class MockDetectorStateHandler(StatefulDetectorHandler[dict[str, Any], int | Non
 
     def create_occurrence(
         self,
-        evaluation_result: DataConditionGroupEvaluation,
+        evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[dict[str, Any]],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:
         value = self.extract_value(data_packet)
         return build_mock_occurrence_and_event(self, value, PriorityLevel(priority))
+
+
+class MockDefaultConditionDetectorHandler(ConditionDetectorHandler[dict[str, Any], int]):
+    """Relies on the default `evaluate` flow; it only fills in the hooks."""
+
+    def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> int:
+        return data_packet.packet["value"]
+
+    def create_occurrence(
+        self,
+        evaluation: DataConditionGroupEvaluation,
+        data_packet: DataPacket[dict[str, Any]],
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        value = self.extract_value(data_packet)
+        return build_mock_occurrence_and_event(self, value, PriorityLevel(priority))
+
+
+class MockFingerprintedConditionDetectorHandler(MockDefaultConditionDetectorHandler):
+    """Replaces the fingerprint the default `evaluate` would build."""
+
+    def get_issue_fingerprint(self) -> list[str]:
+        return ["mock-fingerprint"]
+
+
+class MockEventIdConditionDetectorHandler(MockDefaultConditionDetectorHandler):
+    """Supplies its own event id from `create_occurrence`, as preprod size analysis does."""
+
+    event_id = "0123456789abcdef0123456789abcdef"
+
+    def create_occurrence(
+        self,
+        evaluation: DataConditionGroupEvaluation,
+        data_packet: DataPacket[dict[str, Any]],
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        detector_occurrence, event_data = super().create_occurrence(
+            evaluation, data_packet, priority
+        )
+        event_data["event_id"] = self.event_id
+        return detector_occurrence, event_data
+
+
+class MockOccurrenceIdConditionDetectorHandler(MockDefaultConditionDetectorHandler):
+    """Supplies the occurrence id through the hook rather than through event data."""
+
+    occurrence_id = "11111111111111111111111111111111"
+
+    def get_occurrence_id(self, event_data: EventData) -> str:
+        return self.occurrence_id
+
+
+class MockGroupedConditionDetectorHandler(ConditionDetectorHandler[dict[str, Any], int]):
+    """Returns grouped values, which the default `evaluate` does not support."""
+
+    def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> dict[DetectorGroupKey, int]:
+        return {"group-one": data_packet.packet["value"]}
+
+    def create_occurrence(
+        self,
+        evaluation: DataConditionGroupEvaluation,
+        data_packet: DataPacket[dict[str, Any]],
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        raise AssertionError("grouped values must bail before create_occurrence")
+
+
+class MockDetectorHandler(DetectorHandler[dict[str, Any], int, CustomDetectorEvaluation]):
+    """
+    Decides without a data condition group, and relies on the default `evaluate`.
+
+    Any value above zero triggers; the detector it runs on has no condition group at all.
+    """
+
+    def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> int:
+        return data_packet.packet["value"]
+
+    def evaluate_extracted_value(
+        self, extracted_value: int
+    ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
+        priority = DetectorPriorityLevel.HIGH if extracted_value > 0 else DetectorPriorityLevel.OK
+
+        return (
+            CustomDetectorEvaluation(
+                result=priority,
+                data={"value": extracted_value},
+                triggered=priority != DetectorPriorityLevel.OK,
+            ),
+            priority,
+        )
+
+    def create_occurrence(
+        self,
+        evaluation: CustomDetectorEvaluation,
+        data_packet: DataPacket[dict[str, Any]],
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        value = self.extract_value(data_packet)
+        return build_mock_occurrence_and_event(self, value, PriorityLevel(priority))
+
+
+class MockUndecidedDetectorHandler(MockDetectorHandler):
+    """Reaches no decision at all, the way a misconfigured detector would."""
+
+    def evaluate_extracted_value(
+        self, extracted_value: int
+    ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
+        return None, DetectorPriorityLevel.OK
+
+
+class MockTaintedDetectorHandler(MockDetectorHandler):
+    """Triggers, but carries an error that should taint the result."""
+
+    def evaluate_extracted_value(
+        self, extracted_value: int
+    ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
+        return (
+            CustomDetectorEvaluation(
+                result=DetectorPriorityLevel.HIGH,
+                data={"value": extracted_value},
+                triggered=True,
+                error=ConditionError(msg="decision blew up"),
+            ),
+            DetectorPriorityLevel.HIGH,
+        )
+
+
+class MockFingerprintedDetectorHandler(MockDetectorHandler):
+    """Replaces the fingerprint the default `evaluate` would build."""
+
+    def get_issue_fingerprint(self) -> list[str]:
+        return ["mock-detector-fingerprint"]
+
+
+class MockGroupedDetectorHandler(DetectorHandler[dict[str, Any], int, CustomDetectorEvaluation]):
+    """Returns grouped values, which the default `evaluate` does not support."""
+
+    def extract_value(self, data_packet: DataPacket[dict[str, Any]]) -> dict[DetectorGroupKey, int]:
+        return {"group-one": data_packet.packet["value"]}
+
+    def evaluate_extracted_value(
+        self, extracted_value: int
+    ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
+        raise AssertionError("grouped values must bail before evaluate_extracted_value")
+
+    def create_occurrence(
+        self,
+        evaluation: CustomDetectorEvaluation,
+        data_packet: DataPacket[dict[str, Any]],
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        raise AssertionError("grouped values must bail before create_occurrence")
 
 
 class BaseDetectorHandlerTest(BaseGroupTypeTest):
@@ -134,7 +300,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
             def create_occurrence(
                 self,
-                evaluation_result: DataConditionGroupEvaluation,
+                evaluation: DataConditionGroupEvaluation,
                 data_packet: DataPacket[dict[str, Any]],
                 priority: DetectorPriorityLevel,
             ) -> tuple[DetectorOccurrence, dict[str, Any]]:
@@ -170,7 +336,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
             def create_occurrence(
                 self,
-                evaluation_result: DataConditionGroupEvaluation,
+                evaluation: DataConditionGroupEvaluation,
                 data_packet: DataPacket[dict[str, Any]],
                 priority: DetectorPriorityLevel,
             ) -> tuple[DetectorOccurrence, dict[str, Any]]:
@@ -329,3 +495,579 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         event_data.setdefault("received", issue_occurrence.detection_time)
         event_data.setdefault("tags", {})
         return issue_occurrence, event_data
+
+
+class TestConditionDetectorHandlerEvaluate(BaseGroupTypeTest):
+    """
+    Covers the default stateless `evaluate` flow, with ConditionDetectorHandler supplying
+    `evaluate_extracted_value` from the detector's condition group.
+
+    MockDefaultConditionDetectorHandler implements only `extract_value` and
+    `create_occurrence`, so every assertion here is about the inherited orchestration.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        class DefaultConditionGroupType(GroupType):
+            type_id = 5
+            slug = "default_condition_handler"
+            description = "default condition handler"
+            category = GroupCategory.METRIC.value
+            detector_settings = DetectorSettings(handler=MockDefaultConditionDetectorHandler)
+
+        self.group_type = DefaultConditionGroupType
+
+        self.detector = self.create_detector_with_condition(
+            comparison=5,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+        self.handler = MockDefaultConditionDetectorHandler(self.detector)
+
+    def create_detector_with_condition(
+        self,
+        comparison: int,
+        condition_result: Any,
+    ) -> Detector:
+        detector = self.create_detector(
+            project=self.project,
+            workflow_condition_group=self.create_data_condition_group(),
+            type=self.group_type.slug,
+        )
+
+        self.create_data_condition(
+            type=Condition.GREATER,
+            comparison=comparison,
+            condition_result=condition_result,
+            condition_group=detector.workflow_condition_group,
+        )
+
+        return detector
+
+    def packet(self, value: int) -> DataPacket[dict[str, Any]]:
+        return DataPacket(source_id=str(self.detector.id), packet={"value": value})
+
+    def evaluate_triggered(self, value: int = 10) -> DetectorEvaluation:
+        result = self.handler.evaluate(self.packet(value))
+
+        assert list(result.result.keys()) == [None]
+
+        return result.result[None]
+
+    def test_evaluate__creates_occurrence_when_triggered(self) -> None:
+        result = self.handler.evaluate(self.packet(10))
+
+        assert result.tainted is False
+        assert list(result.result.keys()) == [None]
+
+        evaluation = result.result[None]
+
+        assert isinstance(evaluation.result, IssueOccurrence)
+        assert evaluation.triggered is True
+        assert evaluation.priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate__no_result_when_not_triggered(self) -> None:
+        result = self.handler.evaluate(self.packet(1))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+    def test_evaluate__no_result_without_condition_group(self) -> None:
+        detector = self.create_detector(project=self.project, type=self.group_type.slug)
+        handler = MockDefaultConditionDetectorHandler(detector)
+
+        assert handler.evaluate(self.packet(10)).result == {}
+
+    def test_evaluate__uses_highest_triggered_priority(self) -> None:
+        self.create_data_condition(
+            type=Condition.GREATER,
+            comparison=1,
+            condition_result=DetectorPriorityLevel.LOW,
+            condition_group=self.detector.workflow_condition_group,
+        )
+
+        assert self.evaluate_triggered().priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate__no_result_when_conditions_carry_no_priority(self) -> None:
+        detector = self.create_detector_with_condition(comparison=5, condition_result=True)
+        handler = MockDefaultConditionDetectorHandler(detector)
+
+        assert handler.evaluate(self.packet(10)).result == {}
+
+    def test_evaluate__group_key_is_none(self) -> None:
+        assert self.evaluate_triggered().data["group_key"] is None
+
+    def test_evaluate__default_fingerprint(self) -> None:
+        occurrence = self.evaluate_triggered().result
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
+
+    def test_evaluate__custom_fingerprint(self) -> None:
+        handler = MockFingerprintedConditionDetectorHandler(self.detector)
+
+        evaluation = handler.evaluate(self.packet(10)).result[None]
+        occurrence = evaluation.result
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert occurrence.fingerprint == ["mock-fingerprint"]
+
+    def test_evaluate__event_data_matches_occurrence(self) -> None:
+        evaluation = self.evaluate_triggered()
+        occurrence = evaluation.result
+        event_data = evaluation.data["event_data"]
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert event_data is not None
+        assert event_data["event_id"] == occurrence.event_id
+        assert event_data["project_id"] == self.detector.project_id
+        assert event_data["timestamp"] == occurrence.detection_time
+        assert event_data["received"] == occurrence.detection_time
+        assert event_data["environment"] is None
+        assert event_data["platform"] == "python"
+        assert event_data["tags"] == {}
+
+    def test_evaluate__preserves_event_id_from_create_occurrence(self) -> None:
+        handler = MockEventIdConditionDetectorHandler(self.detector)
+
+        evaluation = handler.evaluate(self.packet(10)).result[None]
+        occurrence = evaluation.result
+        event_data = evaluation.data["event_data"]
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert event_data is not None
+        assert occurrence.event_id == MockEventIdConditionDetectorHandler.event_id
+        assert event_data["event_id"] == MockEventIdConditionDetectorHandler.event_id
+
+    def test_evaluate__produces_valid_issue_platform_payload(self) -> None:
+        evaluation = self.evaluate_triggered()
+        occurrence = evaluation.result
+
+        assert isinstance(occurrence, IssueOccurrence)
+
+        # Raises when the occurrence and event data disagree on the event id.
+        payload = _prepare_occurrence_message(occurrence, evaluation.data["event_data"])
+
+        assert payload is not None
+        assert payload["event"]["event_id"] == occurrence.event_id
+
+    def test_evaluate__propagates_taint(self) -> None:
+        condition = self.detector.get_conditions()[0]
+        tainted_evaluation = DataConditionGroupEvaluation(
+            result=True,
+            triggered=True,
+            error=ConditionError(msg="condition blew up"),
+            data={
+                "condition_evaluations": [
+                    DataConditionEvaluation(
+                        result=DetectorPriorityLevel.HIGH,
+                        data=10,
+                        triggered=True,
+                        condition=condition,
+                    )
+                ],
+                "logic_type": DataConditionGroup.Type.ANY,
+            },
+        )
+
+        with mock.patch(
+            "sentry.workflow_engine.handlers.detector.base.process_data_condition_group",
+            return_value=(tainted_evaluation, []),
+        ):
+            result = self.handler.evaluate(self.packet(10))
+
+        assert result.tainted is True
+        assert result.result[None].priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate__generates_occurrence_id_when_absent(self) -> None:
+        first = self.evaluate_triggered().result
+        second = self.evaluate_triggered().result
+
+        assert isinstance(first, IssueOccurrence)
+        assert isinstance(second, IssueOccurrence)
+
+        # create_occurrence supplies no event id, so the hook mints a fresh one each time.
+        assert UUID(first.event_id) != UUID(second.event_id)
+
+    def test_evaluate__uses_occurrence_id_hook(self) -> None:
+        handler = MockOccurrenceIdConditionDetectorHandler(self.detector)
+
+        evaluation = handler.evaluate(self.packet(10)).result[None]
+        occurrence = evaluation.result
+        event_data = evaluation.data["event_data"]
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert event_data is not None
+        assert occurrence.event_id == MockOccurrenceIdConditionDetectorHandler.occurrence_id
+        assert event_data["event_id"] == MockOccurrenceIdConditionDetectorHandler.occurrence_id
+
+    def test_evaluate__warns_when_extract_value_returns_grouped_values(self) -> None:
+        handler = MockGroupedConditionDetectorHandler(self.detector)
+
+        with mock.patch("sentry.workflow_engine.handlers.detector.base.logger") as mock_logger:
+            result = handler.evaluate(self.packet(10))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+        assert mock_logger.warning.call_count == 1
+        assert "override the evaluate method" in mock_logger.warning.call_args[0][0]
+
+    def test_evaluate__warns_when_slow_conditions_remain(self) -> None:
+        self.create_data_condition(
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1d", "value": 7},
+            condition_result=DetectorPriorityLevel.HIGH,
+            condition_group=self.detector.workflow_condition_group,
+        )
+
+        with mock.patch("sentry.workflow_engine.handlers.detector.base.logger") as mock_logger:
+            result = self.handler.evaluate(self.packet(1))
+
+        assert result.result == {}
+
+        mock_logger.warning.assert_called_once_with(
+            "Slow conditions present for detector",
+            extra={
+                "detector_id": self.detector.id,
+                "condition_group_id": self.detector.workflow_condition_group_id,
+            },
+        )
+
+    def test__evaluate__returns_the_evaluation_map(self) -> None:
+        result = self.handler._evaluate(self.packet(10))
+
+        assert list(result.keys()) == [None]
+        assert isinstance(result[None].result, IssueOccurrence)
+
+
+class TestDetectorHandlerEvaluate(BaseGroupTypeTest):
+    """
+    Covers the default `evaluate` flow as it runs on DetectorHandler, which reaches its
+    decision without any DataConditionGroup.
+
+    The detector under test deliberately has no `workflow_condition_group`, so anything
+    that passes here is orchestration that never touched conditions.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        class ConditionFreeGroupType(GroupType):
+            type_id = 6
+            slug = "condition_free_handler"
+            description = "condition free handler"
+            category = GroupCategory.METRIC.value
+            detector_settings = DetectorSettings(handler=MockDetectorHandler)
+
+        self.group_type = ConditionFreeGroupType
+
+        self.detector = self.create_detector(project=self.project, type=self.group_type.slug)
+
+        self.handler = MockDetectorHandler(self.detector)
+
+    def packet(self, value: int) -> DataPacket[dict[str, Any]]:
+        return DataPacket(source_id=str(self.detector.id), packet={"value": value})
+
+    def evaluate_triggered(self, value: int = 1) -> DetectorEvaluation:
+        result = self.handler.evaluate(self.packet(value))
+
+        assert list(result.result.keys()) == [None]
+
+        return result.result[None]
+
+    def test_detector_has_no_condition_group(self) -> None:
+        assert self.detector.workflow_condition_group is None
+        assert not hasattr(self.handler, "condition_group")
+
+    def test_evaluate__creates_occurrence_when_triggered(self) -> None:
+        result = self.handler.evaluate(self.packet(1))
+
+        assert result.tainted is False
+        assert list(result.result.keys()) == [None]
+
+        evaluation = result.result[None]
+
+        assert isinstance(evaluation.result, IssueOccurrence)
+        assert evaluation.triggered is True
+        assert evaluation.priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate__no_result_when_not_triggered(self) -> None:
+        result = self.handler.evaluate(self.packet(0))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+    def test_evaluate__no_result_when_undecided(self) -> None:
+        handler = MockUndecidedDetectorHandler(self.detector)
+
+        result = handler.evaluate(self.packet(1))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+    def test_evaluate__group_key_is_none(self) -> None:
+        assert self.evaluate_triggered().data["group_key"] is None
+
+    def test_evaluate__carries_the_trigger_evaluation(self) -> None:
+        trigger_evaluation = self.evaluate_triggered().data["trigger_group_evaluation"]
+
+        assert isinstance(trigger_evaluation, CustomDetectorEvaluation)
+        assert trigger_evaluation.result == DetectorPriorityLevel.HIGH
+        assert trigger_evaluation.data == {"value": 1}
+
+    def test_evaluate__trigger_evaluation_is_loggable(self) -> None:
+        artifact = self.evaluate_triggered().to_artifact()
+
+        assert artifact.trigger_evaluation == CustomDetectorEvaluationArtifact(
+            triggered=True,
+            error=None,
+            result=DetectorPriorityLevel.HIGH.value,
+            data={"value": 1},
+        )
+
+    def test_evaluate__default_fingerprint(self) -> None:
+        occurrence = self.evaluate_triggered().result
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
+
+    def test_evaluate__custom_fingerprint(self) -> None:
+        handler = MockFingerprintedDetectorHandler(self.detector)
+
+        occurrence = handler.evaluate(self.packet(1)).result[None].result
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert occurrence.fingerprint == ["mock-detector-fingerprint"]
+
+    def test_evaluate__event_data_matches_occurrence(self) -> None:
+        evaluation = self.evaluate_triggered()
+        occurrence = evaluation.result
+        event_data = evaluation.data["event_data"]
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert event_data is not None
+        assert event_data["event_id"] == occurrence.event_id
+        assert event_data["project_id"] == self.detector.project_id
+        assert event_data["timestamp"] == occurrence.detection_time
+        assert event_data["received"] == occurrence.detection_time
+        assert event_data["environment"] is None
+        assert event_data["platform"] == "python"
+        assert event_data["tags"] == {}
+
+    def test_evaluate__produces_valid_issue_platform_payload(self) -> None:
+        evaluation = self.evaluate_triggered()
+        occurrence = evaluation.result
+
+        assert isinstance(occurrence, IssueOccurrence)
+
+        # Raises when the occurrence and event data disagree on the event id.
+        payload = _prepare_occurrence_message(occurrence, evaluation.data["event_data"])
+
+        assert payload is not None
+        assert payload["event"]["event_id"] == occurrence.event_id
+
+    def test_evaluate__generates_occurrence_id_when_absent(self) -> None:
+        first = self.evaluate_triggered().result
+        second = self.evaluate_triggered().result
+
+        assert isinstance(first, IssueOccurrence)
+        assert isinstance(second, IssueOccurrence)
+
+        assert UUID(first.event_id) != UUID(second.event_id)
+
+    def test_evaluate__propagates_taint(self) -> None:
+        handler = MockTaintedDetectorHandler(self.detector)
+
+        result = handler.evaluate(self.packet(1))
+
+        assert result.tainted is True
+        assert result.result[None].priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate__warns_when_extract_value_returns_grouped_values(self) -> None:
+        handler = MockGroupedDetectorHandler(self.detector)
+
+        with mock.patch("sentry.workflow_engine.handlers.detector.base.logger") as mock_logger:
+            result = handler.evaluate(self.packet(1))
+
+        assert result.result == {}
+        assert result.tainted is False
+
+        assert mock_logger.warning.call_count == 1
+        assert "override the evaluate method" in mock_logger.warning.call_args[0][0]
+
+    def test__evaluate__returns_the_evaluation_map(self) -> None:
+        result = self.handler._evaluate(self.packet(1))
+
+        assert list(result.keys()) == [None]
+        assert isinstance(result[None].result, IssueOccurrence)
+
+    def test__evaluate__records_the_evaluation_metric(self) -> None:
+        with mock.patch("sentry.workflow_engine.handlers.detector.base.metrics.incr") as mock_incr:
+            self.handler._evaluate(self.packet(1))
+
+        mock_incr.assert_called_once_with(
+            "workflow_engine_detector.evaluation",
+            tags={"detector_type": self.group_type.slug, "result": "success"},
+            sample_rate=1.0,
+        )
+
+    def test__evaluate__records_a_failure_metric(self) -> None:
+        with mock.patch.object(
+            MockDetectorHandler, "extract_value", side_effect=ValueError("boom")
+        ):
+            with mock.patch(
+                "sentry.workflow_engine.handlers.detector.base.metrics.incr"
+            ) as mock_incr:
+                with pytest.raises(ValueError):
+                    self.handler._evaluate(self.packet(1))
+
+        assert mock_incr.call_args.kwargs["tags"]["result"] == "failure"
+
+    def test_handler_resolves_from_the_group_type_registry(self) -> None:
+        assert isinstance(self.detector.detector_handler, MockDetectorHandler)
+
+
+class MockIntDetectorHandler(DetectorHandler[int, int, CustomDetectorEvaluation]):
+    """
+    Triggers on any data packet carrying an integer above the threshold.
+
+    The threshold lives on the handler rather than in a DataConditionGroup, so this
+    detector reaches its decision without touching the database.
+    """
+
+    threshold = 10
+
+    def extract_value(self, data_packet: DataPacket[int]) -> int:
+        return data_packet.packet
+
+    def evaluate_extracted_value(
+        self, extracted_value: int
+    ) -> tuple[CustomDetectorEvaluation | None, DetectorPriorityLevel]:
+        priority = (
+            DetectorPriorityLevel.HIGH
+            if extracted_value > self.threshold
+            else DetectorPriorityLevel.OK
+        )
+
+        return (
+            CustomDetectorEvaluation(
+                result=priority,
+                data={"value": extracted_value, "threshold": self.threshold},
+                triggered=priority != DetectorPriorityLevel.OK,
+            ),
+            priority,
+        )
+
+    def create_occurrence(
+        self,
+        evaluation: CustomDetectorEvaluation,
+        data_packet: DataPacket[int],
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, EventData]:
+        assert self.detector.group_type is not None
+
+        return (
+            DetectorOccurrence(
+                issue_title="Value above threshold",
+                subtitle=f"{evaluation.data['value']} is above {evaluation.data['threshold']}",
+                type=self.detector.group_type,
+                level="error",
+                culprit="",
+            ),
+            {},
+        )
+
+
+class TestMockIntDetectorHandler(BaseGroupTypeTest):
+    """
+    End to end proof that a condition-free DetectorHandler works: a detector with no
+    condition group, driven by integer data packets, reaching the issue platform.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        class IntThresholdGroupType(GroupType):
+            type_id = 7
+            slug = "int_threshold"
+            description = "int threshold"
+            category = GroupCategory.METRIC.value
+            detector_settings = DetectorSettings(handler=MockIntDetectorHandler)
+
+        self.group_type = IntThresholdGroupType
+
+        self.detector = self.create_detector(project=self.project, type=self.group_type.slug)
+
+        self.handler = MockIntDetectorHandler(self.detector)
+
+    def packet(self, value: int) -> DataPacket[int]:
+        return DataPacket(source_id=str(self.detector.id), packet=value)
+
+    def test_evaluate__triggers_above_the_threshold(self) -> None:
+        result = self.handler.evaluate(self.packet(11))
+
+        evaluation = result.result[None]
+
+        assert isinstance(evaluation.result, IssueOccurrence)
+        assert evaluation.triggered is True
+        assert evaluation.priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate__does_nothing_at_the_threshold(self) -> None:
+        assert self.handler.evaluate(self.packet(10)).result == {}
+
+    def test_evaluate__does_nothing_below_the_threshold(self) -> None:
+        assert self.handler.evaluate(self.packet(0)).result == {}
+
+    def test_evaluate__does_nothing_for_negative_values(self) -> None:
+        assert self.handler.evaluate(self.packet(-100)).result == {}
+
+    def test_evaluate__occurrence_describes_the_value(self) -> None:
+        occurrence = self.handler.evaluate(self.packet(42)).result[None].result
+
+        assert isinstance(occurrence, IssueOccurrence)
+        assert occurrence.issue_title == "Value above threshold"
+        assert occurrence.subtitle == "42 is above 10"
+        assert occurrence.fingerprint == [f"detector:{self.detector.id}"]
+
+    def test_evaluate__records_the_decision_for_logging(self) -> None:
+        evaluation = self.handler.evaluate(self.packet(42)).result[None]
+
+        assert evaluation.to_artifact().trigger_evaluation == CustomDetectorEvaluationArtifact(
+            triggered=True,
+            error=None,
+            result=DetectorPriorityLevel.HIGH.value,
+            data={"value": 42, "threshold": 10},
+        )
+
+    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
+    def test_process_detectors__sends_the_occurrence_to_the_issue_platform(
+        self, mock_produce_occurrence_to_kafka: mock.MagicMock
+    ) -> None:
+        results = process_detectors(self.packet(11), [self.detector])
+
+        assert len(results) == 1
+
+        detector, evaluations = results[0]
+
+        assert detector == self.detector
+
+        occurrence = evaluations[None].result
+
+        assert isinstance(occurrence, IssueOccurrence)
+
+        mock_produce_occurrence_to_kafka.assert_called_once_with(
+            payload_type=PayloadType.OCCURRENCE,
+            occurrence=occurrence,
+            status_change=None,
+            event_data=evaluations[None].data["event_data"],
+        )
+
+    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
+    def test_process_detectors__sends_nothing_below_the_threshold(
+        self, mock_produce_occurrence_to_kafka: mock.MagicMock
+    ) -> None:
+        assert process_detectors(self.packet(3), [self.detector]) == []
+
+        assert mock_produce_occurrence_to_kafka.call_count == 0

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -38,7 +38,7 @@ def build_mock_group_evaluation() -> DataConditionGroupEvaluation:
 
 
 def build_mock_occurrence_and_event(
-    handler: BaseDetectorHandler[Any, Any],
+    handler: BaseDetectorHandler[Any, Any, Any],
     value: DataPacketEvaluationType,
     priority: PriorityLevel,
 ) -> tuple[DetectorOccurrence, dict[str, Any]]:


### PR DESCRIPTION
This is setup for the DetectorHandler, which does not rely on DataConditionTypes. It will make use of the fact you can now pass CustomerDetectorEvaluation