### PR TITLE
fix(seer-infra-telemetry): Switch Datadog whoami from MCP to API

### DIFF
--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -24,6 +24,7 @@ from sentry.identity.oauth2 import (
     record_event,
 )
 from sentry.identity.services.identity.model import RpcIdentity
+from sentry.integrations.datadog.client import DATADOG_VALID_SITES
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationPipelineViewType
 from sentry.pipeline.views.base import PipelineView
@@ -32,17 +33,6 @@ from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
     from sentry.identity.pipeline import IdentityPipeline
-
-DATADOG_VALID_SITES: dict[str, str] = {
-    "datadoghq.com": "US1",
-    "us3.datadoghq.com": "US3",
-    "us5.datadoghq.com": "US5",
-    "datadoghq.eu": "EU",
-    "ap1.datadoghq.com": "AP1",
-    "ap2.datadoghq.com": "AP2",
-    "ddog-gov.com": "US1-FED",
-    "us2.ddog-gov.com": "US2-FED",
-}
 
 MCP_REGISTER_PATH = "/api/unstable/mcp-server/register"
 MCP_AUTHORIZE_PATH = "/api/unstable/mcp-server/authorize"

--- a/src/sentry/integrations/datadog/client.py
+++ b/src/sentry/integrations/datadog/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import orjson
 from requests import HTTPError, RequestException
 
+from sentry.exceptions import RestrictedIPAddress
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
@@ -52,7 +53,7 @@ def validate_datadog_credentials(api_key: str, app_key: str, site: str) -> str:
         raise IntegrationConfigurationError(
             "Unable to validate Datadog credentials. Please try again."
         )
-    except RequestException:
+    except (RestrictedIPAddress, RequestException):
         raise IntegrationConfigurationError(
             "Could not reach Datadog to validate credentials. Please try again."
         )

--- a/src/sentry/integrations/datadog/client.py
+++ b/src/sentry/integrations/datadog/client.py
@@ -1,25 +1,48 @@
 from __future__ import annotations
 
+import orjson
 from requests import HTTPError, RequestException
 
-from sentry.auth.exceptions import IdentityNotValid
-from sentry.identity.datadog.provider import DatadogWhoami, mcp_base_url_for_site, mcp_whoami
+from sentry.http import safe_urlopen, safe_urlread
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
+DATADOG_VALID_SITES: dict[str, str] = {
+    "datadoghq.com": "US1",
+    "us3.datadoghq.com": "US3",
+    "us5.datadoghq.com": "US5",
+    "datadoghq.eu": "EU",
+    "ap1.datadoghq.com": "AP1",
+    "ap2.datadoghq.com": "AP2",
+    "ddog-gov.com": "US1-FED",
+    "us2.ddog-gov.com": "US2-FED",
+}
 
-def validate_datadog_credentials(api_key: str, app_key: str, site: str) -> DatadogWhoami:
+
+def api_base_url_for_site(site: str | None) -> str | None:
+    """Validated Datadog REST API base URL for a site, or None if it's missing/invalid."""
+    if not site or site not in DATADOG_VALID_SITES:
+        return None
+    return f"https://api.{site}"
+
+
+def validate_datadog_credentials(api_key: str, app_key: str, site: str) -> str:
     """Validate Datadog API + application keys.
 
-    Returns the whoami payload on success, or raises ``IntegrationConfigurationError``
-    if the site or credentials are invalid.
+    Returns the Datadog organization UUID on success, or raises
+    ``IntegrationConfigurationError`` if the site or credentials are invalid.
     """
-    base_url = mcp_base_url_for_site(site)
+    base_url = api_base_url_for_site(site)
     if base_url is None:
         raise IntegrationConfigurationError(f"Invalid Datadog site: {site}")
 
-    headers = {"DD-API-KEY": api_key, "DD-APPLICATION-KEY": app_key}
+    headers = {
+        "DD-API-KEY": api_key,
+        "DD-APPLICATION-KEY": app_key,
+        "Accept": "application/json",
+    }
     try:
