### PR TITLE
fix(seer-explorer): Do not open a reasoning box that renders nothing

### DIFF
--- a/static/app/views/seerExplorer/components/chat/responseGroup.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/responseGroup.spec.tsx
@@ -54,9 +54,17 @@ function llmWaitBlock(): Block {
   };
 }
 
-/** The response's `ThinkingBlock`, so a spinner can be located inside or outside it. */
+/**
+ * The response's `ThinkingBlock`. Located structurally rather than by title: the header shows the
+ * live tool label while active but a static summary once settled, so a title match silently stops
+ * meaning "the box is open".
+ */
+function queryReasoningBox(container: HTMLElement): HTMLElement | null {
+  return container.querySelector<HTMLElement>('[data-disclosure]');
+}
+
 function reasoningBox(container: HTMLElement): HTMLElement {
-  const box = container.querySelector<HTMLElement>('[data-disclosure]');
+  const box = queryReasoningBox(container);
   if (!box) {
     throw new Error('no reasoning box rendered');
   }
@@ -169,11 +177,12 @@ describe('ResponseGroup', () => {
       },
     ];
 
-    render(<ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />, {
-      organization,
-    });
+    const {container} = render(
+      <ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />,
+      {organization}
+    );
 
-    expect(screen.queryByRole('button', {name: /Thinking/})).not.toBeInTheDocument();
+    expect(queryReasoningBox(container)).not.toBeInTheDocument();
   });
 
   it('still opens the box when the call reported call records', () => {
@@ -200,21 +209,23 @@ describe('ResponseGroup', () => {
       },
     ];
 
-    render(<ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />, {
-      organization,
-    });
+    const {container} = render(
+      <ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />,
+      {organization}
+    );
 
-    expect(screen.getByRole('button', {name: /Thinking|Retrieving/})).toBeInTheDocument();
+    expect(queryReasoningBox(container)).toBeInTheDocument();
   });
 
   it('still opens the box for a classic tool call', () => {
     const group = [toolUseBlock('t1')];
 
-    render(<ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />, {
-      organization,
-    });
+    const {container} = render(
+      <ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />,
+      {organization}
+    );
 
-    expect(screen.getByRole('button', {name: /Queried/})).toBeInTheDocument();
+    expect(queryReasoningBox(container)).toBeInTheDocument();
   });
 
   it('collapses the reasoning until it is expanded', async () => {
@@ -247,7 +258,7 @@ describe('ResponseGroup', () => {
       {organization}
     );
 
-    expect(screen.getByRole('button', {name: /spans/})).toHaveAttribute(
+    expect(reasoningBox(container).querySelector('button')).toHaveAttribute(
       'aria-expanded',
       'false'
     );
@@ -262,7 +273,7 @@ describe('ResponseGroup', () => {
       {organization}
     );
 
-    expect(screen.getByRole('button', {name: /spans/})).toHaveAttribute(
+    expect(reasoningBox(container).querySelector('button')).toHaveAttribute(
       'aria-expanded',
       'true'
     );

--- a/static/app/views/seerExplorer/components/chat/responseGroup.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/responseGroup.spec.tsx
@@ -41,6 +41,28 @@ function toolUseBlock(
   };
 }
 
+/**
+ * Seer's global LLM-wait placeholder: `loading` with no tool calls, content defaulting to
+ * "Thinking..." (see `add_loading_response_block`). Appended before every completion.
+ */
+function llmWaitBlock(): Block {
+  return {
+    id: 'loading',
+    message: {role: 'assistant', content: 'Thinking...', tool_calls: null},
+    timestamp: '2024-01-01T00:02:00Z',
+    loading: true,
+  };
+}
+
+/** The response's `ThinkingBlock`, so a spinner can be located inside or outside it. */
+function reasoningBox(container: HTMLElement): HTMLElement {
+  const box = container.querySelector<HTMLElement>('[data-disclosure]');
+  if (!box) {
+    throw new Error('no reasoning box rendered');
+  }
+  return box;
+}
+
 function assistantBlock(id: string, content: string, loading = false): Block {
   return {
     id,
@@ -213,6 +235,38 @@ describe('ResponseGroup', () => {
     );
 
     expect(screen.getByText('my private reasoning')).toBeVisible();
+  });
+
+  it('spins outside the box while the agent works', () => {
+    // Between tool calls seer appends its LLM-wait placeholder. The tool is done, so the box must
+    // settle and let the placeholder below carry the spinner.
+    const group = [toolUseBlock('t1'), llmWaitBlock()];
+
+    const {container} = render(
+      <ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />,
+      {organization}
+    );
+
+    expect(screen.getByRole('button', {name: /spans/})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    expect(reasoningBox(container).contains(screen.getByRole('status'))).toBe(false);
+  });
+
+  it('spins inside the box while a tool works', () => {
+    const group = [toolUseBlock('t1', {loading: true})];
+
+    const {container} = render(
+      <ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />,
+      {organization}
+    );
+
+    expect(screen.getByRole('button', {name: /spans/})).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(reasoningBox(container).contains(screen.getByRole('status'))).toBe(true);
   });
 
   it('renders no reasoning block when the response is a direct answer', () => {

--- a/static/app/views/seerExplorer/components/chat/responseGroup.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/responseGroup.spec.tsx
@@ -122,6 +122,79 @@ describe('ResponseGroup', () => {
     expect(screen.getByText('The final answer')).toBeInTheDocument();
   });
 
+  it('does not open a reasoning box for a call that renders nothing', () => {
+    // `ToolCallList` suppresses a settled call that reported no rows, links, todos or markdown.
+    // Counting it as a trace anyway left an empty box between the previous answer and the next
+    // spinner.
+    const group: Block[] = [
+      {
+        id: 't1',
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 't1-call', function: 'sentry_api_execute', args: '{}'}],
+        },
+        timestamp: '2024-01-01T00:01:00Z',
+        loading: false,
+        tool_results: [
+          {
+            tool_call_id: 't1-call',
+            tool_call_function: 'sentry_api_execute',
+            content: 'ok',
+            structuredContent: null,
+          },
+        ],
+      },
+    ];
+
+    render(<ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />, {
+      organization,
+    });
+
+    expect(screen.queryByRole('button', {name: /Thinking/})).not.toBeInTheDocument();
+  });
+
+  it('still opens the box when the call reported call records', () => {
+    const group: Block[] = [
+      {
+        id: 't1',
+        message: {
+          role: 'tool_use',
+          content: null,
+          tool_calls: [{id: 't1-call', function: 'sentry_api_execute', args: '{}'}],
+        },
+        timestamp: '2024-01-01T00:01:00Z',
+        loading: false,
+        tool_results: [
+          {
+            tool_call_id: 't1-call',
+            tool_call_function: 'sentry_api_execute',
+            content: 'ok',
+            structuredContent: {
+              calls: [{id: 1, kind: 'api', title: 'Retrieving issue 4521'}],
+            },
+          },
+        ],
+      },
+    ];
+
+    render(<ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />, {
+      organization,
+    });
+
+    expect(screen.getByRole('button', {name: /Thinking|Retrieving/})).toBeInTheDocument();
+  });
+
+  it('still opens the box for a classic tool call', () => {
+    const group = [toolUseBlock('t1')];
+
+    render(<ResponseGroup group={group} blockIndex={1} blocks={group} showThinking />, {
+      organization,
+    });
+
+    expect(screen.getByRole('button', {name: /Queried/})).toBeInTheDocument();
+  });
+
   it('collapses the reasoning until it is expanded', async () => {
     const group = [
       toolUseBlock('t1', {thinking_content: 'my private reasoning'}),

--- a/static/app/views/seerExplorer/components/chat/responseGroup.tsx
+++ b/static/app/views/seerExplorer/components/chat/responseGroup.tsx
@@ -163,6 +163,12 @@ export function ResponseGroup({
 }: ResponseGroupProps) {
   const answer = finalAnswer(group);
   const active = group.some(block => block.loading);
+  // Only a running tool keeps the box live. Loading with no tool calls is seer's LLM-wait
+  // placeholder (`is_global_loading`), which announces itself below; letting it drive the box
+  // animated a settled tool row and charged the model's wait to it.
+  const toolActive = group.some(block =>
+    Boolean(block.loading && block.message.tool_calls?.length)
+  );
 
   // The reasoning trace is everything except the answer's content: thinking prose (gated on the
   // `showThinking` toggle), any intermediate narration, and the tool calls.
@@ -178,9 +184,9 @@ export function ResponseGroup({
   });
 
   const startTime = new Date(group[0]!.timestamp);
-  // Keep ThinkingBlock expanded if loading or awaiting user input (approval/question)
+  // Keep ThinkingBlock expanded while a tool runs or we await user input (approval/question)
   const endTime =
-    active || pendingInput ? undefined : new Date(group[group.length - 1]!.timestamp);
+    toolActive || pendingInput ? undefined : new Date(group[group.length - 1]!.timestamp);
 
   return (
     <Container width="100%" position="relative" flexShrink={0} data-block-wrapper="">

--- a/static/app/views/seerExplorer/components/chat/responseGroup.tsx
+++ b/static/app/views/seerExplorer/components/chat/responseGroup.tsx
@@ -18,7 +18,7 @@ import {getToolsStringFromBlock} from 'sentry/views/seerExplorer/utils';
 
 import {AssistantBlock} from './assistant';
 import {MessagePlaceholder, hasValidContent} from './shared';
-import {CODE_MODE_TOOLS, ToolCallList} from './toolUse';
+import {CODE_MODE_TOOLS, ToolCallList, blockRendersToolContent} from './toolUse';
 
 /**
  * One assistant response: a run of consecutive `assistant`/`tool_use` blocks that follows a user
@@ -171,7 +171,9 @@ export function ResponseGroup({
     return (
       (showThinking && hasValidContent(block.message.thinking_content)) ||
       (!isAnswer && hasValidContent(block.message.content)) ||
-      Boolean(block.message.tool_calls?.length)
+      // Not `tool_calls.length`: a call that reported nothing renders no row, and counting it
+      // opens a reasoning box with an empty body.
+      blockRendersToolContent(block, blocks)
     );
   });
 

--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -5,6 +5,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {BlockComponent} from 'sentry/views/seerExplorer/components/chat';
+import {blockRendersToolContent} from 'sentry/views/seerExplorer/components/chat/toolUse';
 import type {
   AgentWriteApproval,
   Block,
@@ -1518,5 +1519,64 @@ describe('ToolUseBlock', () => {
       expect(screen.getByText('Output:')).toBeInTheDocument();
       expect(screen.getByText('Returned HTTP 500')).toBeInTheDocument();
     });
+  });
+});
+
+describe('blockRendersToolContent', () => {
+  // The predicate exists to agree with `ToolCallList`; every case here is one the list suppresses,
+  // so counting it opens a box with an empty body.
+  function codeModeBlock(
+    id: string,
+    structuredContent: Record<string, unknown> | null
+  ): Block {
+    return {
+      id,
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [{id: `${id}-call`, function: 'sentry_api_execute', args: '{}'}],
+      },
+      timestamp: '2024-01-01T00:01:00Z',
+      loading: false,
+      tool_results: [
+        {
+          tool_call_id: `${id}-call`,
+          tool_call_function: 'sentry_api_execute',
+          content: 'ok',
+          structuredContent: structuredContent as any,
+        },
+      ],
+    };
+  }
+
+  it('ignores links that only reported an error', () => {
+    // `ToolCallList` filters `is_error` links out, so a result carrying nothing else renders no row.
+    const block = codeModeBlock('t1', {
+      links: [{kind: 'get_issue_details', params: {is_error: true}}],
+    });
+
+    expect(blockRendersToolContent(block, [block])).toBe(false);
+  });
+
+  it('counts a link that did not error', () => {
+    const block = codeModeBlock('t1', {
+      links: [{kind: 'get_issue_details', params: {issueId: '4521'}}],
+    });
+
+    expect(blockRendersToolContent(block, [block])).toBe(true);
+  });
+
+  it('ignores todos superseded by a later block', () => {
+    // Only the block holding the newest snapshot renders the checklist.
+    const stale = codeModeBlock('t1', {
+      todos: [{id: '1', text: 'old', status: 'completed'}],
+    });
+    const newest = codeModeBlock('t2', {
+      todos: [{id: '2', text: 'new', status: 'pending'}],
+    });
+    const blocks = [stale, newest];
+
+    expect(blockRendersToolContent(stale, blocks)).toBe(false);
+    expect(blockRendersToolContent(newest, blocks)).toBe(true);
   });
 });

--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -1543,7 +1543,7 @@ describe('blockRendersToolContent', () => {
           tool_call_id: `${id}-call`,
           tool_call_function: 'sentry_api_execute',
           content: 'ok',
-          structuredContent: structuredContent as any,
+          structuredContent,
         },
       ],
     };

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -95,6 +95,51 @@ function linkKey(link: ToolLink) {
   return `${link.kind}:${sorted}`;
 }
 
+/**
+ * Whether `ToolCallList` will render anything for this block.
+ *
+ * `ToolCallList` suppresses a tool call that reported nothing, so a caller deciding whether to open
+ * a container around it cannot go by `tool_calls.length` — that opens an empty box.
+ *
+ * Deliberately the same terms as the per-call `hasContent` guard below, minus the residual-link
+ * filtering: residual links are only consumed by rows, and rows already make this true.
+ */
+export function blockRendersToolContent(block: Block, blocks?: Block[]): boolean {
+  const toolCalls = block.message.tool_calls ?? [];
+  if (!toolCalls.length) {
+    return false;
+  }
+  const toolsUsed = getToolsStringFromBlock(block);
+  const results = block.tool_results ?? [];
+  const latestTodos = findLatestTodos(blocks);
+
+  if (latestTodos?.block === block) {
+    return true;
+  }
+  if (block.live_calls?.length) {
+    return true;
+  }
+  if ((block.tool_links ?? []).some(link => link && !link.params?.is_error)) {
+    return true;
+  }
+  if (
+    results.some(result => {
+      const structured = result?.structuredContent;
+      return Boolean(
+        structured?.calls?.length ||
+        structured?.links?.length ||
+        structured?.todos?.length ||
+        (structured && result.content.trimStart().startsWith('{%'))
+      );
+    })
+  ) {
+    return true;
+  }
+  return toolCalls.some(
+    (toolCall, idx) => !CODE_MODE_TOOLS.has(toolCall.function) && Boolean(toolsUsed[idx])
+  );
+}
+
 export function ToolUseBlock({
   block,
   showThinking,

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -148,8 +148,9 @@ export function blockRendersToolContent(block: Block, blocks?: Block[]): boolean
       const structured = result?.structuredContent;
       return Boolean(
         structured?.calls?.length ||
-        structured?.links?.length ||
-        structured?.todos?.length ||
+        // Errored links render no row, and todos render only from the block holding the newest
+        // snapshot — already checked above. Counting either unfiltered reopens the empty box.
+        structured?.links?.some(link => link?.params?.is_error !== true) ||
         (structured && result.content.trimStart().startsWith('{%'))
       );
     })

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -101,25 +101,46 @@ function linkKey(link: ToolLink) {
  * `ToolCallList` suppresses a tool call that reported nothing, so a caller deciding whether to open
  * a container around it cannot go by `tool_calls.length` — that opens an empty box.
  *
- * Deliberately the same terms as the per-call `hasContent` guard below, minus the residual-link
- * filtering: residual links are only consumed by rows, and rows already make this true.
+ * The same terms as the per-call `hasContent` guard below, plus the block's own running placeholder,
+ * and attributing progress and live rows the way the list does: only to a call that has not settled.
  */
 export function blockRendersToolContent(block: Block, blocks?: Block[]): boolean {
   const toolCalls = block.message.tool_calls ?? [];
   if (!toolCalls.length) {
     return false;
   }
-  const toolsUsed = getToolsStringFromBlock(block);
   const results = block.tool_results ?? [];
-  const latestTodos = findLatestTodos(blocks);
+  const settledCallIds = new Set(results.flatMap(result => result?.tool_call_id ?? []));
+  const pendingCallIds = toolCalls.flatMap(toolCall =>
+    toolCall.id && !settledCallIds.has(toolCall.id) ? [toolCall.id] : []
+  );
 
-  if (latestTodos?.block === block) {
+  if (findLatestTodos(blocks)?.block === block) {
     return true;
   }
-  if (block.live_calls?.length) {
+  // The placeholder the list renders after its rows, whether or not any row survived.
+  if (
+    block.loading &&
+    toolCalls.some(
+      toolCall =>
+        CODE_MODE_TOOLS.has(toolCall.function) &&
+        toolCall.id &&
+        !settledCallIds.has(toolCall.id)
+    )
+  ) {
     return true;
   }
-  if ((block.tool_links ?? []).some(link => link && !link.params?.is_error)) {
+  // Live rows hang off the block, so the list can only attribute them to a lone pending call.
+  if (block.live_calls?.length && pendingCallIds.length === 1) {
+    return true;
+  }
+  // Progress narration stands in for rows until its call reports.
+  if (
+    (block.progress ?? []).some(
+      event =>
+        event?.token && event.message?.trim() && pendingCallIds.includes(event.token)
+    )
+  ) {
     return true;
   }
   if (
@@ -135,6 +156,7 @@ export function blockRendersToolContent(block: Block, blocks?: Block[]): boolean
   ) {
     return true;
   }
+  const toolsUsed = getToolsStringFromBlock(block);
   return toolCalls.some(
     (toolCall, idx) => !CODE_MODE_TOOLS.has(toolCall.function) && Boolean(toolsUsed[idx])
   );


### PR DESCRIPTION
A settled Code Mode call that produced nothing renderable left an empty reasoning box in the transcript — visible as a box that fills while the call runs, empties when it settles, and is then followed by the next response's spinner.

Two predicates disagreed about whether a tool call has anything to show. `hasTrace` opened the box on `tool_calls.length`, while `ToolCallList` suppresses a call that reported no rows, links, todos or markdown. Both now go through one predicate, so the container and its contents cannot disagree.

Pre-existing rather than new — it reproduces on master, independent of the in-flight work-visibility changes, though those make it easier to notice because progress rows fill the box during the run.

The predicate deliberately mirrors the per-call guard's terms, minus the residual-link filtering: residual links are only ever consumed by rows, and rows already make it true.