### PR TITLE
ref(dynamic-sampling): Remove the spans/segments measure differentiation

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1332,11 +1332,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         #       so we need to refactor this into an async task we can run and observe
         org_id = organization.id
         measure = SamplingMeasure.SEGMENTS
-        if options.get("dynamic-sampling.check_span_feature_flag"):
-            span_org_ids = options.get("dynamic-sampling.measure.spans") or []
-            if org_id in span_org_ids:
-                measure = SamplingMeasure.SPANS
-
         projects_with_tx_count_and_rates = []
         for chunk in query_project_counts_by_org(
             [org_id], measure, query_interval=timedelta(days=30)
@@ -1459,7 +1454,6 @@ class DeleteConfirmationArgs(TypedDict):
 
 
 def send_delete_confirmation(delete_confirmation_args: DeleteConfirmationArgs):
-    from sentry import options
     from sentry.utils.email import MessageBuilder
 
     organization = delete_confirmation_args["organization"]

--- a/src/sentry/dynamic_sampling/per_org/configuration.py
+++ b/src/sentry/dynamic_sampling/per_org/configuration.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from django.core.exceptions import ObjectDoesNotExist
 
-from sentry import options, quotas
+from sentry import quotas
 from sentry.constants import SAMPLING_MODE_DEFAULT, TARGET_SAMPLE_RATE_DEFAULT, ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.calculations import calculate_recalibration_factor
@@ -99,10 +99,6 @@ class BaseDynamicSamplingConfiguration(ABC):
         return self.measure == SamplingMeasure.SEGMENTS
 
     def _get_sampling_measure(self) -> SamplingMeasure:
-        if options.get("dynamic-sampling.check_span_feature_flag") and self.organization.id in (
-            options.get("dynamic-sampling.measure.spans") or []
-        ):
-            return SamplingMeasure.SPANS
         return SamplingMeasure.SEGMENTS
 
     def _get_projects(self) -> list[Project]:

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -22,7 +22,7 @@ from snuba_sdk import (
 )
 from taskbroker_client.retry import Retry
 
-from sentry import options, quotas
+from sentry import quotas
 from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem, guarded_run
 from sentry.dynamic_sampling.models.projects_rebalancing import (
@@ -81,33 +81,16 @@ ProjectVolumes = tuple[ProjectId, int, DecisionKeepCount, DecisionDropCount]
 OrgProjectVolumes = tuple[OrganizationId, ProjectId, int, DecisionKeepCount, DecisionDropCount]
 
 
-@metrics.wraps("dynamic_sampling.partition_by_measure")
-def _partition_orgs_by_measure(
-    org_ids: list[int],
-) -> dict[SamplingMeasure, list[int]]:
+@metrics.wraps("dynamic_sampling.filter_project_mode_orgs")
+def _without_project_mode_orgs(org_ids: list[int]) -> list[int]:
     """
-    Partition organizations by their sampling measure.
-    Project-mode orgs are filtered out. SPANS orgs (AM3/project-mode) are
-    split off when the check_span_feature_flag option is enabled.
-    All remaining orgs use SEGMENTS.
+    Drop the organizations that sample per project. Their rates come from
+    project options, so the rebalancing task must not overwrite them.
     """
     modes_per_org = OrganizationOption.objects.get_value_bulk_id(org_ids, "sentry:sampling_mode")
-    filtered_org_ids = {
+    return sorted(
         org_id for org_id, mode in modes_per_org.items() if mode != DynamicSamplingMode.PROJECT
-    }
-
-    if not options.get("dynamic-sampling.check_span_feature_flag"):
-        return {
-            SamplingMeasure.SEGMENTS: sorted(filtered_org_ids),
-        }
-
-    span_org_ids: set[int] = set(options.get("dynamic-sampling.measure.spans") or [])
-    filtered_span_org_ids: set[int] = span_org_ids & filtered_org_ids
-    remaining_org_ids: set[int] = filtered_org_ids - filtered_span_org_ids
-    return {
-        SamplingMeasure.SEGMENTS: sorted(remaining_org_ids),
-        SamplingMeasure.SPANS: sorted(filtered_span_org_ids),
-    }
+    )
 
 
 @instrumented_task(
@@ -127,11 +110,7 @@ def boost_low_volume_projects() -> None:
         granularity=Granularity(60),
         measure=SamplingMeasure.SEGMENTS,
     ):
-        orgs_by_measure = _partition_orgs_by_measure(orgs)
-
-        for measure, org_ids in orgs_by_measure.items():
-            _record_partitioning_metrics({measure: org_ids})
-            _process_orgs_for_boost(org_ids, measure)
+        _process_orgs_for_boost(_without_project_mode_orgs(orgs), SamplingMeasure.SEGMENTS)
 
 
 def _process_orgs_for_boost(
@@ -164,16 +143,6 @@ def _process_orgs_for_boost(
         )
 
 
-def _record_partitioning_metrics(orgs_by_measure: dict[SamplingMeasure, list[int]]) -> None:
-    for measure, org_ids in orgs_by_measure.items():
-        metrics.incr(
-            "dynamic_sampling.partition_by_measure.measure",
-            amount=len(org_ids),
-            tags={"measure": measure.value},
-            sample_rate=1,
-        )
-
-
 @instrumented_task(
     name="sentry.dynamic_sampling.boost_low_volume_projects_of_org_with_query",
     namespace=telemetry_experience_tasks,
@@ -196,16 +165,9 @@ def boost_low_volume_projects_of_org_with_query(org_id: OrganizationId) -> None:
     if is_project_mode_sampling(org):
         return
 
-    orgs_by_measure = _partition_orgs_by_measure([org_id])
-    measures: dict[int, SamplingMeasure] = {}
-    for m, org_ids in orgs_by_measure.items():
-        for oid in org_ids:
-            measures[oid] = m
-    measure = measures.get(org_id, SamplingMeasure.SEGMENTS)
-
     projects_with_tx_count_and_rates = fetch_projects_with_total_root_transaction_count_and_rates(
         org_ids=[org_id],
-        measure=measure,
+        measure=SamplingMeasure.SEGMENTS,
     )[org_id]
     rebalanced_projects = calculate_sample_rates_of_projects(
         org_id, projects_with_tx_count_and_rates

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2513,23 +2513,6 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Enables a feature flag check in dynamic sampling tasks that switches
-# organizations between transactions and spans for rebalancing. This check is
-# expensive, so it can be disabled using this option.
-register(
-    "dynamic-sampling.check_span_feature_flag",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
-)
-
-# List of organization IDs that should be using spans for rebalancing in dynamic sampling.
-register(
-    "dynamic-sampling.measure.spans",
-    default=[],
-    type=Sequence,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # === Hybrid cloud subsystem options ===
 # UI rollout
 register(

--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import timedelta
-from typing import Any, NamedTuple
 from unittest.mock import DEFAULT, patch
 
 import pytest
@@ -24,7 +22,6 @@ from sentry.dynamic_sampling.per_org.telemetry import (
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import FALLBACK_SLIDING_WINDOW_SIZE
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
-from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
 from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     BLENDED_SAMPLE_RATE,
@@ -36,8 +33,6 @@ from tests.sentry.dynamic_sampling.per_org.test_helpers import (
     patch_configuration,
 )
 
-SpanOrgIds = Callable[[Organization], list[int]]
-
 
 def assert_measure(
     configuration: BaseDynamicSamplingConfiguration, expected: SamplingMeasure
@@ -47,37 +42,7 @@ def assert_measure(
     assert configuration.is_segment_based == (expected == SamplingMeasure.SEGMENTS)
 
 
-class MeasureOptionCase(NamedTuple):
-    name: str
-    check_span_feature_flag: bool
-    span_org_ids: SpanOrgIds
-    expected_measure: SamplingMeasure
-
-
-def _include_org(organization: Organization) -> list[int]:
-    return [organization.id]
-
-
-def _exclude_org(organization: Organization) -> list[int]:
-    return []
-
-
-MEASURE_OPTION_CASES = (
-    MeasureOptionCase("span-option-disabled", False, _include_org, SamplingMeasure.SEGMENTS),
-    MeasureOptionCase("org-not-in-span-option", True, _exclude_org, SamplingMeasure.SEGMENTS),
-    MeasureOptionCase("org-in-span-option", True, _include_org, SamplingMeasure.SPANS),
-)
-
-
 class DynamicSamplingOrgConfigurationTest(TestCase):
-    def measure_options(self, case: MeasureOptionCase, organization: Organization) -> Any:
-        return self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": case.check_span_feature_flag,
-                "dynamic-sampling.measure.spans": case.span_org_ids(organization),
-            }
-        )
-
     def test_subscription_backed_org_uses_blended_sample_rate(self) -> None:
         org = self.create_organization()
 
@@ -344,107 +309,75 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         assert configuration.project_sample_rates == {}
 
     def test_org_mode_custom_dynamic_sampling_uses_org_target_sample_rate(self) -> None:
-        for case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=case.name):
-                org = self.create_organization()
-                org.update_option("sentry:target_sample_rate", 0.3)
+        org = self.create_organization()
+        org.update_option("sentry:target_sample_rate", 0.3)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.measure_options(case, org),
-                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
-                ):
-                    configuration = get_configuration(org.id)
+        with (
+            self.feature("organizations:dynamic-sampling-custom"),
+            patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
+        ):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
-                assert configuration.is_enabled
-                assert_measure(configuration, case.expected_measure)
-                assert configuration.sample_rate == 0.3
-                assert configuration.get_sample_rate() == 0.3
-                assert configuration.project_sample_rates == {}
-                mocks[BLENDED_SAMPLE_RATE].assert_not_called()
+        assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
+        assert configuration.is_enabled
+        assert_measure(configuration, SamplingMeasure.SEGMENTS)
+        assert configuration.sample_rate == 0.3
+        assert configuration.get_sample_rate() == 0.3
+        assert configuration.project_sample_rates == {}
+        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
 
     def test_project_mode_custom_dynamic_sampling_stores_project_sample_rates(self) -> None:
-        for case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=case.name):
-                org = self.create_organization()
-                project = self.create_project(organization=org)
-                project_without_rate = self.create_project(organization=org)
-                org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-                project.update_option("sentry:target_sample_rate", 0.2)
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        project_without_rate = self.create_project(organization=org)
+        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        project.update_option("sentry:target_sample_rate", 0.2)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.measure_options(case, org),
-                    patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
-                ):
-                    configuration = get_configuration(org.id)
+        with (
+            self.feature("organizations:dynamic-sampling-custom"),
+            patch_configuration({BLENDED_SAMPLE_RATE: DEFAULT}) as mocks,
+        ):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-                assert configuration.is_enabled
-                assert_measure(configuration, case.expected_measure)
-                assert configuration.project_sample_rates == {
-                    project.id: 0.2,
-                    project_without_rate.id: None,
-                }
-                assert configuration.get_sample_rate() is None
-                assert configuration.sample_rate is None
-                mocks[BLENDED_SAMPLE_RATE].assert_not_called()
+        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
+        assert configuration.is_enabled
+        assert_measure(configuration, SamplingMeasure.SEGMENTS)
+        assert configuration.project_sample_rates == {
+            project.id: 0.2,
+            project_without_rate.id: None,
+        }
+        assert configuration.get_sample_rate() is None
+        assert configuration.sample_rate is None
+        mocks[BLENDED_SAMPLE_RATE].assert_not_called()
 
     def test_project_mode_custom_dynamic_sampling_without_project_rates_is_disabled(
         self,
     ) -> None:
-        for case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=case.name):
-                org = self.create_organization()
-                project = self.create_project(organization=org)
-                org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.measure_options(case, org),
-                ):
-                    configuration = get_configuration(org.id)
+        with self.feature("organizations:dynamic-sampling-custom"):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-                assert not configuration.is_enabled
-                assert configuration.measure == case.expected_measure
-                assert configuration.project_sample_rates == {project.id: None}
-                assert configuration.sample_rate is None
+        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
+        assert not configuration.is_enabled
+        assert configuration.measure == SamplingMeasure.SEGMENTS
+        assert configuration.project_sample_rates == {project.id: None}
+        assert configuration.sample_rate is None
 
     def test_project_mode_custom_dynamic_sampling_without_projects_is_disabled(self) -> None:
-        for case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=case.name):
-                org = self.create_organization()
-                org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        org = self.create_organization()
+        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.measure_options(case, org),
-                ):
-                    configuration = get_configuration(org.id)
+        with self.feature("organizations:dynamic-sampling-custom"):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-                assert not configuration.is_enabled
-                assert configuration.measure == case.expected_measure
-                assert configuration.project_sample_rates == {}
-                assert configuration.sample_rate is None
-
-    def test_subscription_backed_org_uses_measure_options(self) -> None:
-        for case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=case.name):
-                org = self.create_organization()
-
-                with (
-                    self.measure_options(case, org),
-                    patch_configuration({BLENDED_SAMPLE_RATE: 1.0}),
-                ):
-                    configuration = get_configuration(org.id)
-
-                assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
-                assert configuration.is_enabled
-                assert_measure(configuration, case.expected_measure)
-                assert configuration.sample_rate == 1.0
+        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
+        assert not configuration.is_enabled
+        assert configuration.measure == SamplingMeasure.SEGMENTS
+        assert configuration.project_sample_rates == {}
+        assert configuration.sample_rate is None
 
 
 class GetProjectSampleRatesTest(TestCase):

