### PR TITLE
feat(hybridcloud): Chain a strict drain into its mailbox's next claim

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -264,6 +264,7 @@ class Dispatcher(enum.StrEnum):
 
     PUSH = "push"
     SCHEDULER = "scheduler"
+    CHAIN = "chain"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -341,10 +342,10 @@ class _MailboxClaim:
         """Whether to stop delivering and release, rather than run into the deadline mid-request."""
         return timezone.now() >= self.valid_until - RELEASE_MARGIN
 
-    def release_remainder(self, next_id: int, *, extra: Mapping[str, Any]) -> None:
+    def release_remainder(self, next_id: int, *, extra: Mapping[str, Any]) -> int:
         """
         Return the claim's unworked tail to the mailbox so the next dispatcher can
-        claim it now instead of at the deadline.
+        claim it now instead of at the deadline; returns how many rows went back.
 
         Matching the exact `schedule_for` this claim wrote is what makes the
         release safe: a record another claim took carries that claim's timestamp,
@@ -365,6 +366,7 @@ class _MailboxClaim:
                 tags={**self.delivery_tags, "outcome": "released"},
             )
         logger.info("deliver_webhook.deadline_release", extra={**extra, "released": released})
+        return released
 
     def records(self) -> list[WebhookPayload] | None:
         """
@@ -561,7 +563,7 @@ def _record_dispatch(*, dispatcher: Dispatcher, mailbox_name: str, claimed: int)
 
 
 def _claim_and_dispatch(
-    head_id: int, mailbox_name: str, *, dispatcher: Dispatcher
+    head_id: int, mailbox_name: str, *, dispatcher: Dispatcher, chain_depth: int = 1
 ) -> _MailboxClaim | None:
     """
     Claim a batch for the mailbox and dispatch its drain.
@@ -579,20 +581,14 @@ def _claim_and_dispatch(
     overlapping drain — duplicating deliveries and breaking mailbox ordering.
 
     `dispatcher` tags this dispatch and is forwarded to the drain so its
-    deliveries carry the same attribution; both callers claim identically.
+    deliveries carry the same attribution; every caller claims identically.
+    `chain_depth` is the dispatched drain's link number — an ordinary dispatch
+    starts a chain of one.
     """
     claim = _claim_mailbox_batch(head_id, mailbox_name, dispatcher=dispatcher)
     if claim is None:
         return None
-    # Only the arguments workers from the previous deploy bind: an unknown kwarg
-    # is a TypeError the taskbroker discards without retry. The drain recovers
-    # the mailbox and deadline from its head row; the full claim shape
-    # (`task_args`) starts crossing the wire one deploy later.
-    drain_mailbox.delay(
-        payload_id=claim.head_id,
-        claimed_count=claim.claimed,
-        dispatcher=claim.dispatcher,
-    )
+    drain_mailbox.delay(**claim.task_args(), chain_depth=chain_depth)
     _record_dispatch(dispatcher=dispatcher, mailbox_name=mailbox_name, claimed=claim.claimed)
     return claim
 
