### PR TITLE
ref(hybridcloud): Distinguish the two unbucketed mailbox routing outcomes

### DIFF
--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -279,13 +279,25 @@ class BaseRequestParser(ABC):
             cache.set(use_buckets_key, 1, timeout=ONE_DAY)
             use_buckets = True
         if not use_buckets:
-            metrics.incr(
-                "hybridcloud.webhookpayload.mailbox_routing",
-                tags={"provider": self.provider, "bucketed": "false"},
-            )
+            self._record_mailbox_routing(bucketed=False, reason="under_volume_gate")
             return str(integration.id)
 
         return self._build_bucketed_identifier(integration, data)
+
+    def _record_mailbox_routing(self, bucketed: bool, reason: str) -> None:
+        """Record which routing outcome a payload took.
+
+        `reason` is the complete breakdown; `bucketed` is kept for the dashboards
+        already built on it.
+        """
+        metrics.incr(
+            "hybridcloud.webhookpayload.mailbox_routing",
+            tags={
+                "provider": self.provider,
+                "bucketed": "true" if bucketed else "false",
+                "reason": reason,
+            },
+        )
 
     def _build_bucketed_identifier(
         self, integration: RpcIntegration | Integration, data: dict[str, Any]
@@ -294,19 +306,13 @@ class BaseRequestParser(ABC):
         the integration-level mailbox when no bucket ID is available."""
         mailbox_bucket_id = self.mailbox_bucket_id(data)
         if mailbox_bucket_id is None:
-            metrics.incr(
-                "hybridcloud.webhookpayload.mailbox_routing",
-                tags={"provider": self.provider, "bucketed": "false"},
-            )
+            self._record_mailbox_routing(bucketed=False, reason="no_bucket_key")
             return str(integration.id)
 
         # Split high volume integrations into 100 buckets.
         # 100 is arbitrary but we can't leave it unbounded.
         bucket_number = mailbox_bucket_id % 100
-        metrics.incr(
-            "hybridcloud.webhookpayload.mailbox_routing",
-            tags={"provider": self.provider, "bucketed": "true"},
-        )
+        self._record_mailbox_routing(bucketed=True, reason="bucketed")
 
         return f"{integration.id}:{bucket_number}"
 

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -285,11 +285,7 @@ class BaseRequestParser(ABC):
         return self._build_bucketed_identifier(integration, data)
 
     def _record_mailbox_routing(self, bucketed: bool, reason: str) -> None:
-        """Record which routing outcome a payload took.
-
-        `reason` is the complete breakdown; `bucketed` is kept for the dashboards
-        already built on it.
-        """
+        """`reason` is the full breakdown; `bucketed` stays for the dashboards on it."""
         metrics.incr(
             "hybridcloud.webhookpayload.mailbox_routing",
             tags={

--- a/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
+++ b/tests/sentry/integrations/middleware/hybrid_cloud/test_base.py
@@ -1,7 +1,9 @@
 from collections.abc import Iterable
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
 from pytest import raises
@@ -33,6 +35,14 @@ def error_regions(region: Cell, invalid_region_names: Iterable[str]) -> HttpResp
 class ExampleRequestParser(BaseRequestParser):
     provider = "test_provider"
     webhook_identifier = WebhookProviderIdentifier.SLACK
+
+
+class BucketingRequestParser(BaseRequestParser):
+    provider = "test_provider"
+    webhook_identifier = WebhookProviderIdentifier.SLACK
+
+    def mailbox_bucket_id(self, data: dict[str, Any]) -> int | None:
+        return data.get("bucket_id")
 
 
 class BaseRequestParserTest(TestCase):
@@ -337,3 +347,52 @@ class BaseRequestParserTest(TestCase):
 
         assert mock_record.call_count == 2
         assert_halt_metric(mock_record, MiddlewareHaltReason.ORG_INTEGRATION_DOES_NOT_EXIST)
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
+    def test_mailbox_identifier_under_volume_gate(self, mock_incr: MagicMock) -> None:
+        integration = self.create_integration(
+            organization=self.organization, provider="test_provider", external_id="test_external_id"
+        )
+        parser = BucketingRequestParser(self.request, self.response_handler)
+
+        assert parser.get_mailbox_identifier(integration, {"bucket_id": 101}) == str(integration.id)
+
+        mock_incr.assert_any_call(
+            "hybridcloud.webhookpayload.mailbox_routing",
+            tags={"provider": "test_provider", "bucketed": "false", "reason": "under_volume_gate"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
+    def test_mailbox_identifier_without_a_bucket_key(self, mock_incr: MagicMock) -> None:
+        integration = self.create_integration(
+            organization=self.organization, provider="test_provider", external_id="test_external_id"
+        )
+        cache.set(f"webhookpayload:test_provider:{integration.id}:use_buckets", 1)
+        parser = BucketingRequestParser(self.request, self.response_handler)
+
+        assert parser.get_mailbox_identifier(integration, {}) == str(integration.id)
+
+        mock_incr.assert_any_call(
+            "hybridcloud.webhookpayload.mailbox_routing",
+            tags={"provider": "test_provider", "bucketed": "false", "reason": "no_bucket_key"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.middleware.hybrid_cloud.parser.metrics.incr")
+    def test_mailbox_identifier_bucketed(self, mock_incr: MagicMock) -> None:
+        integration = self.create_integration(
+            organization=self.organization, provider="test_provider", external_id="test_external_id"
+        )
+        cache.set(f"webhookpayload:test_provider:{integration.id}:use_buckets", 1)
+        parser = BucketingRequestParser(self.request, self.response_handler)
+
+        assert (
+            parser.get_mailbox_identifier(integration, {"bucket_id": 101}) == f"{integration.id}:1"
+        )
+
+        mock_incr.assert_any_call(
+            "hybridcloud.webhookpayload.mailbox_routing",
+            tags={"provider": "test_provider", "bucketed": "true", "reason": "bucketed"},
+        )


### PR DESCRIPTION
`hybridcloud.webhookpayload.mailbox_routing` tagged both of its unbucketed outcomes `bucketed:false`, so one series covered two different situations: the integration is under the 3,000/hr gate, or it is over the gate and the payload carried no bucket key. Deciding whether that gate should exist means knowing how much of "unbucketed" it accounts for, and the metric cannot say.

Adds `reason` — `under_volume_gate` / `no_bucket_key` / `bucketed`. `bucketed` stays for the dashboards already built on it.

**Datadog:** `reason` has to be added to this metric's tag configuration before it is queryable, and that is not retroactive.

Refs CW-1887
