### PR TITLE
ref(ai-monitoring): Decouple conversation APIs from UI feature gate

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.ai_monitoring.conversation_titles import fetch_conversation_title
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -103,9 +102,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization: Organization, conversation_id: str) -> Response:
-        if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
-            return Response(status=404)
-
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
@@ -9,7 +9,6 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.ai_monitoring.conversation_titles import fetch_conversation_titles
 from sentry.ai_monitoring.message_normalizer import (
     FILTERED,
@@ -241,9 +240,6 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization: Organization) -> Response:
-        if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
-            return Response(status=404)
-
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -297,25 +297,21 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             == f"/api/0/organizations/{self.organization.slug}/agents/conversations/{conversation_id}/"
         )
 
-    def do_request(self, conversation_id, query=None, features=None, **kwargs):
-        if features is None:
-            features = ["organizations:gen-ai-conversations"]
-
+    def do_request(self, conversation_id, query=None, **kwargs):
         query = query or {}
 
-        with self.feature(features):
-            return self.client.get(
-                reverse(
-                    self.view,
-                    kwargs={
-                        "organization_id_or_slug": self.organization.slug,
-                        "conversation_id": conversation_id,
-                    },
-                ),
-                query,
-                format="json",
-                **kwargs,
-            )
+        return self.client.get(
+            reverse(
+                self.view,
+                kwargs={
+                    "organization_id_or_slug": self.organization.slug,
+                    "conversation_id": conversation_id,
+                },
+            ),
+            query,
+            format="json",
+            **kwargs,
+        )
 
     def _store_conversation_span(self, conversation_id, timestamp, project=None) -> None:
         """One minimal span, enough for the conversation to resolve to a project."""
@@ -327,11 +323,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             trace_id=uuid4().hex,
             project=project,
         )
-
-    def test_no_feature(self) -> None:
-        conversation_id = uuid4().hex
-        response = self.do_request(conversation_id, features=[])
-        assert response.status_code == 404
 
     def test_no_project(self) -> None:
         conversation_id = uuid4().hex

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -123,26 +123,18 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             == f"/api/0/organizations/{self.organization.slug}/agents/conversations/"
         )
 
-    def do_request(self, query=None, features=None, **kwargs):
-        if features is None:
-            features = ["organizations:gen-ai-conversations"]
-
+    def do_request(self, query=None, **kwargs):
         query = query or {}
 
-        with self.feature(features):
-            return self.client.get(
-                reverse(
-                    self.view,
-                    kwargs={"organization_id_or_slug": self.organization.slug},
-                ),
-                query,
-                format="json",
-                **kwargs,
-            )
-
-    def test_no_feature(self) -> None:
-        response = self.do_request(features=[])
-        assert response.status_code == 404
+        return self.client.get(
+            reverse(
+                self.view,
+                kwargs={"organization_id_or_slug": self.organization.slug},
+            ),
+            query,
+            format="json",
+            **kwargs,
+        )
 
     def test_no_project(self) -> None:
         response = self.do_request()


### PR DESCRIPTION
AI conversation list and detail endpoints no longer return 404 based on the `organizations:gen-ai-conversations` flag. This deploys before the frontend gate removal in #123315 so UI rollout never points users at feature-gated APIs.