### PR TITLE
feat(integrations): Defer GitHub issue form options

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -133,6 +133,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:slack-reinstall-nudge-on-issue-alert", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable GitHub Enterprise to accept github.com as a valid Installation URL
     manager.add("organizations:github-enterprise-github-com-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Load GitHub issue form options asynchronously instead of blocking form config
+    manager.add("organizations:github-issue-form-prefetch", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # API-driven integration setup pipeline (per-provider rollout)
     # ...
     # Project Management Integrations Feature Parity Flags

--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -17,6 +17,7 @@ from sentry.integrations.services.integration import (
     RpcOrganizationIntegration,
     integration_service,
 )
+from sentry.integrations.types import IntegrationIssueConfigField
 from sentry.integrations.utils.github_permissions import get_missing_github_app_permissions
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models.user import User
@@ -112,7 +113,7 @@ class IntegrationSerializer(Serializer):
 
 class IntegrationConfigSerializerResponse(IntegrationSerializerResponse, total=False):
     configOrganization: Sequence[Any]
-    createIssueConfig: list[dict[str, Any]]
+    createIssueConfig: list[IntegrationIssueConfigField]
 
 
 class IntegrationConfigSerializer(IntegrationSerializer):

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -6,6 +6,7 @@ from typing import Any, NoReturn
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.types import IntegrationIssueConfigField
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
 from sentry.shared_integrations.exceptions import (
@@ -52,7 +53,7 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
     @all_silo_function
     def get_create_issue_config(
         self, group: Group | None, user: User | RpcUser, **kwargs
-    ) -> list[dict[str, Any]]:
+    ) -> list[IntegrationIssueConfigField]:
         kwargs["link_referrer"] = "bitbucket_integration"
 
         if group:

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -229,8 +229,10 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         if prefetch_options:
             repo_field["prefetch"] = True
             assignee_field["prefetch"] = True
+            assignee_field["dependsOn"] = ["repo"]
             assignee_field["url"] = autocomplete_url
             label_field["prefetch"] = True
+            label_field["dependsOn"] = ["repo"]
             label_field["url"] = autocomplete_url
 
         return [repo_field, *fields, assignee_field, label_field]

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -7,10 +7,12 @@ from typing import Any, NoReturn
 
 from django.urls import reverse
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.types import IntegrationIssueConfigField
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
@@ -149,7 +151,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
     @all_silo_function
     def get_create_issue_config(
         self, group: Group | None, user: User | RpcUser, **kwargs: Any
-    ) -> list[dict[str, Any]]:
+    ) -> list[IntegrationIssueConfigField]:
         """
         We use the `group` to get three things: organization_slug, project
         defaults, and default title and description. In the case where we're
@@ -176,48 +178,62 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             org = org_context.organization
 
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params, PAGE_LIMIT)
-
-        assignees = self.get_allowed_assignees(default_repo, PAGE_LIMIT) if default_repo else []
-        labels: Sequence[tuple[str, str]] = []
-        if default_repo:
-            owner, repo = default_repo.split("/")
-            labels = self.get_repo_labels(owner, repo, PAGE_LIMIT)
+        prefetch_options = features.has("organizations:github-issue-form-prefetch", org, actor=user)
+        if prefetch_options:
+            defaults = self.get_project_defaults(group.project_id) if group else {}
+            configured_repo = params.get("repo") or defaults.get("repo")
+            default_repo = str(configured_repo) if configured_repo else ""
+            repo_choices = [self.create_default_repo_choice(default_repo)] if default_repo else []
+            assignees: Sequence[tuple[str, str]] = []
+            labels: Sequence[tuple[str, str]] = []
+        else:
+            default_repo, repo_choices = self.get_repository_choices(group, params, PAGE_LIMIT)
+            assignees = self.get_allowed_assignees(default_repo, PAGE_LIMIT) if default_repo else []
+            labels = []
+            if default_repo:
+                owner, repo = default_repo.split("/")
+                labels = self.get_repo_labels(owner, repo, PAGE_LIMIT)
 
         autocomplete_url = reverse(
             "sentry-integration-github-search", args=[org.slug, self.model.id]
         )
 
-        return [
-            {
-                "name": "repo",
-                "label": "GitHub Repository",
-                "type": "select",
-                "default": default_repo,
-                "choices": repo_choices,
-                "url": autocomplete_url,
-                "updatesForm": True,
-                "required": True,
-            },
-            *fields,
-            {
-                "name": "assignee",
-                "label": "Assignee",
-                "default": "",
-                "type": "select",
-                "required": False,
-                "choices": assignees,
-            },
-            {
-                "name": "labels",
-                "label": "Labels",
-                "default": [],
-                "type": "select",
-                "multiple": True,
-                "required": False,
-                "choices": labels,
-            },
-        ]
+        repo_field: IntegrationIssueConfigField = {
+            "name": "repo",
+            "label": "GitHub Repository",
+            "type": "select",
+            "default": default_repo,
+            "choices": repo_choices,
+            "url": autocomplete_url,
+            "updatesForm": True,
+            "required": True,
+        }
+        assignee_field: IntegrationIssueConfigField = {
+            "name": "assignee",
+            "label": "Assignee",
+            "default": "",
+            "type": "select",
+            "required": False,
+            "choices": assignees,
+        }
+        label_field: IntegrationIssueConfigField = {
+            "name": "labels",
+            "label": "Labels",
+            "default": [],
+            "type": "select",
+            "multiple": True,
+            "required": False,
+            "choices": labels,
+        }
+
+        if prefetch_options:
+            repo_field["prefetch"] = True
+            assignee_field["prefetch"] = True
+            assignee_field["url"] = autocomplete_url
+            label_field["prefetch"] = True
+            label_field["url"] = autocomplete_url
+
+        return [repo_field, *fields, assignee_field, label_field]
 
     def create_issue(self, data: Mapping[str, Any], **kwargs: Any) -> Mapping[str, Any]:
         client = self.get_client()

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -66,27 +66,27 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
             SCMIntegrationInteractionType.HANDLE_SEARCH_REPOSITORIES,
             organization_id=installation.organization_id,
             integration_id=integration.id,
-        ).capture() as lifecyle:
+        ).capture() as lifecycle:
             assert isinstance(installation, self.installation_class)
 
-            if not query:
-                repositories = installation.get_repositories(page_number_limit=PAGE_LIMIT)
-                return Response(
-                    [
-                        {"label": repository["name"], "value": repository["identifier"]}
-                        for repository in repositories
-                    ]
-                )
-
-            full_query = build_repository_query(integration.metadata, integration.name, query)
             try:
+                if not query:
+                    repositories = installation.get_repositories(page_number_limit=PAGE_LIMIT)
+                    return Response(
+                        [
+                            {"label": repository["name"], "value": repository["identifier"]}
+                            for repository in repositories
+                        ]
+                    )
+
+                full_query = build_repository_query(integration.metadata, integration.name, query)
                 response = installation.get_client().search_repositories(full_query)
             except ApiError as err:
-                if err.code == 403:
-                    lifecyle.record_halt(str(SourceCodeSearchEndpointHaltReason.RATE_LIMITED))
+                if err.code in {403, 429}:
+                    lifecycle.record_halt(str(SourceCodeSearchEndpointHaltReason.RATE_LIMITED))
                     return Response({"detail": "Rate limit exceeded"}, status=429)
                 if err.code == 422:
-                    lifecyle.record_halt(
+                    lifecycle.record_halt(
                         str(SourceCodeSearchEndpointHaltReason.MISSING_REPOSITORY_OR_NO_ACCESS)
                     )
                     return Response(

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -16,6 +16,8 @@ from sentry.shared_integrations.exceptions import ApiError
 
 T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
+PAGE_LIMIT = 1
+
 
 @control_silo_endpoint
 class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
@@ -67,6 +69,15 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
         ).capture() as lifecyle:
             assert isinstance(installation, self.installation_class)
 
+            if not query:
+                repositories = installation.get_repositories(page_number_limit=PAGE_LIMIT)
+                return Response(
+                    [
+                        {"label": repository["name"], "value": repository["identifier"]}
+                        for repository in repositories
+                    ]
+                )
+
             full_query = build_repository_query(integration.metadata, integration.name, query)
             try:
                 response = installation.get_client().search_repositories(full_query)
@@ -88,3 +99,20 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
             return Response(
                 [{"label": i["name"], "value": i["full_name"]} for i in response.get("items", [])]
             )
+
+    def handle_search_field(self, installation: T, field: str, repo: str | None) -> Response | None:
+        if field not in {"assignee", "labels"}:
+            return None
+        if not repo:
+            return Response([])
+        if repo.count("/") != 1:
+            return Response({"detail": "Invalid repository"}, status=400)
+
+        assert isinstance(installation, self.installation_class)
+        if field == "assignee":
+            choices = installation.get_allowed_assignees(repo, PAGE_LIMIT)
+        else:
+            owner, repo_name = repo.split("/", 1)
+            choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
+
+        return Response([{"label": label, "value": value} for value, label in choices])

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -7,6 +7,7 @@ from typing import Any
 from django.urls import reverse
 
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
+from sentry.integrations.types import IntegrationIssueConfigField
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -65,7 +66,7 @@ class GitlabIssuesSpec(SourceCodeIssueIntegration):
     @all_silo_function
     def get_create_issue_config(
         self, group: Group | None, user: User | RpcUser, **kwargs
-    ) -> list[dict[str, Any]]:
+    ) -> list[IntegrationIssueConfigField]:
         kwargs["link_referrer"] = "gitlab_integration"
         fields = super().get_create_issue_config(group, user, **kwargs)
         params = kwargs.pop("params", {})

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -43,7 +43,7 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import IntegrationProviderSlug
+from sentry.integrations.types import IntegrationIssueConfigField, IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
@@ -1190,7 +1190,7 @@ class JiraIntegration(IssueSyncIntegration):
             if not any(c for c in issue_type_choices if c[0] == issue_type):
                 issue_type = issue_type_meta["id"]
 
-        projects_form_field = {
+        projects_form_field: IntegrationIssueConfigField = {
             "name": "project",
             "label": "Jira Project",
             "choices": [(p["id"], f"{p['key']} - {p['name']}") for p in jira_projects],

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -33,7 +33,11 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
+from sentry.integrations.types import (
+    ExternalProviders,
+    IntegrationIssueConfigField,
+    IntegrationProviderSlug,
+)
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
@@ -824,7 +828,7 @@ class JiraServerIntegration(IssueSyncIntegration):
 
         client = self.get_client()
 
-        project_field = {
+        project_field: IntegrationIssueConfigField = {
             "name": "project",
             "label": "Jira Project",
             "choices": [(p["id"], p["key"]) for p in jira_projects],

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -18,6 +18,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.tasks.sync_status_inbound import (
     sync_status_inbound as sync_status_inbound_task,
 )
+from sentry.integrations.types import IntegrationIssueConfigField
 from sentry.integrations.utils.external_issues import maybe_generate_external_issue_details
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -150,7 +151,7 @@ class IssueBasicIntegration(IntegrationInstallation, ABC):
     @all_silo_function
     def get_create_issue_config(
         self, group: Group | None, user: User | RpcUser, **kwargs
-    ) -> list[dict[str, Any]]:
+    ) -> list[IntegrationIssueConfigField]:
         """
         These fields are used to render a form for the user,
         and are then passed in the format of:

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
 class SourceCodeSearchSerializer(serializers.Serializer[dict[str, str]]):
     field = serializers.CharField(required=True)
-    query = serializers.CharField(required=True)
+    query = serializers.CharField(required=True, allow_blank=True)
 
 
 @control_silo_endpoint
@@ -87,6 +87,9 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
     ) -> Response:
         raise NotImplementedError
 