@@ -959,15 +955,58 @@ def drain_mailbox(
 
     The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
     each defaults so a rolling deploy can bind drains the previous version sent.
-    `chain_depth` — which link of a chain this drain is, an ordinary dispatch
-    being the first — is accepted ahead of drain chaining for the same reason.
+    `chain_depth` is which link of a chain this drain is, an ordinary dispatch
+    being the first.
     """
     claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
-    if claim is not None:
-        _drain_mailbox(claim)
+    if claim is None:
+        return
+    if _drain_mailbox(claim):
+        _maybe_chain(claim, chain_depth)
 
 
-def _drain_mailbox(claim: _MailboxClaim) -> None:
+def _maybe_chain(claim: _MailboxClaim, chain_depth: int) -> None:
+    """
+    Dispatch the mailbox's next claim directly, skipping the scheduler's
+    re-discovery gap, while this lineage is within max_chain_depth links —
+    at the option's default of 1 the ordinary dispatch is the whole chain.
+
+    Strict providers only: their absolute-head gate admits one claim at a time,
+    so a chain stays a single lineage per mailbox — a due-head provider would
+    fork a new one every scheduler cycle. The claim gate still settles
+    ownership; a concurrent dispatcher winning it continues the lineage.
+    """
+    if claim.skip_on_failure:
+        return
+    if chain_depth >= options.get("hybridcloud.webhookpayload.max_chain_depth"):
+        return
+    mailbox_name = claim.mailbox_name
+    guard = _acquire_drain_guard(mailbox_name)
+    if not guard:
+        # Held by another dispatcher, or the cache is unreachable: either way
+        # the scheduler covers the mailbox.
+        return
+    try:
+        head = (
+            WebhookPayload.objects.filter(mailbox_name=mailbox_name)
+            .order_by("id")
+            .values_list("id", "schedule_for")
+            .first()
+        )
+        if head is not None and _is_due(head[1]):
+            _claim_and_dispatch(
+                head[0], mailbox_name, dispatcher=Dispatcher.CHAIN, chain_depth=chain_depth + 1
+            )
+    except Exception:
+        # This drain's work is already delivered; failing the task here would
+        # only retry a finished drain. The scheduler picks the mailbox up.
+        logger.exception("deliver_webhook.chain_failed")
+    finally:
+        if guard:
+            _release_drain_lock(mailbox_name)
+
+
+def _drain_mailbox(claim: _MailboxClaim) -> bool:
     """
     Deliver the claimed records until a strict provider's record fails, the claim
     nears its deadline, or all of them have been processed.
@@ -976,10 +1015,14 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
     deliver on one: concurrent requests complete in arbitrary order, so a
     strict-ordering provider would be delivered out of order exactly when its
     mailbox is deep.
+
+    Returns whether the drain was healthy and left due work behind — it consumed
+    a full claim, or released a tail it had been delivering toward — the signal
+    `_maybe_chain` acts on.
     """
     records = claim.records()
     if records is None:
-        return
+        return False
     skip_on_failure = claim.skip_on_failure
     delivery_tags = claim.delivery_tags
     worker_threads = 1
@@ -1004,6 +1047,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
     walk = iter(records)
     # The first id not yet handed to the pool: where a release starts.
     frontier = claim.head_id
+    chain = False
     try:
         while True:
             extra = {**claim.log_context, "delivered": pool.delivered}
@@ -1025,10 +1069,14 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                         "deliver_webhook.release_overshoot",
                         extra={**claim.log_context, "overshoot_seconds": overshoot},
                     )
-                claim.release_remainder(
+                released = claim.release_remainder(
                     frontier if lowest_cancelled is None else lowest_cancelled,
                     extra={**claim.log_context, "delivered": pool.delivered},
                 )
+                # A drain that delivered nothing before its soft-stop spent its
+                # window in the queue — saturation, exactly when a chain would
+                # add queue load.
+                chain = released > 0 and pool.failed == 0 and pool.delivered > 0
                 break
             while pool.has_room and (record := next(walk, None)) is not None:
                 # Advance past the record before it is delivered: a delete clears
@@ -1050,6 +1098,9 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
                     )
                 else:
                     logger.debug("deliver_webhook.delivery_complete", extra=extra)
+                # A claim at the cap saw nothing but due records and stopped at
+                # the boundary, so the prefix likely continues past it.
+                chain = pool.failed == 0 and len(records) == MAX_MAILBOX_DRAIN
                 break
             if not pool.wait_one():
                 # Every request in flight has outrun REQUEST_BOUND: the cell is
@@ -1075,6 +1126,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> None:
         deleter.flush()
     if pool.unexpected is not None:
         raise pool.unexpected
+    return chain
 
 
 class _DeliveryPool:

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -368,6 +368,22 @@ class _MailboxClaim:
         logger.info("deliver_webhook.deadline_release", extra={**extra, "released": released})
         return released
 
+    def record_cap_headroom(self) -> None:
+        """
+        Record how long this claim could still have delivered for when it ran out
+        of records to deliver — the delivery time MAX_MAILBOX_DRAIN cost us.
+
+        Only meaningful for a claim that filled the cap: a claim that took fewer
+        records took every record the mailbox had due, so its leftover window
+        measures the mailbox's depth rather than the cap's.
+        """
+        headroom = (self.valid_until - RELEASE_MARGIN - timezone.now()).total_seconds()
+        metrics.incr(
+            "hybridcloud.deliver_webhooks.drain.cap_headroom_seconds",
+            amount=max(int(headroom), 0),
+            tags=self.delivery_tags,
+        )
+
     def records(self) -> list[WebhookPayload] | None:
         """
         The records this drain may deliver, or None when it must stand down: its
@@ -1101,6 +1117,8 @@ def _drain_mailbox(claim: _MailboxClaim) -> bool:
                 # A claim at the cap saw nothing but due records and stopped at
                 # the boundary, so the prefix likely continues past it.
                 chain = pool.failed == 0 and len(records) == MAX_MAILBOX_DRAIN
+                if chain:
+                    claim.record_cap_headroom()
                 break
             if not pool.wait_one():
                 # Every request in flight has outrun REQUEST_BOUND: the cell is

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2640,6 +2640,15 @@ register(
     ],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# How many chained drains a strict provider's mailbox may run per lineage,
+# counting the ordinary dispatch as the first link: at 1 a finished drain never
+# chains, and each increment lets a busy mailbox re-dispatch itself once more
+# before falling back to the scheduler.
+register(
+    "hybridcloud.webhookpayload.max_chain_depth",
+    default=1,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Dispatch skip-on-failure providers' mailboxes from their oldest due record
 # instead of gating on the absolute head, so one record in retry backoff cannot
 # hide every due record behind it. Strict-ordering providers keep the gate.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1,8 +1,8 @@
 import threading
 import time
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 import responses
@@ -133,6 +133,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook_one.id,
             claimed_count=2,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -152,6 +155,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook_one.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -194,6 +200,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=due.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
         # The backing-off record keeps its retry schedule.
         backoff_schedule = backoff.schedule_for
@@ -236,6 +245,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=due_one.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
         backoff_schedule = backoff.schedule_for
         backoff.refresh_from_db()
@@ -261,6 +273,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=expired_backoff.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @override_options(DUE_HEAD_OPTIONS)
@@ -319,6 +334,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook_one.id,
             claimed_count=2,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @responses.activate
@@ -413,6 +431,9 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             payload_id=webhook.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
         # Option reads are served from the option store's cache in production,
         # so only payload-table statements count toward the round-trip budget.
@@ -2342,6 +2363,20 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         assert len(responses.calls) == 0
         assert WebhookPayload.objects.count() == 1
 
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_dispatch_passes_the_rows_own_deadline(self, mock_drain: MagicMock) -> None:
+        # The drain must be handed the schedule_for its claim wrote, not a value
+        # recomputed from an offset that may differ between dispatcher and worker.
+        webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
+
+        schedule_webhook_delivery()
+
+        valid_until = datetime.fromtimestamp(
+            mock_drain.delay.call_args.kwargs["valid_until"], tz=UTC
+        )
+        webhook.refresh_from_db()
+        assert webhook.schedule_for == valid_until
+
     @responses.activate
     @override_cells(cell_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
@@ -2810,6 +2845,176 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
 
 
 @control_silo_test
+class ChainDispatchTest(TestCase):
+    """
+    A strict provider's drain that ends healthy with due work behind it
+    dispatches the mailbox's next claim itself, while its lineage is within
+    max_chain_depth links.
+    """
+
+    def _respond_ok(self, provider: str = "jira") -> None:
+        responses.add(
+            responses.POST,
+            f"http://us.testserver/extensions/{provider}/webhook/",
+            status=200,
+            body="",
+        )
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_chains_after_draining_a_full_claim(self, mock_drain: MagicMock) -> None:
+        self._respond_ok()
+        records = create_payloads(4, "jira:123", provider="jira")
+
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="jira:123"
+        )
+
+        assert len(responses.calls) == 3
+        kwargs = mock_drain.delay.call_args.kwargs
+        assert kwargs["payload_id"] == records[3].id
+        assert kwargs["dispatcher"] == Dispatcher.CHAIN
+        assert kwargs["chain_depth"] == 2
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_release_chains_the_tail(self, mock_drain: MagicMock) -> None:
+        self._respond_ok()
+        valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
+        records = create_payloads(3, "jira:123", provider="jira")
+        WebhookPayload.objects.filter(id__in=[r.id for r in records]).update(
+            schedule_for=valid_until
+        )
+
+        with patch.object(
+            deliver_webhooks._MailboxClaim, "nearing_deadline", side_effect=[False, True]
+        ):
+            drain_mailbox(
+                records[0].id,
+                claimed_count=3,
+                valid_until=valid_until.timestamp(),
+                mailbox="jira:123",
+            )
+
+        # One delivered, two released — the chain claims the released tail.
+        assert len(responses.calls) == 1
+        kwargs = mock_drain.delay.call_args.kwargs
+        assert kwargs["payload_id"] == records[1].id
+        assert kwargs["dispatcher"] == Dispatcher.CHAIN
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_no_chain_at_the_default_depth(self, mock_drain: MagicMock) -> None:
+        # The ordinary dispatch is the first link, so the default of 1 means a
+        # finished drain never chains.
+        self._respond_ok()
+        records = create_payloads(4, "jira:123", provider="jira")
+
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="jira:123"
+        )
+
+        assert len(responses.calls) == 3
+        mock_drain.delay.assert_not_called()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_no_chain_past_the_depth_ceiling(self, mock_drain: MagicMock) -> None:
+        self._respond_ok()
+        records = create_payloads(4, "jira:123", provider="jira")
+
+        drain_mailbox(
+            records[0].id,
+            claimed_count=3,
+            valid_until=fresh_deadline(),
+            mailbox="jira:123",
+            chain_depth=3,
+        )
+
+        mock_drain.delay.assert_not_called()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_no_chain_for_skip_on_failure_provider(self, mock_drain: MagicMock) -> None:
+        # Due-head providers would fork a new pipeline every scheduler cycle.
+        self._respond_ok("github")
+        records = create_payloads(4, "github:123", provider="github")
+
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="github:123"
+        )
+
+        assert len(responses.calls) == 3
+        mock_drain.delay.assert_not_called()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_no_chain_after_a_failure_stop(self, mock_drain: MagicMock) -> None:
+        url = "http://us.testserver/extensions/jira/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=500, body="")
+        records = create_payloads(4, "jira:123", provider="jira")
+
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="jira:123"
+        )
+
+        assert len(responses.calls) == 2
+        mock_drain.delay.assert_not_called()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_no_chain_on_a_short_claim(self, mock_drain: MagicMock) -> None:
+        # A claim under the cap means the due prefix ended; nothing to chain to.
+        self._respond_ok()
+        records = create_payloads(2, "jira:123", provider="jira")
+
+        drain_mailbox(
+            records[0].id, claimed_count=2, valid_until=fresh_deadline(), mailbox="jira:123"
+        )
+
+        assert len(responses.calls) == 2
+        mock_drain.delay.assert_not_called()
+
+    @responses.activate
+    @override_cells(cell_config)
+    @override_options({"hybridcloud.webhookpayload.max_chain_depth": 3})
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_no_chain_while_another_dispatcher_holds_the_lock(self, mock_drain: MagicMock) -> None:
+        self._respond_ok()
+        records = create_payloads(4, "jira:123", provider="jira")
+        cache.add("wh:drain_active:jira:123", 1, timeout=15)
+
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="jira:123"
+        )
+
+        mock_drain.delay.assert_not_called()
+        # The other dispatcher's guard must survive the skipped chain.
+        assert cache.get("wh:drain_active:jira:123") is not None
+
+
+@control_silo_test
 class PushTriggerTest(MetricCallsMixin, TestCase):
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_push_trigger_enqueues_drain_for_idle_mailbox(self, mock_drain: MagicMock) -> None:
@@ -2819,6 +3024,9 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=webhook.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
         # The batch is claimed before dispatch; the claim is what keeps other
         # dispatchers off the mailbox while the drain runs.
