### PR TITLE
feat: strict cssTypes

### DIFF
--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -1,7 +1,7 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
-import type {CssMinHeight} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import {Container} from '@sentry/scraps/layout';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
@@ -18,7 +18,7 @@ interface Props {
    * The content to display before the divider. Usually an image or replay.
    */
   before: React.ReactNode;
-  minHeight?: CssMinHeight;
+  minHeight?: CSS['minHeight'];
   /**
    * A callback function triggered when the divider is clicked (mouse down event).
    * Useful when we want to track analytics.

--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -1,6 +1,7 @@
-import {useRef, type CSSProperties} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
+import type {CssMinHeight} from '@sentry/scraps/cssTypes';
 import {Container} from '@sentry/scraps/layout';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
@@ -17,7 +18,7 @@ interface Props {
    * The content to display before the divider. Usually an image or replay.
    */
   before: React.ReactNode;
-  minHeight?: CSSProperties['minHeight'];
+  minHeight?: CssMinHeight;
   /**
    * A callback function triggered when the divider is clicked (mouse down event).
    * Useful when we want to track analytics.
@@ -41,7 +42,7 @@ function Body({onDragHandleMouseDown, after, before, minHeight = '0px'}: Props) 
         width="100%"
         height="100%"
         position="relative"
-        minHeight={typeof minHeight === 'number' ? `${minHeight}px` : minHeight}
+        minHeight={minHeight}
         ref={positionedRef}
       >
         {viewDimensions.width ? (

--- a/static/app/components/core/chat/userMessage.tsx
+++ b/static/app/components/core/chat/userMessage.tsx
@@ -1,6 +1,6 @@
 import {css} from '@emotion/react';
 
-import type {CssMaxWidth, CssWidth} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import {Container} from '@sentry/scraps/layout';
 
 interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -9,13 +9,13 @@ interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
    * Caps how wide the bubble can grow relative to its container. Defaults to
    * `80%` so a bubble never spans the full conversation width.
    */
-  maxWidth?: CssMaxWidth;
+  maxWidth?: CSS['maxWidth'];
   /**
    * How wide the bubble sizes itself. Left unset by default so it hugs its
    * content; pass `100%` to fill up to `maxWidth`, useful for multiline or rich
    * content that reads better in a wider bubble.
    */
-  width?: CssWidth;
+  width?: CSS['width'];
 }
 
 /**

--- a/static/app/components/core/chat/userMessage.tsx
+++ b/static/app/components/core/chat/userMessage.tsx
@@ -1,5 +1,6 @@
 import {css} from '@emotion/react';
 
+import type {CssMaxWidth, CssWidth} from '@sentry/scraps/cssTypes';
 import {Container} from '@sentry/scraps/layout';
 
 interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -8,13 +9,13 @@ interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
    * Caps how wide the bubble can grow relative to its container. Defaults to
    * `80%` so a bubble never spans the full conversation width.
    */
-  maxWidth?: React.CSSProperties['maxWidth'];
+  maxWidth?: CssMaxWidth;
   /**
    * How wide the bubble sizes itself. Left unset by default so it hugs its
    * content; pass `100%` to fill up to `maxWidth`, useful for multiline or rich
    * content that reads better in a wider bubble.
    */
