### PR TITLE
ref(conversations): Reuse node timestamp fallback

### DIFF
--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -488,13 +488,7 @@ function getNodeStartTimestamp(node: AITraceSpanNode): number {
 }
 
 function getNodeEndTimestamp(node: AITraceSpanNode): number {
-  if ('end_timestamp' in node.value && typeof node.value.end_timestamp === 'number') {
-    return node.value.end_timestamp;
-  }
-  if ('timestamp' in node.value && typeof node.value.timestamp === 'number') {
-    return node.value.timestamp;
-  }
-  return 0;
+  return getNodeTimestamp(node);
 }
 
 function getGenAiOpType(node: AITraceSpanNode): string | undefined {


### PR DESCRIPTION
Conversation message timestamps had two identical implementations of the end-timestamp fallback, making a small but important ordering rule easier to change inconsistently.

Reuse `getNodeTimestamp` from `getNodeEndTimestamp` so the fallback behavior has one implementation without changing its result.