### PR TITLE
ref(hybridcloud): Require the claim's deadline and mailbox on drains

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -455,52 +455,17 @@ def _begin_drain(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None,
-    valid_until: float | None,
-    mailbox: str | None,
+    valid_until: float,
+    mailbox: str,
 ) -> _MailboxClaim | None:
-    """
-    The claim a drain runs under, or None when it must stand down first.
-
-    A drain enqueued before dispatch sent the mailbox and deadline reads both off
-    its head row: its claim already wrote its deadline as the rows' schedule_for.
-    That one-query fallback goes away once no such drains are left in flight.
-    """
-    deadline = (
-        datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC)
-        if valid_until is not None
-        else None
-    )
-    if mailbox is None or deadline is None:
-        head = (
-            WebhookPayload.objects.filter(id=payload_id)
-            .values_list("mailbox_name", "schedule_for")
-            .first()
-        )
-        if head is None:
-            # Whoever claimed the mailbox next is delivering the rest. Every
-            # drain resolves through this read until dispatch sends the claim,
-            # so this is where a lost race shows up.
-            _record_lost_head(
-                payload_id,
-                dispatcher=dispatcher,
-                provider=_provider_from_mailbox(mailbox),
-                log_key="deliver_webhook.potential_race",
-            )
-            return None
-        mailbox = mailbox if mailbox is not None else head[0]
-        if deadline is None:
-            # The head's schedule_for is normally the claim's own deadline, but
-            # a failed attempt rewrites it to a retry backoff that passes the
-            # deadline (the first backoff already does). Cap what a redelivered
-            # drain adopts at the widest horizon its claim could have written.
-            deadline = min(head[1], timezone.now() + BATCH_SCHEDULE_OFFSET)
+    """The claim a drain runs under, or None when it has already lapsed."""
     _set_webhook_delivery_sentry_context(mailbox, _provider_from_mailbox(mailbox))
     claim = _MailboxClaim(
         claimed=claimed_count,
         head_id=payload_id,
         mailbox_name=mailbox,
         dispatcher=dispatcher,
-        valid_until=deadline,
+        valid_until=datetime.datetime.fromtimestamp(valid_until, tz=datetime.UTC),
     )
     if claim.lapsed(log_key="deliver_webhook.stale_claim", extra={"id": payload_id}):
         return None
@@ -962,15 +927,15 @@ def drain_mailbox(
     payload_id: int,
     claimed_count: int,
     dispatcher: str | None = None,
-    valid_until: float | None = None,
-    mailbox: str | None = None,
+    *,
+    valid_until: float,
+    mailbox: str,
     chain_depth: int = 1,
 ) -> None:
     """
     Deliver webhooks from the mailbox that `payload_id` is the head of.
 
-    The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`);
-    each defaults so a rolling deploy can bind drains the previous version sent.
+    The arguments are one claim flattened for the wire (`_MailboxClaim.task_args`).
     `chain_depth` is which link of a chain this drain is, an ordinary dispatch
     being the first.
     """
