### PR TITLE
feat(ui): Persist the conversations table column widths

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -1,16 +1,23 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {dragHandle} from 'sentry-test/dragMove';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {COL_WIDTH_MINIMUM} from 'sentry/components/tables/gridEditable';
+import {
+  COL_WIDTH_MINIMUM,
+  COL_WIDTH_UNDEFINED,
+} from 'sentry/components/tables/gridEditable';
 
 import {
   collapseToolsColumnWhenUnused,
   ConversationsTable,
   getUserDisplayName,
   getVisibleToolCount,
+  parseStoredColumnWidths,
 } from './conversationsTable';
+
+const COLUMN_WIDTHS_STORAGE_KEY = 'conversation-table-column-widths';
 
 const BASE_CONVERSATION = {
   conversationId: 'conv-1',
@@ -53,6 +60,7 @@ function renderTable() {
 describe('ConversationsTable', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    localStorage.clear();
     act(() => {
       PageFiltersStore.reset();
       PageFiltersStore.init();
@@ -171,6 +179,54 @@ describe('ConversationsTable', () => {
     );
   });
 
+  it('restores a persisted column width', async () => {
+    localStorage.setItem(COLUMN_WIDTHS_STORAGE_KEY, JSON.stringify({tools: 400}));
+    mockConversations([
+      {...BASE_CONVERSATION, title: 'With tools', toolNames: ['execute_query']},
+    ]);
+
+    renderTable();
+
+    await screen.findByText('With tools');
+
+    const template = screen.getByTestId('grid-editable').style.gridTemplateColumns;
+    expect(template).toContain('400px');
+    expect(template).not.toContain('220px');
+  });
+
+  it('keeps a persisted tools width when no conversation has tools', async () => {
+    localStorage.setItem(COLUMN_WIDTHS_STORAGE_KEY, JSON.stringify({tools: 400}));
+    mockConversations([{...BASE_CONVERSATION, title: 'No tools', toolNames: []}]);
+
+    renderTable();
+
+    await screen.findByText('No tools');
+
+    // Only a tools column still at its default width collapses; a width the
+    // user chose is respected across reloads.
+    expect(screen.getByTestId('grid-editable').style.gridTemplateColumns).toContain(
+      '400px'
+    );
+  });
+
+  it('persists a column width when the user resizes it', async () => {
+    mockConversations([
+      {...BASE_CONVERSATION, title: 'With tools', toolNames: ['execute_query']},
+    ]);
+
+    renderTable();
+
+    await screen.findByText('With tools');
+
+    // Columns measure 0px in jsdom, so the committed width is the drag distance.
+    dragHandle(screen.getByRole('separator', {name: 'Tools'}), {from: 0, to: 300});
+
+    await waitFor(() => {
+      const stored = localStorage.getItem(COLUMN_WIDTHS_STORAGE_KEY);
+      expect(stored && JSON.parse(stored)).toEqual({tools: 300});
+    });
+  });
+
   it('navigates to the conversation detail on row click', async () => {
     mockConversations([{...BASE_CONVERSATION, title: 'Open me'}]);
 
@@ -227,6 +283,38 @@ describe('ConversationsTable', () => {
     expect(router.location.pathname).toBe(initialPath);
 
     openSpy.mockRestore();
+  });
+});
+
+describe('parseStoredColumnWidths', () => {
+  it('keeps widths for known columns', () => {
+    expect(parseStoredColumnWidths({tools: 400, age: 150})).toEqual({
+      tools: 400,
+      age: 150,
+    });
+  });
+
+  it('drops columns it does not know about', () => {
+    expect(parseStoredColumnWidths({tools: 400, retired: 400})).toEqual({tools: 400});
+  });
+
+  it('drops widths below the grid minimum', () => {
+    expect(
+      parseStoredColumnWidths({
+        tools: COL_WIDTH_MINIMUM - 1,
+        age: COL_WIDTH_UNDEFINED,
+      })
+    ).toEqual({});
+  });
+
+  it('drops values that are not finite numbers', () => {
+    expect(parseStoredColumnWidths({tools: '400', age: null, cost: NaN})).toEqual({});
+  });
+
+  it('returns no widths when nothing usable is stored', () => {
+    expect(parseStoredColumnWidths(undefined)).toEqual({});
+    expect(parseStoredColumnWidths(null)).toEqual({});
+    expect(parseStoredColumnWidths('garbage')).toEqual({});
   });
 });
 

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -29,6 +29,7 @@ import {markdownToPlainText} from 'sentry/utils/marked/marked';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
@@ -90,6 +91,13 @@ const COLUMN_DEFAULTS: Record<ColumnKey, {name: string; width: number}> = {
 
 const RIGHT_ALIGNED_COLUMNS = new Set<ColumnKey>(['age']);
 
+// Persisted per-column widths. Only the widths are stored, keyed by column:
+// names are translated, and keying by column (rather than storing the whole
+// column array) keeps a stored layout usable when columns change.
+const COLUMN_WIDTHS_STORAGE_KEY = 'conversation-table-column-widths';
+
+type ColumnWidths = Partial<Record<ColumnKey, number>>;
+
 // Plain-text title/first-message is ellipsized to this length before rendering.
 const CELL_MAX_CHARS = 256;
 
@@ -148,6 +156,31 @@ export function collapseToolsColumnWhenUnused(
   );
 }
 
+/**
+ * Reads the persisted column widths, dropping anything that isn't a width we
+ * would have written: unknown columns, and values below the grid's own resize
+ * floor (which includes a persisted COL_WIDTH_UNDEFINED). Dropped columns fall
+ * back to their default width.
+ */
+export function parseStoredColumnWidths(value?: unknown): ColumnWidths {
+  if (typeof value !== 'object' || value === null) {
+    return {};
+  }
+  const stored = value as Record<string, unknown>;
+  const widths: ColumnWidths = {};
+  for (const key of COLUMN_ORDER) {
+    const width = stored[key];
+    if (
+      typeof width === 'number' &&
+      Number.isFinite(width) &&
+      width >= COL_WIDTH_MINIMUM
+    ) {
+      widths[key] = width;
+    }
+  }
+  return widths;
+}
+
 export function ConversationsTable() {
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -157,21 +190,28 @@ export function ConversationsTable() {
 
   const [highlightedRowKey, setHighlightedRowKey] = useState<number | undefined>();
 
-  const [columnOrder, setColumnOrder] = useState<Array<GridColumnOrder<ColumnKey>>>(() =>
-    COLUMN_ORDER.map(key => ({
-      key,
-      name: COLUMN_DEFAULTS[key].name,
-      width: COLUMN_DEFAULTS[key].width,
-    }))
+  const [storedWidths, setStoredWidths] = useLocalStorageState<ColumnWidths>(
+    COLUMN_WIDTHS_STORAGE_KEY,
+    parseStoredColumnWidths
+  );
+
+  const columnOrder = useMemo<Array<GridColumnOrder<ColumnKey>>>(
+    () =>
+      COLUMN_ORDER.map(key => ({
+        key,
+        name: COLUMN_DEFAULTS[key].name,
+        width: storedWidths[key] ?? COLUMN_DEFAULTS[key].width,
+      })),
+    [storedWidths]
   );
 
   const handleResizeColumn = useCallback(
-    (columnIndex: number, nextColumn: GridColumnOrder<ColumnKey>) => {
-      setColumnOrder(current =>
-        current.map((column, index) => (index === columnIndex ? nextColumn : column))
-      );
+    (_columnIndex: number, nextColumn: GridColumnOrder<ColumnKey>) => {
+      // Keyed by column rather than by index so a stored width survives a
+      // change to the column order.
+      setStoredWidths(current => ({...current, [nextColumn.key]: nextColumn.width}));
     },
-    []
+    [setStoredWidths]
   );
 
   const hasNoTools = useMemo(


### PR DESCRIPTION
Column widths in the conversations table now survive a reload.

Resizing only lasted until the next page load, so anyone who narrowed the conversation column to see more tool calls had to redo it every visit.

A tools column you've sized also keeps that width on a page with no tools, where it previously collapsed back to its default.

Closes TET-2896