-  width?: React.CSSProperties['width'];
+  width?: CssWidth;
 }
 
 /**

--- a/static/app/components/core/cssTypes.ts
+++ b/static/app/components/core/cssTypes.ts
@@ -48,10 +48,15 @@ type HeightUnit =
   | 'cqmin'
   | 'cqmax';
 
-export type CssWidth = BaseSize | `${number}${WidthUnit}` | Globals;
-export type CssMinWidth = CssWidth;
-export type CssMaxWidth = CssWidth | 'none';
-export type CssHeight = BaseSize | `${number}${HeightUnit}` | Globals;
-export type CssMinHeight = CssHeight;
-export type CssMaxHeight = CssHeight | 'none';
-export type CssInset = `${number}${HeightUnit}` | Globals | BaseDimension;
+type Width = BaseSize | `${number}${WidthUnit}` | Globals;
+type Height = BaseSize | `${number}${HeightUnit}` | Globals;
+
+export type CSS = {
+  height: Height;
+  inset: `${number}${HeightUnit}` | Globals | BaseDimension;
+  maxHeight: Height | 'none';
+  maxWidth: Width | 'none';
+  minHeight: Height;
+  minWidth: Width;
+  width: Width;
+};

--- a/static/app/components/core/cssTypes.ts
+++ b/static/app/components/core/cssTypes.ts
@@ -1,14 +1,7 @@
-type Globals = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
+type Globals = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset' | CssFunction;
 type CssFunction = `${string}(${string})`;
-type BaseSize =
-  | 'auto'
-  | 'fit-content'
-  | 'max-content'
-  | 'min-content'
-  | 'stretch'
-  | '0'
-  | 0
-  | CssFunction;
+type BaseDimension = 'auto' | '0' | 0;
+type BaseSize = 'fit-content' | 'max-content' | 'min-content' | 'stretch' | BaseDimension;
 
 /**
  * Units that make sense for either dimension.
@@ -61,3 +54,4 @@ export type CssMaxWidth = CssWidth | 'none';
 export type CssHeight = BaseSize | `${number}${HeightUnit}` | Globals;
 export type CssMinHeight = CssHeight;
 export type CssMaxHeight = CssHeight | 'none';
+export type CssInset = `${number}${HeightUnit}` | Globals | BaseDimension;

--- a/static/app/components/core/cssTypes.ts
+++ b/static/app/components/core/cssTypes.ts
@@ -1,0 +1,63 @@
+type Globals = 'inherit' | 'initial' | 'revert' | 'revert-layer' | 'unset';
+type CssFunction = `${string}(${string})`;
+type BaseSize =
+  | 'auto'
+  | 'fit-content'
+  | 'max-content'
+  | 'min-content'
+  | 'stretch'
+  | '0'
+  | 0
+  | CssFunction;
+
+/**
+ * Units that make sense for either dimension.
+ */
+type BaseUnit = 'px' | 'em' | 'rem' | 'ex' | 'rex' | 'cap' | 'rcap' | 'ch' | 'rch' | '%';
+
+type WidthUnit =
+  | BaseUnit
+  | 'vw'
+  | 'svw'
+  | 'lvw'
+  | 'dvw'
+  | 'vmin'
+  | 'vmax'
+  | 'svmin'
+  | 'svmax'
+  | 'lvmin'
+  | 'lvmax'
+  | 'dvmin'
+  | 'dvmax'
+  | 'cqw'
+  | 'cqi'
+  | 'cqmin'
+  | 'cqmax';
+
+type HeightUnit =
+  | BaseUnit
+  | 'vh'
+  | 'svh'
+  | 'lvh'
+  | 'dvh'
+  | 'vmin'
+  | 'vmax'
+  | 'svmin'
+  | 'svmax'
+  | 'lvmin'
+  | 'lvmax'
+  | 'dvmin'
+  | 'dvmax'
+  | 'lh'
+  | 'rlh'
+  | 'cqh'
+  | 'cqb'
+  | 'cqmin'
+  | 'cqmax';
+
+export type CssWidth = BaseSize | `${number}${WidthUnit}` | Globals;
+export type CssMinWidth = CssWidth;
+export type CssMaxWidth = CssWidth | 'none';
+export type CssHeight = BaseSize | `${number}${HeightUnit}` | Globals;
+export type CssMinHeight = CssHeight;
+export type CssMaxHeight = CssHeight | 'none';

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -1,7 +1,7 @@
 import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
-import type {CssHeight, CssWidth} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import type {Responsive} from '@sentry/scraps/layout';
 import {getRadius, rc} from '@sentry/scraps/layout';
 