@@ -2860,6 +3068,9 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=older_webhook.id,
             claimed_count=2,
             dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2896,6 +3107,9 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=due.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -2966,6 +3180,9 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=webhook_b.id,
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -3018,6 +3235,9 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             payload_id=webhook_two.id,
             claimed_count=1,
             dispatcher=Dispatcher.PUSH,
+            valid_until=ANY,
+            mailbox=ANY,
+            chain_depth=1,
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -51,6 +51,7 @@ DELIVERY_METRIC = "hybridcloud.deliver_webhooks.delivery"
 DELIVERY_TIME_METRIC = "hybridcloud.deliver_webhooks.delivery_time_ms"
 DISPATCH_METRIC = "hybridcloud.deliver_webhooks.dispatch"
 DISPATCH_CLAIMED_METRIC = "hybridcloud.deliver_webhooks.dispatch.claimed"
+CAP_HEADROOM_METRIC = "hybridcloud.deliver_webhooks.drain.cap_headroom_seconds"
 PUSH_TRIGGER_ERROR_METRIC = "hybridcloud.deliver_webhooks.push_trigger.error"
 SCHEDULER_SKIPPED_METRIC = "hybridcloud.deliver_webhooks.scheduler.skipped"
 DUE_ROWS_METRIC = "hybridcloud.schedule_webhook_delivery.due_rows"