@@ -1431,31 +1396,6 @@ def _handle_delivery_result(
         return False
     _finish_delivered(payload_record, deleter, delivery_tags=delivery_tags)
     return True
-
-
-@instrumented_task(
-    name="sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel",
-    namespace=hybridcloud_control_tasks,
-    # The pre-merge task's deadline, kept for the in-flight drains this shim serves.
-    processing_deadline_duration=int(BATCH_SCHEDULE_OFFSET.total_seconds() + 10),
-    silo_mode=SiloMode.CONTROL,
-)
-def drain_mailbox_parallel(
-    payload_id: int,
-    claimed_count: int,
-    dispatcher: str | None = None,
-    valid_until: float | None = None,
-    mailbox: str | None = None,
-    chain_depth: int = 1,
-) -> None:
-    """
-    Transitional alias from when sequential and parallel delivery were separate
-    tasks. Dispatch no longer enqueues this, so it is deletable once no drains
-    from the previous deploy are left in flight.
-    """
-    claim = _begin_drain(payload_id, claimed_count, dispatcher, valid_until, mailbox)
-    if claim is not None:
-        _drain_mailbox(claim)
 
 
 def deliver_message(payload: WebhookPayload) -> tuple[WebhookPayload, Exception | None]:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -30,7 +30,6 @@ from sentry.hybridcloud.tasks.deliver_webhooks import (
     _claim_and_dispatch,
     _due_mailbox_heads,
     drain_mailbox,
-    drain_mailbox_parallel,
     maybe_trigger_drain,
     schedule_webhook_delivery,
 )
@@ -1005,7 +1004,12 @@ def assert_drain_skips_failed_message(provider: str) -> None:
     responses.add(responses.POST, url, status=200, body="")
     records = create_payloads(5, f"{provider}:123", provider=provider)
 
-    drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+    drain_mailbox(
+        records[0].id,
+        claimed_count=MAX_MAILBOX_DRAIN,
+        valid_until=fresh_deadline(),
+        mailbox=f"{provider}:123",
+    )
 
     assert len(responses.calls) == 5
     assert WebhookPayload.objects.count() == 1
@@ -1020,7 +1024,7 @@ def assert_drain_skips_failed_message(provider: str) -> None:
 class DrainMailboxTest(MetricCallsMixin, TestCase):
     @responses.activate
     def test_drain_missing_payload(self) -> None:
-        drain_mailbox(99, claimed_count=MAX_MAILBOX_DRAIN)
+        drain_mailbox(99, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123")
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1030,7 +1034,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             cell_name="lolnope",
         )
         with pytest.raises(CellResolutionError):
-            drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+            drain_mailbox(
+                webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+            )
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -1043,7 +1049,12 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         # github is in the skip-on-failure allowlist: failed messages are skipped
         # and processing continues. All 5 messages are attempted.
@@ -1069,7 +1080,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=5, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id, claimed_count=5, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert len(responses.calls) == 5
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
@@ -1087,7 +1100,12 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         records = create_payloads(4, "github:123", provider="github")
         valid_until = timezone.now() + RELEASE_MARGIN + timedelta(seconds=60)
 
-        drain_mailbox(records[0].id, claimed_count=3, valid_until=valid_until.timestamp())
+        drain_mailbox(
+            records[0].id,
+            claimed_count=3,
+            valid_until=valid_until.timestamp(),
+            mailbox="github:123",
+        )
 
         assert len(responses.calls) == 3
         ((amount, tags),) = self.incr_calls(mock_metrics, CAP_HEADROOM_METRIC)
@@ -1105,7 +1123,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(4, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=3, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert len(responses.calls) == 3
         assert self.incr_calls(mock_metrics, CAP_HEADROOM_METRIC) == []
@@ -1118,7 +1138,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(8, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=6, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id, claimed_count=6, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert len(responses.calls) == 6
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
@@ -1134,7 +1156,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(3, "github:123", provider="github")
 
-        drain_mailbox(records[0].id, claimed_count=3, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id, claimed_count=3, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert len(responses.calls) == 3
         assert WebhookPayload.objects.count() == 0
@@ -1153,7 +1177,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             return (payload, deliver_webhooks.DeliveryFailed())
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
-            drain_mailbox(record.id, claimed_count=1, valid_until=fresh_deadline())
+            drain_mailbox(
+                record.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="jira:123"
+            )
 
         assert attempts_at_request == [1]
         record.refresh_from_db()
@@ -1172,7 +1198,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             return (payload, deliver_webhooks.DeliveryFailed())
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
-            drain_mailbox(record.id, claimed_count=1, valid_until=fresh_deadline())
+            drain_mailbox(
+                record.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+            )
 
         assert attempts_at_request == [0]
         record.refresh_from_db()
@@ -1195,7 +1223,12 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
             with pytest.raises(ValueError):
-                drain_mailbox(records[0].id, claimed_count=4, valid_until=fresh_deadline())
+                drain_mailbox(
+                    records[0].id,
+                    claimed_count=4,
+                    valid_until=fresh_deadline(),
+                    mailbox="github:123",
+                )
 
         remaining = set(WebhookPayload.objects.values_list("id", flat=True))
         # The delivered sibling is gone; the errored head keeps its retry.
@@ -1223,7 +1256,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         fresh = create_payloads(5, "github:123", provider="github")
 
         # The claim covered the 3 stale rows plus 3 fresh ones.
-        drain_mailbox(stale[0].id, claimed_count=6, valid_until=fresh_deadline())
+        drain_mailbox(
+            stale[0].id, claimed_count=6, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         # The 3 stale rows are discarded without requests and only the 3 claimed
         # fresh rows are delivered; the rest stay for the next claim.
@@ -1250,7 +1285,7 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
         head = WebhookPayload.objects.order_by("id").first()
         assert head
-        drain_mailbox(head.id, claimed_count=4, valid_until=fresh_deadline())
+        drain_mailbox(head.id, claimed_count=4, valid_until=fresh_deadline(), mailbox="github:123")
 
         # Only the two fresh rows produce requests; everything is drained.
         assert len(responses.calls) == 2
@@ -1264,7 +1299,12 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="jira:123",
+        )
 
         # jira is not in the allowlist: processing stops on the first failure
         # to preserve strict mailbox ordering.
@@ -1315,7 +1355,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         records = create_payloads(4, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=4, valid_until=fresh_deadline())
+            drain_mailbox(
+                records[0].id, claimed_count=4, valid_until=fresh_deadline(), mailbox="github:123"
+            )
 
         assert len(responses.calls) == 4
         assert WebhookPayload.objects.count() == 0
@@ -1334,7 +1376,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
 
-        drain_mailbox(records[0].id, claimed_count=5, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id, claimed_count=5, valid_until=fresh_deadline(), mailbox="jira:123"
+        )
 
         # jira requires strict ordering: the drain stops at the failure, but the
         # two messages delivered before it must still have their rows removed.
@@ -1368,7 +1412,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         create_payloads(2, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(stale.id, claimed_count=4, valid_until=fresh_deadline())
+            drain_mailbox(
+                stale.id, claimed_count=4, valid_until=fresh_deadline(), mailbox="github:123"
+            )
 
         # Only the two fresh rows are delivered; the stale and attempts-exhausted
         # rows are discarded without a request.
@@ -1390,7 +1436,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         records = create_payloads(5, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=5, valid_until=fresh_deadline())
+            drain_mailbox(
+                records[0].id, claimed_count=5, valid_until=fresh_deadline(), mailbox="github:123"
+            )
 
         assert WebhookPayload.objects.count() == 0
         # Two full batches during the walk plus the remainder at the end.
@@ -1408,7 +1456,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         records = create_payloads(8, "github:123", provider="github")
 
         with CaptureQueriesContext(connections["control"]) as ctx:
-            drain_mailbox(records[0].id, claimed_count=8, valid_until=fresh_deadline())
+            drain_mailbox(
+                records[0].id, claimed_count=8, valid_until=fresh_deadline(), mailbox="github:123"
+            )
 
         assert len(responses.calls) == 8
         assert WebhookPayload.objects.count() == 0
@@ -1421,7 +1471,12 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "github:123", provider="github")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         # All 5 messages are attempted even though all fail.
         assert len(responses.calls) == 5
@@ -1442,7 +1497,12 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         # Mailbox should be empty
         assert not WebhookPayload.objects.filter().exists()
@@ -1455,7 +1515,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS,
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1467,7 +1529,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             cell_name="us",
             attempts=MAX_ATTEMPTS + 1,
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 0
 
@@ -1485,7 +1549,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             cell_name="us",
         )
         with pytest.raises(ValueError):
-            drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+            drain_mailbox(
+                webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+            )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.attempts == 1
@@ -1504,7 +1570,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert len(responses.calls) == 1
@@ -1524,7 +1592,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         assert not WebhookPayload.objects.filter(id=webhook_one.id).exists()
         assert len(responses.calls) == 1
 
@@ -1541,7 +1611,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 401
         assert hook is None
@@ -1560,7 +1632,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 400
         assert hook is None
@@ -1579,7 +1653,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         # We don't retry 403
         assert hook is None
@@ -1599,7 +1675,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             cell_name="us",
             request_path="/plugins/github/organizations/123/webhook/",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="plugins:123"
+        )
 
         # We don't retry if the region 404s
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
@@ -1616,7 +1694,9 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook_one.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
         hook = WebhookPayload.objects.filter(id=webhook_one.id).first()
         assert hook
         assert hook.schedule_for > timezone.now()
@@ -1634,36 +1714,15 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
             body="",
         )
         records = create_payloads(3, "github:123")
-        drain_mailbox(records[0].id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
-
-        # Mailbox should be empty
-        assert not WebhookPayload.objects.filter().exists()
-
-
-@control_silo_test
-class DrainMailboxParallelShimTest(TestCase):
-    @responses.activate
-    @override_cells(cell_config)
-    def test_in_flight_drain_still_delivers(self) -> None:
-        # Dispatch no longer enqueues this task; drains enqueued by the deploy
-        # before the drains merged must still bind and deliver. Dies with the shim.
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        records = create_payloads(3, "github:123")
-
-        drain_mailbox_parallel(
-            payload_id=records[0].id,
-            claimed_count=3,
-            dispatcher=Dispatcher.PUSH,
-            valid_until=(timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp(),
+        drain_mailbox(
+            records[0].id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
             mailbox="github:123",
         )
 
-        assert not WebhookPayload.objects.exists()
+        # Mailbox should be empty
+        assert not WebhookPayload.objects.filter().exists()
 
 
 @control_silo_test
@@ -1692,7 +1751,12 @@ class SlowDeliveryLoggingTest(TestCase):
         expected_date_added = webhook.date_added.isoformat()
 
         with self.assertLogs("sentry.hybridcloud.tasks.deliver_webhooks", level="WARNING") as cm:
-            drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+            drain_mailbox(
+                webhook.id,
+                claimed_count=MAX_MAILBOX_DRAIN,
+                valid_until=fresh_deadline(),
+                mailbox="github:123",
+            )
 
         slow_log = next(r for r in cm.records if "deliver_webhook.slow_delivery" in r.msg)
         # extra dict from logger becomes attributes on LogRecord at runtime
@@ -1722,7 +1786,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123",
             cell_name="us",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1750,7 +1819,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123:0:pull_request",
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1774,7 +1848,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="stripe",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="stripe:123",
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1801,7 +1880,12 @@ class DeliveryTimeMetricsTest(MetricCallsMixin, TestCase):
             cell_name="us",
             provider="github",
         )
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         delivery_time_tags = self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC)
         assert len(delivery_time_tags) == 1
@@ -1832,7 +1916,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -1850,7 +1939,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -1868,7 +1962,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert self.delivery_outcomes(mock_metrics) == ["ok"]
         assert len(self.distribution_calls(mock_metrics, DELIVERY_TIME_METRIC)) == 1
@@ -1886,7 +1985,9 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["conflict"]
@@ -1905,7 +2006,9 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert not WebhookPayload.objects.filter(id=webhook.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx"]
@@ -1931,7 +2034,12 @@ class DroppedDeliveryOutcomeTest(MetricCallsMixin, TestCase):
         )
         first, second = create_payloads(2, "jira:123", provider="jira")
 
-        drain_mailbox(first.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            first.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="jira:123",
+        )
 
         assert not WebhookPayload.objects.filter(id=second.id).exists()
         assert self.delivery_outcomes(mock_metrics) == ["dropped_4xx", "ok"]
@@ -1958,7 +2066,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
@@ -1978,7 +2091,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert self.tags_for(mock_metrics, "hybridcloud.deliver_webhooks.failure") == [
             {"reason": "unauthorized", "destination_region": "us", "provider": "github"}
@@ -2000,7 +2118,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "conflict", "provider": "github"}
@@ -2021,7 +2144,9 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
             mailbox_name="github:123", cell_name="us", provider="github"
         )
 
-        drain_mailbox(webhook.id, claimed_count=1, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id, claimed_count=1, valid_until=fresh_deadline(), mailbox="github:123"
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "dropped_4xx", "provider": "github"}
@@ -2042,7 +2167,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         webhook = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
         webhook.update(provider=None)
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "github"}
@@ -2058,7 +2188,12 @@ class ProviderMetricTagTest(MetricCallsMixin, TestCase):
         )
         webhook = self.create_webhook_payload(mailbox_name="legacy", cell_name="us")
 