+    def handle_search_field(self, installation: T, field: str, repo: str | None) -> Response | None:
+        return None
+
     def get(
         self, request: Request, organization: RpcOrganization, integration_id: int, **kwds: Any
     ) -> Response:
@@ -139,5 +142,10 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
 
             if self.repository_field and field == self.repository_field:
                 return self.handle_search_repositories(integration, installation, query)
+
+            repo = request.GET.get(self.repository_field) if self.repository_field else None
+            response = self.handle_search_field(installation, field, repo)
+            if response is not None:
+                return response
 
             return Response({"detail": "Invalid field"}, status=400)

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -1,8 +1,30 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, StrEnum
-from typing import Generic, TypeVar
+from typing import Any, Generic, NotRequired, TypedDict, TypeVar
 
 from sentry.hybridcloud.rpc import ValueEqualityEnum
+
+
+class IntegrationIssueConfigField(TypedDict):
+    """JSON form field returned by an issue integration."""
+
+    name: str
+    label: str
+    type: str
+    default: NotRequired[Any]
+    defaultValue: NotRequired[Any]
+    required: NotRequired[bool]
+    choices: NotRequired[Sequence[tuple[Any, str]]]
+    url: NotRequired[str]
+    updatesForm: NotRequired[bool]
+    multiple: NotRequired[bool]
+    autosize: NotRequired[bool]
+    maxRows: NotRequired[int]
+    maxLength: NotRequired[int]
+    help: NotRequired[str]
+    placeholder: NotRequired[str]
+    prefetch: NotRequired[bool]
 
 
 class ExternalProviders(ValueEqualityEnum):

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -25,6 +25,7 @@ class IntegrationIssueConfigField(TypedDict):
     help: NotRequired[str]
     placeholder: NotRequired[str]
     prefetch: NotRequired[bool]