@@ -67,6 +68,14 @@ class MetricCallsMixin:
     def tags_for(self, mock_metrics: MagicMock, metric: str) -> list[dict[str, str]]:
         """Tags of each `metrics.incr` call for `metric`, in call order."""
         return [c[1].get("tags", {}) for c in mock_metrics.incr.call_args_list if c[0][0] == metric]
+
+    def incr_calls(self, mock_metrics: MagicMock, metric: str) -> list[tuple[int, dict[str, str]]]:
+        """`(amount, tags)` of each `metrics.incr` call for `metric`, in call order."""
+        return [
+            (c[1].get("amount", 1), c[1].get("tags", {}))
+            for c in mock_metrics.incr.call_args_list
+            if c[0][0] == metric
+        ]
 
     def distribution_calls(
         self, mock_metrics: MagicMock, metric: str
@@ -1008,7 +1017,7 @@ def assert_drain_skips_failed_message(provider: str) -> None:
 
 
 @control_silo_test
-class DrainMailboxTest(TestCase):
+class DrainMailboxTest(MetricCallsMixin, TestCase):
     @responses.activate
     def test_drain_missing_payload(self) -> None:
         drain_mailbox(99, claimed_count=MAX_MAILBOX_DRAIN)
@@ -1065,6 +1074,41 @@ class DrainMailboxTest(TestCase):
         assert len(responses.calls) == 5
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
         assert remaining == {records[5].id, records[6].id, records[7].id}
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch.object(deliver_webhooks, "MAX_MAILBOX_DRAIN", 3)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_claim_at_the_cap_records_its_unused_window(self, mock_metrics: MagicMock) -> None:
+        # The cap ended this drain with a minute of delivery time unspent: rows
+        # the mailbox still holds could have gone out under this claim.
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        records = create_payloads(4, "github:123", provider="github")
+        valid_until = timezone.now() + RELEASE_MARGIN + timedelta(seconds=60)
+
+        drain_mailbox(records[0].id, claimed_count=3, valid_until=valid_until.timestamp())
+
+        assert len(responses.calls) == 3
+        ((amount, tags),) = self.incr_calls(mock_metrics, CAP_HEADROOM_METRIC)
+        assert tags == {**UNATTRIBUTED, "provider": "github"}
+        # Mocked deliveries take milliseconds, leaving the window all but whole.
+        assert 55 <= amount <= 60
+
+    @responses.activate
+    @override_cells(cell_config)
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_claim_below_the_cap_records_no_unused_window(self, mock_metrics: MagicMock) -> None:
+        # A claim the cap never bound took every record that was due, so its
+        # leftover window measures the mailbox's depth rather than the cap's cost.
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        records = create_payloads(4, "github:123", provider="github")
+
+        drain_mailbox(records[0].id, claimed_count=3, valid_until=fresh_deadline())
+
+        assert len(responses.calls) == 3
+        assert self.incr_calls(mock_metrics, CAP_HEADROOM_METRIC) == []
 
     @responses.activate
     @override_cells(cell_config)


### PR DESCRIPTION
Follows #122893 (merged); rebased onto master.

## Problem

A strict provider's mailbox burns one claim per scheduler round trip. The gap between claims isn't the ~10s cycle cadence: under a wide backlog the mailbox competes with every other due head for each cycle's dispatch budget, so a deep strict mailbox can wait many cycles between drains. Re-discovery, not delivery, dominates its burn rate — and strict providers are precisely the ones lanes-style concurrent claims can't serve (see #122897's closing rationale).

## Change

A drain that ends **healthy with due work behind it** dispatches the mailbox's next claim itself, while its lineage is within `hybridcloud.webhookpayload.max_chain_depth` links. The ordinary dispatch counts as the first link, so the option is both the ceiling and the rollout dial: at its default of **1**, no drain ever chains; raising it to N lets a busy mailbox re-dispatch itself N−1 times before falling back to the scheduler, and setting it back to 1 stops new links without a deploy.

"Healthy with work behind" means exactly two endings:

- the drain consumed a claim that had filled the cap (the due prefix continues past it), or
- it released a tail at its soft-stop **after delivering something** — a drain that delivered nothing before the soft-stop spent its window in the queue, which is saturation, exactly when a chain would add queue load.

Never after a failure-stop or a lapse; backoff and the scheduler own those.

**Why strict-only:** the absolute-head gate admits one claim at a time, so a chain stays a single lineage per mailbox. A skip-on-failure provider in due-head mode would have the scheduler start a fresh claim behind every in-flight chain — one new self-sustaining pipeline per cycle, unbounded lanes.

**Safety:** the chain claims under the same drain lock and due-gate as every other dispatcher, so losing the race to a scheduler or push dispatch just continues the lineage under their attribution. A chain ends at the first short claim, and a chain failure is swallowed — the drain's work is already delivered, and the scheduler covers the mailbox.

## Also here: dispatch sends the full claim

#122893 held `valid_until`/`mailbox` off the wire because workers from the deploy before it reject unknown kwargs (and the taskbroker discards, not retries). Every worker has bound them — and `chain_depth` — since that deploy, so dispatch now sends the full claim shape, chain_depth included, and drains stop reading it off their head row.

## Observability and rollout

Chain dispatches land in the existing `dispatch` / `dispatch.claimed` metrics as `dispatcher:chain`. Deploy at least one deploy after #122893, then ramp `max_chain_depth` 1 → 2 → 4 → 8 in the automator, watching strict providers' `oldest_pending_age`, `hybridcloud.control` queue latency, and the `dispatcher:chain` share.