--- a/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_boost_low_volume_projects.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 from sentry.dynamic_sampling.rules.base import get_guarded_project_sample_rate
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.boost_low_volume_projects import (
-    _partition_orgs_by_measure,
     boost_low_volume_projects,
     boost_low_volume_projects_of_org_with_query,
     fetch_projects_with_total_root_transaction_count_and_rates,
@@ -331,75 +330,6 @@ class PrioritiseProjectsSnubaQueryTest(BaseMetricsLayerTestCase, TestCase, Snuba
         assert (p2_2.id, 15, 7, 8) in org_2_results
 
 
-class TestPartitionOrgsByMeasure(TestCase):
-    def test_all_orgs_go_to_segments_by_default(self) -> None:
-        """All orgs should be partitioned to SEGMENTS by default."""
-        org = self.create_organization("test-org")
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": False,
-            }
-        ):
-            result = _partition_orgs_by_measure([org.id])
-            assert org.id in result[SamplingMeasure.SEGMENTS]
-
-    def test_project_mode_orgs_are_excluded(self) -> None:
-        """Orgs with PROJECT sampling mode should be excluded from all partitions."""
-        org = self.create_organization("test-org")
-        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": False,
-            }
-        ):
-            result = _partition_orgs_by_measure([org.id])
-            assert org.id not in result.get(SamplingMeasure.SEGMENTS, [])
-
-    def test_span_orgs_partitioned_when_check_span_flag_enabled(self) -> None:
-        """When check_span_feature_flag is on, orgs in span option go to SPANS."""
-        org_span = self.create_organization("org-span")
-        org_seg = self.create_organization("org-seg")
-
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": True,
-                "dynamic-sampling.measure.spans": [org_span.id],
-            }
-        ):
-            result = _partition_orgs_by_measure([org_span.id, org_seg.id])
-            assert org_span.id in result[SamplingMeasure.SPANS]
-            assert org_seg.id in result[SamplingMeasure.SEGMENTS]
-
-    def test_span_flag_disabled_means_no_span_partition(self) -> None:
-        """When check_span_feature_flag is off, SPANS key should not be in result."""
-        org = self.create_organization("test-org")
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": False,
-                "dynamic-sampling.measure.spans": [org.id],
-            }
-        ):
-            result = _partition_orgs_by_measure([org.id])
-            assert SamplingMeasure.SPANS not in result
-            assert org.id in result[SamplingMeasure.SEGMENTS]
-
-    def test_project_mode_excluded_from_segments_and_spans(self) -> None:
-        """Project-mode orgs should be excluded even if listed in spans option."""
-        org = self.create_organization("test-org")
-        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": True,
-                "dynamic-sampling.measure.spans": [org.id],
-            }
-        ):
-            result = _partition_orgs_by_measure([org.id])
-            assert org.id not in result.get(SamplingMeasure.SEGMENTS, [])
-            assert org.id not in result.get(SamplingMeasure.SPANS, [])
-
-
 @freeze_time(MOCK_DATETIME)
 class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     """
@@ -458,41 +388,6 @@ class TestQueryProjectCountsByOrgEmptyOrgIds(BaseMetricsLayerTestCase, TestCase,
                 org_ids=[], measure=SamplingMeasure.SEGMENTS
             )
             assert mock_query.call_count == 1
-
-    def test_only_measures_with_orgs_are_queried_per_batch(self) -> None:
-        """
-        Simulates the main task loop behavior and confirms that
-        for each batch of orgs, only measures with non-empty org lists
-        result in Snuba queries.
-        """
-        org1 = self.create_organization("test-org1")
-        org2 = self.create_organization("test-org2")
-        self.create_project(organization=org1)
-        self.create_project(organization=org2)
-
-        with patch(
-            "sentry.dynamic_sampling.tasks.boost_low_volume_projects.raw_snql_query"
-        ) as mock_query:
-            mock_query.return_value = {"data": []}
-
-            batches = [[org1.id], [org2.id]]
-
-            for batch in batches:
-                orgs_by_measure = _partition_orgs_by_measure(batch)
-                assert orgs_by_measure.get(SamplingMeasure.SPANS, []) == []
-
-                # Each batch should result in one query for SEGMENTS
-                fetch_projects_with_total_root_transaction_count_and_rates(
-                    org_ids=orgs_by_measure.get(SamplingMeasure.SEGMENTS, []),
-                    measure=SamplingMeasure.SEGMENTS,
-                )
-                # SPANS partition is empty, no query needed
-                fetch_projects_with_total_root_transaction_count_and_rates(
-                    org_ids=orgs_by_measure.get(SamplingMeasure.SPANS, []),
-                    measure=SamplingMeasure.SPANS,
-                )
-
-            assert mock_query.call_count == 2
 
 
 @freeze_time(MOCK_DATETIME)
@@ -821,49 +716,3 @@ class TestEndToEndMeasureDispatching(BaseMetricsLayerTestCase, TestCase, SnubaTe
         )
         assert not got_value
         assert sample_rate is None
-
-    @with_feature(["organizations:dynamic-sampling", "organizations:dynamic-sampling-custom"])
-    def test_with_query_task_uses_spans_measure_for_span_orgs(self) -> None:
-        """
-        boost_low_volume_projects_of_org_with_query should use SPANS measure
-        for orgs listed in the span-metric option when the span flag is enabled.
-        """
-        org = self.create_organization("test-org")
-        p1 = self.create_project(organization=org)
-
-        # Store span metrics (with and without is_segment)
-        self.store_performance_metric(
-            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-            tags={"transaction": "foo", "decision": "keep", "is_segment": "true"},
-            minutes_before_now=30,
-            value=3,
-            project_id=p1.id,
-            org_id=org.id,
-        )
-        self.store_performance_metric(
-            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-            tags={"transaction": "bar", "decision": "keep"},
-            minutes_before_now=30,
-            value=7,
-            project_id=p1.id,
-            org_id=org.id,
-        )
-
-        redis_client = get_redis_client_for_ds()
-        cache_key = generate_sliding_window_org_cache_key(org.id)
-        redis_client.set(cache_key, 0.5)
-
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": True,
-                "dynamic-sampling.measure.spans": [org.id],
-            }
-        ):
-            with self.tasks():
-                boost_low_volume_projects_of_org_with_query.delay(org.id)
-
-        sample_rate, got_value = get_boost_low_volume_projects_sample_rate(
-            org.id, p1.id, error_sample_rate_fallback=None
-        )
-        assert got_value
-        assert sample_rate is not None

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -101,43 +101,6 @@ class TasksTestCase(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
 
         return proj
 
-    def create_project_and_add_span_metrics(self, name, count, org, tags=None, is_old=True):
-        """Create a project with span metrics for SPANS measure (AM3/project mode).
-
-        Also stores a segment metric for org discovery (GetActiveOrgs uses SEGMENTS).
-        """
-        if tags is None:
-            tags = {"transaction": "foo_transaction"}
-
-        if is_old:
-            proj = self.create_old_project(name=name, organization=org)
-        else:
-            proj = self.create_project(name=name, organization=org)
-
-        self.disable_all_biases(project=proj)
-
-        # Store segment metric for org discovery (GetActiveOrgs uses SEGMENTS)
-        self.store_performance_metric(
-            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-            tags={**tags, "is_segment": "true"},
-            minutes_before_now=30,
-            value=count,
-            project_id=proj.id,
-            org_id=org.id,
-        )
-
-        # Store SpanMRI metric for SPANS measure queries (no is_segment filter)
-        self.store_performance_metric(
-            name=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-            tags=tags,
-            minutes_before_now=30,
-            value=count,
-            project_id=proj.id,
-            org_id=org.id,
-        )
-
-        return proj
-
 
 @freeze_time(MOCK_DATETIME)
 class TestBoostLowVolumeProjectsTasks(TasksTestCase):
@@ -206,48 +169,6 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
 
         # we expect only uniform rule
         # also we test here that `generate_rules` can handle trough redis long floats
-        assert generate_rules(proj_a)[0]["samplingValue"] == {
-            "type": "sampleRate",
-            "value": pytest.approx(0.14814814814814817),
-        }
-        assert generate_rules(proj_b)[0]["samplingValue"] == {
-            "type": "sampleRate",
-            "value": pytest.approx(0.1904761904761905),
-        }
-        assert generate_rules(proj_c)[0]["samplingValue"] == {
-            "type": "sampleRate",
-            "value": pytest.approx(0.4444444444444444),
-        }
-        assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
-
-    @with_feature("organizations:dynamic-sampling")
-    @patch("sentry.quotas.backend.get_blended_sample_rate")
-    def test_boost_low_volume_projects_with_spans_measure(
-        self,
-        get_blended_sample_rate,
-    ):
-        """Test boost_low_volume_projects using span metrics (AM3/project mode)."""
-        get_blended_sample_rate.return_value = 0.25
-        test_org = self.create_old_organization(name="sample-org")
-
-        # Create projects with span metrics (SpanMRI without is_segment filter)
-        proj_a = self.create_project_and_add_span_metrics("a", 9, test_org)
-        proj_b = self.create_project_and_add_span_metrics("b", 7, test_org)
-        proj_c = self.create_project_and_add_span_metrics("c", 3, test_org)
-        proj_d = self.create_project_and_add_span_metrics("d", 1, test_org)
-
-        # Enable SPANS measure via feature flag and options
-        with self.options(
-            {
-                "dynamic-sampling.check_span_feature_flag": True,
-                "dynamic-sampling.measure.spans": [test_org.id],
-            }
-        ):
-            with self.tasks():
-                sliding_window_org()
-                boost_low_volume_projects()
-
-        # Verify sample rates are calculated correctly
         assert generate_rules(proj_a)[0]["samplingValue"] == {
             "type": "sampleRate",
             "value": pytest.approx(0.14814814814814817),


### PR DESCRIPTION
- Remove the span/segment differentiation in dynamic sampling
- This was only ever active for a test org, and we want to unship that anyways