### PR TITLE
fix(dashboards): prevent global filter button stretching

### DIFF
--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import styled from '@emotion/styled';
+import {css} from '@emotion/react';
 import type {Location} from 'history';
 import {createParser, useQueryState} from 'nuqs';
 
@@ -203,7 +203,19 @@ export function FiltersBar({
       marginBottom="0"
       padding="lg xl xl"
     >
-      <FiltersRow>
+      <Flex
+        css={css`
+          & button[aria-haspopup] {
+            height: 100%;
+            width: 100%;
+          }
+        `}
+        direction="row"
+        flex={{zero: '0 1 auto', xl: `1 1 ${FILTERS_ROW_FLEX_BASIS_PX}px`}}
+        gap="lg"
+        minWidth={0}
+        wrap="wrap"
+      >
         <PageFilterBar condensed>
           <ProjectPageFilter
             disabled={isEditingDashboard}
@@ -330,7 +342,7 @@ export function FiltersBar({
               </Button>
             </Grid>
           )}
-      </FiltersRow>
+      </Flex>
       <Grid flow="column" align="center" gap="md">
         <CompactSelect
           value={interval}
@@ -358,17 +370,3 @@ const parseReleaseSort = createParser({
 
 // Filters row starts wrapping siblings at this width.
 const FILTERS_ROW_FLEX_BASIS_PX = 480;
-
-const FiltersRow = styled('div')`
-  display: flex;
-  flex-direction: row;
-  gap: ${p => p.theme.space.lg};
-  flex-wrap: wrap;
-  flex: 1 1 ${FILTERS_ROW_FLEX_BASIS_PX}px;
-  min-width: 0;
-
-  & button[aria-haspopup] {
-    height: 100%;
-    width: 100%;
-  }
-`;


### PR DESCRIPTION
**Before**
<img width="1031" height="700" alt="image" src="https://github.com/user-attachments/assets/b80b1a9c-4c6d-461c-ad53-b7912c1091ea" />


**After**
<img width="970" height="657" alt="image" src="https://github.com/user-attachments/assets/662c7049-c241-4734-8512-7332ba0d0af5" />