-        drain_mailbox(webhook.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="legacy",
+        )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
             {**UNATTRIBUTED, "outcome": "ok", "provider": "unknown"}
@@ -2152,6 +2287,7 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=fresh_deadline(),
+            mailbox="github:123",
         )
 
         assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
@@ -2179,6 +2315,7 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             claimed_count=1,
             dispatcher=Dispatcher.SCHEDULER,
             valid_until=fresh_deadline(),
+            mailbox="github:123",
         )
 
         assert self.distribution_tags(mock_metrics, DELIVERY_TIME_METRIC) == [
@@ -2211,6 +2348,7 @@ class DeliveryDispatchTagTest(MetricCallsMixin, TestCase):
             claimed_count=2,
             dispatcher=Dispatcher.PUSH,
             valid_until=fresh_deadline(),
+            mailbox="github:123",
         )
 
         expected = {
@@ -2342,70 +2480,11 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
                 records[0].id,
                 claimed_count=1,
                 valid_until=(timezone.now() + timedelta(minutes=5)).timestamp(),
+                mailbox="github:123",
             )
 
         assert len(responses.calls) == 1
         assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_undated_claim_reads_deadline_from_its_head_row(self) -> None:
-        # Drains enqueued before dispatch sent a deadline find it on their rows:
-        # their claim wrote it there as schedule_for.
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-            provider="github",
-            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET,
-        )
-
-        drain_mailbox(webhook.id, claimed_count=1)
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_undated_claim_caps_a_backoff_rewritten_deadline(self) -> None:
-        # A failed attempt rewrote the head's schedule_for to its retry backoff,
-        # so it no longer carries the claim's deadline. A zero offset makes the
-        # cap immediate: a delivery here could only come from adopting the
-        # backoff as the deadline, which would outlive the claim.
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-            provider="github",
-            schedule_for=timezone.now() + timedelta(minutes=30),
-        )
-
-        with patch.object(deliver_webhooks, "BATCH_SCHEDULE_OFFSET", timedelta(minutes=0)):
-            drain_mailbox(webhook.id, claimed_count=1)
-
-        assert len(responses.calls) == 0
-        assert WebhookPayload.objects.count() == 1
-
-    @responses.activate
-    @override_cells(cell_config)
-    def test_undated_claim_with_lapsed_rows_stands_down(self) -> None:
-        # An undated drain whose rows are already claimable belongs to whoever
-        # claims them next, exactly like a dated drain past its deadline.
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
-        )
-
-        drain_mailbox(webhook.id, claimed_count=1)
-
-        assert len(responses.calls) == 0
-        assert WebhookPayload.objects.count() == 1
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_dispatch_passes_the_rows_own_deadline(self, mock_drain: MagicMock) -> None:
@@ -2433,7 +2512,7 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         )
 
         valid_until = (timezone.now() + BATCH_SCHEDULE_OFFSET).timestamp()
