### PR TITLE
feat(workflow-engine): Add the comparison information to logs

### DIFF
--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeAlias
 
+from sentry.utils import json
 from sentry.workflow_engine.types import DataConditionResult
 
 from .base import BaseWorkflowEngineEvaluation, BaseWorkflowEngineEvaluationArtifact
@@ -20,6 +21,7 @@ ConditionEvaluationData: TypeAlias = Any
 
 @dataclass(frozen=True)
 class DataConditionEvaluationArtifact(BaseWorkflowEngineEvaluationArtifact):
+    comparison: str
     condition_id: int
     condition_type: str
     input_type: str
@@ -57,12 +59,18 @@ class DataConditionEvaluation(
     condition: DataCondition
 
     def _build_artifact(
-        self, *, triggered: bool, error: str | None
+        self,
+        *,
+        triggered: bool,
+        error: str | None,
     ) -> DataConditionEvaluationArtifact:
         safe_input = self.data if isinstance(self.data, (bool, int, float, str)) else None
+        comparison = json.dumps(self.condition.comparison, sort_keys=True)
+
         return DataConditionEvaluationArtifact(
             triggered=triggered,
             error=error,
+            comparison=comparison,
             condition_id=self.condition.id,
             condition_type=self.condition.type,
             input_type=type(self.data).__name__,

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -163,6 +163,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
 
     def test_condition_artifact_excludes_raw_input_data(self) -> None:
         condition = self.create_data_condition()
+        condition.update(comparison={"value": 10, "interval": "1h"})
         evaluation = DataConditionEvaluation(
             condition=condition,
             result=True,
@@ -175,6 +176,7 @@ class TestWorkflowEvaluationArtifact(TestCase):
         assert artifact == {
             "triggered": True,
             "error": None,
+            "comparison": '{"interval":"1h","value":10}',
             "condition_id": condition.id,
             "condition_type": condition.type,
             "input_type": "dict",


### PR DESCRIPTION
# Description
I was trying to test debug a detector and noticed the comparison information was missing. This will dump the json data into a string so we can quickly check any conditions evaluation.