@@ -14,7 +14,7 @@ export interface ImageProps extends Omit<
   alt: string;
   src: string;
   aspectRatio?: CSSProperties['aspectRatio'];
-  height?: Responsive<CssHeight>;
+  height?: Responsive<CSS['height']>;
   /**
    * Determines if the image should be loaded eagerly or lazily.
    * @default 'lazy'
@@ -24,7 +24,7 @@ export interface ImageProps extends Omit<
   objectPosition?: 'center' | 'top' | 'bottom' | 'left' | 'right' | (string & {});
   radius?: Responsive<RadiusSize>;
   ref?: React.Ref<HTMLImageElement>;
-  width?: Responsive<CssWidth>;
+  width?: Responsive<CSS['width']>;
 }
 
 export function Image({loading, width, height, ...props}: ImageProps) {
@@ -33,8 +33,8 @@ export function Image({loading, width, height, ...props}: ImageProps) {
 
 const Img = styled('img')<
   Omit<ImageProps, 'width' | 'height'> & {
-    h?: Responsive<CssHeight>;
-    w?: Responsive<CssWidth>;
+    h?: Responsive<CSS['height']>;
+    w?: Responsive<CSS['width']>;
   }
 >`
   ${p => rc('width', p.w ?? '100%', p.theme)};

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -1,7 +1,7 @@
 import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
-import {CssHeight, CssWidth} from '@sentry/scraps/cssTypes';
+import type {CssHeight, CssWidth} from '@sentry/scraps/cssTypes';
 import type {Responsive} from '@sentry/scraps/layout';
 import {getRadius, rc} from '@sentry/scraps/layout';
 
@@ -14,7 +14,7 @@ export interface ImageProps extends Omit<
   alt: string;
   src: string;
   aspectRatio?: CSSProperties['aspectRatio'];
-  height?: CssHeight;
+  height?: Responsive<CssHeight>;
   /**
    * Determines if the image should be loaded eagerly or lazily.
    * @default 'lazy'
@@ -24,7 +24,7 @@ export interface ImageProps extends Omit<
   objectPosition?: 'center' | 'top' | 'bottom' | 'left' | 'right' | (string & {});
   radius?: Responsive<RadiusSize>;
   ref?: React.Ref<HTMLImageElement>;
-  width?: Responsive<CSSProperties['width']>;
+  width?: Responsive<CssWidth>;
 }
 
 export function Image({loading, width, height, ...props}: ImageProps) {
@@ -33,8 +33,8 @@ export function Image({loading, width, height, ...props}: ImageProps) {
 
 const Img = styled('img')<
   Omit<ImageProps, 'width' | 'height'> & {
-    h: Responsive<CssHeight>;
-    w: Responsive<CssWidth>;
+    h?: Responsive<CssHeight>;
+    w?: Responsive<CssWidth>;
   }
 >`
   ${p => rc('width', p.w ?? '100%', p.theme)};

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -1,6 +1,7 @@
 import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
+import {CssHeight, CssWidth} from '@sentry/scraps/cssTypes';
 import type {Responsive} from '@sentry/scraps/layout';
 import {getRadius, rc} from '@sentry/scraps/layout';
 
@@ -13,7 +14,7 @@ export interface ImageProps extends Omit<
   alt: string;
   src: string;
   aspectRatio?: CSSProperties['aspectRatio'];
-  height?: Responsive<CSSProperties['height']>;
+  height?: CssHeight;
   /**
    * Determines if the image should be loaded eagerly or lazily.
    * @default 'lazy'
@@ -32,8 +33,8 @@ export function Image({loading, width, height, ...props}: ImageProps) {
 
 const Img = styled('img')<
   Omit<ImageProps, 'width' | 'height'> & {
-    h: Responsive<CSSProperties['height']>;
-    w: Responsive<CSSProperties['width']>;
+    h: Responsive<CssHeight>;
+    w: Responsive<CssWidth>;
   }
 >`
   ${p => rc('width', p.w ?? '100%', p.theme)};

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -3,15 +3,7 @@ import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
-import type {
-  CssHeight,
-  CssInset,
-  CssMaxHeight,
-  CssMaxWidth,
-  CssMinHeight,
-  CssMinWidth,
-  CssWidth,
-} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 
 import type {
   BorderVariant,
@@ -56,11 +48,11 @@ interface ContainerLayoutProps {
 
   position?: Responsive<'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'>;
 
-  inset?: Responsive<CssInset>;
-  top?: Responsive<CssInset>;
-  bottom?: Responsive<CssInset>;
-  left?: Responsive<CssInset>;
-  right?: Responsive<CssInset>;
+  inset?: Responsive<CSS['inset']>;
+  top?: Responsive<CSS['inset']>;
+  bottom?: Responsive<CSS['inset']>;
+  left?: Responsive<CSS['inset']>;
+  right?: Responsive<CSS['inset']>;
 
   overflow?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowX?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
@@ -91,13 +83,13 @@ interface ContainerLayoutProps {
 
   radius?: Responsive<Shorthand<RadiusSize, 4>>;
 
-  width?: Responsive<CssWidth>;
-  minWidth?: Responsive<CssMinWidth>;
-  maxWidth?: Responsive<CssMaxWidth>;
+  width?: Responsive<CSS['width']>;
+  minWidth?: Responsive<CSS['minWidth']>;
+  maxWidth?: Responsive<CSS['maxWidth']>;
 
-  height?: Responsive<CssHeight>;
-  minHeight?: Responsive<CssMinHeight>;
-  maxHeight?: Responsive<CssMaxHeight>;
+  height?: Responsive<CSS['height']>;
+  minHeight?: Responsive<CSS['minHeight']>;
+  maxHeight?: Responsive<CSS['maxHeight']>;
 
   border?: Responsive<BorderVariant>;
   borderTop?: Responsive<BorderVariant>;

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -4,6 +4,15 @@ import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
 import type {
+  CssHeight,
+  CssMaxHeight,
+  CssMaxWidth,
+  CssMinHeight,
+  CssMinWidth,
+  CssWidth,
+} from '@sentry/scraps/cssTypes';
+
+import type {
   BorderVariant,
   RadiusSize,
   SpaceSize,
@@ -81,13 +90,13 @@ interface ContainerLayoutProps {
 
   radius?: Responsive<Shorthand<RadiusSize, 4>>;
 
-  width?: Responsive<React.CSSProperties['width']>;
-  minWidth?: Responsive<React.CSSProperties['minWidth']>;
-  maxWidth?: Responsive<React.CSSProperties['maxWidth']>;
+  width?: Responsive<CssWidth>;
+  minWidth?: Responsive<CssMinWidth>;
+  maxWidth?: Responsive<CssMaxWidth>;
 
-  height?: Responsive<React.CSSProperties['height']>;
-  minHeight?: Responsive<React.CSSProperties['minHeight']>;
-  maxHeight?: Responsive<React.CSSProperties['maxHeight']>;
+  height?: Responsive<CssHeight>;
+  minHeight?: Responsive<CssMinHeight>;
+  maxHeight?: Responsive<CssMaxHeight>;
 
   border?: Responsive<BorderVariant>;
   borderTop?: Responsive<BorderVariant>;

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -5,6 +5,7 @@ import {mergeRefs} from '@react-aria/utils';
 
 import type {
   CssHeight,
+  CssInset,
   CssMaxHeight,
   CssMaxWidth,
   CssMinHeight,
@@ -55,11 +56,11 @@ interface ContainerLayoutProps {
 
   position?: Responsive<'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'>;
 
-  inset?: Responsive<React.CSSProperties['inset']>;
-  top?: Responsive<React.CSSProperties['top']>;
-  bottom?: Responsive<React.CSSProperties['bottom']>;
-  left?: Responsive<React.CSSProperties['left']>;
-  right?: Responsive<React.CSSProperties['right']>;
+  inset?: Responsive<CssInset>;
+  top?: Responsive<CssInset>;
+  bottom?: Responsive<CssInset>;
+  left?: Responsive<CssInset>;
+  right?: Responsive<CssInset>;
 
   overflow?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;
   overflowX?: Responsive<'visible' | 'hidden' | 'scroll' | 'auto'>;

--- a/static/app/components/core/principles/tokens/__stories__/components.tsx
+++ b/static/app/components/core/principles/tokens/__stories__/components.tsx
@@ -84,7 +84,7 @@ export function Radius() {
             background: theme.tokens.background.transparent.accent.muted,
           }}
           border="accent"
-          radius={token as any}
+          radius={token}
         />
       )}
     />
@@ -100,7 +100,7 @@ export function FontSize() {
       renderToken={({token}) => {
         if (['3xl', '4xl'].includes(token)) {
           return (
-            <Heading as="h4" size={token as any} variant="accent">
+            <Heading as="h4" size={token} variant="accent">
               Aa
             </Heading>
           );
@@ -130,7 +130,7 @@ export function FontWeight() {
       renderToken={({token, value}) => (
         <Text
           size="lg"
-          style={{fontWeight: value as any}}
+          style={{fontWeight: value}}
           monospace={token.startsWith('mono')}
           variant="accent"
         >
@@ -222,7 +222,7 @@ export function ShadowOffset() {
             width: '32px',
             height: '32px',
             background: theme.tokens.background.primary,
-            boxShadow: `${value}`,
+            boxShadow: value,
           }}
           border="accent"
           radius="xs"

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -109,7 +109,7 @@ export function Body({noRowGap, ...props}: BodyProps) {
   );
 }
 
-interface MainProps extends ContainerProps<'section'> {
+interface MainProps extends Omit<ContainerProps<'section'>, 'width'> {
   children: React.ReactNode;
   /**
    * Set the width of the main content.

--- a/static/app/components/markdownTextArea.tsx
+++ b/static/app/components/markdownTextArea.tsx
@@ -15,7 +15,7 @@ export function MarkdownTextArea({className, ...props}: MarkdownTextAreaProps) {
   return (
     <Container position="relative" className={className}>
       <RightPaddedTextArea autosize rows={5} maxRows={10} {...props} />
-      <Container position="absolute" top="8px " right="10px">
+      <Container position="absolute" top="8px" right="10px">
         <Tooltip title={t('Markdown supported')}>
           <IconMarkdown size="md" variant="muted" />
         </Tooltip>

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useCallback, useRef} from 'react';
 
-import type {CssMinHeight} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
@@ -14,7 +14,7 @@ import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/repl
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface Props {
-  minHeight?: CssMinHeight;
+  minHeight?: CSS['minHeight'];
 }
 
 export function ReplaySliderDiff({minHeight}: Props) {

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -1,4 +1,6 @@
-import {Fragment, useCallback, useRef, type CSSProperties} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
+
+import type {CssMinHeight} from '@sentry/scraps/cssTypes';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
@@ -12,7 +14,7 @@ import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/repl
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface Props {
-  minHeight?: CSSProperties['minHeight'];
+  minHeight?: CssMinHeight;
 }
 
 export function ReplaySliderDiff({minHeight}: Props) {

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -105,7 +105,7 @@ function HeaderFields({children}: RequiredChildren) {
   );
 }
 
-function Body({children, maxWidth}: RequiredChildren & {maxWidth?: CssMaxWidth}) {
+function Body({children, maxWidth}: RequiredChildren & {maxWidth?: CSS['maxWidth']}) {
   return (
     <Stack
       flexGrow={1}
@@ -122,7 +122,7 @@ function Body({children, maxWidth}: RequiredChildren & {maxWidth?: CssMaxWidth})
 
 interface FooterProps extends RequiredChildren {
   label?: string;
-  maxWidth?: CssMaxWidth;
+  maxWidth?: CSS['maxWidth'];
 }
 
 function Footer({children, label, maxWidth}: FooterProps) {

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -104,7 +105,7 @@ function HeaderFields({children}: RequiredChildren) {
   );
 }
 
-function Body({children, maxWidth}: RequiredChildren & {maxWidth?: string}) {
+function Body({children, maxWidth}: RequiredChildren & {maxWidth?: CssMaxWidth}) {
   return (
     <Stack
       flexGrow={1}
@@ -121,7 +122,7 @@ function Body({children, maxWidth}: RequiredChildren & {maxWidth?: string}) {
 
 interface FooterProps extends RequiredChildren {
   label?: string;
-  maxWidth?: string;
+  maxWidth?: CssMaxWidth;
 }
 
 function Footer({children, label, maxWidth}: FooterProps) {

--- a/static/app/stories/tokenReference.tsx
+++ b/static/app/stories/tokenReference.tsx
@@ -6,13 +6,15 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 
-interface TokenReferenceProps {
-  renderToken: (props: {token: string; value: string | number}) => React.ReactNode;
+interface TokenReferenceProps<T extends Record<string, string | number>> {
+  renderToken: (props: {token: keyof T; value: T[keyof T]}) => React.ReactNode;
   scale: string;
-  tokens: Record<string, string | number>;
+  tokens: T;
 }
 
-export function TokenReference(props: TokenReferenceProps) {
+export function TokenReference<T extends Record<string, string | number>>(
+  props: TokenReferenceProps<T>
+) {
   return (
     <Flex
       align="center"
@@ -27,7 +29,7 @@ export function TokenReference(props: TokenReferenceProps) {
     >
       {Object.entries(props.tokens).map(([token, value]) => (
         <Token key={token} scale={props.scale} {...{token, value}}>
-          {props.renderToken({value, token})}
+          {props.renderToken({value: value as T[keyof T], token})}
         </Token>
       ))}
     </Flex>

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -258,7 +258,7 @@ const commonTheme = {
   },
 
   ...typography,
-};
+} as const;
 
 export interface SentryTheme extends Omit<
   typeof lightThemeDefinition,

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -670,7 +670,7 @@ export function MetricDetectorDetailsChart({detector}: MetricDetectorDetailsChar
     return (
       <ChartContainer>
         <ChartBody>
-          <Flex height={CHART_HEIGHT} justify="center" align="center">
+          <Flex justify="center" align="center">
             <Placeholder height={`${CHART_HEIGHT}px`} />
           </Flex>
         </ChartBody>

--- a/static/app/views/detectors/components/forms/common/footer.tsx
+++ b/static/app/views/detectors/components/forms/common/footer.tsx
@@ -1,7 +1,7 @@
 import {Observer} from 'mobx-react-lite';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 
 import {FormContext} from 'sentry/components/forms/formContext';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
@@ -13,7 +13,7 @@ import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 interface NewDetectorFooterProps {
   disabledCreate?: string;
   extras?: React.ReactNode;
-  maxWidth?: CssMaxWidth;
+  maxWidth?: CSS['maxWidth'];
 }
 
 export function NewDetectorFooter({

--- a/static/app/views/detectors/components/forms/common/footer.tsx
+++ b/static/app/views/detectors/components/forms/common/footer.tsx
@@ -1,6 +1,7 @@
 import {Observer} from 'mobx-react-lite';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
+import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
 
 import {FormContext} from 'sentry/components/forms/formContext';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
@@ -12,7 +13,7 @@ import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 interface NewDetectorFooterProps {
   disabledCreate?: string;
   extras?: React.ReactNode;
-  maxWidth?: string;
+  maxWidth?: CssMaxWidth;
 }
 
 export function NewDetectorFooter({

--- a/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricDetectorChart.tsx
@@ -78,7 +78,7 @@ function anomalyMarklineTooltip(ctx: AnomalyTooltipContext) {
 
 function ChartError() {
   return (
-    <Flex justify="center" align="center" height={CHART_HEIGHT}>
+    <Flex justify="center" align="center" height={`${CHART_HEIGHT}px`}>
       <ErrorPanel>
         <IconWarning variant="muted" size="lg" />
         <div>{t('Error loading chart data')}</div>
@@ -89,7 +89,7 @@ function ChartError() {
 
 function ChartLoading() {
   return (
-    <Flex justify="center" align="center" height={CHART_HEIGHT}>
+    <Flex justify="center" align="center" height={`${CHART_HEIGHT}px`}>
       <Placeholder height={`${CHART_HEIGHT}px`} />
     </Flex>
   );

--- a/static/app/views/detectors/components/uptime/assertions/dragDrop.tsx
+++ b/static/app/views/detectors/components/uptime/assertions/dragDrop.tsx
@@ -87,11 +87,13 @@ export function DroppableHitbox(props: DroppableProps) {
     before: {bottom: isGroup ? 'calc(100% - 10px)' : '50%'},
     after: {top: isGroup ? 'calc(100% - 10px)' : '50%'},
     inside: {inset: '0px', top: '-10px', left: '-12px'},
-  };
+  } as const;
 
   const offset = offsetConfig[position];
   const groupHitboxAdjust =
-    isGroup && position === 'after' ? {bottom: '-10px', top: 'calc(100%)'} : {};
+    isGroup && position === 'after'
+      ? ({bottom: '-10px', top: 'calc(100%)'} as const)
+      : {};
 
   return (
     <Container

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector/metricSelector.tsx
@@ -606,7 +606,7 @@ export function MetricSelector({
         }));
 
   const sidePanelAnchorPosition =
-    sidePanelAnchorOffset === null ? '0px' : `${sidePanelAnchorOffset}px`;
+    sidePanelAnchorOffset === null ? '0px' : (`${sidePanelAnchorOffset}px` as const);
   const hasSelectedMetric =
     Boolean(highlightedOption) ||
     (!focusedOption && Boolean(traceMetric.name) && !fieldOption?.isSelected);

--- a/static/app/views/navigation/useTopOffset.tsx
+++ b/static/app/views/navigation/useTopOffset.tsx
@@ -11,24 +11,7 @@ import {
   SUPERUSER_MARQUEE_HEIGHT,
 } from 'sentry/views/navigation/constants';
 
-interface TopOffset {
-  /** The `top` CSS value for the sticky nav sidebar itself (marquee only) */
-  barTop: string;
-  /**
-   * Offset from the viewport top, past the marquee and the header. For
-   * viewport-fixed overlays (drawers, the widget builder) that anchor to the
-   * screen, not to the scrolling content pane.
-   */
-  contentTop: string;
-  /**
-   * Offset for sticky content *inside* the scrolling page pane, below the
-   * sticky TopBar. Header height only: the pane already sits below the marquee,
-   * so including it here would push in-page stickies down by the marquee height.
-   */
-  pageContentTop: string;
-}
-
-export function useTopOffset(): TopOffset {
+export function useTopOffset() {
   const theme = useTheme();
   const organization = useOrganization({allowNull: true});
   const isMobile = !useMedia(`(min-width: ${theme.breakpoints.md})`);
@@ -43,8 +26,19 @@ export function useTopOffset(): TopOffset {
     : PRIMARY_HEADER_HEIGHT;
 
   return {
+    /** The `top` CSS value for the sticky nav sidebar itself (marquee only) */
     barTop: `${superuserOffset}px`,
+    /**
+     * Offset from the viewport top, past the marquee and the header. For
+     * viewport-fixed overlays (drawers, the widget builder) that anchor to the
+     * screen, not to the scrolling content pane.
+     */
     contentTop: `${superuserOffset + headerHeight}px`,
+    /**
+     * Offset for sticky content *inside* the scrolling page pane, below the
+     * sticky TopBar. Header height only: the pane already sits below the marquee,
+     * so including it here would push in-page stickies down by the marquee height.
+     */
     pageContentTop: `${headerHeight}px`,
-  };
+  } as const;
 }

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -182,7 +182,7 @@ export const WipeCardBody = memo(function WipeCardBodyImpl({
 }) {
   const naturalHeight = Math.max(headImage.height || 0, baseImage.height || 0);
   const minHeight = naturalHeight
-    ? `${Math.min(Math.max(naturalHeight, WIPE_MIN_HEIGHT), MAX_IMAGE_HEIGHT)}px`
+    ? (`${Math.min(Math.max(naturalHeight, WIPE_MIN_HEIGHT), MAX_IMAGE_HEIGHT)}px` as const)
     : `${WIPE_MIN_HEIGHT}px`;
   return (
     <Flex>

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -35,7 +35,7 @@ export function BillingDetailsPanel({
   organization: Organization;
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
-  maxPanelWidth?: CssMaxWidth;
+  maxPanelWidth?: CSS['maxWidth'];
   shouldExpandInitially?: boolean;
 }) {
   const [isEditing, setIsEditing] = useState(false);

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
+import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -34,7 +35,7 @@ export function BillingDetailsPanel({
   organization: Organization;
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
-  maxPanelWidth?: string;
+  maxPanelWidth?: CssMaxWidth;
   shouldExpandInitially?: boolean;
 }) {
   const [isEditing, setIsEditing] = useState(false);

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useState} from 'react';
 import type {Location} from 'history';
 
 import {Button} from '@sentry/scraps/button';
-import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -25,7 +25,7 @@ interface CreditCardPanelProps {
   organization: Organization;
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
-  maxPanelWidth?: CssMaxWidth;
+  maxPanelWidth?: CSS['maxWidth'];
   shouldExpandInitially?: boolean;
 }
 

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -2,6 +2,7 @@ import {Fragment, useEffect, useState} from 'react';
 import type {Location} from 'history';
 
 import {Button} from '@sentry/scraps/button';
+import type {CssMaxWidth} from '@sentry/scraps/cssTypes';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -24,7 +25,7 @@ interface CreditCardPanelProps {
   organization: Organization;
   subscription: Subscription;
   analyticsEvent?: GetsentryEventKey;
-  maxPanelWidth?: string;
+  maxPanelWidth?: CssMaxWidth;
   shouldExpandInitially?: boolean;
 }
 

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -4,7 +4,7 @@ import seerConfigMainImg from 'sentry-images/spot/seer-config-main.svg';
 import seerConfigSeerImg from 'sentry-images/spot/seer-config-seer.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
-import type {CssHeight} from '@sentry/scraps/cssTypes';
+import type {CSS} from '@sentry/scraps/cssTypes';
 import {Image} from '@sentry/scraps/image';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -43,7 +43,7 @@ function Cta({
   subtitle: React.ReactNode;
   title: React.ReactNode;
   buttons?: React.ReactNode;
-  heightOverride?: CssHeight;
+  heightOverride?: CSS['height'];
   icon?: React.ReactNode;
 } & ({image: string; imageAlt: string} | {image?: never; imageAlt?: never})) {
   return (

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -4,6 +4,7 @@ import seerConfigMainImg from 'sentry-images/spot/seer-config-main.svg';
 import seerConfigSeerImg from 'sentry-images/spot/seer-config-seer.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
+import type {CssHeight} from '@sentry/scraps/cssTypes';
 import {Image} from '@sentry/scraps/image';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -42,7 +43,7 @@ function Cta({
   subtitle: React.ReactNode;
   title: React.ReactNode;
   buttons?: React.ReactNode;
-  heightOverride?: string;
+  heightOverride?: CssHeight;
   icon?: React.ReactNode;
 } & ({image: string; imageAlt: string} | {image?: never; imageAlt?: never})) {
   return (


### PR DESCRIPTION
This PR adds stricter cssTypes implementations than `React.CSSProperties`, which has no type guarantees as everything is unioned with `(string & {})`, making it a type-hint at best.

In doing so, I found a couple of bugs where we pass wrong things (like unit-less numbers to width/height) that lead to ignored css styles.