### PR TITLE
feat(investigations): Reduce Seer orchestration projection events

### DIFF
--- a/src/sentry/investigations/services/orchestration_events.py
+++ b/src/sentry/investigations/services/orchestration_events.py
@@ -6,17 +6,30 @@ from typing import Any
 
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from rest_framework import serializers
 from rest_framework.exceptions import APIException
 
+from sentry.db.models.fields.bounded import I32_MAX, I64_MAX
+from sentry.investigations.contracts import (
+    EVENT_PAYLOAD_SERIALIZERS,
+    OrchestrationProjectionSerializer,
+)
 from sentry.investigations.models import (
+    Investigation,
     InvestigationOrchestrationEvent,
+    InvestigationOrchestrationEventStatus,
+    InvestigationOrchestrationPhase,
     InvestigationOrchestrationRun,
+    InvestigationOrchestrationStatus,
+    InvestigationProject,
 )
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.utils import json
 
 MAX_ORCHESTRATION_EVENT_BYTES = 1024 * 1024
+_CONTROL_KEY = "_sentryControl"
+_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
 
 
 class InvestigationOrchestrationEventConflict(APIException):
@@ -30,7 +43,17 @@ class OrchestrationEventReceipt:
     duplicate: bool
     application_status: str
     last_applied_sequence: int
-    next_expected_sequence: int
+    notebook_revision: int
+
+    @property
+    def next_expected_sequence(self) -> int:
+        return self.last_applied_sequence + 1
+
+
+@dataclass(frozen=True)
+class _OrchestrationEventApplication:
+    event: InvestigationOrchestrationEvent
+    last_applied_sequence: int
     notebook_revision: int
 
 
@@ -38,7 +61,73 @@ __all__ = [
     "InvestigationOrchestrationEventConflict",
     "OrchestrationEventReceipt",
     "deliver_orchestration_event",
+    "reconcile_orchestration_projection",
+    "synchronize_orchestration_projection",
 ]