-        user = mcp_whoami(base_url, headers)
+        resp = safe_urlopen(f"{base_url}/api/v2/current_user", method="GET", headers=headers)
+        resp.raise_for_status()
     except HTTPError as e:
         status = e.response.status_code if e.response is not None else None
         if status in (401, 403):
@@ -33,14 +56,11 @@ def validate_datadog_credentials(api_key: str, app_key: str, site: str) -> Datad
         raise IntegrationConfigurationError(
             "Could not reach Datadog to validate credentials. Please try again."
         )
-    except IdentityNotValid:
+
+    try:
+        body = orjson.loads(safe_urlread(resp))
+        return body["data"]["relationships"]["org"]["data"]["id"]
+    except (KeyError, IndexError, TypeError, orjson.JSONDecodeError):
         raise IntegrationConfigurationError(
             "Datadog returned an unexpected response while validating credentials."
         )
-
-    if "user_uuid" not in user or "org_uuid" not in user:
-        raise IntegrationConfigurationError(
-            "Datadog credentials are missing expected user/organization info; "
-            "check the application key."
-        )
-    return user

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -11,11 +11,7 @@ from rest_framework.fields import CharField
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
-from sentry.identity.datadog.provider import (
-    DATADOG_VALID_SITES,
-    MCP_ENDPOINT_PATH,
-    mcp_base_url_for_site,
-)
+from sentry.identity.datadog.provider import MCP_ENDPOINT_PATH, mcp_base_url_for_site
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -24,7 +20,7 @@ from sentry.integrations.base import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.datadog.client import validate_datadog_credentials
+from sentry.integrations.datadog.client import DATADOG_VALID_SITES, validate_datadog_credentials
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
@@ -188,12 +184,12 @@ class DatadogIntegrationProvider(IntegrationProvider):
         api_key = config["api_key"]
         app_key = config["app_key"]
         site = config["site"]
