### PR TITLE
feat(conversations): Name the traces behind a conversation

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -16,18 +16,18 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconFire, IconUser} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {AvatarProject} from 'sentry/types/project';
 import {escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isUUID} from 'sentry/utils/string/isUUID';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   getUserDisplayName,
   normalizeUserField,
   UserNotInstrumentedTooltip,
 } from 'sentry/views/explore/conversations/components/conversationsTable';
+import {ConversationTraceLink} from 'sentry/views/explore/conversations/components/conversationTraceLink';
 import {ToolTag} from 'sentry/views/explore/conversations/components/toolTag';
 import type {ConversationUser} from 'sentry/views/explore/conversations/hooks/useConversations';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -102,18 +102,6 @@ export function ConversationSummary({
     return Array.from(seen, ([traceId, spanId]) => ({traceId, spanId}));
   }, [nodeTraceMap]);
 
-  // A single trace deep-links to the trace view; multiple traces open the
-  // traces explorer filtered to this conversation.
-  const singleTrace = traces.length === 1 ? traces[0] : undefined;
-  const tracesUrl = singleTrace
-    ? getTraceUrl(organization.slug, singleTrace.traceId, singleTrace.spanId)
-    : getExploreUrl({
-        organization,
-        selection,
-        query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}"`,
-        table: 'trace',
-      });
-
   return (
     <Flex
       direction={{'screen:xs': 'column', 'screen:md': 'row'}}
@@ -186,20 +174,7 @@ export function ConversationSummary({
                   </InfoText>
                 )}
               </Flex>
-              {traces.length > 0 && (
-                <Link
-                  to={tracesUrl}
-                  onClick={() =>
-                    trackAnalytics('conversations.detail.click-trace-link', {
-                      organization,
-                    })
-                  }
-                >
-                  <Text size="sm" variant="inherit" wrap="nowrap">
-                    {tn('Trace', 'Traces', traces.length)}
-                  </Text>
-                </Link>
-              )}
+              <ConversationTraceLink conversationId={conversationId} traces={traces} />
               {aggregates.toolNames.length > 0 && (
                 <Flex align="center" gap="sm" minWidth={0} wrap="wrap">
                   {aggregates.toolNames.slice(0, VISIBLE_TOOL_COUNT).map(name => (
@@ -329,12 +304,6 @@ function Stat({
         valueContent
       )}
     </Stack>
-  );
-}
-
-function getTraceUrl(orgSlug: string, traceId: string, spanId: string) {
-  return normalizeUrl(
-    `/organizations/${orgSlug}/explore/traces/trace/${traceId}/?node=span-${spanId}`
   );
 }
 

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -385,6 +385,13 @@ function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
     }
   }
 
+  // Errored tools lead, so they survive the row's truncation.
+  const sortedToolNames = Array.from(toolNameSet).sort();
+  const toolNames = [
+    ...sortedToolNames.filter(name => erroredToolNameSet.has(name)),
+    ...sortedToolNames.filter(name => !erroredToolNameSet.has(name)),
+  ];
+
   return {
     llmCalls,
     toolCalls,
@@ -393,7 +400,7 @@ function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
     erroredToolNames: erroredToolNameSet,
     totalTokens,
     totalCost,
-    toolNames: Array.from(toolNameSet).sort(),
+    toolNames,
   };
 }
 

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -11,11 +11,12 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
+import {DateTime} from 'sentry/components/dateTime';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconFire, IconUser} from 'sentry/icons';
+import {IconCalendar, IconFire, IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {AvatarProject} from 'sentry/types/project';
 import {escapeDoubleQuotes} from 'sentry/utils';
@@ -131,6 +132,10 @@ export function ConversationSummary({
         <Flex align="center" gap="xl" minWidth={0} wrap="wrap">
           {isLoading ? (
             <Fragment>
+              <Flex align="center" gap="xs">
+                <Placeholder width="16px" height="16px" />
+                <Placeholder width="140px" height="14px" />
+              </Flex>
               {project && (
                 <Flex align="center" gap="xs">
                   <Placeholder width="16px" height="16px" />
@@ -152,6 +157,23 @@ export function ConversationSummary({
             </Fragment>
           ) : (
             <Fragment>
+              {aggregates.startTimestamp !== null && (
+                <Flex align="center" gap="xs">
+                  <IconCalendar size="md" />
+                  <InfoText
+                    size="sm"
+                    variant="muted"
+                    title={
+                      <TimeSince
+                        date={aggregates.startTimestamp}
+                        disabledAbsoluteTooltip
+                      />
+                    }
+                  >
+                    <DateTime date={aggregates.startTimestamp} year timeZone />
+                  </InfoText>
+                </Flex>
+              )}
               {project && <ProjectBadge project={project} avatarSize={16} disableLink />}
               <Flex align="center" gap="xs" minWidth={0}>
                 <IconUser size="md" />
@@ -311,6 +333,8 @@ interface ConversationAggregates {
   errorCount: number;
   erroredToolNames: Set<string>;
   llmCalls: number;
+  /** When the conversation began, or null when no span carries a start time. */
+  startTimestamp: number | null;
   toolCalls: number;
   toolNames: string[];
   totalCost: number;
@@ -327,12 +351,19 @@ function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
   let errorCount = 0;
   let totalTokens = 0;
   let totalCost = 0;
+  let startTimestamp: number | null = null;
   const toolNameSet = new Set<string>();
   const erroredToolNameSet = new Set<string>();
 
   for (const node of nodes) {
     const opType = getGenAiOpType(node);
     const nodeHasError = hasError(node);
+
+    // Nodes without a timestamp leave space at its [0, 0] default.
+    const [nodeStart] = node.space;
+    if (nodeStart > 0 && (startTimestamp === null || nodeStart < startTimestamp)) {
+      startTimestamp = nodeStart;
+    }
 
     if (getIsAiGenerationSpan(opType)) {
       llmCalls++;
@@ -358,6 +389,7 @@ function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
     llmCalls,
     toolCalls,
     errorCount,
+    startTimestamp,
     erroredToolNames: erroredToolNameSet,
     totalTokens,
     totalCost,

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -129,12 +129,21 @@ export function ConversationSummary({
             </Tooltip>
           )}
         </Container>
-        <Flex align="center" gap="xl" minWidth={0} wrap="wrap">
-          {isLoading ? (
-            <Fragment>
+        {isLoading ? (
+          <Fragment>
+            <Flex align="center" gap="sm" minWidth={0} wrap="wrap">
+              <Placeholder width="40px" height="14px" />
+              <Placeholder width="72px" height="20px" />
+              <Placeholder width="72px" height="20px" />
+            </Flex>
+            <Flex align="center" gap="xl" minWidth={0} wrap="wrap">
               <Flex align="center" gap="xs">
                 <Placeholder width="16px" height="16px" />
                 <Placeholder width="140px" height="14px" />
+              </Flex>
+              <Flex align="center" gap="xs">
+                <Placeholder width="12px" height="12px" />
+                <Placeholder width="40px" height="14px" />
               </Flex>
               {project && (
                 <Flex align="center" gap="xs">
@@ -146,23 +155,50 @@ export function ConversationSummary({
                 <Placeholder width="16px" height="16px" />
                 <Placeholder width="120px" height="14px" />
               </Flex>
-              <Flex align="center" gap="xs">
-                <Placeholder width="12px" height="12px" />
-                <Placeholder width="40px" height="14px" />
+            </Flex>
+          </Fragment>
+        ) : (
+          <Fragment>
+            {aggregates.toolNames.length > 0 && (
+              <Flex align="center" gap="sm" minWidth={0} wrap="wrap">
+                <Text size="sm" wrap="nowrap">
+                  {t('Tools:')}
+                </Text>
+                {aggregates.toolNames.slice(0, VISIBLE_TOOL_COUNT).map(name => (
+                  <ToolTag
+                    key={name}
+                    name={name}
+                    hasError={aggregates.erroredToolNames.has(name)}
+                  />
+                ))}
+                {aggregates.toolNames.length > VISIBLE_TOOL_COUNT && (
+                  <InfoText
+                    size="sm"
+                    variant="muted"
+                    wrap="nowrap"
+                    title={
+                      <Flex wrap="wrap" gap="sm" paddingTop="xs" paddingBottom="xs">
+                        {aggregates.toolNames.slice(VISIBLE_TOOL_COUNT).map(name => (
+                          <ToolTag
+                            key={name}
+                            name={name}
+                            hasError={aggregates.erroredToolNames.has(name)}
+                          />
+                        ))}
+                      </Flex>
+                    }
+                  >
+                    {t('+%s more', aggregates.toolNames.length - VISIBLE_TOOL_COUNT)}
+                  </InfoText>
+                )}
               </Flex>
-              <Flex align="center" gap="sm">
-                <Placeholder width="72px" height="20px" />
-                <Placeholder width="72px" height="20px" />
-              </Flex>
-            </Fragment>
-          ) : (
-            <Fragment>
+            )}
+            <Flex align="center" gap="xl" minWidth={0} wrap="wrap">
               {aggregates.startTimestamp !== null && (
                 <Flex align="center" gap="xs">
                   <IconCalendar size="md" />
                   <InfoText
                     size="sm"
-                    variant="muted"
                     title={
                       <TimeSince
                         date={aggregates.startTimestamp}
@@ -174,6 +210,7 @@ export function ConversationSummary({
                   </InfoText>
                 </Flex>
               )}
+              <ConversationTraceLink conversationId={conversationId} traces={traces} />
               {project && <ProjectBadge project={project} avatarSize={16} disableLink />}
               <Flex align="center" gap="xs" minWidth={0}>
                 <IconUser size="md" />
@@ -196,41 +233,9 @@ export function ConversationSummary({
                   </InfoText>
                 )}
               </Flex>
-              <ConversationTraceLink conversationId={conversationId} traces={traces} />
-              {aggregates.toolNames.length > 0 && (
-                <Flex align="center" gap="sm" minWidth={0} wrap="wrap">
-                  {aggregates.toolNames.slice(0, VISIBLE_TOOL_COUNT).map(name => (
-                    <ToolTag
-                      key={name}
-                      name={name}
-                      hasError={aggregates.erroredToolNames.has(name)}
-                    />
-                  ))}
-                  {aggregates.toolNames.length > VISIBLE_TOOL_COUNT && (
-                    <InfoText
-                      size="sm"
-                      variant="muted"
-                      wrap="nowrap"
-                      title={
-                        <Flex wrap="wrap" gap="sm" paddingTop="xs" paddingBottom="xs">
-                          {aggregates.toolNames.slice(VISIBLE_TOOL_COUNT).map(name => (
-                            <ToolTag
-                              key={name}
-                              name={name}
-                              hasError={aggregates.erroredToolNames.has(name)}
-                            />
-                          ))}
-                        </Flex>
-                      }
-                    >
-                      {t('+%s more', aggregates.toolNames.length - VISIBLE_TOOL_COUNT)}
-                    </InfoText>
-                  )}
-                </Flex>
-              )}
-            </Fragment>
-          )}
-        </Flex>
+            </Flex>
+          </Fragment>
+        )}
       </Stack>
       <Flex align="start" gap="xl" wrap="wrap" flexShrink={0}>
         <Stat

--- a/static/app/views/explore/conversations/components/conversationTraceLink.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationTraceLink.spec.tsx
@@ -1,0 +1,77 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {ConversationTrace} from 'sentry/views/explore/conversations/components/conversationTraceLink';
+import {ConversationTraceLink} from 'sentry/views/explore/conversations/components/conversationTraceLink';
+
+describe('ConversationTraceLink', () => {
+  const organization = OrganizationFixture();
+
+  function makeTraces(count: number): ConversationTrace[] {
+    return Array.from({length: count}, (_, index) => ({
+      traceId: `${index}`.repeat(32),
+      spanId: `span${index}`,
+    }));
+  }
+
+  it('renders nothing without traces', () => {
+    const {container} = render(
+      <ConversationTraceLink conversationId="conversation-1" traces={[]} />,
+      {organization}
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('links a single trace straight to the trace view', () => {
+    render(
+      <ConversationTraceLink
+        conversationId="conversation-1"
+        traces={[{traceId: 'a3805648ffffffffffffffffffffffff', spanId: 'span-1'}]}
+      />,
+      {organization}
+    );
+
+    const link = screen.getByRole('link', {name: 'a3805648'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/traces/trace/a3805648ffffffffffffffffffffffff/?node=span-span-1`
+    );
+  });
+
+  it('lists every trace and "View all" for multiple traces', async () => {
+    render(
+      <ConversationTraceLink conversationId="conversation-1" traces={makeTraces(2)} />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /2 traces/}));
+
+    expect(await screen.findByRole('menuitemradio', {name: '00000000'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/traces/trace/${'0'.repeat(
+        32
+      )}/?node=span-span0`
+    );
+    expect(screen.getByRole('menuitemradio', {name: '11111111'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'View all'})).toBeInTheDocument();
+  });
+
+  it('caps the listed traces and keeps "View all"', async () => {
+    render(
+      <ConversationTraceLink conversationId="conversation-1" traces={makeTraces(8)} />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /8 traces/}));
+
+    expect(
+      await screen.findByRole('menuitemradio', {name: '44444444'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitemradio', {name: '55555555'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', {name: 'View all'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/conversations/components/conversationTraceLink.tsx
+++ b/static/app/views/explore/conversations/components/conversationTraceLink.tsx
@@ -76,6 +76,8 @@ export function ConversationTraceLink({
     ...traces.slice(0, VISIBLE_TRACE_COUNT).map(({traceId, spanId}) => ({
       key: traceId,
       label: getShortTraceId(traceId),
+      // Accents the id and its icon, so each trace reads as a link.
+      priority: 'primary' as const,
       leadingItems: <IconSpan size="xs" />,
       to: getTraceUrl(organization.slug, traceId, spanId),
       onAction: trackClick,
@@ -97,6 +99,7 @@ export function ConversationTraceLink({
   return (
     <DropdownMenu
       items={items}
+      size="sm"
       trigger={(triggerProps, isOpen) => (
         <TraceTrigger
           {...triggerProps}

--- a/static/app/views/explore/conversations/components/conversationTraceLink.tsx
+++ b/static/app/views/explore/conversations/components/conversationTraceLink.tsx
@@ -78,21 +78,15 @@ export function ConversationTraceLink({
       label: getShortTraceId(traceId),
       // Accents the id and its icon, so each trace reads as a link.
       priority: 'primary' as const,
-      leadingItems: <IconSpan size="xs" />,
+      leadingItems: <MenuTraceIcon size="xs" />,
       to: getTraceUrl(organization.slug, traceId, spanId),
       onAction: trackClick,
     })),
     {
-      // Its own section so the menu separates it from the trace ids above.
-      key: 'view-all-section',
-      children: [
-        {
-          key: 'view-all',
-          label: t('View all'),
-          to: viewAllUrl,
-          onAction: trackClick,
-        },
-      ],
+      key: 'view-all',
+      label: t('View all'),
+      to: viewAllUrl,
+      onAction: trackClick,
     },
   ];
 
@@ -120,6 +114,11 @@ export function ConversationTraceLink({
     />
   );
 }
+
+/** The menu pins leading items to the top, so centre the icon on the label. */
+const MenuTraceIcon = styled(IconSpan)`
+  align-self: center;
+`;
 
 const TraceTrigger = styled(DropdownButton)`
   color: ${p => p.theme.tokens.interactive.link.accent.rest};

--- a/static/app/views/explore/conversations/components/conversationTraceLink.tsx
+++ b/static/app/views/explore/conversations/components/conversationTraceLink.tsx
@@ -1,0 +1,137 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {DropdownButton} from 'sentry/components/dropdownButton';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {IconChevron, IconSpan} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {escapeDoubleQuotes} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+
+export interface ConversationTrace {
+  /** A span within the trace, used to focus the trace view on the conversation. */
+  spanId: string;
+  traceId: string;
+}
+
+interface ConversationTraceLinkProps {
+  conversationId: string;
+  traces: ConversationTrace[];
+}
+
+/** Trace ids listed in the dropdown; the rest are reachable through "View all". */
+const VISIBLE_TRACE_COUNT = 5;
+
+/**
+ * The traces a conversation spans. A single trace links straight to the trace
+ * view; several open a dropdown of trace ids alongside a link to all of them.
+ */
+export function ConversationTraceLink({
+  conversationId,
+  traces,
+}: ConversationTraceLinkProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const trackClick = () =>
+    trackAnalytics('conversations.detail.click-trace-link', {organization});
+
+  const [firstTrace] = traces;
+
+  if (!firstTrace) {
+    return null;
+  }
+
+  if (traces.length === 1) {
+    return (
+      <Link
+        to={getTraceUrl(organization.slug, firstTrace.traceId, firstTrace.spanId)}
+        onClick={trackClick}
+      >
+        <Flex align="center" gap="xs">
+          <IconSpan size="xs" />
+          <Text size="sm" variant="inherit" wrap="nowrap">
+            {getShortTraceId(firstTrace.traceId)}
+          </Text>
+        </Flex>
+      </Link>
+    );
+  }
+
+  const viewAllUrl = getExploreUrl({
+    organization,
+    selection,
+    query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}"`,
+    table: 'trace',
+  });
+
+  const items: MenuItemProps[] = [
+    ...traces.slice(0, VISIBLE_TRACE_COUNT).map(({traceId, spanId}) => ({
+      key: traceId,
+      label: getShortTraceId(traceId),
+      leadingItems: <IconSpan size="xs" />,
+      to: getTraceUrl(organization.slug, traceId, spanId),
+      onAction: trackClick,
+    })),
+    {
+      // Its own section so the menu separates it from the trace ids above.
+      key: 'view-all-section',
+      children: [
+        {
+          key: 'view-all',
+          label: t('View all'),
+          to: viewAllUrl,
+          onAction: trackClick,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <DropdownMenu
+      items={items}
+      trigger={(triggerProps, isOpen) => (
+        <TraceTrigger
+          {...triggerProps}
+          isOpen={isOpen}
+          size="zero"
+          variant="transparent"
+          showChevron={false}
+        >
+          <Flex align="center" gap="xs">
+            <IconSpan size="xs" />
+            <Text size="sm" variant="inherit" wrap="nowrap">
+              {tn('%s trace', '%s traces', traces.length)}
+            </Text>
+            <IconChevron direction={isOpen ? 'down' : 'right'} size="xs" />
+          </Flex>
+        </TraceTrigger>
+      )}
+    />
+  );
+}
+
+const TraceTrigger = styled(DropdownButton)`
+  color: ${p => p.theme.tokens.interactive.link.accent.rest};
+
+  &:hover {
+    color: ${p => p.theme.tokens.interactive.link.accent.hover};
+  }
+`;
+
+function getShortTraceId(traceId: string) {
+  return traceId.slice(0, 8);
+}
+
+function getTraceUrl(orgSlug: string, traceId: string, spanId: string) {
+  return normalizeUrl(
+    `/organizations/${orgSlug}/explore/traces/trace/${traceId}/?node=span-${spanId}`
+  );
+}

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -222,6 +222,14 @@ describe('ConversationDetailPage summary errors', () => {
     expect(await screen.findByTestId('conversation-error-icon')).toBeInTheDocument();
   });
 
+  it('renders the earliest span start as the conversation start time', async () => {
+    mockApis();
+    renderPage();
+
+    // The conversation opens with the 1000s span, not the 2000s one that follows.
+    expect(await screen.findByText('Jan 1, 1970 12:16 AM UTC')).toBeInTheDocument();
+  });
+
   it('omits the fire icon in the summary when there are no errors', async () => {
     mockApis();
     renderPage();

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -253,8 +253,10 @@ describe('ConversationDetailPage summary errors', () => {
     ]);
     renderPage();
 
+    expect(await screen.findByText('Tools:')).toBeInTheDocument();
+
     // Alphabetically alpha_tool would lead, but the errored zeta_tool outranks it.
-    const tags = await screen.findAllByText(/^(alpha|zeta)_tool$/);
+    const tags = screen.getAllByText(/^(alpha|zeta)_tool$/);
     const names = tags.map(tag => tag.textContent);
     expect(names.indexOf('zeta_tool')).toBeLessThan(names.indexOf('alpha_tool'));
   });

--- a/static/app/views/explore/conversations/conversationDetail.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.spec.tsx
@@ -230,6 +230,35 @@ describe('ConversationDetailPage summary errors', () => {
     expect(await screen.findByText('Jan 1, 1970 12:16 AM UTC')).toBeInTheDocument();
   });
 
+  it('leads the tool tags with the ones that errored', async () => {
+    mockApis(null, [
+      ...CONVERSATION_BODY,
+      spanFixture({
+        span_id: 'span-tool-ok',
+        'span.name': 'alpha call',
+        'gen_ai.operation.type': 'tool',
+        'gen_ai.tool.name': 'alpha_tool',
+        'precise.start_ts': 3000,
+        'precise.finish_ts': 3000.5,
+      }),
+      spanFixture({
+        span_id: 'span-tool-failed',
+        'span.name': 'zeta call',
+        'span.status': 'internal_error',
+        'gen_ai.operation.type': 'tool',
+        'gen_ai.tool.name': 'zeta_tool',
+        'precise.start_ts': 4000,
+        'precise.finish_ts': 4000.5,
+      }),
+    ]);
+    renderPage();
+
+    // Alphabetically alpha_tool would lead, but the errored zeta_tool outranks it.
+    const tags = await screen.findAllByText(/^(alpha|zeta)_tool$/);
+    const names = tags.map(tag => tag.textContent);
+    expect(names.indexOf('zeta_tool')).toBeLessThan(names.indexOf('alpha_tool'));
+  });
+
   it('omits the fire icon in the summary when there are no errors', async () => {
     mockApis();
     renderPage();


### PR DESCRIPTION
The conversation header linked to its traces behind the bare word "Trace", which told you nothing about where you were going and hid the fact that a conversation often spans several traces. It never said when the conversation happened, listed tools alphabetically so a failing one could hide behind "+N more", and ran tools along the same line as everything else.

Brings the header in line with the design:

- A lone trace shows its id and links straight to it. Multiple traces open a dropdown of the ids, capped at five, with "View all" for the rest.
- Tools move to their own labelled row, with the ones that errored leading so they survive its cutoff.
- The line below reads when, which trace, which project, who — opening with the conversation's start time, taken from the earliest span it contains.

Closes TET-2917