+    dependsOn: NotRequired[Sequence[str]]
 
 
 class ExternalProviders(ValueEqualityEnum):

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -15,7 +15,7 @@ from sentry.integrations.mixins import ResolveSyncAction
 from sentry.integrations.mixins.issues import IntegrationSyncTargetNotFound, IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
-from sentry.integrations.types import IntegrationProviderSlug
+from sentry.integrations.types import IntegrationIssueConfigField, IntegrationProviderSlug
 from sentry.models.activity import Activity
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -159,7 +159,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
     @all_silo_function
     def get_create_issue_config(
         self, group: Group | None, user: RpcUser | User, **kwargs: Any
-    ) -> list[dict[str, Any]]:
+    ) -> list[IntegrationIssueConfigField]:
         kwargs["link_referrer"] = "vsts_integration"
         fields = []
         if group:

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -667,8 +667,8 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             },
         )
 
-        resp = self.install.get_create_issue_config(group=event.group, user=self.user)
-        assert resp[0]["choices"] == [("getsentry/sentry", "sentry")]
+        create_config = self.install.get_create_issue_config(group=event.group, user=self.user)
+        assert create_config[0]["choices"] == [("getsentry/sentry", "sentry")]
 
         responses.add(
             responses.GET,
@@ -683,16 +683,18 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
         # create an issue
         data = {"params": {"repo": "getsentry/hello"}}
-        resp = self.install.get_create_issue_config(group=event.group, user=self.user, **data)
-        assert resp[0]["choices"] == [
+        create_config = self.install.get_create_issue_config(
+            group=event.group, user=self.user, **data
+        )
+        assert create_config[0]["choices"] == [
             ("getsentry/hello", "hello"),
             ("getsentry/sentry", "sentry"),
         ]
         # link an issue
         data = {"params": {"repo": "getsentry/hello"}}
         assert event.group is not None
-        resp = self.install.get_link_issue_config(group=event.group, **data)
-        assert resp[0]["choices"] == [
+        link_config = self.install.get_link_issue_config(group=event.group, **data)
+        assert link_config[0]["choices"] == [
             ("getsentry/hello", "hello"),
             ("getsentry/sentry", "sentry"),
         ]

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -100,6 +100,25 @@ class GitHubIssueBasicAllSiloTest(TestCase):
         assert label_field["type"] == "select"
         assert label_field["label"] == "Labels"
 
+    @responses.activate
+    def test_get_create_issue_config_prefetches_options_without_group(self) -> None:
+        with self.feature("organizations:github-issue-form-prefetch"):
+            config = self.install.get_create_issue_config(
+                None, self.user, params={"repo": "getsentry/sentry"}
+            )
+
+        [repo_field, assignee_field, label_field] = config
+        assert len(responses.calls) == 0
+        assert repo_field["default"] == "getsentry/sentry"
+        assert repo_field["choices"] == [("getsentry/sentry", "sentry")]
+        assert repo_field["prefetch"] is True
+        assert assignee_field["choices"] == []
+        assert assignee_field["prefetch"] is True
+        assert assignee_field["url"] == repo_field["url"]
+        assert label_field["choices"] == []
+        assert label_field["prefetch"] is True
+        assert label_field["url"] == repo_field["url"]
+
 
 class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTestCase):
     @cached_property

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -114,9 +114,11 @@ class GitHubIssueBasicAllSiloTest(TestCase):
         assert repo_field["prefetch"] is True
         assert assignee_field["choices"] == []
         assert assignee_field["prefetch"] is True
+        assert assignee_field["dependsOn"] == ["repo"]
         assert assignee_field["url"] == repo_field["url"]
         assert label_field["choices"] == []
         assert label_field["prefetch"] is True
+        assert label_field["dependsOn"] == ["repo"]
         assert label_field["url"] == repo_field["url"]
 
 

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -154,6 +154,75 @@ class GithubSearchTest(APITestCase):
         assert halt2.args[0] == EventLifecycleOutcome.SUCCESS
 
     @responses.activate
+    def test_prefetches_repo_results_with_empty_query(self) -> None:
+        responses.add(
+            responses.GET,
+            self.base_url + "/installation/repositories",
+            json={
+                "total_count": 2,
+                "repositories": [
+                    {"id": 1, "name": "example", "full_name": "test/example"},
+                    {"id": 2, "name": "other", "full_name": "test/other"},
+                ],
+            },
+        )
+
+        resp = self.client.get(self.url, data={"field": "repo", "query": ""})
+
+        assert resp.status_code == 200
+        assert resp.data == [
+            {"value": "test/example", "label": "example"},
+            {"value": "test/other", "label": "other"},
+        ]
+
+    @responses.activate
+    def test_prefetches_assignee_results(self) -> None:
+        responses.add(
+            responses.GET,
+            self.base_url + "/repos/test/example/assignees",
+            json=[{"login": "octocat"}],
+        )
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "assignee", "query": "", "repo": "test/example"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.data == [
+            {"value": "", "label": "Unassigned"},
+            {"value": "octocat", "label": "octocat"},
+        ]
+
+    @responses.activate
+    def test_prefetches_label_results(self) -> None:
+        responses.add(
+            responses.GET,
+            self.base_url + "/repos/test/example/labels",
+            json=[{"name": "bug"}, {"name": "enhancement"}],
+        )
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "labels", "query": "", "repo": "test/example"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.data == [
+            {"value": "bug", "label": "bug"},
+            {"value": "enhancement", "label": "enhancement"},
+        ]
+
+    def test_rejects_invalid_repo_when_prefetching_fields(self) -> None:
+        resp = self.client.get(
+            self.url,
+            data={"field": "labels", "query": "", "repo": "invalid"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.data == {"detail": "Invalid repository"}
+
+    @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_repo_search_validation_error(self, mock_record: MagicMock) -> None:
         responses.add(

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -176,6 +176,20 @@ class GithubSearchTest(APITestCase):
         ]
 
     @responses.activate
+    def test_prefetch_repo_rate_limit(self) -> None:
+        responses.add(
+            responses.GET,
+            self.base_url + "/installation/repositories",
+            status=429,
+            json={"message": "API rate limit exceeded"},
+        )
+
+        resp = self.client.get(self.url, data={"field": "repo", "query": ""})
+
+        assert resp.status_code == 429
+        assert resp.data == {"detail": "Rate limit exceeded"}
+
+    @responses.activate
     def test_prefetches_assignee_results(self) -> None:
         responses.add(
             responses.GET,


### PR DESCRIPTION
Loading a bunch of things from github is slow, with this change we'll display the form and the frontend will make additional requests in the background to pre-fill some dropdowns. refs #122886 that recently changed the number of pages

Frontend counterpart: https://github.com/getsentry/sentry/pull/123285
fixes https://linear.app/getsentry/issue/IE-45