-        user = validate_datadog_credentials(api_key, app_key, site)
+        org_uuid = validate_datadog_credentials(api_key, app_key, site)
         credentials: DatadogCredentials = {"api_key": api_key, "app_key": app_key, "site": site}
 
         assert self.pipeline.organization is not None
         external_id = hashlib.sha256(
-            f"{self.pipeline.organization.id}:{user['org_uuid']}".encode()
+            f"{self.pipeline.organization.id}:{org_uuid}".encode()
         ).hexdigest()
 
         return {

--- a/static/app/utils/seer/datadogSites.ts
+++ b/static/app/utils/seer/datadogSites.ts
@@ -1,4 +1,4 @@
-// Keep in sync with DATADOG_VALID_SITES in src/sentry/identity/datadog/provider.py.
+// Keep in sync with DATADOG_VALID_SITES in src/sentry/integrations/datadog/client.py.
 export const DATADOG_SITES = [
   {value: 'datadoghq.com', label: 'datadoghq.com (US1)'},
   {value: 'us3.datadoghq.com', label: 'us3.datadoghq.com (US3)'},

--- a/tests/sentry/integrations/datadog/test_client.py
+++ b/tests/sentry/integrations/datadog/test_client.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 import responses
 
+from sentry.exceptions import RestrictedIPAddress
 from sentry.integrations.datadog.client import validate_datadog_credentials
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
@@ -43,6 +44,14 @@ def test_validate_translates_auth_error() -> None:
 @responses.activate
 def test_validate_translates_network_error() -> None:
     responses.add(responses.GET, CURRENT_USER_URL, body=requests.exceptions.ConnectionError("boom"))
+
+    with pytest.raises(IntegrationConfigurationError, match="Could not reach Datadog"):
+        validate_datadog_credentials("api", "app", "datadoghq.com")
+
+
+@responses.activate
+def test_validate_translates_restricted_ip() -> None:
+    responses.add(responses.GET, CURRENT_USER_URL, body=RestrictedIPAddress("blocked"))
 
     with pytest.raises(IntegrationConfigurationError, match="Could not reach Datadog"):
         validate_datadog_credentials("api", "app", "datadoghq.com")

--- a/tests/sentry/integrations/datadog/test_client.py
+++ b/tests/sentry/integrations/datadog/test_client.py
@@ -1,38 +1,25 @@
-from typing import Any
-
 import pytest
 import requests
 import responses
 
 from sentry.integrations.datadog.client import validate_datadog_credentials
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
-from sentry.utils import json
 
-MCP_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
-
-
-def _mock_initialize() -> None:
-    # First MCP call: initialize -> returns the session id header mcp_whoami needs.
-    responses.add(responses.POST, MCP_URL, status=200, headers={"mcp-session-id": "sess-1"})
-
-
-def _mock_whoami(whoami: dict[str, Any]) -> None:
-    _mock_initialize()
-    responses.add(
-        responses.POST,
-        MCP_URL,
-        status=200,
-        json={"result": {"contents": [{"text": json.dumps(whoami)}]}},
-    )
+CURRENT_USER_URL = "https://api.datadoghq.com/api/v2/current_user"
 
 
 @responses.activate
-def test_validate_returns_whoami_and_sends_dd_headers() -> None:
-    _mock_whoami({"user_uuid": "u-1", "org_uuid": "org-1"})
+def test_validate_returns_org_uuid_and_sends_dd_headers() -> None:
+    responses.add(
+        responses.GET,
+        CURRENT_USER_URL,
+        status=200,
+        json={"data": {"relationships": {"org": {"data": {"id": "org-1"}}}}},
+    )
 
     result = validate_datadog_credentials("api", "app", "datadoghq.com")
 
-    assert result["org_uuid"] == "org-1"
+    assert result == "org-1"
     sent = responses.calls[0].request.headers
     assert sent["DD-API-KEY"] == "api"
     assert sent["DD-APPLICATION-KEY"] == "app"
@@ -47,7 +34,7 @@ def test_validate_rejects_invalid_site() -> None:
 
 @responses.activate
 def test_validate_translates_auth_error() -> None:
-    responses.add(responses.POST, MCP_URL, status=403, json={"error": "forbidden"})
+    responses.add(responses.GET, CURRENT_USER_URL, status=403, json={"errors": ["forbidden"]})
 
     with pytest.raises(IntegrationConfigurationError, match="Invalid Datadog API"):
         validate_datadog_credentials("api", "app", "datadoghq.com")
@@ -55,7 +42,7 @@ def test_validate_translates_auth_error() -> None:
 
 @responses.activate
 def test_validate_translates_network_error() -> None:
-    responses.add(responses.POST, MCP_URL, body=requests.exceptions.ConnectionError("boom"))
+    responses.add(responses.GET, CURRENT_USER_URL, body=requests.exceptions.ConnectionError("boom"))
 
     with pytest.raises(IntegrationConfigurationError, match="Could not reach Datadog"):
         validate_datadog_credentials("api", "app", "datadoghq.com")
@@ -63,24 +50,7 @@ def test_validate_translates_network_error() -> None:
 
 @responses.activate
 def test_validate_translates_unexpected_response() -> None:
-    _mock_initialize()
-    responses.add(responses.POST, MCP_URL, status=200, json={"unexpected": "shape"})
+    responses.add(responses.GET, CURRENT_USER_URL, status=200, json={"unexpected": "shape"})
 
     with pytest.raises(IntegrationConfigurationError, match="unexpected response"):
-        validate_datadog_credentials("api", "app", "datadoghq.com")
-
-
-@responses.activate
-def test_validate_requires_org_uuid() -> None:
-    _mock_whoami({"user_uuid": "u-1"})  # whoami omits org_uuid
-
-    with pytest.raises(IntegrationConfigurationError, match="missing expected user/organization"):
-        validate_datadog_credentials("api", "app", "datadoghq.com")
-
-
-@responses.activate
-def test_validate_requires_user_uuid() -> None:
-    _mock_whoami({"org_uuid": "org-1"})
-
-    with pytest.raises(IntegrationConfigurationError, match="missing expected user/organization"):
         validate_datadog_credentials("api", "app", "datadoghq.com")

--- a/tests/sentry/integrations/datadog/test_integration.py
+++ b/tests/sentry/integrations/datadog/test_integration.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 import responses
 
-from sentry.identity.datadog.provider import DATADOG_VALID_SITES
+from sentry.integrations.datadog.client import DATADOG_VALID_SITES
 from sentry.integrations.datadog.integration import (
     DatadogIntegration,
     DatadogIntegrationProvider,
@@ -14,9 +14,8 @@ from sentry.integrations.datadog.integration import (
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
-MCP_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+CURRENT_USER_URL = "https://api.datadoghq.com/api/v2/current_user"
 
 
 def test_frontend_datadog_sites_match_backend() -> None:
@@ -30,13 +29,12 @@ def test_frontend_datadog_sites_match_backend() -> None:
     assert frontend_sites == set(DATADOG_VALID_SITES)
 
 
-def _mock_whoami(whoami: dict[str, Any]) -> None:
-    responses.add(responses.POST, MCP_URL, status=200, headers={"mcp-session-id": "sess-1"})
+def _mock_current_user(org_uuid: str) -> None:
     responses.add(
-        responses.POST,
-        MCP_URL,
+        responses.GET,
+        CURRENT_USER_URL,
         status=200,
-        json={"result": {"contents": [{"text": json.dumps(whoami)}]}},
+        json={"data": {"relationships": {"org": {"data": {"id": org_uuid}}}}},
     )
 
 
@@ -59,7 +57,7 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
 
     @responses.activate
     def test_build_integration_validates_and_stores_metadata(self) -> None:
-        _mock_whoami({"user_uuid": "u-1", "org_uuid": "org-123"})
+        _mock_current_user("org-123")
 
         result = self._provider().build_integration(self._state())
 
@@ -82,7 +80,7 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
 
     @responses.activate
     def test_build_integration_raises_on_invalid_credentials(self) -> None:
-        responses.add(responses.POST, MCP_URL, status=403, json={"error": "forbidden"})
+        responses.add(responses.GET, CURRENT_USER_URL, status=403, json={"errors": ["forbidden"]})
 
         with pytest.raises(IntegrationConfigurationError):
             self._provider().build_integration(self._state())
@@ -140,7 +138,7 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
             metadata={"api_key": "old-api", "app_key": "old-app", "site": "datadoghq.com"},
         )
         installation = integration.get_installation(organization_id=self.organization.id)
-        _mock_whoami({"user_uuid": "u-1", "org_uuid": "org-123"})
+        _mock_current_user("org-123")
 
         installation.update_organization_config(
             {"api_key": "new-api", "app_key": "new-app", "site": "datadoghq.com"}
@@ -163,7 +161,7 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
             metadata={"api_key": "api", "app_key": "app", "site": "datadoghq.com"},
         )
         installation = integration.get_installation(organization_id=self.organization.id)
-        _mock_whoami({"user_uuid": "u-1", "org_uuid": "org-123"})
+        _mock_current_user("org-123")
 
         installation.update_organization_config({"site": "datadoghq.com"})
 
@@ -181,17 +179,11 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
             metadata={"api_key": "api", "app_key": "app", "site": "datadoghq.com"},
         )
         installation = integration.get_installation(organization_id=self.organization.id)
-        eu_url = "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp"
-        responses.add(responses.POST, eu_url, status=200, headers={"mcp-session-id": "sess-1"})
         responses.add(
-            responses.POST,
-            eu_url,
+            responses.GET,
+            "https://api.datadoghq.eu/api/v2/current_user",
             status=200,
-            json={
-                "result": {
-                    "contents": [{"text": json.dumps({"user_uuid": "u-1", "org_uuid": "org-123"})}]
-                }
-            },
+            json={"data": {"relationships": {"org": {"data": {"id": "org-123"}}}}},
         )
 
         installation.update_organization_config({"site": "datadoghq.eu"})


### PR DESCRIPTION
fixes CW-1983

I was getting `Datadog returned an unexpected response while validating credentials.` meaning the Datadog whoami MCP changed response formats. The Datadog MCP is currently marked as unstable and under development, so switch the whoami on Datadog integration installation from MCP to API. 

Use the https://docs.datadoghq.com/api/latest/users/get-current-user/ endpoint which has no additional scope requirements besides a pair of valid keys.