### PR TITLE
fix(preprod): Return snapshot state as enum name string

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -615,7 +615,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 "base_artifact_id": base_artifact_id,
                 "project_id": str(artifact.project_id),
                 "comparison_type": comparison_type,
-                "state": cast(str, artifact.state),
+                "state": PreprodArtifact.ArtifactState(artifact.state).name,
                 "vcs_info": cast(VcsInfoResponseDict, vcs_info.dict()),
                 "app_id": artifact.app_id,
                 "is_selective": snapshot_metrics.is_selective,

--- a/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff.json
+++ b/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff.json
@@ -176,7 +176,7 @@
     }
   ],
   "skipped_count": 1,
-  "state": 1,
+  "state": "UPLOADED",
   "unchanged": [
     {
       "canvas_theme": null,

--- a/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff_compact.json
+++ b/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_diff_compact.json
@@ -114,7 +114,7 @@
     }
   ],
   "skipped_count": 1,
-  "state": 1,
+  "state": "UPLOADED",
   "unchanged": [
     {
       "description": null,

--- a/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_solo.json
+++ b/tests/sentry/preprod/api/endpoints/snapshots_golden/snapshot_solo.json
@@ -94,7 +94,7 @@
   "renamed_count": 0,
   "skipped": [],
   "skipped_count": 0,
-  "state": 1,
+  "state": "UPLOADED",
   "unchanged": [],
   "unchanged_count": 0,
   "vcs_info": {

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -649,7 +649,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data["head_artifact_id"] == str(artifact.id)
-        assert response.data["state"] == PreprodArtifact.ArtifactState.UPLOADED
+        assert response.data["state"] == PreprodArtifact.ArtifactState.UPLOADED.name
         assert response.data["image_count"] == 2
         assert len(response.data["images"]) == 2
         # Images should be sorted by key


### PR DESCRIPTION
## Summary

Stacked on #123239. The snapshot-details GET response serialized `state` as
the raw `ArtifactState` int (e.g. `1`), even though the OpenAPI examples
(`"state": "UPLOADED"`) and the frontend `state: string` type both expect the
enum **name**. Emit `ArtifactState(artifact.state).name` instead, matching the
existing `installable_builds.py` convention and aligning runtime with the
schema.

## Blast radius

- **Frontend:** already types `state` as `string` and never branches on it
  (state-based UI reads `comparison_state`), so no frontend change is needed.
- **Examples/schema:** already string; the examples validator now agrees with
  runtime.

## Testing

- `pytest .../test_preprod_artifact_snapshot.py` (57 passed)
- `make build-api-docs && pnpm run validate-api-examples` → No errors found
- mypy + ruff clean

https://claude.ai/code/session_013SAxBGjuP4a7cxRx3WmZa4