-        drain_mailbox(webhook.id, claimed_count=1, valid_until=valid_until)
+        drain_mailbox(webhook.id, claimed_count=1, valid_until=valid_until, mailbox="github:123")
 
         assert len(responses.calls) == 1
         assert WebhookPayload.objects.count() == 0
@@ -2464,26 +2543,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         ]
 
     @responses.activate
-    @override_cells(cell_config)
-    def test_drain_enqueued_before_deploy_delivers(self) -> None:
-        # Drains queued before this deploys carry no deadline and must keep
-        # running on the one their claim wrote to the rows.
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
-        )
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-            provider="github",
-            schedule_for=timezone.now() + BATCH_SCHEDULE_OFFSET,
-        )
-
-        drain_mailbox(webhook.id, claimed_count=1, dispatcher=Dispatcher.SCHEDULER)
-
-        assert len(responses.calls) == 1
-        assert WebhookPayload.objects.count() == 0
-
-    @responses.activate
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_expired_claim_on_deleted_head_still_names_the_provider(
         self, mock_metrics: MagicMock
@@ -2502,40 +2561,6 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
             {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "github"}
         ]
 
-    @responses.activate
-    @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_without_a_mailbox_reads_it_off_the_head(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # Drains enqueued before dispatch sent a mailbox still name their provider:
-        # the head row carries it, and the drain reads it before anything else.
-        webhook = self.create_webhook_payload(
-            mailbox_name="github:123", cell_name="us", provider="github"
-        )
-
-        drain_mailbox(
-            webhook.id, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired()
-        )
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "delivery_deadline", "provider": "github"}
-        ]
-
-    @responses.activate
-    @override_cells(cell_config)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
-    def test_expired_claim_with_neither_mailbox_nor_head_reports_a_race(
-        self, mock_metrics: MagicMock
-    ) -> None:
-        # Nothing left to name the provider with; the row read is still the race
-        # site for every drain until dispatch sends the claim.
-        drain_mailbox(99, claimed_count=1, dispatcher=Dispatcher.PUSH, valid_until=self.expired())
-
-        assert self.tags_for(mock_metrics, DELIVERY_METRIC) == [
-            {"dispatcher": "push", "outcome": "race", "provider": "unknown"}
-        ]
-
     @override_cells(cell_config)
     def test_strict_provider_never_delivers_concurrently(self) -> None:
         # Depth never buys a strict-ordering provider a second thread: the next