+
+
+def _serialized_size(value: Any) -> int:
+    return len(json.dumps(value).encode())
+
+
+def _validate_projection(projection: dict[str, Any]) -> dict[str, Any]:
+    validator = OrchestrationProjectionSerializer(data=projection)
+    if not validator.is_valid():
+        raise serializers.ValidationError({"payload": validator.errors})  # type: ignore[dict-item]
+    return validator.validated_data
+
+
+def _projection_evidence_project_ids(projection: dict[str, Any]) -> set[int]:
+    """Collect every project the projection's evidence claims to come from.
+
+    The projection has already been validated, so the shape is known and only the
+    optional keys need guarding.
+    """
+
+    project_ids: set[int] = set()
+    for hypothesis in projection.get("hypotheses", []):
+        evidence_groups = [hypothesis.get("evidence", [])]
+        evidence_groups.extend(
+            step.get("evidence", []) for step in hypothesis.get("verificationSteps", [])
+        )
+        for evidence_group in evidence_groups:
+            for evidence in evidence_group:
+                project_ids.update(evidence.get("projectIds") or [])
+    return project_ids
+
+
+def _validate_projection_project_scope(
+    run: InvestigationOrchestrationRun, projection: dict[str, Any]
+) -> None:
+    project_ids = _projection_evidence_project_ids(projection)
+    if not project_ids:
+        return
+    allowed_project_ids = set(
+        InvestigationProject.objects.filter(investigation=run.investigation).values_list(
+            "project_id", flat=True
+        )
+    )
+    if not project_ids.issubset(allowed_project_ids):
+        raise serializers.ValidationError(
+            {"payload": "Projection evidence is outside the investigation project scope."}
+        )
+
+
+def _validate_event_payload(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Check the payload against the schema for its event type and normalize it.
+
+    Unknown fields survive validation; Seer owns the shape of these payloads and
+    may add to them before Sentry knows the field exists. The return value is what
+    gets staged, so the apply path reads coerced values and never re-checks types.
+    """
+
+    schema = EVENT_PAYLOAD_SERIALIZERS.get(event_type)
+    if schema is None:
+        return payload
+    validator = schema(data=payload)
+    if not validator.is_valid():
+        raise serializers.ValidationError({"payload": validator.errors})
+    return validator.validated_data
 
 
 def _stored_event_payload(event: dict[str, Any]) -> dict[str, Any]:
@@ -51,18 +140,322 @@ def _stored_event_payload(event: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _event_generation(event: InvestigationOrchestrationEvent) -> int:
+    return int(event.payload["generation"])
+
+
+def _event_data(event: InvestigationOrchestrationEvent) -> dict[str, Any]:
+    value = event.payload.get("payload")
+    return value if isinstance(value, dict) else {}
+
+
+def _control(run: InvestigationOrchestrationRun) -> dict[str, Any]:
+    value = run.projection.get(_CONTROL_KEY)
+    if not isinstance(value, dict):
+        value = {}
+        run.projection[_CONTROL_KEY] = value
+    return value
+
+
+def _set_projection(
+    run: InvestigationOrchestrationRun,
+    projection: dict[str, Any],
+    *,
+    event_generation: int,
+    authoritative_workflow_version: bool = False,
+) -> None:
+    projection = _validate_projection(projection)
+    _validate_projection_project_scope(run, projection)
+    investigation_id = projection.get("investigationId")
+    run_id = projection.get("runId")
+    generation = projection.get("generation")
+    if isinstance(investigation_id, bool) or not isinstance(investigation_id, int | str):
+        raise serializers.ValidationError({"payload": "Projection IDs are invalid."})
+    if isinstance(run_id, bool) or not isinstance(run_id, int | str):
+        raise serializers.ValidationError({"payload": "Projection IDs are invalid."})
+    try:
+        normalized_investigation_id = int(investigation_id)
+        normalized_run_id = int(run_id)
+    except (TypeError, ValueError) as error:
+        raise serializers.ValidationError({"payload": "Projection IDs are invalid."}) from error
+    if (
+        normalized_investigation_id != run.investigation_id
+        or run.seer_run is None
+        or normalized_run_id != run.seer_run.seer_run_state_id
+        or generation != event_generation
+    ):
+        raise serializers.ValidationError(
+            {"payload": "Projection IDs or generation do not match the event."}
+        )
+
+    previous_control = deepcopy(_control(run))
+    run.projection = deepcopy(projection)
+    run.projection[_CONTROL_KEY] = previous_control
+
+    workflow_version = projection.get("workflowVersion")
+    if isinstance(workflow_version, int) and not isinstance(workflow_version, bool):
+        run.workflow_version = (
+            workflow_version
+            if authoritative_workflow_version
+            else max(run.workflow_version, workflow_version)
+        )
+    run.generation = event_generation
+    phase = projection.get("phase")
+    if phase in InvestigationOrchestrationPhase.values:
+        run.phase = phase
+    status = projection.get("status")
+    if status in InvestigationOrchestrationStatus.values:
+        run.status = status
+    heartbeat = projection["heartbeatAt"]
+    assert isinstance(heartbeat, str)
+    parsed_heartbeat = parse_datetime(heartbeat)
+    assert parsed_heartbeat is not None and timezone.is_aware(parsed_heartbeat)
+    run.heartbeat_at = parsed_heartbeat
+    projection_error = projection.get("error")
+    if projection_error is None or isinstance(projection_error, dict):
+        run.error = deepcopy(projection_error)
+
+
+def _projection_is_stale(
+    run: InvestigationOrchestrationRun,
+    projection: dict[str, Any],
+    *,
+    event_generation: int,
+) -> bool:
+    workflow_version = projection.get("workflowVersion")
+    return (
+        event_generation == run.generation
+        and isinstance(workflow_version, int)
+        and not isinstance(workflow_version, bool)
+        and workflow_version < run.workflow_version
+    )
+
+
+def _apply_event(
+    run: InvestigationOrchestrationRun, event: InvestigationOrchestrationEvent
+) -> tuple[bool, str | None]:
+    # Events are staged verbatim so that their identity does not move when Sentry's
+    # schemas change. Normalizing here is what lets the apply path read coerced
+    # values and defaults without re-checking any types.
+    payload = _validate_event_payload(event.type, _event_data(event))
+    generation = _event_generation(event)
+    if generation < run.generation:
+        return False, "stale_generation"
+    if generation > run.generation and event.type not in {"workflow_updated", "state_snapshot"}:
+        return False, "future_generation_without_projection"
+
+    if event.type in {"workflow_updated", "state_snapshot"}:
+        if _projection_is_stale(run, payload["projection"], event_generation=generation):
+            return False, "stale_workflow_version"
+        _set_projection(run, payload["projection"], event_generation=generation)
+    elif event.type == "workflow_failed":
+        projection = payload.get("projection")
+        if projection is not None:
+            _set_projection(run, projection, event_generation=generation)
+    return True, None
+
+
+def _is_terminal_full_snapshot(
+    event: InvestigationOrchestrationEvent, run: InvestigationOrchestrationRun
+) -> bool:
+    if event.type != "state_snapshot":
+        return False
+    payload = _event_data(event)
+    projection = payload.get("projection")
+    return (
+        payload.get("terminal") is True
+        and payload.get("full") is True
+        and isinstance(payload.get("blocks"), list)
+        and isinstance(projection, dict)
+        and projection.get("status") in _TERMINAL_STATUSES
+        and projection.get("generation") == _event_generation(event)
+        and not _projection_is_stale(run, projection, event_generation=_event_generation(event))
+    )
+
+
+def _mark_event(
+    event: InvestigationOrchestrationEvent,
+    status: str,
+    *,
+    error: dict[str, Any] | None = None,
+) -> None:
+    event.application_status = status
+    event.error = error
+    event.applied_at = timezone.now()
+    event.save(update_fields=["application_status", "error", "applied_at", "date_updated"])
+
+
+def _lock_run_after_investigation(
+    orchestration_run_id: int,
+) -> InvestigationOrchestrationRun:
+    Investigation.objects.select_for_update(of=("self",)).get(
+        orchestration_run__id=orchestration_run_id
+    )
+    return (
+        InvestigationOrchestrationRun.objects.select_for_update(of=("self",))
+        .select_related("investigation")
+        .get(id=orchestration_run_id)
+    )
+
+
+def _apply_available_events(
+    orchestration_run_id: int, delivered_event_id: int
+) -> _OrchestrationEventApplication:
+    """Consume contiguous events after rollback; only a valid terminal snapshot may skip a gap."""
+
+    database = router.db_for_write(InvestigationOrchestrationRun)
+    with transaction.atomic(using=database):
+        run = _lock_run_after_investigation(orchestration_run_id)
+        delivered = InvestigationOrchestrationEvent.objects.get(id=delivered_event_id)
+        if delivered.sequence <= run.last_event_sequence:
+            if delivered.application_status == InvestigationOrchestrationEventStatus.PENDING:
+                _mark_event(
+                    delivered,
+                    InvestigationOrchestrationEventStatus.IGNORED,
+                    error={"reason": "superseded_by_snapshot"},
+                )
+        elif delivered.sequence > run.last_event_sequence + 1 and _is_terminal_full_snapshot(
+            delivered, run
+        ):
+            try:
+                with transaction.atomic(using=database):
+                    applied, ignored_reason = _apply_event(run, delivered)
+            except serializers.ValidationError as error:
+                run.refresh_from_db()
+                run.investigation.refresh_from_db()
+                _mark_event(
+                    delivered,
+                    InvestigationOrchestrationEventStatus.FAILED,
+                    error={"detail": error.detail},
+                )
+                applied = False
+                ignored_reason = None
+            if not applied:
+                if ignored_reason is not None:
+                    _mark_event(
+                        delivered,
+                        InvestigationOrchestrationEventStatus.IGNORED,
+                        error={"reason": ignored_reason},
+                    )
+                run.date_updated = timezone.now()
+                run.save(update_fields=["date_updated"])
+                return _OrchestrationEventApplication(
+                    event=delivered,
+                    last_applied_sequence=run.last_event_sequence,
+                    notebook_revision=run.notebook_revision,
+                )
+            InvestigationOrchestrationEvent.objects.filter(
+                orchestration_run=run,
+                sequence__lt=delivered.sequence,
+                application_status=InvestigationOrchestrationEventStatus.PENDING,
+            ).update(
+                application_status=InvestigationOrchestrationEventStatus.IGNORED,
+                error={"reason": "superseded_by_terminal_snapshot"},
+                applied_at=timezone.now(),
+                date_updated=timezone.now(),
+            )
+            _mark_event(delivered, InvestigationOrchestrationEventStatus.APPLIED)
+            run.last_event_sequence = delivered.sequence
+        else:
+            while True:
+                next_event = InvestigationOrchestrationEvent.objects.filter(
+                    orchestration_run=run,
+                    sequence=run.last_event_sequence + 1,
+                ).first()
+                if next_event is None:
+                    break
+                if next_event.application_status != InvestigationOrchestrationEventStatus.PENDING:
+                    run.last_event_sequence = next_event.sequence
+                    continue
+                try:
+                    with transaction.atomic(using=database):
+                        applied, ignored_reason = _apply_event(run, next_event)
+                except serializers.ValidationError as error:
+                    run.refresh_from_db()
+                    run.investigation.refresh_from_db()
+                    _mark_event(
+                        next_event,
+                        InvestigationOrchestrationEventStatus.FAILED,
+                        error={"detail": error.detail},
+                    )
+                else:
+                    _mark_event(
+                        next_event,
+                        (
+                            InvestigationOrchestrationEventStatus.APPLIED
+                            if applied
+                            else InvestigationOrchestrationEventStatus.IGNORED
+                        ),
+                        error={"reason": ignored_reason} if ignored_reason else None,
+                    )
+                run.last_event_sequence = next_event.sequence
+
+        run.date_updated = timezone.now()
+        run.save(
+            update_fields=[
+                "seer_run",
+                "workflow_version",
+                "generation",
+                "phase",
+                "status",
+                "projection",
+                "notebook_revision",
+                "last_event_sequence",
+                "heartbeat_at",
+                "error",
+                "date_updated",
+            ]
+        )
+        delivered.refresh_from_db()
+        return _OrchestrationEventApplication(
+            event=delivered,
+            last_applied_sequence=run.last_event_sequence,
+            notebook_revision=run.notebook_revision,
+        )
+
+
+def _resolve_seer_run_mirror(
+    *,
+    seer_run_state_id: int,
+    organization_id: int,
+    user_id: int | None,
+) -> SeerRun:
+    """Find or create the SeerRun mirror for a run id Seer reported.
+
+    Seer can report a run id before Sentry has committed the one its create call
+    returned, so the mirror may not exist yet. It is live on arrival: the id only
+    exists because Seer already accepted the run, and the create outbox does not
+    dispatch this type, so nothing else can advance it.
+    """
+
+    seer_run, _ = SeerRun.objects.get_or_create(
+        seer_run_state_id=seer_run_state_id,
+        defaults={
+            "organization_id": organization_id,
+            "type": SeerRunType.INVESTIGATION,
+            "user_id": user_id,
+            "mirror_status": SeerRunMirrorStatus.LIVE,
+            "last_triggered_at": timezone.now(),
+        },
+    )
+    if seer_run.organization_id != organization_id:
+        raise serializers.ValidationError({"event": "Run ID does not match."})
+    return seer_run
+
+
 def deliver_orchestration_event(
     *,
     organization_id: int,
     event: dict[str, Any],
 ) -> OrchestrationEventReceipt:
-    """Durably stage a Seer event without applying it to the run projection."""
+    """Stage an event, then consume contiguous work or fast-forward with a valid terminal snapshot."""
 
-    if len(json.dumps(event).encode()) > MAX_ORCHESTRATION_EVENT_BYTES:
+    if _serialized_size(event) > MAX_ORCHESTRATION_EVENT_BYTES:
         raise serializers.ValidationError({"event": "Event exceeds the maximum size."})
-
+    _validate_event_payload(event["type"], event["payload"])
     stored_payload = _stored_event_payload(event)
     database = router.db_for_write(InvestigationOrchestrationRun)
+    duplicate = False
     with transaction.atomic(using=database):
         try:
             run = (
@@ -77,28 +470,17 @@ def deliver_orchestration_event(
             raise serializers.ValidationError(
                 {"event": "Investigation run was not found."}
             ) from error
-
         if run.seer_run is not None and run.seer_run.seer_run_state_id != event["run_id"]:
             raise serializers.ValidationError({"event": "Run ID does not match."})
         if run.seer_run is None:
             # Seer can emit its first event before Sentry has committed the run id
             # its create call returned, so adopt the id from the event. get_or_create
             # keeps this idempotent with the dispatch path, whichever wins.
-            seer_run, _ = SeerRun.objects.get_or_create(
+            seer_run = _resolve_seer_run_mirror(
                 seer_run_state_id=event["run_id"],
-                defaults={
-                    "organization_id": organization_id,
-                    "type": SeerRunType.INVESTIGATION,
-                    "user_id": run.investigation.created_by_id,
-                    # Adoption only happens because Seer already confirmed the
-                    # run, so the mirror is live on arrival. Nothing else can
-                    # advance it: the create outbox does not dispatch this type.
-                    "mirror_status": SeerRunMirrorStatus.LIVE,
-                    "last_triggered_at": timezone.now(),
-                },
+                organization_id=organization_id,
+                user_id=run.investigation.created_by_id,
             )
-            if seer_run.organization_id != organization_id:
-                raise serializers.ValidationError({"event": "Run ID does not match."})
             if InvestigationOrchestrationRun.objects.filter(seer_run=seer_run).exists():
                 raise InvestigationOrchestrationEventConflict("Run ID is already in use.")
             run.seer_run = seer_run
@@ -111,8 +493,7 @@ def deliver_orchestration_event(
                 ) from error
 
         existing = InvestigationOrchestrationEvent.objects.filter(
-            orchestration_run=run,
-            event_id=event["event_id"],
+            orchestration_run=run, event_id=event["event_id"]
         ).first()
         if existing is not None:
             if (
@@ -124,13 +505,10 @@ def deliver_orchestration_event(
             delivered = existing
             duplicate = True
         else:
-            if (
-                event["sequence"] <= run.last_event_sequence
-                or InvestigationOrchestrationEvent.objects.filter(
-                    orchestration_run=run,
-                    sequence=event["sequence"],
-                ).exists()
-            ):
+            sequence_collision = InvestigationOrchestrationEvent.objects.filter(
+                orchestration_run=run, sequence=event["sequence"]
+            ).exists()
+            if sequence_collision:
                 raise InvestigationOrchestrationEventConflict
             delivered = InvestigationOrchestrationEvent.objects.create(
                 orchestration_run=run,
@@ -139,12 +517,101 @@ def deliver_orchestration_event(
                 type=event["type"],
                 payload=stored_payload,
             )
-            duplicate = False
 
-        return OrchestrationEventReceipt(
-            duplicate=duplicate,
-            application_status=delivered.application_status,
-            last_applied_sequence=run.last_event_sequence,
-            next_expected_sequence=run.last_event_sequence + 1,
-            notebook_revision=run.notebook_revision,
+    outcome = _apply_available_events(run.id, delivered.id)
+    return OrchestrationEventReceipt(
+        duplicate=duplicate,
+        application_status=outcome.event.application_status,
+        last_applied_sequence=outcome.last_applied_sequence,
+        notebook_revision=outcome.notebook_revision,
+    )
+
+
+def _synchronize_orchestration_projection(
+    *,
+    orchestration_run_id: int,
+    seer_run_id: int,
+    projection: dict[str, Any],
+    authoritative: bool,
+) -> InvestigationOrchestrationRun:
+    if (
+        isinstance(seer_run_id, bool)
+        or not isinstance(seer_run_id, int)
+        or not 1 <= seer_run_id <= I64_MAX
+    ):
+        raise serializers.ValidationError({"seer_run_id": "seer_run_id is invalid."})
+    generation = projection.get("generation")
+    if (
+        isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or not 1 <= generation <= I32_MAX
+    ):
+        raise serializers.ValidationError({"projection": "generation is invalid."})
+    database = router.db_for_write(InvestigationOrchestrationRun)
+    with transaction.atomic(using=database):
+        run = _lock_run_after_investigation(orchestration_run_id)
+        if run.seer_run is not None and run.seer_run.seer_run_state_id != seer_run_id:
+            raise InvestigationOrchestrationEventConflict("Run ID does not match.")
+        run.seer_run = _resolve_seer_run_mirror(
+            seer_run_state_id=seer_run_id,
+            organization_id=run.investigation.organization_id,
+            user_id=run.investigation.created_by_id,
         )
+        if authoritative or (
+            generation >= run.generation
+            and not _projection_is_stale(run, projection, event_generation=generation)
+        ):
+            _set_projection(
+                run,
+                projection,
+                event_generation=generation,
+                authoritative_workflow_version=authoritative,
+            )
+        run.date_updated = timezone.now()
+        run.save(
+            update_fields=[
+                "seer_run",
+                "workflow_version",
+                "generation",
+                "phase",
+                "status",
+                "projection",
+                "notebook_revision",
+                "heartbeat_at",
+                "error",
+                "date_updated",
+            ]
+        )
+        return run
+
+
+def synchronize_orchestration_projection(
+    *,
+    orchestration_run_id: int,
+    seer_run_id: int,
+    projection: dict[str, Any],
+) -> InvestigationOrchestrationRun:
+    """Apply a monotonic create or command response without consuming callback sequence."""
+
+    return _synchronize_orchestration_projection(
+        orchestration_run_id=orchestration_run_id,
+        seer_run_id=seer_run_id,
+        projection=projection,
+        authoritative=False,
+    )
+
+
+def reconcile_orchestration_projection(
+    *,
+    orchestration_run_id: int,
+    seer_run_id: int,
+    projection: dict[str, Any],
+) -> InvestigationOrchestrationRun:
+    """Replace run state from an authoritative recovery response."""
+
+    return _synchronize_orchestration_projection(
+        orchestration_run_id=orchestration_run_id,
+        seer_run_id=seer_run_id,
+        projection=projection,
+        authoritative=True,
+    )

--- a/src/sentry/investigations/services/orchestration_events.py
+++ b/src/sentry/investigations/services/orchestration_events.py
@@ -252,6 +252,11 @@ def _apply_event(
         projection = payload.get("projection")
         if projection is not None:
             _set_projection(run, projection, event_generation=generation)
+        run.phase = InvestigationOrchestrationPhase.FAILED
+        run.status = InvestigationOrchestrationStatus.FAILED
+        run.error = deepcopy(payload.get("error"))
+
+    run.heartbeat_at = timezone.now()
     return True, None
 
 

--- a/src/sentry/investigations/services/orchestration_events.py
+++ b/src/sentry/investigations/services/orchestration_events.py
@@ -241,7 +241,12 @@ def _apply_event(
     generation = _event_generation(event)
     if generation < run.generation:
         return False, "stale_generation"
-    if generation > run.generation and event.type not in {"workflow_updated", "state_snapshot"}:
+    # A projection is what establishes a new generation, so only an event carrying
+    # one may move the run forward.
+    carries_projection = event.type in {"workflow_updated", "state_snapshot"} or (
+        event.type == "workflow_failed" and isinstance(payload.get("projection"), dict)
+    )
+    if generation > run.generation and not carries_projection:
         return False, "future_generation_without_projection"
 
     if event.type in {"workflow_updated", "state_snapshot"}:
@@ -249,8 +254,12 @@ def _apply_event(
             return False, "stale_workflow_version"
         _set_projection(run, payload["projection"], event_generation=generation)
     elif event.type == "workflow_failed":
+        # A delayed failure still fails the run, but it must not replace state
+        # that a newer projection has already established.
         projection = payload.get("projection")
-        if projection is not None:
+        if isinstance(projection, dict) and not _projection_is_stale(
+            run, projection, event_generation=generation
+        ):
             _set_projection(run, projection, event_generation=generation)
         run.phase = InvestigationOrchestrationPhase.FAILED
         run.status = InvestigationOrchestrationStatus.FAILED

--- a/src/sentry/investigations/services/orchestration_events.py
+++ b/src/sentry/investigations/services/orchestration_events.py
@@ -264,6 +264,11 @@ def _apply_event(
         run.phase = InvestigationOrchestrationPhase.FAILED
         run.status = InvestigationOrchestrationStatus.FAILED
         run.error = deepcopy(payload.get("error"))
+    else:
+        # The report events are reduced separately. Consuming one here would
+        # advance the sequence past work this deploy cannot perform, so it is
+        # recorded as unapplied and its payload stays available to replay.
+        return False, "unsupported_event_type"
 
     run.heartbeat_at = timezone.now()
     return True, None

--- a/src/sentry/investigations/services/orchestration_events.py
+++ b/src/sentry/investigations/services/orchestration_events.py
@@ -389,6 +389,8 @@ def _apply_available_events(
                 try:
                     with transaction.atomic(using=database):
                         applied, ignored_reason = _apply_event(run, next_event)
+                        if applied:
+                            run.save()
                 except serializers.ValidationError as error:
                     run.refresh_from_db()
                     run.investigation.refresh_from_db()
@@ -552,6 +554,8 @@ def _synchronize_orchestration_projection(
     seer_run_id: int,
     projection: dict[str, Any],
     authoritative: bool,
+    expected_last_event_sequence: int | None = None,
+    expected_workflow_version: int | None = None,
 ) -> InvestigationOrchestrationRun:
     if (
         isinstance(seer_run_id, bool)
@@ -569,6 +573,11 @@ def _synchronize_orchestration_projection(
     database = router.db_for_write(InvestigationOrchestrationRun)
     with transaction.atomic(using=database):
         run = _lock_run_after_investigation(orchestration_run_id)
+        if authoritative and (
+            run.last_event_sequence != expected_last_event_sequence
+            or run.workflow_version != expected_workflow_version
+        ):
+            raise InvestigationOrchestrationEventConflict("Run changed while reconciling.")
         if run.seer_run is not None and run.seer_run.seer_run_state_id != seer_run_id:
             raise InvestigationOrchestrationEventConflict("Run ID does not match.")
         run.seer_run = _resolve_seer_run_mirror(
@@ -625,12 +634,16 @@ def reconcile_orchestration_projection(
     orchestration_run_id: int,
     seer_run_id: int,
     projection: dict[str, Any],
+    expected_last_event_sequence: int,
+    expected_workflow_version: int,
 ) -> InvestigationOrchestrationRun:
-    """Replace run state from an authoritative recovery response."""
+    """Apply recovery only if the event cursor and version observed before fetching still match."""
 
     return _synchronize_orchestration_projection(
         orchestration_run_id=orchestration_run_id,
         seer_run_id=seer_run_id,
         projection=projection,
         authoritative=True,
+        expected_last_event_sequence=expected_last_event_sequence,
+        expected_workflow_version=expected_workflow_version,
     )

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from django.db import IntegrityError, close_old_connections
+from django.utils import timezone
 
 from sentry.db.models.fields.bounded import I64_MAX
 from sentry.investigations.models import (
@@ -34,7 +35,9 @@ from sentry.investigations.services.investigations import (
 from sentry.investigations.services.orchestration import (
     accept_orchestration_command,
     create_agentic_manual_investigation,
+    get_orchestration_projection,
 )
+from sentry.seer.models.run import SeerRunType
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
@@ -419,6 +422,53 @@ class OrchestrationControlServiceTest(TestCase):
         run.refresh_from_db()
         assert run.workflow_version == 1
         assert not InvestigationOrchestrationCommand.objects.filter(orchestration_run=run).exists()
+
+    def test_projection_serialization_overlays_authoritative_run_fields(self) -> None:
+        investigation, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
+        )
+        heartbeat = timezone.now()
+        run.update(
+            seer_run=self.create_seer_run(
+                organization=self.organization,
+                type=SeerRunType.INVESTIGATION,
+                seer_run_state_id=42,
+            ),
+            workflow_version=3,
+            generation=2,
+            phase="investigating",
+            status="processing",
+            notebook_revision=4,
+            heartbeat_at=heartbeat,
+            projection={
+                "investigationId": "stale",
+                "workflowVersion": 1,
+                "phase": "intake",
+                "status": "pending",
+                "heartbeatAt": "stale",
+                "updatedAt": "stale",
+                "report": {"notebookRevision": 0},
+            },
+        )
+        run.refresh_from_db()
+
+        result = get_orchestration_projection(investigation)
+
+        assert result["runId"] == "42"
+        assert result["investigationId"] == str(investigation.id)
+        assert result["workflowVersion"] == 3
+        assert result["generation"] == 2
+        assert result["phase"] == "investigating"
+        assert result["status"] == "processing"
+        assert result["notebookRevision"] == 4
+        assert result["heartbeatAt"] == heartbeat
+        assert result["updatedAt"] == run.date_updated
+        assert result["report"]["notebookRevision"] == 4
 
 
 class OrchestrationCommandConcurrencyTest(TransactionTestCase):

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -1,25 +1,45 @@
 from __future__ import annotations
 
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from rest_framework import serializers
 
+from sentry.db.models.fields.bounded import I64_MAX
 from sentry.investigations.models import (
+    InvestigationOrchestrationEvent,
     InvestigationOrchestrationEventStatus,
     InvestigationOrchestrationRun,
 )
-from sentry.investigations.services.orchestration import create_agentic_manual_investigation
+from sentry.investigations.services.orchestration import (
+    create_agentic_manual_investigation,
+)
 from sentry.investigations.services.orchestration_events import (
     MAX_ORCHESTRATION_EVENT_BYTES,
+    InvestigationOrchestrationEventConflict,
+    OrchestrationEventReceipt,
     deliver_orchestration_event,
+    reconcile_orchestration_projection,
+    synchronize_orchestration_projection,
 )
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.testutils.cases import TestCase
 
 
-class InvestigationOrchestrationEventTransportTest(TestCase):
+class SeerRunMirrorMixin:
+    def seer_run_mirror(self, seer_run_state_id: int) -> SeerRun:
+        """A SeerRun mirror standing in for a run Seer already accepted."""
+
+        return self.create_seer_run(  # type: ignore[attr-defined]
+            organization=self.organization,  # type: ignore[attr-defined]
+            type=SeerRunType.INVESTIGATION,
+            seer_run_state_id=seer_run_state_id,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+
+
+class InvestigationOrchestrationEventTransportTest(SeerRunMirrorMixin, TestCase):
     def test_replays_the_stored_application_status(self) -> None:
         investigation, run = create_agentic_manual_investigation(
             organization=self.organization,
@@ -30,6 +50,11 @@ class InvestigationOrchestrationEventTransportTest(TestCase):
             filters={},
         )
         event_id = uuid4()
+        projection = {
+            **run.projection,
+            "runId": 8128,
+            "heartbeatAt": "2025-01-01T00:00:00+00:00",
+        }
         event = {
             "schema_version": 1,
             "event_id": event_id,
@@ -38,14 +63,10 @@ class InvestigationOrchestrationEventTransportTest(TestCase):
             "sequence": 1,
             "generation": 1,
             "type": "workflow_updated",
-            "payload": {"projection": {}},
+            "payload": {"projection": projection},
         }
         run.update(
-            seer_run=self.create_seer_run(
-                organization=self.organization,
-                type=SeerRunType.INVESTIGATION,
-                seer_run_state_id=8128,
-            ),
+            seer_run=self.seer_run_mirror(8128),
             last_event_sequence=1,
             notebook_revision=2,
         )
@@ -59,7 +80,7 @@ class InvestigationOrchestrationEventTransportTest(TestCase):
                 "runId": 8128,
                 "investigationId": investigation.id,
                 "generation": 1,
-                "payload": {"projection": {}},
+                "payload": {"projection": projection},
             },
             application_status=InvestigationOrchestrationEventStatus.APPLIED,
         )
@@ -103,7 +124,373 @@ class InvestigationOrchestrationEventTransportTest(TestCase):
         assert not investigation.orchestration_run.events.exists()
 
 
-class InvestigationOrchestrationSeerRunAdoptionTest(TestCase):
+class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
+    seer_run_id = 4815
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.seer_run = self.seer_run_mirror(self.seer_run_id)
+        self.investigation = self.create_investigation(
+            organization=self.organization,
+            created_by=self.user,
+            title="Agentic investigation",
+        )
+        self.orchestration_run = self.create_investigation_orchestration_run(
+            investigation=self.investigation,
+            seer_run=self.seer_run,
+            source={"type": "manual"},
+            projection=self.projection(),
+        )
+
+    def projection(
+        self,
+        *,
+        workflow_version: int = 1,
+        generation: int = 1,
+        phase: str = "broad_scan",
+        status: str = "processing",
+        report_revision: int = 0,
+        report_status: str | None = None,
+        clear_intent: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "runId": self.seer_run_id,
+            "investigationId": str(self.investigation.id),
+            "sourceType": "manual",
+            "workflowVersion": workflow_version,
+            "generation": generation,
+            "phase": phase,
+            "status": status,
+            "broadScan": {"status": "running"},
+            "hypotheses": [],
+            "report": {
+                "revision": report_revision,
+                "status": report_status or ("composing" if report_revision else "not_started"),
+                "clearIntent": clear_intent,
+                "notebookRevision": 0,
+                "metadata": {"status": "not_started"},
+            },
+            "pendingInput": None,
+            "errors": [],
+            "heartbeatAt": "2025-01-01T00:00:00+00:00",
+        }
+
+    def event(
+        self,
+        sequence: int,
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        event_id: UUID | None = None,
+        generation: int = 1,
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "event_id": event_id or uuid4(),
+            "run_id": self.seer_run_id,
+            "investigation_id": self.investigation.id,
+            "sequence": sequence,
+            "generation": generation,
+            "type": event_type,
+            "payload": payload,
+        }
+
+    def deliver(self, event: dict[str, Any]) -> OrchestrationEventReceipt:
+        return deliver_orchestration_event(
+            organization_id=self.organization.id,
+            event=event,
+        )
+
+    def test_out_of_order_events_deduplicate_and_ignore_delayed_responses(self) -> None:
+        second_id = uuid4()
+        second = self.event(
+            2,
+            "workflow_updated",
+            {"projection": self.projection(workflow_version=3, phase="investigating")},
+            event_id=second_id,
+        )
+        first = self.event(
+            1,
+            "workflow_updated",
+            {"projection": self.projection(workflow_version=2, phase="planning")},
+        )
+
+        waiting = self.deliver(second)
+        assert waiting.last_applied_sequence == 0
+        assert waiting.application_status == InvestigationOrchestrationEventStatus.PENDING
+
+        applied = self.deliver(first)
+        assert applied.last_applied_sequence == 2
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 3
+        assert self.orchestration_run.phase == "investigating"
+
+        duplicate = self.deliver(second)
+        assert duplicate.duplicate is True
+        assert duplicate.last_applied_sequence == 2
+        assert (
+            InvestigationOrchestrationEvent.objects.filter(
+                orchestration_run=self.orchestration_run
+            ).count()
+            == 2
+        )
+
+        changed = self.event(
+            2,
+            "workflow_updated",
+            {"projection": self.projection(workflow_version=4)},
+            event_id=second_id,
+        )
+        with pytest.raises(InvestigationOrchestrationEventConflict):
+            self.deliver(changed)
+
+        synchronize_orchestration_projection(
+            orchestration_run_id=self.orchestration_run.id,
+            seer_run_id=self.seer_run_id,
+            projection=self.projection(workflow_version=2, phase="planning"),
+        )
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 3
+        assert self.orchestration_run.phase == "investigating"
+
+    def test_synchronize_projection_applies_newer_state_without_consuming_events(self) -> None:
+        synchronize_orchestration_projection(
+            orchestration_run_id=self.orchestration_run.id,
+            seer_run_id=self.seer_run_id,
+            projection=self.projection(
+                workflow_version=2,
+                generation=2,
+                phase="planning",
+            ),
+        )
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        assert self.orchestration_run.generation == 2
+        assert self.orchestration_run.phase == "planning"
+        assert self.orchestration_run.last_event_sequence == 0
+
+    def test_synchronize_projection_rejects_invalid_seer_run_ids(self) -> None:
+        for seer_run_id in (True, 0, I64_MAX + 1):
+            with pytest.raises(serializers.ValidationError):
+                synchronize_orchestration_projection(
+                    orchestration_run_id=self.orchestration_run.id,
+                    seer_run_id=seer_run_id,
+                    projection=self.projection(),
+                )
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.seer_run.seer_run_state_id == self.seer_run_id
+
+    def test_reconcile_projection_can_authoritatively_replace_state(self) -> None:
+        self.orchestration_run.update(
+            workflow_version=3,
+            generation=3,
+            phase="investigating",
+        )
+
+        reconcile_orchestration_projection(
+            orchestration_run_id=self.orchestration_run.id,
+            seer_run_id=self.seer_run_id,
+            projection=self.projection(
+                workflow_version=2,
+                generation=2,
+                phase="planning",
+            ),
+        )
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        assert self.orchestration_run.generation == 2
+        assert self.orchestration_run.phase == "planning"
+        assert self.orchestration_run.last_event_sequence == 0
+
+    def test_stale_and_future_generations_are_consumed_without_mutation(self) -> None:
+        self.deliver(
+            self.event(
+                1,
+                "workflow_updated",
+                {"projection": self.projection(workflow_version=2, generation=2)},
+                generation=2,
+            )
+        )
+        stale = self.deliver(self.event(2, "report_clear", {"reportRevision": 4}, generation=1))
+        future_without_projection = self.deliver(
+            self.event(3, "report_clear", {"reportRevision": 5}, generation=3)
+        )
+
+        assert stale.application_status == InvestigationOrchestrationEventStatus.IGNORED
+        assert future_without_projection.application_status == (
+            InvestigationOrchestrationEventStatus.IGNORED
+        )
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.generation == 2
+        assert self.orchestration_run.notebook_revision == 0
+        assert self.orchestration_run.last_event_sequence == 3
+
+    def test_terminal_full_snapshot_recovers_a_sequence_gap(self) -> None:
+        waiting = self.deliver(
+            self.event(
+                3,
+                "state_snapshot",
+                {
+                    "terminal": False,
+                    "full": True,
+                    "projection": self.projection(workflow_version=3),
+                    "blocks": [],
+                },
+            )
+        )
+        assert waiting.last_applied_sequence == 0
+
+        reconciled = self.deliver(
+            self.event(
+                5,
+                "state_snapshot",
+                {
+                    "terminal": True,
+                    "full": True,
+                    "projection": self.projection(
+                        workflow_version=5,
+                        phase="completed",
+                        status="completed",
+                    ),
+                    "blocks": [],
+                },
+            )
+        )
+
+        assert reconciled.last_applied_sequence == 5
+        assert reconciled.application_status == InvestigationOrchestrationEventStatus.APPLIED
+        waiting_event = InvestigationOrchestrationEvent.objects.get(sequence=3)
+        assert waiting_event.application_status == InvestigationOrchestrationEventStatus.IGNORED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.status == "completed"
+        assert self.orchestration_run.workflow_version == 5
+
+    def test_projection_evidence_must_use_investigation_projects(self) -> None:
+        self.create_investigation_project(
+            investigation=self.investigation,
+            project=self.project,
+        )
+        unlinked_project = self.create_project(organization=self.organization)
+        projection = self.projection()
+        projection["hypotheses"] = [
+            {
+                "id": "hypothesis-1",
+                "order": 0,
+                "statement": "A release caused the regression",
+                "rationale": "The timing lines up.",
+                "status": "completed",
+                "effectiveStatus": "supported",
+                "decisionSource": "agent",
+                "verificationSteps": [],
+                "evidence": [
+                    {
+                        "id": "evidence-1",
+                        "title": "Unlinked project event",
+                        "kind": "event",
+                        "projectIds": [unlinked_project.id],
+                    }
+                ],
+                "toolActivity": [],
+            }
+        ]
+
+        delivered = self.deliver(self.event(1, "workflow_updated", {"projection": projection}))
+
+        assert delivered.application_status == InvestigationOrchestrationEventStatus.FAILED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.projection["hypotheses"] == []
+
+    def test_projection_accepts_evidence_from_an_investigation_project(self) -> None:
+        self.create_investigation_project(
+            investigation=self.investigation,
+            project=self.project,
+        )
+        projection = self.projection()
+        projection["hypotheses"] = [
+            {
+                "id": "hypothesis-1",
+                "order": 0,
+                "statement": "A release caused the regression",
+                "rationale": "The timing lines up.",
+                "status": "completed",
+                "effectiveStatus": "supported",
+                "decisionSource": "agent",
+                "verificationSteps": [],
+                "evidence": [
+                    {
+                        "id": "evidence-1",
+                        "title": "Linked project event",
+                        "kind": "event",
+                        "projectIds": [self.project.id],
+                    }
+                ],
+                "toolActivity": [],
+            }
+        ]
+
+        delivered = self.deliver(self.event(1, "workflow_updated", {"projection": projection}))
+
+        assert delivered.application_status == InvestigationOrchestrationEventStatus.APPLIED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.projection["hypotheses"][0]["evidence"] == [
+            {
+                "id": "evidence-1",
+                "title": "Linked project event",
+                "kind": "event",
+                "projectIds": [self.project.id],
+            }
+        ]
+
+    def test_verification_evidence_must_use_investigation_projects(self) -> None:
+        self.create_investigation_project(
+            investigation=self.investigation,
+            project=self.project,
+        )
+        unlinked_project = self.create_project(organization=self.organization)
+        projection = self.projection()
+        projection["hypotheses"] = [
+            {
+                "id": "hypothesis-1",
+                "order": 0,
+                "statement": "A release caused the regression",
+                "rationale": "The timing lines up.",
+                "status": "completed",
+                "effectiveStatus": "supported",
+                "decisionSource": "agent",
+                "verificationSteps": [
+                    {
+                        "id": "step-1",
+                        "order": 0,
+                        "title": "Inspect the event",
+                        "objective": "Verify the affected project.",
+                        "method": "Read the event details.",
+                        "status": "completed",
+                        "evidence": [
+                            {
+                                "id": "evidence-1",
+                                "title": "Unlinked project event",
+                                "kind": "event",
+                                "projectIds": [unlinked_project.id],
+                            }
+                        ],
+                    }
+                ],
+                "evidence": [],
+                "toolActivity": [],
+            }
+        ]
+
+        delivered = self.deliver(self.event(1, "workflow_updated", {"projection": projection}))
+
+        assert delivered.application_status == InvestigationOrchestrationEventStatus.FAILED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.projection["hypotheses"] == []
+
+
+class InvestigationOrchestrationSeerRunAdoptionTest(SeerRunMirrorMixin, TestCase):
     def orchestration_run(self) -> InvestigationOrchestrationRun:
         investigation, run = create_agentic_manual_investigation(
             organization=self.organization,
@@ -116,15 +503,37 @@ class InvestigationOrchestrationSeerRunAdoptionTest(TestCase):
         return run
 
     def event(self, run: InvestigationOrchestrationRun, **overrides: Any) -> dict[str, Any]:
+        run_id = overrides.pop("run_id", 8128)
         event: dict[str, Any] = {
             "schema_version": 1,
             "event_id": str(uuid4()),
-            "run_id": 8128,
+            "run_id": run_id,
             "investigation_id": run.investigation_id,
             "sequence": 1,
             "generation": 1,
             "type": "workflow_updated",
-            "payload": {"projection": {}},
+            "payload": {
+                "projection": {
+                    "runId": run_id,
+                    "investigationId": str(run.investigation_id),
+                    "sourceType": "manual",
+                    "workflowVersion": 1,
+                    "generation": 1,
+                    "phase": "broad_scan",
+                    "status": "processing",
+                    "broadScan": {"status": "running"},
+                    "hypotheses": [],
+                    "report": {
+                        "revision": 0,
+                        "status": "not_started",
+                        "notebookRevision": 0,
+                        "metadata": {"status": "not_started"},
+                    },
+                    "pendingInput": None,
+                    "errors": [],
+                    "heartbeatAt": "2025-01-01T00:00:00+00:00",
+                }
+            },
         }
         event.update(overrides)
         return event

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -327,6 +327,46 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         self.orchestration_run.refresh_from_db()
         assert self.orchestration_run.heartbeat_at >= before
 
+    def test_workflow_failure_carrying_a_projection_may_advance_the_generation(self) -> None:
+        receipt = self.deliver(
+            self.event(
+                1,
+                "workflow_failed",
+                {
+                    "error": {"code": "seer_failed", "message": "Seer gave up."},
+                    "projection": self.projection(workflow_version=2, generation=2),
+                },
+                generation=2,
+            )
+        )
+
+        assert receipt.application_status == InvestigationOrchestrationEventStatus.APPLIED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.status == InvestigationOrchestrationStatus.FAILED
+        assert self.orchestration_run.generation == 2
+
+    def test_workflow_failure_does_not_apply_a_stale_projection(self) -> None:
+        self.deliver(
+            self.event(1, "workflow_updated", {"projection": self.projection(workflow_version=5)})
+        )
+
+        self.deliver(
+            self.event(
+                2,
+                "workflow_failed",
+                {
+                    "error": {"code": "seer_failed", "message": "Seer gave up."},
+                    "projection": self.projection(workflow_version=2, phase="planning"),
+                },
+            )
+        )
+
+        self.orchestration_run.refresh_from_db()
+        # The run fails either way; what the stale projection must not do is
+        # replace the stored blob with its older contents.
+        assert self.orchestration_run.projection["workflowVersion"] == 5
+        assert self.orchestration_run.status == InvestigationOrchestrationStatus.FAILED
+
     def test_stale_and_future_generations_are_consumed_without_mutation(self) -> None:
         self.deliver(
             self.event(

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -367,6 +367,29 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         assert self.orchestration_run.projection["workflowVersion"] == 5
         assert self.orchestration_run.status == InvestigationOrchestrationStatus.FAILED
 
+    def test_report_events_are_not_reported_as_applied(self) -> None:
+        # Report materialization lands separately. Marking these applied would
+        # advance the sequence past work that never happened.
+        receipt = self.deliver(
+            self.event(
+                1,
+                "report_block_started",
+                {
+                    "reportRevision": 0,
+                    "stableAgentKey": "summary",
+                    "position": 0,
+                    "kind": "text",
+                    "title": "Summary",
+                    "projectIds": [self.project.id],
+                },
+            )
+        )
+
+        assert receipt.application_status == InvestigationOrchestrationEventStatus.IGNORED
+        stored = InvestigationOrchestrationEvent.objects.get(sequence=1)
+        assert stored.error == {"reason": "unsupported_event_type"}
+        assert stored.payload["payload"]["stableAgentKey"] == "summary"
+
     def test_stale_and_future_generations_are_consumed_without_mutation(self) -> None:
         self.deliver(
             self.event(

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -4,13 +4,16 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
+from django.utils import timezone
 from rest_framework import serializers
 
 from sentry.db.models.fields.bounded import I64_MAX
 from sentry.investigations.models import (
     InvestigationOrchestrationEvent,
     InvestigationOrchestrationEventStatus,
+    InvestigationOrchestrationPhase,
     InvestigationOrchestrationRun,
+    InvestigationOrchestrationStatus,
 )
 from sentry.investigations.services.orchestration import (
     create_agentic_manual_investigation,
@@ -304,6 +307,25 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         assert self.orchestration_run.generation == 2
         assert self.orchestration_run.phase == "planning"
         assert self.orchestration_run.last_event_sequence == 0
+
+    def test_workflow_failure_fails_the_run_without_a_projection(self) -> None:
+        error = {"code": "seer_unavailable", "message": "Seer stopped responding."}
+
+        receipt = self.deliver(self.event(1, "workflow_failed", {"error": error}))
+
+        assert receipt.application_status == InvestigationOrchestrationEventStatus.APPLIED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.status == InvestigationOrchestrationStatus.FAILED
+        assert self.orchestration_run.phase == InvestigationOrchestrationPhase.FAILED
+        assert self.orchestration_run.error == error
+
+    def test_applying_an_event_records_a_heartbeat(self) -> None:
+        before = timezone.now()
+
+        self.deliver(self.event(1, "workflow_updated", {"projection": self.projection()}))
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.heartbeat_at >= before
 
     def test_stale_and_future_generations_are_consumed_without_mutation(self) -> None:
         self.deliver(

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -16,6 +16,7 @@ from sentry.investigations.models import (
     InvestigationOrchestrationStatus,
 )
 from sentry.investigations.services.orchestration import (
+    accept_orchestration_command,
     create_agentic_manual_investigation,
 )
 from sentry.investigations.services.orchestration_events import (
@@ -295,6 +296,8 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         reconcile_orchestration_projection(
             orchestration_run_id=self.orchestration_run.id,
             seer_run_id=self.seer_run_id,
+            expected_last_event_sequence=0,
+            expected_workflow_version=3,
             projection=self.projection(
                 workflow_version=2,
                 generation=2,
@@ -306,6 +309,58 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         assert self.orchestration_run.workflow_version == 2
         assert self.orchestration_run.generation == 2
         assert self.orchestration_run.phase == "planning"
+        assert self.orchestration_run.last_event_sequence == 0
+
+    def test_reconcile_projection_rejects_an_intervening_event(self) -> None:
+        self.orchestration_run.update(
+            workflow_version=2,
+            projection=self.projection(workflow_version=2),
+        )
+        self.deliver(
+            self.event(
+                1,
+                "workflow_updated",
+                {"projection": self.projection(workflow_version=2, phase="planning")},
+            )
+        )
+
+        with pytest.raises(InvestigationOrchestrationEventConflict):
+            reconcile_orchestration_projection(
+                orchestration_run_id=self.orchestration_run.id,
+                seer_run_id=self.seer_run_id,
+                expected_last_event_sequence=0,
+                expected_workflow_version=2,
+                projection=self.projection(),
+            )
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        assert self.orchestration_run.projection["workflowVersion"] == 2
+        assert self.orchestration_run.phase == "planning"
+        assert self.orchestration_run.last_event_sequence == 1
+
+    def test_reconcile_projection_rejects_an_intervening_command(self) -> None:
+        accept_orchestration_command(
+            investigation=self.investigation,
+            request_id=uuid4(),
+            expected_workflow_version=1,
+            command_type="cancel",
+            payload={},
+            actor_id=self.user.id,
+        )
+
+        with pytest.raises(InvestigationOrchestrationEventConflict):
+            reconcile_orchestration_projection(
+                orchestration_run_id=self.orchestration_run.id,
+                seer_run_id=self.seer_run_id,
+                expected_last_event_sequence=0,
+                expected_workflow_version=1,
+                projection=self.projection(),
+            )
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        assert self.orchestration_run.projection["workflowVersion"] == 2
         assert self.orchestration_run.last_event_sequence == 0
 
     def test_workflow_failure_fails_the_run_without_a_projection(self) -> None:
@@ -399,9 +454,16 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
                 generation=2,
             )
         )
-        stale = self.deliver(self.event(2, "report_clear", {"reportRevision": 4}, generation=1))
+        stale = self.deliver(
+            self.event(2, "workflow_updated", {"projection": self.projection()}, generation=1)
+        )
         future_without_projection = self.deliver(
-            self.event(3, "report_clear", {"reportRevision": 5}, generation=3)
+            self.event(
+                3,
+                "workflow_failed",
+                {"error": {"code": "seer_failed", "message": "Seer gave up."}},
+                generation=3,
+            )
         )
 
         assert stale.application_status == InvestigationOrchestrationEventStatus.IGNORED
@@ -410,6 +472,10 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         )
         self.orchestration_run.refresh_from_db()
         assert self.orchestration_run.generation == 2
+        assert self.orchestration_run.workflow_version == 2
+        assert self.orchestration_run.projection["generation"] == 2
+        assert self.orchestration_run.status == InvestigationOrchestrationStatus.PROCESSING
+        assert self.orchestration_run.error is None
         assert self.orchestration_run.notebook_revision == 0
         assert self.orchestration_run.last_event_sequence == 3
 
@@ -459,7 +525,7 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
             project=self.project,
         )
         unlinked_project = self.create_project(organization=self.organization)
-        projection = self.projection()
+        projection = self.projection(workflow_version=3)
         projection["hypotheses"] = [
             {
                 "id": "hypothesis-1",
@@ -482,11 +548,23 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
             }
         ]
 
-        delivered = self.deliver(self.event(1, "workflow_updated", {"projection": projection}))
+        invalid_event = self.event(2, "workflow_updated", {"projection": projection})
+        waiting = self.deliver(invalid_event)
+        assert waiting.application_status == InvestigationOrchestrationEventStatus.PENDING
+
+        applied = self.deliver(
+            self.event(1, "workflow_updated", {"projection": self.projection(workflow_version=2)})
+        )
+        assert applied.application_status == InvestigationOrchestrationEventStatus.APPLIED
+        assert applied.last_applied_sequence == 2
+
+        delivered = self.deliver(invalid_event)
 
         assert delivered.application_status == InvestigationOrchestrationEventStatus.FAILED
         self.orchestration_run.refresh_from_db()
         assert self.orchestration_run.projection["hypotheses"] == []
+        assert self.orchestration_run.projection["workflowVersion"] == 2
+        assert self.orchestration_run.workflow_version == 2
 
     def test_projection_accepts_evidence_from_an_investigation_project(self) -> None:
         self.create_investigation_project(

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -21,6 +21,7 @@ from sentry.investigations.models import (
     InvestigationOrchestrationEvent,
     InvestigationOrchestrationEventStatus,
 )
+from sentry.investigations.services.orchestration import create_agentic_manual_investigation
 from sentry.models.activity import Activity
 from sentry.models.project import Project
 from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
@@ -1121,19 +1122,23 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         assert response.status_code == 200
         assert "features" in response.data
 
-    def test_investigation_event_is_scoped_staged_and_idempotent(self) -> None:
+    def test_investigation_event_is_scoped_applied_and_idempotent(self) -> None:
         organization = self.create_organization(owner=self.user)
-        investigation = self.create_investigation(
+        investigation, run = create_agentic_manual_investigation(
             organization=organization,
-            created_by=self.user,
-            source={"type": "manual"},
-        )
-        run = self.create_investigation_orchestration_run(
-            investigation=investigation,
-            source={"type": "manual"},
-            projection={},
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
         )
         event_id = uuid4()
+        projection = {
+            **run.projection,
+            "runId": 42,
+            "status": "processing",
+            "heartbeatAt": "2025-01-01T00:00:00+00:00",
+        }
         event = {
             "schemaVersion": 1,
             "eventId": str(event_id),
@@ -1142,7 +1147,7 @@ class TestSeerRpcViewerContextAuth(APITestCase):
             "sequence": 1,
             "generation": 1,
             "type": "workflow_updated",
-            "payload": {"projection": {"status": "processing"}},
+            "payload": {"projection": projection},
         }
         path = self._get_path("deliver_investigation_event")
         data: dict[str, Any] = {
@@ -1163,9 +1168,9 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         assert response.data == {
             "accepted": True,
             "duplicate": False,
-            "applicationStatus": "pending",
-            "lastAppliedSequence": 0,
-            "nextExpectedSequence": 1,
+            "applicationStatus": "applied",
+            "lastAppliedSequence": 1,
+            "nextExpectedSequence": 2,
             "notebookRevision": 0,
         }
         run.refresh_from_db()
@@ -1174,32 +1179,36 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         assert run.seer_run.seer_run_state_id == 42
         assert run.seer_run.type == SeerRunType.INVESTIGATION.value
         assert run.seer_run.organization_id == organization.id
-        assert run.last_event_sequence == 0
+        # The reducer applies the event, so the sequence advances.
+        assert run.last_event_sequence == 1
         stored = InvestigationOrchestrationEvent.objects.get(
             orchestration_run=run,
             event_id=event_id,
         )
-        assert stored.application_status == InvestigationOrchestrationEventStatus.PENDING
+        assert stored.application_status == InvestigationOrchestrationEventStatus.APPLIED
         assert stored.payload == {
             "schemaVersion": 1,
             "runId": 42,
             "investigationId": investigation.id,
             "generation": 1,
-            "payload": {"projection": {"status": "processing"}},
+            "payload": {"projection": projection},
         }
 
         duplicate = self.client.post(path, data=data, **headers)
 
         assert duplicate.status_code == 200
         assert duplicate.data["duplicate"] is True
-        assert duplicate.data["applicationStatus"] == "pending"
+        assert duplicate.data["applicationStatus"] == "applied"
         assert InvestigationOrchestrationEvent.objects.filter(orchestration_run=run).count() == 1
 
         conflicting_data = {
             **data,
             "args": {
                 **data["args"],
-                "event": {**event, "payload": {"projection": {"status": "failed"}}},
+                "event": {
+                    **event,
+                    "payload": {"projection": {**projection, "status": "failed"}},
+                },
             },
         }
         conflicting = self.client.post(


### PR DESCRIPTION
Stage the events Seer sends for an investigation, then apply the contiguous ones in order and keep the run's projection up to date. A terminal snapshot fast-forwards over a gap in the sequence.

Handles the projection events only: `workflow_updated`, `state_snapshot` and `workflow_failed`. Report block materialization follows in a PR on top of this one.

Payload schemas come from #123534, which this is based on.