### PR TITLE
fix(uptime): Limit max number of messages per process to 10k

### DIFF
--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -28,6 +28,7 @@ def _get_eap_items_producer(name: str = "sentry.uptime.consumers.eap_producer"):
         name,
         Topic.SNUBA_ITEMS,
         exclude_config_keys=["compression.type", "message.max.bytes"],
+        additional_config={"queue.buffering.max.messages": 10_000},
     )
 
 


### PR DESCRIPTION
We added queue limits recently of 100k per process. Since we run a lot of processes in uptime, this caused a fairly large memory increase. Dropping this down to a reasonable level - this should lower our general memory usage and allow us to drop our memory usage back down.

<!-- Describe your PR here. -->