@@ -2544,7 +2569,12 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         peak = ConcurrencyProbe()
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=peak.deliver):
-            drain_mailbox(records[0].id, claimed_count=len(records), valid_until=fresh_deadline())
+            drain_mailbox(
+                records[0].id,
+                claimed_count=len(records),
+                valid_until=fresh_deadline(),
+                mailbox="jira:123",
+            )
 
         assert peak.value == 1
         assert WebhookPayload.objects.count() == 0
@@ -2555,7 +2585,12 @@ class StaleClaimTest(MetricCallsMixin, TestCase):
         peak = ConcurrencyProbe()
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=peak.deliver):
-            drain_mailbox(records[0].id, claimed_count=len(records), valid_until=fresh_deadline())
+            drain_mailbox(
+                records[0].id,
+                claimed_count=len(records),
+                valid_until=fresh_deadline(),
+                mailbox="github:123",
+            )
 
         assert peak.value > 1
         assert WebhookPayload.objects.count() == 0
@@ -3269,7 +3304,12 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
             body="",
         )
         webhook_one = self.create_webhook_payload(mailbox_name="github:123", cell_name="us")
-        drain_mailbox(webhook_one.id, claimed_count=MAX_MAILBOX_DRAIN, valid_until=fresh_deadline())
+        drain_mailbox(
+            webhook_one.id,
+            claimed_count=MAX_MAILBOX_DRAIN,
+            valid_until=fresh_deadline(),
+            mailbox="github:123",
+        )
 
         # The drain emptied the mailbox; a new webhook arriving now must be able to
         # trigger a fresh drain right away.
@@ -3302,11 +3342,8 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # Lock must also be released so the scheduler can pick it up when backoff expires
         assert cache.get(f"wh:drain_active:{webhook.mailbox_name}") is None
 
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_push_trigger_claim_keeps_scheduler_off(
-        self, mock_drain: MagicMock, mock_drain_parallel: MagicMock
-    ) -> None:
+    def test_push_trigger_claim_keeps_scheduler_off(self, mock_drain: MagicMock) -> None:
         create_payloads(3, "github:123")
 
         maybe_trigger_drain("github:123")
@@ -3317,8 +3354,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         # The push trigger's claim moved the head past the drain deadline, so the
         # scheduler must not double-dispatch a drain for this mailbox.
         assert mock_drain.delay.call_count == 1
-        # Tripwire: dispatch must never reach the transitional shim task.
-        assert mock_drain_parallel.delay.call_count == 0
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_scheduler_claim_blocks_push_trigger(self, mock_drain: MagicMock) -> None:


### PR DESCRIPTION
Last of the drain-claim stack (on the chain-dispatch PR #123274; #122893 has merged).

## Change

The transitional fallbacks come out:

- `valid_until` and `mailbox` are required on `drain_mailbox`, so `_begin_drain` reduces to building the claim and asking whether it has lapsed — no head-row read, no nullable mailbox anywhere downstream.
- `drain_mailbox_parallel` is deleted. Dispatch has not enqueued it since the drains merged; it only served in-flight tasks from the deploy before that.
- The tests covering the fallbacks and the shim go with them; every direct drain invocation now states its claim (`valid_until`, `mailbox`) explicitly.

## ⚠️ Rolling deploy

**Deploy at least one deploy after the wire flip** (the chain-dispatch PR) and let its pre-existing drains clear first. A drain enqueued before dispatch sent the claim carries neither argument and raises `TypeError` here; the taskbroker discards it, the rows keep the `schedule_for` their claim wrote, and the next dispatcher re-claims them once it passes — delivery delayed by up to the claim horizon, not dropped.

## Follow-up enabled by this

With `valid_until` always the claim's written value, `_MailboxClaim.records` filtering on `schedule_for = valid_until` would become a true ownership fetch and could subsume its head check — left out here to keep this PR pure removal.

